### PR TITLE
fix(license): correct enterprise-tier license declarations and publish image metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -192,6 +192,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=pipelock"
+      - "--label=org.opencontainers.image.description=Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     dockerfile: Dockerfile.goreleaser
 
   - image_templates:
@@ -200,6 +210,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=pipelock"
+      - "--label=org.opencontainers.image.description=Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
 
@@ -211,6 +231,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=pipelock-init"
+      - "--label=org.opencontainers.image.description=Init container that installs the Pipelock binary into a shared volume for sidecar deployments."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     dockerfile: Dockerfile.init
 
   - image_templates:
@@ -219,6 +249,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=pipelock-init"
+      - "--label=org.opencontainers.image.description=Init container that installs the Pipelock binary into a shared volume for sidecar deployments."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     goarch: arm64
     dockerfile: Dockerfile.init
 
@@ -230,6 +270,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=pipelock-license-service"
+      - "--label=org.opencontainers.image.description=Pipelock license service. Webhook handler for subscription events and license issuance."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     dockerfile: Dockerfile.license-service
 
   - image_templates:
@@ -238,6 +288,16 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=pipelock-license-service"
+      - "--label=org.opencontainers.image.description=Pipelock license service. Webhook handler for subscription events and license issuance."
+      - "--label=org.opencontainers.image.url=https://pipelab.org"
+      - "--label=org.opencontainers.image.source=https://github.com/luckyPipewrench/pipelock"
+      - "--label=org.opencontainers.image.documentation=https://pipelab.org/learn/"
+      - "--label=org.opencontainers.image.vendor=luckyPipewrench"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .CommitDate }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0 AND Elastic-2.0"
     goarch: arm64
     dockerfile: Dockerfile.license-service
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ brew install luckyPipewrench/tap/pipelock
 
 ```bash
 gh attestation verify pipelock_3.3.0_linux_amd64.tar.gz --owner luckyPipewrench
-gh attestation verify oci://ghcr.io/luckypipewrench/pipelock:v3.3.0 --owner luckyPipewrench
+gh attestation verify oci://ghcr.io/luckypipewrench/pipelock:3.3.0 --owner luckyPipewrench
 ```
 
 Release workflows publish SLSA provenance, CycloneDX SBOMs, checksums, and signed container images. Source builds with `go install` produce a Community-only binary; pre-built release artifacts include paid-tier code that activates with a valid license key.

--- a/enterprise/conductor/convergence/convergence.go
+++ b/enterprise/conductor/convergence/convergence.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 // Package convergence produces a read-only fleet convergence report that joins
 // four independent denominators: deployment intent, running images, conductor

--- a/enterprise/conductor/convergence/convergence_test.go
+++ b/enterprise/conductor/convergence/convergence_test.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package convergence
 

--- a/enterprise/conductor/convergence/denominator_test.go
+++ b/enterprise/conductor/convergence/denominator_test.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package convergence
 

--- a/enterprise/conductor/convergence/failopen_test.go
+++ b/enterprise/conductor/convergence/failopen_test.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package convergence
 

--- a/enterprise/licenseservice/entitlement_webhook_test.go
+++ b/enterprise/licenseservice/entitlement_webhook_test.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice
 

--- a/enterprise/licenseservice/webhook_terminal_test.go
+++ b/enterprise/licenseservice/webhook_terminal_test.go
@@ -1,7 +1,7 @@
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
-
 //go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package licenseservice
 

--- a/internal/cli/runtime/conductor_teardown_test.go
+++ b/internal/cli/runtime/conductor_teardown_test.go
@@ -1,7 +1,7 @@
 //go:build enterprise
 
-// Copyright 2026 Josh Waldrep
-// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
 
 package runtime
 

--- a/scripts/check-source-headers.sh
+++ b/scripts/check-source-headers.sh
@@ -7,6 +7,29 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# NOTICE declares licensing by directory, and the build system declares it by
+# tag, so a file is enterprise-tier when either says so. Path alone would miss
+# the enterprise-tagged sources under cmd/ and internal/; tag alone would miss
+# the untagged dashboard templates under enterprise/. Stripping the negated
+# form first keeps `//go:build !enterprise` core stubs out: they carry the
+# Apache identifier and must keep it. Matching the constraint line anchored
+# also keeps prose that merely mentions the tag from being misread as a tag.
+is_enterprise_tier() {
+	local path="$1" constraint
+	case "$path" in
+	enterprise/*) return 0 ;;
+	esac
+	constraint="$(grep -m1 -E '^//go:build ' "$path" || true)"
+	constraint="${constraint//\!enterprise/}"
+	# `enterprise` is a build-tag term, not a substring: an unrelated tag such
+	# as `enterprisefoo` must not turn an Apache-licensed core source into an
+	# ELv2 source.
+	if [[ "$constraint" =~ (^|[^[:alnum:]_])enterprise([^[:alnum:]_]|$) ]]; then
+		return 0
+	fi
+	return 1
+}
+
 missing=0
 while IFS= read -r -d '' path; do
 	if ! grep -q 'Copyright' "$path"; then
@@ -14,11 +37,23 @@ while IFS= read -r -d '' path; do
 		missing=1
 	fi
 
-	# Enterprise-tagged sources carry the repository's ELv2 notice instead of
-	# the Apache SPDX identifier used by the open-source core.
-	if grep -q 'Licensed under the Elastic License 2.0' "$path"; then
+	# Enterprise-tier sources carry the repository's ELv2 notice instead of
+	# the Apache SPDX identifier used by the open-source core. Declaring the
+	# Apache identifier on ELv2 code is the failure that matters: it marks
+	# paid-tier code as permissively licensed, contradicting NOTICE, and no
+	# amount of correct prose elsewhere in the file undoes that claim.
+	if is_enterprise_tier "$path"; then
+		if grep -q 'SPDX-License-Identifier: Apache-2.0' "$path"; then
+			echo "$path: enterprise-tier source declares SPDX-License-Identifier: Apache-2.0; NOTICE licenses it under the Elastic License 2.0" >&2
+			missing=1
+		fi
+		if ! grep -q 'Licensed under the Elastic License 2.0' "$path"; then
+			echo "$path: enterprise-tier source missing Elastic License 2.0 notice" >&2
+			missing=1
+		fi
 		continue
 	fi
+
 	if ! grep -q 'SPDX-License-Identifier: Apache-2.0' "$path"; then
 		echo "$path: missing SPDX-License-Identifier: Apache-2.0" >&2
 		missing=1


### PR DESCRIPTION
## What changed

Three repository-metadata corrections found while auditing every surface this project publishes about itself.

### Enterprise sources declared the wrong license

Seven enterprise-tagged sources carried the open-source core's header template, declaring `SPDX-License-Identifier: Apache-2.0`. NOTICE states that the contents of `enterprise/` are not covered by the Apache License, so those files made a machine-readable licensing claim that contradicts the repository's own statement, on paid-tier code, in the permissive direction. That identifier is what license scanners, SBOM tooling, and compliance systems read.

Six sat under `enterprise/`. The seventh, `internal/cli/runtime/conductor_teardown_test.go`, is enterprise-tagged but lives outside that directory, which is why a directory-scoped look had not found it.

`scripts/check-source-headers.sh` could not catch any of them. It accepted either the ELv2 notice or the Apache identifier for every file with no notion of which tier a file belongs to, so a file that picked the wrong one passed. It now classifies each file first: a source is enterprise-tier when it lives under `enterprise/` or when its `//go:build` constraint line carries a positive `enterprise` term. Enterprise-tier sources must carry the ELv2 notice and must not declare the Apache identifier.

Both halves of that classifier are load-bearing. Path alone misses the enterprise-tagged sources under `cmd/` and `internal/`. Tag alone misses the untagged dashboard templates under `enterprise/`. The negated `!enterprise` form is stripped before matching so the core stubs that legitimately carry the Apache identifier keep it, and `enterprise` is matched as a build-tag term rather than a substring so an unrelated tag cannot reclassify a core source.

### The documented release-verification command pointed at a tag that does not exist

The release-integrity example verified `pipelock:v3.3.0`. Container tags drop the leading v, so that reference resolves to nothing and the command fails with `manifest unknown`. A reader following the documented steps concludes the artifacts cannot be verified. The archive example on the line above was already correct.

### Published container images carried no metadata

All three published images returned an empty label map, so `docker inspect` and any policy tooling that reads image metadata saw nothing. Each image now declares its title, description, source, homepage, documentation, vendor, version, revision, and license.

The license value is the load-bearing one. All three images ship enterprise-tagged code: the pipelock and init images carry the same enterprise-tagged binary, and the license service is enterprise code. Labelling any of them Apache-2.0 alone would repeat, in image metadata, the claim NOTICE explicitly denies. The expression matches the one the Homebrew formula already publishes.

Labels go through `build_flag_templates` because the `dockers` stanza has no `labels` key. Index-level annotations are deliberately not attempted here: these images publish a Docker manifest list, whose schema has no annotations field, so adding them would mean changing the published media type on the release path. That is a separate decision.

The `created` value reuses the same `CommitDate` the binary builds already use, so it stays consistent with the reproducible-build settings in this file rather than stamping wall-clock build time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Container images now include standardized metadata such as version, project, vendor, license, and build information.

- **Documentation**
  - Updated image attestation verification instructions to use the current release tag.

- **Chores**
  - Standardized licensing and copyright notices across enterprise components.
  - Improved license-header validation to apply the correct requirements to enterprise and non-enterprise files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->