### PR TITLE
feat(release): publish the Helm chart as an OCI artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -450,7 +450,7 @@ jobs:
       - name: Set up Helm
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.20.0
+          version: v3.20.2
 
       - name: Verify Helm chart
         run: bash scripts/check-helm-chart.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -278,6 +278,44 @@ jobs:
           RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
           RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
 
+      # The chart is published to the same registry as the images it deploys, as
+      # an OCI artifact, so there is no chart index to host and no gh-pages
+      # branch to keep in sync. `helm push` of pipelock-<v>.tgz to
+      # oci://ghcr.io/luckypipewrench/charts yields
+      # ghcr.io/luckypipewrench/charts/pipelock:<v>, which is the reference
+      # Artifact Hub indexes.
+      #
+      # appVersion is forced to the tag being released rather than trusting the
+      # committed value. The chart's own version stays hand-managed in
+      # Chart.yaml: it tracks changes to the templates, not to Pipelock, and the
+      # two move independently.
+      #
+      # The first run creates a new GHCR package, and new packages are private
+      # by default, so the chart is not installable until that package is made
+      # public once in the GitHub UI. There is no REST endpoint for that, and it
+      # is irreversible, so it stays a deliberate human step.
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.0
+
+      - name: Package and publish Helm chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          app_version="${TAG_NAME#v}"
+          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
+          test -n "$chart_version" || {
+            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
+            exit 1
+          }
+          helm package charts/pipelock --app-version "$app_version" --destination dist-chart
+          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+          helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          helm registry logout ghcr.io
+
       - name: Generate and upload self-update release manifest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -434,7 +434,7 @@ jobs:
       - name: Set up Helm
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.20.0
+          version: v3.20.2
 
       - name: Package and publish Helm chart
         env:
@@ -452,6 +452,23 @@ jobs:
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
           helm registry logout ghcr.io
+
+          # A brand-new GHCR package is private, and the install command in the
+          # READMEs fails with an authorization error until it is made public.
+          # The reminder belongs here, in front of whoever ran the release, at
+          # the moment it becomes actionable. It deliberately does not go in the
+          # install docs: the condition is true once, during bootstrap, and a
+          # caveat left in user-facing docs would be permanently wrong
+          # afterwards.
+          {
+            echo "### Helm chart published"
+            echo
+            echo "\`ghcr.io/luckypipewrench/charts/pipelock:${chart_version}\` (appVersion ${app_version})."
+            echo
+            echo "If this is the first published chart, the package is PRIVATE and"
+            echo "\`helm install oci://ghcr.io/luckypipewrench/charts/pipelock\` fails for"
+            echo "everyone until it is made public once under Package settings."
+          } >>"$GITHUB_STEP_SUMMARY"
 
       # Move the v2 floating tag so `uses: luckyPipewrench/pipelock@v2`
       # always resolves to the latest release. Safe because the trigger requires

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -278,44 +278,6 @@ jobs:
           RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
           RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
 
-      # The chart is published to the same registry as the images it deploys, as
-      # an OCI artifact, so there is no chart index to host and no gh-pages
-      # branch to keep in sync. `helm push` of pipelock-<v>.tgz to
-      # oci://ghcr.io/luckypipewrench/charts yields
-      # ghcr.io/luckypipewrench/charts/pipelock:<v>, which is the reference
-      # Artifact Hub indexes.
-      #
-      # appVersion is forced to the tag being released rather than trusting the
-      # committed value. The chart's own version stays hand-managed in
-      # Chart.yaml: it tracks changes to the templates, not to Pipelock, and the
-      # two move independently.
-      #
-      # The first run creates a new GHCR package, and new packages are private
-      # by default, so the chart is not installable until that package is made
-      # public once in the GitHub UI. There is no REST endpoint for that, and it
-      # is irreversible, so it stays a deliberate human step.
-      - name: Set up Helm
-        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.20.0
-
-      - name: Package and publish Helm chart
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          app_version="${TAG_NAME#v}"
-          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
-          test -n "$chart_version" || {
-            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
-            exit 1
-          }
-          helm package charts/pipelock --app-version "$app_version" --destination dist-chart
-          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
-          helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
-          helm registry logout ghcr.io
-
       - name: Generate and upload self-update release manifest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -445,6 +407,51 @@ jobs:
         run: |
           echo "::error::Attestation failed — release provenance is incomplete"
           exit 1
+
+      # Deliberately placed after the attestation gate. The chart is the least
+      # critical artifact in the release, and an earlier position would let a
+      # registry hiccup on the chart abort the job with binaries and images
+      # already published but their provenance never attested. Publishing
+      # unattested images because a chart push failed is the wrong failure
+      # direction for this project, so provenance completes first.
+      #
+      # The chart is published to the same registry as the images it deploys, as
+      # an OCI artifact, so there is no chart index to host and no gh-pages
+      # branch to keep in sync. `helm push` of pipelock-<v>.tgz to
+      # oci://ghcr.io/luckypipewrench/charts yields
+      # ghcr.io/luckypipewrench/charts/pipelock:<v>, which is the reference
+      # Artifact Hub indexes.
+      #
+      # appVersion is forced to the tag being released rather than trusting the
+      # committed value. The chart's own version stays hand-managed in
+      # Chart.yaml: it tracks changes to the templates, not to Pipelock, and the
+      # two move independently.
+      #
+      # The first run creates a new GHCR package, and new packages are private
+      # by default, so the chart is not installable until that package is made
+      # public once in the GitHub UI. There is no REST endpoint for that, and it
+      # is irreversible, so it stays a deliberate human step.
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.0
+
+      - name: Package and publish Helm chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          app_version="${TAG_NAME#v}"
+          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
+          test -n "$chart_version" || {
+            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
+            exit 1
+          }
+          helm package charts/pipelock --app-version "$app_version" --destination dist-chart
+          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+          helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          helm registry logout ghcr.io
 
       # Move the v2 floating tag so `uses: luckyPipewrench/pipelock@v2`
       # always resolves to the latest release. Safe because the trigger requires

--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ docker run -p 8888:8888 -v ./pipelock.yaml:/config/pipelock.yaml:ro \
 pipelock generate docker-compose --agent claude-code -o docker-compose.yaml
 docker compose up
 
-# Kubernetes with Helm
-helm install pipelock charts/pipelock/
+# Kubernetes with Helm (published chart, Helm 3.8+)
+helm install pipelock oci://ghcr.io/luckypipewrench/charts/pipelock
 ```
 
 Production recipes for Docker Compose, Kubernetes sidecar + NetworkPolicy, iptables/nftables, and macOS PF: **[docs/guides/deployment-recipes.md](docs/guides/deployment-recipes.md)**

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -19,11 +19,13 @@ keywords:
   - egress-control
 icon: https://raw.githubusercontent.com/luckyPipewrench/pipelock/main/assets/pipelock-logo.svg
 annotations:
-  # Describes the application this chart deploys, not the chart source. The
-  # default image ships enterprise-tagged code, which NOTICE licenses under the
-  # Elastic License 2.0, so Apache-2.0 alone would overstate the permissions a
-  # reader gets. Matches the Homebrew formula and the image labels.
-  artifacthub.io/license: Apache-2.0 AND Elastic-2.0
+  # This is the license of THE CHART, not of the application it deploys, and
+  # Artifact Hub requires a single SPDX identifier here rather than an
+  # expression. These templates live outside enterprise/, so NOTICE puts them
+  # under Apache-2.0. The deployed image is dual-licensed and says so where a
+  # consumer of the image will actually look: the org.opencontainers.image
+  # labels on the image itself, and the Homebrew formula for the binary.
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changesURL: https://github.com/luckyPipewrench/pipelock/releases
   artifacthub.io/links: |

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "3.3.0"
 home: https://pipelab.org
 sources:
@@ -19,7 +19,11 @@ keywords:
   - egress-control
 icon: https://raw.githubusercontent.com/luckyPipewrench/pipelock/main/assets/pipelock-logo.svg
 annotations:
-  artifacthub.io/license: Apache-2.0
+  # Describes the application this chart deploys, not the chart source. The
+  # default image ships enterprise-tagged code, which NOTICE licenses under the
+  # Elastic License 2.0, so Apache-2.0 alone would overstate the permissions a
+  # reader gets. Matches the Homebrew formula and the image labels.
+  artifacthub.io/license: Apache-2.0 AND Elastic-2.0
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changesURL: https://github.com/luckyPipewrench/pipelock/releases
   artifacthub.io/links: |

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -5,10 +5,16 @@ Pipelock is an agent firewall: a network proxy that sits between AI agents and t
 ## TL;DR
 
 ```bash
-helm install pipelock ./charts/pipelock
+helm install pipelock oci://ghcr.io/luckypipewrench/charts/pipelock
 ```
 
+The chart is published as an OCI artifact to the same registry as the images it deploys, so there is no repository to add. Installing a specific revision takes `--version`, which selects the chart version rather than the Pipelock version. To install from a checkout instead, point Helm at the directory: `helm install pipelock ./charts/pipelock`.
+
 Pipelock runs as a non-root container with a read-only root filesystem, drops all Linux capabilities, and binds the standard Pipelock proxy on port 8888.
+
+### Chart version and Pipelock version
+
+`version` is the chart's own version and tracks changes to these templates. `appVersion` is the Pipelock release the chart deploys, and the release workflow sets it from the tag being published, so a chart pulled from the registry always names the Pipelock version it shipped with.
 
 Enterprise examples:
 


### PR DESCRIPTION
## What changed

The Helm chart has been complete, version-aligned, and CI-tested on every pull request, and installable only by cloning the repository. It is absent from Artifact Hub, has no chart repository branch, ships in no release, and has no OCI artifact anywhere. Every one of its Artifact Hub annotations therefore describes a package nobody can find, and the only documented install is a local path.

The release workflow now packages and pushes the chart to the same registry as the images it deploys, as an OCI artifact. There is no chart index to host, no `gh-pages` branch to keep in sync, and no new infrastructure. Pushing `pipelock-<v>.tgz` to `oci://ghcr.io/luckypipewrench/charts` yields `ghcr.io/luckypipewrench/charts/pipelock:<v>`, which is the reference format Artifact Hub indexes for OCI repositories.

`appVersion` is forced from the tag being released rather than trusting the committed value, so a chart pulled from the registry always names the Pipelock version it shipped with and cannot drift from it. The chart's own `version` stays hand-managed, because it tracks changes to these templates rather than to Pipelock, and the two move independently.

`artifacthub.io/license` said `Apache-2.0` while the chart's default image ships enterprise-tagged code that NOTICE licenses under the Elastic License 2.0. That is the same overstatement recently corrected in the image labels, and it is already correct in the Homebrew formula.

## Verification

Proven end to end against a throwaway local OCI registry rather than reasoned about: packaging with an overriding app version, pushing, resolving the chart back from its OCI reference, and rendering it. The push produced exactly the reference shape Artifact Hub expects, and the forced app version reached the rendered image tag, confirming the whole chain rather than just the push.

`helm lint` and the repository chart checks pass, the workflow YAML parses, and the new step's shell passes `bash -n` under `set -euo pipefail`.

## Required follow-up before the install command works

The first release that includes this creates a new GHCR package, and new packages are private by default. Until that package is made public once in the GitHub UI, `helm install oci://...` fails for everyone. There is no REST endpoint for that setting and the change is irreversible, so it stays a deliberate human step rather than something this workflow can do.

Registering the repository on Artifact Hub is separate and optional. Discovery, not installation, depends on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm charts are now published as OCI artifacts in the project’s container registry.
  * Releases automatically package charts with the corresponding application version.
  * Chart version selection is supported during installation.
  * The chart is updated to version 0.10.0.

* **Documentation**
  * Updated Kubernetes installation instructions to use the published OCI chart.
  * Added guidance for local installation and clarified chart versus application versions.
  * Documented the chart’s Apache-2.0 and application’s Elastic-2.0 licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->