### PR TITLE
feat(receipt): specify evidence provenance proofs (spec, typed recipes, hostile corpus)

### DIFF
--- a/docs/specs/evidence-provenance-proof-v1.md
+++ b/docs/specs/evidence-provenance-proof-v1.md
@@ -1,0 +1,47 @@
+# Evidence provenance proof v1 (experimental, fixture-only)
+
+Status: experimental and fixture-only. This document specifies no registered receipt payload, production emitter, verifier command, or capability claim.
+
+## Scope and terms
+
+A source is named input bytes. A view is UTF-8 bytes produced from exactly one source by an ordered typed recipe. A match is a half-open byte interval `[byte_start, byte_end)` in that view. All offsets are unsigned UTF-8 **byte** offsets. Rune/character conversion is forbidden.
+
+Implementations MUST reject invalid UTF-8 source or view bytes; starts or ends in UTF-8 continuation bytes; zero-length, out-of-bounds, or arithmetic-overflowing intervals; unsorted, duplicate, or overlapping intervals. Adjacent intervals are valid. Because the wire shape carries `byte_start` and `byte_end`, a verifier rejects `byte_end <= byte_start` and never derives an end from an unrepresented length field.
+
+## Typed recipe language
+
+`transform_profile_digest` is a `sha256:<lowercase hex>` digest of the profile document. A verifier MUST possess the exact digest-matched profile before reconstructing a view. The canonical evidence-provenance v1 profile document is `sdk/conformance/testdata/transform-profile/evidence-provenance-transform-v1.json`; its exact committed bytes have digest `sha256:8bc27d5d89e4e5ba3e0d1e68a25a3f0170f9a5ea2f19edf81a9a90bf82e23b3e`.
+
+That profile document—not a Pipelock implementation—is the normative source of truth for the ordered vocabulary, operation parameter shapes, Unicode/control-character and malformed-input policy, decoding and padding selection, canonical encodings, UTF-8 checks, and byte/decode-pass limits. It declares a 2 MiB input limit, a 1 MiB post-operation output limit, and at most four percent-decode passes. The Go implementation deliberately does not load a conformance document at runtime; its digest test parses the document and fails if those implementation constants or the operation order diverge. This keeps receipt validation hermetic while preventing a second source of truth. It is a distinct document from `pipelock-transform-v1.json`, which remains the source-span transform profile.
+
+Recipes are ordered arrays of typed operations. Operations are never labels or concatenated strings; the following is a convenience summary, while the profile document is authoritative:
+
+- `identity`
+- `url_component { component: url|hostname|path|query_key|query_value, selector, occurrence }`; query key/value requires a selector and zero-based occurrence, including repeated keys.
+- `percent_decode { passes: 1..4 }`
+- `dlp_normalize { profile: "pipelock-dlp-v1" }`
+- `lowercase`, `invisible_strip`, `leetspeak`, `vowel_fold`
+- `hex_decode`, `base32_decode { decode_padding }`, and `base64_decode { decode_padding }`.
+
+Each operation consumes the preceding output; no operation may silently retain undecodable input. Unsupported parameters, malformed encodings, absent URL components, and limit failures are errors. `selector` and `profile` values MUST NOT contain Unicode control characters; implementations MUST reject them. Hex inputs MUST be canonical lowercase hex: re-encoding decoded bytes using lowercase hexadecimal MUST produce exactly the input. Base32 and base64 inputs MUST be canonical for their selected padding mode: re-encoding decoded bytes using the selected RFC 4648 encoding MUST produce exactly the input. Valid UTF-8 is required before the first operation and after every operation. The profile, not the producer or implementation, determines vocabulary, decoding ambiguity, limits, and policy.
+
+## Commitments
+
+Commitments are `hmac-sha256:<hex>`, using an undisclosed verifier-held key of at least 32 bytes. The key MUST NOT be serialized. Publishing an unkeyed digest of undisclosed view or match bytes is prohibited: it would create an offline oracle for low-entropy guesses.
+
+Every preimage uses this frame: `u64be(byte_length) || bytes`, with one frame for the ASCII domain and one for every field. Canonical typed recipe bytes begin with a framed ASCII `pipelock/evidence-provenance/recipe/v1` domain, framed transform-profile digest, and framed fixed-width `u64be(operation_count)`. Each operation is then its own frame containing frames for, in order: fixed-vocabulary operation enum byte, fixed-vocabulary component enum byte (zero when absent), selector bytes, fixed-width `u32be(occurrence)`, fixed-width `u8(passes)`, profile bytes, and fixed-width boolean `decode_padding` byte. Unknown enum values and unsupported operation parameters are errors. The view commitment domain is `pipelock/evidence-provenance/view/v1`; it frames source ordinal, source ID, profile digest, canonical typed recipe bytes, and every byte of the complete view. The match commitment domain is `pipelock/evidence-provenance/match/v1`; it frames source ID, profile digest, canonical recipe bytes, complete-view commitment, match ordinal, byte start, byte end, and match class. Ordinals and offsets are fixed eight-byte unsigned big-endian fields inside length frames. Thus source/match order, recipes, coordinates, and bytes outside a match all alter a commitment.
+
+The experimental typed shape is `EvidenceProvenanceProof`, with `version` exactly `pipelock-evidence-provenance-proof/v1`, ordered `ProvenanceSource` values, and ordered `ProvenanceMatch` values. It commits explicit source and match ordinals as described above; implementations MUST reject duplicate source IDs and duplicate ordinals. `producer.binary_digest` and `producer.ruleset_digest` are independently optional: absent is represented by an omitted field, while a present field MUST be canonical `sha256:<lowercase hex>`. A present producer digest is attested-but-unchecked; independently checked remains verifier-local reporting state and is never a producer-controlled field.
+
+## Verification stages
+
+1. **Structural:** UTF-8, recipe, interval, ordering, and commitment encoding checks pass or fail.
+2. **Reconstructed:** only with source bytes and the exact transform profile, reconstruct the view and validate intervals.
+3. **Commitment checked:** only with the undisclosed HMAC key, recompute complete-view and match commitments.
+4. **Producer independently checked:** only after independently acquiring and hashing a binary/ruleset can producer digests be reported as checked.
+
+Without source bytes/profile/key, report the unavailable stage explicitly, never success. Producer-supplied binary and ruleset digests are **attested-but-unchecked** until stage 4; they do not identify the binary that ran.
+
+## Conformance corpus
+
+`sdk/conformance/testdata/transform-profile/evidence-provenance-v1.json` is byte-exact via base64 values, including hostile invalid UTF-8. Its profile digest is regenerated whenever the separately pinned evidence-provenance profile changes. Meta-tests require a vector for each operation and each declared error. Corpus keys are harmless test-only HMAC keys and do not change the no-offline-oracle rule for emitted receipts.

--- a/internal/contract/receipt/provenance.go
+++ b/internal/contract/receipt/provenance.go
@@ -1,0 +1,370 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+// EvidenceProvenanceProof is experimental and fixture-only. It is deliberately
+// not registered as a receipt payload and must not be emitted by production.
+type EvidenceProvenanceProof struct {
+	Version                string              `json:"version"`
+	TransformProfileDigest string              `json:"transform_profile_digest"`
+	Sources                []ProvenanceSource  `json:"sources"`
+	Producer               ProducerAttestation `json:"producer"`
+}
+
+type ProducerAttestation struct {
+	BinaryDigest  *string `json:"binary_digest,omitempty"`
+	RulesetDigest *string `json:"ruleset_digest,omitempty"`
+}
+
+// EvidenceProvenanceProofVersionV1 is the only supported experimental proof
+// wire version.
+const EvidenceProvenanceProofVersionV1 = "pipelock-evidence-provenance-proof/v1"
+
+const minimumCommitmentKeyBytes = sha256.Size
+
+type ProvenanceSource struct {
+	SourceOrdinal  uint64            `json:"source_ordinal"`
+	SourceID       string            `json:"source_id"`
+	Recipe         normalize.Recipe  `json:"recipe"`
+	ViewCommitment string            `json:"view_commitment"`
+	Matches        []ProvenanceMatch `json:"matches"`
+}
+
+type ProvenanceMatch struct {
+	MatchOrdinal    uint64 `json:"match_ordinal"`
+	ByteStart       uint64 `json:"byte_start"`
+	ByteEnd         uint64 `json:"byte_end"`
+	MatchClass      string `json:"match_class"`
+	MatchCommitment string `json:"match_commitment"`
+}
+
+// Validate checks ordering and identity invariants across sources.
+func (p EvidenceProvenanceProof) Validate() error {
+	if p.Version != EvidenceProvenanceProofVersionV1 {
+		return fmt.Errorf("unsupported evidence provenance proof version %q", p.Version)
+	}
+	if err := (normalize.Recipe{TransformProfileDigest: p.TransformProfileDigest}).Validate(); err != nil {
+		return fmt.Errorf("transform profile digest: %w", err)
+	}
+	if err := p.Producer.Validate(); err != nil {
+		return fmt.Errorf("producer: %w", err)
+	}
+	seenIDs := make(map[string]struct{}, len(p.Sources))
+	seenOrdinals := make(map[uint64]struct{}, len(p.Sources))
+	var previous uint64
+	for index, source := range p.Sources {
+		if source.SourceID == "" {
+			return fmt.Errorf("source %d: missing source ID", index)
+		}
+		if !utf8.ValidString(source.SourceID) {
+			return fmt.Errorf("source %d: source ID: invalid UTF-8", index)
+		}
+		if _, ok := seenIDs[source.SourceID]; ok {
+			return fmt.Errorf("source %d: duplicate source ID %q", index, source.SourceID)
+		}
+		if _, ok := seenOrdinals[source.SourceOrdinal]; ok {
+			return fmt.Errorf("source %d: duplicate source ordinal %d", index, source.SourceOrdinal)
+		}
+		if index > 0 && source.SourceOrdinal <= previous {
+			return fmt.Errorf("source %d: source ordinals must be strictly increasing", index)
+		}
+		if source.Recipe.TransformProfileDigest != p.TransformProfileDigest {
+			return fmt.Errorf("source %d: recipe transform profile digest differs from envelope", index)
+		}
+		if err := source.Recipe.Validate(); err != nil {
+			return fmt.Errorf("source %d recipe: %w", index, err)
+		}
+		if err := validateCommitment(source.ViewCommitment); err != nil {
+			return fmt.Errorf("source %d view commitment: %w", index, err)
+		}
+		for matchIndex, match := range source.Matches {
+			if err := validateMatchStructure(match); err != nil {
+				return fmt.Errorf("source %d match %d: %w", index, matchIndex, err)
+			}
+			if err := validateCommitment(match.MatchCommitment); err != nil {
+				return fmt.Errorf("source %d match %d commitment: %w", index, matchIndex, err)
+			}
+			if matchIndex > 0 {
+				previousMatch := source.Matches[matchIndex-1]
+				switch {
+				case match.MatchOrdinal <= previousMatch.MatchOrdinal:
+					return fmt.Errorf("source %d match %d: match ordinals must be strictly increasing", index, matchIndex)
+				case match.ByteStart < previousMatch.ByteStart:
+					return fmt.Errorf("source %d match %d: intervals are unsorted", index, matchIndex)
+				case match.ByteStart == previousMatch.ByteStart:
+					return fmt.Errorf("source %d match %d: duplicate interval start", index, matchIndex)
+				case match.ByteStart < previousMatch.ByteEnd:
+					return fmt.Errorf("source %d match %d: intervals overlap", index, matchIndex)
+				}
+			}
+		}
+		seenIDs[source.SourceID] = struct{}{}
+		seenOrdinals[source.SourceOrdinal] = struct{}{}
+		previous = source.SourceOrdinal
+	}
+	return nil
+}
+
+// Validate checks that each present producer digest is a canonical SHA-256
+// attestation. Nil is an explicit absent attestation; independent verification
+// is a verifier-local result and is never producer-controlled wire data.
+func (p ProducerAttestation) Validate() error {
+	for _, digest := range []struct {
+		name  string
+		value *string
+	}{{"binary digest", p.BinaryDigest}, {"ruleset digest", p.RulesetDigest}} {
+		if digest.value == nil {
+			continue
+		}
+		if err := validatePrefixedSHA256Digest(*digest.value, "sha256:"); err != nil {
+			return fmt.Errorf("%s: %w", digest.name, err)
+		}
+	}
+	return nil
+}
+
+func validatePrefixedSHA256Digest(value, prefix string) error {
+	if !strings.HasPrefix(value, prefix) {
+		return fmt.Errorf("must use %q prefix", prefix)
+	}
+	encoded := strings.TrimPrefix(value, prefix)
+	if len(encoded) != sha256.Size*2 {
+		return fmt.Errorf("must contain a SHA-256 hex value")
+	}
+	decoded, err := hex.DecodeString(encoded)
+	if err != nil || len(decoded) != sha256.Size || strings.ToLower(encoded) != encoded {
+		return fmt.Errorf("must contain lowercase SHA-256 hex")
+	}
+	return nil
+}
+
+func validateMatchStructure(match ProvenanceMatch) error {
+	if match.ByteEnd <= match.ByteStart {
+		return fmt.Errorf("byte end must be greater than byte start")
+	}
+	if !utf8.ValidString(match.MatchClass) {
+		return fmt.Errorf("match class: invalid UTF-8")
+	}
+	return nil
+}
+
+func validateCommitment(value string) error {
+	return validatePrefixedSHA256Digest(value, "hmac-sha256:")
+}
+
+// ValidateView verifies all offset invariants against the reconstructed view.
+func (s ProvenanceSource) ValidateView(input string) error {
+	view, err := s.Recipe.Apply(input)
+	if err != nil {
+		return fmt.Errorf("source %q recipe: %w", s.SourceID, err)
+	}
+	if !utf8.ValidString(view) {
+		return fmt.Errorf("source %q view: invalid UTF-8", s.SourceID)
+	}
+	for index, match := range s.Matches {
+		if match.ByteStart >= match.ByteEnd || match.ByteEnd > uint64(len(view)) {
+			return fmt.Errorf("source %q match %d: interval out of bounds", s.SourceID, index)
+		}
+		if !byteBoundary(view, match.ByteStart) || !byteBoundary(view, match.ByteEnd) {
+			return fmt.Errorf("source %q match %d: interval splits UTF-8 code point", s.SourceID, index)
+		}
+	}
+	return nil
+}
+
+func byteBoundary(value string, offset uint64) bool {
+	if offset == 0 || offset == uint64(len(value)) {
+		return true
+	}
+	return offset < uint64(len(value)) && (value[offset]&0xc0) != 0x80
+}
+
+// CommitView produces a length-framed, domain-separated HMAC commitment. The
+// secret key is intentionally not serialized: publishing an unkeyed digest of
+// undisclosed content would create an offline oracle for guessed secrets.
+func CommitView(key []byte, source ProvenanceSource, view string) (string, error) {
+	if err := validateCommitmentKey(key); err != nil {
+		return "", err
+	}
+	if source.SourceID == "" {
+		return "", fmt.Errorf("source ID: missing")
+	}
+	if !utf8.ValidString(source.SourceID) {
+		return "", fmt.Errorf("source ID: invalid UTF-8")
+	}
+	if err := source.Recipe.ValidateOutput(view); err != nil {
+		return "", fmt.Errorf("view: %w", err)
+	}
+	recipe, err := recipeBytes(source.Recipe)
+	if err != nil {
+		return "", err
+	}
+	return commitment(key, "pipelock/evidence-provenance/view/v1", uint64Bytes(source.SourceOrdinal), []byte(source.SourceID), []byte(source.Recipe.TransformProfileDigest), recipe, []byte(view)), nil
+}
+
+// CommitMatch binds a match to its source, recipe, complete-view commitment,
+// location, and class; reordering or moving data therefore changes the value.
+func CommitMatch(key []byte, sourceID string, recipe normalize.Recipe, viewCommitment string, match ProvenanceMatch) (string, error) {
+	if err := validateCommitmentKey(key); err != nil {
+		return "", err
+	}
+	if sourceID == "" {
+		return "", fmt.Errorf("source ID: missing")
+	}
+	if !utf8.ValidString(sourceID) {
+		return "", fmt.Errorf("source ID: invalid UTF-8")
+	}
+	if err := validateCommitment(viewCommitment); err != nil {
+		return "", fmt.Errorf("view commitment: %w", err)
+	}
+	if err := validateMatchStructure(match); err != nil {
+		return "", err
+	}
+	encodedRecipe, err := recipeBytes(recipe)
+	if err != nil {
+		return "", err
+	}
+	return commitment(key, "pipelock/evidence-provenance/match/v1", []byte(sourceID), []byte(recipe.TransformProfileDigest), encodedRecipe, []byte(viewCommitment), uint64Bytes(match.MatchOrdinal), uint64Bytes(match.ByteStart), uint64Bytes(match.ByteEnd), []byte(match.MatchClass)), nil
+}
+
+func validateCommitmentKey(key []byte) error {
+	if len(key) < minimumCommitmentKeyBytes {
+		return fmt.Errorf("commitment key must be at least %d bytes", minimumCommitmentKeyBytes)
+	}
+	return nil
+}
+
+func commitment(key []byte, domain string, parts ...[]byte) string {
+	mac := hmac.New(sha256.New, key)
+	writePart(mac, []byte(domain))
+	for _, part := range parts {
+		writePart(mac, part)
+	}
+	return "hmac-sha256:" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// writePart streams one normative frame into mac. It delegates to appendFrame
+// so there is exactly ONE implementation of `u64be(byte_length) || bytes`.
+// Two copies would let a change to one silently diverge commitments from the
+// specification while the other copy still matched it.
+func writePart(mac interface{ Write([]byte) (int, error) }, value []byte) {
+	_, _ = mac.Write(appendFrame(nil, value))
+}
+
+func uint64Bytes(value uint64) []byte {
+	var out [8]byte
+	binary.BigEndian.PutUint64(out[:], value)
+	return out[:]
+}
+
+func recipeBytes(recipe normalize.Recipe) ([]byte, error) {
+	if err := recipe.Validate(); err != nil {
+		return nil, err
+	}
+	result := make([]byte, 0, 128)
+	result = appendFrame(result, []byte("pipelock/evidence-provenance/recipe/v1"))
+	result = appendFrame(result, []byte(recipe.TransformProfileDigest))
+	result = appendFrame(result, uint64Bytes(uint64(len(recipe.Operations))))
+	for _, operation := range recipe.Operations {
+		encoded, err := operationBytes(operation)
+		if err != nil {
+			return nil, err
+		}
+		result = appendFrame(result, encoded)
+	}
+	return result, nil
+}
+
+func operationBytes(operation normalize.Operation) ([]byte, error) {
+	kind, err := operationKindByte(operation.Kind)
+	if err != nil {
+		return nil, err
+	}
+	component, err := componentByte(operation.Component)
+	if err != nil {
+		return nil, err
+	}
+	var occurrence [4]byte
+	binary.BigEndian.PutUint32(occurrence[:], operation.Occurrence)
+	result := make([]byte, 0, 64)
+	result = appendFrame(result, []byte{kind})
+	result = appendFrame(result, []byte{component})
+	result = appendFrame(result, []byte(operation.Selector))
+	result = appendFrame(result, occurrence[:])
+	result = appendFrame(result, []byte{operation.Passes})
+	result = appendFrame(result, []byte(operation.Profile))
+	if operation.DecodePadding {
+		result = appendFrame(result, []byte{1})
+	} else {
+		result = appendFrame(result, []byte{0})
+	}
+	return result, nil
+}
+
+func appendFrame(destination, value []byte) []byte {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	destination = append(destination, length[:]...)
+	return append(destination, value...)
+}
+
+func operationKindByte(kind normalize.OperationKind) (byte, error) {
+	switch kind {
+	case normalize.OperationIdentity:
+		return 1, nil
+	case normalize.OperationURLComponent:
+		return 2, nil
+	case normalize.OperationPercentDecode:
+		return 3, nil
+	case normalize.OperationDLPNormalize:
+		return 4, nil
+	case normalize.OperationLowercase:
+		return 5, nil
+	case normalize.OperationInvisibleStrip:
+		return 6, nil
+	case normalize.OperationHexDecode:
+		return 7, nil
+	case normalize.OperationBase32Decode:
+		return 8, nil
+	case normalize.OperationBase64Decode:
+		return 9, nil
+	case normalize.OperationLeetspeak:
+		return 10, nil
+	case normalize.OperationVowelFold:
+		return 11, nil
+	default:
+		return 0, fmt.Errorf("unknown operation %q", kind)
+	}
+}
+
+func componentByte(component normalize.Component) (byte, error) {
+	switch component {
+	case "":
+		return 0, nil
+	case normalize.ComponentURL:
+		return 1, nil
+	case normalize.ComponentHostname:
+		return 2, nil
+	case normalize.ComponentPath:
+		return 3, nil
+	case normalize.ComponentQueryKey:
+		return 4, nil
+	case normalize.ComponentQueryVal:
+		return 5, nil
+	default:
+		return 0, fmt.Errorf("unknown URL component %q", component)
+	}
+}

--- a/internal/contract/receipt/provenance_test.go
+++ b/internal/contract/receipt/provenance_test.go
@@ -1,0 +1,454 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+const provenanceTestCommitmentKey = "corpus-only-hmac-key-32-bytes-long!"
+
+func TestProvenanceSourceValidateView(t *testing.T) {
+	base := ProvenanceSource{SourceID: "fixture", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}}
+	for _, tc := range []struct {
+		name    string
+		matches []ProvenanceMatch
+		want    string
+	}{
+		{"valid non-BMP and adjacency", []ProvenanceMatch{{ByteStart: 1, ByteEnd: 5}, {ByteStart: 5, ByteEnd: 6}}, ""},
+		{"interval-inside-codepoint", []ProvenanceMatch{{ByteStart: 2, ByteEnd: 5}}, "splits UTF-8"},
+		{"end-inside-codepoint", []ProvenanceMatch{{ByteStart: 1, ByteEnd: 4}}, "splits UTF-8"},
+		{"out-of-bounds", []ProvenanceMatch{{ByteStart: 1, ByteEnd: 7}}, "out of bounds"},
+		{"maximum interval end", []ProvenanceMatch{{ByteStart: 0, ByteEnd: math.MaxUint64}}, "out of bounds"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := base
+			source.Matches = tc.matches
+			err := source.ValidateView("A💩B")
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestProvenanceSourceValidateViewRecipeAndUTF8Errors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source ProvenanceSource
+		input  string
+		want   string
+	}{
+		{
+			name:   "recipe error",
+			source: ProvenanceSource{SourceID: "fixture", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationPercentDecode}}}},
+			input:  "value",
+			want:   "recipe operation",
+		},
+		{
+			name:   "invalid UTF-8 view",
+			source: ProvenanceSource{SourceID: "fixture", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationHexDecode}}}},
+			input:  "ff",
+			want:   "hex decode output: invalid UTF-8",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.source.ValidateView(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceProvenanceProofValidate(t *testing.T) {
+	valid := completeSources(t)
+	for _, tc := range []struct {
+		name    string
+		sources []ProvenanceSource
+		want    string
+	}{
+		{"valid", valid, ""},
+		{"missing source ID", []ProvenanceSource{{SourceOrdinal: 1, Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}}, "missing source ID"},
+		{"duplicate source ID", []ProvenanceSource{{SourceOrdinal: 1, SourceID: "same", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}, {SourceOrdinal: 2, SourceID: "same", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}}, "duplicate source ID"},
+		{"duplicate source ordinal", []ProvenanceSource{{SourceOrdinal: 2, SourceID: "first", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}, {SourceOrdinal: 2, SourceID: "second", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}}, "duplicate source ordinal"},
+		{"non-increasing source ordinal", []ProvenanceSource{{SourceOrdinal: 2, SourceID: "first", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}, {SourceOrdinal: 1, SourceID: "second", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment}}, "source ordinals must be strictly increasing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: tc.sources}).Validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceProvenanceProofValidateRejectsStructuralGaps(t *testing.T) {
+	valid := completeSources(t)
+	for _, tc := range []struct {
+		name  string
+		proof EvidenceProvenanceProof
+		want  string
+	}{
+		{"malformed envelope profile", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: "not-a-digest", Sources: valid}, "invalid SHA-256 digest"},
+		{"unknown envelope profile", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Sources: valid}, "unknown profile"},
+		{"source profile differs", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{{SourceOrdinal: 1, SourceID: "first", Recipe: normalize.Recipe{TransformProfileDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, ViewCommitment: valid[0].ViewCommitment}}}, "differs from envelope"},
+		{"malformed view commitment", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{{SourceOrdinal: 1, SourceID: "first", Recipe: valid[0].Recipe, ViewCommitment: "sha256:bad"}}}, "view commitment"},
+		{"malformed match commitment", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{{SourceOrdinal: 1, SourceID: "first", Recipe: valid[0].Recipe, ViewCommitment: valid[0].ViewCommitment, Matches: []ProvenanceMatch{{ByteEnd: 1, MatchCommitment: "hmac-sha256:not-hex"}}}}}, "match 0 commitment"},
+		{"invalid operation", EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{{SourceOrdinal: 1, SourceID: "first", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity, Selector: "ignored"}}}, ViewCommitment: valid[0].ViewCommitment}}}, "unsupported selector"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.proof.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceProvenanceProofValidateRejectsMatchStructure(t *testing.T) {
+	valid := completeSources(t)
+	base := valid[0]
+	commitment := validCommitment()
+	for _, tc := range []struct {
+		name    string
+		sources []ProvenanceSource
+		want    string
+	}{
+		{"zero-length interval", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 1, ByteStart: 1, ByteEnd: 1, MatchCommitment: commitment}}}}, "byte end must be greater"},
+		{"reversed interval", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 1, ByteStart: 2, ByteEnd: 1, MatchCommitment: commitment}}}}, "byte end must be greater"},
+		{"non-increasing match ordinal", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 2, ByteStart: 0, ByteEnd: 1, MatchCommitment: commitment}, {MatchOrdinal: 2, ByteStart: 2, ByteEnd: 3, MatchCommitment: commitment}}}}, "match ordinals must be strictly increasing"},
+		{"unsorted intervals", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 1, ByteStart: 2, ByteEnd: 3, MatchCommitment: commitment}, {MatchOrdinal: 2, ByteStart: 0, ByteEnd: 1, MatchCommitment: commitment}}}}, "intervals are unsorted"},
+		{"duplicate intervals", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 1, MatchCommitment: commitment}, {MatchOrdinal: 2, ByteStart: 0, ByteEnd: 1, MatchCommitment: commitment}}}}, "duplicate interval start"},
+		{"overlapping intervals", []ProvenanceSource{{SourceOrdinal: 1, SourceID: base.SourceID, Recipe: base.Recipe, ViewCommitment: base.ViewCommitment, Matches: []ProvenanceMatch{{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 2, MatchCommitment: commitment}, {MatchOrdinal: 2, ByteStart: 1, ByteEnd: 3, MatchCommitment: commitment}}}}, "intervals overlap"},
+		{"duplicate source ordinal", []ProvenanceSource{{SourceOrdinal: 1, SourceID: "first", Recipe: base.Recipe, ViewCommitment: base.ViewCommitment}, {SourceOrdinal: 1, SourceID: "second", Recipe: base.Recipe, ViewCommitment: base.ViewCommitment}}, "duplicate source ordinal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proof := EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: tc.sources}
+			err := proof.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvidenceProvenanceProofValidateVersionAndProducer(t *testing.T) {
+	sources := completeSources(t)
+	validDigest := "sha256:" + strings.Repeat("a", 64)
+	upperDigest := "sha256:" + strings.Repeat("A", 64)
+	for _, tc := range []struct {
+		name     string
+		version  string
+		producer ProducerAttestation
+		want     string
+	}{
+		{"valid absent producer", EvidenceProvenanceProofVersionV1, ProducerAttestation{}, ""},
+		{"missing version", "", ProducerAttestation{}, "unsupported evidence provenance proof version"},
+		{"unsupported version", "pipelock-evidence-provenance-proof/v2", ProducerAttestation{}, "unsupported evidence provenance proof version"},
+		{"empty present binary digest", EvidenceProvenanceProofVersionV1, ProducerAttestation{BinaryDigest: stringPointer("")}, "binary digest"},
+		{"malformed binary digest", EvidenceProvenanceProofVersionV1, ProducerAttestation{BinaryDigest: stringPointer("sha256:bad")}, "binary digest"},
+		{"uppercase binary digest", EvidenceProvenanceProofVersionV1, ProducerAttestation{BinaryDigest: stringPointer(upperDigest)}, "lowercase SHA-256 hex"},
+		{"malformed ruleset digest", EvidenceProvenanceProofVersionV1, ProducerAttestation{RulesetDigest: stringPointer("sha512:" + strings.Repeat("a", 64))}, "ruleset digest"},
+		{"valid attested digests", EvidenceProvenanceProofVersionV1, ProducerAttestation{BinaryDigest: stringPointer(validDigest), RulesetDigest: stringPointer(validDigest)}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proof := EvidenceProvenanceProof{Version: tc.version, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: sources, Producer: tc.producer}
+			err := proof.Validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommitmentsBindAllFields(t *testing.T) {
+	key := []byte(provenanceTestCommitmentKey)
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationLowercase}}}
+	source := ProvenanceSource{SourceOrdinal: 1, SourceID: "source-a", Recipe: recipe}
+	view := mustCommitView(t, key, source, "before secret after")
+	match := ProvenanceMatch{MatchOrdinal: 1, ByteStart: 7, ByteEnd: 13, MatchClass: "credential"}
+	baseline := mustCommitMatch(t, key, "source-a", recipe, view, match)
+	viewBaseline := view
+	for _, tc := range []struct {
+		name       string
+		commitment string
+	}{
+		{"source ordinal", mustCommitView(t, key, ProvenanceSource{SourceOrdinal: 2, SourceID: "source-a", Recipe: recipe}, "before secret after")},
+		{"source ID", mustCommitView(t, key, ProvenanceSource{SourceOrdinal: 1, SourceID: "source-b", Recipe: recipe}, "before secret after")},
+		{"recipe", mustCommitView(t, key, ProvenanceSource{SourceOrdinal: 1, SourceID: "source-a", Recipe: normalize.Recipe{TransformProfileDigest: recipe.TransformProfileDigest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}}, "before secret after")},
+		{"complete view", mustCommitView(t, key, source, "before secret after!")},
+	} {
+		t.Run("view "+tc.name, func(t *testing.T) {
+			if tc.commitment == viewBaseline {
+				t.Fatalf("view commitment did not bind mutation: %q", tc.name)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name       string
+		commitment string
+	}{
+		{"source ID in match", mustCommitMatch(t, key, "source-b", recipe, view, match)},
+		{"recipe in match", mustCommitMatch(t, key, "source-a", normalize.Recipe{TransformProfileDigest: recipe.TransformProfileDigest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}, view, match)},
+		{"changed view commitment in match", mustCommitMatch(t, key, "source-a", recipe, mustCommitView(t, key, source, "before secret after!"), match)},
+		{"match ordinal", mustCommitMatch(t, key, "source-a", recipe, view, ProvenanceMatch{MatchOrdinal: 2, ByteStart: 7, ByteEnd: 13, MatchClass: "credential"})},
+		{"byte start", mustCommitMatch(t, key, "source-a", recipe, view, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 6, ByteEnd: 13, MatchClass: "credential"})},
+		{"byte end", mustCommitMatch(t, key, "source-a", recipe, view, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 7, ByteEnd: 12, MatchClass: "credential"})},
+		{"match class", mustCommitMatch(t, key, "source-a", recipe, view, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 7, ByteEnd: 13, MatchClass: "other"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.commitment == baseline || tc.commitment == view {
+				t.Fatalf("commitment did not bind mutation: %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestEvidenceProvenanceProofValidateRejectsReorderedMatches(t *testing.T) {
+	key := []byte(provenanceTestCommitmentKey)
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}
+	source := ProvenanceSource{SourceOrdinal: 1, SourceID: "source-a", Recipe: recipe}
+	view := mustCommitView(t, key, source, "before secret after")
+	first := ProvenanceMatch{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 6, MatchClass: "prefix"}
+	first.MatchCommitment = mustCommitMatch(t, key, source.SourceID, recipe, view, first)
+	second := ProvenanceMatch{MatchOrdinal: 2, ByteStart: 7, ByteEnd: 13, MatchClass: "credential"}
+	second.MatchCommitment = mustCommitMatch(t, key, source.SourceID, recipe, view, second)
+	source.ViewCommitment = view
+	source.Matches = []ProvenanceMatch{second, first}
+	proof := EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{source}}
+	if err := proof.Validate(); err == nil || !strings.Contains(err.Error(), "match ordinals must be strictly increasing") {
+		t.Fatalf("error = %v, want reordered matches rejection", err)
+	}
+}
+
+func TestCommitmentConstructionRejectsInvalidInputs(t *testing.T) {
+	key := []byte(provenanceTestCommitmentKey)
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}
+	for _, tc := range []struct {
+		name   string
+		source ProvenanceSource
+		view   string
+		want   string
+	}{
+		{"empty source ID", ProvenanceSource{SourceOrdinal: 1, Recipe: recipe}, "view", "source ID: missing"},
+		{"invalid UTF-8 source ID", ProvenanceSource{SourceOrdinal: 1, SourceID: string([]byte{0xff}), Recipe: recipe}, "view", "source ID: invalid UTF-8"},
+		{"invalid UTF-8 view", ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: recipe}, string([]byte{0xff}), "view: recipe output: invalid UTF-8"},
+		{"over-limit view", ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: recipe}, strings.Repeat("x", 1<<20+1), "output exceeds profile byte limit"},
+	} {
+		t.Run("view "+tc.name, func(t *testing.T) {
+			if _, err := CommitView(key, tc.source, tc.view); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	validView := mustCommitView(t, key, ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: recipe}, "view")
+	for _, tc := range []struct {
+		name           string
+		sourceID       string
+		viewCommitment string
+		match          ProvenanceMatch
+		want           string
+	}{
+		{"empty source ID", "", validView, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 1}, "source ID: missing"},
+		{"invalid UTF-8 source ID", string([]byte{0xff}), validView, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 1}, "source ID: invalid UTF-8"},
+		{"malformed view commitment", "source", "sha256:bad", ProvenanceMatch{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 1}, "view commitment"},
+		{"zero-length interval", "source", validView, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 1, ByteEnd: 1}, "byte end must be greater"},
+		{"reversed interval", "source", validView, ProvenanceMatch{MatchOrdinal: 1, ByteStart: 2, ByteEnd: 1}, "byte end must be greater"},
+	} {
+		t.Run("match "+tc.name, func(t *testing.T) {
+			if _, err := CommitMatch(key, tc.sourceID, recipe, tc.viewCommitment, tc.match); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommitmentConstructionRejectsShortKeys(t *testing.T) {
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}
+	source := ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: recipe}
+	match := ProvenanceMatch{MatchOrdinal: 1, ByteStart: 0, ByteEnd: 1}
+	for _, key := range [][]byte{nil, {}, make([]byte, minimumCommitmentKeyBytes-1)} {
+		if _, err := CommitView(key, source, "view"); err == nil || !strings.Contains(err.Error(), "commitment key must be at least") {
+			t.Fatalf("CommitView(%d-byte key) error = %v", len(key), err)
+		}
+		if _, err := CommitMatch(key, source.SourceID, recipe, validCommitment(), match); err == nil || !strings.Contains(err.Error(), "commitment key must be at least") {
+			t.Fatalf("CommitMatch(%d-byte key) error = %v", len(key), err)
+		}
+	}
+}
+
+func TestCommitmentEnumBytesAreStable(t *testing.T) {
+	// Pinned by literal value: these bytes are inside every commitment
+	// preimage, so changing one silently invalidates all previously issued
+	// evidence.
+	kinds := map[normalize.OperationKind]byte{
+		normalize.OperationIdentity: 1, normalize.OperationURLComponent: 2, normalize.OperationPercentDecode: 3,
+		normalize.OperationDLPNormalize: 4, normalize.OperationLowercase: 5, normalize.OperationInvisibleStrip: 6,
+		normalize.OperationHexDecode: 7, normalize.OperationBase32Decode: 8, normalize.OperationBase64Decode: 9,
+		normalize.OperationLeetspeak: 10, normalize.OperationVowelFold: 11,
+	}
+	for kind, want := range kinds {
+		t.Run("kind/"+string(kind), func(t *testing.T) {
+			got, err := operationKindByte(kind)
+			if err != nil || got != want {
+				t.Fatalf("operationKindByte(%q) = %d, %v; want %d, nil", kind, got, err, want)
+			}
+		})
+	}
+	// Completeness: without this, adding a twelfth operation ships with no
+	// committed enum byte. operationKindByte would return an error for it and
+	// the pinned table above would still pass, because it only asserts the
+	// kinds it happens to list.
+	for _, kind := range normalize.SupportedOperationKinds() {
+		if _, pinned := kinds[kind]; !pinned {
+			t.Fatalf("operation %q is in the supported vocabulary but has no pinned commitment enum byte", kind)
+		}
+	}
+	if len(kinds) != len(normalize.SupportedOperationKinds()) {
+		t.Fatalf("pinned enum table has %d kinds, vocabulary has %d", len(kinds), len(normalize.SupportedOperationKinds()))
+	}
+	components := map[normalize.Component]byte{
+		"": 0, normalize.ComponentURL: 1, normalize.ComponentHostname: 2,
+		normalize.ComponentPath: 3, normalize.ComponentQueryKey: 4, normalize.ComponentQueryVal: 5,
+	}
+	for component, want := range components {
+		t.Run("component/"+string(component), func(t *testing.T) {
+			got, err := componentByte(component)
+			if err != nil || got != want {
+				t.Fatalf("componentByte(%q) = %d, %v; want %d, nil", component, got, err, want)
+			}
+		})
+	}
+	if _, err := operationKindByte("unknown"); err == nil || !strings.Contains(err.Error(), "unknown operation") {
+		t.Fatalf("operationKindByte unknown error = %v", err)
+	}
+	if _, err := componentByte("unknown"); err == nil || !strings.Contains(err.Error(), "unknown URL component") {
+		t.Fatalf("componentByte unknown error = %v", err)
+	}
+}
+
+func TestProvenanceValidationFormatErrors(t *testing.T) {
+	for _, value := range []string{"hmac-sha256:bad", "hmac-sha256:" + strings.Repeat("A", 64), "sha256:" + strings.Repeat("0", 64)} {
+		if err := validateCommitment(value); err == nil {
+			t.Fatalf("validateCommitment(%q) unexpectedly succeeded", value)
+		}
+	}
+	if err := validateMatchStructure(ProvenanceMatch{ByteEnd: 1, MatchClass: string([]byte{0xff})}); err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("invalid match class error = %v", err)
+	}
+	base := completeSources(t)[0]
+	base.SourceID = string([]byte{0xff})
+	proof := EvidenceProvenanceProof{Version: EvidenceProvenanceProofVersionV1, TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Sources: []ProvenanceSource{base}}
+	if err := proof.Validate(); err == nil || !strings.Contains(err.Error(), "source ID: invalid UTF-8") {
+		t.Fatalf("invalid source ID error = %v", err)
+	}
+}
+
+func TestRecipeBytesEncodesAllOperationFields(t *testing.T) {
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{
+		{Kind: normalize.OperationURLComponent, Component: normalize.ComponentQueryVal, Selector: "marker", Occurrence: 1},
+		{Kind: normalize.OperationPercentDecode, Passes: 2},
+		{Kind: normalize.OperationDLPNormalize, Profile: "pipelock-dlp-v1"},
+		{Kind: normalize.OperationBase32Decode},
+		{Kind: normalize.OperationBase64Decode, DecodePadding: true},
+	}}
+	if _, err := recipeBytes(recipe); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recipeBytes(normalize.Recipe{}); err == nil || !strings.Contains(err.Error(), "missing transform profile digest") {
+		t.Fatalf("invalid recipe error = %v", err)
+	}
+	if _, err := operationBytes(normalize.Operation{Kind: "unknown"}); err == nil || !strings.Contains(err.Error(), "unknown operation") {
+		t.Fatalf("unknown operation encoding error = %v", err)
+	}
+	if _, err := operationBytes(normalize.Operation{Kind: normalize.OperationIdentity, Component: "unknown"}); err == nil || !strings.Contains(err.Error(), "unknown URL component") {
+		t.Fatalf("unknown component encoding error = %v", err)
+	}
+	key := []byte(provenanceTestCommitmentKey)
+	if _, err := CommitView(key, ProvenanceSource{SourceID: "source", Recipe: normalize.Recipe{}}, "view"); err == nil || !strings.Contains(err.Error(), "missing transform profile digest") {
+		t.Fatalf("CommitView invalid recipe error = %v", err)
+	}
+	if _, err := CommitMatch(key, "source", normalize.Recipe{}, validCommitment(), ProvenanceMatch{ByteEnd: 1}); err == nil || !strings.Contains(err.Error(), "missing transform profile digest") {
+		t.Fatalf("CommitMatch invalid recipe error = %v", err)
+	}
+}
+
+func TestCommitmentsSeparateLegacyRecipeCollision(t *testing.T) {
+	key := []byte(provenanceTestCommitmentKey)
+	first := normalize.Operation{Kind: normalize.OperationURLComponent, Component: normalize.ComponentQueryVal, Selector: "marker\x000/0/false/\x00identity\x00\x00"}
+	second := normalize.Operation{Kind: normalize.OperationURLComponent, Component: normalize.ComponentQueryVal, Selector: "marker"}
+	left := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{first}}
+	right := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{second, {Kind: normalize.OperationIdentity}}}
+	if legacyRecipeBytes(left) != legacyRecipeBytes(right) {
+		t.Fatal("test recipes no longer collide under delimiter encoding")
+	}
+	if _, err := CommitView(key, ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: left}, "view"); err == nil || !strings.Contains(err.Error(), "selector for url_component contains control character") {
+		t.Fatalf("colliding selector error = %v, want normative control-character rejection", err)
+	}
+	// The benign twin still commits normally, so the rejection is targeted at
+	// the control bytes rather than at this shape of recipe generally.
+	if _, err := CommitView(key, ProvenanceSource{SourceOrdinal: 1, SourceID: "source", Recipe: right}, "view"); err != nil {
+		t.Fatalf("control-character-free recipe was rejected: %v", err)
+	}
+}
+
+func completeSources(t *testing.T) []ProvenanceSource {
+	t.Helper()
+	key := []byte(provenanceTestCommitmentKey)
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}
+	first := ProvenanceSource{SourceOrdinal: 1, SourceID: "first", Recipe: recipe}
+	first.ViewCommitment = mustCommitView(t, key, first, "one")
+	second := ProvenanceSource{SourceOrdinal: 2, SourceID: "second", Recipe: recipe}
+	second.ViewCommitment = mustCommitView(t, key, second, "two")
+	return []ProvenanceSource{first, second}
+}
+
+func mustCommitView(t *testing.T, key []byte, source ProvenanceSource, view string) string {
+	t.Helper()
+	value, err := CommitView(key, source, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func mustCommitMatch(t *testing.T, key []byte, sourceID string, recipe normalize.Recipe, viewCommitment string, match ProvenanceMatch) string {
+	t.Helper()
+	value, err := CommitMatch(key, sourceID, recipe, viewCommitment, match)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func legacyRecipeBytes(recipe normalize.Recipe) string {
+	result := recipe.TransformProfileDigest
+	for _, operation := range recipe.Operations {
+		result += "\x00" + string(operation.Kind) + "\x00" + string(operation.Component) + "\x00" + operation.Selector + "\x00" + fmt.Sprintf("%d/%d/%t/%s", operation.Occurrence, operation.Passes, operation.DecodePadding, operation.Profile)
+	}
+	return result
+}
+
+func validCommitment() string {
+	return "hmac-sha256:" + strings.Repeat("0", 64)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/internal/normalize/provenance.go
+++ b/internal/normalize/provenance.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Recipe is the fixture-only, typed transform language used by the evidence
+// provenance specification. TransformProfileDigest pins all table and limit
+// choices; callers must not infer behavior from its human-readable name.
+type Recipe struct {
+	TransformProfileDigest string      `json:"transform_profile_digest"`
+	Operations             []Operation `json:"operations"`
+}
+
+// Operation is one ordered transform. Exactly one operation-specific field is
+// meaningful for each Kind.
+type Operation struct {
+	Kind          OperationKind `json:"kind"`
+	Component     Component     `json:"component,omitempty"`
+	Selector      string        `json:"selector,omitempty"`
+	Occurrence    uint32        `json:"occurrence,omitempty"`
+	Passes        uint8         `json:"passes,omitempty"`
+	Profile       string        `json:"profile,omitempty"`
+	DecodePadding bool          `json:"decode_padding,omitempty"`
+}
+
+type OperationKind string
+
+const (
+	OperationIdentity       OperationKind = "identity"
+	OperationURLComponent   OperationKind = "url_component"
+	OperationPercentDecode  OperationKind = "percent_decode"
+	OperationDLPNormalize   OperationKind = "dlp_normalize"
+	OperationLowercase      OperationKind = "lowercase"
+	OperationInvisibleStrip OperationKind = "invisible_strip"
+	OperationHexDecode      OperationKind = "hex_decode"
+	OperationBase32Decode   OperationKind = "base32_decode"
+	OperationBase64Decode   OperationKind = "base64_decode"
+	OperationLeetspeak      OperationKind = "leetspeak"
+	OperationVowelFold      OperationKind = "vowel_fold"
+)
+
+// SupportedOperationKinds is the complete, versioned recipe vocabulary. Corpus
+// tests require one vector for every returned operation.
+func SupportedOperationKinds() []OperationKind {
+	return []OperationKind{OperationIdentity, OperationURLComponent, OperationPercentDecode, OperationDLPNormalize, OperationLowercase, OperationInvisibleStrip, OperationHexDecode, OperationBase32Decode, OperationBase64Decode, OperationLeetspeak, OperationVowelFold}
+}
+
+type Component string
+
+const (
+	ComponentURL      Component = "url"
+	ComponentHostname Component = "hostname"
+	ComponentPath     Component = "path"
+	ComponentQueryKey Component = "query_key"
+	ComponentQueryVal Component = "query_value"
+)
+
+const evidenceProvenanceProfileMaxDecodePasses = 4
+
+const (
+	// EvidenceProvenanceProfileV1Digest identifies the fixture-only evidence
+	// provenance transform profile, not the source-span transform profile.
+	EvidenceProvenanceProfileV1Digest       = "sha256:8bc27d5d89e4e5ba3e0d1e68a25a3f0170f9a5ea2f19edf81a9a90bf82e23b3e"
+	evidenceProvenanceProfileMaxInputBytes  = 2 << 20
+	evidenceProvenanceProfileMaxOutputBytes = 1 << 20
+)
+
+type transformProfile struct {
+	maxInputBytes  int
+	maxOutputBytes int
+}
+
+func resolveTransformProfile(digest string) (transformProfile, error) {
+	if len(digest) != len("sha256:")+64 || !strings.HasPrefix(digest, "sha256:") {
+		return transformProfile{}, fmt.Errorf("transform profile digest: invalid SHA-256 digest")
+	}
+	for _, char := range digest[len("sha256:"):] {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return transformProfile{}, fmt.Errorf("transform profile digest: invalid SHA-256 digest")
+		}
+	}
+	if digest != EvidenceProvenanceProfileV1Digest {
+		return transformProfile{}, fmt.Errorf("transform profile digest: unknown profile %q", digest)
+	}
+	return transformProfile{maxInputBytes: evidenceProvenanceProfileMaxInputBytes, maxOutputBytes: evidenceProvenanceProfileMaxOutputBytes}, nil
+}
+
+// Validate checks that the recipe names a known profile and has an unambiguous
+// operation shape. It does not require source bytes.
+func (r Recipe) Validate() error {
+	if r.TransformProfileDigest == "" {
+		return fmt.Errorf("recipe: missing transform profile digest")
+	}
+	if _, err := resolveTransformProfile(r.TransformProfileDigest); err != nil {
+		return fmt.Errorf("recipe: %w", err)
+	}
+	for index, op := range r.Operations {
+		if err := op.validate(); err != nil {
+			return fmt.Errorf("recipe operation %d (%s): %w", index, op.Kind, err)
+		}
+	}
+	return nil
+}
+
+// Apply deterministically executes recipe on input. It deliberately rejects
+// invalid UTF-8 rather than replacing bytes, because replacement corrupts byte
+// offsets. The transform-profile document supplies the bound and invalid-input
+// policy for interoperable implementations.
+func (r Recipe) Apply(input string) (string, error) {
+	if !utf8.ValidString(input) {
+		return "", fmt.Errorf("recipe input: invalid UTF-8")
+	}
+	if err := r.Validate(); err != nil {
+		return "", err
+	}
+	profile, err := resolveTransformProfile(r.TransformProfileDigest)
+	if err != nil {
+		return "", fmt.Errorf("recipe: %w", err)
+	}
+	if len(input) > profile.maxInputBytes {
+		return "", fmt.Errorf("recipe input: exceeds profile byte limit")
+	}
+	value := input
+	for index, op := range r.Operations {
+		value, err = op.apply(value)
+		if err != nil {
+			return "", fmt.Errorf("recipe operation %d (%s): %w", index, op.Kind, err)
+		}
+		if !utf8.ValidString(value) {
+			return "", fmt.Errorf("recipe operation %d (%s): output: invalid UTF-8", index, op.Kind)
+		}
+		if len(value) > profile.maxOutputBytes {
+			return "", fmt.Errorf("recipe operation %d (%s): output exceeds profile byte limit", index, op.Kind)
+		}
+	}
+	if len(value) > profile.maxOutputBytes {
+		return "", fmt.Errorf("recipe output exceeds profile byte limit")
+	}
+	return value, nil
+}
+
+// ValidateOutput checks that value is valid UTF-8 and fits the recipe's
+// resolved transform profile. It is for commitment constructors that receive
+// an already reconstructed view rather than source bytes to transform.
+func (r Recipe) ValidateOutput(value string) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("recipe output: invalid UTF-8")
+	}
+	profile, err := resolveTransformProfile(r.TransformProfileDigest)
+	if err != nil {
+		return fmt.Errorf("recipe: %w", err)
+	}
+	if len(value) > profile.maxOutputBytes {
+		return fmt.Errorf("recipe output exceeds profile byte limit")
+	}
+	return nil
+}
+
+func (op Operation) apply(value string) (string, error) {
+	switch op.Kind {
+	case OperationIdentity:
+		return value, nil
+	case OperationURLComponent:
+		return op.selectURLComponent(value)
+	case OperationPercentDecode:
+		for range op.Passes {
+			decoded, err := url.PathUnescape(value)
+			if err != nil {
+				return "", fmt.Errorf("percent decode: %w", err)
+			}
+			value = decoded
+		}
+		return value, nil
+	case OperationDLPNormalize:
+		return ForDLP(value), nil
+	case OperationLowercase:
+		return strings.ToLower(value), nil
+	case OperationInvisibleStrip:
+		return StripZeroWidth(value), nil
+	case OperationHexDecode:
+		decoded, err := hex.DecodeString(value)
+		if err != nil {
+			return "", fmt.Errorf("hex decode: %w", err)
+		}
+		if hex.EncodeToString(decoded) != value {
+			return "", fmt.Errorf("hex decode: non-canonical encoding")
+		}
+		if !utf8.Valid(decoded) {
+			return "", fmt.Errorf("hex decode output: invalid UTF-8")
+		}
+		return string(decoded), nil
+	case OperationBase32Decode:
+		encoding := base32.StdEncoding
+		if !op.DecodePadding {
+			encoding = encoding.WithPadding(base32.NoPadding)
+		}
+		decoded, err := encoding.DecodeString(value)
+		if err != nil {
+			return "", fmt.Errorf("base32 decode: %w", err)
+		}
+		if encoding.EncodeToString(decoded) != value {
+			return "", fmt.Errorf("base32 decode: non-canonical encoding")
+		}
+		if !utf8.Valid(decoded) {
+			return "", fmt.Errorf("base32 decode output: invalid UTF-8")
+		}
+		return string(decoded), nil
+	case OperationBase64Decode:
+		encoding := base64.StdEncoding
+		if !op.DecodePadding {
+			encoding = base64.RawStdEncoding
+		}
+		decoded, err := encoding.DecodeString(value)
+		if err != nil {
+			return "", fmt.Errorf("base64 decode: %w", err)
+		}
+		if encoding.EncodeToString(decoded) != value {
+			return "", fmt.Errorf("base64 decode: non-canonical encoding")
+		}
+		if !utf8.Valid(decoded) {
+			return "", fmt.Errorf("base64 decode output: invalid UTF-8")
+		}
+		return string(decoded), nil
+	case OperationLeetspeak:
+		return Leetspeak(value), nil
+	case OperationVowelFold:
+		return FoldVowels(value), nil
+	default:
+		return "", fmt.Errorf("unknown operation %q", op.Kind)
+	}
+}
+
+func (op Operation) validate() error {
+	reject := func(field string) error {
+		return fmt.Errorf("unsupported %s for %s", field, op.Kind)
+	}
+	// The Typed recipe language clause prohibits Unicode control characters in
+	// selector and profile values, so implementations reject them before
+	// evaluating the operation-specific parameter shape.
+	for _, field := range []struct {
+		name  string
+		value string
+	}{{"selector", op.Selector}, {"profile", op.Profile}} {
+		for _, r := range field.value {
+			if unicode.IsControl(r) {
+				return fmt.Errorf("%s for %s contains control character %U", field.name, op.Kind, r)
+			}
+		}
+	}
+	noParameters := func() error {
+		switch {
+		case op.Component != "":
+			return reject("component")
+		case op.Selector != "":
+			return reject("selector")
+		case op.Occurrence != 0:
+			return reject("occurrence")
+		case op.Passes != 0:
+			return reject("passes")
+		case op.Profile != "":
+			return reject("profile")
+		case op.DecodePadding:
+			return reject("decode_padding")
+		default:
+			return nil
+		}
+	}
+	switch op.Kind {
+	case OperationIdentity, OperationLowercase, OperationInvisibleStrip, OperationLeetspeak, OperationVowelFold:
+		return noParameters()
+	case OperationURLComponent:
+		if op.Passes != 0 {
+			return reject("passes")
+		}
+		if op.Profile != "" {
+			return reject("profile")
+		}
+		if op.DecodePadding {
+			return reject("decode_padding")
+		}
+		switch op.Component {
+		case ComponentURL, ComponentHostname, ComponentPath:
+			if op.Selector != "" {
+				return reject("selector")
+			}
+			if op.Occurrence != 0 {
+				return reject("occurrence")
+			}
+		case ComponentQueryKey, ComponentQueryVal:
+			if op.Selector == "" {
+				return fmt.Errorf("query component: missing selector")
+			}
+		default:
+			return fmt.Errorf("unknown URL component %q", op.Component)
+		}
+		return nil
+	case OperationPercentDecode:
+		if op.Passes == 0 || op.Passes > evidenceProvenanceProfileMaxDecodePasses {
+			return fmt.Errorf("percent decode passes must be 1..%d", evidenceProvenanceProfileMaxDecodePasses)
+		}
+		if op.Component != "" {
+			return reject("component")
+		}
+		if op.Selector != "" {
+			return reject("selector")
+		}
+		if op.Occurrence != 0 {
+			return reject("occurrence")
+		}
+		if op.Profile != "" {
+			return reject("profile")
+		}
+		if op.DecodePadding {
+			return reject("decode_padding")
+		}
+		return nil
+	case OperationDLPNormalize:
+		if op.Profile != "pipelock-dlp-v1" {
+			return fmt.Errorf("unknown DLP profile %q", op.Profile)
+		}
+		if op.Component != "" {
+			return reject("component")
+		}
+		if op.Selector != "" {
+			return reject("selector")
+		}
+		if op.Occurrence != 0 {
+			return reject("occurrence")
+		}
+		if op.Passes != 0 {
+			return reject("passes")
+		}
+		if op.DecodePadding {
+			return reject("decode_padding")
+		}
+		return nil
+	case OperationHexDecode:
+		return noParameters()
+	case OperationBase32Decode, OperationBase64Decode:
+		if op.Component != "" {
+			return reject("component")
+		}
+		if op.Selector != "" {
+			return reject("selector")
+		}
+		if op.Occurrence != 0 {
+			return reject("occurrence")
+		}
+		if op.Passes != 0 {
+			return reject("passes")
+		}
+		if op.Profile != "" {
+			return reject("profile")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown operation %q", op.Kind)
+	}
+}
+
+func (op Operation) selectURLComponent(value string) (string, error) {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("URL parse: invalid absolute URL")
+	}
+	switch op.Component {
+	case ComponentURL:
+		return value, nil
+	case ComponentHostname:
+		return parsed.Hostname(), nil
+	case ComponentPath:
+		return parsed.EscapedPath(), nil
+	case ComponentQueryKey, ComponentQueryVal:
+		if op.Selector == "" {
+			return "", fmt.Errorf("query component: missing selector")
+		}
+		query, err := url.ParseQuery(parsed.RawQuery)
+		if err != nil {
+			return "", fmt.Errorf("query parse: %w", err)
+		}
+		values, ok := query[op.Selector]
+		if !ok || int(op.Occurrence) >= len(values) {
+			return "", fmt.Errorf("query component: occurrence %d unavailable", op.Occurrence)
+		}
+		if op.Component == ComponentQueryKey {
+			return op.Selector, nil
+		}
+		return values[op.Occurrence], nil
+	default:
+		return "", fmt.Errorf("unknown URL component %q", op.Component)
+	}
+}

--- a/internal/normalize/provenance_test.go
+++ b/internal/normalize/provenance_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+const provenanceTestDigest = EvidenceProvenanceProfileV1Digest
+
+func TestRecipeApplyOperations(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		op    Operation
+		want  string
+	}{
+		{"identity", "MiXeD", Operation{Kind: OperationIdentity}, "MiXeD"},
+		{"URL", "https://api.vendor.example/a%20b?q=first&q=second", Operation{Kind: OperationURLComponent, Component: ComponentURL}, "https://api.vendor.example/a%20b?q=first&q=second"},
+		{"hostname", "https://api.vendor.example/a", Operation{Kind: OperationURLComponent, Component: ComponentHostname}, "api.vendor.example"},
+		{"path", "https://api.vendor.example/a%20b", Operation{Kind: OperationURLComponent, Component: ComponentPath}, "/a%20b"},
+		{"query key", "https://api.vendor.example/a?marker=first", Operation{Kind: OperationURLComponent, Component: ComponentQueryKey, Selector: "marker"}, "marker"},
+		{"query value occurrence", "https://api.vendor.example/a?marker=first&marker=second", Operation{Kind: OperationURLComponent, Component: ComponentQueryVal, Selector: "marker", Occurrence: 1}, "second"},
+		{"percent decode", "%2520", Operation{Kind: OperationPercentDecode, Passes: 2}, " "},
+		{"DLP normalize", "s\u200becret", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1"}, ForDLP("s\u200becret")},
+		{"lowercase", "MiXeD", Operation{Kind: OperationLowercase}, "mixed"},
+		{"invisible strip", "s\u200becret", Operation{Kind: OperationInvisibleStrip}, "secret"},
+		{"hex decode", "6869", Operation{Kind: OperationHexDecode}, "hi"},
+		{"base32 padded", base32.StdEncoding.EncodeToString([]byte("hi")), Operation{Kind: OperationBase32Decode, DecodePadding: true}, "hi"},
+		{"base32 raw", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("hi")), Operation{Kind: OperationBase32Decode}, "hi"},
+		{"base64 padded", base64.StdEncoding.EncodeToString([]byte("hi")), Operation{Kind: OperationBase64Decode, DecodePadding: true}, "hi"},
+		{"base64 raw", base64.RawStdEncoding.EncodeToString([]byte("hi")), Operation{Kind: OperationBase64Decode}, "hi"},
+		{"leetspeak", "s3cr3t", Operation{Kind: OperationLeetspeak}, Leetspeak("s3cr3t")},
+		{"vowel fold", "sëcrêt", Operation{Kind: OperationVowelFold}, FoldVowels("sëcrêt")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := (Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{tc.op}}).Apply(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("Apply() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecipeApplyRejectsInvalidInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		recipe Recipe
+		input  string
+		want   string
+	}{
+		{"invalid UTF-8", Recipe{TransformProfileDigest: provenanceTestDigest}, string([]byte{0xff}), "recipe input: invalid UTF-8"},
+		{"missing profile", Recipe{}, "value", "missing transform profile digest"},
+		{"malformed profile", Recipe{TransformProfileDigest: "sha256:bad"}, "value", "invalid SHA-256 digest"},
+		{"unknown profile", Recipe{TransformProfileDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "value", "unknown profile"},
+		{"unknown operation", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: "unknown"}}}, "value", "unknown operation"},
+		{"invalid URL", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: ComponentURL}}}, "://", "invalid absolute URL"},
+		{"unknown URL component", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: "unknown"}}}, "https://api.vendor.example", "unknown URL component"},
+		{"missing query selector", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: ComponentQueryVal}}}, "https://api.vendor.example", "missing selector"},
+		{"missing query occurrence", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: ComponentQueryVal, Selector: "missing"}}}, "https://api.vendor.example", "occurrence 0 unavailable"},
+		{"zero percent passes", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode}}}, "value", "passes must be 1..4"},
+		{"excess percent passes", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode, Passes: 5}}}, "value", "passes must be 1..4"},
+		{"malformed percent encoding", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode, Passes: 1}}}, "%zz", "percent decode"},
+		{"percent output invalid UTF-8", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode, Passes: 1}}}, "%ff", "output: invalid UTF-8"},
+		{"percent output invalid UTF-8 before Unicode transform", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode, Passes: 1}, {Kind: OperationLowercase}}}, "%ff", "output: invalid UTF-8"},
+		{"unknown DLP profile", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationDLPNormalize, Profile: "unknown"}}}, "value", "unknown DLP profile"},
+		{"malformed hex", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationHexDecode}}}, "z", "hex decode"},
+		{"non-UTF-8 hex", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationHexDecode}}}, "ff", "hex decode output: invalid UTF-8"},
+		{"non-canonical hex", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationHexDecode}}}, "4A", "hex decode: non-canonical encoding"},
+		{"malformed base32", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase32Decode, DecodePadding: true}}}, "!", "base32 decode"},
+		{"non-UTF-8 base32", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase32Decode, DecodePadding: true}}}, base32.StdEncoding.EncodeToString([]byte{0xff}), "base32 decode output: invalid UTF-8"},
+		{"non-canonical padded base32", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase32Decode, DecodePadding: true}}}, "MZ======", "base32 decode: non-canonical encoding"},
+		{"non-canonical raw base32", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase32Decode}}}, "MZ", "base32 decode: non-canonical encoding"},
+		{"malformed base64", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase64Decode, DecodePadding: true}}}, "!", "base64 decode"},
+		{"non-UTF-8 base64", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase64Decode, DecodePadding: true}}}, base64.StdEncoding.EncodeToString([]byte{0xff}), "base64 decode output: invalid UTF-8"},
+		{"non-canonical padded base64", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase64Decode, DecodePadding: true}}}, "Zh==", "base64 decode: non-canonical encoding"},
+		{"non-canonical raw base64", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationBase64Decode}}}, "Zh", "base64 decode: non-canonical encoding"},
+		{"identity rejects component", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationIdentity, Component: ComponentPath}}}, "value", "unsupported component"},
+		{"lowercase rejects selector", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationLowercase, Selector: "ignored"}}}, "value", "unsupported selector"},
+		{"URL rejects passes", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: ComponentURL, Passes: 1}}}, "https://api.vendor.example", "unsupported passes"},
+		{"percent rejects profile", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationPercentDecode, Passes: 1, Profile: "ignored"}}}, "value", "unsupported profile"},
+		{"DLP rejects occurrence", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", Occurrence: 1}}}, "value", "unsupported occurrence"},
+		{"decoder rejects selector", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationHexDecode, Selector: "ignored"}}}, "6869", "unsupported selector"},
+		{"malformed query encoding", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationURLComponent, Component: ComponentQueryVal, Selector: "marker"}}}, "https://api.vendor.example/?marker=ok&broken=%zz", "query parse"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.recipe.Apply(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecipeApplyProfileByteLimits(t *testing.T) {
+	tooLargeInput := strings.Repeat("x", evidenceProvenanceProfileMaxInputBytes+1)
+	tooLargeOutput := strings.Repeat("x", evidenceProvenanceProfileMaxOutputBytes+1)
+	for _, tc := range []struct {
+		name   string
+		recipe Recipe
+		input  string
+		want   string
+	}{
+		{"input", Recipe{TransformProfileDigest: provenanceTestDigest}, tooLargeInput, "input: exceeds profile byte limit"},
+		{"output after operation", Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationIdentity}}}, tooLargeOutput, "output exceeds profile byte limit"},
+		{"output with zero operations", Recipe{TransformProfileDigest: provenanceTestDigest}, tooLargeOutput, "output exceeds profile byte limit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.recipe.Apply(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestOperationValidateRejectsControlCharacters(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{"selector", Operation{Kind: OperationURLComponent, Component: ComponentQueryVal, Selector: "marker\n"}, "selector for url_component contains control character"},
+		{"profile", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1\t"}, "profile for dlp_normalize contains control character"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.op.validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTransformProfileV1DigestMatchesCanonicalDocument(t *testing.T) {
+	path := filepath.Clean(filepath.Join("..", "..", "sdk", "conformance", "testdata", "transform-profile", "evidence-provenance-transform-v1.json"))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	got := "sha256:" + hex.EncodeToString(sum[:])
+	if got != EvidenceProvenanceProfileV1Digest {
+		t.Fatalf("canonical evidence provenance transform profile digest = %q, want %q", got, EvidenceProvenanceProfileV1Digest)
+	}
+	var profile struct {
+		Format              string `json:"format"`
+		Profile             string `json:"profile"`
+		Version             int    `json:"version"`
+		OperationVocabulary []struct {
+			Kind string `json:"kind"`
+		} `json:"operation_vocabulary"`
+		Limits struct {
+			MaxDecodePasses int `json:"max_decode_passes"`
+			MaxInputBytes   int `json:"max_input_bytes"`
+			MaxOutputBytes  int `json:"max_output_bytes"`
+		} `json:"limits"`
+		Normalization struct {
+			DLPNormalize struct {
+				ConfusableToASCII struct {
+					SingleCodePoints map[string]string `json:"single_code_points"`
+					SequentialRanges []struct {
+						From    string `json:"from"`
+						To      string `json:"to"`
+						Outputs string `json:"outputs"`
+					} `json:"sequential_ranges"`
+				} `json:"confusable_to_ascii"`
+			} `json:"dlp_normalize"`
+		} `json:"normalization"`
+	}
+	if err := json.Unmarshal(data, &profile); err != nil {
+		t.Fatalf("decode evidence provenance transform profile: %v", err)
+	}
+	if profile.Format != "pipelock-evidence-provenance-transform-profile/v1" || profile.Profile != "pipelock-evidence-provenance-transform-v1" || profile.Version != 1 {
+		t.Fatalf("profile identity = format %q profile %q version %d", profile.Format, profile.Profile, profile.Version)
+	}
+	if profile.Limits.MaxDecodePasses != evidenceProvenanceProfileMaxDecodePasses || profile.Limits.MaxInputBytes != evidenceProvenanceProfileMaxInputBytes || profile.Limits.MaxOutputBytes != evidenceProvenanceProfileMaxOutputBytes {
+		t.Fatalf("profile limits = decode passes %d, input %d, output %d; Go = decode passes %d, input %d, output %d", profile.Limits.MaxDecodePasses, profile.Limits.MaxInputBytes, profile.Limits.MaxOutputBytes, evidenceProvenanceProfileMaxDecodePasses, evidenceProvenanceProfileMaxInputBytes, evidenceProvenanceProfileMaxOutputBytes)
+	}
+	gotKinds := make([]OperationKind, 0, len(profile.OperationVocabulary))
+	for _, operation := range profile.OperationVocabulary {
+		gotKinds = append(gotKinds, OperationKind(operation.Kind))
+	}
+	if !slices.Equal(gotKinds, SupportedOperationKinds()) {
+		t.Fatalf("profile operation vocabulary = %v, want %v", gotKinds, SupportedOperationKinds())
+	}
+	if !maps.Equal(profileConfusableToASCII(t, profile.Normalization.DLPNormalize.ConfusableToASCII.SingleCodePoints, profile.Normalization.DLPNormalize.ConfusableToASCII.SequentialRanges), confusableMap) {
+		t.Fatal("profile confusable-to-ASCII mapping differs from Go")
+	}
+}
+
+func profileConfusableToASCII(t *testing.T, singleCodePoints map[string]string, sequentialRanges []struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Outputs string `json:"outputs"`
+},
+) map[rune]rune {
+	t.Helper()
+	result := make(map[rune]rune, len(singleCodePoints))
+	for input, output := range singleCodePoints {
+		inputRune := profileCodePoint(t, input)
+		outputRunes := []rune(output)
+		if len(outputRunes) != 1 {
+			t.Fatalf("profile mapping %q output %q is not one rune", input, output)
+		}
+		result[inputRune] = outputRunes[0]
+	}
+	for _, sequentialRange := range sequentialRanges {
+		start := profileCodePoint(t, sequentialRange.From)
+		end := profileCodePoint(t, sequentialRange.To)
+		outputs := []rune(sequentialRange.Outputs)
+		if end < start || len(outputs) != int(end-start+1) {
+			t.Fatalf("profile sequential range %q-%q has %d outputs", sequentialRange.From, sequentialRange.To, len(outputs))
+		}
+		for index, output := range outputs {
+			result[start+rune(index)] = output
+		}
+	}
+	return result
+}
+
+func profileCodePoint(t *testing.T, value string) rune {
+	t.Helper()
+	if !strings.HasPrefix(value, "U+") {
+		t.Fatalf("profile code point %q lacks U+ prefix", value)
+	}
+	parsed, err := strconv.ParseInt(strings.TrimPrefix(value, "U+"), 16, 32)
+	if err != nil || parsed > utf8.MaxRune {
+		t.Fatalf("profile code point %q: %v", value, err)
+	}
+	return rune(parsed)
+}
+
+func TestRecipeValidateOutput(t *testing.T) {
+	valid := Recipe{TransformProfileDigest: provenanceTestDigest, Operations: []Operation{{Kind: OperationIdentity}}}
+	for _, tc := range []struct {
+		name   string
+		recipe Recipe
+		value  string
+		want   string
+	}{
+		{"valid", valid, "view", ""},
+		{"invalid recipe", Recipe{}, "view", "missing transform profile digest"},
+		{"invalid UTF-8", valid, string([]byte{0xff}), "output: invalid UTF-8"},
+		{"over-limit", valid, strings.Repeat("x", evidenceProvenanceProfileMaxOutputBytes+1), "output exceeds profile byte limit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.recipe.ValidateOutput(tc.value)
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestOperationValidateParameterShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		op   Operation
+		want string
+	}{
+		{"identity parameters", Operation{Kind: OperationIdentity, Occurrence: 1}, "unsupported occurrence"},
+		{"lowercase parameters", Operation{Kind: OperationLowercase, Passes: 1}, "unsupported passes"},
+		{"invisible strip parameters", Operation{Kind: OperationInvisibleStrip, Profile: "x"}, "unsupported profile"},
+		{"leetspeak parameters", Operation{Kind: OperationLeetspeak, DecodePadding: true}, "unsupported decode_padding"},
+		{"vowel fold parameters", Operation{Kind: OperationVowelFold, Component: ComponentPath}, "unsupported component"},
+		{"URL passes", Operation{Kind: OperationURLComponent, Component: ComponentPath, Passes: 1}, "unsupported passes"},
+		{"URL profile", Operation{Kind: OperationURLComponent, Component: ComponentPath, Profile: "x"}, "unsupported profile"},
+		{"URL padding", Operation{Kind: OperationURLComponent, Component: ComponentPath, DecodePadding: true}, "unsupported decode_padding"},
+		{"URL selector", Operation{Kind: OperationURLComponent, Component: ComponentPath, Selector: "marker"}, "unsupported selector"},
+		{"URL occurrence", Operation{Kind: OperationURLComponent, Component: ComponentPath, Occurrence: 1}, "unsupported occurrence"},
+		{"percent component", Operation{Kind: OperationPercentDecode, Passes: 1, Component: ComponentPath}, "unsupported component"},
+		{"percent selector", Operation{Kind: OperationPercentDecode, Passes: 1, Selector: "marker"}, "unsupported selector"},
+		{"percent occurrence", Operation{Kind: OperationPercentDecode, Passes: 1, Occurrence: 1}, "unsupported occurrence"},
+		{"DLP passes", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", Passes: 1}, "unsupported passes"},
+		{"DLP component", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", Component: ComponentPath}, "unsupported component"},
+		{"DLP selector", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", Selector: "marker"}, "unsupported selector"},
+		{"DLP occurrence", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", Occurrence: 1}, "unsupported occurrence"},
+		{"DLP padding", Operation{Kind: OperationDLPNormalize, Profile: "pipelock-dlp-v1", DecodePadding: true}, "unsupported decode_padding"},
+		{"decoder padding is valid", Operation{Kind: OperationBase64Decode, DecodePadding: true}, ""},
+		{"hex rejects padding", Operation{Kind: OperationHexDecode, DecodePadding: true}, "unsupported decode_padding"},
+		{"decoder component", Operation{Kind: OperationHexDecode, Component: ComponentPath}, "unsupported component"},
+		{"decoder selector", Operation{Kind: OperationHexDecode, Selector: "marker"}, "unsupported selector"},
+		{"decoder occurrence", Operation{Kind: OperationHexDecode, Occurrence: 1}, "unsupported occurrence"},
+		{"decoder passes", Operation{Kind: OperationHexDecode, Passes: 1}, "unsupported passes"},
+		{"decoder profile", Operation{Kind: OperationHexDecode, Profile: "x"}, "unsupported profile"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.op.validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSupportedOperationKinds(t *testing.T) {
+	got := SupportedOperationKinds()
+	want := []OperationKind{
+		OperationIdentity,
+		OperationURLComponent,
+		OperationPercentDecode,
+		OperationDLPNormalize,
+		OperationLowercase,
+		OperationInvisibleStrip,
+		OperationHexDecode,
+		OperationBase32Decode,
+		OperationBase64Decode,
+		OperationLeetspeak,
+		OperationVowelFold,
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("SupportedOperationKinds() = %v, want %v", got, want)
+	}
+}

--- a/sdk/conformance/evidence_provenance_test.go
+++ b/sdk/conformance/evidence_provenance_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package conformance_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+type provenanceCorpus struct {
+	Format            string             `json:"format"`
+	ProfileDigest     string             `json:"profile_digest"`
+	OperationCoverage []string           `json:"operation_coverage"`
+	ErrorCoverage     []string           `json:"error_coverage"`
+	ErrorDefinitions  map[string]string  `json:"error_definitions"`
+	Vectors           []provenanceVector `json:"vectors"`
+	IntervalVectors   []intervalVector   `json:"interval_vectors"`
+}
+
+type intervalVector struct {
+	ID        string      `json:"id"`
+	ViewB64   string      `json:"view_b64"`
+	Matches   [][2]uint64 `json:"matches"`
+	WantError string      `json:"want_error"`
+}
+
+type provenanceVector struct {
+	ID                     string                `json:"id"`
+	Operations             []string              `json:"operations"`
+	Errors                 []string              `json:"errors"`
+	InputB64               string                `json:"input_b64"`
+	OutputB64              string                `json:"output_b64"`
+	WantError              string                `json:"want_error"`
+	TransformProfileDigest *string               `json:"transform_profile_digest"`
+	Recipe                 []normalize.Operation `json:"recipe"`
+}
+
+func TestEvidenceProvenanceTransformCorpus(t *testing.T) {
+	corpus := loadProvenanceCorpus(t)
+	if corpus.Format != "pipelock-evidence-transform-corpus/v1" {
+		t.Fatalf("format = %q", corpus.Format)
+	}
+	covered := make(map[string]bool)
+	errors := make(map[string]bool)
+	for _, vector := range corpus.Vectors {
+		t.Run(vector.ID, func(t *testing.T) {
+			input, err := base64.StdEncoding.DecodeString(vector.InputB64)
+			if err != nil {
+				t.Fatalf("input: %v", err)
+			}
+			recipe := normalize.Recipe{TransformProfileDigest: corpus.ProfileDigest, Operations: vector.Recipe}
+			if vector.TransformProfileDigest != nil {
+				recipe.TransformProfileDigest = *vector.TransformProfileDigest
+			}
+			output, err := recipe.Apply(string(input))
+			actualOperations := executedOperationKinds(recipe, string(input), err)
+			for kind := range actualOperations {
+				covered[kind] = true
+			}
+			if err := validateDeclaredOperations(vector, actualOperations); err != nil {
+				t.Fatal(err)
+			}
+			if vector.WantError != "" {
+				if err == nil || !strings.Contains(err.Error(), vector.WantError) {
+					t.Fatalf("error = %v, want %q", err, vector.WantError)
+				}
+				// Bind each declared code to its corpus-defined message via
+				// error_definitions, then require the OBSERVED error to match
+				// that definition. Without this a vector could declare a code
+				// while asserting an unrelated message, and the coverage gate
+				// below would pass without ever exercising the declared path.
+				for _, code := range vector.Errors {
+					want, defined := corpus.ErrorDefinitions[code]
+					if !defined {
+						t.Fatalf("declares error code %q with no entry in error_definitions", code)
+					}
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("declares error code %q (defined as %q) but observed error %v does not match", code, want, err)
+					}
+					errors[code] = true
+				}
+				return
+			}
+			if len(vector.Errors) != 0 {
+				t.Fatal("declares errors but expects success")
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := base64.StdEncoding.DecodeString(vector.OutputB64)
+			if err != nil {
+				t.Fatalf("output: %v", err)
+			}
+			if output != string(want) {
+				t.Fatalf("output = %q, want %q", output, string(want))
+			}
+		})
+	}
+	for _, kind := range normalize.SupportedOperationKinds() {
+		if !covered[string(kind)] {
+			t.Fatalf("operation %q has no corpus vector", kind)
+		}
+		if !slices.Contains(corpus.OperationCoverage, string(kind)) {
+			t.Fatalf("operation %q missing declared coverage", kind)
+		}
+	}
+	for _, code := range corpus.ErrorCoverage {
+		if !errors[code] {
+			t.Fatalf("error %q has no corpus vector", code)
+		}
+	}
+	for _, vector := range corpus.IntervalVectors {
+		t.Run(vector.ID, func(t *testing.T) {
+			view, err := base64.StdEncoding.DecodeString(vector.ViewB64)
+			if err != nil {
+				t.Fatalf("view: %v", err)
+			}
+			matches := make([]contractreceipt.ProvenanceMatch, len(vector.Matches))
+			for index, bounds := range vector.Matches {
+				matches[index] = contractreceipt.ProvenanceMatch{MatchOrdinal: uint64(index + 1), ByteStart: bounds[0], ByteEnd: bounds[1], MatchCommitment: conformanceCommitment}
+			}
+			source := contractreceipt.ProvenanceSource{SourceOrdinal: 1, SourceID: vector.ID, Recipe: normalize.Recipe{TransformProfileDigest: corpus.ProfileDigest, Operations: []normalize.Operation{{Kind: normalize.OperationIdentity}}}, ViewCommitment: conformanceCommitment, Matches: matches}
+			proof := contractreceipt.EvidenceProvenanceProof{Version: contractreceipt.EvidenceProvenanceProofVersionV1, TransformProfileDigest: corpus.ProfileDigest, Sources: []contractreceipt.ProvenanceSource{source}}
+			err = proof.Validate()
+			if err == nil {
+				err = source.ValidateView(string(view))
+			}
+			if vector.WantError == "" && err != nil {
+				t.Fatal(err)
+			}
+			if vector.WantError != "" && (err == nil || !strings.Contains(err.Error(), vector.WantError)) {
+				t.Fatalf("error = %v, want %q", err, vector.WantError)
+			}
+		})
+	}
+}
+
+const conformanceCommitment = "hmac-sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+func TestEvidenceProvenanceCorpusRejectsMetadataThatDoesNotExecute(t *testing.T) {
+	vector := provenanceVector{ID: "declared-but-not-executed", Operations: []string{"lowercase"}, Recipe: []normalize.Operation{{Kind: normalize.OperationIdentity}}}
+	err := validateDeclaredOperations(vector, map[string]bool{string(normalize.OperationIdentity): true})
+	if err == nil || !strings.Contains(err.Error(), "executed operations") {
+		t.Fatalf("error = %v, want metadata mismatch", err)
+	}
+}
+
+func TestExecutedOperationKindsStopsAtFailingOperation(t *testing.T) {
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationPercentDecode, Passes: 1}, {Kind: normalize.OperationLowercase}}}
+	_, err := recipe.Apply("%ff")
+	if err == nil {
+		t.Fatal("recipe unexpectedly succeeded")
+	}
+	got := executedOperationKinds(recipe, "%ff", err)
+	want := map[string]bool{string(normalize.OperationPercentDecode): true}
+	if !mapsEqual(got, want) {
+		t.Fatalf("executed operations = %v, want %v", got, want)
+	}
+}
+
+func TestEvidenceProvenanceCorpusRejectsTrailingJSONValue(t *testing.T) {
+	_, err := decodeProvenanceCorpus([]byte(`{"format":"pipelock-evidence-transform-corpus/v1"} {}`))
+	if err == nil || !strings.Contains(err.Error(), "exactly one JSON value") {
+		t.Fatalf("error = %v, want trailing-value rejection", err)
+	}
+}
+
+func loadProvenanceCorpus(t *testing.T) provenanceCorpus {
+	t.Helper()
+	path := filepath.Clean(filepath.Join(testdataDir, "transform-profile", "evidence-provenance-v1.json"))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corpus, err := decodeProvenanceCorpus(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return corpus
+}
+
+func decodeProvenanceCorpus(data []byte) (provenanceCorpus, error) {
+	var corpus provenanceCorpus
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&corpus); err != nil {
+		return provenanceCorpus{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return provenanceCorpus{}, fmt.Errorf("corpus must contain exactly one JSON value, trailing decode error = %w", err)
+	}
+	return corpus, nil
+}
+
+func mapsEqual(left, right map[string]bool) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key := range left {
+		if !right[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateDeclaredOperations(vector provenanceVector, actual map[string]bool) error {
+	declared := make(map[string]bool, len(vector.Operations))
+	for _, operation := range vector.Operations {
+		if declared[operation] {
+			return fmt.Errorf("%s declares operation %q more than once", vector.ID, operation)
+		}
+		declared[operation] = true
+	}
+	if !mapsEqual(declared, actual) {
+		return fmt.Errorf("%s operations = %v, executed operations = %v", vector.ID, vector.Operations, operationKindsFromSet(actual))
+	}
+	return nil
+}
+
+func operationKindsFromSet(kinds map[string]bool) []string {
+	result := make([]string, 0, len(kinds))
+	for _, kind := range normalize.SupportedOperationKinds() {
+		if kinds[string(kind)] {
+			result = append(result, string(kind))
+		}
+	}
+	return result
+}
+
+func executedOperationKinds(recipe normalize.Recipe, input string, applyErr error) map[string]bool {
+	executed := make(map[string]bool)
+	if !utf8.ValidString(input) || recipe.Validate() != nil || (applyErr != nil && strings.Contains(applyErr.Error(), "recipe input: exceeds profile byte limit")) {
+		return executed
+	}
+	for index, operation := range recipe.Operations {
+		prefix := recipe
+		prefix.Operations = recipe.Operations[:index+1]
+		_, err := prefix.Apply(input)
+		executed[string(operation.Kind)] = true
+		if err != nil {
+			break
+		}
+	}
+	return executed
+}

--- a/sdk/conformance/evidence_provenance_test.go
+++ b/sdk/conformance/evidence_provenance_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,8 +68,15 @@ func TestEvidenceProvenanceTransformCorpus(t *testing.T) {
 			}
 			output, err := recipe.Apply(string(input))
 			actualOperations := executedOperationKinds(recipe, string(input), err)
-			for kind := range actualOperations {
-				covered[kind] = true
+			// The coverage gate below must prove every operation has a WORKING
+			// vector. executedOperationKinds includes the operation that
+			// failed, which is right for the declared-metadata cross-check but
+			// wrong here: counting it would let an operation satisfy coverage
+			// with error vectors alone and never run successfully once.
+			if err == nil {
+				for kind := range actualOperations {
+					covered[kind] = true
+				}
 			}
 			if err := validateDeclaredOperations(vector, actualOperations); err != nil {
 				t.Fatal(err)
@@ -173,8 +181,20 @@ func TestExecutedOperationKindsStopsAtFailingOperation(t *testing.T) {
 
 func TestEvidenceProvenanceCorpusRejectsTrailingJSONValue(t *testing.T) {
 	_, err := decodeProvenanceCorpus([]byte(`{"format":"pipelock-evidence-transform-corpus/v1"} {}`))
+	if err == nil || !strings.Contains(err.Error(), "found a trailing value") {
+		t.Fatalf("error = %v, want a readable trailing-value rejection", err)
+	}
+	// Assert the message is READABLE, not merely present. The previous form
+	// formatted a nil error through %w and emitted "%!w(<nil>)", which the
+	// substring assertion happily accepted.
+	if strings.Contains(err.Error(), "%!w") {
+		t.Fatalf("error message contains a formatting artifact: %v", err)
+	}
+	// A genuinely malformed trailing token is a different failure and must
+	// still surface the decoder's own error.
+	_, err = decodeProvenanceCorpus([]byte(`{"format":"pipelock-evidence-transform-corpus/v1"} @`))
 	if err == nil || !strings.Contains(err.Error(), "exactly one JSON value") {
-		t.Fatalf("error = %v, want trailing-value rejection", err)
+		t.Fatalf("malformed trailing token error = %v", err)
 	}
 }
 
@@ -199,9 +219,15 @@ func decodeProvenanceCorpus(data []byte) (provenanceCorpus, error) {
 	if err := decoder.Decode(&corpus); err != nil {
 		return provenanceCorpus{}, err
 	}
+	// The two failure modes are distinct and must read differently. A trailing
+	// VALUE decodes successfully, so err is nil; formatting nil through %w
+	// produced "%!w(<nil>)" and buried the actual problem.
 	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		return provenanceCorpus{}, fmt.Errorf("corpus must contain exactly one JSON value, trailing decode error = %w", err)
+	switch err := decoder.Decode(&trailing); {
+	case err == nil:
+		return provenanceCorpus{}, fmt.Errorf("corpus must contain exactly one JSON value, found a trailing value")
+	case !errors.Is(err, io.EOF):
+		return provenanceCorpus{}, fmt.Errorf("corpus must contain exactly one JSON value: %w", err)
 	}
 	return corpus, nil
 }

--- a/sdk/conformance/testdata/transform-profile/evidence-provenance-transform-v1.json
+++ b/sdk/conformance/testdata/transform-profile/evidence-provenance-transform-v1.json
@@ -1,0 +1,95 @@
+{
+  "format": "pipelock-evidence-provenance-transform-profile/v1",
+  "profile": "pipelock-evidence-provenance-transform-v1",
+  "version": 1,
+  "normative": true,
+  "byte_interpretation": {
+    "input": "UTF-8 bytes",
+    "output": "UTF-8 bytes",
+    "validity": "MUST reject invalid UTF-8 before the first operation and after every operation; NEVER replace malformed bytes"
+  },
+  "limits": {
+    "max_decode_passes": 4,
+    "max_input_bytes": 2097152,
+    "max_output_bytes": 1048576,
+    "enforcement": "MUST reject an input exceeding max_input_bytes before applying a recipe and an intermediate or final output exceeding max_output_bytes after every operation"
+  },
+  "malformed_input_policy": "reject_never_substitute",
+  "control_character_policy": {
+    "fields": ["selector", "profile"],
+    "rule": "MUST reject a Unicode control character in either field before evaluating the operation"
+  },
+  "url_component_policy": {
+    "input": "MUST be an absolute URL with a non-empty scheme and host",
+    "url": "returns the input bytes unchanged",
+    "hostname": "returns the URL hostname without a port",
+    "path": "returns the escaped path",
+    "query_key_and_query_value": "parse the raw query with application/x-www-form-urlencoded semantics; malformed query escaping is an error; selector identifies a key; occurrence is zero-based among values for that key; a missing key or occurrence is an error"
+  },
+  "decoding": {
+    "percent_decode": {
+      "algorithm": "RFC 3986 percent decoding of path-escaped bytes; plus is not decoded as space",
+      "canonicality": "input need not be canonical, but malformed escapes are errors"
+    },
+    "hex_decode": {
+      "alphabet": "lowercase RFC 4648 base16",
+      "padding": "forbidden",
+      "canonicality": "decode then lowercase-hex re-encode; the result MUST equal the input exactly"
+    },
+    "base32_decode": {
+      "alphabet": "RFC 4648 standard base32 uppercase alphabet",
+      "padding_selector": "decode_padding",
+      "decode_padding_true": "use required RFC 4648 '=' padding",
+      "decode_padding_false": "use raw, unpadded RFC 4648 base32",
+      "canonicality": "decode then re-encode in the selected padding mode; the result MUST equal the input exactly"
+    },
+    "base64_decode": {
+      "alphabet": "RFC 4648 standard base64 alphabet; URL-safe alphabet is forbidden",
+      "padding_selector": "decode_padding",
+      "decode_padding_true": "use required RFC 4648 '=' padding",
+      "decode_padding_false": "use raw, unpadded RFC 4648 base64",
+      "canonicality": "decode then re-encode in the selected padding mode; the result MUST equal the input exactly"
+    }
+  },
+  "normalization": {
+    "lowercase": "Unicode simple lowercase mapping",
+    "invisible_strip": "remove C0 controls except TAB, LF, and CR; remove DEL, C1 controls, U+00AD, U+115F-U+1160, U+200B-U+200F, U+202A-U+202E, U+2060-U+2064, U+2066-U+2069, U+3164, U+FE00-U+FE0F, U+FEFF, U+FFF9-U+FFFB, U+E0000-U+E007F, and U+E0100-U+E01EF",
+    "leetspeak": {"0":"o","1":"i","3":"e","4":"a","5":"s","7":"t","@":"a","$":"s"},
+    "vowel_fold": {"a":"a","e":"a","i":"a","o":"a","u":"a","A":"A","E":"A","I":"A","O":"A","U":"A"},
+    "dlp_normalize": {
+      "profile": "pipelock-dlp-v1",
+      "unicode_version": "15.0.0",
+      "pipeline": ["remove C0, C1, DEL, and the invisible_strip Unicode ranges", "remove U+00A0, U+1680, U+180E, U+2000-U+200A, U+2028-U+2029, U+202F, U+205F, and U+3000", "Unicode NFKC", "apply confusable_to_ascii", "Unicode NFD then remove all Mn code points"],
+      "confusable_to_ascii": {
+        "single_code_points": {
+          "U+0410":"A","U+0412":"B","U+0421":"C","U+0415":"E","U+041D":"H","U+0406":"I","U+0408":"J","U+041A":"K","U+041C":"M","U+041E":"O","U+0420":"P","U+0405":"S","U+0422":"T","U+0425":"X",
+          "U+0430":"a","U+0432":"v","U+0435":"e","U+043D":"h","U+0456":"i","U+043A":"k","U+043C":"m","U+043E":"o","U+0440":"p","U+0441":"c","U+0442":"t","U+0443":"y","U+0445":"x","U+0458":"j","U+0455":"s",
+          "U+0391":"A","U+0392":"B","U+0395":"E","U+0396":"Z","U+0397":"H","U+0399":"I","U+039A":"K","U+039C":"M","U+039D":"N","U+039F":"O","U+03A1":"P","U+03A4":"T","U+03A5":"Y","U+03A7":"X",
+          "U+03B1":"a","U+03B5":"e","U+03B9":"i","U+03BA":"k","U+03BD":"v","U+03BF":"o",
+          "U+0555":"O","U+0585":"o","U+054D":"S","U+057D":"s","U+054C":"L","U+0570":"h","U+0578":"n","U+057C":"n","U+0561":"a",
+          "U+13AA":"A","U+13A2":"I","U+13D2":"P","U+13DA":"S","U+13A1":"E","U+13B3":"W","U+13D4":"T",
+          "U+00D8":"O","U+00F8":"o","U+0110":"D","U+0111":"d","U+0141":"L","U+0142":"l","U+0126":"H","U+0127":"h","U+0166":"T","U+0167":"t",
+          "U+1D00":"A","U+0299":"B","U+1D04":"C","U+1D05":"D","U+1D07":"E","U+A730":"F","U+0262":"G","U+029C":"H","U+026A":"I","U+1D0A":"J","U+1D0B":"K","U+029F":"L","U+1D0D":"M","U+0274":"N","U+1D0F":"O","U+1D18":"P","U+0280":"R","U+A731":"S","U+1D1B":"T","U+1D1C":"U","U+1D20":"V","U+1D21":"W","U+028F":"Y","U+1D22":"Z"
+        },
+        "sequential_ranges": [
+          {"from":"U+1F170","to":"U+1F189","outputs":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+          {"from":"U+1F1E6","to":"U+1F1FF","outputs":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"}
+        ]
+      }
+    }
+  },
+  "operation_vocabulary": [
+    {"kind":"identity","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"return input unchanged"},
+    {"kind":"url_component","required":["kind","component"],"optional":["selector","occurrence"],"forbidden":["passes","profile","decode_padding"],"component":{"type":"string","enum":["url","hostname","path","query_key","query_value"]},"selector":{"type":"string","required_for":["query_key","query_value"],"forbidden_for":["url","hostname","path"],"must_not_contain":"Unicode control character"},"occurrence":{"type":"uint32","minimum":0,"default":0,"forbidden_for":["url","hostname","path"]}},
+    {"kind":"percent_decode","required":["kind","passes"],"optional":[],"forbidden":["component","selector","occurrence","profile","decode_padding"],"passes":{"type":"uint8","minimum":1,"maximum":4}},
+    {"kind":"dlp_normalize","required":["kind","profile"],"optional":[],"forbidden":["component","selector","occurrence","passes","decode_padding"],"profile":{"type":"string","const":"pipelock-dlp-v1","must_not_contain":"Unicode control character"}},
+    {"kind":"lowercase","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"apply normalization.lowercase"},
+    {"kind":"invisible_strip","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"apply normalization.invisible_strip"},
+    {"kind":"hex_decode","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"apply decoding.hex_decode"},
+    {"kind":"base32_decode","required":["kind"],"optional":["decode_padding"],"forbidden":["component","selector","occurrence","passes","profile"],"decode_padding":{"type":"boolean","default":false},"semantics":"apply decoding.base32_decode"},
+    {"kind":"base64_decode","required":["kind"],"optional":["decode_padding"],"forbidden":["component","selector","occurrence","passes","profile"],"decode_padding":{"type":"boolean","default":false},"semantics":"apply decoding.base64_decode"},
+    {"kind":"leetspeak","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"apply normalization.leetspeak"},
+    {"kind":"vowel_fold","required":["kind"],"optional":[],"forbidden":["component","selector","occurrence","passes","profile","decode_padding"],"semantics":"apply normalization.vowel_fold"}
+  ],
+  "recipe_execution": "Apply operation_vocabulary in listed order only as selected by the ordered recipe. An unknown operation, unknown field, forbidden field, missing required field, malformed input, or canonicality failure MUST reject the recipe; no operation may preserve, skip, or substitute undecodable input."
+}

--- a/sdk/conformance/testdata/transform-profile/evidence-provenance-v1.json
+++ b/sdk/conformance/testdata/transform-profile/evidence-provenance-v1.json
@@ -1,0 +1,590 @@
+{
+  "format": "pipelock-evidence-transform-corpus/v1",
+  "profile_digest": "sha256:8bc27d5d89e4e5ba3e0d1e68a25a3f0170f9a5ea2f19edf81a9a90bf82e23b3e",
+  "operation_coverage": [
+    "identity",
+    "url_component",
+    "percent_decode",
+    "dlp_normalize",
+    "lowercase",
+    "invisible_strip",
+    "hex_decode",
+    "base32_decode",
+    "base64_decode",
+    "leetspeak",
+    "vowel_fold"
+  ],
+  "error_coverage": [
+    "invalid_utf8",
+    "missing_profile",
+    "invalid_url",
+    "missing_selector",
+    "missing_occurrence",
+    "invalid_percent",
+    "invalid_percent_utf8",
+    "invalid_percent_utf8_before_unicode",
+    "invalid_query_encoding",
+    "bad_pass_count",
+    "unknown_dlp_profile",
+    "invalid_hex",
+    "invalid_base32",
+    "invalid_base64",
+    "unknown_operation",
+    "control_selector",
+    "control_profile",
+    "noncanonical_hex"
+  ],
+  "error_definitions": {
+    "bad_pass_count": "passes must",
+    "control_profile": "profile for dlp_normalize contains control character",
+    "control_selector": "selector for url_component contains control character",
+    "invalid_base32": "base32 decode",
+    "invalid_base64": "base64 decode",
+    "invalid_hex": "hex decode",
+    "invalid_percent": "percent decode",
+    "invalid_percent_utf8": "output: invalid UTF-8",
+    "invalid_percent_utf8_before_unicode": "output: invalid UTF-8",
+    "invalid_query_encoding": "query parse",
+    "invalid_url": "invalid absolute URL",
+    "invalid_utf8": "invalid UTF-8",
+    "missing_occurrence": "occurrence 1 unavailable",
+    "missing_profile": "missing transform profile digest",
+    "missing_selector": "missing selector",
+    "noncanonical_hex": "hex decode: non-canonical encoding",
+    "unknown_dlp_profile": "unknown DLP profile",
+    "unknown_operation": "unknown operation"
+  },
+  "interval_vectors": [
+    {
+      "id": "interval-valid-nonbmp",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          1,
+          5
+        ],
+        [
+          5,
+          6
+        ]
+      ],
+      "want_error": ""
+    },
+    {
+      "id": "interval-inside-codepoint",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          2,
+          5
+        ]
+      ],
+      "want_error": "splits UTF-8"
+    },
+    {
+      "id": "interval-end-inside-codepoint",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          1,
+          4
+        ]
+      ],
+      "want_error": "splits UTF-8"
+    },
+    {
+      "id": "interval-out-of-bounds",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          1,
+          7
+        ]
+      ],
+      "want_error": "out of bounds"
+    },
+    {
+      "id": "interval-zero-length",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          1,
+          1
+        ]
+      ],
+      "want_error": "byte end must be greater"
+    },
+    {
+      "id": "interval-unsorted",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          5,
+          6
+        ],
+        [
+          1,
+          5
+        ]
+      ],
+      "want_error": "unsorted"
+    },
+    {
+      "id": "interval-duplicate",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          1,
+          5
+        ],
+        [
+          1,
+          5
+        ]
+      ],
+      "want_error": "duplicate"
+    },
+    {
+      "id": "interval-overlap",
+      "view_b64": "QfCfkqlC",
+      "matches": [
+        [
+          0,
+          5
+        ],
+        [
+          1,
+          6
+        ]
+      ],
+      "want_error": "overlap"
+    }
+  ],
+  "vectors": [
+    {
+      "id": "identity",
+      "operations": [
+        "identity"
+      ],
+      "input_b64": "SGVsbG8=",
+      "output_b64": "SGVsbG8=",
+      "recipe": [
+        {
+          "kind": "identity"
+        }
+      ]
+    },
+    {
+      "id": "url-query-repeated",
+      "operations": [
+        "url_component"
+      ],
+      "input_b64": "aHR0cHM6Ly9hcGkudmVuZG9yLmV4YW1wbGUvcD9rPWZpcnN0Jms9c2Vjb25k",
+      "output_b64": "c2Vjb25k",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "query_value",
+          "selector": "k",
+          "occurrence": 1
+        }
+      ]
+    },
+    {
+      "id": "percent-two-pass",
+      "operations": [
+        "percent_decode"
+      ],
+      "input_b64": "JTQ4JTY5",
+      "output_b64": "SGk=",
+      "recipe": [
+        {
+          "kind": "percent_decode",
+          "passes": 2
+        }
+      ]
+    },
+    {
+      "id": "dlp-normalize",
+      "operations": [
+        "dlp_normalize"
+      ],
+      "input_b64": "QUtJQeKAiElPUw==",
+      "output_b64": "QUtJQUlPUw==",
+      "recipe": [
+        {
+          "kind": "dlp_normalize",
+          "profile": "pipelock-dlp-v1"
+        }
+      ]
+    },
+    {
+      "id": "lowercase-nonbmp",
+      "operations": [
+        "lowercase"
+      ],
+      "input_b64": "8JCQgA==",
+      "output_b64": "8JCQqA==",
+      "recipe": [
+        {
+          "kind": "lowercase"
+        }
+      ]
+    },
+    {
+      "id": "invisible-strip",
+      "operations": [
+        "invisible_strip"
+      ],
+      "input_b64": "YeKAjWI=",
+      "output_b64": "YWI=",
+      "recipe": [
+        {
+          "kind": "invisible_strip"
+        }
+      ]
+    },
+    {
+      "id": "hex",
+      "operations": [
+        "hex_decode"
+      ],
+      "input_b64": "NDg2OQ==",
+      "output_b64": "SGk=",
+      "recipe": [
+        {
+          "kind": "hex_decode"
+        }
+      ]
+    },
+    {
+      "id": "base32",
+      "operations": [
+        "base32_decode"
+      ],
+      "input_b64": "SkJVUT09PT0=",
+      "output_b64": "SGk=",
+      "recipe": [
+        {
+          "kind": "base32_decode",
+          "decode_padding": true
+        }
+      ]
+    },
+    {
+      "id": "base64",
+      "operations": [
+        "base64_decode"
+      ],
+      "input_b64": "U0drPQ==",
+      "output_b64": "SGk=",
+      "recipe": [
+        {
+          "kind": "base64_decode",
+          "decode_padding": true
+        }
+      ]
+    },
+    {
+      "id": "leetspeak",
+      "operations": [
+        "leetspeak"
+      ],
+      "input_b64": "MWdub3Iz",
+      "output_b64": "aWdub3Jl",
+      "recipe": [
+        {
+          "kind": "leetspeak"
+        }
+      ]
+    },
+    {
+      "id": "vowel-fold",
+      "operations": [
+        "vowel_fold"
+      ],
+      "input_b64": "aWdub3Jl",
+      "output_b64": "YWduYXJh",
+      "recipe": [
+        {
+          "kind": "vowel_fold"
+        }
+      ]
+    },
+    {
+      "id": "invalid-utf8",
+      "errors": [
+        "invalid_utf8"
+      ],
+      "input_b64": "/w==",
+      "want_error": "invalid UTF-8"
+    },
+    {
+      "id": "missing-profile",
+      "errors": [
+        "missing_profile"
+      ],
+      "input_b64": "SGk=",
+      "want_error": "missing transform profile digest",
+      "transform_profile_digest": ""
+    },
+    {
+      "id": "invalid-url",
+      "operations": [
+        "url_component"
+      ],
+      "errors": [
+        "invalid_url"
+      ],
+      "input_b64": "bm90IGEgdXJs",
+      "want_error": "invalid absolute URL",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "path"
+        }
+      ]
+    },
+    {
+      "id": "missing-selector",
+      "errors": [
+        "missing_selector"
+      ],
+      "input_b64": "aHR0cHM6Ly9hLmV4YW1wbGUvP2s9dg==",
+      "want_error": "missing selector",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "query_value"
+        }
+      ]
+    },
+    {
+      "id": "missing-occurrence",
+      "operations": [
+        "url_component"
+      ],
+      "errors": [
+        "missing_occurrence"
+      ],
+      "input_b64": "aHR0cHM6Ly9hLmV4YW1wbGUvP2s9dg==",
+      "want_error": "occurrence 1 unavailable",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "query_value",
+          "selector": "k",
+          "occurrence": 1
+        }
+      ]
+    },
+    {
+      "id": "invalid-percent",
+      "operations": [
+        "percent_decode"
+      ],
+      "errors": [
+        "invalid_percent"
+      ],
+      "input_b64": "JVo=",
+      "want_error": "percent decode",
+      "recipe": [
+        {
+          "kind": "percent_decode",
+          "passes": 1
+        }
+      ]
+    },
+    {
+      "id": "percent-invalid-utf8",
+      "operations": [
+        "percent_decode"
+      ],
+      "errors": [
+        "invalid_percent_utf8"
+      ],
+      "input_b64": "JWZm",
+      "want_error": "output: invalid UTF-8",
+      "recipe": [
+        {
+          "kind": "percent_decode",
+          "passes": 1
+        }
+      ]
+    },
+    {
+      "id": "percent-invalid-utf8-before-unicode",
+      "operations": [
+        "percent_decode"
+      ],
+      "errors": [
+        "invalid_percent_utf8_before_unicode"
+      ],
+      "input_b64": "JWZm",
+      "want_error": "output: invalid UTF-8",
+      "recipe": [
+        {
+          "kind": "percent_decode",
+          "passes": 1
+        },
+        {
+          "kind": "lowercase"
+        }
+      ]
+    },
+    {
+      "id": "malformed-query-encoding",
+      "operations": [
+        "url_component"
+      ],
+      "errors": [
+        "invalid_query_encoding"
+      ],
+      "input_b64": "aHR0cHM6Ly9hcGkudmVuZG9yLmV4YW1wbGUvP21hcmtlcj1vayZicm9rZW49JXp6",
+      "want_error": "query parse",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "query_value",
+          "selector": "marker"
+        }
+      ]
+    },
+    {
+      "id": "bad-pass-count",
+      "errors": [
+        "bad_pass_count"
+      ],
+      "input_b64": "SGk=",
+      "want_error": "passes must",
+      "recipe": [
+        {
+          "kind": "percent_decode",
+          "passes": 0
+        }
+      ]
+    },
+    {
+      "id": "unknown-dlp",
+      "errors": [
+        "unknown_dlp_profile"
+      ],
+      "input_b64": "SGk=",
+      "want_error": "unknown DLP profile",
+      "recipe": [
+        {
+          "kind": "dlp_normalize",
+          "profile": "nope"
+        }
+      ]
+    },
+    {
+      "id": "invalid-hex",
+      "operations": [
+        "hex_decode"
+      ],
+      "errors": [
+        "invalid_hex"
+      ],
+      "input_b64": "eg==",
+      "want_error": "hex decode",
+      "recipe": [
+        {
+          "kind": "hex_decode"
+        }
+      ]
+    },
+    {
+      "id": "invalid-base32",
+      "operations": [
+        "base32_decode"
+      ],
+      "errors": [
+        "invalid_base32"
+      ],
+      "input_b64": "Kg==",
+      "want_error": "base32 decode",
+      "recipe": [
+        {
+          "kind": "base32_decode",
+          "decode_padding": true
+        }
+      ]
+    },
+    {
+      "id": "invalid-base64",
+      "operations": [
+        "base64_decode"
+      ],
+      "errors": [
+        "invalid_base64"
+      ],
+      "input_b64": "Kg==",
+      "want_error": "base64 decode",
+      "recipe": [
+        {
+          "kind": "base64_decode",
+          "decode_padding": true
+        }
+      ]
+    },
+    {
+      "id": "unknown-operation",
+      "errors": [
+        "unknown_operation"
+      ],
+      "input_b64": "SGk=",
+      "want_error": "unknown operation",
+      "recipe": [
+        {
+          "kind": "not_an_operation"
+        }
+      ]
+    },
+    {
+      "id": "control-selector",
+      "errors": [
+        "control_selector"
+      ],
+      "input_b64": "aHR0cHM6Ly9hcGkudmVuZG9yLmV4YW1wbGUvP21hcmtlcj1vaw==",
+      "want_error": "selector for url_component contains control character",
+      "recipe": [
+        {
+          "kind": "url_component",
+          "component": "query_value",
+          "selector": "marker\n"
+        }
+      ]
+    },
+    {
+      "id": "control-profile",
+      "errors": [
+        "control_profile"
+      ],
+      "input_b64": "SGk=",
+      "want_error": "profile for dlp_normalize contains control character",
+      "recipe": [
+        {
+          "kind": "dlp_normalize",
+          "profile": "pipelock-dlp-v1\t"
+        }
+      ]
+    },
+    {
+      "id": "noncanonical-hex",
+      "operations": [
+        "hex_decode"
+      ],
+      "errors": [
+        "noncanonical_hex"
+      ],
+      "input_b64": "NEE=",
+      "want_error": "hex decode: non-canonical encoding",
+      "recipe": [
+        {
+          "kind": "hex_decode"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This adds a normative specification, a typed transform-recipe language, an experimental unregistered proof schema, and a hostile conformance corpus for evidence provenance. It registers nothing, changes no production path, and advertises no capability.

Stacked on #1167 and retargets to main once that merges.

## Why a new shape rather than repairing the existing one

Three defects in the current `proxy_decision_with_spans` shape cannot be fixed in place.

The scanner emits byte offsets while the receipt documents rune offsets, so any wiring between them silently mis-indexes on non-ASCII content with no verifier-visible error. ASCII fixtures conceal it entirely.

The producer, the schema, and the reproducer speak three different view vocabularies. The scanner emits labels the schema does not accept, the verifier can reproduce only eight transforms, and every `dlp_normalized:*` suffix collapses to a single transform, losing path, query, and component semantics.

Per-match commitments leave everything around the match in the view unconstrained.

## The shape

Offsets are UTF-8 byte offsets into a named transformed view. There is no rune conversion. Instead the verifier rejects what a conversion would have silently corrupted: invalid UTF-8, an interval starting or ending inside a code point, negative or overflowing arithmetic, out-of-bounds intervals, and intervals that are unsorted, duplicated, or overlapping.

View labels are replaced by a typed recipe: an ordered sequence of typed operations with explicit parameters, so component selection, repeated query keys, and occurrence are unambiguous. Normalization data, decoding alphabets, padding behavior, maximum decode passes, invalid-input handling, and size limits are pinned by a transform-profile digest. One vocabulary, one implementation contract.

Commitments cover the complete transformed view as well as each match, and every preimage is length-framed and domain-separated, so reordering sources or matches, changing a recipe, or moving a match changes the commitment.

## The commitment stays keyed on purpose

The commitment key is never serialized into the receipt. Publishing an unkeyed digest of undisclosed content would create an offline oracle: an attacker holding a published receipt could confirm a guessed low-entropy secret. That property is preserved deliberately, and the specification says so rather than leaving it as an implementation accident.

## What this does not do

Nothing here is dispatchable. The schema is not in the payload registry, no payload kind changes maturity, and no production code emits any of it. Wiring a producer is separate work that depends on this specification existing first.

## Producer digests are reported honestly

A binary digest or ruleset digest inside a receipt is self-reported by the process that signed it. The specification requires a verifier to report these as attested but unchecked until it independently recomputes them against the artifacts, because a signature proves who asserted a digest and not which binary actually ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental evidence provenance support for tracking sources, transformed views, and matched intervals.
  * Added deterministic normalization recipes for URL extraction, decoding, text normalization, and character transformations.
  * Added cryptographic commitments to help verify transformed views and matches.

* **Documentation**
  * Added a specification covering provenance terminology, validation, verification states, and conformance requirements.

* **Tests**
  * Added comprehensive validation, transformation, commitment, and conformance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->