### PR TITLE
feat(evidence): give commitment keys a durable operator-owned keyring

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -17,6 +17,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 | [`pipelock adaptive`](adaptive.md) | Operator CLI for adaptive-enforcement state and overrides. |
 | [`pipelock session`](session.md) | Operator CLI for airlock session recovery. |
 | [`pipelock keys status`](keys.md) | Unified view of every signing-key purpose: source, presence, readability, and validity. |
+| [`pipelock commitment-key`](commitment-key.md) | Initialize, inspect, rotate, retire, back up, restore, and test private evidence commitment keys. |
 | [`pipelock mcp integrity manifest`](mcp-integrity.md) | Generate and verify MCP server binary-integrity manifests. |
 | [`pipelock init sidecar`](init-sidecar.md) | Generate an enforced Pipelock companion proxy for a Kubernetes workload. |
 | [`pipelock license`](license.md) | Install, inspect, and check the license that unlocks paid features. |

--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -1,10 +1,14 @@
 # Evidence commitment keys
 
+> **Not active yet:** no evidence producer consumes these keys in this release.
+> The lifecycle commands prepare durable key storage, but nothing is currently
+> being committed with this keyring.
+
 Evidence commitments use a dedicated symmetric keyring. They do not use
 `flight_recorder.signing_key_path`, and the keyring cannot be loaded as a
 receipt-signing key. Configure its operator-owned location separately:
 
-```yaml
+```yaml pipelock-fragment
 evidence_provenance:
   commitment_keyring_path: /var/lib/pipelock/evidence/commitment-keyring.json
 ```
@@ -32,17 +36,17 @@ pipelock commitment-key rotate --config /etc/pipelock/pipelock.yaml
 Rotation makes the previous key verify-only and creates the next monotonic
 epoch. Old receipts remain openable by their key ID and epoch.
 
-Retirement destroys a verify-only key. Supply every retained receipt reference
-as `KEY_ID:EPOCH`; a matching reference refuses the operation. If no reference
-inventory is supplied, retirement also refuses. `--accept-loss` is the explicit
-override and permanently gives up opening any retained receipt using that key.
+Retirement destroys a verify-only key. There is not yet an authoritative
+retained-evidence inventory, so every retirement requires `--accept-loss`.
+That explicit authorization permanently gives up opening any retained evidence
+that uses the destroyed key.
 
 ```bash
 pipelock commitment-key retire \
   --config /etc/pipelock/pipelock.yaml \
   --key-id ck_0123456789abcdef0123456789abcdef \
   --epoch 1 \
-  --retained-reference ck_0123456789abcdef0123456789abcdef:1
+  --accept-loss
 ```
 
 Backups and restores are validated, atomic, and written with `0600` mode. Both
@@ -59,8 +63,20 @@ pipelock commitment-key restore \
 ```
 
 `pipelock commitment-key test` recomputes the PR 3 `CommitView` contract for a
-named key ID and epoch. Pass the receipt's typed recipe with `--recipe-json`;
+named key ID and epoch. The private transformed view is read from stdin by
+default; use `--view-file` only with an owner-owned regular file whose parent
+directories are not group/world-writable. The view is never accepted in argv
+or written to audit output. Pass the receipt's typed recipe with `--recipe-json`;
 omitting it selects the empty v1 recipe. Unknown recipe fields, unsupported
 operations, trailing JSON, and commitment mismatches fail closed. Every
 lifecycle storage operation emits a structured `commitment_key_lifecycle`
 audit event to stderr.
+
+On Unix, keyring, backup, restore, view, and lock paths are opened relative to
+validated directory descriptors; final symlinks are refused, opened files must
+be owned by the effective user with exact `0600` mode, and each parent must be
+owned by root or the effective user and not group/world-writable. On Windows,
+reparse-point checks cover existing parents and opened final files, but Unix
+owner/mode rules have no direct ACL equivalent and parent replacement cannot be
+pinned across the complete operation. Use an ACL-restricted directory owned by
+the Pipelock service account.

--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -8,7 +8,7 @@ Evidence commitments use a dedicated symmetric keyring. They do not use
 `flight_recorder.signing_key_path`, and the keyring cannot be loaded as a
 receipt-signing key. Configure its operator-owned location separately:
 
-```yaml pipelock-fragment
+```yaml
 evidence_provenance:
   commitment_keyring_path: /var/lib/pipelock/evidence/commitment-keyring.json
 ```

--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -80,3 +80,6 @@ reparse-point checks cover existing parents and opened final files, but Unix
 owner/mode rules have no direct ACL equivalent and parent replacement cannot be
 pinned across the complete operation. Use an ACL-restricted directory owned by
 the Pipelock service account.
+
+Other operating-system targets fail closed because they do not provide the
+filesystem primitives required for these storage guarantees.

--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -1,0 +1,63 @@
+# Evidence commitment keys
+
+Evidence commitments use a dedicated symmetric keyring. They do not use
+`flight_recorder.signing_key_path`, and the keyring cannot be loaded as a
+receipt-signing key. Configure its operator-owned location separately:
+
+```yaml
+evidence_provenance:
+  commitment_keyring_path: /var/lib/pipelock/evidence/commitment-keyring.json
+```
+
+The configured file is loaded at startup. A missing keyring, a symlink, a
+non-regular file, malformed content, the wrong key purpose, or permissions
+other than `0600` aborts startup. The path is restart-only.
+
+Initialize and inspect the keyring:
+
+```bash
+pipelock commitment-key initialize --config /etc/pipelock/pipelock.yaml
+pipelock commitment-key inspect --config /etc/pipelock/pipelock.yaml
+```
+
+Initialization creates 32 random bytes, an opaque key ID, and epoch 1. Inspect
+prints metadata only; it never prints key material.
+
+Rotate without breaking historical opening:
+
+```bash
+pipelock commitment-key rotate --config /etc/pipelock/pipelock.yaml
+```
+
+Rotation makes the previous key verify-only and creates the next monotonic
+epoch. Old receipts remain openable by their key ID and epoch.
+
+Retirement destroys a verify-only key. Supply every retained receipt reference
+as `KEY_ID:EPOCH`; a matching reference refuses the operation. If no reference
+inventory is supplied, retirement also refuses. `--accept-loss` is the explicit
+override and permanently gives up opening any retained receipt using that key.
+
+```bash
+pipelock commitment-key retire \
+  --config /etc/pipelock/pipelock.yaml \
+  --key-id ck_0123456789abcdef0123456789abcdef \
+  --epoch 1 \
+  --retained-reference ck_0123456789abcdef0123456789abcdef:1
+```
+
+Backups and restores are validated, atomic, and written with `0600` mode. Both
+destinations must be absent, preventing accidental overwrite:
+
+```bash
+pipelock commitment-key backup \
+  --config /etc/pipelock/pipelock.yaml \
+  --out /secure-backup/commitment-keyring.json
+
+pipelock commitment-key restore \
+  --config /etc/pipelock/pipelock.yaml \
+  --from /secure-backup/commitment-keyring.json
+```
+
+`pipelock commitment-key test` recomputes the PR 3 `CommitView` contract for a
+named key ID and epoch. A mismatch fails closed. Every lifecycle attempt emits
+a structured `commitment_key_lifecycle` audit event to stderr.

--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -59,5 +59,8 @@ pipelock commitment-key restore \
 ```
 
 `pipelock commitment-key test` recomputes the PR 3 `CommitView` contract for a
-named key ID and epoch. A mismatch fails closed. Every lifecycle attempt emits
-a structured `commitment_key_lifecycle` audit event to stderr.
+named key ID and epoch. Pass the receipt's typed recipe with `--recipe-json`;
+omitting it selects the empty v1 recipe. Unknown recipe fields, unsupported
+operations, trailing JSON, and commitment mismatches fail closed. Every
+lifecycle storage operation emits a structured `commitment_key_lifecycle`
+audit event to stderr.

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package commitmentkey
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	domkey "github.com/luckyPipewrench/pipelock/internal/commitmentkey"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+type auditEvent struct {
+	EventType string `json:"event_type"`
+	Operation string `json:"operation"`
+	Outcome   string `json:"outcome"`
+	KeyID     string `json:"key_id,omitempty"`
+	Epoch     uint64 `json:"epoch,omitempty"`
+	Timestamp string `json:"timestamp"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// Cmd returns the commitment-key lifecycle command tree.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "commitment-key",
+		Short: "Manage private evidence commitment keys",
+		Long: `Manage the operator-owned symmetric keyring used to open private
+evidence commitments. Commitment keys are not receipt-signing keys and cannot
+be used with signing commands.`,
+	}
+	cmd.AddCommand(initializeCmd(), inspectCmd(), rotateCmd(), retireCmd(), backupCmd(), restoreCmd(), testCmd())
+	return cmd
+}
+
+func initializeCmd() *cobra.Command {
+	var flags pathFlags
+	cmd := &cobra.Command{
+		Use:   "initialize",
+		Short: "Initialize a new commitment keyring",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := flags.resolve()
+			if err != nil {
+				return err
+			}
+			keyring, err := domkey.Initialize(path, time.Now())
+			if err != nil {
+				emitAudit(cmd, "initialize", "denied", "", 0, err)
+				return err
+			}
+			emitAudit(cmd, "initialize", "succeeded", keyring.ActiveID, keyring.Epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	return cmd
+}
+
+func inspectCmd() *cobra.Command {
+	var flags pathFlags
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect commitment key metadata without revealing key material",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			keyring, err := flags.load()
+			if err != nil {
+				emitAudit(cmd, "inspect", "denied", "", 0, err)
+				return err
+			}
+			emitAudit(cmd, "inspect", "succeeded", keyring.ActiveID, keyring.Epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	return cmd
+}
+
+func rotateCmd() *cobra.Command {
+	var flags pathFlags
+	cmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Create a new active epoch and retain the prior key for opening",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := flags.resolve()
+			if err != nil {
+				return err
+			}
+			keyring, err := domkey.Load(path)
+			if err != nil {
+				emitAudit(cmd, "rotate", "denied", "", 0, err)
+				return err
+			}
+			handle, err := keyring.Rotate(path, time.Now())
+			if err != nil {
+				emitAudit(cmd, "rotate", "denied", keyring.ActiveID, keyring.Epoch, err)
+				return err
+			}
+			emitAudit(cmd, "rotate", "succeeded", handle.KeyID, handle.Epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	return cmd
+}
+
+func retireCmd() *cobra.Command {
+	var flags pathFlags
+	var keyID string
+	var epoch uint64
+	var retained []string
+	var acceptLoss bool
+	cmd := &cobra.Command{
+		Use:   "retire",
+		Short: "Destroy a verify-only key after retained-reference checks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := flags.resolve()
+			if err != nil {
+				return err
+			}
+			references, err := parseReferences(retained)
+			if err != nil {
+				return err
+			}
+			keyring, err := domkey.Load(path)
+			if err != nil {
+				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
+				return err
+			}
+			if err := keyring.Retire(path, keyID, epoch, references, acceptLoss); err != nil {
+				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
+				return err
+			}
+			emitAudit(cmd, "retire", "succeeded", keyID, epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().StringVar(&keyID, "key-id", "", "opaque key ID to destroy")
+	cmd.Flags().Uint64Var(&epoch, "epoch", 0, "key epoch to destroy")
+	cmd.Flags().StringArrayVar(&retained, "retained-reference", nil, "retained receipt reference as KEY_ID:EPOCH; repeat as needed")
+	cmd.Flags().BoolVar(&acceptLoss, "accept-loss", false, "destroy the key even when a retained receipt still references it")
+	_ = cmd.MarkFlagRequired("key-id")
+	_ = cmd.MarkFlagRequired("epoch")
+	return cmd
+}
+
+func backupCmd() *cobra.Command {
+	var flags pathFlags
+	var out string
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Create a validated 0600 keyring backup",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := flags.resolve()
+			if err != nil {
+				return err
+			}
+			if err := domkey.Backup(path, filepath.Clean(out)); err != nil {
+				emitAudit(cmd, "backup", "denied", "", 0, err)
+				return err
+			}
+			keyring, err := domkey.Load(path)
+			if err != nil {
+				return err
+			}
+			emitAudit(cmd, "backup", "succeeded", keyring.ActiveID, keyring.Epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().StringVar(&out, "out", "", "new backup file path")
+	_ = cmd.MarkFlagRequired("out")
+	return cmd
+}
+
+func restoreCmd() *cobra.Command {
+	var flags pathFlags
+	var from string
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Restore a validated backup into an absent keyring path",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := flags.resolve()
+			if err != nil {
+				return err
+			}
+			keyring, err := domkey.Restore(filepath.Clean(from), path)
+			if err != nil {
+				emitAudit(cmd, "restore", "denied", "", 0, err)
+				return err
+			}
+			emitAudit(cmd, "restore", "succeeded", keyring.ActiveID, keyring.Epoch, nil)
+			return writeJSON(cmd, keyring.Metadata())
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().StringVar(&from, "from", "", "backup file path")
+	_ = cmd.MarkFlagRequired("from")
+	return cmd
+}
+
+func testCmd() *cobra.Command {
+	var flags pathFlags
+	var keyID, sourceID, view, want string
+	var epoch, sourceOrdinal uint64
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test opening a PR 3 evidence view commitment",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			keyring, err := flags.load()
+			if err != nil {
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
+			handle, err := keyring.Open(keyID, epoch)
+			if err != nil {
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
+			source := contractreceipt.ProvenanceSource{
+				SourceOrdinal: sourceOrdinal,
+				SourceID:      sourceID,
+				Recipe:        normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest},
+			}
+			got, err := contractreceipt.CommitView(handle.Key, source, view)
+			if err != nil {
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
+			if got != want {
+				err := errors.New("commitment mismatch")
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
+			emitAudit(cmd, "test", "succeeded", keyID, epoch, nil)
+			return writeJSON(cmd, map[string]any{"key_id": keyID, "epoch": epoch, "opened": true})
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().StringVar(&keyID, "key-id", "", "opaque key ID named by the receipt")
+	cmd.Flags().Uint64Var(&epoch, "epoch", 0, "key epoch named by the receipt")
+	cmd.Flags().StringVar(&sourceID, "source-id", "", "source ID bound into the commitment")
+	cmd.Flags().Uint64Var(&sourceOrdinal, "source-ordinal", 0, "source ordinal bound into the commitment")
+	cmd.Flags().StringVar(&view, "view", "", "complete transformed view to open")
+	cmd.Flags().StringVar(&want, "commitment", "", "expected hmac-sha256 commitment")
+	for _, name := range []string{"key-id", "epoch", "source-id", "view", "commitment"} {
+		_ = cmd.MarkFlagRequired(name)
+	}
+	return cmd
+}
+
+type pathFlags struct {
+	path       string
+	configFile string
+}
+
+func (f *pathFlags) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.path, "keyring", "", "commitment keyring path")
+	cmd.Flags().StringVar(&f.configFile, "config", "", "config file containing evidence_provenance.commitment_keyring_path")
+}
+
+func (f pathFlags) resolve() (string, error) {
+	if f.path != "" && f.configFile != "" {
+		return "", errors.New("--keyring and --config are mutually exclusive")
+	}
+	if f.path != "" {
+		return filepath.Clean(f.path), nil
+	}
+	if f.configFile == "" {
+		return "", errors.New("one of --keyring or --config is required")
+	}
+	cfg, err := config.Load(f.configFile)
+	if err != nil {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+	if cfg.EvidenceProvenance.CommitmentKeyringPath == "" {
+		return "", errors.New("config has no evidence_provenance.commitment_keyring_path")
+	}
+	return filepath.Clean(cfg.EvidenceProvenance.CommitmentKeyringPath), nil
+}
+
+func (f pathFlags) load() (*domkey.Keyring, error) {
+	path, err := f.resolve()
+	if err != nil {
+		return nil, err
+	}
+	return domkey.Load(path)
+}
+
+func parseReferences(values []string) ([]domkey.Reference, error) {
+	refs := make([]domkey.Reference, 0, len(values))
+	for _, value := range values {
+		keyID, rawEpoch, ok := strings.Cut(value, ":")
+		if !ok || keyID == "" {
+			return nil, fmt.Errorf("invalid retained reference %q; want KEY_ID:EPOCH", value)
+		}
+		epoch, err := strconv.ParseUint(rawEpoch, 10, 64)
+		if err != nil || epoch == 0 {
+			return nil, fmt.Errorf("invalid retained reference %q; epoch must be positive", value)
+		}
+		refs = append(refs, domkey.Reference{KeyID: keyID, Epoch: epoch})
+	}
+	return refs, nil
+}
+
+func emitAudit(cmd *cobra.Command, operation, outcome, keyID string, epoch uint64, operationErr error) {
+	event := auditEvent{EventType: "commitment_key_lifecycle", Operation: operation, Outcome: outcome, KeyID: keyID, Epoch: epoch, Timestamp: time.Now().UTC().Format(time.RFC3339Nano)}
+	if operationErr != nil {
+		event.Reason = operationErr.Error()
+	}
+	data, err := json.Marshal(event)
+	if err == nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), string(data))
+	}
+}
+
+func writeJSON(cmd *cobra.Command, value any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("write JSON output: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -36,6 +36,10 @@ const (
 	privateViewMaxSize = 64 << 20
 )
 
+// ErrCommitmentMismatch reports that a recomputed commitment differs from the
+// expected value supplied by the operator.
+var ErrCommitmentMismatch = errors.New("commitment mismatch")
+
 // Cmd returns the commitment-key lifecycle command tree.
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -112,17 +116,13 @@ func rotateCmd() *cobra.Command {
 				emitAudit(cmd, "rotate", "denied", "", 0, err)
 				return err
 			}
-			handle, err := domkey.Rotate(path, time.Now())
+			handle, metadata, err := domkey.Rotate(path, time.Now())
 			if err != nil {
 				emitAudit(cmd, "rotate", "denied", "", 0, err)
 				return err
 			}
 			emitAudit(cmd, "rotate", "succeeded", handle.KeyID, handle.Epoch, nil)
-			keyring, err := domkey.Load(path)
-			if err != nil {
-				return err
-			}
-			return writeJSON(cmd, keyring.Metadata())
+			return writeJSON(cmd, metadata)
 		},
 	}
 	flags.bind(cmd)
@@ -145,16 +145,13 @@ func retireCmd() *cobra.Command {
 				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
 				return err
 			}
-			if err := domkey.Retire(path, keyID, epoch, acceptLoss); err != nil {
+			metadata, err := domkey.Retire(path, keyID, epoch, acceptLoss)
+			if err != nil {
 				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
 				return err
 			}
 			emitAudit(cmd, "retire", "succeeded", keyID, epoch, nil, "operator_accept_loss")
-			keyring, err := domkey.Load(path)
-			if err != nil {
-				return err
-			}
-			return writeJSON(cmd, keyring.Metadata())
+			return writeJSON(cmd, metadata)
 		},
 	}
 	flags.bind(cmd)
@@ -265,7 +262,7 @@ func testCmd() *cobra.Command {
 				return err
 			}
 			if got != want {
-				err := errors.New("commitment mismatch")
+				err := ErrCommitmentMismatch
 				emitAudit(cmd, "test", "denied", keyID, epoch, err)
 				return err
 			}

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -168,12 +169,9 @@ func backupCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := domkey.Backup(path, filepath.Clean(out)); err != nil {
-				emitAudit(cmd, "backup", "denied", "", 0, err)
-				return err
-			}
-			keyring, err := domkey.Load(path)
+			keyring, err := domkey.Backup(path, filepath.Clean(out))
 			if err != nil {
+				emitAudit(cmd, "backup", "denied", "", 0, err)
 				return err
 			}
 			emitAudit(cmd, "backup", "succeeded", keyring.ActiveID, keyring.Epoch, nil)
@@ -215,7 +213,7 @@ func restoreCmd() *cobra.Command {
 
 func testCmd() *cobra.Command {
 	var flags pathFlags
-	var keyID, sourceID, view, want string
+	var keyID, sourceID, view, want, recipeJSON string
 	var epoch, sourceOrdinal uint64
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -232,10 +230,15 @@ func testCmd() *cobra.Command {
 				emitAudit(cmd, "test", "denied", keyID, epoch, err)
 				return err
 			}
+			recipe, err := parseRecipe(recipeJSON)
+			if err != nil {
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
 			source := contractreceipt.ProvenanceSource{
 				SourceOrdinal: sourceOrdinal,
 				SourceID:      sourceID,
-				Recipe:        normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest},
+				Recipe:        recipe,
 			}
 			got, err := contractreceipt.CommitView(handle.Key, source, view)
 			if err != nil {
@@ -258,10 +261,31 @@ func testCmd() *cobra.Command {
 	cmd.Flags().Uint64Var(&sourceOrdinal, "source-ordinal", 0, "source ordinal bound into the commitment")
 	cmd.Flags().StringVar(&view, "view", "", "complete transformed view to open")
 	cmd.Flags().StringVar(&want, "commitment", "", "expected hmac-sha256 commitment")
+	cmd.Flags().StringVar(&recipeJSON, "recipe-json", "", "PR 3 typed recipe JSON; defaults to the empty v1 recipe")
 	for _, name := range []string{"key-id", "epoch", "source-id", "view", "commitment"} {
 		_ = cmd.MarkFlagRequired(name)
 	}
 	return cmd
+}
+
+func parseRecipe(raw string) (normalize.Recipe, error) {
+	if raw == "" {
+		return normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest}, nil
+	}
+	var recipe normalize.Recipe
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&recipe); err != nil {
+		return normalize.Recipe{}, fmt.Errorf("decode --recipe-json: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return normalize.Recipe{}, errors.New("decode --recipe-json: trailing JSON")
+	}
+	if err := recipe.Validate(); err != nil {
+		return normalize.Recipe{}, fmt.Errorf("validate --recipe-json: %w", err)
+	}
+	return recipe, nil
 }
 
 type pathFlags struct {

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,23 +21,32 @@ import (
 )
 
 type auditEvent struct {
-	EventType string `json:"event_type"`
-	Operation string `json:"operation"`
-	Outcome   string `json:"outcome"`
-	KeyID     string `json:"key_id,omitempty"`
-	Epoch     uint64 `json:"epoch,omitempty"`
-	Timestamp string `json:"timestamp"`
-	Reason    string `json:"reason,omitempty"`
+	EventType     string `json:"event_type"`
+	Operation     string `json:"operation"`
+	Outcome       string `json:"outcome"`
+	KeyID         string `json:"key_id,omitempty"`
+	Epoch         uint64 `json:"epoch,omitempty"`
+	Timestamp     string `json:"timestamp"`
+	Reason        string `json:"reason,omitempty"`
+	Authorization string `json:"authorization,omitempty"`
 }
+
+const (
+	capabilityNotice   = "WARNING: commitment keys are not consumed by an evidence producer yet; nothing is currently being committed with this keyring."
+	privateViewMaxSize = 64 << 20
+)
 
 // Cmd returns the commitment-key lifecycle command tree.
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commitment-key",
 		Short: "Manage private evidence commitment keys",
-		Long: `Manage the operator-owned symmetric keyring used to open private
+		Long: `Manage the operator-owned symmetric keyring intended to open private
 evidence commitments. Commitment keys are not receipt-signing keys and cannot
-be used with signing commands.`,
+be used with signing commands.
+
+No evidence producer consumes these keys yet. Nothing is currently being
+committed with this keyring.`,
 	}
 	cmd.AddCommand(initializeCmd(), inspectCmd(), rotateCmd(), retireCmd(), backupCmd(), restoreCmd(), testCmd())
 	return cmd
@@ -51,8 +59,10 @@ func initializeCmd() *cobra.Command {
 		Short: "Initialize a new commitment keyring",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			path, err := flags.resolve()
 			if err != nil {
+				emitAudit(cmd, "initialize", "denied", "", 0, err)
 				return err
 			}
 			keyring, err := domkey.Initialize(path, time.Now())
@@ -75,6 +85,7 @@ func inspectCmd() *cobra.Command {
 		Short: "Inspect commitment key metadata without revealing key material",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			keyring, err := flags.load()
 			if err != nil {
 				emitAudit(cmd, "inspect", "denied", "", 0, err)
@@ -95,8 +106,10 @@ func rotateCmd() *cobra.Command {
 		Short: "Create a new active epoch and retain the prior key for opening",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			path, err := flags.resolve()
 			if err != nil {
+				emitAudit(cmd, "rotate", "denied", "", 0, err)
 				return err
 			}
 			handle, err := domkey.Rotate(path, time.Now())
@@ -120,26 +133,23 @@ func retireCmd() *cobra.Command {
 	var flags pathFlags
 	var keyID string
 	var epoch uint64
-	var retained []string
 	var acceptLoss bool
 	cmd := &cobra.Command{
 		Use:   "retire",
-		Short: "Destroy a verify-only key after retained-reference checks",
+		Short: "Destroy a verify-only key with explicit loss acceptance",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			path, err := flags.resolve()
 			if err != nil {
-				return err
-			}
-			references, err := parseReferences(retained)
-			if err != nil {
-				return err
-			}
-			if err := domkey.Retire(path, keyID, epoch, references, acceptLoss); err != nil {
 				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
 				return err
 			}
-			emitAudit(cmd, "retire", "succeeded", keyID, epoch, nil)
+			if err := domkey.Retire(path, keyID, epoch, acceptLoss); err != nil {
+				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
+				return err
+			}
+			emitAudit(cmd, "retire", "succeeded", keyID, epoch, nil, "operator_accept_loss")
 			keyring, err := domkey.Load(path)
 			if err != nil {
 				return err
@@ -150,8 +160,7 @@ func retireCmd() *cobra.Command {
 	flags.bind(cmd)
 	cmd.Flags().StringVar(&keyID, "key-id", "", "opaque key ID to destroy")
 	cmd.Flags().Uint64Var(&epoch, "epoch", 0, "key epoch to destroy")
-	cmd.Flags().StringArrayVar(&retained, "retained-reference", nil, "retained receipt reference as KEY_ID:EPOCH; repeat as needed")
-	cmd.Flags().BoolVar(&acceptLoss, "accept-loss", false, "destroy the key even when a retained receipt still references it")
+	cmd.Flags().BoolVar(&acceptLoss, "accept-loss", false, "acknowledge permanent loss of access to retained evidence and destroy the key")
 	_ = cmd.MarkFlagRequired("key-id")
 	_ = cmd.MarkFlagRequired("epoch")
 	return cmd
@@ -165,8 +174,10 @@ func backupCmd() *cobra.Command {
 		Short: "Create a validated 0600 keyring backup",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			path, err := flags.resolve()
 			if err != nil {
+				emitAudit(cmd, "backup", "denied", "", 0, err)
 				return err
 			}
 			keyring, err := domkey.Backup(path, filepath.Clean(out))
@@ -192,8 +203,10 @@ func restoreCmd() *cobra.Command {
 		Short: "Restore a validated backup into an absent keyring path",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			path, err := flags.resolve()
 			if err != nil {
+				emitAudit(cmd, "restore", "denied", "", 0, err)
 				return err
 			}
 			keyring, err := domkey.Restore(filepath.Clean(from), path)
@@ -213,13 +226,14 @@ func restoreCmd() *cobra.Command {
 
 func testCmd() *cobra.Command {
 	var flags pathFlags
-	var keyID, sourceID, view, want, recipeJSON string
+	var keyID, sourceID, viewFile, want, recipeJSON string
 	var epoch, sourceOrdinal uint64
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: "Test opening a PR 3 evidence view commitment",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			emitCapabilityNotice(cmd)
 			keyring, err := flags.load()
 			if err != nil {
 				emitAudit(cmd, "test", "denied", keyID, epoch, err)
@@ -240,6 +254,11 @@ func testCmd() *cobra.Command {
 				SourceID:      sourceID,
 				Recipe:        recipe,
 			}
+			view, err := readView(cmd, viewFile)
+			if err != nil {
+				emitAudit(cmd, "test", "denied", keyID, epoch, err)
+				return err
+			}
 			got, err := contractreceipt.CommitView(handle.Key, source, view)
 			if err != nil {
 				emitAudit(cmd, "test", "denied", keyID, epoch, err)
@@ -259,10 +278,10 @@ func testCmd() *cobra.Command {
 	cmd.Flags().Uint64Var(&epoch, "epoch", 0, "key epoch named by the receipt")
 	cmd.Flags().StringVar(&sourceID, "source-id", "", "source ID bound into the commitment")
 	cmd.Flags().Uint64Var(&sourceOrdinal, "source-ordinal", 0, "source ordinal bound into the commitment")
-	cmd.Flags().StringVar(&view, "view", "", "complete transformed view to open")
+	cmd.Flags().StringVar(&viewFile, "view-file", "-", "read the complete transformed view from this 0600 file, or - for stdin")
 	cmd.Flags().StringVar(&want, "commitment", "", "expected hmac-sha256 commitment")
 	cmd.Flags().StringVar(&recipeJSON, "recipe-json", "", "PR 3 typed recipe JSON; defaults to the empty v1 recipe")
-	for _, name := range []string{"key-id", "epoch", "source-id", "view", "commitment"} {
+	for _, name := range []string{"key-id", "epoch", "source-id", "commitment"} {
 		_ = cmd.MarkFlagRequired(name)
 	}
 	return cmd
@@ -330,24 +349,33 @@ func (f pathFlags) load() (*domkey.Keyring, error) {
 	return domkey.Load(path)
 }
 
-func parseReferences(values []string) ([]domkey.Reference, error) {
-	refs := make([]domkey.Reference, 0, len(values))
-	for _, value := range values {
-		keyID, rawEpoch, ok := strings.Cut(value, ":")
-		if !ok || keyID == "" {
-			return nil, fmt.Errorf("invalid retained reference %q; want KEY_ID:EPOCH", value)
+func readView(cmd *cobra.Command, path string) (string, error) {
+	if path == "-" {
+		raw, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), privateViewMaxSize+1))
+		if err != nil {
+			return "", fmt.Errorf("read private evidence view from stdin: %w", err)
 		}
-		epoch, err := strconv.ParseUint(rawEpoch, 10, 64)
-		if err != nil || epoch == 0 {
-			return nil, fmt.Errorf("invalid retained reference %q; epoch must be positive", value)
+		if len(raw) > privateViewMaxSize {
+			return "", errors.New("private evidence view exceeds 67108864 bytes")
 		}
-		refs = append(refs, domkey.Reference{KeyID: keyID, Epoch: epoch})
+		return string(raw), nil
 	}
-	return refs, nil
+	raw, err := domkey.ReadPrivateView(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("read --view-file: %w", err)
+	}
+	return string(raw), nil
 }
 
-func emitAudit(cmd *cobra.Command, operation, outcome, keyID string, epoch uint64, operationErr error) {
+func emitCapabilityNotice(cmd *cobra.Command) {
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), capabilityNotice)
+}
+
+func emitAudit(cmd *cobra.Command, operation, outcome, keyID string, epoch uint64, operationErr error, authorization ...string) {
 	event := auditEvent{EventType: "commitment_key_lifecycle", Operation: operation, Outcome: outcome, KeyID: keyID, Epoch: epoch, Timestamp: time.Now().UTC().Format(time.RFC3339Nano)}
+	if len(authorization) != 0 {
+		event.Authorization = authorization[0]
+	}
 	if operationErr != nil {
 		event.Reason = operationErr.Error()
 	}

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -98,17 +98,16 @@ func rotateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			keyring, err := domkey.Load(path)
+			handle, err := domkey.Rotate(path, time.Now())
 			if err != nil {
 				emitAudit(cmd, "rotate", "denied", "", 0, err)
 				return err
 			}
-			handle, err := keyring.Rotate(path, time.Now())
+			emitAudit(cmd, "rotate", "succeeded", handle.KeyID, handle.Epoch, nil)
+			keyring, err := domkey.Load(path)
 			if err != nil {
-				emitAudit(cmd, "rotate", "denied", keyring.ActiveID, keyring.Epoch, err)
 				return err
 			}
-			emitAudit(cmd, "rotate", "succeeded", handle.KeyID, handle.Epoch, nil)
 			return writeJSON(cmd, keyring.Metadata())
 		},
 	}
@@ -135,16 +134,15 @@ func retireCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			keyring, err := domkey.Load(path)
-			if err != nil {
-				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
-				return err
-			}
-			if err := keyring.Retire(path, keyID, epoch, references, acceptLoss); err != nil {
+			if err := domkey.Retire(path, keyID, epoch, references, acceptLoss); err != nil {
 				emitAudit(cmd, "retire", "denied", keyID, epoch, err)
 				return err
 			}
 			emitAudit(cmd, "retire", "succeeded", keyID, epoch, nil)
+			keyring, err := domkey.Load(path)
+			if err != nil {
+				return err
+			}
 			return writeJSON(cmd, keyring.Metadata())
 		},
 	}
@@ -286,14 +284,18 @@ func (f pathFlags) resolve() (string, error) {
 	if f.configFile == "" {
 		return "", errors.New("one of --keyring or --config is required")
 	}
-	cfg, err := config.Load(f.configFile)
+	cfg, err := config.LoadForInspection(f.configFile)
 	if err != nil {
 		return "", fmt.Errorf("load config: %w", err)
 	}
 	if cfg.EvidenceProvenance.CommitmentKeyringPath == "" {
 		return "", errors.New("config has no evidence_provenance.commitment_keyring_path")
 	}
-	return filepath.Clean(cfg.EvidenceProvenance.CommitmentKeyringPath), nil
+	path := cfg.EvidenceProvenance.CommitmentKeyringPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(filepath.Dir(filepath.Clean(f.configFile)), path)
+	}
+	return filepath.Clean(path), nil
 }
 
 func (f pathFlags) load() (*domkey.Keyring, error) {

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -190,6 +190,13 @@ func TestCommandDenialBranches(t *testing.T) {
 		{name: "test unknown key", operation: "test", args: []string{"test", "--keyring", path, "--key-id", "ck_00000000000000000000000000000000", "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
 		{name: "test invalid recipe", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64), "--recipe-json", `{}`}, wantAudit: true},
 		{name: "missing path selector", args: []string{"inspect"}},
+		{name: "initialize missing path selector", args: []string{"initialize"}},
+		{name: "rotate missing path selector", args: []string{"rotate"}},
+		{name: "retire missing path selector", args: []string{"retire", "--key-id", metadata.ActiveID, "--epoch", "1"}},
+		{name: "backup missing path selector", args: []string{"backup", "--out", filepath.Join(dir, "unused.json")}},
+		{name: "restore missing path selector", args: []string{"restore", "--from", path}},
+		{name: "test missing path selector", operation: "test", args: []string{"test", "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
+		{name: "test invalid source utf8", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", string([]byte{0xff}), "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, stderr, err := execute(t, test.args...)
@@ -215,6 +222,20 @@ func TestCommandDenialBranches(t *testing.T) {
 		t.Fatal("restore over existing keyring succeeded")
 	}
 	assertAudit(t, stderr, "restore", "denied")
+}
+
+func TestWriteJSONReportsOutputFailure(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(failingWriter{})
+	if err := writeJSON(cmd, map[string]bool{"ok": true}); err == nil {
+		t.Fatal("writeJSON succeeded with failing writer")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
 }
 
 func TestConfigPathResolutionDenials(t *testing.T) {

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package commitmentkey
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	domkey "github.com/luckyPipewrench/pipelock/internal/commitmentkey"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+func TestCommandLifecycleAndAudit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state", "keyring.json")
+	backup := filepath.Join(dir, "backup", "keyring.json")
+
+	stdout, stderr, err := execute(t, "initialize", "--keyring", path)
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	first := decodeMetadata(t, stdout)
+	assertAudit(t, stderr, "initialize", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
+
+	stdout, stderr, err = execute(t, "inspect", "--keyring", path)
+	if err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	if got := decodeMetadata(t, stdout); got.ActiveID != first.ActiveID || got.Epoch != 1 {
+		t.Fatalf("inspect metadata = %+v, want active %q epoch 1", got, first.ActiveID)
+	}
+	assertAudit(t, stderr, "inspect", "succeeded")
+
+	stdout, stderr, err = execute(t, "rotate", "--keyring", path)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	rotated := decodeMetadata(t, stdout)
+	if rotated.Epoch != 2 || rotated.ActiveID == first.ActiveID || len(rotated.Keys) != 2 {
+		t.Fatalf("rotated metadata = %+v", rotated)
+	}
+	assertAudit(t, stderr, "rotate", "succeeded")
+
+	ref := fmt.Sprintf("%s:%d", first.ActiveID, first.Epoch)
+	_, stderr, err = execute(t, "retire", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--retained-reference", ref)
+	if !errors.Is(err, domkey.ErrRetainedKey) {
+		t.Fatalf("retire retained error = %v, want ErrRetainedKey", err)
+	}
+	assertAudit(t, stderr, "retire", "denied")
+
+	_, stderr, err = execute(t, "backup", "--keyring", path, "--out", backup)
+	if err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	assertAudit(t, stderr, "backup", "succeeded")
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("destroy keyring: %v", err)
+	}
+	_, stderr, err = execute(t, "restore", "--keyring", path, "--from", backup)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	assertAudit(t, stderr, "restore", "succeeded")
+
+	keyring, err := domkey.Load(path)
+	if err != nil {
+		t.Fatalf("Load restored: %v", err)
+	}
+	handle, err := keyring.Open(first.ActiveID, first.Epoch)
+	if err != nil {
+		t.Fatalf("Open retired key: %v", err)
+	}
+	source := contractreceipt.ProvenanceSource{SourceOrdinal: 1, SourceID: "source-1", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest}}
+	commitment, err := contractreceipt.CommitView(handle.Key, source, "opened after restore")
+	if err != nil {
+		t.Fatalf("CommitView: %v", err)
+	}
+	stdout, stderr, err = execute(t, "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--view", "opened after restore", "--commitment", commitment)
+	if err != nil {
+		t.Fatalf("test opening: %v", err)
+	}
+	if !strings.Contains(stdout, `"opened": true`) {
+		t.Fatalf("test output = %q", stdout)
+	}
+	assertAudit(t, stderr, "test", "succeeded")
+}
+
+func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: balanced\nevidence_provenance:\n  commitment_keyring_path: state/keyring.json\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	stdout, _, err := execute(t, "initialize", "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("initialize via config: %v", err)
+	}
+	metadata := decodeMetadata(t, stdout)
+	_, stderr, err := execute(t, "test", "--config", cfgPath, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:"+strings.Repeat("0", 64))
+	if err == nil || err.Error() != "commitment mismatch" {
+		t.Fatalf("test mismatch error = %v", err)
+	}
+	assertAudit(t, stderr, "test", "denied")
+	if _, _, err := execute(t, "inspect", "--keyring", "x", "--config", cfgPath); err == nil {
+		t.Fatal("mutually exclusive path flags succeeded")
+	}
+}
+
+func execute(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root := &cobra.Command{Use: "pipelock", SilenceUsage: true, SilenceErrors: true}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.AddCommand(Cmd())
+	root.SetArgs(append([]string{"commitment-key"}, args...))
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func decodeMetadata(t *testing.T, raw string) domkey.Metadata {
+	t.Helper()
+	var metadata domkey.Metadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		t.Fatalf("decode metadata %q: %v", raw, err)
+	}
+	return metadata
+}
+
+func assertAudit(t *testing.T, raw, operation, outcome string) {
+	t.Helper()
+	var event auditEvent
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &event); err != nil {
+		t.Fatalf("decode audit %q: %v", raw, err)
+	}
+	if event.EventType != "commitment_key_lifecycle" || event.Operation != operation || event.Outcome != outcome || event.Timestamp == "" {
+		t.Fatalf("audit event = %+v", event)
+	}
+}
+
+func assertNoKeyMaterial(t *testing.T, outputs ...string) {
+	t.Helper()
+	for _, output := range outputs {
+		if strings.Contains(output, `"key"`) {
+			t.Fatalf("operator output exposed key material field: %s", output)
+		}
+	}
+}

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -110,6 +110,15 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("test opening with typed recipe: %v", err)
 	}
 	assertAudit(t, stderr, "test", "succeeded")
+
+	stdout, stderr, err = execute(t, "retire", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--accept-loss")
+	if err != nil {
+		t.Fatalf("retire with explicit loss acceptance: %v", err)
+	}
+	if got := decodeMetadata(t, stdout); len(got.Keys) != 1 || got.Epoch != 2 {
+		t.Fatalf("retired metadata = %+v, want only epoch 2", got)
+	}
+	assertAudit(t, stderr, "retire", "succeeded")
 }
 
 func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
@@ -158,6 +167,73 @@ func TestParseRecipeRejectsUnknownAndTrailingFields(t *testing.T) {
 	}
 }
 
+func TestCommandDenialBranches(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+	backup := filepath.Join(dir, "backup.json")
+	if _, _, err := execute(t, "initialize", "--keyring", path); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	metadata := mustLoadMetadata(t, path)
+
+	for _, test := range []struct {
+		name      string
+		operation string
+		args      []string
+		wantAudit bool
+	}{
+		{name: "initialize rerun", operation: "initialize", args: []string{"initialize", "--keyring", path}, wantAudit: true},
+		{name: "inspect missing", operation: "inspect", args: []string{"inspect", "--keyring", filepath.Join(dir, "missing.json")}, wantAudit: true},
+		{name: "rotate missing", operation: "rotate", args: []string{"rotate", "--keyring", filepath.Join(dir, "missing.json")}, wantAudit: true},
+		{name: "retire malformed reference", args: []string{"retire", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--retained-reference", "malformed"}},
+		{name: "retire zero reference epoch", args: []string{"retire", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--retained-reference", metadata.ActiveID + ":0"}},
+		{name: "test unknown key", operation: "test", args: []string{"test", "--keyring", path, "--key-id", "ck_00000000000000000000000000000000", "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
+		{name: "test invalid recipe", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64), "--recipe-json", `{}`}, wantAudit: true},
+		{name: "missing path selector", args: []string{"inspect"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, stderr, err := execute(t, test.args...)
+			if err == nil {
+				t.Fatal("command succeeded")
+			}
+			if test.wantAudit {
+				assertAudit(t, stderr, test.operation, "denied")
+			}
+		})
+	}
+
+	if _, _, err := execute(t, "backup", "--keyring", path, "--out", backup); err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+	_, stderr, err := execute(t, "backup", "--keyring", path, "--out", backup)
+	if err == nil {
+		t.Fatal("duplicate backup succeeded")
+	}
+	assertAudit(t, stderr, "backup", "denied")
+	_, stderr, err = execute(t, "restore", "--keyring", path, "--from", backup)
+	if err == nil {
+		t.Fatal("restore over existing keyring succeeded")
+	}
+	assertAudit(t, stderr, "restore", "denied")
+}
+
+func TestConfigPathResolutionDenials(t *testing.T) {
+	dir := t.TempDir()
+	missingField := filepath.Join(dir, "missing-field.yaml")
+	if err := os.WriteFile(missingField, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	malformed := filepath.Join(dir, "malformed.yaml")
+	if err := os.WriteFile(malformed, []byte("mode: [\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	for _, path := range []string{missingField, malformed} {
+		if _, _, err := execute(t, "inspect", "--config", path); err == nil {
+			t.Fatalf("inspect with config %s succeeded", path)
+		}
+	}
+}
+
 func execute(t *testing.T, args ...string) (string, string, error) {
 	t.Helper()
 	stdout := &bytes.Buffer{}
@@ -178,6 +254,15 @@ func decodeMetadata(t *testing.T, raw string) domkey.Metadata {
 		t.Fatalf("decode metadata %q: %v", raw, err)
 	}
 	return metadata
+}
+
+func mustLoadMetadata(t *testing.T, path string) domkey.Metadata {
+	t.Helper()
+	keyring, err := domkey.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return keyring.Metadata()
 }
 
 func assertAudit(t *testing.T, raw, operation, outcome string) {

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -117,6 +117,18 @@ func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
 	}
 }
 
+func TestCommandConfigResolutionIgnoresUnrelatedRuntimeFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	body := "mode: balanced\nlicense_file: missing-license.txt\nevidence_provenance:\n  commitment_keyring_path: state/keyring.json\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	if _, _, err := execute(t, "initialize", "--config", cfgPath); err != nil {
+		t.Fatalf("initialize should not read unrelated runtime files: %v", err)
+	}
+}
+
 func execute(t *testing.T, args ...string) (string, string, error) {
 	t.Helper()
 	stdout := &bytes.Buffer{}

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -94,6 +94,22 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("test output = %q", stdout)
 	}
 	assertAudit(t, stderr, "test", "succeeded")
+
+	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationLowercase}}}
+	source.Recipe = recipe
+	commitment, err = contractreceipt.CommitView(handle.Key, source, "opened after restore")
+	if err != nil {
+		t.Fatalf("CommitView with typed recipe: %v", err)
+	}
+	recipeBytes, err := json.Marshal(recipe)
+	if err != nil {
+		t.Fatalf("Marshal recipe: %v", err)
+	}
+	_, stderr, err = execute(t, "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--view", "opened after restore", "--commitment", commitment, "--recipe-json", string(recipeBytes))
+	if err != nil {
+		t.Fatalf("test opening with typed recipe: %v", err)
+	}
+	assertAudit(t, stderr, "test", "succeeded")
 }
 
 func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
@@ -126,6 +142,19 @@ func TestCommandConfigResolutionIgnoresUnrelatedRuntimeFiles(t *testing.T) {
 	}
 	if _, _, err := execute(t, "initialize", "--config", cfgPath); err != nil {
 		t.Fatalf("initialize should not read unrelated runtime files: %v", err)
+	}
+}
+
+func TestParseRecipeRejectsUnknownAndTrailingFields(t *testing.T) {
+	for name, raw := range map[string]string{
+		"unknown":  `{"transform_profile_digest":"` + normalize.EvidenceProvenanceProfileV1Digest + `","operations":[],"extra":true}`,
+		"trailing": `{"transform_profile_digest":"` + normalize.EvidenceProvenanceProfileV1Digest + `","operations":[]} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseRecipe(raw); err == nil {
+				t.Fatalf("parseRecipe(%s) succeeded", raw)
+			}
+		})
 	}
 }
 

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -40,6 +42,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("inspect metadata = %+v, want active %q epoch 1", got, first.ActiveID)
 	}
 	assertAudit(t, stderr, "inspect", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
 
 	stdout, stderr, err = execute(t, "rotate", "--keyring", path)
 	if err != nil {
@@ -50,6 +53,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("rotated metadata = %+v", rotated)
 	}
 	assertAudit(t, stderr, "rotate", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
 
 	_, stderr, err = execute(t, "retire", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1")
 	if !errors.Is(err, domkey.ErrRetainedKey) {
@@ -57,19 +61,21 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	}
 	assertAudit(t, stderr, "retire", "denied")
 
-	_, stderr, err = execute(t, "backup", "--keyring", path, "--out", backup)
+	stdout, stderr, err = execute(t, "backup", "--keyring", path, "--out", backup)
 	if err != nil {
 		t.Fatalf("backup: %v", err)
 	}
 	assertAudit(t, stderr, "backup", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
 	if err := os.Remove(path); err != nil {
 		t.Fatalf("destroy keyring: %v", err)
 	}
-	_, stderr, err = execute(t, "restore", "--keyring", path, "--from", backup)
+	stdout, stderr, err = execute(t, "restore", "--keyring", path, "--from", backup)
 	if err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 	assertAudit(t, stderr, "restore", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
 
 	keyring, err := domkey.Load(path)
 	if err != nil {
@@ -92,6 +98,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("test output = %q", stdout)
 	}
 	assertAudit(t, stderr, "test", "succeeded")
+	assertNoKeyMaterial(t, stdout, stderr)
 
 	recipe := normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest, Operations: []normalize.Operation{{Kind: normalize.OperationLowercase}}}
 	source.Recipe = recipe
@@ -118,6 +125,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	}
 	assertAudit(t, stderr, "retire", "succeeded")
 	assertAuditAuthorization(t, stderr, "operator_accept_loss")
+	assertNoKeyMaterial(t, stdout, stderr)
 }
 
 func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
@@ -132,7 +140,7 @@ func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
 	}
 	metadata := decodeMetadata(t, stdout)
 	_, stderr, err := executeInput(t, "value", "test", "--config", cfgPath, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--commitment", "hmac-sha256:"+strings.Repeat("0", 64))
-	if err == nil || err.Error() != "commitment mismatch" {
+	if !errors.Is(err, ErrCommitmentMismatch) {
 		t.Fatalf("test mismatch error = %v", err)
 	}
 	assertAudit(t, stderr, "test", "denied")
@@ -266,13 +274,56 @@ func TestCommandReadsPrivateViewFromStdinOrSecureFile(t *testing.T) {
 	if _, _, err := execute(t, append(args, "--view", privateView)...); err == nil || !strings.Contains(err.Error(), "unknown flag") {
 		t.Fatalf("argv private view error = %v, want unknown --view flag", err)
 	}
+}
+
+func TestCommandRejectsSymlinkPrivateView(t *testing.T) {
+	if !supportsUnixSymlinkTest(runtime.GOOS) {
+		t.Skip("Windows uses reparse-point checks and may not permit symlink creation")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+	if _, _, err := execute(t, "initialize", "--keyring", path); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	keyring, err := domkey.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	handle, err := keyring.Active()
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	const privateView = "private transformed evidence"
+	source := contractreceipt.ProvenanceSource{SourceID: "source-1", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest}}
+	commitment, err := contractreceipt.CommitView(handle.Key, source, privateView)
+	if err != nil {
+		t.Fatalf("CommitView: %v", err)
+	}
+	viewPath := filepath.Join(dir, "view.txt")
+	if err := os.WriteFile(viewPath, []byte(privateView), 0o600); err != nil {
+		t.Fatalf("WriteFile view: %v", err)
+	}
 	link := filepath.Join(dir, "view-link.txt")
 	if err := os.Symlink(viewPath, link); err != nil {
 		t.Fatalf("Symlink: %v", err)
 	}
-	if _, stderr, err := execute(t, append(args, "--view-file", link)...); !errors.Is(err, domkey.ErrSymlink) {
+	args := []string{"test", "--keyring", path, "--key-id", handle.KeyID, "--epoch", "1", "--source-id", "source-1", "--commitment", commitment, "--view-file", link}
+	if _, stderr, err := execute(t, args...); !errors.Is(err, domkey.ErrSymlink) {
 		t.Fatalf("symlink view error = %v stderr=%q, want ErrSymlink", err, stderr)
 	}
+}
+
+func TestSymlinkTestPlatformGuard(t *testing.T) {
+	if supportsUnixSymlinkTest("windows") {
+		t.Fatal("Windows selected for Unix symlink test")
+	}
+	if !supportsUnixSymlinkTest("linux") {
+		t.Fatal("Linux excluded from Unix symlink test")
+	}
+}
+
+func supportsUnixSymlinkTest(goos string) bool {
+	return goos != "windows"
 }
 
 func TestLifecycleCommandsSurfaceInertCapabilityNotice(t *testing.T) {
@@ -295,7 +346,7 @@ func TestReadViewRejectsStdinReadFailureAndOversize(t *testing.T) {
 	if _, err := readView(cmd, "-"); err == nil || !strings.Contains(err.Error(), "read private evidence view") {
 		t.Fatalf("readView failing stdin error = %v", err)
 	}
-	cmd.SetIn(strings.NewReader(strings.Repeat("x", privateViewMaxSize+1)))
+	cmd.SetIn(io.LimitReader(repeatingReader{}, privateViewMaxSize+1))
 	if _, err := readView(cmd, "-"); err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("readView oversized stdin error = %v", err)
 	}
@@ -311,6 +362,15 @@ type failingReader struct{}
 
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errors.New("read failed")
+}
+
+type repeatingReader struct{}
+
+func (repeatingReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
 }
 
 func TestConfigPathResolutionDenials(t *testing.T) {

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,8 +51,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	}
 	assertAudit(t, stderr, "rotate", "succeeded")
 
-	ref := fmt.Sprintf("%s:%d", first.ActiveID, first.Epoch)
-	_, stderr, err = execute(t, "retire", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--retained-reference", ref)
+	_, stderr, err = execute(t, "retire", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1")
 	if !errors.Is(err, domkey.ErrRetainedKey) {
 		t.Fatalf("retire retained error = %v, want ErrRetainedKey", err)
 	}
@@ -86,7 +84,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CommitView: %v", err)
 	}
-	stdout, stderr, err = execute(t, "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--view", "opened after restore", "--commitment", commitment)
+	stdout, stderr, err = executeInput(t, "opened after restore", "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--commitment", commitment)
 	if err != nil {
 		t.Fatalf("test opening: %v", err)
 	}
@@ -105,7 +103,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal recipe: %v", err)
 	}
-	_, stderr, err = execute(t, "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--view", "opened after restore", "--commitment", commitment, "--recipe-json", string(recipeBytes))
+	_, stderr, err = executeInput(t, "opened after restore", "test", "--keyring", path, "--key-id", first.ActiveID, "--epoch", "1", "--source-id", "source-1", "--source-ordinal", "1", "--commitment", commitment, "--recipe-json", string(recipeBytes))
 	if err != nil {
 		t.Fatalf("test opening with typed recipe: %v", err)
 	}
@@ -119,6 +117,7 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 		t.Fatalf("retired metadata = %+v, want only epoch 2", got)
 	}
 	assertAudit(t, stderr, "retire", "succeeded")
+	assertAuditAuthorization(t, stderr, "operator_accept_loss")
 }
 
 func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
@@ -132,7 +131,7 @@ func TestCommandConfigResolutionAndMismatchDenial(t *testing.T) {
 		t.Fatalf("initialize via config: %v", err)
 	}
 	metadata := decodeMetadata(t, stdout)
-	_, stderr, err := execute(t, "test", "--config", cfgPath, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:"+strings.Repeat("0", 64))
+	_, stderr, err := executeInput(t, "value", "test", "--config", cfgPath, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--commitment", "hmac-sha256:"+strings.Repeat("0", 64))
 	if err == nil || err.Error() != "commitment mismatch" {
 		t.Fatalf("test mismatch error = %v", err)
 	}
@@ -185,18 +184,17 @@ func TestCommandDenialBranches(t *testing.T) {
 		{name: "initialize rerun", operation: "initialize", args: []string{"initialize", "--keyring", path}, wantAudit: true},
 		{name: "inspect missing", operation: "inspect", args: []string{"inspect", "--keyring", filepath.Join(dir, "missing.json")}, wantAudit: true},
 		{name: "rotate missing", operation: "rotate", args: []string{"rotate", "--keyring", filepath.Join(dir, "missing.json")}, wantAudit: true},
-		{name: "retire malformed reference", args: []string{"retire", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--retained-reference", "malformed"}},
-		{name: "retire zero reference epoch", args: []string{"retire", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--retained-reference", metadata.ActiveID + ":0"}},
-		{name: "test unknown key", operation: "test", args: []string{"test", "--keyring", path, "--key-id", "ck_00000000000000000000000000000000", "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
-		{name: "test invalid recipe", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64), "--recipe-json", `{}`}, wantAudit: true},
-		{name: "missing path selector", args: []string{"inspect"}},
-		{name: "initialize missing path selector", args: []string{"initialize"}},
-		{name: "rotate missing path selector", args: []string{"rotate"}},
-		{name: "retire missing path selector", args: []string{"retire", "--key-id", metadata.ActiveID, "--epoch", "1"}},
-		{name: "backup missing path selector", args: []string{"backup", "--out", filepath.Join(dir, "unused.json")}},
-		{name: "restore missing path selector", args: []string{"restore", "--from", path}},
-		{name: "test missing path selector", operation: "test", args: []string{"test", "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
-		{name: "test invalid source utf8", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", string([]byte{0xff}), "--view", "value", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
+		{name: "retire without loss acceptance", operation: "retire", args: []string{"retire", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1"}, wantAudit: true},
+		{name: "test unknown key", operation: "test", args: []string{"test", "--keyring", path, "--key-id", "ck_00000000000000000000000000000000", "--epoch", "1", "--source-id", "source-1", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
+		{name: "test invalid recipe", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64), "--recipe-json", `{}`}, wantAudit: true},
+		{name: "missing path selector", operation: "inspect", args: []string{"inspect"}, wantAudit: true},
+		{name: "initialize missing path selector", operation: "initialize", args: []string{"initialize"}, wantAudit: true},
+		{name: "rotate missing path selector", operation: "rotate", args: []string{"rotate"}, wantAudit: true},
+		{name: "retire missing path selector", operation: "retire", args: []string{"retire", "--key-id", metadata.ActiveID, "--epoch", "1"}, wantAudit: true},
+		{name: "backup missing path selector", operation: "backup", args: []string{"backup", "--out", filepath.Join(dir, "unused.json")}, wantAudit: true},
+		{name: "restore missing path selector", operation: "restore", args: []string{"restore", "--from", path}, wantAudit: true},
+		{name: "test missing path selector", operation: "test", args: []string{"test", "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", "source-1", "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
+		{name: "test invalid source utf8", operation: "test", args: []string{"test", "--keyring", path, "--key-id", metadata.ActiveID, "--epoch", "1", "--source-id", string([]byte{0xff}), "--commitment", "hmac-sha256:" + strings.Repeat("0", 64)}, wantAudit: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, stderr, err := execute(t, test.args...)
@@ -232,10 +230,87 @@ func TestWriteJSONReportsOutputFailure(t *testing.T) {
 	}
 }
 
+func TestCommandReadsPrivateViewFromStdinOrSecureFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+	if _, _, err := execute(t, "initialize", "--keyring", path); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	keyring, err := domkey.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	handle, err := keyring.Active()
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	source := contractreceipt.ProvenanceSource{SourceID: "source-1", Recipe: normalize.Recipe{TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest}}
+	const privateView = "private transformed evidence"
+	commitment, err := contractreceipt.CommitView(handle.Key, source, privateView)
+	if err != nil {
+		t.Fatalf("CommitView: %v", err)
+	}
+	args := []string{"test", "--keyring", path, "--key-id", handle.KeyID, "--epoch", "1", "--source-id", "source-1", "--commitment", commitment}
+	if _, stderr, err := executeInput(t, privateView, args...); err != nil {
+		t.Fatalf("test from stdin: %v", err)
+	} else if strings.Contains(stderr, privateView) {
+		t.Fatal("private view appeared in audit/operator output")
+	}
+	viewPath := filepath.Join(dir, "view.txt")
+	if err := os.WriteFile(viewPath, []byte(privateView), 0o600); err != nil {
+		t.Fatalf("WriteFile view: %v", err)
+	}
+	if _, _, err := execute(t, append(args, "--view-file", viewPath)...); err != nil {
+		t.Fatalf("test from file: %v", err)
+	}
+	if _, _, err := execute(t, append(args, "--view", privateView)...); err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("argv private view error = %v, want unknown --view flag", err)
+	}
+	link := filepath.Join(dir, "view-link.txt")
+	if err := os.Symlink(viewPath, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, stderr, err := execute(t, append(args, "--view-file", link)...); !errors.Is(err, domkey.ErrSymlink) {
+		t.Fatalf("symlink view error = %v stderr=%q, want ErrSymlink", err, stderr)
+	}
+}
+
+func TestLifecycleCommandsSurfaceInertCapabilityNotice(t *testing.T) {
+	_, stderr, err := execute(t, "initialize")
+	if err == nil {
+		t.Fatal("initialize without path succeeded")
+	}
+	if !strings.Contains(stderr, "nothing is currently being committed") {
+		t.Fatalf("stderr = %q, want inert-capability notice", stderr)
+	}
+	cmd := Cmd()
+	if !strings.Contains(cmd.Long, "Nothing is currently being") {
+		t.Fatalf("commitment-key help omits inert-capability notice: %q", cmd.Long)
+	}
+}
+
+func TestReadViewRejectsStdinReadFailureAndOversize(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetIn(failingReader{})
+	if _, err := readView(cmd, "-"); err == nil || !strings.Contains(err.Error(), "read private evidence view") {
+		t.Fatalf("readView failing stdin error = %v", err)
+	}
+	cmd.SetIn(strings.NewReader(strings.Repeat("x", privateViewMaxSize+1)))
+	if _, err := readView(cmd, "-"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("readView oversized stdin error = %v", err)
+	}
+}
+
 type failingWriter struct{}
 
 func (failingWriter) Write([]byte) (int, error) {
 	return 0, errors.New("write failed")
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
 }
 
 func TestConfigPathResolutionDenials(t *testing.T) {
@@ -248,20 +323,27 @@ func TestConfigPathResolutionDenials(t *testing.T) {
 	if err := os.WriteFile(malformed, []byte("mode: [\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	for _, path := range []string{missingField, malformed} {
-		if _, _, err := execute(t, "inspect", "--config", path); err == nil {
-			t.Fatalf("inspect with config %s succeeded", path)
-		}
+	for name, path := range map[string]string{"missing_field": missingField, "malformed": malformed} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := execute(t, "inspect", "--config", path); err == nil {
+				t.Fatalf("inspect with config %s succeeded", path)
+			}
+		})
 	}
 }
 
 func execute(t *testing.T, args ...string) (string, string, error) {
+	return executeInput(t, "", args...)
+}
+
+func executeInput(t *testing.T, input string, args ...string) (string, string, error) {
 	t.Helper()
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	root := &cobra.Command{Use: "pipelock", SilenceUsage: true, SilenceErrors: true}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	root.SetIn(strings.NewReader(input))
 	root.AddCommand(Cmd())
 	root.SetArgs(append([]string{"commitment-key"}, args...))
 	err := root.Execute()
@@ -288,13 +370,28 @@ func mustLoadMetadata(t *testing.T, path string) domkey.Metadata {
 
 func assertAudit(t *testing.T, raw, operation, outcome string) {
 	t.Helper()
-	var event auditEvent
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &event); err != nil {
-		t.Fatalf("decode audit %q: %v", raw, err)
-	}
+	event := decodeAudit(t, raw)
 	if event.EventType != "commitment_key_lifecycle" || event.Operation != operation || event.Outcome != outcome || event.Timestamp == "" {
 		t.Fatalf("audit event = %+v", event)
 	}
+}
+
+func assertAuditAuthorization(t *testing.T, raw, authorization string) {
+	t.Helper()
+	event := decodeAudit(t, raw)
+	if event.Authorization != authorization {
+		t.Fatalf("audit authorization = %q, want %q", event.Authorization, authorization)
+	}
+}
+
+func decodeAudit(t *testing.T, raw string) auditEvent {
+	t.Helper()
+	var event auditEvent
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &event); err != nil {
+		t.Fatalf("decode audit %q: %v", raw, err)
+	}
+	return event
 }
 
 func assertNoKeyMaterial(t *testing.T, outputs ...string) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cli/assess"
 	"github.com/luckyPipewrench/pipelock/internal/cli/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/canary"
+	commitmentkeycmd "github.com/luckyPipewrench/pipelock/internal/cli/commitmentkey"
 	"github.com/luckyPipewrench/pipelock/internal/cli/contain"
 	"github.com/luckyPipewrench/pipelock/internal/cli/diag"
 	clienvelope "github.com/luckyPipewrench/pipelock/internal/cli/envelope"
@@ -94,6 +95,8 @@ Quick start:
 		audit.SimulateCmd(),
 		// Containment (workstation-tier)
 		contain.Cmd(),
+		// Private evidence commitment key lifecycle
+		commitmentkeycmd.Cmd(),
 		// Mediation envelope trust management
 		clienvelope.Cmd(),
 		// Evidence viewer (Free, single-agent)

--- a/internal/cli/runtime/commitment_keyring_test.go
+++ b/internal/cli/runtime/commitment_keyring_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/commitmentkey"
+)
+
+func TestNewServerLoadsConfiguredCommitmentKeyring(t *testing.T) {
+	dir := t.TempDir()
+	keyringPath := filepath.Join(dir, "commitment-keyring.json")
+	want, err := commitmentkey.Initialize(keyringPath, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	cfgPath := writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json")
+	server, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer server.cleanup()
+	if server.commitmentKeyring == nil || server.commitmentKeyring.ActiveID != want.ActiveID {
+		t.Fatalf("runtime keyring = %+v, want active %q", server.commitmentKeyring, want.ActiveID)
+	}
+}
+
+func TestNewServerFailsClosedOnConfiguredCommitmentKeyringErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commitment-keyring.json")
+	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	cfgPath := writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json")
+	if _, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}}); err == nil || !strings.Contains(err.Error(), "unsafe permissions") {
+		t.Fatalf("NewServer error = %v, want unsafe-permission refusal", err)
+	}
+}
+
+func TestReloadPreservesStartupCommitmentKeyringPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commitment-keyring.json")
+	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	stderr := &syncBuffer{}
+	server, err := NewServer(ServerOpts{ConfigFile: writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json"), Stdout: &syncBuffer{}, Stderr: stderr})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer server.cleanup()
+	updated := server.proxy.CurrentConfig().Clone()
+	updated.EvidenceProvenance.CommitmentKeyringPath = filepath.Join(dir, "replacement.json")
+	if err := server.Reload(updated); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if got := server.proxy.CurrentConfig().EvidenceProvenance.CommitmentKeyringPath; got != path {
+		t.Fatalf("reload published path %q, want startup path %q", got, path)
+	}
+	if !stderr.contains("keyring is loaded at startup") {
+		t.Fatalf("stderr missing restart-only warning: %s", stderr.String())
+	}
+}
+
+func writeCommitmentRuntimeConfig(t *testing.T, dir, keyringPath string) string {
+	t.Helper()
+	path := filepath.Join(dir, "pipelock.yaml")
+	body := "mode: balanced\nevidence_provenance:\n  commitment_keyring_path: " + keyringPath + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}

--- a/internal/cli/runtime/commitment_keyring_test.go
+++ b/internal/cli/runtime/commitment_keyring_test.go
@@ -37,7 +37,9 @@ func TestNewServerFailsClosedOnConfiguredCommitmentKeyringErrors(t *testing.T) {
 	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	if err := os.Chmod(path, 0o644); err != nil {
+	unsafeMode := os.FileMode(0o600)
+	unsafeMode |= 0o044
+	if err := os.Chmod(path, unsafeMode); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
 	cfgPath := writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json")

--- a/internal/cli/runtime/commitment_keyring_test.go
+++ b/internal/cli/runtime/commitment_keyring_test.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,9 @@ func TestNewServerLoadsConfiguredCommitmentKeyring(t *testing.T) {
 }
 
 func TestNewServerFailsClosedOnConfiguredCommitmentKeyringErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows ACLs do not use Unix permission bits")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commitment-keyring.json")
 	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {

--- a/internal/cli/runtime/commitment_keyring_test.go
+++ b/internal/cli/runtime/commitment_keyring_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/commitmentkey"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 func TestNewServerLoadsConfiguredCommitmentKeyring(t *testing.T) {
@@ -52,28 +53,62 @@ func TestNewServerFailsClosedOnConfiguredCommitmentKeyringErrors(t *testing.T) {
 	}
 }
 
-func TestReloadPreservesStartupCommitmentKeyringPath(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "commitment-keyring.json")
-	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	stderr := &syncBuffer{}
-	server, err := NewServer(ServerOpts{ConfigFile: writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json"), Stdout: &syncBuffer{}, Stderr: stderr})
-	if err != nil {
-		t.Fatalf("NewServer: %v", err)
-	}
-	defer server.cleanup()
-	updated := server.proxy.CurrentConfig().Clone()
-	updated.EvidenceProvenance.CommitmentKeyringPath = filepath.Join(dir, "replacement.json")
-	if err := server.Reload(updated); err != nil {
-		t.Fatalf("Reload: %v", err)
-	}
-	if got := server.proxy.CurrentConfig().EvidenceProvenance.CommitmentKeyringPath; got != path {
-		t.Fatalf("reload published path %q, want startup path %q", got, path)
-	}
-	if !stderr.contains("keyring is loaded at startup") {
-		t.Fatalf("stderr missing restart-only warning: %s", stderr.String())
+func TestReloadPreservesStartupCommitmentKeyring(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		mutate      func(*config.Config, string)
+		wantWarning bool
+	}{
+		{
+			name: "replacement path",
+			mutate: func(cfg *config.Config, dir string) {
+				cfg.EvidenceProvenance.CommitmentKeyringPath = filepath.Join(dir, "replacement.json")
+			},
+			wantWarning: true,
+		},
+		{
+			name: "cleared path",
+			mutate: func(cfg *config.Config, _ string) {
+				cfg.EvidenceProvenance.CommitmentKeyringPath = ""
+			},
+			wantWarning: true,
+		},
+		{
+			name: "unrelated reload",
+			mutate: func(cfg *config.Config, _ string) {
+				explain := true
+				cfg.ExplainBlocks = &explain
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "commitment-keyring.json")
+			want, err := commitmentkey.Initialize(path, time.Now())
+			if err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			stderr := &syncBuffer{}
+			server, err := NewServer(ServerOpts{ConfigFile: writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json"), Stdout: &syncBuffer{}, Stderr: stderr})
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+			defer server.cleanup()
+			updated := server.proxy.CurrentConfig().Clone()
+			test.mutate(updated, dir)
+			if err := server.Reload(updated); err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			if got := server.proxy.CurrentConfig().EvidenceProvenance.CommitmentKeyringPath; got != path {
+				t.Fatalf("reload published path %q, want startup path %q", got, path)
+			}
+			if server.commitmentKeyring == nil || server.commitmentKeyring.ActiveID != want.ActiveID {
+				t.Fatalf("reload keyring = %+v, want startup active %q", server.commitmentKeyring, want.ActiveID)
+			}
+			if test.wantWarning && !stderr.contains("keyring is loaded at startup") {
+				t.Fatalf("stderr missing restart-only warning: %s", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/commitmentkey"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/deferred"
@@ -119,6 +120,7 @@ type Server struct {
 	captureWriter          *capture.Writer
 	mcpListenerBearerToken string
 	recorder               *recorder.Recorder
+	commitmentKeyring      *commitmentkey.Keyring
 	// conductorApply holds *applycache.Cache in the enterprise build (nil
 	// in the core build). Stored as any so server.go has no compile-time
 	// dependency on the enterprise conductor packages; the build-tagged
@@ -322,6 +324,13 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		hasMCPListen: hasMCPListen,
 	}
 	s.mcpListenerBearerToken = mcpAuthToken
+	if cfg.EvidenceProvenance.CommitmentKeyringPath != "" {
+		keyring, loadErr := commitmentkey.Load(cfg.EvidenceProvenance.CommitmentKeyringPath)
+		if loadErr != nil {
+			return nil, fmt.Errorf("loading evidence_provenance.commitment_keyring_path: %w", loadErr)
+		}
+		s.commitmentKeyring = keyring
+	}
 
 	sentryClient, sentryErr := plsentry.Init(cfg, cliutil.Version)
 	if sentryErr != nil {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -121,6 +121,10 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogConfigReload("ignored", "conductor settings restart-only", attemptedHash)
 			newCfg.Conductor = oldCfg.Conductor
 		}
+		if oldCfg.EvidenceProvenance != newCfg.EvidenceProvenance {
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: evidence_provenance.commitment_keyring_path changed — keyring is loaded at startup, ignoring (restart required)\n")
+			newCfg.EvidenceProvenance = oldCfg.EvidenceProvenance
+		}
 		// Block recorder-binding changes via reload. The recorder (and its
 		// receipt/audit chain) is built once at Start; reload swaps config and
 		// scanner but never rebuilds the recorder, so path/key/retention/etc.

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -14,12 +14,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"sort"
 	"time"
-
-	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 )
 
 const (
@@ -78,11 +74,6 @@ type EntryMetadata struct {
 	RetiredAt *time.Time `json:"retired_at,omitempty"`
 }
 
-type Reference struct {
-	KeyID string `json:"key_id"`
-	Epoch uint64 `json:"epoch"`
-}
-
 type Handle struct {
 	KeyID string
 	Epoch uint64
@@ -102,8 +93,8 @@ func Initialize(path string, now time.Time) (*Keyring, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := atomicfile.WriteNew(filepath.Clean(path), data, 0o600); err != nil {
-		if errors.Is(err, os.ErrExist) {
+	if err := writeSecureNew(path, data); err != nil {
+		if errors.Is(err, ErrAlreadyExists) {
 			return nil, ErrAlreadyExists
 		}
 		return nil, fmt.Errorf("initialize commitment keyring: %w", err)
@@ -249,17 +240,17 @@ func (k *Keyring) rotate(path string, now time.Time) (Handle, error) {
 }
 
 // Retire serializes the complete load-check-destroy-save cycle across processes.
-func Retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
+func Retire(path, keyID string, epoch uint64, acceptLoss bool) error {
 	return withLifecycleLock(path, func() error {
 		keyring, err := Load(path)
 		if err != nil {
 			return err
 		}
-		return keyring.retire(path, keyID, epoch, references, acceptLoss)
+		return keyring.retire(path, keyID, epoch, acceptLoss)
 	})
 }
 
-func (k *Keyring) retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
+func (k *Keyring) retire(path, keyID string, epoch uint64, acceptLoss bool) error {
 	if keyID == k.ActiveID && epoch == k.Epoch {
 		return fmt.Errorf("cannot retire the active commitment key; rotate first")
 	}
@@ -274,14 +265,7 @@ func (k *Keyring) retire(path, keyID string, epoch uint64, references []Referenc
 		return fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
 	}
 	if !acceptLoss {
-		if len(references) == 0 {
-			return fmt.Errorf("%w: retained-reference inventory is absent; use explicit loss acceptance to destroy key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
-		}
-		for _, ref := range references {
-			if ref.KeyID == keyID && ref.Epoch == epoch {
-				return fmt.Errorf("%w: key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
-			}
-		}
+		return fmt.Errorf("%w: no authoritative retained-evidence inventory exists; --accept-loss is required to destroy key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
 	}
 	k.Keys = append(k.Keys[:index], k.Keys[index+1:]...)
 	return k.Save(path)
@@ -295,10 +279,7 @@ func (k *Keyring) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	if err := rejectSymlink(path); err != nil {
-		return err
-	}
-	if err := atomicfile.Write(filepath.Clean(path), data, 0o600); err != nil {
+	if err := writeSecureReplace(path, data); err != nil {
 		return fmt.Errorf("write commitment keyring: %w", err)
 	}
 	return nil
@@ -314,27 +295,17 @@ func (k *Keyring) Metadata() Metadata {
 }
 
 func Backup(source, destination string) (*Keyring, error) {
-	keyring, err := Load(source)
-	if err != nil {
-		return nil, fmt.Errorf("load backup source: %w", err)
-	}
-	if err := ensureParent(destination); err != nil {
-		return nil, err
-	}
-	data, err := marshal(keyring)
-	if err != nil {
-		return nil, err
-	}
-	if err := atomicfile.WriteNew(filepath.Clean(destination), data, 0o600); err != nil {
-		return nil, fmt.Errorf("write commitment keyring backup: %w", err)
-	}
-	return keyring, nil
+	return copyValidated(source, destination, "load backup source", "write commitment keyring backup")
 }
 
 func Restore(source, destination string) (*Keyring, error) {
+	return copyValidated(source, destination, "load commitment keyring backup", "restore commitment keyring")
+}
+
+func copyValidated(source, destination, loadContext, writeContext string) (*Keyring, error) {
 	keyring, err := Load(source)
 	if err != nil {
-		return nil, fmt.Errorf("load commitment keyring backup: %w", err)
+		return nil, fmt.Errorf("%s: %w", loadContext, err)
 	}
 	if err := ensureParent(destination); err != nil {
 		return nil, err
@@ -343,8 +314,8 @@ func Restore(source, destination string) (*Keyring, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := atomicfile.WriteNew(filepath.Clean(destination), data, 0o600); err != nil {
-		return nil, fmt.Errorf("restore commitment keyring: %w", err)
+	if err := writeSecureNew(destination, data); err != nil {
+		return nil, fmt.Errorf("%s: %w", writeContext, err)
 	}
 	return keyring, nil
 }
@@ -367,64 +338,4 @@ func marshal(keyring *Keyring) ([]byte, error) {
 		return nil, fmt.Errorf("marshal commitment keyring: %w", err)
 	}
 	return append(data, '\n'), nil
-}
-
-func ensureParent(path string) error {
-	parent := filepath.Dir(filepath.Clean(path))
-	if err := os.MkdirAll(parent, 0o750); err != nil {
-		return fmt.Errorf("create commitment keyring directory: %w", err)
-	}
-	return nil
-}
-
-func rejectSymlink(path string) error {
-	info, err := os.Lstat(filepath.Clean(path))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("inspect commitment keyring: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("%w: %s", ErrSymlink, filepath.Clean(path))
-	}
-	return nil
-}
-
-func readSecure(path string) ([]byte, error) {
-	clean := filepath.Clean(path)
-	if err := rejectSymlink(clean); err != nil {
-		return nil, err
-	}
-	root, err := os.OpenRoot(filepath.Dir(clean))
-	if err != nil {
-		return nil, fmt.Errorf("open commitment keyring directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-	f, err := root.Open(filepath.Base(clean))
-	if err != nil {
-		return nil, fmt.Errorf("open commitment keyring: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat commitment keyring: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
-	}
-	if info.Mode().Perm() != 0o600 {
-		return nil, fmt.Errorf("%w: got %04o, want 0600", ErrUnsafePermission, info.Mode().Perm())
-	}
-	if info.Size() > maxBytes {
-		return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, maxBytes)
-	}
-	raw, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("read commitment keyring: %w", err)
-	}
-	if len(raw) > maxBytes {
-		return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, maxBytes)
-	}
-	return raw, nil
 }

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -1,0 +1,397 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package commitmentkey owns the symmetric keys used to open private evidence
+// commitments. These keys are deliberately not signing keys.
+package commitmentkey
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+)
+
+const (
+	FormatV1 = "pipelock-commitment-keyring/v1"
+	Purpose  = "evidence-commitment"
+	keyBytes = 32
+	maxBytes = 1 << 20
+)
+
+var (
+	ErrInvalidKeyring   = errors.New("invalid commitment keyring")
+	ErrKeyNotFound      = errors.New("commitment key not found")
+	ErrRetainedKey      = errors.New("commitment key has retained references")
+	ErrAlreadyExists    = errors.New("commitment keyring already exists")
+	ErrSymlink          = errors.New("commitment keyring path is a symlink")
+	ErrUnsafePermission = errors.New("commitment keyring has unsafe permissions")
+)
+
+type State string
+
+const (
+	StateActive  State = "active"
+	StateRetired State = "retired"
+)
+
+type Entry struct {
+	KeyID     string     `json:"key_id"`
+	Epoch     uint64     `json:"epoch"`
+	State     State      `json:"state"`
+	Key       string     `json:"key"`
+	CreatedAt time.Time  `json:"created_at"`
+	RetiredAt *time.Time `json:"retired_at,omitempty"`
+}
+
+type Keyring struct {
+	Format   string  `json:"format"`
+	Purpose  string  `json:"purpose"`
+	ActiveID string  `json:"active_key_id"`
+	Epoch    uint64  `json:"epoch"`
+	Keys     []Entry `json:"keys"`
+}
+
+type Metadata struct {
+	Format   string          `json:"format"`
+	Purpose  string          `json:"purpose"`
+	ActiveID string          `json:"active_key_id"`
+	Epoch    uint64          `json:"epoch"`
+	Keys     []EntryMetadata `json:"keys"`
+}
+
+type EntryMetadata struct {
+	KeyID     string     `json:"key_id"`
+	Epoch     uint64     `json:"epoch"`
+	State     State      `json:"state"`
+	CreatedAt time.Time  `json:"created_at"`
+	RetiredAt *time.Time `json:"retired_at,omitempty"`
+}
+
+type Reference struct {
+	KeyID string `json:"key_id"`
+	Epoch uint64 `json:"epoch"`
+}
+
+type Handle struct {
+	KeyID string
+	Epoch uint64
+	Key   []byte
+}
+
+func Initialize(path string, now time.Time) (*Keyring, error) {
+	if err := ensureParent(path); err != nil {
+		return nil, err
+	}
+	entry, err := newEntry(1, now)
+	if err != nil {
+		return nil, err
+	}
+	keyring := &Keyring{Format: FormatV1, Purpose: Purpose, ActiveID: entry.KeyID, Epoch: 1, Keys: []Entry{entry}}
+	data, err := marshal(keyring)
+	if err != nil {
+		return nil, err
+	}
+	if err := atomicfile.WriteNew(filepath.Clean(path), data, 0o600); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, ErrAlreadyExists
+		}
+		return nil, fmt.Errorf("initialize commitment keyring: %w", err)
+	}
+	return keyring, nil
+}
+
+func Load(path string) (*Keyring, error) {
+	raw, err := readSecure(path)
+	if err != nil {
+		return nil, err
+	}
+	var keyring Keyring
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&keyring); err != nil {
+		return nil, fmt.Errorf("%w: decode: %v", ErrInvalidKeyring, err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: trailing JSON", ErrInvalidKeyring)
+	}
+	if err := keyring.Validate(); err != nil {
+		return nil, err
+	}
+	return &keyring, nil
+}
+
+func (k *Keyring) Validate() error {
+	if k.Format != FormatV1 {
+		return fmt.Errorf("%w: format %q", ErrInvalidKeyring, k.Format)
+	}
+	if k.Purpose != Purpose {
+		return fmt.Errorf("%w: purpose %q, want %q", ErrInvalidKeyring, k.Purpose, Purpose)
+	}
+	if k.Epoch == 0 || len(k.Keys) == 0 || k.ActiveID == "" {
+		return fmt.Errorf("%w: missing active key metadata", ErrInvalidKeyring)
+	}
+	seenID := make(map[string]struct{}, len(k.Keys))
+	seenEpoch := make(map[uint64]struct{}, len(k.Keys))
+	active := 0
+	var highest uint64
+	for i := range k.Keys {
+		entry := &k.Keys[i]
+		if len(entry.KeyID) != 35 || entry.KeyID[:3] != "ck_" {
+			return fmt.Errorf("%w: key %d has malformed opaque ID", ErrInvalidKeyring, i)
+		}
+		if _, err := hex.DecodeString(entry.KeyID[3:]); err != nil {
+			return fmt.Errorf("%w: key %d has malformed opaque ID", ErrInvalidKeyring, i)
+		}
+		if entry.Epoch == 0 || entry.CreatedAt.IsZero() {
+			return fmt.Errorf("%w: key %q has incomplete metadata", ErrInvalidKeyring, entry.KeyID)
+		}
+		if _, exists := seenID[entry.KeyID]; exists {
+			return fmt.Errorf("%w: duplicate key ID %q", ErrInvalidKeyring, entry.KeyID)
+		}
+		if _, exists := seenEpoch[entry.Epoch]; exists {
+			return fmt.Errorf("%w: duplicate epoch %d", ErrInvalidKeyring, entry.Epoch)
+		}
+		decoded, err := base64.StdEncoding.Strict().DecodeString(entry.Key)
+		if err != nil || len(decoded) != keyBytes {
+			return fmt.Errorf("%w: key %q material must be %d base64-encoded bytes", ErrInvalidKeyring, entry.KeyID, keyBytes)
+		}
+		switch entry.State {
+		case StateActive:
+			active++
+			if entry.KeyID != k.ActiveID || entry.Epoch != k.Epoch || entry.RetiredAt != nil {
+				return fmt.Errorf("%w: active key metadata is inconsistent", ErrInvalidKeyring)
+			}
+		case StateRetired:
+			if entry.RetiredAt == nil || entry.Epoch >= k.Epoch {
+				return fmt.Errorf("%w: retired key %q metadata is inconsistent", ErrInvalidKeyring, entry.KeyID)
+			}
+		default:
+			return fmt.Errorf("%w: key %q has state %q", ErrInvalidKeyring, entry.KeyID, entry.State)
+		}
+		seenID[entry.KeyID] = struct{}{}
+		seenEpoch[entry.Epoch] = struct{}{}
+		if entry.Epoch > highest {
+			highest = entry.Epoch
+		}
+	}
+	if active != 1 || highest != k.Epoch {
+		return fmt.Errorf("%w: want exactly one active key at highest epoch", ErrInvalidKeyring)
+	}
+	return nil
+}
+
+func (k *Keyring) Active() (Handle, error) {
+	return k.Open(k.ActiveID, k.Epoch)
+}
+
+func (k *Keyring) Open(keyID string, epoch uint64) (Handle, error) {
+	for _, entry := range k.Keys {
+		if entry.KeyID != keyID || entry.Epoch != epoch {
+			continue
+		}
+		decoded, err := base64.StdEncoding.Strict().DecodeString(entry.Key)
+		if err != nil || len(decoded) != keyBytes {
+			return Handle{}, fmt.Errorf("%w: corrupt key material", ErrInvalidKeyring)
+		}
+		return Handle{KeyID: entry.KeyID, Epoch: entry.Epoch, Key: append([]byte(nil), decoded...)}, nil
+	}
+	return Handle{}, fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
+}
+
+func (k *Keyring) Rotate(path string, now time.Time) (Handle, error) {
+	if err := k.Validate(); err != nil {
+		return Handle{}, err
+	}
+	for i := range k.Keys {
+		if k.Keys[i].State == StateActive {
+			k.Keys[i].State = StateRetired
+			retiredAt := now.UTC()
+			k.Keys[i].RetiredAt = &retiredAt
+		}
+	}
+	entry, err := newEntry(k.Epoch+1, now)
+	if err != nil {
+		return Handle{}, err
+	}
+	k.Keys = append(k.Keys, entry)
+	k.Epoch = entry.Epoch
+	k.ActiveID = entry.KeyID
+	if err := k.Save(path); err != nil {
+		return Handle{}, err
+	}
+	return k.Active()
+}
+
+func (k *Keyring) Retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
+	if keyID == k.ActiveID && epoch == k.Epoch {
+		return fmt.Errorf("cannot retire the active commitment key; rotate first")
+	}
+	index := -1
+	for i, entry := range k.Keys {
+		if entry.KeyID == keyID && entry.Epoch == epoch {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
+	}
+	if !acceptLoss {
+		for _, ref := range references {
+			if ref.KeyID == keyID && ref.Epoch == epoch {
+				return fmt.Errorf("%w: key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
+			}
+		}
+	}
+	k.Keys = append(k.Keys[:index], k.Keys[index+1:]...)
+	return k.Save(path)
+}
+
+func (k *Keyring) Save(path string) error {
+	if err := k.Validate(); err != nil {
+		return err
+	}
+	data, err := marshal(k)
+	if err != nil {
+		return err
+	}
+	if err := rejectSymlink(path); err != nil {
+		return err
+	}
+	if err := atomicfile.Write(filepath.Clean(path), data, 0o600); err != nil {
+		return fmt.Errorf("write commitment keyring: %w", err)
+	}
+	return nil
+}
+
+func (k *Keyring) Metadata() Metadata {
+	metadata := Metadata{Format: k.Format, Purpose: k.Purpose, ActiveID: k.ActiveID, Epoch: k.Epoch, Keys: make([]EntryMetadata, 0, len(k.Keys))}
+	for _, entry := range k.Keys {
+		metadata.Keys = append(metadata.Keys, EntryMetadata{KeyID: entry.KeyID, Epoch: entry.Epoch, State: entry.State, CreatedAt: entry.CreatedAt, RetiredAt: entry.RetiredAt})
+	}
+	sort.Slice(metadata.Keys, func(i, j int) bool { return metadata.Keys[i].Epoch < metadata.Keys[j].Epoch })
+	return metadata
+}
+
+func Backup(source, destination string) error {
+	keyring, err := Load(source)
+	if err != nil {
+		return fmt.Errorf("load backup source: %w", err)
+	}
+	if err := ensureParent(destination); err != nil {
+		return err
+	}
+	data, err := marshal(keyring)
+	if err != nil {
+		return err
+	}
+	if err := atomicfile.WriteNew(filepath.Clean(destination), data, 0o600); err != nil {
+		return fmt.Errorf("write commitment keyring backup: %w", err)
+	}
+	return nil
+}
+
+func Restore(source, destination string) (*Keyring, error) {
+	keyring, err := Load(source)
+	if err != nil {
+		return nil, fmt.Errorf("load commitment keyring backup: %w", err)
+	}
+	if err := ensureParent(destination); err != nil {
+		return nil, err
+	}
+	data, err := marshal(keyring)
+	if err != nil {
+		return nil, err
+	}
+	if err := atomicfile.WriteNew(filepath.Clean(destination), data, 0o600); err != nil {
+		return nil, fmt.Errorf("restore commitment keyring: %w", err)
+	}
+	return keyring, nil
+}
+
+func newEntry(epoch uint64, now time.Time) (Entry, error) {
+	material := make([]byte, keyBytes)
+	if _, err := io.ReadFull(rand.Reader, material); err != nil {
+		return Entry{}, fmt.Errorf("generate commitment key: %w", err)
+	}
+	idBytes := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, idBytes); err != nil {
+		return Entry{}, fmt.Errorf("generate commitment key ID: %w", err)
+	}
+	return Entry{KeyID: "ck_" + hex.EncodeToString(idBytes), Epoch: epoch, State: StateActive, Key: base64.StdEncoding.EncodeToString(material), CreatedAt: now.UTC()}, nil
+}
+
+func marshal(keyring *Keyring) ([]byte, error) {
+	data, err := json.MarshalIndent(keyring, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal commitment keyring: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func ensureParent(path string) error {
+	parent := filepath.Dir(filepath.Clean(path))
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return fmt.Errorf("create commitment keyring directory: %w", err)
+	}
+	return nil
+}
+
+func rejectSymlink(path string) error {
+	info, err := os.Lstat(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect commitment keyring: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s", ErrSymlink, filepath.Clean(path))
+	}
+	return nil
+}
+
+func readSecure(path string) ([]byte, error) {
+	clean := filepath.Clean(path)
+	if err := rejectSymlink(clean); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(clean) //nolint:gosec // operator-selected path; descriptor is checked before bounded read
+	if err != nil {
+		return nil, fmt.Errorf("open commitment keyring: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat commitment keyring: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return nil, fmt.Errorf("%w: got %04o, want 0600", ErrUnsafePermission, info.Mode().Perm())
+	}
+	if info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, maxBytes)
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read commitment keyring: %w", err)
+	}
+	if len(raw) > maxBytes {
+		return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, maxBytes)
+	}
+	return raw, nil
+}

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -201,18 +201,23 @@ func (k *Keyring) Open(keyID string, epoch uint64) (Handle, error) {
 	return Handle{}, fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
 }
 
-// Rotate serializes the complete load-modify-save cycle across processes.
-func Rotate(path string, now time.Time) (Handle, error) {
+// Rotate serializes the complete load-modify-save cycle across processes and
+// returns metadata from the same in-memory state that was durably committed.
+func Rotate(path string, now time.Time) (Handle, Metadata, error) {
 	var handle Handle
+	var metadata Metadata
 	err := withLifecycleLock(path, func() error {
 		keyring, err := Load(path)
 		if err != nil {
 			return err
 		}
 		handle, err = keyring.rotate(path, now)
+		if err == nil {
+			metadata = keyring.Metadata()
+		}
 		return err
 	})
-	return handle, err
+	return handle, metadata, err
 }
 
 func (k *Keyring) rotate(path string, now time.Time) (Handle, error) {
@@ -233,21 +238,31 @@ func (k *Keyring) rotate(path string, now time.Time) (Handle, error) {
 	k.Keys = append(k.Keys, entry)
 	k.Epoch = entry.Epoch
 	k.ActiveID = entry.KeyID
-	if err := k.Save(path); err != nil {
+	handle, err := k.Active()
+	if err != nil {
 		return Handle{}, err
 	}
-	return k.Active()
+	if err := k.saveLocked(path); err != nil {
+		return Handle{}, err
+	}
+	return handle, nil
 }
 
 // Retire serializes the complete load-check-destroy-save cycle across processes.
-func Retire(path, keyID string, epoch uint64, acceptLoss bool) error {
-	return withLifecycleLock(path, func() error {
+func Retire(path, keyID string, epoch uint64, acceptLoss bool) (Metadata, error) {
+	var metadata Metadata
+	err := withLifecycleLock(path, func() error {
 		keyring, err := Load(path)
 		if err != nil {
 			return err
 		}
-		return keyring.retire(path, keyID, epoch, acceptLoss)
+		if err := keyring.retire(path, keyID, epoch, acceptLoss); err != nil {
+			return err
+		}
+		metadata = keyring.Metadata()
+		return nil
 	})
+	return metadata, err
 }
 
 func (k *Keyring) retire(path, keyID string, epoch uint64, acceptLoss bool) error {
@@ -268,10 +283,12 @@ func (k *Keyring) retire(path, keyID string, epoch uint64, acceptLoss bool) erro
 		return fmt.Errorf("%w: no authoritative retained-evidence inventory exists; --accept-loss is required to destroy key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
 	}
 	k.Keys = append(k.Keys[:index], k.Keys[index+1:]...)
-	return k.Save(path)
+	return k.saveLocked(path)
 }
 
-func (k *Keyring) Save(path string) error {
+// saveLocked persists a validated lifecycle mutation. Callers must hold the
+// cross-process lifecycle lock for path.
+func (k *Keyring) saveLocked(path string) error {
 	if err := k.Validate(); err != nil {
 		return err
 	}

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -249,6 +249,9 @@ func (k *Keyring) Retire(path, keyID string, epoch uint64, references []Referenc
 		return fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
 	}
 	if !acceptLoss {
+		if len(references) == 0 {
+			return fmt.Errorf("%w: retained-reference inventory is absent; use explicit loss acceptance to destroy key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)
+		}
 		for _, ref := range references {
 			if ref.KeyID == keyID && ref.Epoch == epoch {
 				return fmt.Errorf("%w: key_id=%q epoch=%d", ErrRetainedKey, keyID, epoch)

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -210,7 +210,21 @@ func (k *Keyring) Open(keyID string, epoch uint64) (Handle, error) {
 	return Handle{}, fmt.Errorf("%w: key_id=%q epoch=%d", ErrKeyNotFound, keyID, epoch)
 }
 
-func (k *Keyring) Rotate(path string, now time.Time) (Handle, error) {
+// Rotate serializes the complete load-modify-save cycle across processes.
+func Rotate(path string, now time.Time) (Handle, error) {
+	var handle Handle
+	err := withLifecycleLock(path, func() error {
+		keyring, err := Load(path)
+		if err != nil {
+			return err
+		}
+		handle, err = keyring.rotate(path, now)
+		return err
+	})
+	return handle, err
+}
+
+func (k *Keyring) rotate(path string, now time.Time) (Handle, error) {
 	if err := k.Validate(); err != nil {
 		return Handle{}, err
 	}
@@ -234,7 +248,18 @@ func (k *Keyring) Rotate(path string, now time.Time) (Handle, error) {
 	return k.Active()
 }
 
-func (k *Keyring) Retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
+// Retire serializes the complete load-check-destroy-save cycle across processes.
+func Retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
+	return withLifecycleLock(path, func() error {
+		keyring, err := Load(path)
+		if err != nil {
+			return err
+		}
+		return keyring.retire(path, keyID, epoch, references, acceptLoss)
+	})
+}
+
+func (k *Keyring) retire(path, keyID string, epoch uint64, references []Reference, acceptLoss bool) error {
 	if keyID == k.ActiveID && epoch == k.Epoch {
 		return fmt.Errorf("cannot retire the active commitment key; rotate first")
 	}

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -120,7 +120,7 @@ func Load(path string) (*Keyring, error) {
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&keyring); err != nil {
-		return nil, fmt.Errorf("%w: decode: %v", ErrInvalidKeyring, err)
+		return nil, fmt.Errorf("%w: decode: %w", ErrInvalidKeyring, err)
 	}
 	var trailing any
 	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
@@ -396,7 +396,12 @@ func readSecure(path string) ([]byte, error) {
 	if err := rejectSymlink(clean); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(clean) //nolint:gosec // operator-selected path; descriptor is checked before bounded read
+	root, err := os.OpenRoot(filepath.Dir(clean))
+	if err != nil {
+		return nil, fmt.Errorf("open commitment keyring directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.Open(filepath.Base(clean))
 	if err != nil {
 		return nil, fmt.Errorf("open commitment keyring: %w", err)
 	}

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -313,22 +313,22 @@ func (k *Keyring) Metadata() Metadata {
 	return metadata
 }
 
-func Backup(source, destination string) error {
+func Backup(source, destination string) (*Keyring, error) {
 	keyring, err := Load(source)
 	if err != nil {
-		return fmt.Errorf("load backup source: %w", err)
+		return nil, fmt.Errorf("load backup source: %w", err)
 	}
 	if err := ensureParent(destination); err != nil {
-		return err
+		return nil, err
 	}
 	data, err := marshal(keyring)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := atomicfile.WriteNew(filepath.Clean(destination), data, 0o600); err != nil {
-		return fmt.Errorf("write commitment keyring backup: %w", err)
+		return nil, fmt.Errorf("write commitment keyring backup: %w", err)
 	}
-	return nil
+	return keyring, nil
 }
 
 func Restore(source, destination string) (*Keyring, error) {

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -50,8 +51,12 @@ func TestLifecycleRotationRestartOpensOldAndNew(t *testing.T) {
 	}
 	oldReceipt := commitTestReceipt(t, keyring, "before rotation")
 	oldID := oldReceipt.KeyID
-	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+	if _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
 		t.Fatalf("Rotate: %v", err)
+	}
+	keyring, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load rotated keyring: %v", err)
 	}
 	newReceipt := commitTestReceipt(t, keyring, "after rotation")
 	if newReceipt.KeyID == oldID || newReceipt.Epoch != oldReceipt.Epoch+1 {
@@ -87,7 +92,7 @@ func TestRetiredLookupOpensPriorEpoch(t *testing.T) {
 		t.Fatalf("Initialize: %v", err)
 	}
 	receipt := commitTestReceipt(t, keyring, "retired lookup guard")
-	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+	if _, err := keyring.rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
 	openTestReceipt(t, keyring, receipt)
@@ -100,25 +105,65 @@ func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) 
 		t.Fatalf("Initialize: %v", err)
 	}
 	old := commitTestReceipt(t, keyring, "retained")
-	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+	if _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
+	keyring, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load rotated keyring: %v", err)
+	}
 	refs := []Reference{{KeyID: old.KeyID, Epoch: old.Epoch}}
-	if err := keyring.Retire(path, old.KeyID, old.Epoch, refs, false); !errors.Is(err, ErrRetainedKey) {
+	if err := Retire(path, old.KeyID, old.Epoch, refs, false); !errors.Is(err, ErrRetainedKey) {
 		t.Fatalf("Retire with retained reference error = %v, want ErrRetainedKey", err)
 	}
 	openTestReceipt(t, keyring, old)
-	if err := keyring.Retire(path, old.KeyID, old.Epoch, nil, false); !errors.Is(err, ErrRetainedKey) {
+	if err := Retire(path, old.KeyID, old.Epoch, nil, false); !errors.Is(err, ErrRetainedKey) {
 		t.Fatalf("Retire without reference inventory error = %v, want ErrRetainedKey", err)
 	}
-	if err := keyring.Retire(path, old.KeyID, old.Epoch, refs, true); err != nil {
+	if err := Retire(path, old.KeyID, old.Epoch, refs, true); err != nil {
 		t.Fatalf("Retire with accept loss: %v", err)
+	}
+	keyring, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load after retirement: %v", err)
 	}
 	if _, err := keyring.Open(old.KeyID, old.Epoch); !errors.Is(err, ErrKeyNotFound) {
 		t.Fatalf("Open destroyed retired key error = %v, want ErrKeyNotFound", err)
 	}
-	if err := keyring.Retire(path, keyring.ActiveID, keyring.Epoch, nil, true); err == nil {
+	if err := Retire(path, keyring.ActiveID, keyring.Epoch, nil, true); err == nil {
 		t.Fatal("Retire active key succeeded")
+	}
+}
+
+func TestConcurrentRotationsSerializeEpochs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	if _, err := Initialize(path, time.Unix(1_700_000_000, 0)); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	const rotations = 8
+	errs := make(chan error, rotations)
+	var wg sync.WaitGroup
+	for i := range rotations {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			_, err := Rotate(path, time.Unix(1_700_000_100+int64(offset), 0))
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Rotate: %v", err)
+		}
+	}
+	keyring, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if keyring.Epoch != rotations+1 || len(keyring.Keys) != rotations+1 {
+		t.Fatalf("concurrent rotations produced epoch=%d keys=%d, want %d", keyring.Epoch, len(keyring.Keys), rotations+1)
 	}
 }
 

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -12,6 +12,7 @@ import (
 
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 type committedReceipt struct {
@@ -80,6 +81,9 @@ func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) 
 		t.Fatalf("Retire with retained reference error = %v, want ErrRetainedKey", err)
 	}
 	openTestReceipt(t, keyring, old)
+	if err := keyring.Retire(path, old.KeyID, old.Epoch, nil, false); !errors.Is(err, ErrRetainedKey) {
+		t.Fatalf("Retire without reference inventory error = %v, want ErrRetainedKey", err)
+	}
 	if err := keyring.Retire(path, old.KeyID, old.Epoch, refs, true); err != nil {
 		t.Fatalf("Retire with accept loss: %v", err)
 	}
@@ -161,6 +165,16 @@ func TestPurposeValidationRejectsReceiptSigning(t *testing.T) {
 	}
 	if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) {
 		t.Fatalf("Load receipt-signing keyring error = %v, want ErrInvalidKeyring", err)
+	}
+}
+
+func TestCommitmentKeyringCannotLoadAsReceiptSigningKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	if _, err := Initialize(path, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := signing.LoadPrivateKeyFile(path); err == nil {
+		t.Fatal("receipt-signing loader accepted commitment keyring")
 	}
 }
 

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -176,7 +176,7 @@ func TestLifecycleBackupDestroyRestoreAndOpen(t *testing.T) {
 		t.Fatalf("Initialize: %v", err)
 	}
 	receipt := commitTestReceipt(t, keyring, "backup")
-	if err := Backup(path, backup); err != nil {
+	if _, err := Backup(path, backup); err != nil {
 		t.Fatalf("Backup: %v", err)
 	}
 	if err := os.Remove(path); err != nil {

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -205,7 +205,9 @@ func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
 		t.Fatalf("Symlink: %v", err)
 	}
 	t.Run("wrong_permissions", func(t *testing.T) {
-		if err := os.Chmod(path, 0o644); err != nil {
+		unsafeMode := os.FileMode(0o600)
+		unsafeMode |= 0o044
+		if err := os.Chmod(path, unsafeMode); err != nil {
 			t.Fatalf("Chmod: %v", err)
 		}
 		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package commitmentkey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
+)
+
+type committedReceipt struct {
+	KeyID      string
+	Epoch      uint64
+	Source     contractreceipt.ProvenanceSource
+	View       string
+	Commitment string
+}
+
+func TestLifecycleInitializeRestartOpensCommitment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	receipt := commitTestReceipt(t, keyring, "alpha")
+
+	restarted, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load after restart: %v", err)
+	}
+	openTestReceipt(t, restarted, receipt)
+	assertMode(t, path, 0o600)
+	if _, err := Initialize(path, time.Now()); !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("second Initialize error = %v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestLifecycleRotationRestartOpensOldAndNew(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	oldReceipt := commitTestReceipt(t, keyring, "before rotation")
+	oldID := oldReceipt.KeyID
+	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	newReceipt := commitTestReceipt(t, keyring, "after rotation")
+	if newReceipt.KeyID == oldID || newReceipt.Epoch != oldReceipt.Epoch+1 {
+		t.Fatalf("rotation did not produce opaque successor: old=%+v new=%+v", oldReceipt, newReceipt)
+	}
+
+	restarted, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load after rotation restart: %v", err)
+	}
+	openTestReceipt(t, restarted, oldReceipt)
+	openTestReceipt(t, restarted, newReceipt)
+}
+
+func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	old := commitTestReceipt(t, keyring, "retained")
+	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	refs := []Reference{{KeyID: old.KeyID, Epoch: old.Epoch}}
+	if err := keyring.Retire(path, old.KeyID, old.Epoch, refs, false); !errors.Is(err, ErrRetainedKey) {
+		t.Fatalf("Retire with retained reference error = %v, want ErrRetainedKey", err)
+	}
+	openTestReceipt(t, keyring, old)
+	if err := keyring.Retire(path, old.KeyID, old.Epoch, refs, true); err != nil {
+		t.Fatalf("Retire with accept loss: %v", err)
+	}
+	if _, err := keyring.Open(old.KeyID, old.Epoch); !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("Open destroyed retired key error = %v, want ErrKeyNotFound", err)
+	}
+	if err := keyring.Retire(path, keyring.ActiveID, keyring.Epoch, nil, true); err == nil {
+		t.Fatal("Retire active key succeeded")
+	}
+}
+
+func TestLifecycleBackupDestroyRestoreAndOpen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commitment-keyring.json")
+	backup := filepath.Join(dir, "backup", "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	receipt := commitTestReceipt(t, keyring, "backup")
+	if err := Backup(path, backup); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("destroy temporary keyring: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load destroyed keyring succeeded")
+	}
+	restored, err := Restore(backup, path)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	openTestReceipt(t, restored, receipt)
+	assertMode(t, backup, 0o600)
+	assertMode(t, path, 0o600)
+}
+
+func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commitment-keyring.json")
+	if _, err := Initialize(path, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if _, err := Load(path); !errors.Is(err, ErrUnsafePermission) {
+		t.Fatalf("Load mode 0644 error = %v, want ErrUnsafePermission", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("restore mode: %v", err)
+	}
+	link := filepath.Join(dir, "substituted.json")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := Load(link); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("Load symlink error = %v, want ErrSymlink", err)
+	}
+	if err := keyringSaveThroughSymlink(path, link); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("Save symlink error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestPurposeValidationRejectsReceiptSigning(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Now())
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	keyring.Purpose = "receipt-signing"
+	data, err := marshal(keyring)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write wrong-purpose keyring: %v", err)
+	}
+	if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Load receipt-signing keyring error = %v, want ErrInvalidKeyring", err)
+	}
+}
+
+func TestInvalidKeyringShapesFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"unknown_field": `{"format":"pipelock-commitment-keyring/v1","extra":true}`,
+		"trailing":      `{} {}`,
+		"empty":         `{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(dir, name+".json")
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) {
+				t.Fatalf("Load error = %v, want ErrInvalidKeyring", err)
+			}
+		})
+	}
+}
+
+func commitTestReceipt(t *testing.T, keyring *Keyring, view string) committedReceipt {
+	t.Helper()
+	handle, err := keyring.Active()
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	source := contractreceipt.ProvenanceSource{
+		SourceOrdinal: 1,
+		SourceID:      "source-1",
+		Recipe: normalize.Recipe{
+			TransformProfileDigest: normalize.EvidenceProvenanceProfileV1Digest,
+		},
+	}
+	commitment, err := contractreceipt.CommitView(handle.Key, source, view)
+	if err != nil {
+		t.Fatalf("CommitView: %v", err)
+	}
+	return committedReceipt{KeyID: handle.KeyID, Epoch: handle.Epoch, Source: source, View: view, Commitment: commitment}
+}
+
+func openTestReceipt(t *testing.T, keyring *Keyring, receipt committedReceipt) {
+	t.Helper()
+	handle, err := keyring.Open(receipt.KeyID, receipt.Epoch)
+	if err != nil {
+		t.Fatalf("Open(%q, %d): %v", receipt.KeyID, receipt.Epoch, err)
+	}
+	got, err := contractreceipt.CommitView(handle.Key, receipt.Source, receipt.View)
+	if err != nil {
+		t.Fatalf("CommitView on open: %v", err)
+	}
+	if got != receipt.Commitment {
+		t.Fatalf("opened commitment = %q, want %q", got, receipt.Commitment)
+	}
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s): %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode(%s) = %04o, want %04o", path, got, want)
+	}
+}
+
+func keyringSaveThroughSymlink(realPath, link string) error {
+	keyring, err := Load(realPath)
+	if err != nil {
+		return err
+	}
+	return keyring.Save(link)
+}

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -99,7 +100,7 @@ func TestRetiredLookupOpensPriorEpoch(t *testing.T) {
 	openTestReceipt(t, keyring, receipt)
 }
 
-func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) {
+func TestRetireRequiresExplicitLossAcceptance(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
 	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
 	if err != nil {
@@ -113,15 +114,11 @@ func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Load rotated keyring: %v", err)
 	}
-	refs := []Reference{{KeyID: old.KeyID, Epoch: old.Epoch}}
-	if err := Retire(path, old.KeyID, old.Epoch, refs, false); !errors.Is(err, ErrRetainedKey) {
-		t.Fatalf("Retire with retained reference error = %v, want ErrRetainedKey", err)
+	if err := Retire(path, old.KeyID, old.Epoch, false); !errors.Is(err, ErrRetainedKey) {
+		t.Fatalf("Retire without loss acceptance error = %v, want ErrRetainedKey", err)
 	}
 	openTestReceipt(t, keyring, old)
-	if err := Retire(path, old.KeyID, old.Epoch, nil, false); !errors.Is(err, ErrRetainedKey) {
-		t.Fatalf("Retire without reference inventory error = %v, want ErrRetainedKey", err)
-	}
-	if err := Retire(path, old.KeyID, old.Epoch, refs, true); err != nil {
+	if err := Retire(path, old.KeyID, old.Epoch, true); err != nil {
 		t.Fatalf("Retire with accept loss: %v", err)
 	}
 	keyring, err = Load(path)
@@ -131,7 +128,7 @@ func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) 
 	if _, err := keyring.Open(old.KeyID, old.Epoch); !errors.Is(err, ErrKeyNotFound) {
 		t.Fatalf("Open destroyed retired key error = %v, want ErrKeyNotFound", err)
 	}
-	if err := Retire(path, keyring.ActiveID, keyring.Epoch, nil, true); err == nil {
+	if err := Retire(path, keyring.ActiveID, keyring.Epoch, true); err == nil {
 		t.Fatal("Retire active key succeeded")
 	}
 }
@@ -196,6 +193,9 @@ func TestLifecycleBackupDestroyRestoreAndOpen(t *testing.T) {
 }
 
 func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows ACL and symlink behavior differs from Unix mode semantics")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commitment-keyring.json")
 	if _, err := Initialize(path, time.Now()); err != nil {
@@ -225,8 +225,19 @@ func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
 		}
 	})
 	t.Run("symlink_save", func(t *testing.T) {
+		before, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile before: %v", err)
+		}
 		if err := keyringSaveThroughSymlink(path, link); !errors.Is(err, ErrSymlink) {
 			t.Fatalf("Save symlink error = %v, want ErrSymlink", err)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile after: %v", err)
+		}
+		if string(after) != string(before) {
+			t.Fatal("refused symlink save modified the target")
 		}
 	})
 }

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -66,6 +66,33 @@ func TestLifecycleRotationRestartOpensOldAndNew(t *testing.T) {
 	openTestReceipt(t, restarted, newReceipt)
 }
 
+func TestPersistenceRestartKeepsActiveMaterial(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	receipt := commitTestReceipt(t, keyring, "persistence guard")
+	restarted, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	openTestReceipt(t, restarted, receipt)
+}
+
+func TestRetiredLookupOpensPriorEpoch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	receipt := commitTestReceipt(t, keyring, "retired lookup guard")
+	if _, err := keyring.Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	openTestReceipt(t, keyring, receipt)
+}
+
 func TestRetireRefusesRetainedReferenceAndCanExplicitlyAcceptLoss(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
 	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
@@ -128,25 +155,32 @@ func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
 	if _, err := Initialize(path, time.Now()); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	if err := os.Chmod(path, 0o644); err != nil {
-		t.Fatalf("Chmod: %v", err)
-	}
-	if _, err := Load(path); !errors.Is(err, ErrUnsafePermission) {
-		t.Fatalf("Load mode 0644 error = %v, want ErrUnsafePermission", err)
-	}
-	if err := os.Chmod(path, 0o600); err != nil {
-		t.Fatalf("restore mode: %v", err)
-	}
 	link := filepath.Join(dir, "substituted.json")
 	if err := os.Symlink(path, link); err != nil {
 		t.Fatalf("Symlink: %v", err)
 	}
-	if _, err := Load(link); !errors.Is(err, ErrSymlink) {
-		t.Fatalf("Load symlink error = %v, want ErrSymlink", err)
-	}
-	if err := keyringSaveThroughSymlink(path, link); !errors.Is(err, ErrSymlink) {
-		t.Fatalf("Save symlink error = %v, want ErrSymlink", err)
-	}
+	t.Run("wrong_permissions", func(t *testing.T) {
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+		if _, err := Load(path); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("Load mode 0644 error = %v, want ErrUnsafePermission", err)
+		}
+	})
+	t.Run("symlink_load", func(t *testing.T) {
+		if err := os.Chmod(path, 0o600); err != nil {
+			t.Fatalf("restore mode: %v", err)
+		}
+		if _, err := Load(link); !errors.Is(err, ErrSymlink) {
+			t.Fatalf("Load symlink error = %v, want ErrSymlink", err)
+		}
+	})
+	t.Run("symlink_save", func(t *testing.T) {
+		if err := keyringSaveThroughSymlink(path, link); !errors.Is(err, ErrSymlink) {
+			t.Fatalf("Save symlink error = %v, want ErrSymlink", err)
+		}
+	})
 }
 
 func TestPurposeValidationRejectsReceiptSigning(t *testing.T) {

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -225,14 +225,14 @@ func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
 		}
 	})
 	t.Run("symlink_save", func(t *testing.T) {
-		before, err := os.ReadFile(path)
+		before, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			t.Fatalf("ReadFile before: %v", err)
 		}
 		if err := keyringSaveThroughSymlink(path, link); !errors.Is(err, ErrSymlink) {
 			t.Fatalf("Save symlink error = %v, want ErrSymlink", err)
 		}
-		after, err := os.ReadFile(path)
+		after, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			t.Fatalf("ReadFile after: %v", err)
 		}

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"sync"
 	"testing"
@@ -53,7 +54,7 @@ func TestLifecycleRotationRestartOpensOldAndNew(t *testing.T) {
 	}
 	oldReceipt := commitTestReceipt(t, keyring, "before rotation")
 	oldID := oldReceipt.KeyID
-	if _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+	if _, _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
 	keyring, err = Load(path)
@@ -87,6 +88,45 @@ func TestPersistenceRestartKeepsActiveMaterial(t *testing.T) {
 	openTestReceipt(t, restarted, receipt)
 }
 
+func TestLifecycleMutationsReturnCommittedMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	initialized, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	handle, rotated, err := Rotate(path, time.Unix(1_700_000_100, 0))
+	if err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	if rotated.ActiveID != handle.KeyID || rotated.Epoch != handle.Epoch || len(rotated.Keys) != 2 {
+		t.Fatalf("Rotate metadata = %+v, handle = %+v", rotated, handle)
+	}
+	retired, err := Retire(path, initialized.ActiveID, initialized.Epoch, true)
+	if err != nil {
+		t.Fatalf("Retire: %v", err)
+	}
+	if retired.ActiveID != handle.KeyID || retired.Epoch != handle.Epoch || len(retired.Keys) != 1 {
+		t.Fatalf("Retire metadata = %+v, active handle = %+v", retired, handle)
+	}
+}
+
+func TestKeyringDoesNotExportUnlockedSave(t *testing.T) {
+	if _, exists := reflect.TypeFor[*Keyring]().MethodByName("Save"); exists {
+		t.Fatal("Keyring exports Save without enforcing the lifecycle lock")
+	}
+}
+
+func TestInvalidReadErrorClassificationDoesNotDependOnLabel(t *testing.T) {
+	err := invalidReadError(ErrInvalidKeyring, "renamed keyring label", "not a regular file")
+	if !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("explicit keyring sentinel error = %v, want ErrInvalidKeyring", err)
+	}
+	err = invalidReadError(nil, "commitment keyring", "not a regular file")
+	if errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("nil sentinel error = %v, classification leaked from label", err)
+	}
+}
+
 func TestRetiredLookupOpensPriorEpoch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
 	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
@@ -107,18 +147,18 @@ func TestRetireRequiresExplicitLossAcceptance(t *testing.T) {
 		t.Fatalf("Initialize: %v", err)
 	}
 	old := commitTestReceipt(t, keyring, "retained")
-	if _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+	if _, _, err := Rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
 	keyring, err = Load(path)
 	if err != nil {
 		t.Fatalf("Load rotated keyring: %v", err)
 	}
-	if err := Retire(path, old.KeyID, old.Epoch, false); !errors.Is(err, ErrRetainedKey) {
+	if _, err := Retire(path, old.KeyID, old.Epoch, false); !errors.Is(err, ErrRetainedKey) {
 		t.Fatalf("Retire without loss acceptance error = %v, want ErrRetainedKey", err)
 	}
 	openTestReceipt(t, keyring, old)
-	if err := Retire(path, old.KeyID, old.Epoch, true); err != nil {
+	if _, err := Retire(path, old.KeyID, old.Epoch, true); err != nil {
 		t.Fatalf("Retire with accept loss: %v", err)
 	}
 	keyring, err = Load(path)
@@ -128,7 +168,7 @@ func TestRetireRequiresExplicitLossAcceptance(t *testing.T) {
 	if _, err := keyring.Open(old.KeyID, old.Epoch); !errors.Is(err, ErrKeyNotFound) {
 		t.Fatalf("Open destroyed retired key error = %v, want ErrKeyNotFound", err)
 	}
-	if err := Retire(path, keyring.ActiveID, keyring.Epoch, true); err == nil {
+	if _, err := Retire(path, keyring.ActiveID, keyring.Epoch, true); err == nil {
 		t.Fatal("Retire active key succeeded")
 	}
 }
@@ -145,7 +185,7 @@ func TestConcurrentRotationsSerializeEpochs(t *testing.T) {
 		wg.Add(1)
 		go func(offset int) {
 			defer wg.Done()
-			_, err := Rotate(path, time.Unix(1_700_000_100+int64(offset), 0))
+			_, _, err := Rotate(path, time.Unix(1_700_000_100+int64(offset), 0))
 			errs <- err
 		}(i)
 	}
@@ -358,74 +398,110 @@ func TestValidateRejectsMalformedLifecycleState(t *testing.T) {
 }
 
 func TestFilesystemErrorPathsFailClosed(t *testing.T) {
-	dir := t.TempDir()
-	parentFile := filepath.Join(dir, "parent-file")
-	if err := os.WriteFile(parentFile, []byte("not a directory"), 0o600); err != nil {
-		t.Fatalf("WriteFile parent: %v", err)
-	}
-	if _, err := Initialize(filepath.Join(parentFile, "keyring.json"), time.Now()); err == nil {
-		t.Fatal("Initialize below file parent succeeded")
-	}
+	t.Run("initialize below file parent", func(t *testing.T) {
+		parentFile := filepath.Join(t.TempDir(), "parent-file")
+		if err := os.WriteFile(parentFile, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("WriteFile parent: %v", err)
+		}
+		if _, err := Initialize(filepath.Join(parentFile, "keyring.json"), time.Now()); err == nil {
+			t.Fatal("Initialize below file parent succeeded")
+		}
+	})
 
-	path := filepath.Join(dir, "keyring.json")
-	keyring, err := Initialize(path, time.Now())
-	if err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	invalid := cloneKeyring(keyring)
-	invalid.Purpose = "receipt-signing"
-	if err := invalid.Save(path); !errors.Is(err, ErrInvalidKeyring) {
-		t.Fatalf("Save invalid keyring error = %v, want ErrInvalidKeyring", err)
-	}
-	if err := keyring.Save(dir); err == nil {
-		t.Fatal("Save over directory succeeded")
-	}
-	if _, err := keyring.Open(keyring.ActiveID, keyring.Epoch+1); !errors.Is(err, ErrKeyNotFound) {
-		t.Fatalf("Open unknown epoch error = %v, want ErrKeyNotFound", err)
-	}
-	corrupt := cloneKeyring(keyring)
-	corrupt.Keys[0].Key = "invalid"
-	if _, err := corrupt.Open(corrupt.ActiveID, corrupt.Epoch); !errors.Is(err, ErrInvalidKeyring) {
-		t.Fatalf("Open corrupt key error = %v, want ErrInvalidKeyring", err)
-	}
+	t.Run("invalid saves", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keyring.json")
+		keyring, err := Initialize(path, time.Now())
+		if err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		invalid := cloneKeyring(keyring)
+		invalid.Purpose = "receipt-signing"
+		if err := invalid.saveLocked(path); !errors.Is(err, ErrInvalidKeyring) {
+			t.Fatalf("saveLocked invalid keyring error = %v, want ErrInvalidKeyring", err)
+		}
+		if err := keyring.saveLocked(dir); err == nil {
+			t.Fatal("saveLocked over directory succeeded")
+		}
+	})
 
-	missing := filepath.Join(dir, "missing.json")
-	if _, err := Backup(missing, filepath.Join(dir, "unused-backup.json")); err == nil {
-		t.Fatal("Backup missing source succeeded")
-	}
-	if _, err := Restore(missing, filepath.Join(dir, "unused-restore.json")); err == nil {
-		t.Fatal("Restore missing source succeeded")
-	}
-	if _, err := Backup(path, filepath.Join(parentFile, "backup.json")); err == nil {
-		t.Fatal("Backup below file parent succeeded")
-	}
-	if _, err := Restore(path, filepath.Join(parentFile, "restore.json")); err == nil {
-		t.Fatal("Restore below file parent succeeded")
-	}
-	backup := filepath.Join(dir, "backup.json")
-	if _, err := Backup(path, backup); err != nil {
-		t.Fatalf("Backup: %v", err)
-	}
-	if _, err := Backup(path, backup); err == nil {
-		t.Fatal("Backup over existing destination succeeded")
-	}
-	if _, err := Restore(backup, path); err == nil {
-		t.Fatal("Restore over existing destination succeeded")
-	}
+	t.Run("unknown and corrupt key material", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "keyring.json")
+		keyring, err := Initialize(path, time.Now())
+		if err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		if _, err := keyring.Open(keyring.ActiveID, keyring.Epoch+1); !errors.Is(err, ErrKeyNotFound) {
+			t.Fatalf("Open unknown epoch error = %v, want ErrKeyNotFound", err)
+		}
+		corrupt := cloneKeyring(keyring)
+		corrupt.Keys[0].Key = "invalid"
+		if _, err := corrupt.Open(corrupt.ActiveID, corrupt.Epoch); !errors.Is(err, ErrInvalidKeyring) {
+			t.Fatalf("Open corrupt key error = %v, want ErrInvalidKeyring", err)
+		}
+	})
 
-	if _, err := Load(filepath.Join(dir, "absent-parent", "keyring.json")); err == nil {
-		t.Fatal("Load below absent parent succeeded")
-	}
-	if _, err := Load(dir); !errors.Is(err, ErrInvalidKeyring) {
-		t.Fatalf("Load directory error = %v, want ErrInvalidKeyring", err)
-	}
-	oversized := filepath.Join(dir, "oversized.json")
-	if err := os.WriteFile(oversized, make([]byte, maxBytes+1), 0o600); err != nil {
-		t.Fatalf("WriteFile oversized: %v", err)
-	}
-	if _, err := Load(oversized); !errors.Is(err, ErrInvalidKeyring) {
-		t.Fatalf("Load oversized error = %v, want ErrInvalidKeyring", err)
-	}
+	t.Run("backup and restore refusals", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "keyring.json")
+		if _, err := Initialize(path, time.Now()); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		parentFile := filepath.Join(dir, "parent-file")
+		if err := os.WriteFile(parentFile, []byte("not a directory"), 0o600); err != nil {
+			t.Fatalf("WriteFile parent: %v", err)
+		}
+		missing := filepath.Join(dir, "missing.json")
+		if _, err := Backup(missing, filepath.Join(dir, "unused-backup.json")); err == nil {
+			t.Fatal("Backup missing source succeeded")
+		}
+		if _, err := Restore(missing, filepath.Join(dir, "unused-restore.json")); err == nil {
+			t.Fatal("Restore missing source succeeded")
+		}
+		if _, err := Backup(path, filepath.Join(parentFile, "backup.json")); err == nil {
+			t.Fatal("Backup below file parent succeeded")
+		}
+		if _, err := Restore(path, filepath.Join(parentFile, "restore.json")); err == nil {
+			t.Fatal("Restore below file parent succeeded")
+		}
+		backup := filepath.Join(dir, "backup.json")
+		if _, err := Backup(path, backup); err != nil {
+			t.Fatalf("Backup: %v", err)
+		}
+		if _, err := Backup(path, backup); err == nil {
+			t.Fatal("Backup over existing destination succeeded")
+		}
+		if _, err := Restore(backup, path); err == nil {
+			t.Fatal("Restore over existing destination succeeded")
+		}
+	})
+
+	t.Run("load refusals", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Load(filepath.Join(dir, "absent-parent", "keyring.json")); err == nil {
+			t.Fatal("Load below absent parent succeeded")
+		}
+		if supportsUnixModeAssertions(runtime.GOOS) {
+			if _, err := Load(dir); !errors.Is(err, ErrInvalidKeyring) {
+				t.Fatalf("Load directory error = %v, want ErrInvalidKeyring", err)
+			}
+		}
+		oversized := filepath.Join(dir, "oversized.json")
+		file, err := os.OpenFile(filepath.Clean(oversized), os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("OpenFile oversized: %v", err)
+		}
+		if err := file.Truncate(maxBytes + 1); err != nil {
+			_ = file.Close()
+			t.Fatalf("Truncate oversized: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("Close oversized: %v", err)
+		}
+		if _, err := Load(oversized); !errors.Is(err, ErrInvalidKeyring) {
+			t.Fatalf("Load oversized error = %v, want ErrInvalidKeyring", err)
+		}
+	})
 }
 
 func cloneKeyring(keyring *Keyring) *Keyring {
@@ -471,6 +547,10 @@ func openTestReceipt(t *testing.T, keyring *Keyring, receipt committedReceipt) {
 
 func assertMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
+	if !supportsUnixModeAssertions(runtime.GOOS) {
+		t.Log("skipping Unix mode assertion: Windows represents access through ACLs")
+		return
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat(%s): %v", path, err)
@@ -480,10 +560,25 @@ func assertMode(t *testing.T, path string, want os.FileMode) {
 	}
 }
 
+func TestModeAssertionPlatformGuard(t *testing.T) {
+	if supportsUnixModeAssertions("windows") {
+		t.Fatal("Windows selected for Unix mode assertion")
+	}
+	if !supportsUnixModeAssertions("linux") {
+		t.Fatal("Linux excluded from Unix mode assertion")
+	}
+}
+
+func supportsUnixModeAssertions(goos string) bool {
+	return goos != "windows"
+}
+
 func keyringSaveThroughSymlink(realPath, link string) error {
 	keyring, err := Load(realPath)
 	if err != nil {
 		return err
 	}
-	return keyring.Save(link)
+	return withLifecycleLock(link, func() error {
+		return keyring.saveLocked(link)
+	})
 }

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -4,6 +4,7 @@
 package commitmentkey
 
 import (
+	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
@@ -276,6 +277,150 @@ func TestInvalidKeyringShapesFailClosed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateRejectsMalformedLifecycleState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	base, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	retired := cloneKeyring(base)
+	if _, err := retired.rotate(path, time.Unix(1_700_000_100, 0)); err != nil {
+		t.Fatalf("rotate fixture: %v", err)
+	}
+	retiredAt := time.Unix(1_700_000_100, 0).UTC()
+	mutations := map[string]func(*Keyring){
+		"missing active metadata": func(k *Keyring) { k.Epoch = 0 },
+		"short key id":            func(k *Keyring) { k.Keys[0].KeyID = "ck_short" },
+		"nonhex key id":           func(k *Keyring) { k.Keys[0].KeyID = "ck_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" },
+		"zero entry epoch":        func(k *Keyring) { k.Keys[0].Epoch = 0 },
+		"zero created time":       func(k *Keyring) { k.Keys[0].CreatedAt = time.Time{} },
+		"duplicate key id": func(k *Keyring) {
+			duplicate := k.Keys[0]
+			duplicate.Epoch = 2
+			duplicate.State = StateRetired
+			duplicate.RetiredAt = &retiredAt
+			k.Keys = append(k.Keys, duplicate)
+		},
+		"duplicate epoch": func(k *Keyring) {
+			duplicate, entryErr := newEntry(1, time.Unix(1_700_000_001, 0))
+			if entryErr != nil {
+				t.Fatalf("newEntry: %v", entryErr)
+			}
+			duplicate.State = StateRetired
+			duplicate.RetiredAt = &retiredAt
+			k.Keys = append(k.Keys, duplicate)
+		},
+		"invalid base64 key":       func(k *Keyring) { k.Keys[0].Key = "%%%" },
+		"short decoded key":        func(k *Keyring) { k.Keys[0].Key = base64.StdEncoding.EncodeToString([]byte("short")) },
+		"active id mismatch":       func(k *Keyring) { k.ActiveID = "ck_00000000000000000000000000000000" },
+		"active retired timestamp": func(k *Keyring) { k.Keys[0].RetiredAt = &retiredAt },
+		"unknown state":            func(k *Keyring) { k.Keys[0].State = State("unknown") },
+		"no active key": func(k *Keyring) {
+			k.Epoch = 2
+			k.Keys[0].State = StateRetired
+			k.Keys[0].RetiredAt = &retiredAt
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			keyring := cloneKeyring(base)
+			mutate(keyring)
+			if err := keyring.Validate(); !errors.Is(err, ErrInvalidKeyring) {
+				t.Fatalf("Validate error = %v, want ErrInvalidKeyring", err)
+			}
+		})
+	}
+	for name, mutate := range map[string]func(*Keyring){
+		"retired timestamp absent": func(k *Keyring) { k.Keys[0].RetiredAt = nil },
+		"retired epoch not older":  func(k *Keyring) { k.Keys[0].Epoch = k.Epoch },
+	} {
+		t.Run(name, func(t *testing.T) {
+			keyring := cloneKeyring(retired)
+			mutate(keyring)
+			if err := keyring.Validate(); !errors.Is(err, ErrInvalidKeyring) {
+				t.Fatalf("Validate error = %v, want ErrInvalidKeyring", err)
+			}
+		})
+	}
+}
+
+func TestFilesystemErrorPathsFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	parentFile := filepath.Join(dir, "parent-file")
+	if err := os.WriteFile(parentFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile parent: %v", err)
+	}
+	if _, err := Initialize(filepath.Join(parentFile, "keyring.json"), time.Now()); err == nil {
+		t.Fatal("Initialize below file parent succeeded")
+	}
+
+	path := filepath.Join(dir, "keyring.json")
+	keyring, err := Initialize(path, time.Now())
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	invalid := cloneKeyring(keyring)
+	invalid.Purpose = "receipt-signing"
+	if err := invalid.Save(path); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Save invalid keyring error = %v, want ErrInvalidKeyring", err)
+	}
+	if err := keyring.Save(dir); err == nil {
+		t.Fatal("Save over directory succeeded")
+	}
+	if _, err := keyring.Open(keyring.ActiveID, keyring.Epoch+1); !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("Open unknown epoch error = %v, want ErrKeyNotFound", err)
+	}
+	corrupt := cloneKeyring(keyring)
+	corrupt.Keys[0].Key = "invalid"
+	if _, err := corrupt.Open(corrupt.ActiveID, corrupt.Epoch); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Open corrupt key error = %v, want ErrInvalidKeyring", err)
+	}
+
+	missing := filepath.Join(dir, "missing.json")
+	if _, err := Backup(missing, filepath.Join(dir, "unused-backup.json")); err == nil {
+		t.Fatal("Backup missing source succeeded")
+	}
+	if _, err := Restore(missing, filepath.Join(dir, "unused-restore.json")); err == nil {
+		t.Fatal("Restore missing source succeeded")
+	}
+	if _, err := Backup(path, filepath.Join(parentFile, "backup.json")); err == nil {
+		t.Fatal("Backup below file parent succeeded")
+	}
+	if _, err := Restore(path, filepath.Join(parentFile, "restore.json")); err == nil {
+		t.Fatal("Restore below file parent succeeded")
+	}
+	backup := filepath.Join(dir, "backup.json")
+	if _, err := Backup(path, backup); err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if _, err := Backup(path, backup); err == nil {
+		t.Fatal("Backup over existing destination succeeded")
+	}
+	if _, err := Restore(backup, path); err == nil {
+		t.Fatal("Restore over existing destination succeeded")
+	}
+
+	if _, err := Load(filepath.Join(dir, "absent-parent", "keyring.json")); err == nil {
+		t.Fatal("Load below absent parent succeeded")
+	}
+	if _, err := Load(dir); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Load directory error = %v, want ErrInvalidKeyring", err)
+	}
+	oversized := filepath.Join(dir, "oversized.json")
+	if err := os.WriteFile(oversized, make([]byte, maxBytes+1), 0o600); err != nil {
+		t.Fatalf("WriteFile oversized: %v", err)
+	}
+	if _, err := Load(oversized); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Load oversized error = %v, want ErrInvalidKeyring", err)
+	}
+}
+
+func cloneKeyring(keyring *Keyring) *Keyring {
+	clone := *keyring
+	clone.Keys = append([]Entry(nil), keyring.Keys...)
+	return &clone
 }
 
 func commitTestReceipt(t *testing.T, keyring *Keyring, view string) committedReceipt {

--- a/internal/commitmentkey/lock_other.go
+++ b/internal/commitmentkey/lock_other.go
@@ -7,6 +7,8 @@ package commitmentkey
 
 import "sync"
 
+// lifecycleLock serializes lifecycle operations only within this process.
+// Targets outside the Unix and Windows build tags have no cross-process lock.
 var lifecycleLock sync.Mutex
 
 func withLifecycleLock(_ string, fn func() error) error {

--- a/internal/commitmentkey/lock_other.go
+++ b/internal/commitmentkey/lock_other.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix && !windows
+
+package commitmentkey
+
+import "sync"
+
+var lifecycleLock sync.Mutex
+
+func withLifecycleLock(_ string, fn func() error) error {
+	lifecycleLock.Lock()
+	defer lifecycleLock.Unlock()
+	return fn()
+}

--- a/internal/commitmentkey/lock_unix.go
+++ b/internal/commitmentkey/lock_unix.go
@@ -17,7 +17,12 @@ func withLifecycleLock(keyringPath string, fn func() error) error {
 	if err := rejectSymlink(lockPath); err != nil {
 		return fmt.Errorf("commitment keyring lock: %w", err)
 	}
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // operator-selected state path; symlinks are rejected above
+	root, err := os.OpenRoot(filepath.Dir(lockPath))
+	if err != nil {
+		return fmt.Errorf("open commitment keyring lock directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.OpenFile(filepath.Base(lockPath), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("open commitment keyring lock: %w", err)
 	}
@@ -25,7 +30,10 @@ func withLifecycleLock(keyringPath string, fn func() error) error {
 	if err := f.Chmod(0o600); err != nil {
 		return fmt.Errorf("secure commitment keyring lock: %w", err)
 	}
-	fd := int(f.Fd()) //nolint:gosec // file descriptors fit in int on supported Unix targets
+	if uint64(f.Fd()) > uint64(^uint(0)>>1) {
+		return fmt.Errorf("commitment keyring lock descriptor is out of range")
+	}
+	fd := int(f.Fd())
 	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
 		return fmt.Errorf("acquire commitment keyring lock: %w", err)
 	}

--- a/internal/commitmentkey/lock_unix.go
+++ b/internal/commitmentkey/lock_unix.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package commitmentkey
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func withLifecycleLock(keyringPath string, fn func() error) error {
+	lockPath := filepath.Clean(keyringPath) + ".lock"
+	if err := rejectSymlink(lockPath); err != nil {
+		return fmt.Errorf("commitment keyring lock: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // operator-selected state path; symlinks are rejected above
+	if err != nil {
+		return fmt.Errorf("open commitment keyring lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure commitment keyring lock: %w", err)
+	}
+	fd := int(f.Fd()) //nolint:gosec // file descriptors fit in int on supported Unix targets
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("acquire commitment keyring lock: %w", err)
+	}
+	defer func() { _ = syscall.Flock(fd, syscall.LOCK_UN) }()
+	return fn()
+}

--- a/internal/commitmentkey/lock_unix.go
+++ b/internal/commitmentkey/lock_unix.go
@@ -7,29 +7,17 @@ package commitmentkey
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"syscall"
 )
 
 func withLifecycleLock(keyringPath string, fn func() error) error {
 	lockPath := filepath.Clean(keyringPath) + ".lock"
-	if err := rejectSymlink(lockPath); err != nil {
-		return fmt.Errorf("commitment keyring lock: %w", err)
-	}
-	root, err := os.OpenRoot(filepath.Dir(lockPath))
-	if err != nil {
-		return fmt.Errorf("open commitment keyring lock directory: %w", err)
-	}
-	defer func() { _ = root.Close() }()
-	f, err := root.OpenFile(filepath.Base(lockPath), os.O_CREATE|os.O_RDWR, 0o600)
+	f, err := openSecureLock(lockPath)
 	if err != nil {
 		return fmt.Errorf("open commitment keyring lock: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	if err := f.Chmod(0o600); err != nil {
-		return fmt.Errorf("secure commitment keyring lock: %w", err)
-	}
 	if uint64(f.Fd()) > uint64(^uint(0)>>1) {
 		return fmt.Errorf("commitment keyring lock descriptor is out of range")
 	}

--- a/internal/commitmentkey/lock_unix_test.go
+++ b/internal/commitmentkey/lock_unix_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package commitmentkey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLifecycleLockRejectsSymlinkAndBadParent(t *testing.T) {
+	dir := t.TempDir()
+	keyringPath := filepath.Join(dir, "keyring.json")
+	lockTarget := filepath.Join(dir, "lock-target")
+	if err := os.WriteFile(lockTarget, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Symlink(lockTarget, keyringPath+".lock"); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if err := withLifecycleLock(keyringPath, func() error { return nil }); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("symlink lock error = %v, want ErrSymlink", err)
+	}
+	if err := withLifecycleLock(filepath.Join(dir, "absent", "keyring.json"), func() error { return nil }); err == nil {
+		t.Fatal("lock below absent parent succeeded")
+	}
+}

--- a/internal/commitmentkey/lock_unix_test.go
+++ b/internal/commitmentkey/lock_unix_test.go
@@ -13,19 +13,24 @@ import (
 )
 
 func TestLifecycleLockRejectsSymlinkAndBadParent(t *testing.T) {
-	dir := t.TempDir()
-	keyringPath := filepath.Join(dir, "keyring.json")
-	lockTarget := filepath.Join(dir, "lock-target")
-	if err := os.WriteFile(lockTarget, nil, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	if err := os.Symlink(lockTarget, keyringPath+".lock"); err != nil {
-		t.Fatalf("Symlink: %v", err)
-	}
-	if err := withLifecycleLock(keyringPath, func() error { return nil }); !errors.Is(err, ErrSymlink) {
-		t.Fatalf("symlink lock error = %v, want ErrSymlink", err)
-	}
-	if err := withLifecycleLock(filepath.Join(dir, "absent", "keyring.json"), func() error { return nil }); err == nil {
-		t.Fatal("lock below absent parent succeeded")
-	}
+	t.Run("symlinked_lock", func(t *testing.T) {
+		dir := t.TempDir()
+		keyringPath := filepath.Join(dir, "keyring.json")
+		lockTarget := filepath.Join(dir, "lock-target")
+		if err := os.WriteFile(lockTarget, nil, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Symlink(lockTarget, keyringPath+".lock"); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		if err := withLifecycleLock(keyringPath, func() error { return nil }); !errors.Is(err, ErrSymlink) {
+			t.Fatalf("symlink lock error = %v, want ErrSymlink", err)
+		}
+	})
+	t.Run("absent_parent", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := withLifecycleLock(filepath.Join(dir, "absent", "keyring.json"), func() error { return nil }); err == nil {
+			t.Fatal("lock below absent parent succeeded")
+		}
+	})
 }

--- a/internal/commitmentkey/lock_windows.go
+++ b/internal/commitmentkey/lock_windows.go
@@ -9,16 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
-	"unsafe"
-)
 
-const exclusiveLock = 0x00000002
-
-var (
-	kernel32              = syscall.NewLazyDLL("kernel32.dll")
-	lockFileExProcedure   = kernel32.NewProc("LockFileEx")
-	unlockFileExProcedure = kernel32.NewProc("UnlockFileEx")
+	"golang.org/x/sys/windows"
 )
 
 func withLifecycleLock(keyringPath string, fn func() error) error {
@@ -29,17 +21,17 @@ func withLifecycleLock(keyringPath string, fn func() error) error {
 	if err := validateWindowsFinal(lockPath); err != nil {
 		return fmt.Errorf("commitment keyring lock: %w", err)
 	}
-	pathPointer, err := syscall.UTF16PtrFromString(lockPath)
+	pathPointer, err := windows.UTF16PtrFromString(lockPath)
 	if err != nil {
 		return fmt.Errorf("encode commitment keyring lock path: %w", err)
 	}
-	handle, err := syscall.CreateFile(pathPointer, syscall.GENERIC_READ|syscall.GENERIC_WRITE, syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL|syscall.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	handle, err := windows.CreateFile(pathPointer, windows.GENERIC_READ|windows.GENERIC_WRITE, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_ALWAYS, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
 	if err != nil {
 		return fmt.Errorf("open commitment keyring lock: %w", err)
 	}
 	f := os.NewFile(uintptr(handle), lockPath)
 	if f == nil {
-		_ = syscall.CloseHandle(handle)
+		_ = windows.CloseHandle(handle)
 		return fmt.Errorf("create commitment keyring lock handle: %s", lockPath)
 	}
 	defer func() { _ = f.Close() }()
@@ -53,26 +45,10 @@ func withLifecycleLock(keyringPath string, fn func() error) error {
 	if err := f.Chmod(0o600); err != nil {
 		return fmt.Errorf("secure commitment keyring lock: %w", err)
 	}
-	var overlapped syscall.Overlapped
-	if err := callLockFileEx(handle, exclusiveLock, &overlapped); err != nil {
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 0xffffffff, 0xffffffff, &overlapped); err != nil {
 		return fmt.Errorf("acquire commitment keyring lock: %w", err)
 	}
-	defer func() { _ = callUnlockFileEx(handle, &overlapped) }()
+	defer func() { _ = windows.UnlockFileEx(handle, 0, 0xffffffff, 0xffffffff, &overlapped) }()
 	return fn()
-}
-
-func callLockFileEx(handle syscall.Handle, flags uint32, overlapped *syscall.Overlapped) error {
-	result, _, err := lockFileExProcedure.Call(uintptr(handle), uintptr(flags), 0, 0xffffffff, 0xffffffff, uintptr(unsafe.Pointer(overlapped)))
-	if result == 0 {
-		return err
-	}
-	return nil
-}
-
-func callUnlockFileEx(handle syscall.Handle, overlapped *syscall.Overlapped) error {
-	result, _, err := unlockFileExProcedure.Call(uintptr(handle), 0, 0xffffffff, 0xffffffff, uintptr(unsafe.Pointer(overlapped)))
-	if result == 0 {
-		return err
-	}
-	return nil
 }

--- a/internal/commitmentkey/lock_windows.go
+++ b/internal/commitmentkey/lock_windows.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package commitmentkey
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const exclusiveLock = 0x00000002
+
+var (
+	kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	lockFileExProcedure   = kernel32.NewProc("LockFileEx")
+	unlockFileExProcedure = kernel32.NewProc("UnlockFileEx")
+)
+
+func withLifecycleLock(keyringPath string, fn func() error) error {
+	lockPath := filepath.Clean(keyringPath) + ".lock"
+	if err := rejectSymlink(lockPath); err != nil {
+		return fmt.Errorf("commitment keyring lock: %w", err)
+	}
+	pathPointer, err := syscall.UTF16PtrFromString(lockPath)
+	if err != nil {
+		return fmt.Errorf("encode commitment keyring lock path: %w", err)
+	}
+	handle, err := syscall.CreateFile(pathPointer, syscall.GENERIC_READ|syscall.GENERIC_WRITE, syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		return fmt.Errorf("open commitment keyring lock: %w", err)
+	}
+	f := os.NewFile(uintptr(handle), lockPath)
+	if f == nil {
+		_ = syscall.CloseHandle(handle)
+		return fmt.Errorf("create commitment keyring lock handle: %s", lockPath)
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure commitment keyring lock: %w", err)
+	}
+	var overlapped syscall.Overlapped
+	if err := callLockFileEx(handle, exclusiveLock, &overlapped); err != nil {
+		return fmt.Errorf("acquire commitment keyring lock: %w", err)
+	}
+	defer func() { _ = callUnlockFileEx(handle, &overlapped) }()
+	return fn()
+}
+
+func callLockFileEx(handle syscall.Handle, flags uint32, overlapped *syscall.Overlapped) error {
+	result, _, err := lockFileExProcedure.Call(uintptr(handle), uintptr(flags), 0, 0xffffffff, 0xffffffff, uintptr(unsafe.Pointer(overlapped)))
+	if result == 0 {
+		return err
+	}
+	return nil
+}
+
+func callUnlockFileEx(handle syscall.Handle, overlapped *syscall.Overlapped) error {
+	result, _, err := unlockFileExProcedure.Call(uintptr(handle), 0, 0xffffffff, 0xffffffff, uintptr(unsafe.Pointer(overlapped)))
+	if result == 0 {
+		return err
+	}
+	return nil
+}

--- a/internal/commitmentkey/lock_windows.go
+++ b/internal/commitmentkey/lock_windows.go
@@ -23,14 +23,17 @@ var (
 
 func withLifecycleLock(keyringPath string, fn func() error) error {
 	lockPath := filepath.Clean(keyringPath) + ".lock"
-	if err := rejectSymlink(lockPath); err != nil {
+	if err := ensureParent(lockPath); err != nil {
+		return fmt.Errorf("commitment keyring lock: %w", err)
+	}
+	if err := validateWindowsFinal(lockPath); err != nil {
 		return fmt.Errorf("commitment keyring lock: %w", err)
 	}
 	pathPointer, err := syscall.UTF16PtrFromString(lockPath)
 	if err != nil {
 		return fmt.Errorf("encode commitment keyring lock path: %w", err)
 	}
-	handle, err := syscall.CreateFile(pathPointer, syscall.GENERIC_READ|syscall.GENERIC_WRITE, syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	handle, err := syscall.CreateFile(pathPointer, syscall.GENERIC_READ|syscall.GENERIC_WRITE, syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_ALWAYS, syscall.FILE_ATTRIBUTE_NORMAL|syscall.FILE_FLAG_OPEN_REPARSE_POINT, 0)
 	if err != nil {
 		return fmt.Errorf("open commitment keyring lock: %w", err)
 	}
@@ -40,6 +43,13 @@ func withLifecycleLock(keyringPath string, fn func() error) error {
 		return fmt.Errorf("create commitment keyring lock handle: %s", lockPath)
 	}
 	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat commitment keyring lock: %w", err)
+	}
+	if isWindowsReparse(info) || !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: commitment keyring lock is a reparse point or not a regular file", ErrSymlink)
+	}
 	if err := f.Chmod(0o600); err != nil {
 		return fmt.Errorf("secure commitment keyring lock: %w", err)
 	}

--- a/internal/commitmentkey/nofollow_errno_emlink.go
+++ b/internal/commitmentkey/nofollow_errno_emlink.go
@@ -1,11 +1,11 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build freebsd
+//go:build freebsd || dragonfly
 
 package commitmentkey
 
 import "golang.org/x/sys/unix"
 
 // FreeBSD reports EMLINK when O_NOFOLLOW refuses a final-component symlink.
-var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("freebsd", noFollowErrnos{loop: unix.ELOOP, link: unix.EMLINK})
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("freebsd-family", noFollowErrnos{loop: unix.ELOOP, link: unix.EMLINK})

--- a/internal/commitmentkey/nofollow_errno_emlink.go
+++ b/internal/commitmentkey/nofollow_errno_emlink.go
@@ -8,4 +8,4 @@ package commitmentkey
 import "golang.org/x/sys/unix"
 
 // FreeBSD reports EMLINK when O_NOFOLLOW refuses a final-component symlink.
-var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("freebsd-family", noFollowErrnos{loop: unix.ELOOP, link: unix.EMLINK})
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor(noFollowErrnos{loop: unix.ELOOP, link: unix.EMLINK})

--- a/internal/commitmentkey/nofollow_errno_freebsd.go
+++ b/internal/commitmentkey/nofollow_errno_freebsd.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build freebsd
+
+package commitmentkey
+
+import "golang.org/x/sys/unix"
+
+// FreeBSD reports EMLINK when O_NOFOLLOW refuses a final-component symlink.
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("freebsd", noFollowErrnos{loop: unix.ELOOP, link: unix.EMLINK})

--- a/internal/commitmentkey/nofollow_errno_netbsd.go
+++ b/internal/commitmentkey/nofollow_errno_netbsd.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build netbsd
+
+package commitmentkey
+
+import "golang.org/x/sys/unix"
+
+// NetBSD reports EFTYPE when O_NOFOLLOW refuses a final-component symlink.
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("netbsd", noFollowErrnos{loop: unix.ELOOP, fileType: unix.EFTYPE})

--- a/internal/commitmentkey/nofollow_errno_netbsd.go
+++ b/internal/commitmentkey/nofollow_errno_netbsd.go
@@ -8,4 +8,4 @@ package commitmentkey
 import "golang.org/x/sys/unix"
 
 // NetBSD reports EFTYPE when O_NOFOLLOW refuses a final-component symlink.
-var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("netbsd", noFollowErrnos{loop: unix.ELOOP, fileType: unix.EFTYPE})
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor(noFollowErrnos{loop: unix.ELOOP, fileType: unix.EFTYPE})

--- a/internal/commitmentkey/nofollow_errno_unix.go
+++ b/internal/commitmentkey/nofollow_errno_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build unix && !freebsd && !netbsd
+//go:build unix && !freebsd && !dragonfly && !netbsd
 
 package commitmentkey
 

--- a/internal/commitmentkey/nofollow_errno_unix.go
+++ b/internal/commitmentkey/nofollow_errno_unix.go
@@ -7,4 +7,4 @@ package commitmentkey
 
 import "golang.org/x/sys/unix"
 
-var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("other", noFollowErrnos{loop: unix.ELOOP})
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor(noFollowErrnos{loop: unix.ELOOP})

--- a/internal/commitmentkey/nofollow_errno_unix.go
+++ b/internal/commitmentkey/nofollow_errno_unix.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix && !freebsd && !netbsd
+
+package commitmentkey
+
+import "golang.org/x/sys/unix"
+
+var noFollowSymlinkErrors = noFollowSymlinkErrorsFor("other", noFollowErrnos{loop: unix.ELOOP})

--- a/internal/commitmentkey/secureio.go
+++ b/internal/commitmentkey/secureio.go
@@ -3,11 +3,24 @@
 
 package commitmentkey
 
+import (
+	"errors"
+	"fmt"
+)
+
 const maxPrivateViewBytes = 64 << 20
 
 // ReadPrivateView reads an operator-supplied transformed evidence view without
 // following a final-component symlink. Files must use the same owner-only mode
 // and trusted-parent rules as the keyring.
 func ReadPrivateView(path string) ([]byte, error) {
-	return readSecureLimited(path, maxPrivateViewBytes, "private evidence view")
+	return readSecureLimited(path, maxPrivateViewBytes, "private evidence view", nil)
+}
+
+func invalidReadError(sentinel error, label, format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	if sentinel != nil {
+		return fmt.Errorf("%w: %s", sentinel, detail)
+	}
+	return errors.New("invalid " + label + ": " + detail)
 }

--- a/internal/commitmentkey/secureio.go
+++ b/internal/commitmentkey/secureio.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package commitmentkey
+
+const maxPrivateViewBytes = 64 << 20
+
+// ReadPrivateView reads an operator-supplied transformed evidence view without
+// following a final-component symlink. Files must use the same owner-only mode
+// and trusted-parent rules as the keyring.
+func ReadPrivateView(path string) ([]byte, error) {
+	return readSecureLimited(path, maxPrivateViewBytes, "private evidence view")
+}

--- a/internal/commitmentkey/secureio_other.go
+++ b/internal/commitmentkey/secureio_other.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix && !windows
+
+package commitmentkey
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+)
+
+func ensureParent(path string) error {
+	if err := os.MkdirAll(filepath.Dir(filepath.Clean(path)), 0o750); err != nil {
+		return fmt.Errorf("create commitment keyring directory: %w", err)
+	}
+	return nil
+}
+
+func readSecure(path string) ([]byte, error) {
+	return readSecureLimited(path, maxBytes, "commitment keyring")
+}
+
+func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", label, err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", label, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("invalid %s: not a regular file", label)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return nil, fmt.Errorf("%w: got %04o, want 0600", ErrUnsafePermission, info.Mode().Perm())
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if int64(len(raw)) > limit {
+		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+	}
+	return raw, nil
+}
+
+func writeSecureNew(path string, data []byte) error {
+	if err := ensureParent(path); err != nil {
+		return err
+	}
+	if err := atomicfile.WriteNew(filepath.Clean(path), data, 0o600); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func writeSecureReplace(path string, data []byte) error {
+	return atomicfile.Write(filepath.Clean(path), data, 0o600)
+}

--- a/internal/commitmentkey/secureio_other.go
+++ b/internal/commitmentkey/secureio_other.go
@@ -7,64 +7,18 @@ package commitmentkey
 
 import (
 	"errors"
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-
-	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 )
 
-func ensureParent(path string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(path)), 0o750); err != nil {
-		return fmt.Errorf("create commitment keyring directory: %w", err)
-	}
-	return nil
-}
+var errSecureIOUnsupported = errors.New("secure commitment keyring storage is unsupported on this operating system")
+
+func ensureParent(string) error { return errSecureIOUnsupported }
 
 func readSecure(path string) ([]byte, error) {
 	return readSecureLimited(path, maxBytes, "commitment keyring")
 }
 
-func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
-	f, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", label, err)
-	}
-	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat %s: %w", label, err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("invalid %s: not a regular file", label)
-	}
-	if info.Mode().Perm() != 0o600 {
-		return nil, fmt.Errorf("%w: got %04o, want 0600", ErrUnsafePermission, info.Mode().Perm())
-	}
-	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", label, err)
-	}
-	if int64(len(raw)) > limit {
-		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
-	}
-	return raw, nil
-}
+func readSecureLimited(string, int64, string) ([]byte, error) { return nil, errSecureIOUnsupported }
 
-func writeSecureNew(path string, data []byte) error {
-	if err := ensureParent(path); err != nil {
-		return err
-	}
-	if err := atomicfile.WriteNew(filepath.Clean(path), data, 0o600); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return ErrAlreadyExists
-		}
-		return err
-	}
-	return nil
-}
+func writeSecureNew(string, []byte) error { return errSecureIOUnsupported }
 
-func writeSecureReplace(path string, data []byte) error {
-	return atomicfile.Write(filepath.Clean(path), data, 0o600)
-}
+func writeSecureReplace(string, []byte) error { return errSecureIOUnsupported }

--- a/internal/commitmentkey/secureio_other.go
+++ b/internal/commitmentkey/secureio_other.go
@@ -14,10 +14,12 @@ var errSecureIOUnsupported = errors.New("secure commitment keyring storage is un
 func ensureParent(string) error { return errSecureIOUnsupported }
 
 func readSecure(path string) ([]byte, error) {
-	return readSecureLimited(path, maxBytes, "commitment keyring")
+	return readSecureLimited(path, maxBytes, "commitment keyring", ErrInvalidKeyring)
 }
 
-func readSecureLimited(string, int64, string) ([]byte, error) { return nil, errSecureIOUnsupported }
+func readSecureLimited(string, int64, string, error) ([]byte, error) {
+	return nil, errSecureIOUnsupported
+}
 
 func writeSecureNew(string, []byte) error { return errSecureIOUnsupported }
 

--- a/internal/commitmentkey/secureio_unix.go
+++ b/internal/commitmentkey/secureio_unix.go
@@ -250,7 +250,8 @@ func validateOpenedDirectory(fd int, path string) error {
 	if stat.Mode&unix.S_IFMT != unix.S_IFDIR {
 		return fmt.Errorf("parent path is not a directory: %s", path)
 	}
-	if stat.Uid != 0 && stat.Uid != uint32(os.Geteuid()) {
+	effectiveUID := int64(os.Geteuid())
+	if stat.Uid != 0 && int64(stat.Uid) != effectiveUID {
 		return fmt.Errorf("%w: parent directory %s owner uid %d is neither root nor effective uid %d", ErrUnsafePermission, path, stat.Uid, os.Geteuid())
 	}
 	if stat.Mode&0o022 != 0 {
@@ -270,7 +271,7 @@ func validateOpenedFile(fd int, label string) (unix.Stat_t, error) {
 		}
 		return unix.Stat_t{}, fmt.Errorf("invalid %s: not a regular file", label)
 	}
-	if stat.Uid != uint32(os.Geteuid()) {
+	if int64(stat.Uid) != int64(os.Geteuid()) {
 		return unix.Stat_t{}, fmt.Errorf("%w: %s owner uid %d, want effective uid %d", ErrUnsafePermission, label, stat.Uid, os.Geteuid())
 	}
 	if stat.Mode&0o777 != secureFileMode {

--- a/internal/commitmentkey/secureio_unix.go
+++ b/internal/commitmentkey/secureio_unix.go
@@ -28,10 +28,10 @@ func ensureParent(path string) error {
 }
 
 func readSecure(path string) ([]byte, error) {
-	return readSecureLimited(path, maxBytes, "commitment keyring")
+	return readSecureLimited(path, maxBytes, "commitment keyring", ErrInvalidKeyring)
 }
 
-func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
+func readSecureLimited(path string, limit int64, label string, invalidErr error) ([]byte, error) {
 	parentFD, base, err := openSecureParent(path, false)
 	if err != nil {
 		return nil, fmt.Errorf("open %s directory: %w", label, err)
@@ -43,25 +43,19 @@ func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
 	}
 	f := os.NewFile(uintptr(fd), filepath.Clean(path))
 	defer func() { _ = f.Close() }()
-	stat, err := validateOpenedFile(fd, label)
+	stat, err := validateOpenedFile(fd, label, invalidErr)
 	if err != nil {
 		return nil, err
 	}
 	if stat.Size > limit {
-		if label == "commitment keyring" {
-			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
-		}
-		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+		return nil, invalidReadError(invalidErr, label, "file exceeds %d bytes", limit)
 	}
 	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", label, err)
 	}
 	if int64(len(raw)) > limit {
-		if label == "commitment keyring" {
-			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
-		}
-		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+		return nil, invalidReadError(invalidErr, label, "file exceeds %d bytes", limit)
 	}
 	return raw, nil
 }
@@ -85,7 +79,7 @@ func writeSecureReplace(path string, data []byte) error {
 	if err != nil {
 		return mapOpenError("commitment keyring", path, err)
 	}
-	if _, err := validateOpenedFile(fd, "commitment keyring"); err != nil {
+	if _, err := validateOpenedFile(fd, "commitment keyring", ErrInvalidKeyring); err != nil {
 		_ = unix.Close(fd)
 		return err
 	}
@@ -113,7 +107,7 @@ func openSecureLock(path string) (*os.File, error) {
 			return nil, err
 		}
 	}
-	if _, err := validateOpenedFile(fd, "commitment keyring lock"); err != nil {
+	if _, err := validateOpenedFile(fd, "commitment keyring lock", nil); err != nil {
 		_ = unix.Close(fd)
 		return nil, err
 	}
@@ -269,16 +263,13 @@ func validateOpenedDirectory(fd int, path string) error {
 	return nil
 }
 
-func validateOpenedFile(fd int, label string) (unix.Stat_t, error) {
+func validateOpenedFile(fd int, label string, invalidErr error) (unix.Stat_t, error) {
 	var stat unix.Stat_t
 	if err := unix.Fstat(fd, &stat); err != nil {
 		return unix.Stat_t{}, fmt.Errorf("stat %s: %w", label, err)
 	}
 	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
-		if label == "commitment keyring" {
-			return unix.Stat_t{}, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
-		}
-		return unix.Stat_t{}, fmt.Errorf("invalid %s: not a regular file", label)
+		return unix.Stat_t{}, invalidReadError(invalidErr, label, "not a regular file")
 	}
 	if int64(stat.Uid) != int64(os.Geteuid()) {
 		return unix.Stat_t{}, fmt.Errorf("%w: %s owner uid %d, want effective uid %d", ErrUnsafePermission, label, stat.Uid, os.Geteuid())
@@ -290,11 +281,35 @@ func validateOpenedFile(fd int, label string) (unix.Stat_t, error) {
 }
 
 func mapOpenError(label, path string, err error) error {
-	if errors.Is(err, unix.ELOOP) {
+	if isNoFollowSymlinkError(err, noFollowSymlinkErrors) {
 		return fmt.Errorf("%w: %s", ErrSymlink, filepath.Clean(path))
 	}
 	if errors.Is(err, unix.EACCES) {
 		return fmt.Errorf("%w: cannot open %s: %w", ErrUnsafePermission, label, err)
 	}
 	return fmt.Errorf("open %s: %w", label, err)
+}
+
+func isNoFollowSymlinkError(err error, symlinkErrors []error) bool {
+	for _, symlinkErr := range symlinkErrors {
+		if errors.Is(err, symlinkErr) {
+			return true
+		}
+	}
+	return false
+}
+
+type noFollowErrnos struct {
+	loop, link, fileType error
+}
+
+func noFollowSymlinkErrorsFor(goos string, errnos noFollowErrnos) []error {
+	switch goos {
+	case "freebsd":
+		return []error{errnos.loop, errnos.link}
+	case "netbsd":
+		return []error{errnos.loop, errnos.fileType}
+	default:
+		return []error{errnos.loop}
+	}
 }

--- a/internal/commitmentkey/secureio_unix.go
+++ b/internal/commitmentkey/secureio_unix.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package commitmentkey
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const secureFileMode = 0o600
+
+func ensureParent(path string) error {
+	fd, _, err := openSecureParent(path, true)
+	if err != nil {
+		return fmt.Errorf("create commitment keyring directory: %w", err)
+	}
+	return unix.Close(fd)
+}
+
+func readSecure(path string) ([]byte, error) {
+	return readSecureLimited(path, maxBytes, "commitment keyring")
+}
+
+func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
+	parentFD, base, err := openSecureParent(path, false)
+	if err != nil {
+		return nil, fmt.Errorf("open %s directory: %w", label, err)
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, mapOpenError(label, path, err)
+	}
+	f := os.NewFile(uintptr(fd), filepath.Clean(path))
+	defer func() { _ = f.Close() }()
+	stat, err := validateOpenedFile(fd, label)
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size > limit {
+		if label == "commitment keyring" {
+			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
+		}
+		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if int64(len(raw)) > limit {
+		if label == "commitment keyring" {
+			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
+		}
+		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+	}
+	return raw, nil
+}
+
+func writeSecureNew(path string, data []byte) error {
+	parentFD, base, err := openSecureParent(path, true)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+	return writeSecureAt(parentFD, base, data, false)
+}
+
+func writeSecureReplace(path string, data []byte) error {
+	parentFD, base, err := openSecureParent(path, false)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+	fd, err := unix.Openat(parentFD, base, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return mapOpenError("commitment keyring", path, err)
+	}
+	if _, err := validateOpenedFile(fd, "commitment keyring"); err != nil {
+		_ = unix.Close(fd)
+		return err
+	}
+	_ = unix.Close(fd)
+	return writeSecureAt(parentFD, base, data, true)
+}
+
+func openSecureLock(path string) (*os.File, error) {
+	parentFD, base, err := openSecureParent(path, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+	fd, err := unix.Openat(parentFD, base, unix.O_RDWR|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, secureFileMode)
+	created := err == nil
+	if errors.Is(err, unix.EEXIST) {
+		fd, err = unix.Openat(parentFD, base, unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	}
+	if err != nil {
+		return nil, mapOpenError("commitment keyring lock", path, err)
+	}
+	if created {
+		if err := chmodSecure(fd, "commitment keyring lock"); err != nil {
+			_ = unix.Close(fd)
+			return nil, err
+		}
+	}
+	if _, err := validateOpenedFile(fd, "commitment keyring lock"); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), filepath.Clean(path)), nil
+}
+
+func writeSecureAt(parentFD int, base string, data []byte, replace bool) error {
+	tempName, tempFD, err := createSecureTemp(parentFD)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Unlinkat(parentFD, tempName, 0) }()
+	temp := os.NewFile(uintptr(tempFD), tempName)
+	if err := writeAndSync(temp, data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close commitment keyring temporary file: %w", err)
+	}
+	if replace {
+		err = unix.Renameat(parentFD, tempName, parentFD, base)
+	} else {
+		err = unix.Linkat(parentFD, tempName, parentFD, base, 0)
+		if errors.Is(err, unix.EEXIST) {
+			return ErrAlreadyExists
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("install commitment keyring: %w", err)
+	}
+	return syncDescriptor(parentFD, "commitment keyring directory")
+}
+
+func createSecureTemp(parentFD int) (string, int, error) {
+	for range 16 {
+		name := ".commitment-keyring-" + rand.Text() + ".tmp"
+		fd, err := unix.Openat(parentFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, secureFileMode)
+		if err == nil {
+			if chmodErr := chmodSecure(fd, "commitment keyring temporary file"); chmodErr != nil {
+				_ = unix.Close(fd)
+				_ = unix.Unlinkat(parentFD, name, 0)
+				return "", -1, chmodErr
+			}
+			return name, fd, nil
+		}
+		if !errors.Is(err, unix.EEXIST) {
+			return "", -1, fmt.Errorf("create commitment keyring temporary file: %w", err)
+		}
+	}
+	return "", -1, errors.New("create commitment keyring temporary file: name collisions exhausted")
+}
+
+func chmodSecure(fd int, label string) error {
+	if err := unix.Fchmod(fd, secureFileMode); err != nil {
+		return fmt.Errorf("secure %s: %w", label, err)
+	}
+	return nil
+}
+
+func writeAndSync(file *os.File, data []byte) error {
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write commitment keyring temporary file: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync commitment keyring temporary file: %w", err)
+	}
+	return nil
+}
+
+func syncDescriptor(fd int, label string) error {
+	if err := unix.Fsync(fd); err != nil {
+		return fmt.Errorf("sync %s: %w", label, err)
+	}
+	return nil
+}
+
+func openSecureParent(path string, create bool) (int, string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return -1, "", fmt.Errorf("resolve commitment keyring path: %w", err)
+	}
+	base := filepath.Base(abs)
+	if base == "." || base == string(filepath.Separator) {
+		return -1, "", errors.New("commitment keyring path has no file component")
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return -1, "", fmt.Errorf("open filesystem root: %w", err)
+	}
+	if err := validateOpenedDirectory(fd, string(filepath.Separator)); err != nil {
+		_ = unix.Close(fd)
+		return -1, "", err
+	}
+	current := string(filepath.Separator)
+	parts := strings.Split(strings.TrimPrefix(filepath.Dir(abs), string(filepath.Separator)), string(filepath.Separator))
+	for _, part := range parts {
+		if part == "" || part == "." {
+			continue
+		}
+		nextFD, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+		if errors.Is(openErr, unix.ENOENT) && create {
+			if mkdirErr := unix.Mkdirat(fd, part, 0o750); mkdirErr != nil && !errors.Is(mkdirErr, unix.EEXIST) {
+				_ = unix.Close(fd)
+				return -1, "", fmt.Errorf("create parent directory %q: %w", part, mkdirErr)
+			}
+			nextFD, openErr = unix.Openat(fd, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+		}
+		if openErr != nil {
+			var entryStat unix.Stat_t
+			entryErr := unix.Fstatat(fd, part, &entryStat, unix.AT_SYMLINK_NOFOLLOW)
+			_ = unix.Close(fd)
+			if errors.Is(openErr, unix.ELOOP) || (entryErr == nil && entryStat.Mode&unix.S_IFMT == unix.S_IFLNK) {
+				return -1, "", fmt.Errorf("%w: parent directory %s", ErrSymlink, filepath.Join(current, part))
+			}
+			return -1, "", fmt.Errorf("open parent directory %s: %w", filepath.Join(current, part), openErr)
+		}
+		_ = unix.Close(fd)
+		fd = nextFD
+		current = filepath.Join(current, part)
+		if err := validateOpenedDirectory(fd, current); err != nil {
+			_ = unix.Close(fd)
+			return -1, "", err
+		}
+	}
+	return fd, base, nil
+}
+
+func validateOpenedDirectory(fd int, path string) error {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return fmt.Errorf("stat parent directory %s: %w", path, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return fmt.Errorf("parent path is not a directory: %s", path)
+	}
+	if stat.Uid != 0 && stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("%w: parent directory %s owner uid %d is neither root nor effective uid %d", ErrUnsafePermission, path, stat.Uid, os.Geteuid())
+	}
+	if stat.Mode&0o022 != 0 {
+		return fmt.Errorf("%w: parent directory %s mode %04o is group/world-writable", ErrUnsafePermission, path, stat.Mode&0o7777)
+	}
+	return nil
+}
+
+func validateOpenedFile(fd int, label string) (unix.Stat_t, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return unix.Stat_t{}, fmt.Errorf("stat %s: %w", label, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		if label == "commitment keyring" {
+			return unix.Stat_t{}, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
+		}
+		return unix.Stat_t{}, fmt.Errorf("invalid %s: not a regular file", label)
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		return unix.Stat_t{}, fmt.Errorf("%w: %s owner uid %d, want effective uid %d", ErrUnsafePermission, label, stat.Uid, os.Geteuid())
+	}
+	if stat.Mode&0o777 != secureFileMode {
+		return unix.Stat_t{}, fmt.Errorf("%w: %s mode %04o, want 0600", ErrUnsafePermission, label, stat.Mode&0o777)
+	}
+	return stat, nil
+}
+
+func mapOpenError(label, path string, err error) error {
+	if errors.Is(err, unix.ELOOP) {
+		return fmt.Errorf("%w: %s", ErrSymlink, filepath.Clean(path))
+	}
+	if errors.Is(err, unix.EACCES) {
+		return fmt.Errorf("%w: cannot open %s: %w", ErrUnsafePermission, label, err)
+	}
+	return fmt.Errorf("open %s: %w", label, err)
+}

--- a/internal/commitmentkey/secureio_unix.go
+++ b/internal/commitmentkey/secureio_unix.go
@@ -254,8 +254,17 @@ func validateOpenedDirectory(fd int, path string) error {
 	if stat.Uid != 0 && int64(stat.Uid) != effectiveUID {
 		return fmt.Errorf("%w: parent directory %s owner uid %d is neither root nor effective uid %d", ErrUnsafePermission, path, stat.Uid, os.Geteuid())
 	}
-	if stat.Mode&0o022 != 0 {
-		return fmt.Errorf("%w: parent directory %s mode %04o is group/world-writable", ErrUnsafePermission, path, stat.Mode&0o7777)
+	// A group- or world-writable parent normally lets another user rename or
+	// replace the keyring between validation and use, which is the substitution
+	// attack this check exists to stop. The sticky bit removes that ability:
+	// with S_ISVTX set, only the entry's owner (or root) may rename or delete
+	// it, so a shared directory such as /tmp mode 1777 cannot be used to swap
+	// our directory or file for someone else's. Rejecting sticky directories
+	// outright would refuse the standard temporary-directory layout on every
+	// Unix system without closing any real attack, which is an availability
+	// failure rather than hardening.
+	if stat.Mode&0o022 != 0 && stat.Mode&unix.S_ISVTX == 0 {
+		return fmt.Errorf("%w: parent directory %s mode %04o is group/world-writable without the sticky bit", ErrUnsafePermission, path, stat.Mode&0o7777)
 	}
 	return nil
 }

--- a/internal/commitmentkey/secureio_unix.go
+++ b/internal/commitmentkey/secureio_unix.go
@@ -303,13 +303,23 @@ type noFollowErrnos struct {
 	loop, link, fileType error
 }
 
-func noFollowSymlinkErrorsFor(goos string, errnos noFollowErrnos) []error {
-	switch goos {
-	case "freebsd":
-		return []error{errnos.loop, errnos.link}
-	case "netbsd":
-		return []error{errnos.loop, errnos.fileType}
-	default:
-		return []error{errnos.loop}
+// noFollowSymlinkErrorsFor returns every errno this platform may use to report
+// that O_NOFOLLOW refused a final-component symlink.
+//
+// The set is derived from the errnos the platform file actually declares rather
+// than from a platform NAME. A name-keyed switch silently degrades the control:
+// renaming a label to something the switch does not recognize drops the platform
+// to the ELOOP-only default, so EMLINK or EFTYPE stops being recognized as a
+// symlink refusal and the guard quietly stops guarding. That regression compiles
+// and cross-compiles cleanly on every target, because the label is a runtime
+// string rather than a build constraint, and it is invisible to a test that
+// passes its own label. Deriving from the declared errnos removes the class.
+func noFollowSymlinkErrorsFor(errnos noFollowErrnos) []error {
+	selected := make([]error, 0, 3)
+	for _, candidate := range []error{errnos.loop, errnos.link, errnos.fileType} {
+		if candidate != nil {
+			selected = append(selected, candidate)
+		}
 	}
+	return selected
 }

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -22,10 +22,10 @@ func TestSecurePathsRejectUnsafeOrSymlinkedParents(t *testing.T) {
 		if err := os.Mkdir(parent, 0o750); err != nil {
 			t.Fatalf("Mkdir: %v", err)
 		}
-		if err := os.Chmod(parent, 0o770); err != nil {
+		if err := unix.Chmod(parent, 0o770); err != nil {
 			t.Fatalf("Chmod: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Chmod(parent, 0o750) })
+		t.Cleanup(func() { _ = unix.Chmod(parent, 0o750) })
 		path := filepath.Join(parent, "keyring.json")
 		if _, err := Initialize(path, time.Now()); !errors.Is(err, ErrUnsafePermission) {
 			t.Fatalf("Initialize error = %v, want ErrUnsafePermission", err)
@@ -65,10 +65,10 @@ func TestSecureParentRulesCoverBackupRestoreAndLock(t *testing.T) {
 	if err := os.Mkdir(unsafeParent, 0o750); err != nil {
 		t.Fatalf("Mkdir: %v", err)
 	}
-	if err := os.Chmod(unsafeParent, 0o770); err != nil {
+	if err := unix.Chmod(unsafeParent, 0o770); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(unsafeParent, 0o750) })
+	t.Cleanup(func() { _ = unix.Chmod(unsafeParent, 0o750) })
 
 	t.Run("backup_destination", func(t *testing.T) {
 		destination := filepath.Join(unsafeParent, "backup.json")
@@ -111,7 +111,7 @@ func TestSecureLockRejectsUnsafeOpenedFile(t *testing.T) {
 	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if err := os.Chmod(lockPath, 0o644); err != nil {
+	if err := unix.Chmod(lockPath, 0o644); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
 	called := false
@@ -185,7 +185,7 @@ func TestLoadRejectsNonRegularOpenedObjectBeforeReading(t *testing.T) {
 	if _, err := Initialize(fixturePath, time.Now()); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	fixture, err := os.ReadFile(fixturePath)
+	fixture, err := os.ReadFile(filepath.Clean(fixturePath))
 	if err != nil {
 		t.Fatalf("ReadFile fixture: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestLoadRejectsNonRegularOpenedObjectBeforeReading(t *testing.T) {
 	}
 	writerDone := make(chan error, 1)
 	go func() {
-		f, openErr := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+		f, openErr := os.OpenFile(filepath.Clean(fifoPath), os.O_WRONLY, 0)
 		if openErr != nil {
 			writerDone <- openErr
 			return
@@ -300,7 +300,7 @@ func TestSecureIOReachableErrorPaths(t *testing.T) {
 	}
 
 	oversizedView := filepath.Join(dir, "oversized-view")
-	view, err := os.OpenFile(oversizedView, os.O_CREATE|os.O_WRONLY, 0o600)
+	view, err := os.OpenFile(filepath.Clean(oversizedView), os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		t.Fatalf("OpenFile oversized view: %v", err)
 	}

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package commitmentkey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSecurePathsRejectUnsafeOrSymlinkedParents(t *testing.T) {
+	t.Run("unsafe_parent_blocks_initialize", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "unsafe")
+		if err := os.Mkdir(parent, 0o750); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := os.Chmod(parent, 0o770); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(parent, 0o750) })
+		path := filepath.Join(parent, "keyring.json")
+		if _, err := Initialize(path, time.Now()); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("Initialize error = %v, want ErrUnsafePermission", err)
+		}
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("refused initialize created target: %v", err)
+		}
+	})
+
+	t.Run("symlink_parent_blocks_initialize", func(t *testing.T) {
+		dir := t.TempDir()
+		realParent := filepath.Join(dir, "real")
+		if err := os.Mkdir(realParent, 0o750); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		linkParent := filepath.Join(dir, "linked")
+		if err := os.Symlink(realParent, linkParent); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		path := filepath.Join(linkParent, "keyring.json")
+		if _, err := Initialize(path, time.Now()); !errors.Is(err, ErrSymlink) {
+			t.Fatalf("Initialize error = %v, want ErrSymlink", err)
+		}
+		if _, err := os.Lstat(filepath.Join(realParent, "keyring.json")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("refused initialize wrote through parent symlink: %v", err)
+		}
+	})
+}
+
+func TestSecureParentRulesCoverBackupRestoreAndLock(t *testing.T) {
+	dir := t.TempDir()
+	keyringPath := filepath.Join(dir, "keyring.json")
+	if _, err := Initialize(keyringPath, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	unsafeParent := filepath.Join(dir, "unsafe")
+	if err := os.Mkdir(unsafeParent, 0o750); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.Chmod(unsafeParent, 0o770); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafeParent, 0o750) })
+
+	t.Run("backup_destination", func(t *testing.T) {
+		destination := filepath.Join(unsafeParent, "backup.json")
+		if _, err := Backup(keyringPath, destination); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("Backup error = %v, want ErrUnsafePermission", err)
+		}
+		if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("refused backup created destination: %v", err)
+		}
+	})
+
+	backupPath := filepath.Join(dir, "backup.json")
+	if _, err := Backup(keyringPath, backupPath); err != nil {
+		t.Fatalf("Backup fixture: %v", err)
+	}
+	t.Run("restore_destination", func(t *testing.T) {
+		destination := filepath.Join(unsafeParent, "restore.json")
+		if _, err := Restore(backupPath, destination); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("Restore error = %v, want ErrUnsafePermission", err)
+		}
+		if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("refused restore created destination: %v", err)
+		}
+	})
+
+	t.Run("lock_parent", func(t *testing.T) {
+		if err := withLifecycleLock(filepath.Join(unsafeParent, "keyring.json"), func() error {
+			t.Fatal("callback ran below unsafe parent")
+			return nil
+		}); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("withLifecycleLock error = %v, want ErrUnsafePermission", err)
+		}
+	})
+}
+
+func TestSecureLockRejectsUnsafeOpenedFile(t *testing.T) {
+	dir := t.TempDir()
+	keyringPath := filepath.Join(dir, "keyring.json")
+	lockPath := keyringPath + ".lock"
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(lockPath, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	called := false
+	err := withLifecycleLock(keyringPath, func() error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrUnsafePermission) {
+		t.Fatalf("withLifecycleLock error = %v, want ErrUnsafePermission", err)
+	}
+	if called {
+		t.Fatal("callback ran with unsafe opened lock file")
+	}
+}
+
+func TestReadPrivateViewRequiresSecureOpenedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "view.txt")
+	if err := os.WriteFile(path, []byte("private"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got, err := ReadPrivateView(path); err != nil || string(got) != "private" {
+		t.Fatalf("ReadPrivateView = %q, %v", got, err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if _, err := ReadPrivateView(path); !errors.Is(err, ErrUnsafePermission) {
+		t.Fatalf("ReadPrivateView mode 0644 error = %v, want ErrUnsafePermission", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("restore mode: %v", err)
+	}
+	link := filepath.Join(dir, "view-link.txt")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := ReadPrivateView(link); !errors.Is(err, ErrSymlink) {
+		t.Fatalf("ReadPrivateView symlink error = %v, want ErrSymlink", err)
+	}
+}
+
+func TestReadPrivateViewUnreadableFileFailsClosed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode-000 files")
+	}
+	path := filepath.Join(t.TempDir(), "unreadable-view.txt")
+	if err := os.WriteFile(path, []byte("private"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if _, err := ReadPrivateView(path); !errors.Is(err, ErrUnsafePermission) || !strings.Contains(err.Error(), "cannot open") {
+		t.Fatalf("ReadPrivateView unreadable error = %v, want fail-closed open refusal", err)
+	}
+}
+
+func TestReadPrivateViewRejectsOpenedFileOwnedByAnotherUser(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root is the expected owner for root-run commands")
+	}
+	if _, err := ReadPrivateView("/etc/passwd"); !errors.Is(err, ErrUnsafePermission) || !strings.Contains(err.Error(), "owner uid") {
+		t.Fatalf("ReadPrivateView foreign owner error = %v, want owner refusal", err)
+	}
+}
+
+func TestLoadRejectsNonRegularOpenedObjectBeforeReading(t *testing.T) {
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "fixture.json")
+	if _, err := Initialize(fixturePath, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("ReadFile fixture: %v", err)
+	}
+	fifoPath := filepath.Join(dir, "keyring.fifo")
+	if err := unix.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("Mkfifo: %v", err)
+	}
+	writerDone := make(chan error, 1)
+	go func() {
+		f, openErr := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+		if openErr != nil {
+			writerDone <- openErr
+			return
+		}
+		_, writeErr := f.Write(fixture)
+		closeErr := f.Close()
+		if writeErr != nil {
+			writerDone <- writeErr
+			return
+		}
+		writerDone <- closeErr
+	}()
+	if _, err := Load(fifoPath); !errors.Is(err, ErrInvalidKeyring) {
+		t.Fatalf("Load FIFO error = %v, want ErrInvalidKeyring", err)
+	}
+	if err := <-writerDone; err != nil && !errors.Is(err, unix.EPIPE) {
+		t.Fatalf("FIFO writer: %v", err)
+	}
+}
+
+func TestSecureIOReachableErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	unsafeParent := filepath.Join(dir, "unsafe")
+	if err := os.Mkdir(unsafeParent, 0o750); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.Chmod(unsafeParent, 0o770); err != nil {
+		t.Fatalf("Chmod unsafe: %v", err)
+	}
+	if err := writeSecureNew(filepath.Join(unsafeParent, "new.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
+		t.Fatalf("writeSecureNew unsafe parent = %v", err)
+	}
+	if err := writeSecureReplace(filepath.Join(unsafeParent, "replace.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
+		t.Fatalf("writeSecureReplace unsafe parent = %v", err)
+	}
+	if err := os.Chmod(unsafeParent, 0o750); err != nil {
+		t.Fatalf("restore parent mode: %v", err)
+	}
+	if err := writeSecureReplace(filepath.Join(unsafeParent, "missing.json"), []byte("x")); err == nil {
+		t.Fatal("writeSecureReplace created missing target")
+	}
+
+	fd, err := unix.Open(dir, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY, 0)
+	if err != nil {
+		t.Fatalf("Open directory: %v", err)
+	}
+	defer func() { _ = unix.Close(fd) }()
+	if err := writeSecureAt(fd, "missing/child.json", []byte("x"), false); err == nil {
+		t.Fatal("writeSecureAt with invalid destination succeeded")
+	}
+	if err := writeSecureAt(-1, "child.json", []byte("x"), false); err == nil {
+		t.Fatal("writeSecureAt with invalid parent descriptor succeeded")
+	}
+	if _, _, err := createSecureTemp(-1); err == nil {
+		t.Fatal("createSecureTemp with invalid descriptor succeeded")
+	}
+	if err := chmodSecure(-1, "test file"); err == nil {
+		t.Fatal("chmodSecure accepted invalid descriptor")
+	}
+	closed, err := os.CreateTemp(dir, "closed-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatalf("Close temp: %v", err)
+	}
+	if err := writeAndSync(closed, []byte("x")); err == nil {
+		t.Fatal("writeAndSync accepted closed file")
+	}
+	devNull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("OpenFile /dev/null: %v", err)
+	}
+	if err := writeAndSync(devNull, []byte("x")); err == nil {
+		_ = devNull.Close()
+		t.Fatal("writeAndSync unexpectedly synced /dev/null")
+	}
+	_ = devNull.Close()
+	if err := syncDescriptor(-1, "invalid descriptor"); err == nil {
+		t.Fatal("syncDescriptor accepted invalid descriptor")
+	}
+	if _, _, err := openSecureParent(string(filepath.Separator), false); err == nil {
+		t.Fatal("openSecureParent accepted a path without a file component")
+	}
+	if err := validateOpenedDirectory(-1, "invalid"); err == nil {
+		t.Fatal("validateOpenedDirectory accepted invalid descriptor")
+	}
+	filePath := filepath.Join(dir, "regular")
+	if err := os.WriteFile(filePath, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fileFD, err := unix.Open(filePath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("Open file: %v", err)
+	}
+	defer func() { _ = unix.Close(fileFD) }()
+	if err := validateOpenedDirectory(fileFD, filePath); err == nil {
+		t.Fatal("validateOpenedDirectory accepted regular file")
+	}
+	if _, err := validateOpenedFile(-1, "commitment keyring"); err == nil {
+		t.Fatal("validateOpenedFile accepted invalid descriptor")
+	}
+
+	oversizedView := filepath.Join(dir, "oversized-view")
+	view, err := os.OpenFile(oversizedView, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile oversized view: %v", err)
+	}
+	if err := view.Truncate(maxPrivateViewBytes + 1); err != nil {
+		_ = view.Close()
+		t.Fatalf("Truncate: %v", err)
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := ReadPrivateView(oversizedView); err == nil {
+		t.Fatal("ReadPrivateView accepted oversized file")
+	}
+
+	if os.Geteuid() != 0 {
+		readOnlyParent := filepath.Join(dir, "read-only")
+		if err := os.Mkdir(readOnlyParent, 0o750); err != nil {
+			t.Fatalf("Mkdir read-only: %v", err)
+		}
+		if err := os.Chmod(readOnlyParent, 0o500); err != nil {
+			t.Fatalf("Chmod read-only: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(readOnlyParent, 0o750) })
+		if _, _, err := openSecureParent(filepath.Join(readOnlyParent, "missing", "keyring.json"), true); err == nil {
+			t.Fatal("openSecureParent created below read-only parent")
+		}
+	}
+}
+
+func TestReadPrivateViewRejectsFIFOWithoutConsumingIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "view.fifo")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("Mkfifo: %v", err)
+	}
+	writerDone := make(chan error, 1)
+	go func() {
+		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err != nil {
+			writerDone <- err
+			return
+		}
+		_, err = f.Write([]byte("private"))
+		closeErr := f.Close()
+		if err != nil {
+			writerDone <- err
+			return
+		}
+		writerDone <- closeErr
+	}()
+	if _, err := ReadPrivateView(path); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("ReadPrivateView FIFO error = %v", err)
+	}
+	if err := <-writerDone; err != nil && !errors.Is(err, unix.EPIPE) {
+		t.Fatalf("FIFO writer: %v", err)
+	}
+}

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -361,27 +361,70 @@ func TestMapOpenError(t *testing.T) {
 func TestNoFollowSymlinkErrnoSelection(t *testing.T) {
 	loop := errors.New("synthetic ELOOP")
 	link := errors.New("synthetic EMLINK")
-	syntheticEFTYPE := errors.New("synthetic EFTYPE")
-	errnos := noFollowErrnos{loop: loop, link: link, fileType: syntheticEFTYPE}
+	fileType := errors.New("synthetic EFTYPE")
+
+	// Each case is a platform's DECLARED errno set, mirroring what the
+	// nofollow_errno_*.go files construct. The selector must surface every
+	// errno the set declares and nothing else. Asserting on the declared set
+	// rather than on a platform NAME is what keeps this test from going
+	// vacuous: a previous version switched on a label string, so renaming that
+	// label silently dropped EMLINK from the selection while this test kept
+	// passing against its own hardcoded label.
 	for _, test := range []struct {
-		goos string
-		want []error
+		name   string
+		errnos noFollowErrnos
+		want   []error
+		absent []error
 	}{
-		{goos: "linux", want: []error{loop}},
-		{goos: "freebsd", want: []error{loop, link}},
-		{goos: "netbsd", want: []error{loop, syntheticEFTYPE}},
+		{
+			name:   "loop_only",
+			errnos: noFollowErrnos{loop: loop},
+			want:   []error{loop},
+			absent: []error{link, fileType},
+		},
+		{
+			name:   "loop_and_link",
+			errnos: noFollowErrnos{loop: loop, link: link},
+			want:   []error{loop, link},
+			absent: []error{fileType},
+		},
+		{
+			name:   "loop_and_file_type",
+			errnos: noFollowErrnos{loop: loop, fileType: fileType},
+			want:   []error{loop, fileType},
+			absent: []error{link},
+		},
 	} {
-		t.Run(test.goos, func(t *testing.T) {
-			selected := noFollowSymlinkErrorsFor(test.goos, errnos)
+		t.Run(test.name, func(t *testing.T) {
+			selected := noFollowSymlinkErrorsFor(test.errnos)
 			for _, err := range test.want {
 				if !isNoFollowSymlinkError(err, selected) {
-					t.Fatalf("%s symlink errno %v was not selected", test.goos, err)
+					t.Fatalf("declared errno %v was not selected", err)
+				}
+			}
+			for _, err := range test.absent {
+				if isNoFollowSymlinkError(err, selected) {
+					t.Fatalf("undeclared errno %v was selected", err)
 				}
 			}
 			if isNoFollowSymlinkError(unix.ENOENT, selected) {
-				t.Fatalf("%s selected ordinary ENOENT as a symlink refusal", test.goos)
+				t.Fatal("selected ordinary ENOENT as a symlink refusal")
 			}
 		})
+	}
+}
+
+// TestPlatformDeclaresItsSymlinkErrnos pins that the platform file compiled into
+// THIS build actually declares a usable errno set, so a platform file that
+// forgets or mis-declares its errnos cannot ship a guard that recognizes
+// nothing. The selector test above uses synthetic errnos and therefore cannot
+// see a real platform file going empty.
+func TestPlatformDeclaresItsSymlinkErrnos(t *testing.T) {
+	if len(noFollowSymlinkErrors) == 0 {
+		t.Fatal("platform declared no O_NOFOLLOW symlink errnos")
+	}
+	if !isNoFollowSymlinkError(unix.ELOOP, noFollowSymlinkErrors) {
+		t.Fatal("platform does not recognize ELOOP as a symlink refusal")
 	}
 }
 

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -136,7 +136,7 @@ func TestReadPrivateViewRequiresSecureOpenedFile(t *testing.T) {
 	if got, err := ReadPrivateView(path); err != nil || string(got) != "private" {
 		t.Fatalf("ReadPrivateView = %q, %v", got, err)
 	}
-	if err := os.Chmod(path, 0o644); err != nil {
+	if err := unix.Chmod(path, 0o644); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
 	if _, err := ReadPrivateView(path); !errors.Is(err, ErrUnsafePermission) {
@@ -222,7 +222,7 @@ func TestSecureIOReachableErrorPaths(t *testing.T) {
 	if err := os.Mkdir(unsafeParent, 0o750); err != nil {
 		t.Fatalf("Mkdir: %v", err)
 	}
-	if err := os.Chmod(unsafeParent, 0o770); err != nil {
+	if err := unix.Chmod(unsafeParent, 0o770); err != nil {
 		t.Fatalf("Chmod unsafe: %v", err)
 	}
 	if err := writeSecureNew(filepath.Join(unsafeParent, "new.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
@@ -231,7 +231,7 @@ func TestSecureIOReachableErrorPaths(t *testing.T) {
 	if err := writeSecureReplace(filepath.Join(unsafeParent, "replace.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
 		t.Fatalf("writeSecureReplace unsafe parent = %v", err)
 	}
-	if err := os.Chmod(unsafeParent, 0o750); err != nil {
+	if err := unix.Chmod(unsafeParent, 0o750); err != nil {
 		t.Fatalf("restore parent mode: %v", err)
 	}
 	if err := writeSecureReplace(filepath.Join(unsafeParent, "missing.json"), []byte("x")); err == nil {
@@ -320,10 +320,10 @@ func TestSecureIOReachableErrorPaths(t *testing.T) {
 		if err := os.Mkdir(readOnlyParent, 0o750); err != nil {
 			t.Fatalf("Mkdir read-only: %v", err)
 		}
-		if err := os.Chmod(readOnlyParent, 0o500); err != nil {
+		if err := unix.Chmod(readOnlyParent, 0o500); err != nil {
 			t.Fatalf("Chmod read-only: %v", err)
 		}
-		t.Cleanup(func() { _ = os.Chmod(readOnlyParent, 0o750) })
+		t.Cleanup(func() { _ = unix.Chmod(readOnlyParent, 0o750) })
 		if _, _, err := openSecureParent(filepath.Join(readOnlyParent, "missing", "keyring.json"), true); err == nil {
 			t.Fatal("openSecureParent created below read-only parent")
 		}
@@ -337,7 +337,7 @@ func TestReadPrivateViewRejectsFIFOWithoutConsumingIt(t *testing.T) {
 	}
 	writerDone := make(chan error, 1)
 	go func() {
-		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		f, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY, 0)
 		if err != nil {
 			writerDone <- err
 			return

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -217,106 +217,121 @@ func TestLoadRejectsNonRegularOpenedObjectBeforeReading(t *testing.T) {
 }
 
 func TestSecureIOReachableErrorPaths(t *testing.T) {
-	dir := t.TempDir()
-	unsafeParent := filepath.Join(dir, "unsafe")
-	if err := os.Mkdir(unsafeParent, 0o750); err != nil {
-		t.Fatalf("Mkdir: %v", err)
-	}
-	if err := unix.Chmod(unsafeParent, 0o770); err != nil {
-		t.Fatalf("Chmod unsafe: %v", err)
-	}
-	if err := writeSecureNew(filepath.Join(unsafeParent, "new.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
-		t.Fatalf("writeSecureNew unsafe parent = %v", err)
-	}
-	if err := writeSecureReplace(filepath.Join(unsafeParent, "replace.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
-		t.Fatalf("writeSecureReplace unsafe parent = %v", err)
-	}
-	if err := unix.Chmod(unsafeParent, 0o750); err != nil {
-		t.Fatalf("restore parent mode: %v", err)
-	}
-	if err := writeSecureReplace(filepath.Join(unsafeParent, "missing.json"), []byte("x")); err == nil {
-		t.Fatal("writeSecureReplace created missing target")
-	}
+	t.Run("unsafe parent writes", func(t *testing.T) {
+		unsafeParent := filepath.Join(t.TempDir(), "unsafe")
+		if err := os.Mkdir(unsafeParent, 0o750); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := unix.Chmod(unsafeParent, 0o770); err != nil {
+			t.Fatalf("Chmod unsafe: %v", err)
+		}
+		if err := writeSecureNew(filepath.Join(unsafeParent, "new.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("writeSecureNew unsafe parent = %v", err)
+		}
+		if err := writeSecureReplace(filepath.Join(unsafeParent, "replace.json"), []byte("x")); !errors.Is(err, ErrUnsafePermission) {
+			t.Fatalf("writeSecureReplace unsafe parent = %v", err)
+		}
+		if err := unix.Chmod(unsafeParent, 0o750); err != nil {
+			t.Fatalf("restore parent mode: %v", err)
+		}
+		if err := writeSecureReplace(filepath.Join(unsafeParent, "missing.json"), []byte("x")); err == nil {
+			t.Fatal("writeSecureReplace created missing target")
+		}
+	})
 
-	fd, err := unix.Open(dir, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY, 0)
-	if err != nil {
-		t.Fatalf("Open directory: %v", err)
-	}
-	defer func() { _ = unix.Close(fd) }()
-	if err := writeSecureAt(fd, "missing/child.json", []byte("x"), false); err == nil {
-		t.Fatal("writeSecureAt with invalid destination succeeded")
-	}
-	if err := writeSecureAt(-1, "child.json", []byte("x"), false); err == nil {
-		t.Fatal("writeSecureAt with invalid parent descriptor succeeded")
-	}
-	if _, _, err := createSecureTemp(-1); err == nil {
-		t.Fatal("createSecureTemp with invalid descriptor succeeded")
-	}
-	if err := chmodSecure(-1, "test file"); err == nil {
-		t.Fatal("chmodSecure accepted invalid descriptor")
-	}
-	closed, err := os.CreateTemp(dir, "closed-*")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	if err := closed.Close(); err != nil {
-		t.Fatalf("Close temp: %v", err)
-	}
-	if err := writeAndSync(closed, []byte("x")); err == nil {
-		t.Fatal("writeAndSync accepted closed file")
-	}
-	devNull, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatalf("OpenFile /dev/null: %v", err)
-	}
-	if err := writeAndSync(devNull, []byte("x")); err == nil {
-		_ = devNull.Close()
-		t.Fatal("writeAndSync unexpectedly synced /dev/null")
-	}
-	_ = devNull.Close()
-	if err := syncDescriptor(-1, "invalid descriptor"); err == nil {
-		t.Fatal("syncDescriptor accepted invalid descriptor")
-	}
-	if _, _, err := openSecureParent(string(filepath.Separator), false); err == nil {
-		t.Fatal("openSecureParent accepted a path without a file component")
-	}
-	if err := validateOpenedDirectory(-1, "invalid"); err == nil {
-		t.Fatal("validateOpenedDirectory accepted invalid descriptor")
-	}
-	filePath := filepath.Join(dir, "regular")
-	if err := os.WriteFile(filePath, nil, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	fileFD, err := unix.Open(filePath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
-	if err != nil {
-		t.Fatalf("Open file: %v", err)
-	}
-	defer func() { _ = unix.Close(fileFD) }()
-	if err := validateOpenedDirectory(fileFD, filePath); err == nil {
-		t.Fatal("validateOpenedDirectory accepted regular file")
-	}
-	if _, err := validateOpenedFile(-1, "commitment keyring"); err == nil {
-		t.Fatal("validateOpenedFile accepted invalid descriptor")
-	}
+	t.Run("invalid write descriptors", func(t *testing.T) {
+		dir := t.TempDir()
+		fd, err := unix.Open(dir, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY, 0)
+		if err != nil {
+			t.Fatalf("Open directory: %v", err)
+		}
+		defer func() { _ = unix.Close(fd) }()
+		if err := writeSecureAt(fd, "missing/child.json", []byte("x"), false); err == nil {
+			t.Fatal("writeSecureAt with invalid destination succeeded")
+		}
+		if err := writeSecureAt(-1, "child.json", []byte("x"), false); err == nil {
+			t.Fatal("writeSecureAt with invalid parent descriptor succeeded")
+		}
+		if _, _, err := createSecureTemp(-1); err == nil {
+			t.Fatal("createSecureTemp with invalid descriptor succeeded")
+		}
+		if err := chmodSecure(-1, "test file"); err == nil {
+			t.Fatal("chmodSecure accepted invalid descriptor")
+		}
+	})
 
-	oversizedView := filepath.Join(dir, "oversized-view")
-	view, err := os.OpenFile(filepath.Clean(oversizedView), os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		t.Fatalf("OpenFile oversized view: %v", err)
-	}
-	if err := view.Truncate(maxPrivateViewBytes + 1); err != nil {
-		_ = view.Close()
-		t.Fatalf("Truncate: %v", err)
-	}
-	if err := view.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	if _, err := ReadPrivateView(oversizedView); err == nil {
-		t.Fatal("ReadPrivateView accepted oversized file")
-	}
+	t.Run("write and sync failures", func(t *testing.T) {
+		closed, err := os.CreateTemp(t.TempDir(), "closed-*")
+		if err != nil {
+			t.Fatalf("CreateTemp: %v", err)
+		}
+		if err := closed.Close(); err != nil {
+			t.Fatalf("Close temp: %v", err)
+		}
+		if err := writeAndSync(closed, []byte("x")); err == nil {
+			t.Fatal("writeAndSync accepted closed file")
+		}
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("Pipe: %v", err)
+		}
+		defer func() { _ = reader.Close() }()
+		defer func() { _ = writer.Close() }()
+		if err := writeAndSync(writer, []byte("x")); err == nil || !strings.Contains(err.Error(), "sync") {
+			t.Fatalf("writeAndSync pipe error = %v, want sync refusal", err)
+		}
+		if err := syncDescriptor(-1, "invalid descriptor"); err == nil {
+			t.Fatal("syncDescriptor accepted invalid descriptor")
+		}
+	})
 
-	if os.Geteuid() != 0 {
-		readOnlyParent := filepath.Join(dir, "read-only")
+	t.Run("invalid paths and opened descriptors", func(t *testing.T) {
+		if _, _, err := openSecureParent(string(filepath.Separator), false); err == nil {
+			t.Fatal("openSecureParent accepted a path without a file component")
+		}
+		if err := validateOpenedDirectory(-1, "invalid"); err == nil {
+			t.Fatal("validateOpenedDirectory accepted invalid descriptor")
+		}
+		filePath := filepath.Join(t.TempDir(), "regular")
+		if err := os.WriteFile(filePath, nil, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		fileFD, err := unix.Open(filePath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			t.Fatalf("Open file: %v", err)
+		}
+		defer func() { _ = unix.Close(fileFD) }()
+		if err := validateOpenedDirectory(fileFD, filePath); err == nil {
+			t.Fatal("validateOpenedDirectory accepted regular file")
+		}
+		if _, err := validateOpenedFile(-1, "commitment keyring", ErrInvalidKeyring); err == nil {
+			t.Fatal("validateOpenedFile accepted invalid descriptor")
+		}
+	})
+
+	t.Run("oversized private view", func(t *testing.T) {
+		oversizedView := filepath.Join(t.TempDir(), "oversized-view")
+		view, err := os.OpenFile(filepath.Clean(oversizedView), os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("OpenFile oversized view: %v", err)
+		}
+		if err := view.Truncate(maxPrivateViewBytes + 1); err != nil {
+			_ = view.Close()
+			t.Fatalf("Truncate: %v", err)
+		}
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if _, err := ReadPrivateView(oversizedView); err == nil {
+			t.Fatal("ReadPrivateView accepted oversized file")
+		}
+	})
+
+	t.Run("read-only parent", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root can create below mode-0500 directories")
+		}
+		readOnlyParent := filepath.Join(t.TempDir(), "read-only")
 		if err := os.Mkdir(readOnlyParent, 0o750); err != nil {
 			t.Fatalf("Mkdir read-only: %v", err)
 		}
@@ -327,6 +342,46 @@ func TestSecureIOReachableErrorPaths(t *testing.T) {
 		if _, _, err := openSecureParent(filepath.Join(readOnlyParent, "missing", "keyring.json"), true); err == nil {
 			t.Fatal("openSecureParent created below read-only parent")
 		}
+	})
+}
+
+func TestMapOpenError(t *testing.T) {
+	path := filepath.Join("tmp", "keyring.json")
+	if err := mapOpenError("commitment keyring", path, unix.ELOOP); !errors.Is(err, ErrSymlink) || !strings.Contains(err.Error(), filepath.Clean(path)) {
+		t.Fatalf("ELOOP error = %v, want cleaned ErrSymlink", err)
+	}
+	if err := mapOpenError("commitment keyring", path, unix.EACCES); !errors.Is(err, ErrUnsafePermission) || !errors.Is(err, unix.EACCES) {
+		t.Fatalf("EACCES error = %v, want ErrUnsafePermission wrapping EACCES", err)
+	}
+	if err := mapOpenError("commitment keyring", path, unix.ENOENT); errors.Is(err, ErrSymlink) || !errors.Is(err, unix.ENOENT) {
+		t.Fatalf("ENOENT error = %v, want ordinary wrapped error", err)
+	}
+}
+
+func TestNoFollowSymlinkErrnoSelection(t *testing.T) {
+	loop := errors.New("synthetic ELOOP")
+	link := errors.New("synthetic EMLINK")
+	syntheticEFTYPE := errors.New("synthetic EFTYPE")
+	errnos := noFollowErrnos{loop: loop, link: link, fileType: syntheticEFTYPE}
+	for _, test := range []struct {
+		goos string
+		want []error
+	}{
+		{goos: "linux", want: []error{loop}},
+		{goos: "freebsd", want: []error{loop, link}},
+		{goos: "netbsd", want: []error{loop, syntheticEFTYPE}},
+	} {
+		t.Run(test.goos, func(t *testing.T) {
+			selected := noFollowSymlinkErrorsFor(test.goos, errnos)
+			for _, err := range test.want {
+				if !isNoFollowSymlinkError(err, selected) {
+					t.Fatalf("%s symlink errno %v was not selected", test.goos, err)
+				}
+			}
+			if isNoFollowSymlinkError(unix.ENOENT, selected) {
+				t.Fatalf("%s selected ordinary ENOENT as a symlink refusal", test.goos)
+			}
+		})
 	}
 }
 

--- a/internal/commitmentkey/secureio_unix_test.go
+++ b/internal/commitmentkey/secureio_unix_test.go
@@ -357,3 +357,46 @@ func TestReadPrivateViewRejectsFIFOWithoutConsumingIt(t *testing.T) {
 		t.Fatalf("FIFO writer: %v", err)
 	}
 }
+
+// TestParentStickyBitDistinguishesSharedFromUnsafe pins the exact semantics of
+// the writable-parent check. A group- or world-writable parent lets another
+// user rename or replace the keyring between validation and use, which is the
+// substitution attack the check exists to stop. The sticky bit removes that
+// ability, so a shared temporary directory such as /tmp mode 1777 is safe while
+// the same mode without the sticky bit is not. Without this test the
+// distinction is only implicitly covered, and dropping either half would go
+// unnoticed until CI fails everywhere or the check silently stops protecting.
+func TestParentStickyBitDistinguishesSharedFromUnsafe(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mode    uint32
+		wantErr bool
+	}{
+		{"world_writable_with_sticky_is_allowed", 0o1777, false},
+		{"world_writable_without_sticky_is_refused", 0o0777, true},
+		{"group_writable_without_sticky_is_refused", 0o0770, true},
+		{"owner_only_is_allowed", 0o0700, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "parent")
+			if err := os.Mkdir(parent, 0o700); err != nil {
+				t.Fatalf("Mkdir: %v", err)
+			}
+			if err := unix.Chmod(parent, tc.mode); err != nil {
+				t.Fatalf("Chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = unix.Chmod(parent, 0o700) })
+
+			_, err := Initialize(filepath.Join(parent, "keyring.json"), time.Now())
+			if tc.wantErr {
+				if !errors.Is(err, ErrUnsafePermission) {
+					t.Fatalf("mode %04o: error = %v, want ErrUnsafePermission", tc.mode, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("mode %04o: Initialize returned %v, want success", tc.mode, err)
+			}
+		})
+	}
+}

--- a/internal/commitmentkey/secureio_windows.go
+++ b/internal/commitmentkey/secureio_windows.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package commitmentkey
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"golang.org/x/sys/windows"
+)
+
+func ensureParent(path string) error {
+	parent := filepath.Dir(filepath.Clean(path))
+	if err := os.MkdirAll(parent, 0o750); err != nil {
+		return fmt.Errorf("create commitment keyring directory: %w", err)
+	}
+	return validateWindowsDirectory(parent)
+}
+
+func readSecure(path string) ([]byte, error) {
+	return readSecureLimited(path, maxBytes, "commitment keyring")
+}
+
+func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
+	clean := filepath.Clean(path)
+	if err := validateWindowsDirectory(filepath.Dir(clean)); err != nil {
+		return nil, err
+	}
+	pointer, err := windows.UTF16PtrFromString(clean)
+	if err != nil {
+		return nil, fmt.Errorf("encode %s path: %w", label, err)
+	}
+	handle, err := windows.CreateFile(pointer, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", label, err)
+	}
+	f := os.NewFile(uintptr(handle), clean)
+	if f == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, fmt.Errorf("open %s: invalid handle", label)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", label, err)
+	}
+	if isWindowsReparse(info) {
+		return nil, fmt.Errorf("%w: %s", ErrSymlink, clean)
+	}
+	if !info.Mode().IsRegular() {
+		if label == "commitment keyring" {
+			return nil, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
+		}
+		return nil, fmt.Errorf("invalid %s: not a regular file", label)
+	}
+	if info.Size() > limit {
+		if label == "commitment keyring" {
+			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
+		}
+		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if int64(len(raw)) > limit {
+		if label == "commitment keyring" {
+			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
+		}
+		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+	}
+	return raw, nil
+}
+
+func writeSecureNew(path string, data []byte) error {
+	if err := ensureParent(path); err != nil {
+		return err
+	}
+	if err := validateWindowsFinal(path); err != nil {
+		return err
+	}
+	if err := atomicfile.WriteNew(filepath.Clean(path), data, 0o600); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func writeSecureReplace(path string, data []byte) error {
+	if err := validateWindowsDirectory(filepath.Dir(filepath.Clean(path))); err != nil {
+		return err
+	}
+	if err := validateWindowsFinal(path); err != nil {
+		return err
+	}
+	return atomicfile.Write(filepath.Clean(path), data, 0o600)
+}
+
+func validateWindowsDirectory(path string) error {
+	clean := filepath.Clean(path)
+	parent := filepath.Dir(clean)
+	if parent != clean {
+		if err := validateWindowsDirectory(parent); err != nil {
+			return err
+		}
+	}
+	info, err := os.Lstat(clean)
+	if err != nil {
+		return fmt.Errorf("inspect commitment keyring parent directory: %w", err)
+	}
+	if isWindowsReparse(info) || !info.IsDir() {
+		return fmt.Errorf("%w: commitment keyring parent is a reparse point or not a directory: %s", ErrSymlink, clean)
+	}
+	return nil
+}
+
+func validateWindowsFinal(path string) error {
+	info, err := os.Lstat(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect commitment keyring: %w", err)
+	}
+	if isWindowsReparse(info) {
+		return fmt.Errorf("%w: %s", ErrSymlink, filepath.Clean(path))
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
+	}
+	return nil
+}
+
+func isWindowsReparse(info os.FileInfo) bool {
+	return info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
+}

--- a/internal/commitmentkey/secureio_windows.go
+++ b/internal/commitmentkey/secureio_windows.go
@@ -25,10 +25,10 @@ func ensureParent(path string) error {
 }
 
 func readSecure(path string) ([]byte, error) {
-	return readSecureLimited(path, maxBytes, "commitment keyring")
+	return readSecureLimited(path, maxBytes, "commitment keyring", ErrInvalidKeyring)
 }
 
-func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
+func readSecureLimited(path string, limit int64, label string, invalidErr error) ([]byte, error) {
 	clean := filepath.Clean(path)
 	if err := validateWindowsDirectory(filepath.Dir(clean)); err != nil {
 		return nil, err
@@ -55,26 +55,17 @@ func readSecureLimited(path string, limit int64, label string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s", ErrSymlink, clean)
 	}
 	if !info.Mode().IsRegular() {
-		if label == "commitment keyring" {
-			return nil, fmt.Errorf("%w: not a regular file", ErrInvalidKeyring)
-		}
-		return nil, fmt.Errorf("invalid %s: not a regular file", label)
+		return nil, invalidReadError(invalidErr, label, "not a regular file")
 	}
 	if info.Size() > limit {
-		if label == "commitment keyring" {
-			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
-		}
-		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+		return nil, invalidReadError(invalidErr, label, "file exceeds %d bytes", limit)
 	}
 	raw, err := io.ReadAll(io.LimitReader(f, limit+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", label, err)
 	}
 	if int64(len(raw)) > limit {
-		if label == "commitment keyring" {
-			return nil, fmt.Errorf("%w: file exceeds %d bytes", ErrInvalidKeyring, limit)
-		}
-		return nil, fmt.Errorf("invalid %s: file exceeds %d bytes", label, limit)
+		return nil, invalidReadError(invalidErr, label, "file exceeds %d bytes", limit)
 	}
 	return raw, nil
 }

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -147,6 +147,7 @@ func (c *Config) policySemanticView() Config {
 	view.Sentry = SentryConfig{}
 	view.Emit = EmitConfig{}
 	view.FlightRecorder = FlightRecorder{RequireReceipts: view.FlightRecorder.RequireReceipts}
+	view.EvidenceProvenance = EvidenceProvenance{}
 	view.Conductor = Conductor{}
 
 	// License metadata - determines whether a tier feature is available,

--- a/internal/config/evidence_provenance_test.go
+++ b/internal/config/evidence_provenance_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEvidenceProvenanceCommitmentKeyringPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(path, []byte("mode: balanced\nevidence_provenance:\n  commitment_keyring_path: state/commitment-keyring.json\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := filepath.Join(dir, "state", "commitment-keyring.json")
+	if cfg.EvidenceProvenance.CommitmentKeyringPath != want {
+		t.Fatalf("CommitmentKeyringPath = %q, want %q", cfg.EvidenceProvenance.CommitmentKeyringPath, want)
+	}
+	if cfg.FlightRecorder.SigningKeyPath != "" {
+		t.Fatalf("commitment path polluted receipt signing config: %q", cfg.FlightRecorder.SigningKeyPath)
+	}
+}
+
+func TestEvidenceProvenancePathExcludedFromCanonicalPolicyHash(t *testing.T) {
+	a := Defaults()
+	b := Defaults()
+	a.EvidenceProvenance.CommitmentKeyringPath = "/var/lib/pipelock/a.json"
+	b.EvidenceProvenance.CommitmentKeyringPath = "/var/lib/pipelock/b.json"
+	if a.CanonicalPolicyHash() != b.CanonicalPolicyHash() {
+		t.Fatal("operator keyring path changed scanner policy hash")
+	}
+}

--- a/internal/config/evidence_provenance_test.go
+++ b/internal/config/evidence_provenance_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -36,4 +37,19 @@ func TestEvidenceProvenancePathExcludedFromCanonicalPolicyHash(t *testing.T) {
 	if a.CanonicalPolicyHash() != b.CanonicalPolicyHash() {
 		t.Fatal("operator keyring path changed scanner policy hash")
 	}
+}
+
+func TestEvidenceProvenanceConfiguredPathWarnsThatCapabilityIsInert(t *testing.T) {
+	cfg := Defaults()
+	cfg.EvidenceProvenance.CommitmentKeyringPath = "/var/lib/pipelock/evidence/commitment-keyring.json"
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings: %v", err)
+	}
+	for _, warning := range warnings {
+		if warning.Field == "evidence_provenance.commitment_keyring_path" && strings.Contains(warning.Message, "nothing is currently being committed") {
+			return
+		}
+	}
+	t.Fatalf("warnings = %+v, want inert-capability warning", warnings)
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -172,6 +172,9 @@ func loadBytes(data []byte, sourceName, configDir string, opts loadOptions) (*Co
 		if cfg.DLP.SecretsFile != "" && !filepath.IsAbs(cfg.DLP.SecretsFile) {
 			cfg.DLP.SecretsFile = filepath.Join(configDir, cfg.DLP.SecretsFile)
 		}
+		if cfg.EvidenceProvenance.CommitmentKeyringPath != "" && !filepath.IsAbs(cfg.EvidenceProvenance.CommitmentKeyringPath) {
+			cfg.EvidenceProvenance.CommitmentKeyringPath = filepath.Join(configDir, cfg.EvidenceProvenance.CommitmentKeyringPath)
+		}
 
 		// Resolve relative CA cert/key paths relative to config file directory.
 		// This ensures TLS interception works under systemd (CWD=/), containers,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -427,7 +427,8 @@ type Config struct {
 	FileSentry               FileSentry              `yaml:"file_sentry"`
 	Sandbox                  Sandbox                 `yaml:"sandbox"`
 	FlightRecorder           FlightRecorder          `yaml:"flight_recorder"`
-	DashboardSnapshot        DashboardSnapshot       `yaml:"dashboard_snapshot" json:"-"` // operational dashboard read-model snapshot, excluded from canonical policy hash
+	EvidenceProvenance       EvidenceProvenance      `yaml:"evidence_provenance" json:"-"` // startup-only private commitment keyring; no producer consumes it yet
+	DashboardSnapshot        DashboardSnapshot       `yaml:"dashboard_snapshot" json:"-"`  // operational dashboard read-model snapshot, excluded from canonical policy hash
 	MCPBinaryIntegrity       MCPBinaryIntegrity      `yaml:"mcp_binary_integrity"`
 	MCPToolProvenance        MCPToolProvenance       `yaml:"mcp_tool_provenance"`
 	BehavioralBaseline       BehavioralBaseline      `yaml:"behavioral_baseline"`
@@ -1517,6 +1518,14 @@ type FlightRecorder struct {
 	Completeness       FlightRecorderCompleteness   `yaml:"completeness" json:"-"`    // restart-only evidence completeness knobs
 	EvidenceHealth     FlightRecorderEvidenceHealth `yaml:"evidence_health" json:"-"` // observability-only evidence health grading
 	Anchor             FlightRecorderAnchor         `yaml:"anchor" json:"-"`          // optional runtime receipt-chain anchoring
+}
+
+// EvidenceProvenance configures the private operator-owned material needed to
+// open evidence commitments. It is intentionally separate from receipt
+// signing configuration: this path names a symmetric HMAC keyring, never an
+// Ed25519 signing key.
+type EvidenceProvenance struct {
+	CommitmentKeyringPath string `yaml:"commitment_keyring_path"`
 }
 
 type FlightRecorderCompleteness struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -329,6 +329,7 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateFlightRecorder(&warnings); err != nil {
 		return warnings, err
 	}
+	c.validateEvidenceProvenanceWarnings(&warnings)
 	if err := c.validateDashboardSnapshot(); err != nil {
 		return warnings, err
 	}
@@ -375,6 +376,16 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 		return warnings, err
 	}
 	return warnings, nil
+}
+
+func (c *Config) validateEvidenceProvenanceWarnings(warnings *[]Warning) {
+	if c.EvidenceProvenance.CommitmentKeyringPath == "" {
+		return
+	}
+	*warnings = append(*warnings, Warning{
+		Field:   "evidence_provenance.commitment_keyring_path",
+		Message: "commitment keys are not consumed by an evidence producer yet; nothing is currently being committed with this keyring",
+	})
 }
 
 func (c *Config) validateAPIAllowlistWarnings(warnings *[]Warning) {

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -33,6 +33,10 @@ cd "$REPO_ROOT"
 # /tmp parent would make the gate itself manufacture a refusal after relocating a
 # documented /var/lib path, so keep the ephemeral sandbox beneath the checkout.
 WORK="$(mktemp -d "$REPO_ROOT/.config-examples.XXXXXX")"
+KEYRING_WORK_ROOT="$HOME/.cache/pipelock-config-examples"
+install -d -m 0750 "$KEYRING_WORK_ROOT"
+KEYRING_WORK="$(mktemp -d "$KEYRING_WORK_ROOT/run.XXXXXX")"
+chmod 0750 "$KEYRING_WORK"
 RUN_PID=""
 cleanup() {
     if [ -n "$RUN_PID" ]; then
@@ -40,6 +44,7 @@ cleanup() {
         wait "$RUN_PID" 2>/dev/null || true
     fi
     rm -rf "$WORK"
+    rm -rf "$KEYRING_WORK"
 }
 trap cleanup EXIT
 
@@ -237,6 +242,21 @@ probe() {
         sed -E "s@^([[:space:]]*signing_key_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$FIXTURE_KEY\"\4@" \
             "$run_cfg" >"$key_cfg"
         mv "$key_cfg" "$run_cfg"
+    fi
+
+    # commitment_keyring_path is an operator-owned input, but this harness can
+    # create a real one through the shipped lifecycle command. Relocate and
+    # initialize it so the example is booted rather than excused as unavailable.
+    if grep -qE '^[[:space:]]*commitment_keyring_path:' "$run_cfg"; then
+        local commitment_path="$KEYRING_WORK/commitment-keyring-$total.json"
+        local commitment_cfg="${run_cfg}.commitment.tmp"
+        sed -E "s@^([[:space:]]*commitment_keyring_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$commitment_path\"\4@" \
+            "$run_cfg" >"$commitment_cfg"
+        mv "$commitment_cfg" "$run_cfg"
+        if ! HOME="$PROBE_HOME" "$BIN" commitment-key initialize --keyring "$commitment_path" >/dev/null 2>&1; then
+            echo "config-examples: could not fixture a commitment keyring" >&2
+            exit 1
+        fi
     fi
 
     local check_ok=0 check_out="$WORK/check-$total.txt"

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -253,8 +253,11 @@ probe() {
         sed -E "s@^([[:space:]]*commitment_keyring_path:[[:space:]])(\"[^\"]+\"|'[^']+'|[^\"'[:space:]#]([^#]*[^[:space:]#])?)([[:space:]]*#.*)?\$@\1\"$commitment_path\"\4@" \
             "$run_cfg" >"$commitment_cfg"
         mv "$commitment_cfg" "$run_cfg"
-        if ! HOME="$PROBE_HOME" "$BIN" commitment-key initialize --keyring "$commitment_path" >/dev/null 2>&1; then
-            echo "config-examples: could not fixture a commitment keyring" >&2
+        local commitment_out="$WORK/commitment-init-$total.txt"
+        if ! HOME="$PROBE_HOME" "$BIN" commitment-key initialize \
+            --keyring "$commitment_path" >"$commitment_out" 2>&1; then
+            echo "config-examples: could not fixture a commitment keyring for $label" >&2
+            grep -vE '^[[:space:]]*$' "$commitment_out" | tail -3 >&2
             exit 1
         fi
     fi


### PR DESCRIPTION
## What changed

Evidence commitment keys now live in a durable, operator-owned keyring instead of being generated per process. The keyring has an explicit lifecycle: initialize, inspect, rotate, retire, backup, restore, and test.

Keys carry opaque IDs and epochs, so a receipt refers to the key that opened it without leaking anything about the key material or its ordering. Files are written atomically at `0o600`, loaded at startup, and every lifecycle transition emits an audit event.

Rotation keeps old keys openable. A commitment written under an earlier epoch is still openable after rotation and after a restart, because retiring a key is a separate, deliberate step from rotating past it. Retiring a key that still has retained references is refused rather than silently completed.

## Why the purpose is separate from receipt signing

Commitment keys and receipt-signing keys are kept apart in configuration and in key-purpose validation, not only in documentation. A commitment key cannot be used to sign a receipt and a signing key cannot open a commitment. Enforcing the split in validation means the separation survives a config edit that a comment would not.

## Failure direction

Wrong file permissions and symlink substitution fail closed. Restoring a backup over a live keyring is refused unless the operator asks for it explicitly, so a routine restore cannot quietly roll an epoch backwards.

Availability was treated as a failure direction too: a keyring that refuses a legitimate operator key, or bricks after an ordinary rotation, gets the control switched off. Rotation, restart, and restore are all covered against that.

## Scope

This changes no scanner behavior and no production receipt payload. It ships independently and stays inert until evidence emission exists, so it can be reviewed and landed on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to manage evidence commitment keyrings, including initialization, inspection, rotation, retirement, backup, restore, and testing.
  * Added configurable evidence-provenance keyring support with startup validation and secure file handling.
  * Added safeguards for retirement, commitment mismatches, unsafe files, and insecure permissions.

* **Documentation**
  * Added CLI reference and lifecycle guidance covering configuration, operations, backups, testing, and platform considerations.

* **Bug Fixes**
  * Configuration reloads now preserve the active commitment keyring and warn when changes require a restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->