### PR TITLE
fix(conductor): expose build info in metrics

### DIFF
--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -82,6 +82,18 @@ type controlKeySpec struct {
 	purpose signing.KeyPurpose
 }
 
+type serveHandler struct {
+	*controlplane.Handler
+	auditStore *controlplane.SQLiteAuditStore
+}
+
+func (h *serveHandler) Close() error {
+	if h == nil || h.auditStore == nil {
+		return nil
+	}
+	return h.auditStore.Close()
+}
+
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conductor",
@@ -175,6 +187,7 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = handler.Close() }()
 	serverCert, err := tlsfile.LoadX509KeyPair(opts.tlsCert, opts.tlsKey)
 	if err != nil {
 		return fmt.Errorf("load Conductor server TLS identity: %w", err)
@@ -259,7 +272,7 @@ func runServe(cmd *cobra.Command, opts serveOptions) error {
 	return firstErr
 }
 
-func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, http.Handler, *tls.Config, error) {
+func buildServeHandler(ctx context.Context, opts serveOptions) (*serveHandler, http.Handler, *tls.Config, error) {
 	if strings.TrimSpace(opts.storageDir) == "" {
 		return nil, nil, nil, errors.New("--storage-dir is required")
 	}
@@ -354,6 +367,12 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	keepAuditStore := false
+	defer func() {
+		if !keepAuditStore {
+			_ = auditStore.Close()
+		}
+	}()
 	if opts.auditRetention > 0 {
 		result, err := auditStore.PruneAuditBatchesBefore(ctx, time.Now().UTC().Add(-opts.auditRetention))
 		if err != nil {
@@ -411,7 +430,8 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 	if err := ctx.Err(); err != nil {
 		return nil, nil, nil, err
 	}
-	return handler, handler.ProbeHandler(), tlsConfig, nil
+	keepAuditStore = true
+	return &serveHandler{Handler: handler, auditStore: auditStore}, handler.ProbeHandler(), tlsConfig, nil
 }
 
 func conductorRequestLogger(w io.Writer) *slog.Logger {

--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -26,6 +26,7 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -374,6 +375,7 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (http.Handler, ht
 		return nil, nil, nil, err
 	}
 	m := metrics.New()
+	m.RegisterInfo(cliutil.Version)
 	m.RecordConductorPolicyHashStatusCounts(store.PolicyHashStatusCounts())
 	handler, err := controlplane.NewHandler(controlplane.HandlerOptions{
 		Store:              store,

--- a/enterprise/cli/conductor/cmd_test.go
+++ b/enterprise/cli/conductor/cmd_test.go
@@ -97,6 +97,11 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildServeHandler() error = %v", err)
 	}
+	t.Cleanup(func() {
+		if err := handler.Close(); err != nil {
+			t.Errorf("close initial audit store: %v", err)
+		}
+	})
 	if tlsConfig.ClientAuth != tls.RequireAndVerifyClientCert || tlsConfig.MinVersion != tls.VersionTLS13 {
 		t.Fatalf("TLS config = %+v", tlsConfig)
 	}
@@ -139,15 +144,30 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	// A restarted Conductor gets a new registry. Rebuilding from the same
 	// options must expose one info series, not panic from duplicate registration
 	// or omit the version on the replacement probe handler.
-	_, rebuiltProbeHandler, _, err := buildServeHandler(context.Background(), opts)
+	if err := handler.Close(); err != nil {
+		t.Fatalf("close initial audit store: %v", err)
+	}
+	if _, err := handler.auditStore.ListAuditBatches(context.Background(), controlplane.AuditBatchQuery{OrgID: "org-main"}); err == nil {
+		t.Fatal("initial audit store remained usable after Close")
+	}
+	rebuiltHandler, rebuiltProbeHandler, _, err := buildServeHandler(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("rebuild serve handler: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := rebuiltHandler.Close(); err != nil {
+			t.Errorf("close rebuilt audit store: %v", err)
+		}
+	})
 	w = httptest.NewRecorder()
 	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.MetricsPath, nil)
 	rebuiltProbeHandler.ServeHTTP(w, req)
-	if got := strings.Count(w.Body.String(), `pipelock_info{version="`+cliutil.Version+`"} 1`); got != 1 {
-		t.Fatalf("rebuilt metrics info series count = %d, want 1:\n%s", got, w.Body.String())
+	metricsBody = w.Body.String()
+	if got := strings.Count(metricsBody, "pipelock_info{"); got != 1 {
+		t.Fatalf("rebuilt metrics info family count = %d, want 1:\n%s", got, metricsBody)
+	}
+	if !strings.Contains(metricsBody, `pipelock_info{version="`+cliutil.Version+`"} 1`) {
+		t.Fatalf("rebuilt metrics body missing build info for version %q:\n%s", cliutil.Version, metricsBody)
 	}
 }
 
@@ -227,6 +247,11 @@ func TestBuildServeHandlerFleetSkewOverrideUsesAdminCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildServeHandler: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := handler.Close(); err != nil {
+			t.Errorf("close audit store: %v", err)
+		}
+	})
 
 	keyPath, _ := writePolicyKeyFile(t, dir, wantPurposeFlag, "policy-key-override")
 	cfgPath := writeFile(t, dir, "policy.yaml", testConfigYAML)
@@ -295,7 +320,7 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 	if err := os.WriteFile(tokenPath, []byte("secret-token\n"), 0o600); err != nil {
 		t.Fatalf("WriteFile(token): %v", err)
 	}
-	_, _, _, err = buildServeHandler(context.Background(), serveOptions{
+	validHandler, _, _, err := buildServeHandler(context.Background(), serveOptions{
 		storageDir:          filepath.Join(dir, "store"),
 		followerTrustDomain: defaultTrustDomain,
 		tlsCert:             "server.pem",
@@ -391,6 +416,11 @@ func TestBuildServeHandlerRequiresAuthInputs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildServeHandler(no trusted audit keys) error = %v, want nil", err)
 	}
+	t.Cleanup(func() {
+		if err := validHandler.Close(); err != nil {
+			t.Errorf("close audit store: %v", err)
+		}
+	})
 }
 
 func TestBuildServeHandlerRejectsNegativeAuditRetention(t *testing.T) {
@@ -478,6 +508,11 @@ func TestBuildServeHandlerPrunesAuditRetention(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildServeHandler(retention) error = %v", err)
 	}
+	t.Cleanup(func() {
+		if err := handler.Close(); err != nil {
+			t.Errorf("close audit store: %v", err)
+		}
+	})
 	if handler == nil {
 		t.Fatal("buildServeHandler(retention) handler = nil")
 	}

--- a/enterprise/cli/conductor/cmd_test.go
+++ b/enterprise/cli/conductor/cmd_test.go
@@ -27,6 +27,7 @@ import (
 
 	conductorcore "github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -71,7 +72,7 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 		t.Fatalf("WriteFile(ca): %v", err)
 	}
 
-	handler, probeHandler, tlsConfig, err := buildServeHandler(context.Background(), serveOptions{
+	opts := serveOptions{
 		listen:              defaultListen,
 		storageDir:          filepath.Join(dir, "store"),
 		conductorID:         "conductor-test",
@@ -91,7 +92,8 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 		tlsCert:  filepath.Join(dir, "server.pem"),
 		tlsKey:   filepath.Join(dir, "server.key"),
 		clientCA: caPath,
-	})
+	}
+	handler, probeHandler, tlsConfig, err := buildServeHandler(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("buildServeHandler() error = %v", err)
 	}
@@ -129,6 +131,23 @@ func TestBuildServeHandlerWiresControlPlane(t *testing.T) {
 	}
 	if !strings.Contains(metricsBody, `pipelock_conductor_policy_bundle_policy_hash_status_count{status="unknown_unverified"} 0`) {
 		t.Fatalf("metrics body missing policy hash status gauge:\n%s", metricsBody)
+	}
+	if !strings.Contains(metricsBody, `pipelock_info{version="`+cliutil.Version+`"} 1`) {
+		t.Fatalf("metrics body missing build info for version %q:\n%s", cliutil.Version, metricsBody)
+	}
+
+	// A restarted Conductor gets a new registry. Rebuilding from the same
+	// options must expose one info series, not panic from duplicate registration
+	// or omit the version on the replacement probe handler.
+	_, rebuiltProbeHandler, _, err := buildServeHandler(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("rebuild serve handler: %v", err)
+	}
+	w = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, controlplane.MetricsPath, nil)
+	rebuiltProbeHandler.ServeHTTP(w, req)
+	if got := strings.Count(w.Body.String(), `pipelock_info{version="`+cliutil.Version+`"} 1`); got != 1 {
+		t.Fatalf("rebuilt metrics info series count = %d, want 1:\n%s", got, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
Conductor’s probe listener now exposes `pipelock_info{version="..."} 1`, matching the main proxy metrics surface.

The metric uses the existing build version and a fresh per-process registry, so restarts expose exactly one info series.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conductor metrics now report the current application build version.

* **Bug Fixes**
  * Prevented duplicate application information metrics when the service handler is rebuilt.
  * Ensured version information remains available after metrics registry replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->