### PR TITLE
fix(chart): stop a second release overwriting the published chart

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,101 @@
+name: Publish Helm chart
+
+# Publishes the chart on demand, without cutting a release.
+#
+# The release workflow already publishes the chart on every tag. This exists for
+# the bootstrap case and for republishing after a registry-side accident: the
+# chart's first publication creates a new GHCR package, and waiting for the next
+# release to create it would tie an unrelated decision to a release schedule.
+#
+# It refuses to overwrite an existing tag. The release gate keeps the chart
+# version equal to the released Pipelock version, so a collision here means the
+# chart for that version is already published and the run has nothing to do.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Package and check for a collision, but do not push.'
+        type: boolean
+        default: true
+
+permissions: {}
+
+concurrency:
+  group: publish-chart-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: Verify the chart is releasable
+        run: bash scripts/check-helm-chart.sh
+
+      - name: Package and publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
+          app_version="$(helm show chart charts/pipelock | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2 }')"
+          test -n "$chart_version" || {
+            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
+            exit 1
+          }
+          test "$chart_version" = "$app_version" || {
+            echo "::error::chart version ${chart_version} != appVersion ${app_version}; the release gate requires these to match"
+            exit 1
+          }
+
+          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+
+          # Refuse to overwrite. An OCI registry accepts a re-push to an existing
+          # tag silently, which would change what an already-published version
+          # means for anyone who pinned it.
+          if helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" >/dev/null 2>&1; then
+            helm registry logout ghcr.io
+            echo "::error::chart ${chart_version} is already published; bump the chart and app version rather than overwriting a published tag"
+            exit 1
+          fi
+
+          helm package charts/pipelock --destination dist-chart
+
+          if [ "$DRY_RUN" = "true" ]; then
+            helm registry logout ghcr.io
+            echo "Dry run: packaged pipelock-${chart_version}.tgz and confirmed the tag is free. Nothing pushed."
+            {
+              echo "### Helm chart dry run"
+              echo
+              echo "Would publish \`ghcr.io/luckypipewrench/charts/pipelock:${chart_version}\`."
+              echo "The tag is currently free. Re-run with dry_run disabled to publish."
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          helm registry logout ghcr.io
+
+          {
+            echo "### Helm chart published"
+            echo
+            echo "\`ghcr.io/luckypipewrench/charts/pipelock:${chart_version}\`."
+            echo
+            echo "If this is the first published chart, the package is PRIVATE and"
+            echo "\`helm install oci://ghcr.io/luckypipewrench/charts/pipelock\` fails for"
+            echo "everyone until it is made public once under Package settings."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -3,9 +3,11 @@ name: Publish Helm chart
 # Publishes the chart on demand, without cutting a release.
 #
 # The release workflow already publishes the chart on every tag. This exists for
-# the bootstrap case and for republishing after a registry-side accident: the
-# chart's first publication creates a new GHCR package, and waiting for the next
-# release to create it would tie an unrelated decision to a release schedule.
+# the bootstrap case: the chart's first publication creates a new GHCR package,
+# and waiting for the next release to create it would tie an unrelated decision
+# to a release schedule. It runs only from the default branch and only for a
+# chart version that has already been released, so it cannot publish an
+# unreviewed chart or one that deploys an image that does not exist.
 #
 # It refuses to overwrite an existing tag. The release gate keeps the chart
 # version equal to the released Pipelock version, so a collision here means the
@@ -48,8 +50,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+
+          # Run only from the default branch. Restricting to a tag ref instead
+          # would be stricter but useless: a dispatch runs the workflow file as
+          # it exists at the selected ref, and no released tag contains this
+          # file, so the bootstrap case this workflow exists for could never
+          # run. The default branch is protected and reviewed, which is the
+          # property that actually matters here, and it is where the chart that
+          # will be published lives.
+          test "${GITHUB_REF_NAME}" = "${DEFAULT_BRANCH}" || {
+            echo "::error::run this from ${DEFAULT_BRANCH}; refusing to publish a chart from an unreviewed ref"
+            exit 1
+          }
 
           chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
           app_version="$(helm show chart charts/pipelock | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2 }')"
@@ -62,21 +77,33 @@ jobs:
             exit 1
           }
 
+          # The chart deploys an image tagged with its own version, so publishing
+          # a version that was never released would produce a chart that cannot
+          # pull. Requiring a matching release also stops this from publishing a
+          # chart mid-way through a pre-tag bump, when the default branch names a
+          # version that does not exist yet.
+          if ! gh release view "v${chart_version}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::no released v${chart_version}; the chart deploys pipelock:${chart_version}, which must exist first"
+            exit 1
+          fi
+
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
 
           # Refuse to overwrite. An OCI registry accepts a re-push to an existing
           # tag silently, which would change what an already-published version
           # means for anyone who pinned it.
-          if helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" >/dev/null 2>&1; then
-            helm registry logout ghcr.io
+          if chart_lookup_output="$(helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" 2>&1)"; then
             echo "::error::chart ${chart_version} is already published; bump the chart and app version rather than overwriting a published tag"
+            exit 1
+          elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
+            echo "::error::could not determine whether chart ${chart_version} already exists; refusing to publish"
             exit 1
           fi
 
           helm package charts/pipelock --destination dist-chart
 
           if [ "$DRY_RUN" = "true" ]; then
-            helm registry logout ghcr.io
             echo "Dry run: packaged pipelock-${chart_version}.tgz and confirmed the tag is free. Nothing pushed."
             {
               echo "### Helm chart dry run"
@@ -88,7 +115,6 @@ jobs:
           fi
 
           helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
-          helm registry logout ghcr.io
 
           {
             echo "### Helm chart published"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -450,6 +450,19 @@ jobs:
           }
           helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+
+          # Refuse to overwrite a published tag. The release gate keeps the chart
+          # version equal to the release version, so this can only trigger when
+          # the same version is released twice, which a re-pushed tag allows.
+          # An OCI registry accepts a re-push silently, so without this the
+          # second run would change what an already-published version means for
+          # anyone who pinned it.
+          if helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" >/dev/null 2>&1; then
+            helm registry logout ghcr.io
+            echo "::error::chart ${chart_version} is already published; refusing to overwrite a published tag"
+            exit 1
+          fi
+
           helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
           helm registry logout ghcr.io
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -422,10 +422,9 @@ jobs:
       # ghcr.io/luckypipewrench/charts/pipelock:<v>, which is the reference
       # Artifact Hub indexes.
       #
-      # appVersion is forced to the tag being released rather than trusting the
-      # committed value. The chart's own version stays hand-managed in
-      # Chart.yaml: it tracks changes to the templates, not to Pipelock, and the
-      # two move independently.
+      # Both appVersion and the chart version are release-gated to the tag being
+      # published. OCI charts are addressed by chart version, so this prevents
+      # a later release from replacing an already-published chart tag.
       #
       # The first run creates a new GHCR package, and new packages are private
       # by default, so the chart is not installable until that package is made
@@ -450,6 +449,7 @@ jobs:
           }
           helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
 
           # Refuse to overwrite a published tag. The release gate keeps the chart
           # version equal to the release version, so this can only trigger when
@@ -457,14 +457,15 @@ jobs:
           # An OCI registry accepts a re-push silently, so without this the
           # second run would change what an already-published version means for
           # anyone who pinned it.
-          if helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" >/dev/null 2>&1; then
-            helm registry logout ghcr.io
+          if chart_lookup_output="$(helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" 2>&1)"; then
             echo "::error::chart ${chart_version} is already published; refusing to overwrite a published tag"
+            exit 1
+          elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
+            echo "::error::could not determine whether chart ${chart_version} already exists; refusing to publish"
             exit 1
           fi
 
           helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
-          helm registry logout ghcr.io
 
           # A brand-new GHCR package is private, and the install command in the
           # READMEs fails with an authorization error until it is made public.

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v2
 name: pipelock
 description: Agent firewall for AI agents. Network scanning, process containment, and tool policy enforcement.
 type: application
-version: 0.10.0
+# The chart version tracks the Pipelock version it deploys, and the release
+# gate enforces that both equal the release tag. The chart publishes to an
+# OCI registry under this version as the tag, so a version that did not move
+# every release would overwrite the previously published chart in place.
+version: 3.3.0
 appVersion: "3.3.0"
 home: https://pipelab.org
 sources:

--- a/charts/pipelock/README.md
+++ b/charts/pipelock/README.md
@@ -8,13 +8,13 @@ Pipelock is an agent firewall: a network proxy that sits between AI agents and t
 helm install pipelock oci://ghcr.io/luckypipewrench/charts/pipelock
 ```
 
-The chart is published as an OCI artifact to the same registry as the images it deploys, so there is no repository to add. Installing a specific revision takes `--version`, which selects the chart version rather than the Pipelock version. To install from a checkout instead, point Helm at the directory: `helm install pipelock ./charts/pipelock`.
+The chart is published as an OCI artifact to the same registry as the images it deploys, so there is no repository to add. Installing a specific revision takes `--version`, which selects the chart version; Pipelock intentionally keeps that version equal to its release version. To install from a checkout instead, point Helm at the directory: `helm install pipelock ./charts/pipelock`.
 
 Pipelock runs as a non-root container with a read-only root filesystem, drops all Linux capabilities, and binds the standard Pipelock proxy on port 8888.
 
 ### Chart version and Pipelock version
 
-`version` is the chart's own version and tracks changes to these templates. `appVersion` is the Pipelock release the chart deploys, and the release workflow sets it from the tag being published, so a chart pulled from the registry always names the Pipelock version it shipped with.
+`version` and `appVersion` both equal the Pipelock release. The release gate enforces the invariant because OCI registries address a chart by `version`; allowing it to lag would replace an existing version with a chart that deploys a different Pipelock release.
 
 Enterprise examples:
 

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -90,6 +90,28 @@ else
   echo "  [ok]   Chart appVersion: $app"
 fi
 
+# 2b. Chart version must ALSO equal the release version, because the chart is
+# published to an OCI registry under its own version as the tag.
+#
+# appVersion is required to change every release by the check above, so the
+# packaged chart differs every release. If the chart version did not change with
+# it, the second release would push a different artifact to the SAME tag and the
+# registry would accept it silently. Reproduced against a local registry: chart
+# 0.10.0 pushed with appVersion 3.3.0, then again with appVersion 3.4.0; the tag
+# resolved to 3.4.0 afterwards, so anyone pinning --version 0.10.0 would get a
+# different Pipelock depending on when they installed.
+#
+# Tying the two together removes that class rather than guarding one instance of
+# it. Independent chart versioning would buy something if the chart could ship
+# between releases, but publication is tag-triggered, so it cannot. One number
+# also means there is no separate bump to forget.
+chart_version="$(grep -E '^version:' "$CHART" | head -n 1 | sed -E 's/^version:[[:space:]]*"?([^"[:space:]]+)"?.*/\1/' || true)"
+if [ "$chart_version" != "$VER" ]; then
+  note "charts/pipelock/Chart.yaml version is '$chart_version', expected '$VER'. The chart publishes to an OCI registry under its own version as the tag, so a version that does not move every release overwrites the previously published chart."
+else
+  echo "  [ok]   Chart version: $chart_version"
+fi
+
 # 3. The release keyring must be present BEFORE anything is built.
 #
 # GoReleaser embeds the public release keyring via


### PR DESCRIPTION
## What changed

The chart publishes to an OCI registry under its own version as the tag. The release gate requires `appVersion` to change every release, so the packaged chart differs every release, but nothing required the chart's own `version` to move with it. The second release would therefore push a different artifact to the same tag, and a registry accepts that silently.

Reproduced against a local registry: chart `0.10.0` pushed with appVersion 3.3.0, then pushed again unchanged with appVersion 3.4.0. Both pushes succeeded and the tag afterwards resolved to 3.4.0, so anyone pinning `--version 0.10.0` would get a different Pipelock depending on when they installed it. Nothing is published yet, so nothing is broken today; this is the last point at which it costs nothing to fix.

The chart version now tracks the Pipelock version it deploys, enforced by the same gate that already enforces `appVersion`. That removes the class rather than guarding an instance of it: there is no second number to forget and no window where the two disagree. Independent chart versioning would be worth keeping if the chart could ship between releases, but publication is tag-triggered, so it cannot.

Both publish paths also refuse to overwrite an existing tag, which catches the case the gate cannot see: the same version released twice from a re-pushed tag.

## Publishing without a release

Adds a dispatchable publish workflow so the chart's first publication does not have to wait for an unrelated release. It defaults to a dry run, verifies the chart, and refuses a collision the same way.

It runs only from the default branch and only for a chart version that has already been released. Restricting it to a tag ref would be stricter and useless: a dispatch runs the workflow file as it exists at the selected ref, and no released tag contains this file, so the case the workflow exists for could never run. The default branch is protected and reviewed, which is the property that matters, and requiring a matching release stops a publish part-way through a pre-tag bump when the branch names a version that does not exist yet.

## Failure direction

The collision check originally treated any failed registry lookup as "the tag is free", so an outage, an auth failure, or a rate limit would have fallen through to a push and overwritten a published chart. Both paths now proceed only on Helm's explicit not-found response and refuse on anything else.

Verified against a local registry across all three states: tag free proceeds, tag taken refuses, registry unreachable refuses. The consequence is that a registry outage blocks chart publication and skips the later floating-tag update while binaries and images are already attested. That is a visible partial-release state needing an operator retry, and it is the correct trade against silently replacing a published chart.

## Verification

The new gate check is non-vacuous against the exact state the old gate permitted: with `appVersion` bumped and the chart version left behind, the appVersion check passes and only the new check fails. Both workflow files parse, both new shell blocks pass `bash -n`, the chart lints, and the gate passes for a matching release version and fails for a mismatched one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow to validate, package, and optionally publish Helm charts.
  * Added dry-run support to verify charts without publishing them.

* **Bug Fixes**
  * Prevented overwriting existing chart versions in the OCI registry.
  * Added release checks ensuring chart and application versions remain aligned.

* **Documentation**
  * Clarified chart versioning and release requirements in Helm chart documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->