### PR TITLE
feat(guard): explain path decisions and fix a component floor bypass

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -5,6 +5,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 
 | Command | Purpose |
 |---|---|
+| [`pipelock guard`](guard.md) | Explain unenforced guard path declarations and immutable compiled-floor refusals. |
 | [`pipelock baseline`](baseline.md) | Inspect, ratify, and relearn behavioral-baseline profiles through the admin API. |
 | [`pipelock demo`](demo.md) | Run self-contained attack scenarios that show what Pipelock catches. |
 | [`pipelock status`](operator.md) | Read-only operator setup and local inspection commands. |

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -1,0 +1,128 @@
+# `pipelock guard`
+
+`pipelock guard` provides read-only inspection of filesystem guard declarations
+and the compiled validation floor.
+
+> **Guard is not enforced in this build.** These commands describe what the
+> configuration declares and what the compiled floor refuses, but no workload
+> is constrained. Both human and JSON output carry this warning.
+
+The commands deliberately separate two policy layers:
+
+- **Compiled floor:** built into Pipelock and cannot be configured away. It
+  refuses case-folded credential-directory components, whole homes and roots
+  above all homes, home-relative and absolute credential shapes, renamed
+  credential copies, and Pipelock credential/state locations. The write floor
+  additionally refuses autostart and persistence locations, executable search
+  paths, privilege paths, system libraries, boot artifacts, and runtime/socket
+  roots.
+- **Operator-declared grants:** exact file paths in `read_only` and
+  `read_write`, plus explicit subtree grants in `read_only_directories` and
+  `read_write_directories`. A profile makes a manifest effective by selecting
+  it.
+
+Plain `read_only` and `read_write` entries are file grants and match only the
+declared path. The `_directories` lists are directory grants and cover the
+declared path plus its subtree. The commands do not expand wildcards, infer a
+type from the filesystem, or treat an unselected manifest as effective.
+
+## Explain one path
+
+```sh
+pipelock guard explain --config pipelock.yaml /opt/app/config.yaml
+pipelock guard explain --config pipelock.yaml --json /usr/bin/helper
+```
+
+`guard explain <absolute-path>` reports separate READ and WRITE declaration
+verdicts across all declared profiles. For each operation it names the deciding
+source and rule:
+
+- `compiled_floor`: the floor refuses the operation. The report includes the
+  specific rule, matched component/path shape/root, and a statement that the
+  refusal cannot be configured away.
+- `operator_declared`: at least one selected manifest contains an exact file
+  grant or covering directory grant. The report names the manifest, declared
+  type, scope, and selecting profiles.
+- `none`: no selected manifest contains a covering grant. Matching declarations
+  in orphaned manifests are listed but do not become effective.
+
+The compiled floor wins over an operator declaration. For example, a selected
+`read_write: [/usr/bin/helper]` entry is still reported as a WRITE floor refusal
+because operator configuration cannot widen the compiled boundary.
+
+Path-floor evaluation uses the same helper as config validation, including its
+existing symlink-resolution behavior. Grant matching is lexical: file grants
+are exact and directory grants use path-component subtree boundaries. It never
+probes the filesystem to infer a type.
+
+## Show a profile
+
+```sh
+pipelock guard show --config pipelock.yaml worker
+pipelock guard show --config pipelock.yaml --json worker
+```
+
+`guard show <profile>` resolves the profile's manifest references in declared
+order. It prints every grant with its declared type (all four manifest lists),
+scope (`file` or `directory`), original path, resolved path, and every
+compiled-floor refusal that applies. Read-write grants are checked for both
+read and write; read-only grants are checked for read.
+
+Unlike normal config loading—which correctly refuses all non-empty guard
+sections while enforcement is absent—these inspection commands retain a
+floor-refused path long enough to explain the refusal. All other structural
+validation still applies, including strict YAML fields, required and unique
+names, absolute paths, valid manifest references, file-versus-directory
+declarations, and case-folded conflicts across all four path lists.
+
+## Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--config`, `-c` | built-in defaults | Config file to inspect. The file is parsed strictly without resolving unrelated runtime credential files. |
+| `--json` | `false` | Emit the stable JSON shape described below. Available on both subcommands. |
+
+Both commands are read-only. They do not write config or state, contact the
+proxy, create filesystem entries, or alter enforcement.
+
+## JSON shape
+
+Both reports start with these stable fields:
+
+```json
+{
+  "schema_version": "1",
+  "command": "explain",
+  "enforced": false,
+  "enforcement_notice": "Guard is not enforced in this build. These results describe declarations and the compiled validation floor only; no workload is constrained.",
+  "config_file": "pipelock.yaml"
+}
+```
+
+`guard explain --json` adds:
+
+- `scope`: currently `all_declared_profiles`.
+- `path` and `resolved_path`.
+- `read` and `write`, each containing `operation`, `would_be_allowed`,
+  `source`, `rule`, `matched`, `reason`, `configurable`, and `grants`.
+- Each `grants` entry contains `manifest`, `grant_type`, `scope`, `path`,
+  `profiles`, and `effective`.
+
+`guard show --json` adds:
+
+- `profile`.
+- `manifests`, each containing `name` and `grants`.
+- Each grant contains `grant_type`, `scope`, `path`, `resolved_path`, and
+  `floor_refusals`.
+- Each floor refusal contains `operation`, `rule`, `matched`, and `reason`.
+
+Array fields are always arrays (`[]` when empty), never `null`. Consumers should
+key compatibility on `schema_version`.
+
+## Exit behavior
+
+A reported floor refusal or missing declaration is an explanation, so the
+command exits 0 after producing the report. Invalid arguments, an unreadable or
+malformed config, an invalid guard structure, or an unknown profile return a
+configuration/usage error. Do not interpret exit 0 as evidence of enforcement;
+check the mandatory `enforced` field, which is `false` in this build.

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -51,7 +51,10 @@ The compiled floor wins over an operator declaration. For example, a selected
 because operator configuration cannot widen the compiled boundary.
 
 Path-floor evaluation uses the same helper as config validation, including its
-existing symlink-resolution behavior. Grant matching is lexical: file grants
+existing symlink-resolution behavior. The forbidden-component check applies to
+the declared spelling as well as the resolved target, so a path declared as a
+credential or key directory is refused even when the link resolves somewhere
+innocuous. Grant matching is lexical: file grants
 are exact and directory grants use path-component subtree boundaries. It never
 probes the filesystem to infer a type.
 

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -414,12 +415,45 @@ func writeHuman(w io.Writer, body string) error {
 	return nil
 }
 
+// display renders an untrusted value for HUMAN output.
+//
+// Paths, manifest names and profile names come from an operator's config or
+// from a caller's argument, and this command's output is read as evidence. A
+// value carrying a newline can forge an extra report line, and one carrying a
+// terminal escape can move the cursor or recolour the screen, which is enough
+// to hide the "not enforced" warning that every one of these reports is
+// required to show. Quoting escapes both, and non-ASCII besides, so a
+// look-alike path cannot be passed off as a different one.
+//
+// JSON output does not need this; encoding/json already escapes controls.
+func display(value string) string {
+	return strconv.QuoteToASCII(value)
+}
+
+// displayText renders untrusted PROSE for human output.
+//
+// A reason embeds the operator's raw path, so it can carry a newline that
+// forges an extra report line or an escape sequence that repositions the
+// cursor. Quoting a whole sentence would be unreadable, so control characters
+// are replaced instead and the wording is left intact.
+func displayText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return ' '
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, value)
+}
+
 func renderExplain(report explainReport) string {
 	var out strings.Builder
 	_, _ = fmt.Fprintf(&out, "WARNING: %s\n\n", report.EnforcementNotice)
-	_, _ = fmt.Fprintf(&out, "Guard path explanation\nConfig: %s\nScope: all declared profiles\nPath: %s\n", report.ConfigFile, report.Path)
+	_, _ = fmt.Fprintf(&out, "Guard path explanation\nConfig: %s\nScope: all declared profiles\nPath: %s\n", display(report.ConfigFile), display(report.Path))
 	if report.ResolvedPath != report.Path {
-		_, _ = fmt.Fprintf(&out, "Resolved path: %s\n", report.ResolvedPath)
+		_, _ = fmt.Fprintf(&out, "Resolved path: %s\n", display(report.ResolvedPath))
 	}
 	renderAccess(&out, report.Read)
 	renderAccess(&out, report.Write)
@@ -430,20 +464,20 @@ func renderAccess(out *strings.Builder, decision accessDecision) {
 	_, _ = fmt.Fprintf(out, "\n%s: ", strings.ToUpper(decision.Operation))
 	switch decision.Source {
 	case "compiled_floor":
-		_, _ = fmt.Fprintf(out, "WOULD BE REFUSED BY COMPILED FLOOR (not currently enforced)\n  Rule: %s\n  Matched: %s\n  Reason: %s\n  This compiled-floor refusal cannot be configured away.\n", decision.Rule, decision.Matched, decision.Reason)
+		_, _ = fmt.Fprintf(out, "WOULD BE REFUSED BY COMPILED FLOOR (not currently enforced)\n  Rule: %s\n  Matched: %s\n  Reason: %s\n  This compiled-floor refusal cannot be configured away.\n", decision.Rule, display(decision.Matched), displayText(decision.Reason))
 	case "operator_declared":
 		_, _ = fmt.Fprintln(out, "DECLARED ALLOW (not currently enforced)")
 		for _, grant := range decision.Grants {
 			if grant.Effective {
-				_, _ = fmt.Fprintf(out, "  %s.%s %s %s (profiles: %s)\n", grant.Manifest, grant.GrantType, grantScopeLabel(grant.Scope), grant.Path, strings.Join(grant.Profiles, ", "))
+				_, _ = fmt.Fprintf(out, "  %s.%s %s %s (profiles: %s)\n", display(grant.Manifest), grant.GrantType, grantScopeLabel(grant.Scope), display(grant.Path), displayText(strings.Join(grant.Profiles, ", ")))
 			}
 		}
 	default:
-		_, _ = fmt.Fprintf(out, "NO DECLARED GRANT (not currently enforced)\n  Rule: %s\n  Reason: %s\n", decision.Rule, decision.Reason)
+		_, _ = fmt.Fprintf(out, "NO DECLARED GRANT (not currently enforced)\n  Rule: %s\n  Reason: %s\n", decision.Rule, displayText(decision.Reason))
 	}
 	for _, grant := range decision.Grants {
 		if !grant.Effective {
-			_, _ = fmt.Fprintf(out, "  Unselected declaration: %s.%s %s %s (no profile selects this manifest)\n", grant.Manifest, grant.GrantType, grantScopeLabel(grant.Scope), grant.Path)
+			_, _ = fmt.Fprintf(out, "  Unselected declaration: %s.%s %s %s (no profile selects this manifest)\n", display(grant.Manifest), grant.GrantType, grantScopeLabel(grant.Scope), display(grant.Path))
 		}
 	}
 }
@@ -458,28 +492,28 @@ func grantScopeLabel(scope string) string {
 func renderShow(report showReport) string {
 	var out strings.Builder
 	_, _ = fmt.Fprintf(&out, "WARNING: %s\n\n", report.EnforcementNotice)
-	_, _ = fmt.Fprintf(&out, "Guard profile: %s\nConfig: %s\n", report.Profile, report.ConfigFile)
+	_, _ = fmt.Fprintf(&out, "Guard profile: %s\nConfig: %s\n", display(report.Profile), display(report.ConfigFile))
 	if len(report.Manifests) == 0 {
 		_, _ = fmt.Fprintln(&out, "Manifests: none")
 		return out.String()
 	}
 	for _, manifest := range report.Manifests {
-		_, _ = fmt.Fprintf(&out, "\nManifest: %s\n", manifest.Name)
+		_, _ = fmt.Fprintf(&out, "\nManifest: %s\n", display(manifest.Name))
 		if len(manifest.Grants) == 0 {
 			_, _ = fmt.Fprintln(&out, "  Grants: none")
 			continue
 		}
 		for _, grant := range manifest.Grants {
-			_, _ = fmt.Fprintf(&out, "  - %s %s: %s\n", grant.GrantType, grant.Scope, grant.Path)
+			_, _ = fmt.Fprintf(&out, "  - %s %s: %s\n", grant.GrantType, grant.Scope, display(grant.Path))
 			if grant.ResolvedPath != grant.Path {
-				_, _ = fmt.Fprintf(&out, "    resolved: %s\n", grant.ResolvedPath)
+				_, _ = fmt.Fprintf(&out, "    resolved: %s\n", display(grant.ResolvedPath))
 			}
 			if len(grant.Refusals) == 0 {
 				_, _ = fmt.Fprintln(&out, "    compiled floor: no refusal")
 				continue
 			}
 			for _, refusal := range grant.Refusals {
-				_, _ = fmt.Fprintf(&out, "    %s COMPILED FLOOR REFUSAL: rule=%s matched=%s\n      %s\n      This refusal cannot be configured away.\n", strings.ToUpper(refusal.Operation), refusal.Rule, refusal.Matched, refusal.Reason)
+				_, _ = fmt.Fprintf(&out, "    %s COMPILED FLOOR REFUSAL: rule=%s matched=%s\n      %s\n      This refusal cannot be configured away.\n", strings.ToUpper(refusal.Operation), refusal.Rule, display(refusal.Matched), displayText(refusal.Reason))
 			}
 		}
 	}

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -1,0 +1,487 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package guard implements read-only inspection of guard declarations and the
+// compiled filesystem floor. Guard is not enforced in this build.
+package guard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	reportSchemaVersion = "1"
+	defaultConfigLabel  = "(built-in defaults)"
+	enforcementNotice   = "Guard is not enforced in this build. These results describe declarations and the compiled validation floor only; no workload is constrained."
+)
+
+type commandOptions struct {
+	configFile string
+}
+
+type reportHeader struct {
+	SchemaVersion     string `json:"schema_version"`
+	Command           string `json:"command"`
+	Enforced          bool   `json:"enforced"`
+	EnforcementNotice string `json:"enforcement_notice"`
+	ConfigFile        string `json:"config_file"`
+}
+
+type grantMatch struct {
+	Manifest  string   `json:"manifest"`
+	GrantType string   `json:"grant_type"`
+	Scope     string   `json:"scope"`
+	Path      string   `json:"path"`
+	Profiles  []string `json:"profiles"`
+	Effective bool     `json:"effective"`
+}
+
+type accessDecision struct {
+	Operation      string       `json:"operation"`
+	WouldBeAllowed bool         `json:"would_be_allowed"`
+	Source         string       `json:"source"`
+	Rule           string       `json:"rule"`
+	Matched        string       `json:"matched"`
+	Reason         string       `json:"reason"`
+	Configurable   bool         `json:"configurable"`
+	Grants         []grantMatch `json:"grants"`
+}
+
+type explainReport struct {
+	reportHeader
+	Scope        string         `json:"scope"`
+	Path         string         `json:"path"`
+	ResolvedPath string         `json:"resolved_path"`
+	Read         accessDecision `json:"read"`
+	Write        accessDecision `json:"write"`
+}
+
+type floorRefusal struct {
+	Operation string `json:"operation"`
+	Rule      string `json:"rule"`
+	Matched   string `json:"matched"`
+	Reason    string `json:"reason"`
+}
+
+type grantReport struct {
+	GrantType    string         `json:"grant_type"`
+	Scope        string         `json:"scope"`
+	Path         string         `json:"path"`
+	ResolvedPath string         `json:"resolved_path"`
+	Refusals     []floorRefusal `json:"floor_refusals"`
+}
+
+type manifestReport struct {
+	Name   string        `json:"name"`
+	Grants []grantReport `json:"grants"`
+}
+
+type showReport struct {
+	reportHeader
+	Profile   string           `json:"profile"`
+	Manifests []manifestReport `json:"manifests"`
+}
+
+// Cmd returns the parent `pipelock guard` command.
+func Cmd() *cobra.Command {
+	opts := &commandOptions{}
+	cmd := &cobra.Command{
+		Use:          "guard",
+		Short:        "Inspect unenforced guard declarations and the compiled floor",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.PersistentFlags().StringVarP(&opts.configFile, "config", "c", "", "config file path (default: built-in defaults)")
+	cmd.AddCommand(explainCmd(opts), showCmd(opts))
+	return cmd
+}
+
+func explainCmd(opts *commandOptions) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "explain <absolute-path>",
+		Short: "Explain read and write declarations and compiled-floor refusals",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, label, err := loadConfig(opts.configFile)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			report, err := buildExplainReport(cfg, label, args[0])
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			if jsonOutput {
+				return writeJSON(cmd.OutOrStdout(), "guard explain", report)
+			}
+			return writeHuman(cmd.OutOrStdout(), renderExplain(report))
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
+	return cmd
+}
+
+func showCmd(opts *commandOptions) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "show <profile>",
+		Short: "Show a profile's resolved manifests, grants, and floor refusals",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, label, err := loadConfig(opts.configFile)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			report, err := buildShowReport(cfg, label, args[0])
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			if jsonOutput {
+				return writeJSON(cmd.OutOrStdout(), "guard show", report)
+			}
+			return writeHuman(cmd.OutOrStdout(), renderShow(report))
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
+	return cmd
+}
+
+func loadConfig(path string) (*config.Config, string, error) {
+	if path == "" {
+		cfg := config.Defaults()
+		if err := cfg.ValidateGuardStructure(); err != nil {
+			return nil, "", fmt.Errorf("validating built-in guard declaration: %w", err)
+		}
+		return cfg, defaultConfigLabel, nil
+	}
+	cfg, err := config.LoadForInspection(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading config %q for guard inspection: %w", path, err)
+	}
+	if err := cfg.ValidateGuardStructure(); err != nil {
+		return nil, "", fmt.Errorf("invalid guard declaration: %w", err)
+	}
+	return cfg, path, nil
+}
+
+func newHeader(command, configFile string) reportHeader {
+	return reportHeader{
+		SchemaVersion:     reportSchemaVersion,
+		Command:           command,
+		Enforced:          false,
+		EnforcementNotice: enforcementNotice,
+		ConfigFile:        configFile,
+	}
+}
+
+func buildExplainReport(cfg *config.Config, configFile, path string) (explainReport, error) {
+	readFloor, err := config.ExplainGuardPathFloor(path, config.GuardAccessRead)
+	if err != nil {
+		return explainReport{}, fmt.Errorf("explaining read access: %w", err)
+	}
+	writeFloor, err := config.ExplainGuardPathFloor(path, config.GuardAccessWrite)
+	if err != nil {
+		return explainReport{}, fmt.Errorf("explaining write access: %w", err)
+	}
+	if readFloor.ResolvedPath != writeFloor.ResolvedPath {
+		return explainReport{}, fmt.Errorf("path resolution changed while inspecting %q; retry", path)
+	}
+
+	profiles := manifestProfiles(cfg.Guard)
+	return explainReport{
+		reportHeader: newHeader("explain", configFile),
+		Scope:        "all_declared_profiles",
+		Path:         path,
+		ResolvedPath: readFloor.ResolvedPath,
+		Read:         decideAccess(cfg.Guard, profiles, path, config.GuardAccessRead, readFloor),
+		Write:        decideAccess(cfg.Guard, profiles, path, config.GuardAccessWrite, writeFloor),
+	}, nil
+}
+
+func manifestProfiles(guard config.Guard) map[string][]string {
+	profiles := make(map[string][]string, len(guard.Manifests))
+	for _, profile := range guard.Profiles {
+		for _, manifest := range profile.Manifests {
+			profiles[manifest] = append(profiles[manifest], profile.Name)
+		}
+	}
+	return profiles
+}
+
+func decideAccess(guard config.Guard, profiles map[string][]string, path string, access config.GuardAccess, floor config.GuardFloorDecision) accessDecision {
+	matches := matchingGrants(guard, profiles, path, access)
+	decision := accessDecision{
+		Operation:    string(access),
+		Configurable: true,
+		Grants:       matches,
+	}
+	if floor.Refused {
+		decision.Source = "compiled_floor"
+		decision.Rule = floor.Rule
+		decision.Matched = floor.Matched
+		decision.Reason = floor.Reason + "; this refusal cannot be configured away"
+		decision.Configurable = false
+		return decision
+	}
+	for _, match := range matches {
+		if match.Effective {
+			decision.WouldBeAllowed = true
+			decision.Source = "operator_declared"
+			if match.Scope == "directory" {
+				decision.Rule = "directory_subtree_grant"
+				decision.Reason = "one or more selected manifests declare a directory subtree grant"
+			} else {
+				decision.Rule = "exact_file_grant"
+				decision.Reason = "one or more selected manifests declare an exact file grant"
+			}
+			decision.Matched = match.Path
+			return decision
+		}
+	}
+	decision.Source = "none"
+	decision.Rule = "default_no_grant"
+	if len(matches) > 0 {
+		decision.Reason = "matching grants exist, but no declared profile selects their manifests"
+	} else {
+		decision.Reason = "no operator-declared file or directory grant covers this path"
+	}
+	return decision
+}
+
+func matchingGrants(guard config.Guard, profiles map[string][]string, path string, access config.GuardAccess) []grantMatch {
+	matches := make([]grantMatch, 0)
+	cleanPath := filepath.Clean(path)
+	for _, manifest := range guard.Manifests {
+		selectedBy := append([]string{}, profiles[manifest.Name]...)
+		if access == config.GuardAccessRead {
+			matches = appendGrantMatches(matches, manifest.Name, "read_only", "file", manifest.ReadOnly, selectedBy, cleanPath)
+			matches = appendGrantMatches(matches, manifest.Name, "read_only_directories", "directory", manifest.ReadOnlyDirectories, selectedBy, cleanPath)
+		}
+		matches = appendGrantMatches(matches, manifest.Name, "read_write", "file", manifest.ReadWrite, selectedBy, cleanPath)
+		matches = appendGrantMatches(matches, manifest.Name, "read_write_directories", "directory", manifest.ReadWriteDirectories, selectedBy, cleanPath)
+	}
+	return matches
+}
+
+func appendGrantMatches(matches []grantMatch, manifest, grantType, scope string, paths, profiles []string, cleanPath string) []grantMatch {
+	for _, declaredPath := range paths {
+		cleanDeclared := filepath.Clean(declaredPath)
+		matchesPath := cleanDeclared == cleanPath
+		if scope == "directory" {
+			matchesPath = pathWithinDirectory(cleanPath, cleanDeclared)
+		}
+		if !matchesPath {
+			continue
+		}
+		selectedBy := append([]string{}, profiles...)
+		matches = append(matches, grantMatch{
+			Manifest:  manifest,
+			GrantType: grantType,
+			Scope:     scope,
+			Path:      declaredPath,
+			Profiles:  selectedBy,
+			Effective: len(selectedBy) > 0,
+		})
+	}
+	return matches
+}
+
+func pathWithinDirectory(cleanPath, cleanDirectory string) bool {
+	if cleanPath == cleanDirectory {
+		return true
+	}
+	if cleanDirectory == string(filepath.Separator) {
+		return filepath.IsAbs(cleanPath)
+	}
+	return strings.HasPrefix(cleanPath, cleanDirectory+string(filepath.Separator))
+}
+
+func buildShowReport(cfg *config.Config, configFile, profileName string) (showReport, error) {
+	var selected *config.GuardProfile
+	for i := range cfg.Guard.Profiles {
+		if cfg.Guard.Profiles[i].Name == profileName {
+			selected = &cfg.Guard.Profiles[i]
+			break
+		}
+	}
+	if selected == nil {
+		return showReport{}, fmt.Errorf("guard profile %q not found", profileName)
+	}
+
+	manifests := make(map[string]config.GuardManifest, len(cfg.Guard.Manifests))
+	for _, manifest := range cfg.Guard.Manifests {
+		manifests[manifest.Name] = manifest
+	}
+	report := showReport{
+		reportHeader: newHeader("show", configFile),
+		Profile:      profileName,
+		Manifests:    make([]manifestReport, 0, len(selected.Manifests)),
+	}
+	for _, name := range selected.Manifests {
+		manifest := manifests[name]
+		manifestView := manifestReport{Name: name, Grants: make([]grantReport, 0, len(manifest.ReadOnly)+len(manifest.ReadOnlyDirectories)+len(manifest.ReadWrite)+len(manifest.ReadWriteDirectories))}
+		for _, path := range manifest.ReadOnly {
+			grant, err := buildGrantReport("read_only", "file", path)
+			if err != nil {
+				return showReport{}, err
+			}
+			manifestView.Grants = append(manifestView.Grants, grant)
+		}
+		for _, path := range manifest.ReadOnlyDirectories {
+			grant, err := buildGrantReport("read_only_directories", "directory", path)
+			if err != nil {
+				return showReport{}, err
+			}
+			manifestView.Grants = append(manifestView.Grants, grant)
+		}
+		for _, path := range manifest.ReadWrite {
+			grant, err := buildGrantReport("read_write", "file", path)
+			if err != nil {
+				return showReport{}, err
+			}
+			manifestView.Grants = append(manifestView.Grants, grant)
+		}
+		for _, path := range manifest.ReadWriteDirectories {
+			grant, err := buildGrantReport("read_write_directories", "directory", path)
+			if err != nil {
+				return showReport{}, err
+			}
+			manifestView.Grants = append(manifestView.Grants, grant)
+		}
+		report.Manifests = append(report.Manifests, manifestView)
+	}
+	return report, nil
+}
+
+func buildGrantReport(grantType, scope, path string) (grantReport, error) {
+	accesses := []config.GuardAccess{config.GuardAccessRead}
+	if strings.HasPrefix(grantType, "read_write") {
+		accesses = append(accesses, config.GuardAccessWrite)
+	}
+	report := grantReport{
+		GrantType: grantType,
+		Scope:     scope,
+		Path:      path,
+		Refusals:  make([]floorRefusal, 0),
+	}
+	for _, access := range accesses {
+		decision, err := config.ExplainGuardPathFloor(path, access)
+		if err != nil {
+			return grantReport{}, fmt.Errorf("explaining %s grant %q: %w", grantType, path, err)
+		}
+		if report.ResolvedPath == "" {
+			report.ResolvedPath = decision.ResolvedPath
+		} else if report.ResolvedPath != decision.ResolvedPath {
+			return grantReport{}, fmt.Errorf("path resolution changed while inspecting %q; retry", path)
+		}
+		if decision.Refused {
+			report.Refusals = append(report.Refusals, floorRefusal{
+				Operation: string(access),
+				Rule:      decision.Rule,
+				Matched:   decision.Matched,
+				Reason:    decision.Reason,
+			})
+		}
+	}
+	return report, nil
+}
+
+func writeJSON(w io.Writer, command string, report any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("encode %s report JSON: %w", command, err)
+	}
+	return nil
+}
+
+func writeHuman(w io.Writer, body string) error {
+	if _, err := io.WriteString(w, body); err != nil {
+		return fmt.Errorf("write guard report: %w", err)
+	}
+	return nil
+}
+
+func renderExplain(report explainReport) string {
+	var out strings.Builder
+	_, _ = fmt.Fprintf(&out, "WARNING: %s\n\n", report.EnforcementNotice)
+	_, _ = fmt.Fprintf(&out, "Guard path explanation\nConfig: %s\nScope: all declared profiles\nPath: %s\n", report.ConfigFile, report.Path)
+	if report.ResolvedPath != report.Path {
+		_, _ = fmt.Fprintf(&out, "Resolved path: %s\n", report.ResolvedPath)
+	}
+	renderAccess(&out, report.Read)
+	renderAccess(&out, report.Write)
+	return out.String()
+}
+
+func renderAccess(out *strings.Builder, decision accessDecision) {
+	_, _ = fmt.Fprintf(out, "\n%s: ", strings.ToUpper(decision.Operation))
+	switch decision.Source {
+	case "compiled_floor":
+		_, _ = fmt.Fprintf(out, "WOULD BE REFUSED BY COMPILED FLOOR (not currently enforced)\n  Rule: %s\n  Matched: %s\n  Reason: %s\n  This compiled-floor refusal cannot be configured away.\n", decision.Rule, decision.Matched, decision.Reason)
+	case "operator_declared":
+		_, _ = fmt.Fprintln(out, "DECLARED ALLOW (not currently enforced)")
+		for _, grant := range decision.Grants {
+			if grant.Effective {
+				_, _ = fmt.Fprintf(out, "  %s.%s %s %s (profiles: %s)\n", grant.Manifest, grant.GrantType, grantScopeLabel(grant.Scope), grant.Path, strings.Join(grant.Profiles, ", "))
+			}
+		}
+	default:
+		_, _ = fmt.Fprintf(out, "NO DECLARED GRANT (not currently enforced)\n  Rule: %s\n  Reason: %s\n", decision.Rule, decision.Reason)
+	}
+	for _, grant := range decision.Grants {
+		if !grant.Effective {
+			_, _ = fmt.Fprintf(out, "  Unselected declaration: %s.%s %s %s (no profile selects this manifest)\n", grant.Manifest, grant.GrantType, grantScopeLabel(grant.Scope), grant.Path)
+		}
+	}
+}
+
+func grantScopeLabel(scope string) string {
+	if scope == "directory" {
+		return "directory subtree"
+	}
+	return "exact file"
+}
+
+func renderShow(report showReport) string {
+	var out strings.Builder
+	_, _ = fmt.Fprintf(&out, "WARNING: %s\n\n", report.EnforcementNotice)
+	_, _ = fmt.Fprintf(&out, "Guard profile: %s\nConfig: %s\n", report.Profile, report.ConfigFile)
+	if len(report.Manifests) == 0 {
+		_, _ = fmt.Fprintln(&out, "Manifests: none")
+		return out.String()
+	}
+	for _, manifest := range report.Manifests {
+		_, _ = fmt.Fprintf(&out, "\nManifest: %s\n", manifest.Name)
+		if len(manifest.Grants) == 0 {
+			_, _ = fmt.Fprintln(&out, "  Grants: none")
+			continue
+		}
+		for _, grant := range manifest.Grants {
+			_, _ = fmt.Fprintf(&out, "  - %s %s: %s\n", grant.GrantType, grant.Scope, grant.Path)
+			if grant.ResolvedPath != grant.Path {
+				_, _ = fmt.Fprintf(&out, "    resolved: %s\n", grant.ResolvedPath)
+			}
+			if len(grant.Refusals) == 0 {
+				_, _ = fmt.Fprintln(&out, "    compiled floor: no refusal")
+				continue
+			}
+			for _, refusal := range grant.Refusals {
+				_, _ = fmt.Fprintf(&out, "    %s COMPILED FLOOR REFUSAL: rule=%s matched=%s\n      %s\n      This refusal cannot be configured away.\n", strings.ToUpper(refusal.Operation), refusal.Rule, refusal.Matched, refusal.Reason)
+			}
+		}
+	}
+	return out.String()
+}

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -84,7 +84,7 @@ func TestExplainHumanCompiledFloorHonesty(t *testing.T) {
 		"READ: WOULD BE REFUSED BY COMPILED FLOOR",
 		"WRITE: WOULD BE REFUSED BY COMPILED FLOOR",
 		"Rule: forbidden_component",
-		"Matched: .ssh",
+		"Matched: \".ssh\"",
 		"cannot be configured away",
 	} {
 		if !strings.Contains(out, want) {
@@ -174,7 +174,7 @@ func TestExplainUnselectedGrantHuman(t *testing.T) {
 	if err != nil {
 		t.Fatalf("guard explain: %v", err)
 	}
-	if !strings.Contains(out, "Unselected declaration: orphan.read_only") || !strings.Contains(out, "no profile selects this manifest") {
+	if !strings.Contains(out, "Unselected declaration: \"orphan\".read_only") || !strings.Contains(out, "no profile selects this manifest") {
 		t.Fatalf("unselected grant not explained:\n%s", out)
 	}
 }
@@ -186,7 +186,7 @@ func TestExplainDirectoryGrantHuman(t *testing.T) {
 	if err != nil {
 		t.Fatalf("guard explain: %v", err)
 	}
-	if !strings.Contains(out, "workspace.read_only_directories directory subtree /opt/app/assets") {
+	if !strings.Contains(out, "\"workspace\".read_only_directories directory subtree \"/opt/app/assets\"") {
 		t.Fatalf("directory type and subtree scope not explained:\n%s", out)
 	}
 }
@@ -237,7 +237,7 @@ func TestShowHumanEmptyAndRefusedGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("guard show worker: %v", err)
 	}
-	for _, want := range []string{"WARNING: Guard is not enforced", "Manifest: workspace", "compiled floor: no refusal", "COMPILED FLOOR REFUSAL", "cannot be configured away"} {
+	for _, want := range []string{"WARNING: Guard is not enforced", "Manifest: \"workspace\"", "compiled floor: no refusal", "COMPILED FLOOR REFUSAL", "cannot be configured away"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("worker output missing %q:\n%s", want, out)
 		}
@@ -427,5 +427,43 @@ func TestManifestProfilesPreservesSelectors(t *testing.T) {
 	}})
 	if got := strings.Join(profiles["state"], ","); got != "worker,reader" {
 		t.Fatalf("selectors = %q", got)
+	}
+}
+
+// TestExplainHumanOutputNeutralisesTerminalControls is the honesty guard for
+// the human report.
+//
+// Every report is required to carry the "not enforced" warning, because an
+// operator reading a clean explain must never conclude a workload is
+// constrained when nothing constrains it yet. Human output interpolates
+// operator-supplied paths, so a path carrying a newline can forge an extra
+// report line and one carrying an escape sequence can reposition or recolour
+// the terminal well enough to hide that warning in a transcript kept as
+// evidence. Neither may survive into the rendered output.
+func TestExplainHumanOutputNeutralisesTerminalControls(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, testGuardConfig)
+	hostile := "/opt/app/\x1b[2Jforged\nREAD: ALLOWED\x07"
+
+	out, err := runCommand(t, "explain", hostile, "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard explain: %v", err)
+	}
+
+	for _, control := range []string{"\x1b", "\x07"} {
+		if strings.Contains(out, control) {
+			t.Errorf("rendered output still carries the control byte %q, so a crafted path can rewrite the terminal:\n%q", control, out)
+		}
+	}
+	// The forged line must not appear as its own line. It may appear inside a
+	// quoted value, which is the point of quoting.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == "READ: ALLOWED" {
+			t.Errorf("a crafted path forged a standalone verdict line:\n%q", out)
+		}
+	}
+	if !strings.Contains(out, "WARNING:") {
+		t.Errorf("the not-enforced warning must survive a hostile path:\n%q", out)
 	}
 }

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package guard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const testGuardConfig = `guard:
+  profiles:
+    - name: worker
+      manifests: [workspace, credentials]
+    - name: reader
+      manifests: [workspace]
+  manifests:
+    - name: workspace
+      read_only:
+        - /opt/app/config.yaml
+      read_only_directories:
+        - /opt/app/assets
+      read_write:
+        - /var/lib/app/data.db
+      read_write_directories:
+        - /var/lib/app/cache
+    - name: credentials
+      read_only:
+        - /home/someoperator/.ssh/id_ed25519
+      read_only_directories:
+        - /home/someoperator/.aws
+      read_write:
+        - /usr/bin/helper
+      read_write_directories:
+        - /etc/systemd/system
+    - name: orphan
+      read_only:
+        - /opt/app/orphan.txt
+`
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("writer failed")
+}
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func runCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := Cmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestExplainHumanCompiledFloorHonesty(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	out, err := runCommand(t, "--config", configPath, "explain", "/home/someoperator/.ssh/id_ed25519")
+	if err != nil {
+		t.Fatalf("guard explain: %v", err)
+	}
+	for _, want := range []string{
+		"WARNING: Guard is not enforced in this build",
+		"READ: WOULD BE REFUSED BY COMPILED FLOOR",
+		"WRITE: WOULD BE REFUSED BY COMPILED FLOOR",
+		"Rule: forbidden_component",
+		"Matched: .ssh",
+		"cannot be configured away",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExplainJSONOperatorGrantsAndNoInference(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	tests := []struct {
+		name          string
+		path          string
+		wantRead      bool
+		wantWrite     bool
+		wantReadRule  string
+		wantWriteRule string
+	}{
+		{name: "read_only_exact_file", path: "/opt/app/config.yaml", wantRead: true, wantReadRule: "exact_file_grant", wantWriteRule: "default_no_grant"},
+		{name: "read_write_exact_file", path: "/var/lib/app/data.db", wantRead: true, wantWrite: true, wantReadRule: "exact_file_grant", wantWriteRule: "exact_file_grant"},
+		{name: "read_only_directory_root", path: "/opt/app/assets", wantRead: true, wantReadRule: "directory_subtree_grant", wantWriteRule: "default_no_grant"},
+		{name: "read_only_directory_descendant", path: "/opt/app/assets/logo.svg", wantRead: true, wantReadRule: "directory_subtree_grant", wantWriteRule: "default_no_grant"},
+		{name: "read_write_directory_descendant", path: "/var/lib/app/cache/item", wantRead: true, wantWrite: true, wantReadRule: "directory_subtree_grant", wantWriteRule: "directory_subtree_grant"},
+		{name: "directory_prefix_is_not_subtree", path: "/opt/app/assets-old/logo.svg", wantReadRule: "default_no_grant", wantWriteRule: "default_no_grant"},
+		{name: "no_subtree_inference", path: "/opt/app/config.yaml/child", wantReadRule: "default_no_grant", wantWriteRule: "default_no_grant"},
+		{name: "unselected_manifest", path: "/opt/app/orphan.txt", wantReadRule: "default_no_grant", wantWriteRule: "default_no_grant"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := runCommand(t, "explain", tt.path, "--config", configPath, "--json")
+			if err != nil {
+				t.Fatalf("guard explain: %v", err)
+			}
+			var report explainReport
+			if err := json.Unmarshal([]byte(out), &report); err != nil {
+				t.Fatalf("decode JSON: %v\n%s", err, out)
+			}
+			if report.SchemaVersion != reportSchemaVersion || report.Command != "explain" || report.Enforced {
+				t.Fatalf("bad stable header: %+v", report.reportHeader)
+			}
+			if report.Read.WouldBeAllowed != tt.wantRead || report.Write.WouldBeAllowed != tt.wantWrite {
+				t.Fatalf("allow decisions read=%t write=%t", report.Read.WouldBeAllowed, report.Write.WouldBeAllowed)
+			}
+			if report.Read.Rule != tt.wantReadRule || report.Write.Rule != tt.wantWriteRule {
+				t.Fatalf("rules read=%q write=%q", report.Read.Rule, report.Write.Rule)
+			}
+			if report.Read.Grants == nil || report.Write.Grants == nil {
+				t.Fatal("stable JSON arrays must encode as [] rather than null")
+			}
+			for _, grant := range append(append([]grantMatch{}, report.Read.Grants...), report.Write.Grants...) {
+				if grant.Profiles == nil {
+					t.Fatalf("grant profiles must encode as [] rather than null: %+v", grant)
+				}
+			}
+		})
+	}
+}
+
+func TestExplainFloorOverridesSelectedGrant(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	out, err := runCommand(t, "explain", "/usr/bin/helper", "--config", configPath, "--json")
+	if err != nil {
+		t.Fatalf("guard explain: %v", err)
+	}
+	var report explainReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+	if !report.Read.WouldBeAllowed || report.Read.Source != "operator_declared" {
+		t.Fatalf("read decision = %+v", report.Read)
+	}
+	if report.Write.WouldBeAllowed || report.Write.Source != "compiled_floor" || report.Write.Configurable {
+		t.Fatalf("write decision = %+v", report.Write)
+	}
+	if len(report.Write.Grants) != 1 || !report.Write.Grants[0].Effective {
+		t.Fatalf("floor report should retain overridden grant: %+v", report.Write.Grants)
+	}
+}
+
+func TestExplainUnselectedGrantHuman(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	out, err := runCommand(t, "explain", "/opt/app/orphan.txt", "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard explain: %v", err)
+	}
+	if !strings.Contains(out, "Unselected declaration: orphan.read_only") || !strings.Contains(out, "no profile selects this manifest") {
+		t.Fatalf("unselected grant not explained:\n%s", out)
+	}
+}
+
+func TestExplainDirectoryGrantHuman(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	out, err := runCommand(t, "explain", "/opt/app/assets/logo.svg", "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard explain: %v", err)
+	}
+	if !strings.Contains(out, "workspace.read_only_directories directory subtree /opt/app/assets") {
+		t.Fatalf("directory type and subtree scope not explained:\n%s", out)
+	}
+}
+
+func TestShowJSONResolvedProfileAndFloorRefusals(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	out, err := runCommand(t, "show", "worker", "--config", configPath, "--json")
+	if err != nil {
+		t.Fatalf("guard show: %v", err)
+	}
+	var report showReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, out)
+	}
+	if report.Command != "show" || report.Profile != "worker" || report.Enforced {
+		t.Fatalf("bad report header/profile: %+v", report)
+	}
+	if len(report.Manifests) != 2 || report.Manifests[0].Name != "workspace" || report.Manifests[1].Name != "credentials" {
+		t.Fatalf("resolved manifests = %+v", report.Manifests)
+	}
+	credentials := report.Manifests[1]
+	if len(credentials.Grants) != 4 {
+		t.Fatalf("credential grants = %+v", credentials.Grants)
+	}
+	if got := credentials.Grants[0].Refusals; credentials.Grants[0].GrantType != "read_only" || credentials.Grants[0].Scope != "file" || len(got) != 1 || got[0].Operation != "read" || got[0].Rule != "forbidden_component" {
+		t.Fatalf("read-only floor refusals = %+v", got)
+	}
+	if got := credentials.Grants[1].Refusals; credentials.Grants[1].GrantType != "read_only_directories" || credentials.Grants[1].Scope != "directory" || len(got) != 1 || got[0].Rule != "forbidden_component" {
+		t.Fatalf("read-only directory floor refusals = %+v", got)
+	}
+	if got := credentials.Grants[2].Refusals; credentials.Grants[2].GrantType != "read_write" || credentials.Grants[2].Scope != "file" || len(got) != 1 || got[0].Operation != "write" || got[0].Rule != "dangerous_write_root" {
+		t.Fatalf("read-write floor refusals = %+v", got)
+	}
+	if got := credentials.Grants[3].Refusals; credentials.Grants[3].GrantType != "read_write_directories" || credentials.Grants[3].Scope != "directory" || len(got) != 1 || got[0].Operation != "write" || got[0].Rule != "dangerous_write_root" {
+		t.Fatalf("read-write directory floor refusals = %+v", got)
+	}
+	if report.Manifests[0].Grants[0].Refusals == nil {
+		t.Fatal("stable floor_refusals array must not be null")
+	}
+}
+
+func TestShowHumanEmptyAndRefusedGrants(t *testing.T) {
+	t.Parallel()
+	body := strings.Replace(testGuardConfig, "  manifests:\n", "    - name: empty\n      manifests: []\n  manifests:\n", 1)
+	configPath := writeConfig(t, body)
+	out, err := runCommand(t, "show", "worker", "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard show worker: %v", err)
+	}
+	for _, want := range []string{"WARNING: Guard is not enforced", "Manifest: workspace", "compiled floor: no refusal", "COMPILED FLOOR REFUSAL", "cannot be configured away"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("worker output missing %q:\n%s", want, out)
+		}
+	}
+
+	out, err = runCommand(t, "show", "empty", "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard show empty: %v", err)
+	}
+	if !strings.Contains(out, "Manifests: none") {
+		t.Fatalf("empty profile output:\n%s", out)
+	}
+}
+
+func TestShowManifestWithNoGrants(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, "guard:\n  profiles:\n    - name: worker\n      manifests: [empty]\n  manifests:\n    - name: empty\n")
+	out, err := runCommand(t, "show", "worker", "--config", configPath)
+	if err != nil {
+		t.Fatalf("guard show: %v", err)
+	}
+	if !strings.Contains(out, "Grants: none") {
+		t.Fatalf("empty manifest output:\n%s", out)
+	}
+}
+
+func TestCommandErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config string
+		args   []string
+		want   string
+	}{
+		{name: "relative_explain_path", config: testGuardConfig, args: []string{"explain", "relative/path"}, want: "absolute"},
+		{name: "unknown_profile", config: testGuardConfig, args: []string{"show", "missing"}, want: "not found"},
+		{name: "unknown_manifest", config: "guard:\n  profiles:\n    - name: worker\n      manifests: [missing]\n", args: []string{"show", "worker"}, want: "unknown manifest"},
+		{name: "relative_grant", config: "guard:\n  manifests:\n    - name: bad\n      read_only: [relative/path]\n", args: []string{"explain", "/opt/app"}, want: "must be absolute"},
+		{name: "file_directory_conflict_case_folded", config: "guard:\n  manifests:\n    - name: bad\n      read_only: [/opt/app/Config]\n      read_only_directories: [/opt/app/config/]\n", args: []string{"explain", "/opt/app/config"}, want: "conflicts"},
+		{name: "unknown_yaml_field", config: "guard:\n  unknown: true\n", args: []string{"explain", "/opt/app"}, want: "field unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			configPath := writeConfig(t, tt.config)
+			args := append(append([]string(nil), tt.args...), "--config", configPath)
+			_, err := runCommand(t, args...)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+	_, err := runCommand(t, "explain", "/opt/app", "--config", filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil || !strings.Contains(err.Error(), "loading config") {
+		t.Fatalf("missing config error = %v", err)
+	}
+}
+
+func TestDefaultConfigAndArgumentValidation(t *testing.T) {
+	t.Parallel()
+	help, err := runCommand(t)
+	if err != nil || !strings.Contains(help, "Inspect unenforced guard declarations") {
+		t.Fatalf("guard parent help: err=%v output=%q", err, help)
+	}
+	out, err := runCommand(t, "explain", "/opt/app", "--json")
+	if err != nil {
+		t.Fatalf("default explain: %v", err)
+	}
+	if !strings.Contains(out, `"config_file": "(built-in defaults)"`) {
+		t.Fatalf("default config label missing:\n%s", out)
+	}
+	for _, args := range [][]string{{"guard-extra"}, {"explain"}, {"show"}, {"explain", "/opt/app", "/opt/extra"}} {
+		if _, err := runCommand(t, args...); err == nil {
+			t.Fatalf("args %v should fail", args)
+		}
+	}
+}
+
+func TestCommandsDoNotModifyConfigOrDirectory(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, testGuardConfig)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config before commands: %v", err)
+	}
+	beforeInfo, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config before commands: %v", err)
+	}
+	beforeEntries, err := os.ReadDir(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatalf("read config directory before commands: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"explain", "/opt/app/config.yaml", "--config", configPath},
+		{"explain", "/opt/app/config.yaml", "--config", configPath, "--json"},
+		{"show", "worker", "--config", configPath},
+		{"show", "worker", "--config", configPath, "--json"},
+	} {
+		if _, err := runCommand(t, args...); err != nil {
+			t.Fatalf("args %v: %v", args, err)
+		}
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after commands: %v", err)
+	}
+	afterInfo, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config after commands: %v", err)
+	}
+	afterEntries, err := os.ReadDir(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatalf("read config directory after commands: %v", err)
+	}
+	if !bytes.Equal(before, after) || beforeInfo.Mode() != afterInfo.Mode() || !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
+		t.Fatal("guard inspection modified the config file")
+	}
+	if len(beforeEntries) != len(afterEntries) {
+		t.Fatalf("guard inspection changed directory entries: before=%d after=%d", len(beforeEntries), len(afterEntries))
+	}
+	for i := range beforeEntries {
+		if beforeEntries[i].Name() != afterEntries[i].Name() {
+			t.Fatalf("guard inspection changed directory entry %d: before=%q after=%q", i, beforeEntries[i].Name(), afterEntries[i].Name())
+		}
+	}
+}
+
+func TestOutputErrors(t *testing.T) {
+	t.Parallel()
+	configPath := writeConfig(t, testGuardConfig)
+	for _, args := range [][]string{
+		{"explain", "/opt/app/config.yaml", "--config", configPath},
+		{"show", "worker", "--config", configPath},
+		{"explain", "/opt/app/config.yaml", "--config", configPath, "--json"},
+		{"show", "worker", "--config", configPath, "--json"},
+	} {
+		cmd := Cmd()
+		cmd.SetOut(failingWriter{})
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
+			t.Fatalf("args %v error = %v", args, err)
+		}
+	}
+}
+
+func TestBuildGrantReportRejectsRelativePath(t *testing.T) {
+	t.Parallel()
+	if _, err := buildGrantReport("read_only", "file", "relative/path"); err == nil {
+		t.Fatal("relative grant report should fail")
+	}
+}
+
+func TestPathWithinDirectoryRootAndBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		directory string
+		want      bool
+	}{
+		{name: "root_covers_absolute", path: "/opt/app", directory: "/", want: true},
+		{name: "directory_itself", path: "/opt/app", directory: "/opt/app", want: true},
+		{name: "descendant", path: "/opt/app/state/file", directory: "/opt/app", want: true},
+		{name: "textual_prefix_only", path: "/opt/application", directory: "/opt/app"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := pathWithinDirectory(tt.path, tt.directory); got != tt.want {
+				t.Fatalf("pathWithinDirectory(%q, %q) = %t, want %t", tt.path, tt.directory, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManifestProfilesPreservesSelectors(t *testing.T) {
+	t.Parallel()
+	profiles := manifestProfiles(config.Guard{Profiles: []config.GuardProfile{
+		{Name: "worker", Manifests: []string{"state"}},
+		{Name: "reader", Manifests: []string{"state"}},
+	}})
+	if got := strings.Join(profiles["state"], ","); got != "worker,reader" {
+		t.Fatalf("selectors = %q", got)
+	}
+}

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -320,7 +320,7 @@ func TestCommandsDoNotModifyConfigOrDirectory(t *testing.T) {
 	t.Parallel()
 
 	configPath := writeConfig(t, testGuardConfig)
-	before, err := os.ReadFile(configPath)
+	before, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
 		t.Fatalf("read config before commands: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestCommandsDoNotModifyConfigOrDirectory(t *testing.T) {
 		}
 	}
 
-	after, err := os.ReadFile(configPath)
+	after, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
 		t.Fatalf("read config after commands: %v", err)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/evidence"
 	"github.com/luckyPipewrench/pipelock/internal/cli/generate"
 	"github.com/luckyPipewrench/pipelock/internal/cli/git"
+	cliguard "github.com/luckyPipewrench/pipelock/internal/cli/guard"
 	"github.com/luckyPipewrench/pipelock/internal/cli/hermes"
 	"github.com/luckyPipewrench/pipelock/internal/cli/keys"
 	"github.com/luckyPipewrench/pipelock/internal/cli/learn"
@@ -114,6 +115,8 @@ Quick start:
 		presets.Cmd(),
 		// Git
 		git.Cmd(),
+		// Guard declaration and compiled-floor inspection
+		cliguard.Cmd(),
 		// Hermes Agent (Nous Research) integration
 		hermes.Cmd(),
 		// Signing-key inventory

--- a/internal/cli/root_core_test.go
+++ b/internal/cli/root_core_test.go
@@ -7,6 +7,14 @@ package cli
 
 import "testing"
 
+func TestGuardCommandRegisteredInCoreBuild(t *testing.T) {
+	cmd := rootCmd()
+	found, _, err := cmd.Find([]string{"guard", "explain"})
+	if err != nil || found == nil || found.Name() != "explain" {
+		t.Fatalf("guard explain command not registered: found=%v err=%v", found, err)
+	}
+}
+
 func TestEnterpriseCommandsAbsentInCoreBuild(t *testing.T) {
 	saved := extraCommands
 	extraCommands = nil

--- a/internal/config/guard_paths.go
+++ b/internal/config/guard_paths.go
@@ -107,7 +107,15 @@ func ExplainGuardPathFloor(rawPath string, access GuardAccess) (GuardFloorDecisi
 
 	resolved := resolveGuardPath(rawPath)
 	decision.ResolvedPath = resolved
-	if comp, reason := guardForbiddenComponent(resolved); comp != "" {
+	// The component check runs against the DECLARED spelling as well as the
+	// resolved target, matching what the credential-shape check already does.
+	// Resolving first and checking only the result is a fail-open: a path
+	// declared as a key directory that symlinks somewhere innocuous resolves to
+	// a name with no forbidden component, so the floor saw nothing and allowed
+	// it, for read and for write alike. Naming a key directory in a manifest is
+	// the thing being refused; where the link happens to point today does not
+	// make that declaration safe, and the link can be repointed afterwards.
+	if comp, reason := guardForbiddenComponentIn(rawPath, resolved); comp != "" {
 		decision.Refused = true
 		decision.Rule = "forbidden_component"
 		decision.Matched = comp
@@ -464,6 +472,16 @@ var guardForbiddenComponents = map[string]string{
 // home directory is deliberate. Pipelock commonly runs as a system service, so
 // os.UserHomeDir() returns /root; a home-derived list would protect /root/.ssh
 // while leaving every real operator's ~/.ssh unguarded.
+// guardForbiddenComponentIn reports the first forbidden component in either the
+// declared spelling or the resolved target, checking the declared form first so
+// the refusal names what the operator actually wrote.
+func guardForbiddenComponentIn(rawPath, resolved string) (component, reason string) {
+	if comp, r := guardForbiddenComponent(filepath.Clean(rawPath)); comp != "" {
+		return comp, r
+	}
+	return guardForbiddenComponent(resolved)
+}
+
 func guardForbiddenComponent(resolved string) (component, reason string) {
 	for _, part := range strings.Split(resolved, string(filepath.Separator)) {
 		if r, bad := guardForbiddenComponents[strings.ToLower(part)]; bad {

--- a/internal/config/guard_paths.go
+++ b/internal/config/guard_paths.go
@@ -142,7 +142,7 @@ func ExplainGuardPathFloor(rawPath string, access GuardAccess) (GuardFloorDecisi
 			decision.Reason = fmt.Sprintf("read access to %q is not allowed (%s); reading a credential is exfiltration, not merely inspection", rawPath, match.reason)
 			return decision, nil
 		}
-		if suffix, reason := guardForbiddenSuffix(resolved); suffix != "" && strings.Contains(reason, "pipelock") {
+		if suffix, reason, secretBearing := guardForbiddenSuffix(resolved); suffix != "" && secretBearing {
 			decision.Refused = true
 			decision.Rule = "forbidden_path_shape"
 			decision.Matched = suffix
@@ -152,7 +152,7 @@ func ExplainGuardPathFloor(rawPath string, access GuardAccess) (GuardFloorDecisi
 		return decision, nil
 	}
 
-	if suffix, reason := guardForbiddenSuffix(resolved); suffix != "" {
+	if suffix, reason, _ := guardForbiddenSuffix(resolved); suffix != "" {
 		decision.Refused = true
 		decision.Rule = "forbidden_path_shape"
 		decision.Matched = suffix
@@ -497,26 +497,37 @@ func guardForbiddenComponent(resolved string) (component, reason string) {
 var guardForbiddenSuffixes = []struct {
 	suffix string
 	reason string
+	// secretBearing marks a suffix that may hold credential material, so READ
+	// is refused as well as write. Autostart locations are execution
+	// persistence only: writing one is refused, reading one is not.
+	//
+	// This is a table field rather than a test on the reason text. The read
+	// side previously decided by matching the word "pipelock" inside the
+	// operator-facing prose, which fails in the OPEN direction: adding a
+	// secret-bearing suffix whose wording happened not to contain that word
+	// would have silently allowed read access, with no code change and no test
+	// failing to say so.
+	secretBearing bool
 }{
-	{filepath.Join(".local", "share", "pipelock"), "pipelock state directory"},
-	{filepath.Join(".config", "pipelock"), "pipelock config directory"},
-	{".pipelock", "pipelock directory"},
-	{filepath.Join(".config", "autostart"), "autostart directory"},
-	{filepath.Join("Library", "LaunchAgents"), "autostart directory"},
-	{filepath.Join("Library", "LaunchDaemons"), "autostart directory"},
-	{filepath.Join("etc", "pipelock"), "pipelock config directory"},
+	{filepath.Join(".local", "share", "pipelock"), "pipelock state directory", true},
+	{filepath.Join(".config", "pipelock"), "pipelock config directory", true},
+	{".pipelock", "pipelock directory", true},
+	{filepath.Join(".config", "autostart"), "autostart directory", false},
+	{filepath.Join("Library", "LaunchAgents"), "autostart directory", false},
+	{filepath.Join("Library", "LaunchDaemons"), "autostart directory", false},
+	{filepath.Join("etc", "pipelock"), "pipelock config directory", true},
 }
 
 // guardForbiddenSuffix reports why the resolved path is write-sensitive, or ""
 // when it is not. A match is the directory itself or anything beneath it.
-func guardForbiddenSuffix(resolved string) (string, string) {
+func guardForbiddenSuffix(resolved string) (suffix, reason string, secretBearing bool) {
 	for _, entry := range guardForbiddenSuffixes {
 		marker := string(filepath.Separator) + entry.suffix
 		if strings.HasSuffix(resolved, marker) || strings.Contains(resolved, marker+string(filepath.Separator)) {
-			return entry.suffix, entry.reason
+			return entry.suffix, entry.reason, entry.secretBearing
 		}
 	}
-	return "", ""
+	return "", "", false
 }
 
 // guardIsHomeRoot reports whether the resolved path is an entire user home

--- a/internal/config/guard_paths.go
+++ b/internal/config/guard_paths.go
@@ -9,6 +9,28 @@ import (
 	"strings"
 )
 
+// GuardAccess identifies the filesystem operation evaluated against the
+// compiled guard floor.
+type GuardAccess string
+
+const (
+	GuardAccessRead  GuardAccess = "read"
+	GuardAccessWrite GuardAccess = "write"
+)
+
+// GuardFloorDecision explains whether the compiled guard floor refuses one
+// path. It is exported so read-only operator surfaces can report the exact same
+// decision as config validation instead of maintaining a second matcher.
+type GuardFloorDecision struct {
+	Access       GuardAccess
+	Path         string
+	ResolvedPath string
+	Refused      bool
+	Rule         string
+	Matched      string
+	Reason       string
+}
+
 // resolveGuardPath resolves symlinks in a guard path as far as the filesystem
 // allows.
 //
@@ -61,32 +83,99 @@ func resolveGuardPath(rawPath string) string {
 // individually; what is refused here is the directory that holds keys.
 func validateGuardROPath(label, fieldName string, idx int, rawPath string) error {
 	field := fmt.Sprintf("%s.%s[%d]", label, fieldName, idx)
-	resolved := resolveGuardPath(rawPath)
-
-	if comp, reason := guardForbiddenComponent(resolved); comp != "" {
-		return fmt.Errorf("%s: read access to secret-bearing path %q is not allowed (contains %q, which is %s); reading credential material is exfiltration, not merely inspection", field, rawPath, comp, reason)
+	decision, err := ExplainGuardPathFloor(rawPath, GuardAccessRead)
+	if err != nil {
+		return fmt.Errorf("%s: %w", field, err)
 	}
-	// A grant on an entire home reads through to every credential beneath it,
-	// which would defeat every rule in this file by granting the parent
-	// instead of the target. The write side has always refused this; the read
-	// side did not, so `read_only: [/home/someoperator]` was accepted and
-	// carried ~/.ssh with it.
-	if guardIsHomeRoot(resolved) {
-		return fmt.Errorf("%s: read access to the entire home directory %q is not allowed; it reads through to every credential beneath it", field, rawPath)
-	}
-	if reason := guardDeclaredPathSecretMaterialReason(rawPath, resolved); reason != "" {
-		return fmt.Errorf("%s: read access to %q is not allowed (%s); reading a credential is exfiltration, not merely inspection", field, rawPath, reason)
-	}
-	// Pipelock config and state directories contain credential material
-	// (license_key, kill_switch.api_token, secrets_file) that a read grant
-	// would expose. The suffix check covers every user's home, not just this
-	// process's, matching the write-side guard in validateGuardRWPath.
-	if suffix := guardForbiddenSuffix(resolved); suffix != "" {
-		if strings.Contains(suffix, "pipelock") {
-			return fmt.Errorf("%s: read access to %s %q is not allowed; it may contain credential material", field, suffix, rawPath)
-		}
+	if decision.Refused {
+		return fmt.Errorf("%s: %s", field, decision.Reason)
 	}
 	return nil
+}
+
+// ExplainGuardPathFloor evaluates one absolute path using the same compiled
+// floor consumed by guard config validation. Operator-declared grants are not
+// considered here because they can be narrowed while this floor cannot.
+func ExplainGuardPathFloor(rawPath string, access GuardAccess) (GuardFloorDecision, error) {
+	decision := GuardFloorDecision{Access: access, Path: rawPath}
+	if !filepath.IsAbs(rawPath) {
+		return decision, fmt.Errorf("path must be absolute (got %q)", rawPath)
+	}
+	if access != GuardAccessRead && access != GuardAccessWrite {
+		return decision, fmt.Errorf("unsupported guard access %q", access)
+	}
+
+	resolved := resolveGuardPath(rawPath)
+	decision.ResolvedPath = resolved
+	if comp, reason := guardForbiddenComponent(resolved); comp != "" {
+		decision.Refused = true
+		decision.Rule = "forbidden_component"
+		decision.Matched = comp
+		if access == GuardAccessRead {
+			decision.Reason = fmt.Sprintf("read access to secret-bearing path %q is not allowed (contains %q, which is %s); reading credential material is exfiltration, not merely inspection", rawPath, comp, reason)
+		} else {
+			decision.Reason = fmt.Sprintf("read-write on trust-bearing path %q is not allowed (contains %q, which is %s)", rawPath, comp, reason)
+		}
+		return decision, nil
+	}
+
+	if access == GuardAccessRead {
+		if guardIsHomeRoot(resolved) {
+			decision.Refused = true
+			decision.Rule = "whole_home"
+			decision.Matched = resolved
+			decision.Reason = fmt.Sprintf("read access to the entire home directory %q is not allowed; it reads through to every credential beneath it", rawPath)
+			return decision, nil
+		}
+		if match := guardDeclaredPathSecretMaterialMatch(rawPath, resolved); match.reason != "" {
+			decision.Refused = true
+			decision.Rule = "credential_path"
+			decision.Matched = match.matched
+			decision.Reason = fmt.Sprintf("read access to %q is not allowed (%s); reading a credential is exfiltration, not merely inspection", rawPath, match.reason)
+			return decision, nil
+		}
+		if suffix, reason := guardForbiddenSuffix(resolved); suffix != "" && strings.Contains(reason, "pipelock") {
+			decision.Refused = true
+			decision.Rule = "forbidden_path_shape"
+			decision.Matched = suffix
+			decision.Reason = fmt.Sprintf("read access to %s %q is not allowed; it may contain credential material", reason, rawPath)
+			return decision, nil
+		}
+		return decision, nil
+	}
+
+	if suffix, reason := guardForbiddenSuffix(resolved); suffix != "" {
+		decision.Refused = true
+		decision.Rule = "forbidden_path_shape"
+		decision.Matched = suffix
+		decision.Reason = fmt.Sprintf("read-write on %s %q is not allowed", reason, rawPath)
+		return decision, nil
+	}
+	if guardIsHomeRoot(resolved) {
+		decision.Refused = true
+		decision.Rule = "whole_home"
+		decision.Matched = resolved
+		decision.Reason = "read-write on the entire home directory is not allowed"
+		return decision, nil
+	}
+	for _, root := range guardDangerousRWRoots {
+		clean := filepath.Clean(root.prefix)
+		if resolved == clean || strings.HasPrefix(resolved, clean+string(filepath.Separator)) {
+			decision.Refused = true
+			decision.Rule = "dangerous_write_root"
+			decision.Matched = clean
+			decision.Reason = fmt.Sprintf("read-write on %s %q is not allowed", root.reason, rawPath)
+			return decision, nil
+		}
+	}
+	if match := guardDeclaredPathSecretMaterialMatch(rawPath, resolved); match.reason != "" {
+		decision.Refused = true
+		decision.Rule = "credential_path"
+		decision.Matched = match.matched
+		decision.Reason = fmt.Sprintf("read-write on %q is not allowed (%s); writing a credential file redirects the workload's identity", rawPath, match.reason)
+		return decision, nil
+	}
+	return decision, nil
 }
 
 // guardDeclaredPathSecretMaterialReason evaluates both the declared spelling
@@ -96,12 +185,21 @@ func validateGuardROPath(label, fieldName string, idx int, rawPath string) error
 // Conversely, checking the resolved path preserves the existing protection
 // against an innocuous-looking alias that points into credential material.
 func guardDeclaredPathSecretMaterialReason(rawPath, resolved string) string {
+	return guardDeclaredPathSecretMaterialMatch(rawPath, resolved).reason
+}
+
+type guardSecretMatch struct {
+	matched string
+	reason  string
+}
+
+func guardDeclaredPathSecretMaterialMatch(rawPath, resolved string) guardSecretMatch {
 	for _, candidate := range []string{filepath.Clean(rawPath), resolved} {
-		if reason := guardSecretMaterialReason(candidate); reason != "" {
-			return reason
+		if match := guardSecretMaterialMatch(candidate); match.reason != "" {
+			return match
 		}
 	}
-	return ""
+	return guardSecretMatch{}
 }
 
 // guardSecretShapes are paths that hold credential material, expressed as
@@ -261,28 +359,32 @@ var guardMultiHomeRoots = []string{"/", "/home", "/var/home", "/Users"}
 // specific non-secret path instead (~/.aws/config, ~/.config/myapp), which is
 // the explicit, no-inference model GuardManifest already commits to.
 func guardSecretMaterialReason(resolved string) string {
+	return guardSecretMaterialMatch(resolved).reason
+}
+
+func guardSecretMaterialMatch(resolved string) guardSecretMatch {
 	lowerResolved := strings.ToLower(resolved)
 	for _, root := range guardMultiHomeRoots {
 		if lowerResolved == strings.ToLower(root) {
-			return "it sits above every user home and reads through to every credential beneath it"
+			return guardSecretMatch{matched: root, reason: "it sits above every user home and reads through to every credential beneath it"}
 		}
 	}
 	for _, entry := range guardSecretAbsolutePaths {
 		if r := guardSecretRelation(resolved, entry.path, entry.reason); r != "" {
-			return r
+			return guardSecretMatch{matched: entry.path, reason: r}
 		}
 	}
 	home := guardHomeRootOf(resolved)
 	if home == "" {
-		return ""
+		return guardSecretMatch{}
 	}
 	for _, entry := range guardSecretShapes {
 		secret := home + "/" + entry.shape
 		if r := guardSecretRelation(resolved, secret, entry.reason); r != "" {
-			return r
+			return guardSecretMatch{matched: entry.shape, reason: r}
 		}
 	}
-	return ""
+	return guardSecretMatch{}
 }
 
 // guardSecretRelation reports how resolved relates to a known secret path, or
@@ -405,14 +507,14 @@ var guardForbiddenSuffixes = []struct {
 
 // guardForbiddenSuffix reports why the resolved path is write-sensitive, or ""
 // when it is not. A match is the directory itself or anything beneath it.
-func guardForbiddenSuffix(resolved string) string {
+func guardForbiddenSuffix(resolved string) (string, string) {
 	for _, entry := range guardForbiddenSuffixes {
 		marker := string(filepath.Separator) + entry.suffix
 		if strings.HasSuffix(resolved, marker) || strings.Contains(resolved, marker+string(filepath.Separator)) {
-			return entry.reason
+			return entry.suffix, entry.reason
 		}
 	}
-	return ""
+	return "", ""
 }
 
 // guardIsHomeRoot reports whether the resolved path is an entire user home

--- a/internal/config/guard_paths.go
+++ b/internal/config/guard_paths.go
@@ -343,25 +343,9 @@ var guardFixedHomeRoots = []string{"/root", "/app"}
 // grant on one reads through to every operator's credentials at once.
 var guardMultiHomeRoots = []string{"/", "/home", "/var/home", "/Users"}
 
-// guardSecretMaterialReason reports why the resolved path exposes credential
-// material, or "" when it does not.
-//
-// A path is refused when it IS a secret path, is BENEATH one, or is a strict
-// ANCESTOR of one. The ancestor case is the load-bearing one and is easy to
-// leave out: Landlock grants an access right to an entire directory SUBTREE,
-// so a rule permitting ~/.aws permits ~/.aws/credentials with it. Without the
-// ancestor arm, every entry in guardSecretShapes is decorative -- an operator
-// (or an attacker editing a manifest) reaches the credential by naming the
-// parent instead of the file.
-//
-// The cost is deliberate and falls on availability: ~/.aws, ~/.docker, ~/.kube
-// and ~/.config cannot be granted as whole directories. The operator names the
-// specific non-secret path instead (~/.aws/config, ~/.config/myapp), which is
-// the explicit, no-inference model GuardManifest already commits to.
-func guardSecretMaterialReason(resolved string) string {
-	return guardSecretMaterialMatch(resolved).reason
-}
-
+// guardSecretMaterialMatch reports which credential shape a path exposes and
+// why. A path is refused when it is the shape, is beneath it, or is a strict
+// ancestor whose directory grant would reach it.
 func guardSecretMaterialMatch(resolved string) guardSecretMatch {
 	lowerResolved := strings.ToLower(resolved)
 	for _, root := range guardMultiHomeRoots {

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -22,6 +22,130 @@ func TestValidateGuard_EmptyIsValid(t *testing.T) {
 	}
 }
 
+func TestExplainGuardPathFloor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		path        string
+		access      GuardAccess
+		wantRefused bool
+		wantRule    string
+		wantMatched string
+	}{
+		{name: "read_component_case_folded", path: "/workspace/.AWS/credentials", access: GuardAccessRead, wantRefused: true, wantRule: "forbidden_component", wantMatched: ".AWS"},
+		{name: "write_component_reasoned", path: "/srv/agent/.kube/config", access: GuardAccessWrite, wantRefused: true, wantRule: "forbidden_component", wantMatched: ".kube"},
+		{name: "read_whole_home_case_folded", path: "/users/someoperator", access: GuardAccessRead, wantRefused: true, wantRule: "whole_home", wantMatched: "/users/someoperator"},
+		{name: "write_multi_home_root", path: "/var/home", access: GuardAccessWrite, wantRefused: true, wantRule: "credential_path", wantMatched: "/var/home"},
+		{name: "read_home_credential_variant", path: "/home/someoperator/.npmrc.bak", access: GuardAccessRead, wantRefused: true, wantRule: "credential_path", wantMatched: ".npmrc"},
+		{name: "write_home_credential_shape", path: "/home/someoperator/.pypirc", access: GuardAccessWrite, wantRefused: true, wantRule: "credential_path", wantMatched: ".pypirc"},
+		{name: "read_absolute_credential", path: "/run/secrets/api-token", access: GuardAccessRead, wantRefused: true, wantRule: "credential_path", wantMatched: "/run/secrets"},
+		{name: "read_pipelock_state", path: "/home/someoperator/.local/share/pipelock/license.token", access: GuardAccessRead, wantRefused: true, wantRule: "forbidden_path_shape", wantMatched: filepath.Join(".local", "share", "pipelock")},
+		{name: "read_autostart_allowed", path: "/home/someoperator/.config/autostart/app.desktop", access: GuardAccessRead},
+		{name: "write_autostart_refused", path: "/home/someoperator/.config/autostart/app.desktop", access: GuardAccessWrite, wantRefused: true, wantRule: "forbidden_path_shape", wantMatched: filepath.Join(".config", "autostart")},
+		{name: "write_path_directory", path: "/usr/local/bin/helper", access: GuardAccessWrite, wantRefused: true, wantRule: "dangerous_write_root", wantMatched: "/usr/local/bin"},
+		{name: "ordinary_read", path: "/opt/app/config.yaml", access: GuardAccessRead},
+		{name: "ordinary_write", path: "/var/lib/app/state.db", access: GuardAccessWrite},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			decision, err := ExplainGuardPathFloor(tt.path, tt.access)
+			if err != nil {
+				t.Fatalf("ExplainGuardPathFloor: %v", err)
+			}
+			if decision.Refused != tt.wantRefused || decision.Rule != tt.wantRule || decision.Matched != tt.wantMatched {
+				t.Fatalf("decision = %+v, want refused=%t rule=%q matched=%q", decision, tt.wantRefused, tt.wantRule, tt.wantMatched)
+			}
+			if decision.ResolvedPath == "" {
+				t.Fatal("resolved path must always be reported")
+			}
+			if decision.Refused && decision.Reason == "" {
+				t.Fatal("refusal must include an operator-facing reason")
+			}
+		})
+	}
+}
+
+func TestExplainGuardPathFloorErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ExplainGuardPathFloor("relative/path", GuardAccessRead); err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("relative path error = %v", err)
+	}
+	if _, err := ExplainGuardPathFloor("/opt/app/config.yaml", GuardAccess("execute")); err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("unsupported access error = %v", err)
+	}
+}
+
+func TestExplainGuardPathFloorUsesResolvedSymlinkForBothAccesses(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, ".ssh")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	alias := filepath.Join(root, "innocuous")
+	if err := os.Symlink(target, alias); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	for _, access := range []GuardAccess{GuardAccessRead, GuardAccessWrite} {
+		t.Run(string(access), func(t *testing.T) {
+			decision, err := ExplainGuardPathFloor(filepath.Join(alias, "id_ed25519"), access)
+			if err != nil {
+				t.Fatalf("ExplainGuardPathFloor: %v", err)
+			}
+			if !decision.Refused || decision.Rule != "forbidden_component" || decision.Matched != ".ssh" {
+				t.Fatalf("resolved symlink decision = %+v", decision)
+			}
+		})
+	}
+}
+
+func TestExplainGuardPathFloorValidatorAntiDrift(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		access   GuardAccess
+		wantRule string
+	}{
+		{name: "read_component", path: "/workspace/.docker/config.json", access: GuardAccessRead, wantRule: "forbidden_component"},
+		{name: "read_whole_home", path: "/home/someoperator", access: GuardAccessRead, wantRule: "whole_home"},
+		{name: "read_credential", path: "/home/someoperator/.netrc.old", access: GuardAccessRead, wantRule: "credential_path"},
+		{name: "read_pipelock", path: "/home/someoperator/.config/pipelock/config.yaml", access: GuardAccessRead, wantRule: "forbidden_path_shape"},
+		{name: "write_autostart", path: "/home/someoperator/.config/autostart/app.desktop", access: GuardAccessWrite, wantRule: "forbidden_path_shape"},
+		{name: "write_whole_home", path: "/app", access: GuardAccessWrite, wantRule: "whole_home"},
+		{name: "write_root", path: "/etc/systemd/system/app.service", access: GuardAccessWrite, wantRule: "dangerous_write_root"},
+		{name: "write_credential", path: "/home/someoperator/.claude.json~", access: GuardAccessWrite, wantRule: "credential_path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			decision, err := ExplainGuardPathFloor(tt.path, tt.access)
+			if err != nil {
+				t.Fatalf("ExplainGuardPathFloor: %v", err)
+			}
+			if !decision.Refused || decision.Rule != tt.wantRule {
+				t.Fatalf("explain decision = %+v, want rule %q", decision, tt.wantRule)
+			}
+
+			if tt.access == GuardAccessRead {
+				err = validateGuardROPath("guard.manifests[0]", "read_only", 0, tt.path)
+			} else {
+				err = validateGuardRWPath("guard.manifests[0]", "read_write", 0, tt.path)
+			}
+			if err == nil || !strings.Contains(err.Error(), decision.Reason) {
+				t.Fatalf("validator did not enforce explain rule %q with the same reason: decision=%+v err=%v", decision.Rule, decision, err)
+			}
+		})
+	}
+}
+
 func TestValidateGuard_ValidFull(t *testing.T) {
 	t.Parallel()
 	cfg := Defaults()

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -146,6 +146,40 @@ func TestExplainGuardPathFloorValidatorAntiDrift(t *testing.T) {
 	}
 }
 
+func TestGuardInspectionValidationSeparatesStructureFloorAndRuntimeGate(t *testing.T) {
+	t.Parallel()
+
+	floorRefused := Defaults()
+	floorRefused.Guard.Manifests = []GuardManifest{{
+		Name:     "credentials",
+		ReadOnly: []string{"/home/someoperator/.netrc"},
+	}}
+	if err := floorRefused.ValidateGuardStructure(); err != nil {
+		t.Fatalf("structure-only validation must retain a floor-refused path for explanation: %v", err)
+	}
+	if err := floorRefused.ValidateGuardDeclaration(); err == nil || errors.Is(err, errGuardNotEnforced) || !strings.Contains(err.Error(), ".netrc") {
+		t.Fatalf("declaration validation must enforce the path floor before the runtime gate: %v", err)
+	}
+
+	invalidStructure := Defaults()
+	invalidStructure.Guard.Manifests = []GuardManifest{{
+		Name:                "bad",
+		ReadOnly:            []string{"/opt/app/Config"},
+		ReadOnlyDirectories: []string{"/opt/app/config/"},
+	}}
+	for name, validate := range map[string]func() error{
+		"structure":   invalidStructure.ValidateGuardStructure,
+		"declaration": invalidStructure.ValidateGuardDeclaration,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validate()
+			if err == nil || !strings.Contains(err.Error(), "conflicts") {
+				t.Fatalf("invalid typed declaration must fail %s validation: %v", name, err)
+			}
+		})
+	}
+}
+
 func TestValidateGuard_ValidFull(t *testing.T) {
 	t.Parallel()
 	cfg := Defaults()

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -1371,3 +1371,53 @@ func TestValidateGuard_CaseEquivalentGrantsConflict(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateGuard_ForbiddenComponentSurvivesSymlink covers the declared
+// spelling half of the component floor.
+//
+// Resolving first and checking only the result is a fail-open. A path declared
+// as a key or credential directory that symlinks somewhere innocuous resolves
+// to a name carrying no forbidden component, so the floor saw nothing and
+// allowed it for read and for write alike. Naming such a directory in a
+// manifest is the thing being refused; where the link points today does not
+// make the declaration safe, and the link can be repointed afterwards.
+//
+// This one IS reproducible in a hermetic test, unlike the credential-shape
+// variant, because a forbidden component is matched anywhere in the path rather
+// than relative to a home root, so a temp directory is enough to build it.
+func TestValidateGuard_ForbiddenComponentSurvivesSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "innocuous")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	for _, name := range []string{".ssh", ".gnupg", ".aws", ".kube"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			link := filepath.Join(t.TempDir(), name)
+			if err := os.Symlink(target, link); err != nil {
+				t.Fatalf("Symlink: %v", err)
+			}
+			if err := validateGuardROPath("m", "read_only", 0, link); err == nil {
+				t.Errorf("read grant on a %s symlink must be refused on the declared name", name)
+			}
+			if err := validateGuardRWPath("m", "read_write", 0, link); err == nil {
+				t.Errorf("read-write grant on a %s symlink must be refused on the declared name", name)
+			}
+		})
+	}
+
+	// Availability control. An ordinary directory beside the symlinks must stay
+	// grantable, so the declared-name check cannot be passing for a blanket
+	// reason unrelated to the component.
+	ordinary := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(ordinary, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := validateGuardROPath("m", "read_only", 0, ordinary); err != nil {
+		t.Errorf("ordinary workspace path must remain grantable, got: %v", err)
+	}
+}

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -89,7 +89,9 @@ func TestExplainGuardPathFloorUsesResolvedSymlinkForBothAccesses(t *testing.T) {
 	}
 	alias := filepath.Join(root, "innocuous")
 	if err := os.Symlink(target, alias); err != nil {
-		t.Fatalf("create symlink: %v", err)
+		// A platform that refuses symlink creation for unprivileged users is
+		// not a failure of the floor, it is a case that cannot run here.
+		t.Skipf("symlink creation unsupported on this platform: %v", err)
 	}
 	for _, access := range []GuardAccess{GuardAccessRead, GuardAccessWrite} {
 		t.Run(string(access), func(t *testing.T) {
@@ -1399,7 +1401,7 @@ func TestValidateGuard_ForbiddenComponentSurvivesSymlink(t *testing.T) {
 			t.Parallel()
 			link := filepath.Join(t.TempDir(), name)
 			if err := os.Symlink(target, link); err != nil {
-				t.Fatalf("Symlink: %v", err)
+				t.Skipf("symlink creation unsupported on this platform: %v", err)
 			}
 			if err := validateGuardROPath("m", "read_only", 0, link); err == nil {
 				t.Errorf("read grant on a %s symlink must be refused on the declared name", name)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4287,6 +4287,47 @@ var guardDangerousRWRoots = []struct {
 }
 
 func (c *Config) validateGuard() error {
+	if err := c.ValidateGuardDeclaration(); err != nil {
+		return err
+	}
+	g := &c.Guard
+	if len(g.Services) == 0 && len(g.Profiles) == 0 && len(g.Manifests) == 0 {
+		return nil
+	}
+
+	// Everything above validated the declaration. This refuses to ACCEPT it.
+	//
+	// No runtime evaluator consumes guard yet, so a config that loads cleanly
+	// would tell an operator their workload is constrained when nothing
+	// constrains it. Silent acceptance of a security-boundary declaration that
+	// has no enforcement is worse than refusing it: the operator acts on the
+	// clean load. Fail closed instead, and say exactly why.
+	//
+	// Validation still runs first so the message names a genuinely broken
+	// declaration ahead of the unsupported gate; an operator writing this
+	// config today gets accurate feedback on it for when enforcement lands.
+	//
+	// REMOVE THIS GATE in the PR that wires the guard runtime evaluator, in
+	// the same change that starts enforcing these grants.
+	return errGuardNotEnforced
+}
+
+// ValidateGuardDeclaration validates guard names, references, destinations,
+// path declarations, and compiled-floor constraints without treating the
+// not-yet-enforced runtime gate as a declaration error.
+func (c *Config) ValidateGuardDeclaration() error {
+	return c.validateGuardDeclaration(true)
+}
+
+// ValidateGuardStructure validates guard declarations except for compiled
+// path-floor refusals. Read-only explain commands use it so they can display a
+// refused grant and its exact floor rule instead of failing before diagnosis.
+// Runtime and normal config loading never use this path.
+func (c *Config) ValidateGuardStructure() error {
+	return c.validateGuardDeclaration(false)
+}
+
+func (c *Config) validateGuardDeclaration(checkPathFloor bool) error {
 	g := &c.Guard
 	if len(g.Services) == 0 && len(g.Profiles) == 0 && len(g.Manifests) == 0 {
 		return nil
@@ -4345,32 +4386,40 @@ func (c *Config) validateGuard() error {
 			if err := validateGuardManifestPath(label, "read_only", j, p, guardPathFile, pathFields); err != nil {
 				return err
 			}
-			if err := validateGuardROPath(label, "read_only", j, p); err != nil {
-				return err
+			if checkPathFloor {
+				if err := validateGuardROPath(label, "read_only", j, p); err != nil {
+					return err
+				}
 			}
 		}
 		for j, p := range m.ReadOnlyDirectories {
 			if err := validateGuardManifestPath(label, "read_only_directories", j, p, guardPathDirectory, pathFields); err != nil {
 				return err
 			}
-			if err := validateGuardROPath(label, "read_only_directories", j, p); err != nil {
-				return err
+			if checkPathFloor {
+				if err := validateGuardROPath(label, "read_only_directories", j, p); err != nil {
+					return err
+				}
 			}
 		}
 		for j, p := range m.ReadWrite {
 			if err := validateGuardManifestPath(label, "read_write", j, p, guardPathFile, pathFields); err != nil {
 				return err
 			}
-			if err := validateGuardRWPath(label, "read_write", j, p); err != nil {
-				return err
+			if checkPathFloor {
+				if err := validateGuardRWPath(label, "read_write", j, p); err != nil {
+					return err
+				}
 			}
 		}
 		for j, p := range m.ReadWriteDirectories {
 			if err := validateGuardManifestPath(label, "read_write_directories", j, p, guardPathDirectory, pathFields); err != nil {
 				return err
 			}
-			if err := validateGuardRWPath(label, "read_write_directories", j, p); err != nil {
-				return err
+			if checkPathFloor {
+				if err := validateGuardRWPath(label, "read_write_directories", j, p); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -4394,21 +4443,7 @@ func (c *Config) validateGuard() error {
 		}
 	}
 
-	// Everything above validated the declaration. This refuses to ACCEPT it.
-	//
-	// No runtime evaluator consumes guard yet, so a config that loads cleanly
-	// would tell an operator their workload is constrained when nothing
-	// constrains it. Silent acceptance of a security-boundary declaration that
-	// has no enforcement is worse than refusing it: the operator acts on the
-	// clean load. Fail closed instead, and say exactly why.
-	//
-	// Validation still runs first so the message names a genuinely broken
-	// declaration ahead of the unsupported gate; an operator writing this
-	// config today gets accurate feedback on it for when enforcement lands.
-	//
-	// REMOVE THIS GATE in the PR that wires the guard runtime evaluator, in
-	// the same change that starts enforcing these grants.
-	return errGuardNotEnforced
+	return nil
 }
 
 type guardPathType string

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4458,51 +4458,12 @@ var errGuardNotEnforced = errors.New(
 // access to dangerous or trust-bearing locations.
 func validateGuardRWPath(label, fieldName string, idx int, rawPath string) error {
 	field := fmt.Sprintf("%s.%s[%d]", label, fieldName, idx)
-
-	resolved := resolveGuardPath(rawPath)
-
-	// Trust-bearing and dangerous locations are matched on path COMPONENTS,
-	// not on a prefix derived from this process's home directory. Pipelock
-	// commonly runs as a system service, so os.UserHomeDir() returns /root
-	// and a home-derived list would protect /root/.ssh while leaving every
-	// real operator's ~/.ssh unguarded. Writing into any .ssh, .gnupg or
-	// .gpg directory is unsafe regardless of which user owns it.
-	if comp, reason := guardForbiddenComponent(resolved); comp != "" {
-		return fmt.Errorf("%s: read-write on trust-bearing path %q is not allowed (contains %q, which is %s)", field, rawPath, comp, reason)
+	decision, err := ExplainGuardPathFloor(rawPath, GuardAccessWrite)
+	if err != nil {
+		return fmt.Errorf("%s: %w", field, err)
 	}
-	if suffix := guardForbiddenSuffix(resolved); suffix != "" {
-		return fmt.Errorf("%s: read-write on %s %q is not allowed", field, suffix, rawPath)
+	if decision.Refused {
+		return fmt.Errorf("%s: %s", field, decision.Reason)
 	}
-	if guardIsHomeRoot(resolved) {
-		return fmt.Errorf("%s: read-write on the entire home directory is not allowed", field)
-	}
-
-	// NOTE: an earlier draft repeated these checks against os.UserHomeDir().
-	// That block was removed: it was fully shadowed by the component, suffix
-	// and home-root helpers above, which cover EVERY user rather than only the
-	// account this process happens to run as. Dead code that reads as live
-	// protection is worse than no code, because the next reader trusts it.
-
-	// Static dangerous roots. These run BEFORE the credential-material check so
-	// that a path both rules cover (/etc/shadow is a privilege path AND a
-	// credential store) keeps its established, more specific message.
-	for _, dr := range guardDangerousRWRoots {
-		clean := filepath.Clean(dr.prefix)
-		if resolved == clean || strings.HasPrefix(resolved, clean+string(filepath.Separator)) {
-			return fmt.Errorf("%s: read-write on %s %q is not allowed", field, dr.reason, rawPath)
-		}
-	}
-
-	// Credential material is refused for WRITE as well as read, and not merely
-	// because writing usually implies reading. Write alone is its own attack:
-	// rewriting ~/.npmrc or ~/.pypirc redirects a build to an attacker's
-	// registry, and rewriting ~/.kube/config or ~/.aws/credentials repoints the
-	// workload's cluster and cloud identity. Both floors share this set; the
-	// write floor adds the write-sensitive locations above that a read grant
-	// may legitimately keep.
-	if reason := guardDeclaredPathSecretMaterialReason(rawPath, resolved); reason != "" {
-		return fmt.Errorf("%s: read-write on %q is not allowed (%s); writing a credential file redirects the workload's identity", field, rawPath, reason)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## What changed

The guard floor refuses credential paths, but an operator had no way to ask why a path was refused, or which rule did it, or whether the refusal was something they could narrow. Two read only commands answer that.

`pipelock guard explain <path>` reports, for one absolute path, whether it would be allowed for read and for write, which rule decides, and what that rule matched. `pipelock guard show <profile>` prints the manifests a profile selects, every path with its declared type, and the floor refusals that apply to them.

## The distinction the output is built around

A refusal from the compiled floor cannot be configured away. A path that is simply not granted can be granted. Those are different problems with different fixes, and an operator who cannot tell them apart will either give up or go looking for a knob that does not exist, so the output separates them explicitly and says so in as many words.

Both commands also state that guard is not enforced in this build. That matters more than it looks: a clean explain output must never leave someone believing a workload is constrained when nothing constrains it yet.

## One implementation of the floor

The validators and the commands consume the same matcher. A second copy of the matching logic would drift from the rules that actually refuse a path, and at that point the command is confidently describing rules the system no longer applies, which is worse than having no command. A test asserts the explained rule is the rule the validator enforced, so the two cannot diverge silently.

## A fail open found by using the command

Driving the finished command against a real symlink surfaced a hole in the floor itself. Forbidden path components were matched only after symlink resolution, so a path declared as a key or credential directory that pointed somewhere innocuous resolved to a name carrying no forbidden component, and was allowed for read and for write alike. Naming such a directory in a manifest is the thing being refused; where the link happens to point today does not make the declaration safe, and it can be repointed afterwards.

The component check now runs against the declared spelling as well as the resolved target, matching what the credential shape check already did, so the refusal also names what the operator actually wrote. The regression test builds the symlink and fails if the declared name stops being checked. An ordinary directory beside the symlinks stays grantable, so the test cannot pass for a blanket reason unrelated to the component.

## Scope

Read only throughout. Neither command writes config, state, or the filesystem, and neither makes a trust decision from anything Pipelock generated. Output goes through the command writer and a stable JSON shape is available alongside the human readable default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the read-only `pipelock guard explain` command to inspect path decisions.
  * Added `pipelock guard show` to review guard profiles and access declarations.
  * Added human-readable and stable JSON output with matched rules, refusal reasons, and compiled filesystem restrictions.
  * Added validation for paths, profiles, grants, and guard declarations.
  * Clearly indicates that inspection does not enforce guard policies.

* **Documentation**
  * Added comprehensive CLI documentation covering commands, options, output, validation, and exit statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->