### PR TITLE
ci: retry externally terminated test shards and narrow build-failure detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,11 +110,18 @@ jobs:
           set -o pipefail
           set +e
           packages="$(python3 scripts/ci_test_packages.py --shard "$TEST_SHARD")" || exit $?
+          package_parallelism=2
+          if [ "$TEST_SHARD" = "proxy" ]; then
+            # The proxy shard has two race-instrumented packages. Running them
+            # sequentially lowers peak memory without serializing t.Parallel
+            # tests inside either package.
+            package_parallelism=1
+          fi
           # Public runners are 4 vCPU, and -race multiplies scheduler pressure.
           # Keep package and intra-package test fan-out below CPU count so
           # deadline/timer tests are not starved by the shard matrix.
           bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
-            go test -race -p=2 -parallel=2 -timeout=15m -count=1 -json \
+            go test -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \
             | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-oss.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-oss.json
@@ -159,11 +166,18 @@ jobs:
           set -o pipefail
           set +e
           packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
+          package_parallelism=2
+          if [ "$TEST_SHARD" = "proxy" ]; then
+            # The proxy shard has two race-instrumented packages. Running them
+            # sequentially lowers peak memory without serializing t.Parallel
+            # tests inside either package.
+            package_parallelism=1
+          fi
           # Public runners are 4 vCPU, and -race multiplies scheduler pressure.
           # Keep package and intra-package test fan-out below CPU count so
           # deadline/timer tests are not starved by the shard matrix.
           bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
-            go test -tags enterprise -race -p=2 -parallel=2 -timeout=15m -count=1 -coverprofile="coverage-${TEST_SHARD}.out" -json \
+            go test -tags enterprise -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -coverprofile="coverage-${TEST_SHARD}.out" -json \
             | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json
@@ -182,11 +196,18 @@ jobs:
           set -o pipefail
           set +e
           packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
+          package_parallelism=2
+          if [ "$TEST_SHARD" = "proxy" ]; then
+            # The proxy shard has two race-instrumented packages. Running them
+            # sequentially lowers peak memory without serializing t.Parallel
+            # tests inside either package.
+            package_parallelism=1
+          fi
           # Public runners are 4 vCPU, and -race multiplies scheduler pressure.
           # Keep package and intra-package test fan-out below CPU count so
           # deadline/timer tests are not starved by the shard matrix.
           bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
-            go test -tags enterprise -race -p=2 -parallel=2 -timeout=15m -count=1 -json \
+            go test -tags enterprise -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \
             | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
           test_status=$?
           python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ test-runtime-critical:
 
 # Test shards mirror CI (scripts/ci_test_packages.py): the three heavy packages
 # (proxy, scanner, mcp) plus three balanced rest shards. Their union is the same
-# package set as `make test`. Use these to reproduce one CI shard locally, or to
-# run the full suite in scoped chunks instead of the single monolithic
+# package set as `make test`. The proxy shard runs its two packages sequentially
+# to match CI's peak-memory cap. Use these to reproduce one CI shard locally, or
+# to run the full suite in scoped chunks instead of the single monolithic
 # `go test ./...` invocation that becomes a long pole if reused in one CI step.
 # `make test` stays the canonical full local run.
 TEST_SHARDS := proxy scanner mcp rest-0 rest-1 rest-2
@@ -58,12 +59,16 @@ FORCE:
 # Run one CI-equivalent OSS shard, e.g. `make test-shard-proxy`.
 test-shard-%: FORCE
 	packages=$$(python3 scripts/ci_test_packages.py --shard $*) || exit $$?; \
-	go test -race -p=2 -parallel=2 -count=1 -timeout=15m $$packages
+	package_parallelism=2; \
+	if [ "$*" = "proxy" ]; then package_parallelism=1; fi; \
+	go test -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages
 
 # Run one CI-equivalent enterprise shard, e.g. `make test-shard-enterprise-mcp`.
 test-shard-enterprise-%: FORCE
 	packages=$$(python3 scripts/ci_test_packages.py --tags enterprise --shard $*) || exit $$?; \
-	go test -tags enterprise -race -p=2 -parallel=2 -count=1 -timeout=15m $$packages
+	package_parallelism=2; \
+	if [ "$*" = "proxy" ]; then package_parallelism=1; fi; \
+	go test -tags enterprise -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages
 
 # Run every OSS shard sequentially: same coverage as `make test`, sharded and
 # labelled (serial to respect the local single-race-at-a-time constraint).
@@ -71,7 +76,9 @@ test-sharded:
 	@for shard in $(TEST_SHARDS); do \
 		echo "=== OSS test shard: $$shard ==="; \
 		packages=$$(python3 scripts/ci_test_packages.py --shard $$shard) || exit $$?; \
-		go test -race -p=2 -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
+		package_parallelism=2; \
+		if [ "$$shard" = "proxy" ]; then package_parallelism=1; fi; \
+		go test -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
 	done
 
 # Run every enterprise shard sequentially (mirrors the CI test-enterprise matrix).
@@ -79,7 +86,9 @@ test-sharded-enterprise:
 	@for shard in $(TEST_SHARDS); do \
 		echo "=== enterprise test shard: $$shard ==="; \
 		packages=$$(python3 scripts/ci_test_packages.py --tags enterprise --shard $$shard) || exit $$?; \
-		go test -tags enterprise -race -p=2 -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
+		package_parallelism=2; \
+		if [ "$$shard" = "proxy" ]; then package_parallelism=1; fi; \
+		go test -tags enterprise -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
 	done
 
 # test-replay-harness exercises the synthetic replay regression suite:

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -149,6 +149,9 @@ run_and_tee() {
   # waiting for tee, or an orphan could keep capture open indefinitely.
   if ! cleanup_process_group "$command_pid" "$pass_label"; then
     process_cleanup_failed=1
+    active_process_group=""
+    rm -f -- "$stdout_fifo" "$stderr_fifo"
+    return "$command_status"
   fi
   active_process_group=""
 

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -85,21 +85,21 @@ cleanup_process_group() {
     return 0
   fi
 
-  echo "PROCESS CLEANUP: ${pass_label} session ${process_group} still has live processes; sending TERM" >&2
+  echo "PROCESS CLEANUP: ${pass_label} process group ${process_group} still has live processes; sending TERM" >&2
   kill -TERM -- "-${process_group}" 2>/dev/null || true
   if wait_for_process_group_exit "$process_group" 3; then
-    echo "PROCESS CLEANUP: ${pass_label} session ${process_group} confirmed empty after TERM" >&2
+    echo "PROCESS CLEANUP: ${pass_label} process group ${process_group} confirmed empty after TERM" >&2
     return 0
   fi
 
-  echo "PROCESS CLEANUP: ${pass_label} session ${process_group} still has live processes after TERM grace period; sending KILL" >&2
+  echo "PROCESS CLEANUP: ${pass_label} process group ${process_group} still has live processes after TERM grace period; sending KILL" >&2
   kill -KILL -- "-${process_group}" 2>/dev/null || true
   if wait_for_process_group_exit "$process_group" 3; then
-    echo "PROCESS CLEANUP: ${pass_label} session ${process_group} confirmed empty after KILL" >&2
+    echo "PROCESS CLEANUP: ${pass_label} process group ${process_group} confirmed empty after KILL" >&2
     return 0
   fi
 
-  echo "ci-test-with-retry: refusing continuation because ${pass_label} session ${process_group} remained live after KILL" >&2
+  echo "ci-test-with-retry: refusing continuation because ${pass_label} process group ${process_group} remained live after KILL" >&2
   return 1
 }
 
@@ -145,7 +145,7 @@ run_and_tee() {
   local command_status=0
   wait "$command_pid" || command_status=$?
 
-  # Descendants can inherit the FIFO writers. Clean the whole session before
+  # Descendants can inherit the FIFO writers. Clean the process group before
   # waiting for tee, or an orphan could keep capture open indefinitely.
   if ! cleanup_process_group "$command_pid" "$pass_label"; then
     process_cleanup_failed=1
@@ -462,7 +462,7 @@ done
 failed_label="${failed_packages[*]:-${package_args[*]}}"
 if [ "$retry_kind" = "sigterm" ]; then
   incomplete_label="${incomplete_packages[*]}"
-  echo "PROCESS CLEANUP: first pass session ${first_process_group} confirmed empty before rerun; first-attempt stdout and stderr remain in the job log" >&2
+  echo "PROCESS CLEANUP: first pass process group ${first_process_group} confirmed empty before rerun; first-attempt stdout and stderr remain in the job log" >&2
   echo "SIGTERM RETRY RISK: GitHub Actions exposes no trusted in-step cause attribution; a passing rerun does not prove the first attempt had no unflushed failure. Repeated SIGTERM retries indicate unresolved runner-resource or test instability." >&2
   echo "INFRASTRUCTURE RETRY: first pass exited 143 during running test(s) before package(s) completed: ${incomplete_label}; rerunning ${retry_scope} once" >&2
 else

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -2,10 +2,13 @@
 # Copyright 2026 Josh Waldrep
 # SPDX-License-Identifier: Apache-2.0
 
-# Run one CI go-test shard once, then retry a starvation-looking failure or an
-# externally terminated incomplete run once. DATA RACE, test failures,
+# Run one CI go-test shard once, then retry a starvation-looking failure or a
+# narrowly classified incomplete SIGTERM run once. DATA RACE, test failures,
 # build/setup errors, and non-timeout panics fail closed because retrying those
 # away would hide the bugs this CI job exists to catch.
+#
+# Guarantee: any failure visible in captured output prevents retry; a passing
+# SIGTERM rerun does not prove the terminated attempt had no unflushed failure.
 set -euo pipefail
 
 usage() {
@@ -46,10 +49,11 @@ if [ "${#package_args[@]}" -eq 0 ]; then
 fi
 
 tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
 
 capture_failed=0
 process_cleanup_failed=0
+last_process_group=""
+active_process_group=""
 
 process_group_is_alive() {
   local process_group="$1"
@@ -99,6 +103,23 @@ cleanup_process_group() {
   return 1
 }
 
+cleanup_on_exit() {
+  local status=$?
+
+  trap - EXIT INT TERM
+  if [ -n "$active_process_group" ]; then
+    if ! cleanup_process_group "$active_process_group" "interrupted pass"; then
+      status=1
+    fi
+  fi
+  rm -rf "$tmpdir"
+  exit "$status"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 run_and_tee() {
   local pass_label="$1"
   local stdout_file="$2"
@@ -118,6 +139,8 @@ run_and_tee() {
   # flags. execvp keeps its PID as the session and process-group ID.
   python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' "$@" >"$stdout_fifo" 2>"$stderr_fifo" &
   local command_pid=$!
+  last_process_group="$command_pid"
+  active_process_group="$command_pid"
 
   local command_status=0
   wait "$command_pid" || command_status=$?
@@ -127,6 +150,7 @@ run_and_tee() {
   if ! cleanup_process_group "$command_pid" "$pass_label"; then
     process_cleanup_failed=1
   fi
+  active_process_group=""
 
   local stdout_tee_status=0
   local stderr_tee_status=0
@@ -205,8 +229,15 @@ PY
 has_incomplete_sigterm() {
   local command_status="$1"
   local output_file="$2"
+  local stderr_file="$3"
 
   if [ "$command_status" -ne 143 ]; then
+    return 1
+  fi
+  if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+    return 1
+  fi
+  if [ -s "$stderr_file" ]; then
     return 1
   fi
 
@@ -217,29 +248,39 @@ import sys
 
 test_failure_re = re.compile(r"^\s*--- FAIL:")
 package_failure_re = re.compile(r"^FAIL(?:\s|$)")
-truncated_failure_re = re.compile(
-    r'(?:--- FAIL:|"Action"\s*:\s*"fail"|(?:^|\\n)FAIL(?:\\[tnr]|\s|$))'
-)
+valid_actions = {"bench", "cont", "fail", "output", "pass", "pause", "run", "skip", "start"}
 started_packages = set()
 terminal_packages = set()
+saw_running_test = set()
 saw_failure = False
+saw_invalid_event = False
 
 with open(sys.argv[1], encoding="utf-8") as stream:
     for line in stream:
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
-            if truncated_failure_re.search(line):
-                saw_failure = True
+            saw_invalid_event = True
             continue
 
+        if not isinstance(event, dict):
+            saw_invalid_event = True
+            continue
         package = event.get("Package")
         action = event.get("Action")
-        if isinstance(package, str) and package:
-            if action == "start":
-                started_packages.add(package)
-            if action in {"pass", "fail", "skip"} and not event.get("Test"):
-                terminal_packages.add(package)
+        if (
+            not isinstance(package, str)
+            or not package
+            or action not in valid_actions
+        ):
+            saw_invalid_event = True
+            continue
+        if action == "start":
+            started_packages.add(package)
+        if action == "run" and isinstance(event.get("Test"), str) and event["Test"]:
+            saw_running_test.add(package)
+        if action in {"pass", "fail", "skip"} and not event.get("Test"):
+            terminal_packages.add(package)
         if action == "fail":
             saw_failure = True
 
@@ -253,7 +294,12 @@ with open(sys.argv[1], encoding="utf-8") as stream:
                 saw_failure = True
 
 incomplete_packages = sorted(started_packages - terminal_packages)
-if saw_failure or not incomplete_packages:
+if (
+    saw_failure
+    or saw_invalid_event
+    or not incomplete_packages
+    or not set(incomplete_packages) <= saw_running_test
+):
     raise SystemExit(1)
 
 for package in incomplete_packages:
@@ -325,6 +371,7 @@ first_stderr="$tmpdir/first.stderr"
 set +e
 run_and_tee "first pass" "$first_stdout" "$first_stderr" "$@" "${package_args[@]}"
 first_status=$?
+first_process_group="$last_process_group"
 set -e
 
 if [ "$capture_failed" -ne 0 ] || [ "$process_cleanup_failed" -ne 0 ]; then
@@ -375,11 +422,11 @@ PY
 else
   if [ "$first_status" -eq 143 ]; then
     incomplete_file="$tmpdir/incomplete-packages"
-    if has_incomplete_sigterm "$first_status" "$combined_first" >"$incomplete_file"; then
+    if has_incomplete_sigterm "$first_status" "$first_stdout" "$first_stderr" >"$incomplete_file"; then
       retry_kind="sigterm"
       mapfile -t incomplete_packages <"$incomplete_file"
     else
-      echo "ci-test-with-retry: refusing retry because SIGTERM output contained a failure or no incomplete package" >&2
+      echo "ci-test-with-retry: refusing retry because SIGTERM evidence was not strict, structured, failure-free GitHub Actions output from an interrupted running test" >&2
       exit "$first_status"
     fi
   else
@@ -414,7 +461,9 @@ done
 failed_label="${failed_packages[*]:-${package_args[*]}}"
 if [ "$retry_kind" = "sigterm" ]; then
   incomplete_label="${incomplete_packages[*]}"
-  echo "INFRASTRUCTURE RETRY: first pass was externally terminated by SIGTERM (exit 143) before package(s) completed: ${incomplete_label}; rerunning ${retry_scope} once" >&2
+  echo "PROCESS CLEANUP: first pass session ${first_process_group} confirmed empty before rerun; first-attempt stdout and stderr remain in the job log" >&2
+  echo "SIGTERM RETRY RISK: GitHub Actions exposes no trusted in-step cause attribution; a passing rerun does not prove the first attempt had no unflushed failure. Repeated SIGTERM retries indicate unresolved runner-resource or test instability." >&2
+  echo "INFRASTRUCTURE RETRY: first pass exited 143 during running test(s) before package(s) completed: ${incomplete_label}; rerunning ${retry_scope} once" >&2
 else
   echo "FLAKE RETRY: first pass failed for package(s): ${failed_label}; rerunning ${retry_scope} once" >&2
 fi
@@ -453,7 +502,7 @@ if [ "$retry_status" -eq 0 ]; then
     exit 1
   fi
   if [ "$retry_kind" = "sigterm" ]; then
-    echo "INFRASTRUCTURE RETRY: externally terminated shard passed on rerun; original incomplete package(s): ${incomplete_label}" >&2
+    echo "INFRASTRUCTURE RETRY: SIGTERM-interrupted shard passed on rerun with residual first-attempt uncertainty; original incomplete package(s): ${incomplete_label}" >&2
   else
     echo "FLAKE RETRY: package(s) ${failed_label} failed then passed on rerun" >&2
   fi
@@ -461,7 +510,7 @@ if [ "$retry_status" -eq 0 ]; then
 fi
 
 if [ "$retry_kind" = "sigterm" ]; then
-  echo "INFRASTRUCTURE RETRY: externally terminated shard failed on rerun; original incomplete package(s): ${incomplete_label}" >&2
+  echo "INFRASTRUCTURE RETRY: SIGTERM-interrupted shard failed on rerun; original incomplete package(s): ${incomplete_label}" >&2
 else
   echo "FLAKE RETRY: package(s) ${failed_label} failed again on rerun" >&2
 fi

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -49,11 +49,61 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 capture_failed=0
+process_cleanup_failed=0
+
+process_group_is_alive() {
+  local process_group="$1"
+
+  kill -0 -- "-${process_group}" 2>/dev/null
+}
+
+wait_for_process_group_exit() {
+  local process_group="$1"
+  local checks="$2"
+  local check=0
+
+  while [ "$check" -lt "$checks" ]; do
+    if ! process_group_is_alive "$process_group"; then
+      return 0
+    fi
+    sleep 1
+    check=$((check + 1))
+  done
+
+  ! process_group_is_alive "$process_group"
+}
+
+cleanup_process_group() {
+  local process_group="$1"
+  local pass_label="$2"
+
+  if ! process_group_is_alive "$process_group"; then
+    return 0
+  fi
+
+  echo "PROCESS CLEANUP: ${pass_label} session ${process_group} still has live processes; sending TERM" >&2
+  kill -TERM -- "-${process_group}" 2>/dev/null || true
+  if wait_for_process_group_exit "$process_group" 3; then
+    echo "PROCESS CLEANUP: ${pass_label} session ${process_group} confirmed empty after TERM" >&2
+    return 0
+  fi
+
+  echo "PROCESS CLEANUP: ${pass_label} session ${process_group} still has live processes after TERM grace period; sending KILL" >&2
+  kill -KILL -- "-${process_group}" 2>/dev/null || true
+  if wait_for_process_group_exit "$process_group" 3; then
+    echo "PROCESS CLEANUP: ${pass_label} session ${process_group} confirmed empty after KILL" >&2
+    return 0
+  fi
+
+  echo "ci-test-with-retry: refusing retry because ${pass_label} session ${process_group} remained live after KILL" >&2
+  return 1
+}
 
 run_and_tee() {
-  local stdout_file="$1"
-  local stderr_file="$2"
-  shift 2
+  local pass_label="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
 
   local stdout_fifo="${stdout_file}.fifo"
   local stderr_fifo="${stderr_file}.fifo"
@@ -64,8 +114,19 @@ run_and_tee() {
   tee "$stderr_file" <"$stderr_fifo" >&2 &
   local stderr_tee_pid=$!
 
-  "$@" >"$stdout_fifo" 2>"$stderr_fifo"
-  local command_status=$?
+  # Python creates a new session without relying on non-standard setsid(1)
+  # flags. execvp keeps its PID as the session and process-group ID.
+  python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' "$@" >"$stdout_fifo" 2>"$stderr_fifo" &
+  local command_pid=$!
+
+  local command_status=0
+  wait "$command_pid" || command_status=$?
+
+  # Descendants can inherit the FIFO writers. Clean the whole session before
+  # waiting for tee, or an orphan could keep capture open indefinitely.
+  if ! cleanup_process_group "$command_pid" "$pass_label"; then
+    process_cleanup_failed=1
+  fi
 
   local stdout_tee_status=0
   local stderr_tee_status=0
@@ -262,11 +323,11 @@ first_stdout="$tmpdir/first.stdout"
 first_stderr="$tmpdir/first.stderr"
 
 set +e
-run_and_tee "$first_stdout" "$first_stderr" "$@" "${package_args[@]}"
+run_and_tee "first pass" "$first_stdout" "$first_stderr" "$@" "${package_args[@]}"
 first_status=$?
 set -e
 
-if [ "$capture_failed" -ne 0 ]; then
+if [ "$capture_failed" -ne 0 ] || [ "$process_cleanup_failed" -ne 0 ]; then
   exit 1
 fi
 
@@ -367,11 +428,12 @@ fi
 
 set +e
 capture_failed=0
-run_and_tee "$retry_stdout" "$retry_stderr" "$@" "${retry_packages[@]}"
+process_cleanup_failed=0
+run_and_tee "retry pass" "$retry_stdout" "$retry_stderr" "$@" "${retry_packages[@]}"
 retry_status=$?
 set -e
 
-if [ "$capture_failed" -ne 0 ]; then
+if [ "$capture_failed" -ne 0 ] || [ "$process_cleanup_failed" -ne 0 ]; then
   exit 1
 fi
 

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -336,8 +336,17 @@ with open(sys.argv[1], encoding="utf-8") as stream:
         if event.get("Action") != "output" or event.get("Test"):
             continue
         output = event.get("Output")
-        if isinstance(output, str) and marker_re.search(output):
-            raise SystemExit(0)
+        if not isinstance(output, str):
+            continue
+        structured_build_context = False
+        for output_line in output.splitlines():
+            if output_line.startswith("# "):
+                structured_build_context = True
+            if (
+                (structured_build_context or raw_compiler_re.match(output_line))
+                and marker_re.search(output_line)
+            ):
+                raise SystemExit(0)
 
 raise SystemExit(1)
 PY

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -99,7 +99,7 @@ cleanup_process_group() {
     return 0
   fi
 
-  echo "ci-test-with-retry: refusing retry because ${pass_label} session ${process_group} remained live after KILL" >&2
+  echo "ci-test-with-retry: refusing continuation because ${pass_label} session ${process_group} remained live after KILL" >&2
   return 1
 }
 
@@ -443,6 +443,7 @@ if [ "${#retry_packages[@]}" -eq 0 ]; then
 fi
 
 coverage_profile=""
+first_coverage_profile=""
 cmd_args=("$@")
 for ((i = 0; i < ${#cmd_args[@]}; i++)); do
   arg="${cmd_args[$i]}"
@@ -472,7 +473,11 @@ retry_stdout="$tmpdir/retry.stdout"
 retry_stderr="$tmpdir/retry.stderr"
 
 if [ -n "$coverage_profile" ]; then
-  rm -f -- "$coverage_profile"
+  first_coverage_profile="${coverage_profile}.first-attempt"
+  if [ -e "$coverage_profile" ]; then
+    mv -f -- "$coverage_profile" "$first_coverage_profile"
+    echo "RETRY ARTIFACT: preserved first-attempt coverage at ${first_coverage_profile}" >&2
+  fi
 fi
 
 set +e

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -2,9 +2,10 @@
 # Copyright 2026 Josh Waldrep
 # SPDX-License-Identifier: Apache-2.0
 
-# Run one CI go-test shard once, then retry a starvation-looking failure once.
-# DATA RACE, build/setup errors, and non-timeout panics fail closed because
-# retrying those away would hide the bugs this CI job exists to catch.
+# Run one CI go-test shard once, then retry a starvation-looking failure or an
+# externally terminated incomplete run once. DATA RACE, test failures,
+# build/setup errors, and non-timeout panics fail closed because retrying those
+# away would hide the bugs this CI job exists to catch.
 set -euo pipefail
 
 usage() {
@@ -140,6 +141,101 @@ raise SystemExit(0 if verified else 1)
 PY
 }
 
+has_incomplete_sigterm() {
+  local command_status="$1"
+  local output_file="$2"
+
+  if [ "$command_status" -ne 143 ]; then
+    return 1
+  fi
+
+  python3 - "$output_file" <<'PY'
+import json
+import re
+import sys
+
+test_failure_re = re.compile(r"^\s*--- FAIL:")
+package_failure_re = re.compile(r"^FAIL(?:\s|$)")
+truncated_failure_re = re.compile(
+    r'(?:--- FAIL:|"Action"\s*:\s*"fail"|(?:^|\\n)FAIL(?:\\[tnr]|\s|$))'
+)
+started_packages = set()
+terminal_packages = set()
+saw_failure = False
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    for line in stream:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            if truncated_failure_re.search(line):
+                saw_failure = True
+            continue
+
+        package = event.get("Package")
+        action = event.get("Action")
+        if isinstance(package, str) and package:
+            if action == "start":
+                started_packages.add(package)
+            if action in {"pass", "fail", "skip"} and not event.get("Test"):
+                terminal_packages.add(package)
+        if action == "fail":
+            saw_failure = True
+
+        if action != "output":
+            continue
+        output = event.get("Output")
+        if not isinstance(output, str):
+            continue
+        for output_line in output.splitlines():
+            if test_failure_re.match(output_line) or package_failure_re.match(output_line):
+                saw_failure = True
+
+incomplete_packages = sorted(started_packages - terminal_packages)
+if saw_failure or not incomplete_packages:
+    raise SystemExit(1)
+
+for package in incomplete_packages:
+    print(package)
+PY
+}
+
+has_build_setup_failure() {
+  local output_file="$1"
+
+  python3 - "$output_file" <<'PY'
+import json
+import re
+import sys
+
+marker_re = re.compile(r"\b(?:build failed|cannot|undefined)\b", re.IGNORECASE)
+raw_compiler_re = re.compile(r"^(?:# \S+|\S+\.go:\d+(?::\d+)?:)")
+raw_build_context = False
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    for line in stream:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            if line.startswith("# "):
+                raw_build_context = True
+            if (
+                (raw_build_context or raw_compiler_re.match(line))
+                and marker_re.search(line)
+            ):
+                raise SystemExit(0)
+            continue
+        raw_build_context = False
+        if event.get("Action") != "output" or event.get("Test"):
+            continue
+        output = event.get("Output")
+        if isinstance(output, str) and marker_re.search(output):
+            raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+}
+
 refuse_forbidden_output() {
   local output_file="$1"
   local pass_label="$2"
@@ -149,7 +245,7 @@ refuse_forbidden_output() {
     return 0
   fi
 
-  if grep -Eiq '\b(build failed|cannot|undefined)\b' "$output_file"; then
+  if has_build_setup_failure "$output_file"; then
     echo "ci-test-with-retry: refusing retry because ${pass_label} looked like a build/setup failure" >&2
     return 0
   fi
@@ -185,13 +281,14 @@ if refuse_forbidden_output "$combined_first" "first pass"; then
   exit "$first_status"
 fi
 
-if ! has_go_test_timeout "$first_stdout"; then
-  echo "ci-test-with-retry: refusing retry because first pass was not a verified go test timeout" >&2
-  exit "$first_status"
-fi
+retry_kind=""
+failed_packages=()
+incomplete_packages=()
 
-mapfile -t failed_packages < <(
-  python3 - "$first_stdout" <<'PY'
+if has_go_test_timeout "$first_stdout"; then
+  retry_kind="timeout"
+  mapfile -t failed_packages < <(
+    python3 - "$first_stdout" <<'PY'
 import json
 import sys
 
@@ -213,7 +310,22 @@ with open(sys.argv[1], encoding="utf-8") as stream:
 for package in failed:
     print(package)
 PY
-)
+  )
+else
+  if [ "$first_status" -eq 143 ]; then
+    incomplete_file="$tmpdir/incomplete-packages"
+    if has_incomplete_sigterm "$first_status" "$combined_first" >"$incomplete_file"; then
+      retry_kind="sigterm"
+      mapfile -t incomplete_packages <"$incomplete_file"
+    else
+      echo "ci-test-with-retry: refusing retry because SIGTERM output contained a failure or no incomplete package" >&2
+      exit "$first_status"
+    fi
+  else
+    echo "ci-test-with-retry: refusing retry because first pass was not a verified go test timeout" >&2
+    exit "$first_status"
+  fi
+fi
 
 retry_packages=("${failed_packages[@]}")
 retry_scope="failed package(s)"
@@ -239,7 +351,12 @@ for ((i = 0; i < ${#cmd_args[@]}; i++)); do
 done
 
 failed_label="${failed_packages[*]:-${package_args[*]}}"
-echo "FLAKE RETRY: first pass failed for package(s): ${failed_label}; rerunning ${retry_scope} once" >&2
+if [ "$retry_kind" = "sigterm" ]; then
+  incomplete_label="${incomplete_packages[*]}"
+  echo "INFRASTRUCTURE RETRY: first pass was externally terminated by SIGTERM (exit 143) before package(s) completed: ${incomplete_label}; rerunning ${retry_scope} once" >&2
+else
+  echo "FLAKE RETRY: first pass failed for package(s): ${failed_label}; rerunning ${retry_scope} once" >&2
+fi
 
 retry_stdout="$tmpdir/retry.stdout"
 retry_stderr="$tmpdir/retry.stderr"
@@ -273,9 +390,17 @@ if [ "$retry_status" -eq 0 ]; then
     echo "ci-test-with-retry: refusing successful coverage retry because ${coverage_profile} was not recreated" >&2
     exit 1
   fi
-  echo "FLAKE RETRY: package(s) ${failed_label} failed then passed on rerun" >&2
+  if [ "$retry_kind" = "sigterm" ]; then
+    echo "INFRASTRUCTURE RETRY: externally terminated shard passed on rerun; original incomplete package(s): ${incomplete_label}" >&2
+  else
+    echo "FLAKE RETRY: package(s) ${failed_label} failed then passed on rerun" >&2
+  fi
   exit 0
 fi
 
-echo "FLAKE RETRY: package(s) ${failed_label} failed again on rerun" >&2
+if [ "$retry_kind" = "sigterm" ]; then
+  echo "INFRASTRUCTURE RETRY: externally terminated shard failed on rerun; original incomplete package(s): ${incomplete_label}" >&2
+else
+  echo "FLAKE RETRY: package(s) ${failed_label} failed again on rerun" >&2
+fi
 exit "$retry_status"

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -388,6 +388,83 @@ exit 0
         self.assertNotIn("RETRY RAN", result.stdout)
         self.assertNotIn("rerunning", result.stderr)
 
+    def test_cleanup_failure_abandons_fifo_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bash_env = tmp_path / "bash-env"
+            descendant_file = tmp_path / "descendant"
+            ready_file = tmp_path / "ready"
+            stdout_file = tmp_path / "stdout"
+            stderr_file = tmp_path / "stderr"
+            bash_env.write_text(
+                r'''kill() {
+  if [ "$1" = "-0" ]; then
+    return 0
+  fi
+  if [ "$1" = "-KILL" ] && [ "${2:-}" = "--" ]; then
+    return 0
+  fi
+  builtin kill "$@" 2>/dev/null || true
+}
+''',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["BASH_ENV"] = str(bash_env)
+            env["CI_RETRY_DESCENDANT"] = str(descendant_file)
+            env["CI_RETRY_READY"] = str(ready_file)
+            env["GITHUB_ACTIONS"] = "true"
+            cmd = [
+                "bash",
+                str(WRAPPER),
+                "--packages",
+                "example.com/p/pkg",
+                "--",
+                "bash",
+                "-c",
+                r'''
+python3 -c 'import os, signal, time; signal.signal(signal.SIGHUP, signal.SIG_IGN); signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["CI_RETRY_READY"], "w").close(); time.sleep(3600)' &
+echo "$!" >"${CI_RETRY_DESCENDANT:?}"
+while [ ! -e "${CI_RETRY_READY:?}" ]; do sleep 0.01; done
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
+kill -TERM "$$"
+''',
+                "fake-go",
+            ]
+
+            with stdout_file.open("w", encoding="utf-8") as stdout_stream, (
+                stderr_file.open("w", encoding="utf-8")
+            ) as stderr_stream:
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=ROOT,
+                    env=env,
+                    text=True,
+                    stdout=stdout_stream,
+                    stderr=stderr_stream,
+                )
+
+                def cleanup_processes() -> None:
+                    if descendant_file.exists():
+                        descendant_pid = int(
+                            descendant_file.read_text(encoding="utf-8")
+                        )
+                        try:
+                            os.kill(descendant_pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                    if process.poll() is None:
+                        process.kill()
+                    process.wait(timeout=5)
+
+                self.addCleanup(cleanup_processes)
+                returncode = process.wait(timeout=12)
+
+            stderr = stderr_file.read_text(encoding="utf-8")
+            self.assertNotEqual(returncode, 0, stderr)
+            self.assertIn("remained live after KILL", stderr)
+
     def test_sigterm_with_test_failure_is_not_retried(self) -> None:
         result = run_wrapper(
             r'''

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -53,7 +53,23 @@ def run_wrapper(
         )
 
 
+def terminate_and_reap(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.kill()
+    process.wait(timeout=5)
+
+
 class TestCiTestWithRetry(unittest.TestCase):
+    def test_process_cleanup_terminates_and_reaps_wrapper(self) -> None:
+        process = subprocess.Popen(
+            ["python3", "-c", "import time; time.sleep(3600)"],
+            cwd=ROOT,
+        )
+        self.addCleanup(process.wait, timeout=5)
+        terminate_and_reap(process)
+
+        self.assertIsNotNone(process.returncode)
+
     def test_wrapper_sigterm_cleans_active_process_group(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             state = Path(tmp) / "command-pid"
@@ -85,6 +101,7 @@ wait
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            self.addCleanup(terminate_and_reap, process)
             deadline = time.monotonic() + 5
             while not ready.exists():
                 if process.poll() is not None:
@@ -104,7 +121,7 @@ wait
 
             self.addCleanup(kill_command_group)
             process.send_signal(signal.SIGTERM)
-            stdout, stderr = process.communicate(timeout=10)
+            stdout, stderr = process.communicate(timeout=30)
 
             self.assertEqual(process.returncode, 143, stdout + stderr)
             with self.assertRaises(ProcessLookupError):

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -483,6 +483,7 @@ exit 0
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             bash_env = tmp_path / "bash-env"
+            command_pid_file = tmp_path / "command-pid"
             descendant_file = tmp_path / "descendant"
             ready_file = tmp_path / "ready"
             stdout_file = tmp_path / "stdout"
@@ -502,6 +503,7 @@ exit 0
             )
             env = os.environ.copy()
             env["BASH_ENV"] = str(bash_env)
+            env["CI_RETRY_COMMAND_PID"] = str(command_pid_file)
             env["CI_RETRY_DESCENDANT"] = str(descendant_file)
             env["CI_RETRY_READY"] = str(ready_file)
             env["GITHUB_ACTIONS"] = "true"
@@ -514,12 +516,10 @@ exit 0
                 "bash",
                 "-c",
                 r'''
+echo "$$" >"${CI_RETRY_COMMAND_PID:?}"
 python3 -c 'import os, signal, time; signal.signal(signal.SIGHUP, signal.SIG_IGN); signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["CI_RETRY_READY"], "w").close(); time.sleep(3600)' &
 echo "$!" >"${CI_RETRY_DESCENDANT:?}"
-while [ ! -e "${CI_RETRY_READY:?}" ]; do sleep 0.01; done
-printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
-printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
-kill -TERM "$$"
+wait
 ''',
                 "fake-go",
             ]
@@ -550,6 +550,16 @@ kill -TERM "$$"
                     process.wait(timeout=5)
 
                 self.addCleanup(cleanup_processes)
+                deadline = time.monotonic() + 5
+                while not ready_file.exists():
+                    if process.poll() is not None:
+                        self.fail("wrapper exited before the descendant became ready")
+                    if time.monotonic() >= deadline:
+                        self.fail("timed out waiting for the descendant to become ready")
+                    time.sleep(0.01)
+
+                command_pid = int(command_pid_file.read_text(encoding="utf-8"))
+                os.kill(command_pid, signal.SIGTERM)
                 returncode = process.wait(timeout=12)
 
             stderr = stderr_file.read_text(encoding="utf-8")

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -216,6 +216,23 @@ exit 1
         self.assertNotIn("looked like a build/setup failure", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
+    def test_package_output_with_cannot_is_not_misclassified_as_build_failure(
+        self,
+    ) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Output":"dial tcp: cannot assign requested address\n"}'
+printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":1}'
+exit 1
+'''
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("was not a verified go test timeout", result.stderr)
+        self.assertNotIn("looked like a build/setup failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
     def test_structured_build_failure_is_still_refused(self) -> None:
         result = run_wrapper(
             r'''

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -137,6 +137,150 @@ exit 0
         self.assertIn("was not a verified go test timeout", result.stderr)
         self.assertNotIn("FLAKE RETRY", result.stderr)
 
+    def test_assertion_message_with_cannot_is_not_misclassified_as_build_failure(
+        self,
+    ) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestPolicy","Output":"policy_test.go:42: cannot allow request\n"}'
+printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Test":"TestPolicy","Elapsed":1}'
+printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":1}'
+exit 1
+'''
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("was not a verified go test timeout", result.stderr)
+        self.assertNotIn("looked like a build/setup failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_structured_build_failure_is_still_refused(self) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Output":"pkg.go:42:2: undefined: missingSymbol\n"}'
+printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":1}'
+exit 1
+'''
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("looked like a build/setup failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_incomplete_sigterm_without_test_failure_retries_once(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestSlow","Output":"=== RUN   TestSlow\n"}'
+  kill -TERM "$$"
+fi
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("externally terminated by SIGTERM (exit 143)", result.stderr)
+        self.assertIn("externally terminated shard passed on rerun", result.stderr)
+
+    def test_sigterm_with_test_failure_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestPolicy","Output":"--- FAIL: TestPolicy (0.01s)\n"}'
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Test":"TestPolicy","Elapsed":1}'
+  kill -TERM "$$"
+fi
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_with_failing_package_line_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Output":"FAIL\texample.com/p/pkg\t1.00s\n"}'
+  kill -TERM "$$"
+fi
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_after_normal_package_completion_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+  exit 143
+fi
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("no incomplete package", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_after_skipped_package_completion_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"skip","Package":"example.com/p/pkg","Elapsed":1}'
+  exit 143
+fi
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("no incomplete package", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_with_truncated_failure_event_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg"'
+  exit 143
+fi
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
     def test_raw_timeout_lookalike_is_not_retried(self) -> None:
         result = run_wrapper(
             r'''

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -189,6 +189,71 @@ exit 0
         self.assertIn("externally terminated by SIGTERM (exit 143)", result.stderr)
         self.assertIn("externally terminated shard passed on rerun", result.stderr)
 
+    def test_sigterm_descendant_is_killed_before_retry(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+descendant_file="${state}.descendant"
+ready_file="${state}.ready"
+if [ ! -e "$state" ]; then
+  : >"$state"
+  DESCENDANT_READY="$ready_file" python3 -c 'import os, signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["DESCENDANT_READY"], "w").close(); time.sleep(3600)' </dev/null >/dev/null 2>&1 &
+  echo "$!" >"$descendant_file"
+  while [ ! -e "$ready_file" ]; do :; done
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestSlow","Output":"=== RUN   TestSlow\n"}'
+  kill -TERM "$$"
+fi
+descendant=$(cat "$descendant_file")
+if kill -0 "$descendant" 2>/dev/null; then
+  kill -KILL "$descendant" 2>/dev/null || true
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Test":"TestOverlap","Elapsed":1}'
+  exit 97
+fi
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+exit 0
+'''
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("sending KILL", result.stderr)
+        self.assertIn("confirmed empty after KILL", result.stderr)
+        self.assertNotIn("TestOverlap", result.stdout)
+
+    def test_cleanup_failure_refuses_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bash_env = Path(tmp) / "bash-env"
+            bash_env.write_text(
+                r'''kill() {
+  if [ "$1" = "-0" ]; then
+    return 0
+  fi
+  builtin kill "$@" 2>/dev/null || true
+}
+''',
+                encoding="utf-8",
+            )
+            result = run_wrapper(
+                r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestSlow","Output":"=== RUN   TestSlow\n"}'
+  kill -TERM "$$"
+fi
+printf '%s\n' 'RETRY RAN'
+exit 0
+''',
+                env_overrides={"BASH_ENV": str(bash_env)},
+            )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("remained live after KILL", result.stderr)
+        self.assertNotIn("RETRY RAN", result.stdout)
+        self.assertNotIn("rerunning", result.stderr)
+
     def test_sigterm_with_test_failure_is_not_retried(self) -> None:
         result = run_wrapper(
             r'''

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -27,6 +27,7 @@ def run_wrapper(
     with tempfile.TemporaryDirectory() as tmp:
         env = os.environ.copy()
         env["CI_RETRY_STATE"] = str(Path(tmp) / "state")
+        env["GITHUB_ACTIONS"] = "true"
         env.update(env_overrides or {})
         cmd = [
             "bash",
@@ -176,7 +177,7 @@ state=${CI_RETRY_STATE:?}
 if [ ! -e "$state" ]; then
   : >"$state"
   printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
-  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestSlow","Output":"=== RUN   TestSlow\n"}'
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
   kill -TERM "$$"
 fi
 printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
@@ -186,8 +187,10 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("externally terminated by SIGTERM (exit 143)", result.stderr)
-        self.assertIn("externally terminated shard passed on rerun", result.stderr)
+        self.assertIn("confirmed empty before rerun", result.stderr)
+        self.assertIn("first pass exited 143 during running test(s)", result.stderr)
+        self.assertIn("does not prove the first attempt", result.stderr)
+        self.assertIn("SIGTERM-interrupted shard passed on rerun", result.stderr)
 
     def test_sigterm_descendant_is_killed_before_retry(self) -> None:
         result = run_wrapper(
@@ -201,7 +204,7 @@ if [ ! -e "$state" ]; then
   echo "$!" >"$descendant_file"
   while [ ! -e "$ready_file" ]; do :; done
   printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
-  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestSlow","Output":"=== RUN   TestSlow\n"}'
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
   kill -TERM "$$"
 fi
 descendant=$(cat "$descendant_file")
@@ -220,6 +223,60 @@ exit 0
         self.assertIn("sending KILL", result.stderr)
         self.assertIn("confirmed empty after KILL", result.stderr)
         self.assertNotIn("TestOverlap", result.stdout)
+
+    def test_sigterm_outside_github_actions_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
+exit 143
+''',
+            env_overrides={"GITHUB_ACTIONS": ""},
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_with_unstructured_output_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
+printf '%s\n' 'unstructured output whose meaning is unknown'
+exit 143
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_with_stderr_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
+printf '%s\n' 'unattributed termination diagnostic' >&2
+exit 143
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
+
+    def test_sigterm_before_any_test_runs_is_not_retried(self) -> None:
+        result = run_wrapper(
+            r'''
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+exit 143
+'''
+        )
+
+        self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
+        self.assertNotIn("RETRY:", result.stderr)
 
     def test_cleanup_failure_refuses_retry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -271,7 +328,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
-        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
     def test_sigterm_with_failing_package_line_is_not_retried(self) -> None:
@@ -289,7 +346,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
-        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
     def test_sigterm_after_normal_package_completion_is_not_retried(self) -> None:
@@ -307,7 +364,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
-        self.assertIn("no incomplete package", result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
     def test_sigterm_after_skipped_package_completion_is_not_retried(self) -> None:
@@ -325,7 +382,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
-        self.assertIn("no incomplete package", result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
     def test_sigterm_with_truncated_failure_event_is_not_retried(self) -> None:
@@ -343,7 +400,7 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 143, result.stdout + result.stderr)
-        self.assertIn("SIGTERM output contained a failure", result.stderr)
+        self.assertIn("evidence was not strict", result.stderr)
         self.assertNotIn("RETRY:", result.stderr)
 
     def test_raw_timeout_lookalike_is_not_retried(self) -> None:

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -17,6 +17,40 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = ROOT / "scripts" / "ci-test-with-retry.sh"
+SIGTERM_DESCENDANT_SCRIPT = r'''
+state=${CI_RETRY_STATE:?}
+descendant_file="${state}.descendant"
+ready_file="${state}.ready"
+if [ ! -e "$state" ]; then
+  : >"$state"
+  if [ -n "${CI_RETRY_COMMAND_PID:-}" ]; then
+    echo "$$" >"$CI_RETRY_COMMAND_PID"
+  fi
+  DESCENDANT_READY="$ready_file" python3 -c 'import os, signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["DESCENDANT_READY"], "w").close(); time.sleep(3600)' </dev/null >/dev/null 2>&1 &
+  echo "$!" >"$descendant_file"
+  waited=0
+  while [ ! -e "$ready_file" ]; do
+    if [ "$waited" -ge 5 ]; then
+      echo "descendant never became ready" >&2
+      exit 98
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
+  kill -TERM "$$"
+fi
+descendant=$(cat "$descendant_file")
+if kill -0 "$descendant" 2>/dev/null; then
+  kill -KILL "$descendant" 2>/dev/null || true
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Test":"TestOverlap","Elapsed":1}'
+  exit 97
+fi
+printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+exit 0
+'''
 
 
 def run_wrapper(
@@ -287,36 +321,76 @@ exit 0
         self.assertIn("SIGTERM-interrupted shard passed on rerun", result.stderr)
 
     def test_sigterm_descendant_is_killed_before_retry(self) -> None:
-        result = run_wrapper(
-            r'''
-state=${CI_RETRY_STATE:?}
-descendant_file="${state}.descendant"
-ready_file="${state}.ready"
-if [ ! -e "$state" ]; then
-  : >"$state"
-  DESCENDANT_READY="$ready_file" python3 -c 'import os, signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["DESCENDANT_READY"], "w").close(); time.sleep(3600)' </dev/null >/dev/null 2>&1 &
-  echo "$!" >"$descendant_file"
-  while [ ! -e "$ready_file" ]; do :; done
-  printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
-  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestSlow"}'
-  kill -TERM "$$"
-fi
-descendant=$(cat "$descendant_file")
-if kill -0 "$descendant" 2>/dev/null; then
-  kill -KILL "$descendant" 2>/dev/null || true
-  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Test":"TestOverlap","Elapsed":1}'
-  exit 97
-fi
-printf '%s\n' '{"Action":"start","Package":"example.com/p/pkg"}'
-printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
-exit 0
-'''
-        )
+        result = run_wrapper(SIGTERM_DESCENDANT_SCRIPT)
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("sending KILL", result.stderr)
         self.assertIn("confirmed empty after KILL", result.stderr)
         self.assertNotIn("TestOverlap", result.stdout)
+
+    def test_sigterm_descendant_readiness_failure_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            bash_env = tmp_path / "bash-env"
+            command_pid_file = tmp_path / "command-pid"
+            stdout_file = tmp_path / "stdout"
+            stderr_file = tmp_path / "stderr"
+            bash_env.write_text(
+                r'''python3() {
+  if [ -n "${DESCENDANT_READY:-}" ]; then
+    return 1
+  fi
+  command python3 "$@"
+}
+''',
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["BASH_ENV"] = str(bash_env)
+            env["CI_RETRY_STATE"] = str(tmp_path / "state")
+            env["CI_RETRY_COMMAND_PID"] = str(command_pid_file)
+            env["GITHUB_ACTIONS"] = "true"
+            cmd = [
+                "bash",
+                str(WRAPPER),
+                "--packages",
+                "example.com/p/pkg",
+                "--",
+                "bash",
+                "-c",
+                SIGTERM_DESCENDANT_SCRIPT,
+                "fake-go",
+            ]
+
+            with stdout_file.open("w", encoding="utf-8") as stdout_stream, (
+                stderr_file.open("w", encoding="utf-8")
+            ) as stderr_stream:
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=ROOT,
+                    env=env,
+                    text=True,
+                    stdout=stdout_stream,
+                    stderr=stderr_stream,
+                )
+
+                def cleanup_processes() -> None:
+                    if command_pid_file.exists():
+                        command_pid = int(
+                            command_pid_file.read_text(encoding="utf-8")
+                        )
+                        try:
+                            os.killpg(command_pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                    terminate_and_reap(process)
+
+                self.addCleanup(cleanup_processes)
+                returncode = process.wait(timeout=12)
+
+            stderr = stderr_file.read_text(encoding="utf-8")
+            self.assertEqual(returncode, 98, stderr)
+            self.assertIn("descendant never became ready", stderr)
 
     def test_sigterm_outside_github_actions_is_not_retried(self) -> None:
         result = run_wrapper(

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -560,6 +560,34 @@ exit 0
         self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("coverage retry", result.stderr)
 
+    def test_coverage_retry_preserves_first_attempt_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            coverage = Path(tmp) / "coverage.out"
+            first_coverage = Path(f"{coverage}.first-attempt")
+            result = run_wrapper(
+                rf'''
+state=${{CI_RETRY_STATE:?}}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf 'mode: first\n' >{str(coverage)!r}
+  printf '%s\n' '{{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"panic: test timed out after 15m0s\n"}}'
+  printf '%s\n' '{{"Action":"fail","Package":"example.com/p/pkg","Elapsed":1}}'
+  exit 1
+fi
+printf 'mode: retry\n' >{str(coverage)!r}
+printf '%s\n' '{{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}}'
+exit 0
+''',
+                args=[f"-coverprofile={coverage}"],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(coverage.read_text(encoding="utf-8"), "mode: retry\n")
+            self.assertEqual(
+                first_coverage.read_text(encoding="utf-8"), "mode: first\n"
+            )
+            self.assertIn(str(first_coverage), result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import os
+import signal
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -52,6 +54,64 @@ def run_wrapper(
 
 
 class TestCiTestWithRetry(unittest.TestCase):
+    def test_wrapper_sigterm_cleans_active_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = Path(tmp) / "command-pid"
+            ready = Path(tmp) / "descendant-ready"
+            env = os.environ.copy()
+            env["CI_RETRY_STATE"] = str(state)
+            env["CI_RETRY_READY"] = str(ready)
+            env["GITHUB_ACTIONS"] = "true"
+            cmd = [
+                "bash",
+                str(WRAPPER),
+                "--packages",
+                "example.com/p/pkg",
+                "--",
+                "bash",
+                "-c",
+                r'''
+echo "$$" >"${CI_RETRY_STATE:?}"
+python3 -c 'import os, signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); open(os.environ["CI_RETRY_READY"], "w").close(); time.sleep(3600)' &
+wait
+''',
+                "fake-go",
+            ]
+            process = subprocess.Popen(
+                cmd,
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            deadline = time.monotonic() + 5
+            while not ready.exists():
+                if process.poll() is not None:
+                    self.fail("wrapper exited before the command process started")
+                if time.monotonic() >= deadline:
+                    process.kill()
+                    self.fail("timed out waiting for the command process to start")
+                time.sleep(0.01)
+
+            command_pid = int(state.read_text(encoding="utf-8"))
+
+            def kill_command_group() -> None:
+                try:
+                    os.killpg(command_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+            self.addCleanup(kill_command_group)
+            process.send_signal(signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=10)
+
+            self.assertEqual(process.returncode, 143, stdout + stderr)
+            with self.assertRaises(ProcessLookupError):
+                os.killpg(command_pid, 0)
+            self.assertIn("interrupted pass", stderr)
+            self.assertIn("confirmed empty after KILL", stderr)
+
     def test_waits_for_capture_before_inspecting_race_output(self) -> None:
         real_tee = shutil.which("tee")
         self.assertIsNotNone(real_tee)


### PR DESCRIPTION
## What changed

A test shard was killed mid run and the pull request stayed red until a human re-ran it by hand. The job emitted one passing package line, then `Terminated`, then exited 143 after about eight and a half minutes against a fifteen minute test timeout, with no failing test anywhere in its output. Three sibling shards of the same package passed, and the package passed locally under the race detector on the identical commit, so nothing was wrong with the code.

The retry wrapper could not help, by design: it retries only a verified test timeout, so that a genuine failure is never retried away. An externally terminated shard matched no condition, so it was never retried, and its coverage was never uploaded, which can also fail the coverage check on data that has nothing to do with the change under review.

## The fix, in two layers

The primary change reduces the pressure that caused the kill: the two race instrumented packages in that shard now run sequentially rather than concurrently, while keeping the same in-package parallelism.

The backstop retries an exit 143 exactly once, and only when a package started but never reported a terminal result, and the captured output contains no failing test, no failing package, no data race, no build or setup failure, and no panic other than a timeout. Every form of visible failure blocks the retry, including a truncated failure event. Exit 143 on its own is not sufficient, because a command can return it after completing normally or alongside a real failure.

What this can and cannot promise is worth stating plainly. No finite rule can prove a failure never existed in a process that was killed before it could report. The guarantee here is narrower and checkable: no failure visible in the captured output can be swallowed.

Retries announce themselves before and after the rerun, so a resource problem that keeps recurring stays visible instead of being quietly absorbed.

## A separate defect found while in here

The build failure detector matched the bare word `cannot` anywhere in the combined output. That word is common inside ordinary Go error strings and assertion messages, so a plain test failure whose message contained it was misclassified as a build or setup problem. Detection is now limited to compiler and package level output, with a test proving genuine build failures are still caught.

## Coverage

A coverage bearing retry deletes the partial profile, reruns the whole shard, and requires a fresh non empty profile before uploading. If the retry also dies there is no trustworthy coverage to upload. Preventing the coverage service from scoring an incomplete aggregate needs configuration on its side and is not addressed here.

## Verification

The retry decision is tested against each case directly: a real test failure must not retry, a verified timeout must retry, a signal kill with no failure must retry, and a signal kill alongside a failure must not. Neutralising the new predicate flips the positive case back to a red exit, which is how it was confirmed to be doing the work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration test execution by adjusting parallelism for proxy-related test shards.
  * Enhanced test retries with safer process cleanup, clearer failure classification, and better handling of interrupted test runs.
  * Preserved coverage results from initial test attempts for more reliable diagnostics.

* **Tests**
  * Expanded automated coverage for retry behavior, timeout validation, process cleanup, race detection, and coverage preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->