### PR TITLE
fix(metrics): derive adaptive session gauges from live state

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -176,7 +176,7 @@ metrics are both observability and enforcement context.
 | `pipelock_session_escalations_total` | counter | `from`, `to` | Escalation events by session enforcement level transition (e.g. `elevated` → `high`, `high` → `critical`). These transitions feed adaptive enforcement decisions on later requests. |
 | `pipelock_sessions_active` | gauge | (none) | Currently tracked sessions. |
 | `pipelock_sessions_evicted_total` | counter | (none) | Sessions evicted by TTL or capacity limit. |
-| `pipelock_adaptive_sessions_current` | gauge | `level` | Currently escalated sessions by enforcement level. |
+| `pipelock_adaptive_sessions_current` | gauge | `level` | Currently escalated sessions. Each logical session is counted once at its strongest effective global or destination-scoped level. |
 | `pipelock_session_auto_deescalation_total` | counter | `from`, `to` | Autonomous time-based session de-escalations. |
 
 ## Adaptive Enforcement Metrics

--- a/examples/prometheus/pipelock-alerts.yaml
+++ b/examples/prometheus/pipelock-alerts.yaml
@@ -231,14 +231,14 @@ groups:
       # --- Adaptive Enforcement ---
 
       - alert: PipelockHighEscalatedSessions
-        expr: sum by (instance) (pipelock_adaptive_sessions_current{level=~"block|critical"}) > 0
+        expr: sum by (instance) (pipelock_adaptive_sessions_current{level=~"high|critical"}) > 0
         for: 0m
         labels:
           severity: critical
         annotations:
-          summary: "Sessions at block/critical level on {{ $labels.instance }}"
+          summary: "Sessions at high/critical level on {{ $labels.instance }}"
           description: >-
-            {{ $value }} session(s) have been escalated to block or critical
+            {{ $value }} session(s) have been escalated to high or critical
             enforcement level due to sustained anomalous behavior.
 
       # --- Scan API ---

--- a/examples/prometheus/pipelock-alerts.yaml
+++ b/examples/prometheus/pipelock-alerts.yaml
@@ -85,16 +85,17 @@ groups:
       # --- Session Profiling ---
 
       - alert: PipelockSessionEscalation
-        expr: increase(pipelock_session_escalations_total{to="block"}[5m]) > 0
+        expr: increase(pipelock_session_escalations_total{to=~"high|critical"}[5m]) > 0
         for: 0m
         labels:
           severity: critical
         annotations:
-          summary: "Session threat score reached block level on {{ $labels.instance }}"
+          summary: "Session threat score reached high/critical level on {{ $labels.instance }}"
           description: >-
-            A session's threat score escalated from {{ $labels.from }} to block
-            due to sustained anomalous behavior. In v1 this is an observability
-            event; enforcement behavior is not automatically changed.
+            A session's threat score escalated from {{ $labels.from }} to
+            {{ $labels.to }} due to sustained anomalous behavior. Adaptive
+            enforcement can automatically upgrade later requests according to
+            the configured actions for this level.
 
       - alert: PipelockHighAnomalyRate
         expr: rate(pipelock_session_anomalies_total[10m]) > 1

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -61,7 +61,7 @@ type Metrics struct {
 	sessionsActive           prometheus.Gauge
 	sessionsEvicted          prometheus.Counter
 	adaptiveUpgrades         *prometheus.CounterVec
-	adaptiveSessionsCurrent  *prometheus.GaugeVec
+	adaptiveSessionsCurrent  *adaptiveSessionGauge
 	sessionAutoDeescalations *prometheus.CounterVec
 	chainDetections          *prometheus.CounterVec
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1717,6 +1717,72 @@ func TestSetAdaptiveSessionLevel_NilSafe(t *testing.T) {
 	m.SetAdaptiveSessionLevel("elevated", 1)
 }
 
+func TestAdaptiveSessionGauge_PreservesNegativeFallbackAndAggregatesSources(t *testing.T) {
+	m := New()
+	m.SetAdaptiveSessionLevel("elevated", -1)
+
+	scrape := func() string {
+		w := httptest.NewRecorder()
+		m.PrometheusHandler().ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+		return w.Body.String()
+	}
+	if body := scrape(); !strings.Contains(body, `pipelock_adaptive_sessions_current{level="elevated"} -1`) {
+		t.Fatalf("negative fallback gauge was hidden:\n%s", body)
+	}
+
+	removeOne := m.RegisterAdaptiveSessionState(func() map[string]float64 {
+		return map[string]float64{"elevated": 1}
+	})
+	removeTwo := m.RegisterAdaptiveSessionState(func() map[string]float64 {
+		return map[string]float64{"elevated": 2, "high": 1}
+	})
+
+	body := scrape()
+	for _, want := range []string{
+		`pipelock_adaptive_sessions_current{level="elevated"} 3`,
+		`pipelock_adaptive_sessions_current{level="high"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("source aggregation missing %q:\n%s", want, body)
+		}
+	}
+
+	// Removing an older manager must not erase the newer manager's source.
+	// This is the replacement-manager close ordering used during reloads.
+	removeOne()
+	body = scrape()
+	for _, want := range []string{
+		`pipelock_adaptive_sessions_current{level="elevated"} 2`,
+		`pipelock_adaptive_sessions_current{level="high"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("newer source was erased after older unregister, missing %q:\n%s", want, body)
+		}
+	}
+
+	// When the last authoritative source goes away, discarded transition
+	// history must not reappear. Previously observed labels stay as explicit
+	// zero series, matching GaugeVec's initialized-label behavior.
+	removeTwo()
+	body = scrape()
+	for _, want := range []string{
+		`pipelock_adaptive_sessions_current{level="elevated"} 0`,
+		`pipelock_adaptive_sessions_current{level="high"} 0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("last-source zero state missing %q:\n%s", want, body)
+		}
+	}
+
+	// A registry that has hosted an authoritative source must never resume
+	// transition accounting. Long-lived transports can retain a retired
+	// manager's recorder and emit a stale transition after reload.
+	m.SetAdaptiveSessionLevel("elevated", 1)
+	if body = scrape(); !strings.Contains(body, `pipelock_adaptive_sessions_current{level="elevated"} 0`) {
+		t.Fatalf("retired source repopulated transition fallback:\n%s", body)
+	}
+}
+
 func TestRecordFileSentryFinding(t *testing.T) {
 	m := New()
 	m.RecordFileSentryFinding("Anthropic API Key", "critical", true)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1747,8 +1747,9 @@ func TestAdaptiveSessionGauge_PreservesNegativeFallbackAndAggregatesSources(t *t
 		}
 	}
 
-	// Removing an older manager must not erase the newer manager's source.
-	// This is the replacement-manager close ordering used during reloads.
+	// Removing one independently registered source must not erase another.
+	// This exercises registration ownership; proxy reload retains its one active
+	// session manager and reconfigures it in place.
 	removeOne()
 	body = scrape()
 	for _, want := range []string{

--- a/internal/metrics/session.go
+++ b/internal/metrics/session.go
@@ -124,7 +124,8 @@ func (g *adaptiveSessionGauge) registerSource(source func() map[string]float64) 
 	g.authoritative = true
 	// A session manager source is authoritative. Discard prior transition
 	// deltas and never resume them on this registry: long-lived transports may
-	// retain a retired manager's recorder after reload and emit stale deltas.
+	// retain a recorder after a reload disables session profiling and emit stale
+	// deltas.
 	g.fallback = make(map[string]float64)
 	g.mu.Unlock()
 
@@ -250,10 +251,10 @@ func (m *Metrics) SetAdaptiveSessionLevel(level string, delta float64) {
 }
 
 // RegisterAdaptiveSessionState adds source to the authoritative current
-// adaptive-session gauge. Sources are summed, because independently created
-// session managers may share one Metrics registry. The returned function
-// unregisters only this source, so a manager that closes after a replacement
-// cannot clear the replacement.
+// adaptive-session gauge. Sources are summed for independently created session
+// managers that intentionally share one Metrics registry. The returned function
+// unregisters only its own source. The proxy runtime itself maintains one active
+// session manager and reconfigures it in place across enabled-to-enabled reloads.
 func (m *Metrics) RegisterAdaptiveSessionState(source func() map[string]float64) func() {
 	if m == nil || source == nil {
 		return func() {}

--- a/internal/metrics/session.go
+++ b/internal/metrics/session.go
@@ -3,7 +3,138 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"sort"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// adaptiveSessionGauge is a state-backed collector for the current adaptive
+// enforcement levels. Transition deltas are inherently lossy across reloads
+// and restored session state: a later de-escalation can otherwise decrement a
+// fresh registry below zero. Session managers therefore supply current state
+// at scrape time. The fallback is retained for metrics-only callers that do
+// not have a SessionManager.
+type adaptiveSessionGauge struct {
+	desc *prometheus.Desc
+
+	mu            sync.RWMutex
+	sources       map[uint64]*adaptiveSessionSource
+	sourceID      uint64
+	authoritative bool
+	fallback      map[string]float64
+	// observed retains labels that this process has already exposed. GaugeVec
+	// keeps an initialized label at zero after its value is decremented, and
+	// alerting/dashboards may distinguish that from an absent time series.
+	observed map[string]struct{}
+}
+
+type adaptiveSessionSource struct {
+	mu      sync.RWMutex
+	active  bool
+	collect func() map[string]float64
+}
+
+func (s *adaptiveSessionSource) values() map[string]float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.active {
+		return nil
+	}
+	return s.collect()
+}
+
+func (s *adaptiveSessionSource) deactivate() {
+	s.mu.Lock()
+	s.active = false
+	s.mu.Unlock()
+}
+
+func newAdaptiveSessionGauge() *adaptiveSessionGauge {
+	return &adaptiveSessionGauge{
+		desc: prometheus.NewDesc(
+			"pipelock_adaptive_sessions_current",
+			"Currently escalated sessions by effective enforcement level.",
+			[]string{"level"}, nil,
+		),
+		sources:  make(map[uint64]*adaptiveSessionSource),
+		fallback: make(map[string]float64),
+		observed: make(map[string]struct{}),
+	}
+}
+
+func (g *adaptiveSessionGauge) Describe(ch chan<- *prometheus.Desc) {
+	ch <- g.desc
+}
+
+func (g *adaptiveSessionGauge) Collect(ch chan<- prometheus.Metric) {
+	g.mu.RLock()
+	sources := make([]*adaptiveSessionSource, 0, len(g.sources))
+	for _, source := range g.sources {
+		sources = append(sources, source)
+	}
+	values := make(map[string]float64, len(g.fallback)+len(g.observed))
+	for level := range g.observed {
+		values[level] = 0
+	}
+	if !g.authoritative {
+		for level, value := range g.fallback {
+			values[level] = value
+		}
+	}
+	g.mu.RUnlock()
+	for _, source := range sources {
+		for level, value := range source.values() {
+			values[level] += value
+			g.mu.Lock()
+			g.observed[level] = struct{}{}
+			g.mu.Unlock()
+		}
+	}
+
+	levels := make([]string, 0, len(values))
+	for level := range values {
+		levels = append(levels, level)
+	}
+	sort.Strings(levels)
+	for _, level := range levels {
+		metric, err := prometheus.NewConstMetric(g.desc, prometheus.GaugeValue, values[level], level)
+		if err == nil {
+			ch <- metric
+		}
+	}
+}
+
+func (g *adaptiveSessionGauge) add(level string, delta float64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.observed[level] = struct{}{}
+	if !g.authoritative {
+		g.fallback[level] += delta
+	}
+}
+
+func (g *adaptiveSessionGauge) registerSource(source func() map[string]float64) func() {
+	registered := &adaptiveSessionSource{active: true, collect: source}
+	g.mu.Lock()
+	g.sourceID++
+	id := g.sourceID
+	g.sources[id] = registered
+	g.authoritative = true
+	// A session manager source is authoritative. Discard prior transition
+	// deltas and never resume them on this registry: long-lived transports may
+	// retain a retired manager's recorder after reload and emit stale deltas.
+	g.fallback = make(map[string]float64)
+	g.mu.Unlock()
+
+	return func() {
+		registered.deactivate()
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		delete(g.sources, id)
+	}
+}
 
 // registerSessionMetrics builds and registers session anomaly/escalation
 // counters, the active/evicted session lifecycle metrics, adaptive
@@ -41,11 +172,7 @@ func (m *Metrics) registerSessionMetrics(reg *prometheus.Registry) {
 		Help:      "Requests where adaptive enforcement upgraded the action (e.g. warn→block).",
 	}, []string{"from_action", "to_action", "level"})
 
-	m.adaptiveSessionsCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "pipelock",
-		Name:      "adaptive_sessions_current",
-		Help:      "Currently escalated sessions by enforcement level.",
-	}, []string{"level"})
+	m.adaptiveSessionsCurrent = newAdaptiveSessionGauge()
 
 	m.sessionAutoDeescalations = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pipelock_session_auto_deescalation_total",
@@ -112,13 +239,26 @@ func (m *Metrics) RecordAdaptiveUpgrade(fromAction, toAction, level string) {
 	m.adaptiveUpgrades.WithLabelValues(fromAction, toAction, level).Inc()
 }
 
-// SetAdaptiveSessionLevel adjusts the gauge tracking currently escalated sessions
-// at the given level by delta (positive to increment, negative to decrement).
+// SetAdaptiveSessionLevel adjusts the fallback gauge for callers without a
+// SessionManager. A registered SessionManager state source overrides these
+// deltas at scrape time.
 func (m *Metrics) SetAdaptiveSessionLevel(level string, delta float64) {
 	if m == nil {
 		return
 	}
-	m.adaptiveSessionsCurrent.WithLabelValues(level).Add(delta)
+	m.adaptiveSessionsCurrent.add(level, delta)
+}
+
+// RegisterAdaptiveSessionState adds source to the authoritative current
+// adaptive-session gauge. Sources are summed, because independently created
+// session managers may share one Metrics registry. The returned function
+// unregisters only this source, so a manager that closes after a replacement
+// cannot clear the replacement.
+func (m *Metrics) RegisterAdaptiveSessionState(source func() map[string]float64) func() {
+	if m == nil || source == nil {
+		return func() {}
+	}
+	return m.adaptiveSessionsCurrent.registerSource(source)
 }
 
 // RecordSessionAutoDeescalation increments the auto-deescalation counter for

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1171,14 +1171,15 @@ type SessionManager struct {
 	ipDomains       map[string][]domainEntry
 	ipBurstCooldown map[string]time.Time // per-IP burst cooldown timestamps
 
-	cfgPtr         atomic.Pointer[config.SessionProfiling]
-	adaptiveCfgPtr atomic.Pointer[config.AdaptiveEnforcement]
-	airlockCfgPtr  atomic.Pointer[config.Airlock]
-	metrics        *metrics.Metrics // nil-safe; used for gauge/counter updates
-	logger         *audit.Logger    // nil-safe; used for airlock de-escalation logging
-	done           chan struct{}
-	closed         sync.Once
-	maintenance    sync.Once
+	cfgPtr          atomic.Pointer[config.SessionProfiling]
+	adaptiveCfgPtr  atomic.Pointer[config.AdaptiveEnforcement]
+	airlockCfgPtr   atomic.Pointer[config.Airlock]
+	metrics         *metrics.Metrics // nil-safe; used for gauge/counter updates
+	unregisterGauge func()
+	logger          *audit.Logger // nil-safe; used for airlock de-escalation logging
+	done            chan struct{}
+	closed          sync.Once
+	maintenance     sync.Once
 
 	// Behavioral baseline: profile-then-lock analysis.
 	// nil when behavioral_baseline.enabled is false.
@@ -1205,6 +1206,9 @@ func NewSessionManager(cfg *config.SessionProfiling, adaptiveCfg *config.Adaptiv
 	}
 	sm.cfgPtr.Store(cfg)
 	sm.adaptiveCfgPtr.Store(adaptiveCfg)
+	if m != nil {
+		sm.unregisterGauge = m.RegisterAdaptiveSessionState(sm.AdaptiveSessionLevelCounts)
+	}
 	if len(opts) > 0 {
 		if opts[0].AirlockCfg != nil {
 			sm.airlockCfgPtr.Store(opts[0].AirlockCfg)
@@ -1622,7 +1626,54 @@ func (s *SessionState) recomputeScopedBlockAll(adaptiveCfg *config.AdaptiveEnfor
 func (sm *SessionManager) Close() {
 	sm.closed.Do(func() {
 		close(sm.done)
+		if sm.unregisterGauge != nil {
+			sm.unregisterGauge()
+		}
 	})
+}
+
+// AdaptiveSessionLevelCounts returns the current number of escalated adaptive
+// sessions by effective enforcement level. It is the authoritative source for
+// pipelock_adaptive_sessions_current: unlike transition accounting, this stays
+// correct when a session survives a reload or is recovered after metrics state
+// was lost. A session contributes once at its strongest live global-or-scoped
+// enforcement level, which matches the metric's "sessions" contract even when
+// several destination lanes are active concurrently.
+func (sm *SessionManager) AdaptiveSessionLevelCounts() map[string]float64 {
+	counts := make(map[string]float64)
+	if sm == nil {
+		return counts
+	}
+
+	// Snapshot session pointers under the manager lock, then release it before
+	// taking individual session locks. Several lifecycle paths acquire these
+	// locks in the opposite order, so holding sm.mu here would risk a scrape
+	// deadlock. Removed sessions remain valid Go objects; a concurrent eviction
+	// may make one scrape briefly stale, but the next scrape reconciles from the
+	// current map and cannot go negative.
+	sm.mu.RLock()
+	sessions := make([]*SessionState, 0, len(sm.sessions))
+	for _, sess := range sm.sessions {
+		sessions = append(sessions, sess)
+	}
+	sm.mu.RUnlock()
+	for _, sess := range sessions {
+		sess.mu.Lock()
+		level := 0
+		if sess.globalSignalsAuthoritative {
+			level = sess.escalationLevel
+		}
+		for _, scoped := range sess.scopes {
+			if scoped.escalationLevel > level {
+				level = scoped.escalationLevel
+			}
+		}
+		if level > 0 {
+			counts[session.EscalationLabel(level)]++
+		}
+		sess.mu.Unlock()
+	}
+	return counts
 }
 
 // Snapshot returns a sorted read-only snapshot of all sessions.

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1206,14 +1206,14 @@ func NewSessionManager(cfg *config.SessionProfiling, adaptiveCfg *config.Adaptiv
 	}
 	sm.cfgPtr.Store(cfg)
 	sm.adaptiveCfgPtr.Store(adaptiveCfg)
-	if m != nil {
-		sm.unregisterGauge = m.RegisterAdaptiveSessionState(sm.AdaptiveSessionLevelCounts)
-	}
 	if len(opts) > 0 {
 		if opts[0].AirlockCfg != nil {
 			sm.airlockCfgPtr.Store(opts[0].AirlockCfg)
 		}
 		sm.logger = opts[0].Logger
+	}
+	if m != nil {
+		sm.unregisterGauge = m.RegisterAdaptiveSessionState(sm.AdaptiveSessionLevelCounts)
 	}
 
 	return sm

--- a/internal/proxy/session_test.go
+++ b/internal/proxy/session_test.go
@@ -2021,6 +2021,17 @@ func TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement(t *testing.T) {
 		t.Errorf("expected deescalation counter %q", wantCounter)
 	}
 
+	// The session was restored at an elevated level (as happens after a stale
+	// metric registry/reload) without a matching prior gauge increment. The
+	// gauge must be derived from the live session state rather than driven
+	// negative by this recovery transition.
+	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
+		t.Fatalf("elevated gauge after recovery = %.0f, want 0 from live session state", got)
+	}
+	if !scrapeMetric(t, m, `pipelock_adaptive_sessions_current{level="`+testLevelElevated+`"} 0`) {
+		t.Fatal("recovered elevated label disappeared; GaugeVec-compatible scrape must expose zero")
+	}
+
 	// The "normal" level gauge should NOT have been incremented (to > 0 guard).
 	// Gather raw metrics and check that "normal" label does not appear in
 	// pipelock_adaptive_sessions_current.
@@ -2039,6 +2050,117 @@ func TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// TestSessionManager_AdaptiveGaugeDerivesFromLiveState proves the gauge follows
+// the session manager rather than the history of metric transition calls. It
+// covers the shared HTTP/MCP scoped transition helper as well as the legacy
+// session-wide lane.
+func TestSessionManager_AdaptiveGaugeDerivesFromLiveState(t *testing.T) {
+	cfg := testSessionConfig()
+	m := metrics.New()
+	adaptiveCfg := &config.AdaptiveEnforcement{
+		Enabled:                   true,
+		DecayPerCleanRequest:      0.5,
+		CleanRequestsToDeescalate: 1,
+	}
+	sm := NewSessionManager(cfg, adaptiveCfg, m)
+	defer sm.Close()
+
+	sess := sm.GetOrCreate("adaptive-gauge-client")
+	params := decide.EscalationParams{Threshold: 3, Metrics: m, Session: "adaptive-gauge-client"}
+
+	// Legacy/global HTTP lane: a real escalation emits its event counter and
+	// the state-derived gauge becomes 1.
+	recordAdaptiveSignalForScope(sess, "", session.SignalBlock, adaptiveCfg, params)
+	if got := adaptiveElevatedGaugeValue(t, m); got != 1 {
+		t.Fatalf("global escalation gauge = %.0f, want 1", got)
+	}
+	recordCleanForAdaptiveScope(sess, "", adaptiveCfg, true, adaptiveRecoveryContext{metrics: m})
+	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
+		t.Fatalf("global recovery gauge = %.0f, want 0", got)
+	}
+
+	// Destination-scoped lanes are the shared HTTP/MCP path. They must count
+	// independently while active and return to an explicit zero on recovery.
+	scope := adaptiveScopeForHost("metrics.vendor.example")
+	scopedSess := sm.GetOrCreate("adaptive-gauge-scoped-client")
+	scopedParams := decide.EscalationParams{Threshold: 3, Metrics: m, Session: "adaptive-gauge-scoped-client"}
+	recordAdaptiveSignalForScope(scopedSess, scope, session.SignalBlock, adaptiveCfg, scopedParams)
+	if got := adaptiveElevatedGaugeValue(t, m); got != 1 {
+		t.Fatalf("scoped escalation gauge = %.0f, want 1", got)
+	}
+	recordCleanForAdaptiveScope(scopedSess, scope, adaptiveCfg, true, adaptiveRecoveryContext{scope: scope, metrics: m})
+	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
+		t.Fatalf("scoped recovery gauge = %.0f, want 0", got)
+	}
+
+	// Reload retains this manager and its live session state; reset then removes
+	// it. Neither path may depend on a paired historical gauge delta.
+	recordAdaptiveSignalForScope(sess, "", session.SignalBlock, adaptiveCfg, params)
+	sm.UpdateConfig(cfg, adaptiveCfg, nil)
+	if got := adaptiveElevatedGaugeValue(t, m); got != 1 {
+		t.Fatalf("reload-preserved gauge = %.0f, want 1", got)
+	}
+	if reset, skipped := sm.ResetAllIdentitySessions(); reset != 2 || skipped != 0 {
+		t.Fatalf("ResetAllIdentitySessions = reset %d skipped %d, want 2/0", reset, skipped)
+	}
+	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
+		t.Fatalf("reset gauge = %.0f, want 0", got)
+	}
+
+	if !scrapeMetric(t, m, `pipelock_session_escalations_total{from="normal",to="elevated"} 3`) {
+		t.Fatal("escalation counter lost transition semantics")
+	}
+	if !scrapeMetric(t, m, `pipelock_session_auto_deescalation_total{from="elevated",to="normal"} 2`) {
+		t.Fatal("de-escalation counter lost transition semantics")
+	}
+}
+
+func TestSessionManager_AdaptiveGaugeCountsOneStrongestLevelPerSession(t *testing.T) {
+	m := metrics.New()
+	sm := NewSessionManager(testSessionConfig(), nil, m)
+	defer sm.Close()
+
+	// A single logical session can have several destination lanes active. The
+	// metric is explicitly a session count, so it exposes that session once at
+	// its strongest effective enforcement level rather than once per lane.
+	sess := sm.GetOrCreate("multi-scope-gauge-client")
+	sess.mu.Lock()
+	sess.getOrCreateScopeLocked(adaptiveScopeForHost("first.vendor.example")).escalationLevel = 1
+	sess.getOrCreateScopeLocked(adaptiveScopeForHost("second.vendor.example")).escalationLevel = 2
+	sess.mu.Unlock()
+
+	if got := sm.AdaptiveSessionLevelCounts(); len(got) != 1 || got[testLevelHigh] != 1 {
+		t.Fatalf("AdaptiveSessionLevelCounts = %#v, want one high session", got)
+	}
+	if !scrapeMetric(t, m, `pipelock_adaptive_sessions_current{level="`+testLevelHigh+`"} 1`) {
+		t.Fatal("strongest active scoped level was not exposed")
+	}
+	if scrapeMetric(t, m, `pipelock_adaptive_sessions_current{level="`+testLevelElevated+`"} 1`) {
+		t.Fatal("one multi-scope session was counted once per active lane")
+	}
+}
+
+func TestSessionManager_CloseFencesRetainedRecorderGauge(t *testing.T) {
+	m := metrics.New()
+	adaptiveCfg := &config.AdaptiveEnforcement{Enabled: true, EscalationThreshold: 3}
+	sm := NewSessionManager(testSessionConfig(), adaptiveCfg, m)
+	sess := sm.GetOrCreate("retained-transport-client")
+	sm.Close()
+
+	// WebSocket and intercepted tunnel lifetimes can retain a recorder after a
+	// reload closes its manager. Enforcement continues from that retained state,
+	// but its transition must not revive a current-session gauge owned by the
+	// retired manager.
+	params := decide.EscalationParams{Threshold: 3, Metrics: m, Session: "retained-transport-client"}
+	recordAdaptiveSignalForScope(sess, "", session.SignalBlock, adaptiveCfg, params)
+	if !sess.IsEscalated() {
+		t.Fatal("retained recorder did not preserve its enforcement state")
+	}
+	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
+		t.Fatalf("retired recorder repopulated elevated gauge = %.0f, want 0", got)
 	}
 }
 

--- a/internal/proxy/session_test.go
+++ b/internal/proxy/session_test.go
@@ -1982,17 +1982,17 @@ func TestSessionManager_SweepNilMetrics(t *testing.T) {
 	}
 }
 
-// TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement verifies that
-// when a session de-escalates to level 0, the sweep emits the deescalation
-// counter but does NOT call SetAdaptiveSessionLevel for the "normal" label
-// (the to > 0 guard prevents incrementing a gauge for un-escalated sessions).
+// TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement verifies that a
+// live-state elevation followed by time-based recovery emits the deescalation
+// counter, keeps the observed elevated label at zero, and does not increment
+// the normal label.
 func TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement(t *testing.T) {
 	cfg := testSessionConfig()
 	m := metrics.New()
 	blockAllTrue := true
 	adaptiveCfg := &config.AdaptiveEnforcement{
 		Enabled:             true,
-		EscalationThreshold: 5.0,
+		EscalationThreshold: 3.0,
 		Levels: config.EscalationLevels{
 			Critical: config.EscalationActions{BlockAll: &blockAllTrue},
 		},
@@ -2000,13 +2000,22 @@ func TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement(t *testing.T) {
 	sm := NewSessionManager(cfg, adaptiveCfg, m)
 	defer sm.Close()
 
-	// Single session at level 1 (elevated), will recover to level 0 (normal).
+	// Drive an actual adaptive signal and scrape while it is elevated. This
+	// registers the label via the authoritative live-state source, rather than
+	// through the legacy transition-delta compatibility lane.
 	sess := sm.GetOrCreate("to-zero-client")
+	recordAdaptiveSignalForScope(sess, "", session.SignalBlock, adaptiveCfg, decide.EscalationParams{
+		Threshold: adaptiveCfg.EscalationThreshold,
+		Metrics:   m,
+		Session:   "to-zero-client",
+	})
+	if got := adaptiveElevatedGaugeValue(t, m); got != 1 {
+		t.Fatalf("elevated gauge before recovery = %.0f, want 1 from live session state", got)
+	}
+
+	// Advance this live elevation beyond the recovery interval.
 	sess.mu.Lock()
-	sess.escalationLevel = 1
 	sess.lastEscalation = time.Now().Add(-6 * time.Minute)
-	sess.currentThreshold = 10.0
-	sess.threatScore = 5.0
 	sess.mu.Unlock()
 
 	sm.sweepDeescalation()
@@ -2021,10 +2030,8 @@ func TestSessionManager_SweepMetrics_ToZeroSkipsGaugeIncrement(t *testing.T) {
 		t.Errorf("expected deescalation counter %q", wantCounter)
 	}
 
-	// The session was restored at an elevated level (as happens after a stale
-	// metric registry/reload) without a matching prior gauge increment. The
-	// gauge must be derived from the live session state rather than driven
-	// negative by this recovery transition.
+	// The gauge is derived from the now-recovered live session state rather than
+	// from the recovery transition delta.
 	if got := adaptiveElevatedGaugeValue(t, m); got != 0 {
 		t.Fatalf("elevated gauge after recovery = %.0f, want 0 from live session state", got)
 	}
@@ -2151,9 +2158,9 @@ func TestSessionManager_CloseFencesRetainedRecorderGauge(t *testing.T) {
 	sm.Close()
 
 	// WebSocket and intercepted tunnel lifetimes can retain a recorder after a
-	// reload closes its manager. Enforcement continues from that retained state,
-	// but its transition must not revive a current-session gauge owned by the
-	// retired manager.
+	// reload disables session profiling and closes its manager. Enforcement
+	// continues from that retained state, but its transition must not revive a
+	// current-session gauge owned by the retired manager.
 	params := decide.EscalationParams{Threshold: 3, Metrics: m, Session: "retained-transport-client"}
 	recordAdaptiveSignalForScope(sess, "", session.SignalBlock, adaptiveCfg, params)
 	if !sess.IsEscalated() {


### PR DESCRIPTION
`pipelock_adaptive_sessions_current` now derives its values from live session-manager state instead of paired transition deltas. This prevents negative or stale counts after recovery, reset, eviction, and reload.

Each logical session contributes once at its strongest effective global or destination-scoped level. Closing a manager permanently retires its source, so retained long-lived transports cannot revive stale counts. The Prometheus alert example now matches the actual `high` and `critical` level labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive session metrics to accurately reflect live session state.
  * Ensured each session is counted once at its strongest applicable enforcement level.
  * Preserved zero-valued labels and cleared metrics correctly after recovery, resets, or session manager closure.
  * Updated high-escalation alerts to trigger for both high and critical enforcement levels.

* **Documentation**
  * Clarified how adaptive sessions are counted in the metrics documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->