### PR TITLE
fix(metrics): stop reporting a self-awarded evidence assurance level

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2479,9 +2479,9 @@ dashboard_snapshot:
 | `raw_escrow` | `false` | Encrypt raw (pre-redaction) detail to sidecar files |
 | `escrow_public_key` | (required if raw_escrow) | X25519 public key (hex) for escrow encryption |
 | `completeness.heartbeat_interval` | `60s` | Restart-only interval for signed session heartbeat records. Must parse as a positive duration and be no more than 24h. |
-| `evidence_health.enabled` | `true` | Enable observability-only evidence health grading and `/stats` evidence-health output. This does not gate traffic. |
+| `evidence_health.enabled` | `true` | Enable process-local evidence health monitoring and `/stats` evidence-health output. This does not grade an AEL artifact or gate traffic. |
 | `evidence_health.self_audit_interval` | `30s` | Evidence self-audit interval. Must be between 5s and 10m. |
-| `evidence_health.max_anchor_lag` | `24h` | Maximum accepted age/lag window for anchor freshness reporting. A stale or missing anchor lowers the `anchoring_fresh` health diagnostic; anchoring does not raise `current_ael` above the single-recorder ceiling. |
+| `evidence_health.max_anchor_lag` | `24h` | Maximum accepted age/lag window for anchor freshness reporting. A stale or missing anchor lowers the `anchoring_fresh` diagnostic. It does not change an AEL grade. |
 | `anchor.rekor_url` | (empty) | Rekor v1 base URL. Setting it activates the Rekor auto-anchor backend. There is no public default. Mutually exclusive with `anchor.local_log`. |
 | `anchor.rekor_key_path` | (empty) | Ed25519 private key that signs Rekor entry submissions. Required with `anchor.rekor_url`; loaded again on every attempt so file replacement is picked up without restart. |
 | `anchor.local_log` | (empty) | Deterministic local anchor-log JSONL path. Setting it activates the local test/development backend. Mutually exclusive with `anchor.rekor_url`; not an operator-independent witness. |

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -380,8 +380,9 @@ entry key, invalid chain, or write failure increments
 `/stats` evidence-health JSON, and prints a `CRITICAL` line to stderr. Proxy
 traffic and receipt emission continue without waiting for the retry, which runs
 on a later pass. Successful markers feed the `anchoring_fresh` evidence-health
-diagnostic and anchor-lag metrics; they do not raise `current_ael` above the
-single-recorder ceiling.
+diagnostic and anchor-lag metrics. They do not award an AEL grade. The deprecated
+`current_ael` surface is unavailable because a live process cannot independently
+grade its own evidence.
 
 The log operator determines the ceiling of the proof. A self-hosted Rekor log
 adds tamper evidence and durability, but it is not independent from its

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -127,8 +127,9 @@ health sampler is not measuring that fact in the current runtime.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `pipelock_evidence_current_ael` | gauge | (none) | Current evidence assurance level, currently 0 through 1. Pipelock has one recorder, so no health or anchoring signal can establish AEL-2's separately keyed second recorder or any cumulative higher rung. The level is not a green completeness claim. |
-| `pipelock_evidence_ael_requirement_ok` | gauge | `requirement` | One when a bounded evidence-health signal is currently satisfied. Requirement labels are `recorder_enabled`, `emitter_healthy`, `durability_gate`, `heartbeats`, `anchoring_fresh`, `cpc_active`, and `selfaudit_ok`; these diagnostics do not independently award an AEL rung. |
+| `pipelock_evidence_local_recorder_operational` | gauge | (none) | One when this process's recorder and emitter are running with no locally observed sequence gap, self-audit failure, or ungated fsync failure. This does not check for a competing writer, prove corpus-wide integrity, or award an AEL grade. |
+| `pipelock_evidence_current_ael` | gauge | (none) | **Deprecated.** Always `NaN` (not a number). A live process cannot independently grade its own in-memory state. The series remains for one compatibility window so dashboards fail visibly instead of silently changing meaning. |
+| `pipelock_evidence_ael_requirement_ok` | gauge | `requirement` | **Deprecated.** Diagnostic inputs from the former live AEL estimate. Requirement labels are `recorder_enabled`, `emitter_healthy`, `durability_gate`, `heartbeats`, `anchoring_fresh`, `cpc_active`, and `selfaudit_ok`. These values do not award an AEL grade. |
 | `pipelock_evidence_chain_head_seq` | gauge | (none) | Last emitted in-memory receipt sequence, omitted when evidence health is not measured. |
 | `pipelock_evidence_chain_head_age_seconds` | gauge | (none) | Seconds since the last durable chain entry, omitted when evidence health is not measured. |
 | `pipelock_evidence_heartbeat_interval_seconds` | gauge | (none) | Configured receipt heartbeat interval in seconds; absent from JSON stats until heartbeats are enabled. |
@@ -140,9 +141,27 @@ health sampler is not measuring that fact in the current runtime.
 | `pipelock_evidence_selfaudit_ok` | gauge | (none) | One while evidence self-audit checks pass; latches to zero after a failure in the process. |
 | `pipelock_evidence_selfaudit_failures_total` | counter | `check` | Evidence self-audit failures by bounded check label: `durability_invariant`, `tail_divergence`, or `sampler_error`. |
 
-The `/stats` endpoint also includes a nullable `evidence_health` object with
-the same chain-head, sequence-gap, fsync, anchor, durability, and requirement
-state. Treat `null` as "not measured," not as healthy.
+The `/stats` endpoint also includes a nullable `evidence_health` object. In the
+`pipelock.evidencehealth.v2` object:
+
+- `current_ael` is retained as the string `UNAVAILABLE` for one compatibility
+  window. The string is deliberate: numeric clients fail visibly instead of
+  silently turning JSON `null` into the valid-looking number zero.
+- `local_recorder_operational` is the same process-local status as the new gauge.
+- `run_state` is `OPEN` while the recorder process is running. `run_id` is `null`
+  until bounded per-run recording exists. These are lifecycle facts, not
+  verification states.
+- `ael_artifact_capability` is a producer declaration. Today it reports no AEL
+  artifact-format versions, no bounded runs, no closed-run export, and no
+  verification-result import. Its `known_limitations` list includes the missing
+  concurrent-writer isolation. The declaration contains no AEL grade.
+
+Treat a top-level `evidence_health: null` as "not measured," not as healthy.
+During a rolling upgrade, old instances may still emit numeric
+`pipelock_evidence_current_ael` samples while new instances emit `NaN`. Do not
+aggregate that legacy series across versions. Migrate alerts to
+`pipelock_evidence_local_recorder_operational` and keep the process-local scope
+in the alert text.
 
 ## Session Profiling Metrics
 

--- a/internal/cli/runtime/evidence_health.go
+++ b/internal/cli/runtime/evidence_health.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	evidenceHealthSchema    = "pipelock.evidencehealth.v2"
+	evidenceHealthSchema    = metrics.EvidenceHealthSchemaV2
 	evidenceAnchorStateFile = "anchor-state.json"
 	maxTailReadBytes        = 64 * 1024
 	anchorStateHashBytes    = 32

--- a/internal/cli/runtime/evidence_health.go
+++ b/internal/cli/runtime/evidence_health.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	evidenceHealthSchema    = "pipelock.evidencehealth.v1"
+	evidenceHealthSchema    = "pipelock.evidencehealth.v2"
 	evidenceAnchorStateFile = "anchor-state.json"
 	maxTailReadBytes        = 64 * 1024
 	anchorStateHashBytes    = 32
@@ -306,20 +306,20 @@ func (h *evidenceHealthMonitor) stats() (metrics.EvidenceHealthStats, bool) {
 	fsyncStats := h.fsyncStats()
 	gapStats := h.gapStats()
 	fileStats := h.fileStats(cfg)
-	in := metrics.EvidenceAELInput{
+	operational := metrics.EvidenceOperationalInput{
 		RecorderEnabled:  requirements[metrics.EvidenceRequirementRecorderEnabled],
 		EmitterHealthy:   requirements[metrics.EvidenceRequirementEmitterHealthy],
-		DurabilityGate:   requirements[metrics.EvidenceRequirementDurabilityGate],
-		Heartbeats:       requirements[metrics.EvidenceRequirementHeartbeats],
-		AnchoringFresh:   requirements[metrics.EvidenceRequirementAnchoringFresh],
-		CPCActive:        false,
 		SelfAuditOK:      requirements[metrics.EvidenceRequirementSelfAuditOK],
 		UnresolvedGaps:   gapStats.Resume+gapStats.SelfAudit > 0,
 		UngatedFsyncFail: fsyncStats.Ungated > 0,
 	}
 	return metrics.EvidenceHealthStats{
 		Schema:                     evidenceHealthSchema,
-		CurrentAEL:                 metrics.EvidenceCurrentAEL(in),
+		CurrentAEL:                 metrics.EvidenceCurrentAELUnavailable,
+		LocalRecorderOperational:   metrics.EvidenceLocalRecorderOperational(operational),
+		RunState:                   metrics.EvidenceRunStateOpen,
+		RunID:                      nil,
+		AELArtifactCapability:      metrics.CurrentEvidenceArtifactCapability(),
 		Requirements:               requirements,
 		ChainHeadSeq:               snap.ChainSeq,
 		ChainHeadAgeSeconds:        ageSeconds,

--- a/internal/cli/runtime/evidence_health_test.go
+++ b/internal/cli/runtime/evidence_health_test.go
@@ -29,6 +29,35 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
+func TestEvidenceHealthSeparatesLiveStateFromAELCapability(t *testing.T) {
+	h, _, e, _ := newEvidenceHealthTestMonitor(t, nil)
+	emitEvidenceHealthTestReceipt(t, e, "https://api.vendor.example/baseline")
+
+	stats, ok := h.stats()
+	if !ok {
+		t.Fatal("stats unavailable")
+	}
+	if stats.Schema != "pipelock.evidencehealth.v2" {
+		t.Fatalf("schema = %q, want pipelock.evidencehealth.v2", stats.Schema)
+	}
+	if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE", stats.CurrentAEL)
+	}
+	if !stats.LocalRecorderOperational {
+		t.Fatal("healthy local recorder reported non-operational")
+	}
+	if stats.RunState != metrics.EvidenceRunStateOpen || stats.RunID != nil {
+		t.Fatalf("run lifecycle = %q/%v, want OPEN with no bounded run id", stats.RunState, stats.RunID)
+	}
+	capability := stats.AELArtifactCapability
+	if capability.Schema == "" || capability.AELFormatVersions == nil {
+		t.Fatalf("capability declaration is not explicit: %+v", capability)
+	}
+	if capability.BoundedRuns || capability.ClosedRunExport || capability.VerificationResultImport || len(capability.AELFormatVersions) != 0 {
+		t.Fatalf("capability declaration overstates the runtime: %+v", capability)
+	}
+}
+
 func TestEvidenceHealthSelfAuditDurabilityInvariantLatchesAndEmits(t *testing.T) {
 	t.Run("positive_divergence", func(t *testing.T) {
 		h, m, e, _ := newEvidenceHealthTestMonitor(t, func(cfg *config.Config) {
@@ -163,8 +192,11 @@ func TestEvidenceHealthSelfAuditSamplerErrorFailsClosedWithoutPanic(t *testing.T
 	if stats.Requirements[metrics.EvidenceRequirementSelfAuditOK] {
 		t.Fatal("selfaudit_ok requirement = true after sampler error")
 	}
-	if stats.CurrentAEL != 0 {
-		t.Fatalf("current AEL = %d, want 0 after sampler error", stats.CurrentAEL)
+	if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE after sampler error", stats.CurrentAEL)
+	}
+	if stats.LocalRecorderOperational {
+		t.Fatal("local recorder reported operational after sampler error")
 	}
 	if stats.DurabilityBlocks != 0 {
 		t.Fatalf("durability blocks = %d, want 0; self-audit must not gate traffic", stats.DurabilityBlocks)
@@ -252,8 +284,11 @@ func TestEvidenceHealthAnchorStateMalformedMarkersFailClosed(t *testing.T) {
 			if stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 				t.Fatal("malformed marker made anchoring_fresh true")
 			}
-			if stats.CurrentAEL != 0 {
-				t.Fatalf("current AEL = %d, want 0 after malformed marker", stats.CurrentAEL)
+			if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+				t.Fatalf("current AEL = %q, want UNAVAILABLE after malformed marker", stats.CurrentAEL)
+			}
+			if stats.LocalRecorderOperational {
+				t.Fatal("local recorder reported operational after malformed marker")
 			}
 		})
 	}
@@ -771,8 +806,11 @@ func TestEvidenceHealthAnchorStateValidMarkerCanOnlyUseAcceptedFreshness(t *test
 	if !stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatal("valid fresh marker did not set anchoring_fresh")
 	}
-	if stats.CurrentAEL != 1 {
-		t.Fatalf("current AEL = %d, want 1; a local anchor cannot supply AEL-2's second recorder", stats.CurrentAEL)
+	if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE", stats.CurrentAEL)
+	}
+	if !stats.LocalRecorderOperational {
+		t.Fatal("valid local recorder reported non-operational")
 	}
 
 	older := validEvidenceHealthAnchorState()
@@ -813,8 +851,11 @@ func TestEvidenceHealthAnchorStateValidMarkerCanOnlyUseAcceptedFreshness(t *test
 	if afterStale.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatal("valid stale marker set anchoring_fresh")
 	}
-	if afterStale.CurrentAEL != 1 {
-		t.Fatalf("current AEL = %d, want 1 for stale marker; a single recorder cannot claim AEL-2", afterStale.CurrentAEL)
+	if afterStale.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE for stale marker", afterStale.CurrentAEL)
+	}
+	if !afterStale.LocalRecorderOperational {
+		t.Fatal("stale anchor incorrectly degraded local recorder operation")
 	}
 }
 
@@ -844,8 +885,8 @@ func TestEvidenceHealthRekorMarkerWithReceiptSignerKeyDoesNotRaiseAEL(t *testing
 	if !stats.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatal("accepted Rekor marker did not set anchoring_fresh")
 	}
-	if stats.CurrentAEL != 1 {
-		t.Fatalf("current AEL = %d, want 1; a same-key Rekor checkpoint cannot satisfy AEL-2 or AEL-3", stats.CurrentAEL)
+	if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE", stats.CurrentAEL)
 	}
 }
 
@@ -1053,8 +1094,11 @@ func assertEvidenceHealthLatched(t *testing.T, h *evidenceHealthMonitor) {
 	if stats.Requirements[metrics.EvidenceRequirementSelfAuditOK] {
 		t.Fatal("selfaudit_ok requirement = true, want false")
 	}
-	if stats.CurrentAEL != 0 {
-		t.Fatalf("current AEL = %d, want 0", stats.CurrentAEL)
+	if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+		t.Fatalf("current AEL = %q, want UNAVAILABLE", stats.CurrentAEL)
+	}
+	if stats.LocalRecorderOperational {
+		t.Fatal("local recorder reported operational after latched self-audit failure")
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1516,7 +1516,7 @@ type FlightRecorder struct {
 	SigningKeyPath     string                       `yaml:"signing_key_path"`         // Ed25519 private key for checkpoint signing and action receipts
 	RequireReceipts    bool                         `yaml:"require_receipts"`         // fail closed when a required receipt cannot be emitted (default false)
 	Completeness       FlightRecorderCompleteness   `yaml:"completeness" json:"-"`    // restart-only evidence completeness knobs
-	EvidenceHealth     FlightRecorderEvidenceHealth `yaml:"evidence_health" json:"-"` // observability-only evidence health grading
+	EvidenceHealth     FlightRecorderEvidenceHealth `yaml:"evidence_health" json:"-"` // process-local evidence health monitoring
 	Anchor             FlightRecorderAnchor         `yaml:"anchor" json:"-"`          // optional runtime receipt-chain anchoring
 }
 

--- a/internal/metrics/evidence.go
+++ b/internal/metrics/evidence.go
@@ -26,6 +26,11 @@ const (
 	// JSON field. A string makes legacy numeric decoders fail visibly instead of
 	// silently coercing JSON null into the valid-looking AEL-0 value.
 	EvidenceCurrentAELUnavailable = "UNAVAILABLE"
+	// EvidenceHealthSchemaV2 is the canonical evidence-health schema for this
+	// release. The sanitized snapshot forces it so an alternate callback cannot
+	// declare the v1 contract while emitting v2 field shapes, which would let a
+	// consumer that selects its decoder from the schema pick the wrong one.
+	EvidenceHealthSchemaV2 = "pipelock.evidencehealth.v2"
 
 	evidenceArtifactCapabilitySchema = "pipelock.ael-artifact-capability.v1"
 )
@@ -523,7 +528,10 @@ func (m *Metrics) EvidenceHealthStatsSnapshot() (EvidenceHealthStats, bool) {
 	// The callback backs both /stats and the Prometheus collector. Force the
 	// deprecated producer-computed grade and producer-set verification lifecycle
 	// to honest current-release values so an alternate callback cannot restore a
-	// self-awarded AEL number or label an open legacy run as verified.
+	// self-awarded AEL number or label an open legacy run as verified. The schema
+	// is forced with them: a preserved v1 schema alongside v2 field shapes would
+	// point a schema-selecting decoder at the wrong contract.
+	stats.Schema = EvidenceHealthSchemaV2
 	stats.CurrentAEL = EvidenceCurrentAELUnavailable
 	stats.RunState = EvidenceRunStateOpen
 	stats.RunID = nil

--- a/internal/metrics/evidence.go
+++ b/internal/metrics/evidence.go
@@ -19,16 +19,15 @@ const (
 	EvidenceRequirementCPCActive       = "cpc_active"
 	EvidenceRequirementSelfAuditOK     = "selfaudit_ok"
 
-	// evidenceMaximumSupportedAEL is deliberately a product-capability ceiling,
-	// not a statement about a particular anchor's current health. Pipelock has
-	// one receipt recorder today. It does not verify a separately keyed second
-	// recorder with declared custody separation (AEL-2), so it cannot honestly
-	// claim AEL-2 or any cumulative rung above it. A local anchor is a test
-	// backend, while the current Rekor path does not establish the required
-	// separate log key or per-payload inclusion proof; neither can raise this
-	// ceiling. Raise it only alongside an implementation that verifies every
-	// prerequisite of the next AEL rung.
-	evidenceMaximumSupportedAEL = 1
+	// EvidenceRunStateOpen identifies a live recorder process. It is a lifecycle
+	// fact, not an AEL verification state.
+	EvidenceRunStateOpen = "OPEN"
+	// EvidenceCurrentAELUnavailable is the only value emitted on the deprecated
+	// JSON field. A string makes legacy numeric decoders fail visibly instead of
+	// silently coercing JSON null into the valid-looking AEL-0 value.
+	EvidenceCurrentAELUnavailable = "UNAVAILABLE"
+
+	evidenceArtifactCapabilitySchema = "pipelock.ael-artifact-capability.v1"
 )
 
 var evidenceSequenceGapSources = map[string]bool{
@@ -73,23 +72,61 @@ var evidenceAELRequirementOrder = []string{
 // Prometheus collectors and the JSON /stats endpoint. Nil/false callback
 // results mean evidence health is not measured and should render UNKNOWN.
 type EvidenceHealthStats struct {
-	Schema                     string                  `json:"schema"`
-	CurrentAEL                 int                     `json:"current_ael"`
-	Requirements               map[string]bool         `json:"requirements"`
-	ChainHeadSeq               uint64                  `json:"chain_head_seq"`
-	ChainHeadAgeSeconds        *float64                `json:"chain_head_age_seconds"`
-	HeartbeatIntervalSeconds   *float64                `json:"heartbeat_interval_seconds"`
-	SequenceGaps               EvidenceGapStats        `json:"sequence_gaps"`
-	FsyncErrors                EvidenceFsyncStats      `json:"fsync_errors"`
-	Files                      EvidenceFileStats       `json:"files"`
-	DurabilityBlocks           uint64                  `json:"durability_blocks"`
-	DurabilityInvariantOK      bool                    `json:"durability_invariant_ok"`
-	Anchor                     *EvidenceAnchorStats    `json:"anchor"`
-	AutoAnchor                 EvidenceAutoAnchorStats `json:"auto_anchor"`
-	CPC                        any                     `json:"cpc"`
-	AnchoredFinalSeq           uint64                  `json:"-"`
-	AnchorLagReceipts          uint64                  `json:"-"`
-	LastAnchorTimestampSeconds float64                 `json:"-"`
+	Schema string `json:"schema"`
+	// CurrentAEL is retained as UNAVAILABLE for one compatibility window. A live
+	// process cannot independently verify and award an AEL grade to itself.
+	// Deprecated: use LocalRecorderOperational, RunState, and
+	// AELArtifactCapability.
+	CurrentAEL                 string                     `json:"current_ael"`
+	LocalRecorderOperational   bool                       `json:"local_recorder_operational"`
+	RunState                   string                     `json:"run_state"`
+	RunID                      *string                    `json:"run_id"`
+	AELArtifactCapability      EvidenceArtifactCapability `json:"ael_artifact_capability"`
+	Requirements               map[string]bool            `json:"requirements"`
+	ChainHeadSeq               uint64                     `json:"chain_head_seq"`
+	ChainHeadAgeSeconds        *float64                   `json:"chain_head_age_seconds"`
+	HeartbeatIntervalSeconds   *float64                   `json:"heartbeat_interval_seconds"`
+	SequenceGaps               EvidenceGapStats           `json:"sequence_gaps"`
+	FsyncErrors                EvidenceFsyncStats         `json:"fsync_errors"`
+	Files                      EvidenceFileStats          `json:"files"`
+	DurabilityBlocks           uint64                     `json:"durability_blocks"`
+	DurabilityInvariantOK      bool                       `json:"durability_invariant_ok"`
+	Anchor                     *EvidenceAnchorStats       `json:"anchor"`
+	AutoAnchor                 EvidenceAutoAnchorStats    `json:"auto_anchor"`
+	CPC                        any                        `json:"cpc"`
+	AnchoredFinalSeq           uint64                     `json:"-"`
+	AnchorLagReceipts          uint64                     `json:"-"`
+	LastAnchorTimestampSeconds float64                    `json:"-"`
+}
+
+// EvidenceArtifactCapability is a producer declaration, not an AEL grade or
+// verification result. It deliberately contains no target, maximum, or current
+// AEL rung.
+type EvidenceArtifactCapability struct {
+	Schema                   string   `json:"schema"`
+	AELFormatVersions        []int    `json:"ael_format_versions"`
+	BoundedRuns              bool     `json:"bounded_runs"`
+	ClosedRunExport          bool     `json:"closed_run_export"`
+	VerificationResultImport bool     `json:"verification_result_import"`
+	KnownLimitations         []string `json:"known_limitations"`
+}
+
+// CurrentEvidenceArtifactCapability returns Pipelock's current producer
+// declaration. Empty format versions and false operation flags are explicit
+// unsupported states, not unknown values.
+func CurrentEvidenceArtifactCapability() EvidenceArtifactCapability {
+	return EvidenceArtifactCapability{
+		Schema:                   evidenceArtifactCapabilitySchema,
+		AELFormatVersions:        []int{},
+		BoundedRuns:              false,
+		ClosedRunExport:          false,
+		VerificationResultImport: false,
+		KnownLimitations: []string{
+			"ael_artifact_export_not_implemented",
+			"concurrent_writer_isolation_not_enforced",
+			"verification_result_import_not_implemented",
+		},
+	}
 }
 
 type EvidenceGapStats struct {
@@ -135,63 +172,17 @@ type EvidenceAutoAnchorStats struct {
 	LastError string `json:"last_error"`
 }
 
-type EvidenceAELInput struct {
+type EvidenceOperationalInput struct {
 	RecorderEnabled  bool
 	EmitterHealthy   bool
-	DurabilityGate   bool
-	Heartbeats       bool
-	AnchoringFresh   bool
-	CPCActive        bool
 	SelfAuditOK      bool
 	UnresolvedGaps   bool
 	UngatedFsyncFail bool
 }
 
-type evidenceAELRule struct {
-	rung int
-	ok   func(EvidenceAELInput) bool
-}
-
-var evidenceAELRules = []evidenceAELRule{
-	{rung: 0, ok: func(in EvidenceAELInput) bool {
-		return in.RecorderEnabled
-	}},
-	{rung: 1, ok: func(in EvidenceAELInput) bool {
-		return in.RecorderEnabled && in.EmitterHealthy && in.SelfAuditOK && !in.UngatedFsyncFail
-	}},
-	{rung: 2, ok: func(in EvidenceAELInput) bool {
-		return in.DurabilityGate && in.Heartbeats && !in.UnresolvedGaps
-	}},
-	{rung: 3, ok: func(in EvidenceAELInput) bool {
-		return in.AnchoringFresh
-	}},
-	{rung: 4, ok: func(in EvidenceAELInput) bool {
-		return in.CPCActive
-	}},
-}
-
-func EvidenceCurrentAEL(in EvidenceAELInput) int {
-	level := 0
-	for _, rule := range evidenceAELRules {
-		if rule.rung > evidenceMaximumSupportedAEL {
-			return level
-		}
-		if !rule.ok(in) {
-			return level
-		}
-		level = rule.rung
-	}
-	return level
-}
-
-func clampEvidenceCurrentAEL(level int) int {
-	if level < 0 {
-		return 0
-	}
-	if level > evidenceMaximumSupportedAEL {
-		return evidenceMaximumSupportedAEL
-	}
-	return level
+func EvidenceLocalRecorderOperational(in EvidenceOperationalInput) bool {
+	return in.RecorderEnabled && in.EmitterHealthy && in.SelfAuditOK &&
+		!in.UnresolvedGaps && !in.UngatedFsyncFail
 }
 
 func (m *Metrics) registerEvidenceMetrics(reg *prometheus.Registry) {
@@ -229,7 +220,7 @@ func (m *Metrics) registerEvidenceMetrics(reg *prometheus.Registry) {
 		Namespace: "pipelock",
 		Subsystem: "evidence",
 		Name:      "ael_requirement_ok",
-		Help:      "Evidence assurance requirement state as 1/0 by closed requirement label.",
+		Help:      "Deprecated diagnostic inputs from the former live AEL estimate; these 1/0 values do not award an AEL grade.",
 	}, []string{"requirement"})
 	m.evidenceSelfAuditOK = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "pipelock",
@@ -529,10 +520,14 @@ func (m *Metrics) EvidenceHealthStatsSnapshot() (EvidenceHealthStats, bool) {
 	if !ok {
 		return stats, false
 	}
-	// The callback backs both /stats and the Prometheus collector. Clamp here
-	// as well as in EvidenceCurrentAEL so no alternate producer can publish an
-	// unsupported AEL rung.
-	stats.CurrentAEL = clampEvidenceCurrentAEL(stats.CurrentAEL)
+	// The callback backs both /stats and the Prometheus collector. Force the
+	// deprecated producer-computed grade and producer-set verification lifecycle
+	// to honest current-release values so an alternate callback cannot restore a
+	// self-awarded AEL number or label an open legacy run as verified.
+	stats.CurrentAEL = EvidenceCurrentAELUnavailable
+	stats.RunState = EvidenceRunStateOpen
+	stats.RunID = nil
+	stats.AELArtifactCapability = CurrentEvidenceArtifactCapability()
 	return stats, true
 }
 
@@ -546,11 +541,12 @@ func (m *Metrics) SetEvidenceHealthFunc(fn func() (EvidenceHealthStats, bool)) {
 }
 
 type evidenceCollector struct {
-	m       *Metrics
-	age     *prometheus.Desc
-	seq     *prometheus.Desc
-	lag     *prometheus.Desc
-	current *prometheus.Desc
+	m                *Metrics
+	age              *prometheus.Desc
+	seq              *prometheus.Desc
+	lag              *prometheus.Desc
+	current          *prometheus.Desc
+	localOperational *prometheus.Desc
 }
 
 func newEvidenceCollector(m *Metrics) *evidenceCollector {
@@ -574,7 +570,12 @@ func newEvidenceCollector(m *Metrics) *evidenceCollector {
 		),
 		current: prometheus.NewDesc(
 			"pipelock_evidence_current_ael",
-			"Current evidence assurance level, capped at 1 until Pipelock verifies higher-rung evidence requirements.",
+			"Deprecated self-reported AEL gauge; always NaN because a live process cannot award AEL and grades require a separately verified exported artifact.",
+			nil, labels,
+		),
+		localOperational: prometheus.NewDesc(
+			"pipelock_evidence_local_recorder_operational",
+			"One when this process's recorder and emitter are operational with no locally observed gap, self-audit, or ungated fsync failure; does not establish corpus-wide integrity or an AEL grade.",
 			nil, labels,
 		),
 	}
@@ -585,6 +586,7 @@ func (c *evidenceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.seq
 	ch <- c.lag
 	ch <- c.current
+	ch <- c.localOperational
 }
 
 func (c *evidenceCollector) Collect(ch chan<- prometheus.Metric) {
@@ -597,5 +599,10 @@ func (c *evidenceCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	ch <- prometheus.MustNewConstMetric(c.seq, prometheus.GaugeValue, float64(stats.ChainHeadSeq))
 	ch <- prometheus.MustNewConstMetric(c.lag, prometheus.GaugeValue, float64(stats.AnchorLagReceipts))
-	ch <- prometheus.MustNewConstMetric(c.current, prometheus.GaugeValue, float64(stats.CurrentAEL))
+	ch <- prometheus.MustNewConstMetric(c.current, prometheus.GaugeValue, math.NaN())
+	operational := 0.0
+	if stats.LocalRecorderOperational {
+		operational = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.localOperational, prometheus.GaugeValue, operational)
 }

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -51,6 +51,7 @@ func TestEvidenceHealthStatsSnapshotRejectsAlternateAELProducer(t *testing.T) {
 	producerRunID := "producer-chosen-run"
 	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
 		return EvidenceHealthStats{
+			Schema:     "pipelock.evidencehealth.v1",
 			CurrentAEL: "AEL-4",
 			RunState:   "VERIFIED",
 			RunID:      &producerRunID,
@@ -65,6 +66,9 @@ func TestEvidenceHealthStatsSnapshotRejectsAlternateAELProducer(t *testing.T) {
 	stats, ok := m.EvidenceHealthStatsSnapshot()
 	if !ok {
 		t.Fatal("EvidenceHealthStatsSnapshot unavailable")
+	}
+	if stats.Schema != EvidenceHealthSchemaV2 {
+		t.Fatalf("Schema = %q, want %q: a preserved legacy schema points a schema-selecting decoder at the wrong contract", stats.Schema, EvidenceHealthSchemaV2)
 	}
 	if stats.CurrentAEL != EvidenceCurrentAELUnavailable {
 		t.Fatalf("CurrentAEL = %q, want %q", stats.CurrentAEL, EvidenceCurrentAELUnavailable)

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -360,36 +360,48 @@ func TestEvidenceHealthUnmeasuredStatsNullAndDynamicGaugesAbsent(t *testing.T) {
 }
 
 func TestEvidenceCollectorSeparatesLocalOperationFromDeprecatedAEL(t *testing.T) {
-	m := New()
-	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
-		return EvidenceHealthStats{CurrentAEL: "AEL-4", LocalRecorderOperational: true, ChainHeadSeq: 9}, true
-	})
-	reg := prometheus.NewPedanticRegistry()
-	if err := reg.Register(m.evidenceCollector); err != nil {
-		t.Fatalf("register evidence collector: %v", err)
+	tests := []struct {
+		name        string
+		operational bool
+		wantGauge   float64
+	}{
+		{name: "operational", operational: true, wantGauge: 1},
+		{name: "not operational", operational: false, wantGauge: 0},
 	}
-	fams, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("gather: %v", err)
-	}
-	foundCurrent := false
-	foundOperational := false
-	for _, fam := range fams {
-		switch fam.GetName() {
-		case "pipelock_evidence_current_ael":
-			foundCurrent = true
-			if v := fam.GetMetric()[0].GetGauge().GetValue(); !math.IsNaN(v) {
-				t.Fatalf("exported pipelock_evidence_current_ael = %v, want NaN", v)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New()
+			m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
+				return EvidenceHealthStats{CurrentAEL: "AEL-4", LocalRecorderOperational: tc.operational, ChainHeadSeq: 9}, true
+			})
+			reg := prometheus.NewPedanticRegistry()
+			if err := reg.Register(m.evidenceCollector); err != nil {
+				t.Fatalf("register evidence collector: %v", err)
 			}
-		case "pipelock_evidence_local_recorder_operational":
-			foundOperational = true
-			if v := fam.GetMetric()[0].GetGauge().GetValue(); v != 1 {
-				t.Fatalf("exported pipelock_evidence_local_recorder_operational = %v, want 1", v)
+			fams, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gather: %v", err)
 			}
-		}
-	}
-	if !foundCurrent || !foundOperational {
-		t.Fatalf("metric presence current_ael=%v local_recorder_operational=%v, want both", foundCurrent, foundOperational)
+			foundCurrent := false
+			foundOperational := false
+			for _, fam := range fams {
+				switch fam.GetName() {
+				case "pipelock_evidence_current_ael":
+					foundCurrent = true
+					if v := fam.GetMetric()[0].GetGauge().GetValue(); !math.IsNaN(v) {
+						t.Fatalf("exported pipelock_evidence_current_ael = %v, want NaN", v)
+					}
+				case "pipelock_evidence_local_recorder_operational":
+					foundOperational = true
+					if v := fam.GetMetric()[0].GetGauge().GetValue(); v != tc.wantGauge {
+						t.Fatalf("exported pipelock_evidence_local_recorder_operational = %v, want %v", v, tc.wantGauge)
+					}
+				}
+			}
+			if !foundCurrent || !foundOperational {
+				t.Fatalf("metric presence current_ael=%v local_recorder_operational=%v, want both", foundCurrent, foundOperational)
+			}
+		})
 	}
 }
 

--- a/internal/metrics/evidence_test.go
+++ b/internal/metrics/evidence_test.go
@@ -15,94 +15,88 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestEvidenceCurrentAELTable(t *testing.T) {
-	base := EvidenceAELInput{
+func TestEvidenceLocalRecorderOperationalTable(t *testing.T) {
+	base := EvidenceOperationalInput{
 		RecorderEnabled: true,
 		EmitterHealthy:  true,
 		SelfAuditOK:     true,
 	}
 	tests := []struct {
 		name string
-		in   EvidenceAELInput
-		want int
+		in   EvidenceOperationalInput
+		want bool
 	}{
-		{name: "recorder_disabled", in: EvidenceAELInput{}, want: 0},
-		{name: "recorder_only", in: EvidenceAELInput{RecorderEnabled: true}, want: 0},
-		{name: "selfaudit_latched_bad", in: EvidenceAELInput{RecorderEnabled: true, EmitterHealthy: true}, want: 0},
-		{name: "best_effort", in: base, want: 1},
-		{name: "durable_heartbeat_does_not_claim_second_recorder", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
-			in.DurabilityGate = true
-			in.Heartbeats = true
-		}), want: 1},
-		{name: "fresh_anchor_does_not_claim_external_grade", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
-			in.DurabilityGate = true
-			in.Heartbeats = true
-			in.AnchoringFresh = true
-		}), want: 1},
-		{name: "cpc_active_does_not_bypass_cumulative_requirements", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
-			in.DurabilityGate = true
-			in.Heartbeats = true
-			in.AnchoringFresh = true
-			in.CPCActive = true
-		}), want: 1},
-		{name: "ungated_fsync_failure_degrades_to_zero", in: withEvidenceAEL(base, func(in *EvidenceAELInput) {
+		{name: "recorder_disabled", in: EvidenceOperationalInput{}, want: false},
+		{name: "recorder_only", in: EvidenceOperationalInput{RecorderEnabled: true}, want: false},
+		{name: "selfaudit_latched_bad", in: EvidenceOperationalInput{RecorderEnabled: true, EmitterHealthy: true}, want: false},
+		{name: "local_process_healthy", in: base, want: true},
+		{name: "unresolved_gap", in: withEvidenceOperational(base, func(in *EvidenceOperationalInput) {
+			in.UnresolvedGaps = true
+		}), want: false},
+		{name: "ungated_fsync_failure", in: withEvidenceOperational(base, func(in *EvidenceOperationalInput) {
 			in.UngatedFsyncFail = true
-		}), want: 0},
+		}), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EvidenceCurrentAEL(tt.in); got != tt.want {
-				t.Fatalf("EvidenceCurrentAEL = %d, want %d", got, tt.want)
+			if got := EvidenceLocalRecorderOperational(tt.in); got != tt.want {
+				t.Fatalf("EvidenceLocalRecorderOperational = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-// This fixture contains every signal the pre-cap ladder mistook for AEL-4.
-// It must remain at the one-recorder ceiling until the runtime can verify the
-// separate recorders, external log, and counterparty evidence that AEL needs.
-// Temporarily raising evidenceMaximumSupportedAEL makes this test fail at 4,
-// proving the ceiling is load-bearing rather than a vacuous assertion.
-func TestEvidenceCurrentAELSingleRecorderCeilingRejectsLegacyOverclaim(t *testing.T) {
-	in := EvidenceAELInput{
-		RecorderEnabled: true,
-		EmitterHealthy:  true,
-		DurabilityGate:  true,
-		Heartbeats:      true,
-		AnchoringFresh:  true,
-		CPCActive:       true,
-		SelfAuditOK:     true,
-	}
-	if got := EvidenceCurrentAEL(in); got != 1 {
-		t.Fatalf("EvidenceCurrentAEL = %d, want one-recorder ceiling 1", got)
-	}
-}
-
-func TestEvidenceHealthStatsSnapshotClampsAlternateAELProducer(t *testing.T) {
+func TestEvidenceHealthStatsSnapshotRejectsAlternateAELProducer(t *testing.T) {
 	m := New()
+	producerRunID := "producer-chosen-run"
 	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
-		return EvidenceHealthStats{CurrentAEL: 4}, true
+		return EvidenceHealthStats{
+			CurrentAEL: "AEL-4",
+			RunState:   "VERIFIED",
+			RunID:      &producerRunID,
+			AELArtifactCapability: EvidenceArtifactCapability{
+				AELFormatVersions:        []int{4},
+				BoundedRuns:              true,
+				ClosedRunExport:          true,
+				VerificationResultImport: true,
+			},
+		}, true
 	})
 	stats, ok := m.EvidenceHealthStatsSnapshot()
 	if !ok {
 		t.Fatal("EvidenceHealthStatsSnapshot unavailable")
 	}
-	if stats.CurrentAEL != 1 {
-		t.Fatalf("CurrentAEL = %d, want one-recorder ceiling 1", stats.CurrentAEL)
+	if stats.CurrentAEL != EvidenceCurrentAELUnavailable {
+		t.Fatalf("CurrentAEL = %q, want %q", stats.CurrentAEL, EvidenceCurrentAELUnavailable)
+	}
+	if stats.RunState != EvidenceRunStateOpen || stats.RunID != nil {
+		t.Fatalf("run lifecycle = %q/%v, want OPEN with no bounded run id", stats.RunState, stats.RunID)
+	}
+	if stats.AELArtifactCapability.BoundedRuns || stats.AELArtifactCapability.ClosedRunExport || stats.AELArtifactCapability.VerificationResultImport || len(stats.AELArtifactCapability.AELFormatVersions) != 0 {
+		t.Fatalf("capability callback restored unsupported claim: %+v", stats.AELArtifactCapability)
 	}
 }
 
-func TestEvidenceAELRungZeroIsNarrowerThanRungOne(t *testing.T) {
-	recorderOnly := EvidenceAELInput{RecorderEnabled: true}
-	if !evidenceAELRules[0].ok(recorderOnly) {
-		t.Fatal("rung 0 rejected recorder-only evidence")
+func TestCurrentEvidenceArtifactCapabilityDoesNotDeclareGrade(t *testing.T) {
+	capability := CurrentEvidenceArtifactCapability()
+	raw, err := json.Marshal(capability)
+	if err != nil {
+		t.Fatalf("Marshal capability: %v", err)
 	}
-	if evidenceAELRules[1].ok(recorderOnly) {
-		t.Fatal("rung 1 accepted recorder-only evidence")
+	for _, forbidden := range []string{"current_ael", "maximum_ael", "target_ael", "verified"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Fatalf("capability declaration contains forbidden grade/status field %q: %s", forbidden, raw)
+		}
+	}
+	if capability.Schema == "" || capability.AELFormatVersions == nil {
+		t.Fatalf("capability declaration is not explicit: %+v", capability)
+	}
+	if capability.BoundedRuns || capability.ClosedRunExport || capability.VerificationResultImport || len(capability.AELFormatVersions) != 0 {
+		t.Fatalf("capability overstates current implementation: %+v", capability)
 	}
 }
 
-func withEvidenceAEL(base EvidenceAELInput, mutate func(*EvidenceAELInput)) EvidenceAELInput {
+func withEvidenceOperational(base EvidenceOperationalInput, mutate func(*EvidenceOperationalInput)) EvidenceOperationalInput {
 	mutate(&base)
 	return base
 }
@@ -237,8 +231,10 @@ func TestEvidenceMetricsSettersSnapshotsAndDynamicCollector(t *testing.T) {
 
 	age := 7.5
 	stats := EvidenceHealthStats{
-		Schema:                   "pipelock.evidencehealth.v1",
-		CurrentAEL:               3,
+		Schema:                   "pipelock.evidencehealth.v2",
+		LocalRecorderOperational: true,
+		RunState:                 EvidenceRunStateOpen,
+		AELArtifactCapability:    CurrentEvidenceArtifactCapability(),
 		ChainHeadSeq:             9,
 		ChainHeadAgeSeconds:      &age,
 		AnchorLagReceipts:        4,
@@ -248,11 +244,11 @@ func TestEvidenceMetricsSettersSnapshotsAndDynamicCollector(t *testing.T) {
 		return stats, true
 	})
 	gotStats, ok := m.EvidenceHealthStatsSnapshot()
-	if !ok || gotStats.CurrentAEL != 1 || gotStats.ChainHeadSeq != 9 {
+	if !ok || gotStats.CurrentAEL != EvidenceCurrentAELUnavailable || !gotStats.LocalRecorderOperational || gotStats.ChainHeadSeq != 9 {
 		t.Fatalf("EvidenceHealthStatsSnapshot = (%+v, %v), want stats ok", gotStats, ok)
 	}
-	if got := testutil.CollectAndCount(m.evidenceCollector); got != 4 {
-		t.Fatalf("dynamic evidence collector emitted %d metrics, want 4", got)
+	if got := testutil.CollectAndCount(m.evidenceCollector); got != 5 {
+		t.Fatalf("dynamic evidence collector emitted %d metrics, want 5", got)
 	}
 
 	rec := httptest.NewRecorder()
@@ -263,16 +259,22 @@ func TestEvidenceMetricsSettersSnapshotsAndDynamicCollector(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("Unmarshal stats: %v", err)
 	}
-	if body.EvidenceHealth == nil || body.EvidenceHealth.CurrentAEL != 1 || body.EvidenceHealth.ChainHeadSeq != 9 {
-		t.Fatalf("stats evidence_health = %+v, want current_ael=1 chain_head_seq=9", body.EvidenceHealth)
+	if !strings.Contains(rec.Body.String(), `"current_ael":"UNAVAILABLE"`) {
+		t.Fatalf("stats did not retain deprecated current_ael as UNAVAILABLE: %s", rec.Body.String())
+	}
+	if body.EvidenceHealth == nil || body.EvidenceHealth.CurrentAEL != EvidenceCurrentAELUnavailable || !body.EvidenceHealth.LocalRecorderOperational || body.EvidenceHealth.RunState != EvidenceRunStateOpen || body.EvidenceHealth.RunID != nil || body.EvidenceHealth.ChainHeadSeq != 9 {
+		t.Fatalf("stats evidence_health = %+v, want current_ael=UNAVAILABLE local_recorder_operational=true OPEN unbounded run and chain_head_seq=9", body.EvidenceHealth)
+	}
+	if body.EvidenceHealth.AELArtifactCapability.Schema == "" || body.EvidenceHealth.AELArtifactCapability.AELFormatVersions == nil {
+		t.Fatalf("stats capability declaration is not explicit: %+v", body.EvidenceHealth.AELArtifactCapability)
 	}
 
 	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
 		stats.ChainHeadAgeSeconds = nil
 		return stats, true
 	})
-	if got := testutil.CollectAndCount(m.evidenceCollector); got != 3 {
-		t.Fatalf("dynamic evidence collector emitted %d metrics without age, want 3", got)
+	if got := testutil.CollectAndCount(m.evidenceCollector); got != 4 {
+		t.Fatalf("dynamic evidence collector emitted %d metrics without age, want 4", got)
 	}
 }
 
@@ -298,7 +300,7 @@ func TestEvidenceMetricsNilAndZeroValueFailClosed(t *testing.T) {
 	if got := nilMetrics.EvidenceAutoAnchorStatsSnapshot(); got != (EvidenceAutoAnchorStats{}) {
 		t.Fatalf("nil auto-anchor stats = %+v, want zero", got)
 	}
-	if stats, ok := nilMetrics.EvidenceHealthStatsSnapshot(); ok || stats.CurrentAEL != 0 || stats.Requirements != nil {
+	if stats, ok := nilMetrics.EvidenceHealthStatsSnapshot(); ok || stats.CurrentAEL != "" || stats.Requirements != nil {
 		t.Fatalf("nil EvidenceHealthStatsSnapshot = (%+v, %v), want zero false", stats, ok)
 	}
 
@@ -311,10 +313,10 @@ func TestEvidenceMetricsNilAndZeroValueFailClosed(t *testing.T) {
 	zero.SetEvidenceRequirement(EvidenceRequirementRecorderEnabled, true)
 	zero.SetEvidenceRequirements(nil)
 	zero.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
-		return EvidenceHealthStats{CurrentAEL: 1}, true
+		return EvidenceHealthStats{CurrentAEL: "AEL-1"}, true
 	})
-	if stats, ok := zero.EvidenceHealthStatsSnapshot(); !ok || stats.CurrentAEL != 1 {
-		t.Fatalf("zero-value health snapshot = (%+v, %v), want current_ael=1 ok", stats, ok)
+	if stats, ok := zero.EvidenceHealthStatsSnapshot(); !ok || stats.CurrentAEL != EvidenceCurrentAELUnavailable {
+		t.Fatalf("zero-value health snapshot = (%+v, %v), want current_ael=UNAVAILABLE ok", stats, ok)
 	}
 }
 
@@ -353,31 +355,10 @@ func TestEvidenceHealthUnmeasuredStatsNullAndDynamicGaugesAbsent(t *testing.T) {
 	}
 }
 
-func TestClampEvidenceCurrentAELBounds(t *testing.T) {
-	cases := []struct {
-		name     string
-		in, want int
-	}{
-		{name: "below minimum", in: -100, want: 0},
-		{name: "negative", in: -1, want: 0},
-		{name: "zero", in: 0, want: 0},
-		{name: "supported maximum", in: 1, want: 1},
-		{name: "above maximum", in: 2, want: evidenceMaximumSupportedAEL},
-		{name: "far above maximum", in: 4, want: evidenceMaximumSupportedAEL},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := clampEvidenceCurrentAEL(c.in); got != c.want {
-				t.Fatalf("clampEvidenceCurrentAEL(%d) = %d, want %d", c.in, got, c.want)
-			}
-		})
-	}
-}
-
-func TestEvidenceCollectorExportsCappedCurrentAEL(t *testing.T) {
+func TestEvidenceCollectorSeparatesLocalOperationFromDeprecatedAEL(t *testing.T) {
 	m := New()
 	m.SetEvidenceHealthFunc(func() (EvidenceHealthStats, bool) {
-		return EvidenceHealthStats{CurrentAEL: 4, ChainHeadSeq: 9}, true
+		return EvidenceHealthStats{CurrentAEL: "AEL-4", LocalRecorderOperational: true, ChainHeadSeq: 9}, true
 	})
 	reg := prometheus.NewPedanticRegistry()
 	if err := reg.Register(m.evidenceCollector); err != nil {
@@ -387,18 +368,24 @@ func TestEvidenceCollectorExportsCappedCurrentAEL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gather: %v", err)
 	}
-	found := false
+	foundCurrent := false
+	foundOperational := false
 	for _, fam := range fams {
-		if fam.GetName() != "pipelock_evidence_current_ael" {
-			continue
-		}
-		found = true
-		if v := fam.GetMetric()[0].GetGauge().GetValue(); v != 1 {
-			t.Fatalf("exported pipelock_evidence_current_ael = %v, want capped 1", v)
+		switch fam.GetName() {
+		case "pipelock_evidence_current_ael":
+			foundCurrent = true
+			if v := fam.GetMetric()[0].GetGauge().GetValue(); !math.IsNaN(v) {
+				t.Fatalf("exported pipelock_evidence_current_ael = %v, want NaN", v)
+			}
+		case "pipelock_evidence_local_recorder_operational":
+			foundOperational = true
+			if v := fam.GetMetric()[0].GetGauge().GetValue(); v != 1 {
+				t.Fatalf("exported pipelock_evidence_local_recorder_operational = %v, want 1", v)
+			}
 		}
 	}
-	if !found {
-		t.Fatal("pipelock_evidence_current_ael was not exported")
+	if !foundCurrent || !foundOperational {
+		t.Fatalf("metric presence current_ael=%v local_recorder_operational=%v, want both", foundCurrent, foundOperational)
 	}
 }
 


### PR DESCRIPTION
## What changed

Pipelock no longer publishes an evidence assurance level computed from its own running state. A live process cannot verify and grade its own output, so the number it exported was a self-assessment carrying the name of an independently earned grade.

Three honest surfaces replace it. A process-local operational signal reports whether this process has recording enabled, a healthy emitter, a passing local self-audit, no locally observed sequence gaps, and no ungated durability failures. A run lifecycle field reports the state of the current run. An artifact capability declaration states which evidence artifact formats and export operations this build supports, and names its own gaps instead of implying coverage it does not have.

The operational signal excludes optional features on purpose, so a healthy basic recorder is not reported unhealthy for declining to enable them. It also states what it does not prove: it describes one process and makes no claim about the integrity of a shared evidence directory.

Two defects surfaced while removing the old computation. The heartbeat condition sat in a rung above the supported ceiling, so it could never be evaluated and had no effect on the reported level. An enabled recorder on its own satisfied the lowest rung, which requires verifiable signatures, canonical payloads, and ordered commitments that only an exported artifact can demonstrate.

## Compatibility

Both previous surfaces remain for one release. The Prometheus gauge exports NaN, and the JSON field reports UNAVAILABLE. The JSON field changes from a number to a string deliberately, because a null decodes as zero in typed clients and would read as a real assurance level. The evidence health schema advances to v2. Do not aggregate the deprecated series across mixed versions; migrate to the operational signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that evidence health provides operational diagnostics, does not grade artifacts, and does not gate traffic.
  * Documented anchoring freshness and lag metrics, deprecated AEL surfaces, compatibility behavior, and migration guidance.
* **Improvements**
  * Added local recorder operational status and artifact capability reporting.
  * Deprecated AEL values now appear as unavailable.
  * Updated health reporting to schema version 2 with open, unbounded run tracking and enhanced lifecycle details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->