### PR TITLE
fix(taint): make MCP action classification deterministic for multi-target calls

### DIFF
--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -64,6 +65,7 @@ type taintDecision struct {
 	Authority           session.AuthorityKind
 	Result              session.PolicyDecisionResult
 	ActionRef           string
+	OverrideRefs        []string
 	RequiresReauth      bool
 	TaskOverrideApplied bool
 }
@@ -107,9 +109,10 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 	decision.Sensitivity = classified.Sensitivity
 	decision.ActionRef = classified.ActionRef
 	decision.ActionRef = mcpActionRef(toolName, decision.ActionRef)
+	decision.OverrideRefs = mcpOverrideRefs(toolName, classified.OverrideRefs, decision.ActionRef)
 	if tp, ok := opts.Rec.(session.TaskContextProvider); ok {
 		decision.Task = tp.TaskSnapshot()
-		if taintRuntimeTrustOverrideApplies(tp.RuntimeTrustOverrides(), decision.Task, decision.Risk, decision.ActionRef) {
+		if taintRuntimeTrustOverrideApplies(tp.RuntimeTrustOverrides(), decision.Task, decision.Risk, decision.OverrideRefs) {
 			decision.Result = session.PolicyDecisionResult{
 				Decision: session.PolicyAllow,
 				Reason:   "taint_runtime_task_override",
@@ -128,7 +131,7 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 			ClassificationConfident: classified.Confident,
 		},
 	)
-	if taintTrustOverrideApplies(taintCfg.TrustOverrides, decision.Risk, decision.ActionRef) {
+	if taintTrustOverrideApplies(taintCfg.TrustOverrides, decision.Risk, decision.OverrideRefs) {
 		decision.Result = session.PolicyDecisionResult{
 			Decision: session.PolicyAllow,
 			Reason:   "taint_trust_override",
@@ -173,12 +176,26 @@ func mcpActionRef(toolName, target string) string {
 	return strings.Join(parts, ":")
 }
 
-func taintTrustOverrideApplies(overrides []config.TaintTrustOverride, risk session.SessionRisk, actionRef string) bool {
+func mcpOverrideRefs(toolName string, targets []string, primary string) []string {
+	if len(targets) == 0 {
+		return []string{primary}
+	}
+	refs := make([]string, 0, len(targets))
+	for _, target := range targets {
+		ref := mcpActionRef(toolName, target)
+		if !slices.Contains(refs, ref) {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+func taintTrustOverrideApplies(overrides []config.TaintTrustOverride, risk session.SessionRisk, actionRefs []string) bool {
 	for _, override := range overrides {
 		if !override.ExpiresAt.IsZero() && override.ExpiresAt.Before(time.Now().UTC()) {
 			continue
 		}
-		if !taintOverrideMatches(override, risk, actionRef) {
+		if !taintOverrideMatches(override, risk, actionRefs) {
 			continue
 		}
 		return true
@@ -186,10 +203,10 @@ func taintTrustOverrideApplies(overrides []config.TaintTrustOverride, risk sessi
 	return false
 }
 
-func taintOverrideMatches(override config.TaintTrustOverride, risk session.SessionRisk, actionRef string) bool {
+func taintOverrideMatches(override config.TaintTrustOverride, risk session.SessionRisk, actionRefs []string) bool {
 	switch override.Scope {
 	case taintScopeAction:
-		if override.ActionMatch == "" || !taintWildcardMatch(actionRef, override.ActionMatch) {
+		if override.ActionMatch == "" || !allTaintActionRefsMatch(actionRefs, override.ActionMatch) {
 			return false
 		}
 		if override.SourceMatch != "" && !taintRiskSourceMatches(risk, override.SourceMatch) {
@@ -200,7 +217,7 @@ func taintOverrideMatches(override config.TaintTrustOverride, risk session.Sessi
 		if override.SourceMatch == "" || !taintRiskSourceMatches(risk, override.SourceMatch) {
 			return false
 		}
-		if override.ActionMatch != "" && !taintWildcardMatch(actionRef, override.ActionMatch) {
+		if override.ActionMatch != "" && !allTaintActionRefsMatch(actionRefs, override.ActionMatch) {
 			return false
 		}
 		return true
@@ -209,7 +226,7 @@ func taintOverrideMatches(override config.TaintTrustOverride, risk session.Sessi
 	}
 }
 
-func taintRuntimeTrustOverrideApplies(overrides []session.TrustOverride, task session.TaskContext, risk session.SessionRisk, actionRef string) bool {
+func taintRuntimeTrustOverrideApplies(overrides []session.TrustOverride, task session.TaskContext, risk session.SessionRisk, actionRefs []string) bool {
 	now := time.Now().UTC()
 	for _, override := range overrides {
 		if override.Scope != taintScopeTask {
@@ -221,7 +238,7 @@ func taintRuntimeTrustOverrideApplies(overrides []session.TrustOverride, task se
 		if !override.ExpiresAt.IsZero() && override.ExpiresAt.Before(now) {
 			continue
 		}
-		if override.ActionMatch != "" && !taintWildcardMatch(actionRef, override.ActionMatch) {
+		if override.ActionMatch != "" && !allTaintActionRefsMatch(actionRefs, override.ActionMatch) {
 			continue
 		}
 		if override.SourceMatch != "" && !taintRiskSourceMatches(risk, override.SourceMatch) {
@@ -230,6 +247,18 @@ func taintRuntimeTrustOverrideApplies(overrides []session.TrustOverride, task se
 		return true
 	}
 	return false
+}
+
+func allTaintActionRefsMatch(actionRefs []string, pattern string) bool {
+	if len(actionRefs) == 0 {
+		return false
+	}
+	for _, actionRef := range actionRefs {
+		if !taintWildcardMatch(actionRef, pattern) {
+			return false
+		}
+	}
+	return true
 }
 
 func taintRiskSourceMatches(risk session.SessionRisk, pattern string) bool {

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -482,6 +482,79 @@ func TestEvaluateMCPTaint_TrustOverrideHonorsScope(t *testing.T) {
 	}
 }
 
+func TestEvaluateMCPTaint_TrustOverrideUsesControllingTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        string
+		actionMatch string
+		want        session.PolicyDecision
+		wantRef     string
+	}{
+		{
+			name:        "legacy benign target cannot override protected target",
+			args:        `{"path":"/srv/prod/db.conf","archive_path":"/tmp/notes.txt"}`,
+			actionMatch: "mcp:write_file:/tmp/notes.txt",
+			want:        session.PolicyAsk,
+			wantRef:     "mcp:write_file:/srv/prod/db.conf",
+		},
+		{
+			name:        "controlling protected target can be overridden explicitly",
+			args:        `{"path":"/srv/prod/db.conf","archive_path":"/tmp/notes.txt"}`,
+			actionMatch: "mcp:write_file:/srv/prod/db.conf",
+			want:        session.PolicyAllow,
+			wantRef:     "mcp:write_file:/srv/prod/db.conf",
+		},
+		{
+			name:        "override must cover every equally protected target",
+			args:        `{"path":"/srv/prod/db.conf","archive_path":"/srv/prod/archive.conf"}`,
+			actionMatch: "mcp:write_file:/srv/prod/db.conf",
+			want:        session.PolicyAsk,
+			wantRef:     "mcp:write_file:/srv/prod/archive.conf",
+		},
+		{
+			name:        "wildcard can cover every equally protected target",
+			args:        `{"path":"/srv/prod/db.conf","archive_path":"/srv/prod/archive.conf"}`,
+			actionMatch: "mcp:write_file:/srv/prod/*",
+			want:        session.PolicyAllow,
+			wantRef:     "mcp:write_file:/srv/prod/archive.conf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.Defaults()
+			cfg.Taint.ProtectedPaths = []string{"/srv/prod/*"}
+			cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+				Scope:       "action",
+				ActionMatch: tt.actionMatch,
+				ExpiresAt:   nowPlusHour(t),
+			}}
+			rec := &taintRecorder{
+				risk: session.SessionRisk{
+					Level:        session.TaintExternalUntrusted,
+					Contaminated: true,
+				},
+			}
+
+			decision := evaluateMCPTaint(
+				MCPProxyOpts{Rec: rec, TaintCfg: &cfg.Taint},
+				"write_file",
+				tt.args,
+			)
+			if decision.Result.Decision != tt.want {
+				t.Fatalf("decision = %v, want %v (action ref %q)", decision.Result.Decision, tt.want, decision.ActionRef)
+			}
+			if decision.ActionRef != tt.wantRef {
+				t.Fatalf("action ref = %q, want %q", decision.ActionRef, tt.wantRef)
+			}
+		})
+	}
+}
+
 func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
@@ -26,10 +27,11 @@ type ClassificationOptions struct {
 // came from a concrete method/tool/path signal instead of a low-confidence
 // fallback.
 type ActionClassification struct {
-	Class       ActionClass
-	Sensitivity ActionSensitivity
-	ActionRef   string
-	Confident   bool
+	Class        ActionClass
+	Sensitivity  ActionSensitivity
+	ActionRef    string
+	OverrideRefs []string
+	Confident    bool
 }
 
 // ClassifyURLSource maps a URL to a taint level using host-based trust rules.
@@ -166,59 +168,257 @@ func ClassifyMCPToolCall(toolName, argsJSON string, protectedPatterns, elevatedP
 func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns, elevatedPatterns []string, opts ClassificationOptions) ActionClassification {
 	name := strings.ToLower(toolName)
 	args := flattenJSONStrings(argsJSON)
-	targetPath := firstPathLikeValue(args)
+	legacyPath := firstPathLikeValue(args)
+	legacyURL := firstURLLikeValue(args)
+	targets, parsed := extractMCPActionTargets(argsJSON)
+	if !parsed {
+		// Malformed arguments have no trustworthy key/value structure. Keep the
+		// legacy first-match behavior rather than guessing roles from raw text.
+		targets.refs = compactNonEmpty(legacyPath)
+		if !looksLikeURL(legacyPath) {
+			targets.paths = compactNonEmpty(legacyPath)
+		}
+		targets.urls = compactNonEmpty(legacyURL)
+	}
+	pathClass := classifyMCPPathTargets(targets.refs, legacyPath, protectedPatterns, elevatedPatterns, opts)
+	targetPath := pathClass.ActionRef
+	targetURL := compatibleFirstTarget(targets.urls, legacyURL)
 	category := chains.ClassifyTool(toolName, argsJSON, nil)
 
-	if secretPath := firstSecretPath(args); secretPath != "" {
-		return ActionClassification{Class: ActionClassSecret, Sensitivity: SensitivityProtected, ActionRef: secretPath, Confident: true}
+	secretTargets := secretPaths(targets.paths)
+	if secretPath := compatibleFirstTarget(secretTargets, firstSecretPath(args)); secretPath != "" {
+		return ActionClassification{Class: ActionClassSecret, Sensitivity: SensitivityProtected, ActionRef: secretPath, OverrideRefs: secretTargets, Confident: true}
 	}
 
 	if looksLikeShellTool(name) || category == "exec" {
 		command := strings.Join(args, " ")
 		if isMutatingShellCommand(command) {
-			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, Confident: true}
+			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 		}
-		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 	}
 
 	if category == "persist" {
-		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 	}
 
 	if looksLikeWriteTool(name) || category == "write" || hasWriteIntent(argsJSON) {
-		pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
-		return ActionClassification{Class: ActionClassWrite, Sensitivity: pathClass.Sensitivity, ActionRef: targetPath, Confident: pathClass.Confident}
+		return ActionClassification{Class: ActionClassWrite, Sensitivity: pathClass.Sensitivity, ActionRef: pathClass.ActionRef, OverrideRefs: pathClass.OverrideRefs, Confident: pathClass.Confident}
 	}
 
 	if looksLikePublishTool(name, argsJSON) || hasMutatingNetworkIntent(argsJSON) {
-		return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: firstURLLikeValue(args), Confident: true}
+		return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: targetURL, OverrideRefs: targets.urls, Confident: true}
 	}
 
 	if looksLikeBrowseTool(name) || category == "network" {
 		if hasMutatingNetworkIntent(argsJSON) {
-			return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: firstURLLikeValue(args), Confident: true}
+			return ActionClassification{Class: ActionClassPublish, Sensitivity: SensitivityElevated, ActionRef: targetURL, OverrideRefs: targets.urls, Confident: true}
 		}
-		return ActionClassification{Class: ActionClassBrowse, Sensitivity: SensitivityNormal, ActionRef: firstURLLikeValue(args), Confident: true}
+		return ActionClassification{Class: ActionClassBrowse, Sensitivity: SensitivityNormal, ActionRef: targetURL, OverrideRefs: targets.urls, Confident: true}
 	}
 
 	if looksLikeReadTool(name) || category == "read" || category == "list" {
-		pathClass := ClassifyPathSensitivityWithConfidence(targetPath, protectedPatterns, elevatedPatterns, opts)
-		return ActionClassification{Class: ActionClassRead, Sensitivity: failSafeSensitivity(opts, pathClass.Confident), ActionRef: targetPath, Confident: pathClass.Confident}
+		return ActionClassification{Class: ActionClassRead, Sensitivity: failSafeSensitivity(opts, pathClass.Confident), ActionRef: targetPath, OverrideRefs: pathClass.OverrideRefs, Confident: pathClass.Confident}
 	}
 
 	if hasExecIntent(argsJSON) {
 		command := strings.Join(args, " ")
 		if isMutatingShellCommand(command) {
-			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, Confident: true}
+			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 		}
-		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, Confident: true}
+		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 	}
 
 	sensitivity := SensitivityNormal
 	if opts.FailSafe {
 		sensitivity = SensitivityProtected
 	}
-	return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, Confident: false}
+	return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, OverrideRefs: pathClass.OverrideRefs, Confident: false}
+}
+
+type mcpActionTargets struct {
+	refs  []string
+	paths []string
+	urls  []string
+}
+
+type mcpArgumentRole uint8
+
+const (
+	mcpArgumentUnknown mcpArgumentRole = iota
+	mcpArgumentTarget
+)
+
+// extractMCPActionTargets keeps argument roles attached while walking JSON.
+// Target-like keys admit path values containing spaces. Unknown keys admit
+// only standalone path/URL values so an attacker cannot evade classification
+// merely by renaming a parameter. Keys can expand recognition, never suppress
+// it, because the calling agent controls them.
+func extractMCPActionTargets(raw string) (mcpActionTargets, bool) {
+	decoded, ok := decodeJSONValue(raw)
+	if !ok {
+		return mcpActionTargets{}, false
+	}
+
+	var targets mcpActionTargets
+	var walk func(any, mcpArgumentRole)
+	walk = func(value any, inheritedRole mcpArgumentRole) {
+		switch tv := value.(type) {
+		case string:
+			if looksLikeURL(tv) {
+				if inheritedRole == mcpArgumentTarget || isStandaloneArgumentValue(tv) {
+					targets.refs = append(targets.refs, tv)
+					targets.urls = append(targets.urls, tv)
+				}
+				return
+			}
+			if looksLikePath(tv) && (inheritedRole == mcpArgumentTarget || isStandaloneArgumentValue(tv)) {
+				targets.refs = append(targets.refs, tv)
+				targets.paths = append(targets.paths, tv)
+			}
+		case []any:
+			for _, item := range tv {
+				walk(item, inheritedRole)
+			}
+		case map[string]any:
+			for _, key := range slices.Sorted(maps.Keys(tv)) {
+				role := mcpArgumentRoleForKey(key)
+				if role == mcpArgumentUnknown {
+					role = inheritedRole
+				}
+				walk(tv[key], role)
+			}
+		}
+	}
+	walk(decoded, mcpArgumentUnknown)
+	return targets, true
+}
+
+func mcpArgumentRoleForKey(key string) mcpArgumentRole {
+	tokens := splitArgumentKey(key)
+	for _, token := range tokens {
+		switch token {
+		case "path", "paths", "file", "files", "filename", "filenames", "filepath", "filepaths",
+			"target", "targets", "dest", "destination", "src", "source", "uri", "uris", "url", "urls":
+			return mcpArgumentTarget
+		}
+	}
+	return mcpArgumentUnknown
+}
+
+func splitArgumentKey(key string) []string {
+	var words []string
+	var word []rune
+	flush := func() {
+		if len(word) == 0 {
+			return
+		}
+		words = append(words, strings.ToLower(string(word)))
+		word = word[:0]
+	}
+	var previous rune
+	for _, current := range key {
+		if !unicode.IsLetter(current) && !unicode.IsDigit(current) {
+			flush()
+			previous = 0
+			continue
+		}
+		if len(word) > 0 && unicode.IsUpper(current) && (unicode.IsLower(previous) || unicode.IsDigit(previous)) {
+			flush()
+		}
+		word = append(word, current)
+		previous = current
+	}
+	flush()
+	return words
+}
+
+func isStandaloneArgumentValue(value string) bool {
+	if strings.TrimSpace(value) != value {
+		return false
+	}
+	if len(strings.Fields(value)) == 1 {
+		return true
+	}
+	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, "./") ||
+		strings.HasPrefix(value, "../") || strings.HasPrefix(value, "~/") ||
+		strings.HasPrefix(value, `\\`) {
+		return true
+	}
+	return len(value) >= 3 && unicode.IsLetter(rune(value[0])) && value[1] == ':' && (value[2] == '/' || value[2] == '\\')
+}
+
+func looksLikeURL(value string) bool {
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
+}
+
+func compactNonEmpty(value string) []string {
+	if value == "" {
+		return nil
+	}
+	return []string{value}
+}
+
+func secretPaths(paths []string) []string {
+	var secrets []string
+	for _, targetPath := range paths {
+		if looksLikeSecretPath(targetPath) {
+			secrets = append(secrets, targetPath)
+		}
+	}
+	return secrets
+}
+
+func compatibleFirstTarget(candidates []string, legacy string) string {
+	for _, candidate := range candidates {
+		if candidate == legacy {
+			return legacy
+		}
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+
+func classifyMCPPathTargets(candidates []string, legacy string, protectedPatterns, elevatedPatterns []string, opts ClassificationOptions) ActionClassification {
+	if len(candidates) == 0 {
+		classified := ClassifyPathSensitivityWithConfidence("", protectedPatterns, elevatedPatterns, opts)
+		classified.ActionRef = ""
+		return classified
+	}
+
+	mostSensitive := SensitivityNormal
+	for _, candidate := range candidates {
+		sensitivity := ClassifyPathSensitivity(candidate, protectedPatterns, elevatedPatterns)
+		if sensitivity > mostSensitive {
+			mostSensitive = sensitivity
+		}
+	}
+
+	if legacy != "" && ClassifyPathSensitivity(legacy, protectedPatterns, elevatedPatterns) == mostSensitive {
+		for _, candidate := range candidates {
+			if candidate == legacy {
+				return ActionClassification{Sensitivity: mostSensitive, ActionRef: legacy, OverrideRefs: targetsWithSensitivity(candidates, mostSensitive, protectedPatterns, elevatedPatterns), Confident: true}
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		if ClassifyPathSensitivity(candidate, protectedPatterns, elevatedPatterns) == mostSensitive {
+			return ActionClassification{Sensitivity: mostSensitive, ActionRef: candidate, OverrideRefs: targetsWithSensitivity(candidates, mostSensitive, protectedPatterns, elevatedPatterns), Confident: true}
+		}
+	}
+	return ActionClassification{Sensitivity: mostSensitive, Confident: true}
+}
+
+func targetsWithSensitivity(candidates []string, sensitivity ActionSensitivity, protectedPatterns, elevatedPatterns []string) []string {
+	var matches []string
+	for _, candidate := range candidates {
+		if ClassifyPathSensitivity(candidate, protectedPatterns, elevatedPatterns) == sensitivity {
+			matches = append(matches, candidate)
+		}
+	}
+	return matches
 }
 
 func classifyShellSensitivity(command, targetPath string, protectedPatterns, elevatedPatterns []string) ActionSensitivity {

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -5,10 +5,12 @@ package session
 
 import (
 	"encoding/json"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/mcp/chains"
@@ -302,9 +304,17 @@ func flattenJSONStrings(raw string) []string {
 				walk(item)
 			}
 		case map[string]any:
-			for key, value := range tv {
+			// Sorted, not map order. Callers take the FIRST path-like,
+			// URL-like or secret-like entry out of this slice and use it
+			// as the action reference, which an operator's trust override
+			// is then matched against. Go does not specify map iteration
+			// order, so ranging tv directly can make the selection vary
+			// between runs when a tool call carries distinct candidates,
+			// causing the same call to match an override on one run and
+			// miss it on the next.
+			for _, key := range slices.Sorted(maps.Keys(tv)) {
 				out = append(out, key)
-				walk(value)
+				walk(tv[key])
 			}
 		}
 	}

--- a/internal/session/taint_classify_determinism_test.go
+++ b/internal/session/taint_classify_determinism_test.go
@@ -105,12 +105,24 @@ func TestClassifyMCPToolCall_ShellCommandOrderIsStable(t *testing.T) {
 
 	const argsJSON = `{"x":"git","push":"origin main"}`
 
-	firstClass, firstSensitivity, _ := session.ClassifyMCPToolCall("shell", argsJSON, nil, nil)
-	for run := 1; run < classifyRuns; run++ {
+	// Pinned, not taken from the first run. Using run zero as the oracle
+	// would let a deterministic regression that changes the verdict pass,
+	// because every later run would agree with the new wrong answer.
+	//
+	// Sorted keys emit push, origin main, x, git, which spells no mutating
+	// pattern, so this is a non-mutating exec and sensitivity stays
+	// protected. Unsorted, the value git can land before the key push and
+	// form "git push", which flips sensitivity to elevated.
+	const (
+		wantClass       = session.ActionClassExec
+		wantSensitivity = session.SensitivityProtected
+	)
+
+	for run := range classifyRuns {
 		class, sensitivity, _ := session.ClassifyMCPToolCall("shell", argsJSON, nil, nil)
-		if class != firstClass || sensitivity != firstSensitivity {
+		if class != wantClass || sensitivity != wantSensitivity {
 			t.Fatalf("run %d: class/sensitivity = %v/%v, want %v/%v on every run",
-				run, class, sensitivity, firstClass, firstSensitivity)
+				run, class, sensitivity, wantClass, wantSensitivity)
 		}
 	}
 }

--- a/internal/session/taint_classify_determinism_test.go
+++ b/internal/session/taint_classify_determinism_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session_test
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+// classifyRuns is high enough that map-order randomization cannot pass by
+// chance. Each iteration re-decodes the arguments into a fresh map and
+// exercises a new map iteration; with three candidate keys, current Go
+// runtime behavior makes 400 consecutive runs agreeing on one arbitrary
+// winner negligibly likely.
+const classifyRuns = 400
+
+// TestClassifyMCPToolCall_ActionRefIsStableAcrossRuns pins the action
+// reference for a tool call carrying several candidate targets.
+//
+// The reference is not cosmetic. It is what an operator's taint trust
+// override is matched against, so a reference that varies between runs makes
+// the same tool call honor an override on one run and miss it on the next.
+// Selecting it by Go map iteration order could make that happen when the
+// arguments held distinct path or URL candidates.
+//
+// Both assertions matter and they fail for different reasons. Stability
+// catches the randomization. The exact expected value catches a future change
+// that is deterministic but silently picks a different target.
+func TestClassifyMCPToolCall_ActionRefIsStableAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		tool      string
+		argsJSON  string
+		wantClass session.ActionClass
+		wantRef   string
+	}{
+		{
+			name: "browse picks the first url by sorted key",
+			tool: "fetch",
+			// Deliberately not in sorted order in the document, so a
+			// document-order implementation and a sorted implementation
+			// disagree and the assertion pins which one shipped.
+			argsJSON: `{"zeta_url":"https://zeta.vendor.example/z",` +
+				`"alpha_url":"https://alpha.vendor.example/a",` +
+				`"mid_url":"https://mid.vendor.example/m"}`,
+			wantClass: session.ActionClassBrowse,
+			wantRef:   "https://alpha.vendor.example/a",
+		},
+		{
+			name: "read picks the first path by sorted key",
+			tool: "read_file",
+			argsJSON: `{"zeta_path":"/srv/zeta/data.txt",` +
+				`"alpha_path":"/srv/alpha/data.txt",` +
+				`"mid_path":"/srv/mid/data.txt"}`,
+			wantClass: session.ActionClassRead,
+			wantRef:   "/srv/alpha/data.txt",
+		},
+		{
+			name: "nested objects are ordered at every depth",
+			tool: "fetch",
+			argsJSON: `{"outer":{"zeta_url":"https://zeta.vendor.example/z",` +
+				`"alpha_url":"https://alpha.vendor.example/a"},` +
+				`"also":{"beta_url":"https://beta.vendor.example/b"}}`,
+			// "also" sorts before "outer", so its subtree is walked first.
+			wantClass: session.ActionClassBrowse,
+			wantRef:   "https://beta.vendor.example/b",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for run := range classifyRuns {
+				class, _, ref := session.ClassifyMCPToolCall(tc.tool, tc.argsJSON, nil, nil)
+				if class != tc.wantClass {
+					t.Fatalf("run %d: class = %v, want %v", run, class, tc.wantClass)
+				}
+				if ref != tc.wantRef {
+					t.Fatalf("run %d: action ref = %q, want %q (selection must not vary between runs)",
+						run, ref, tc.wantRef)
+				}
+			}
+		})
+	}
+}
+
+// TestClassifyMCPToolCall_ShellCommandOrderIsStable covers the second
+// consumer of the same flattened slice. The exec path joins every extracted
+// string into one command line and scans it for multi-token shell patterns
+// such as "git push", so an unordered walk can push two tokens together
+// across a join boundary and manufacture a match that the same input does not
+// produce on the next run.
+//
+// These arguments are built for exactly that. The walk emits each key before
+// its value, so the value "git" landing immediately before the key "push"
+// spells the pattern, and whether that adjacency happens depends entirely on
+// which key is visited first. Sorted keys settle it the same way every time.
+func TestClassifyMCPToolCall_ShellCommandOrderIsStable(t *testing.T) {
+	t.Parallel()
+
+	const argsJSON = `{"x":"git","push":"origin main"}`
+
+	firstClass, firstSensitivity, _ := session.ClassifyMCPToolCall("shell", argsJSON, nil, nil)
+	for run := 1; run < classifyRuns; run++ {
+		class, sensitivity, _ := session.ClassifyMCPToolCall("shell", argsJSON, nil, nil)
+		if class != firstClass || sensitivity != firstSensitivity {
+			t.Fatalf("run %d: class/sensitivity = %v/%v, want %v/%v on every run",
+				run, class, sensitivity, firstClass, firstSensitivity)
+		}
+	}
+}

--- a/internal/session/taint_target_selection_repro_test.go
+++ b/internal/session/taint_target_selection_repro_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package session_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+func TestClassifyMCPToolCall_TargetSelection(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             string
+		wantClass        session.ActionClass
+		wantSensitivity  session.ActionSensitivity
+		wantRef          string
+		wantOverrideRefs []string
+		wantConfident    bool
+	}{
+		{
+			name:             "most restrictive target wins despite key order",
+			args:             `{"path":"/srv/prod/db.conf","archive_path":"/tmp/notes.txt"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "/srv/prod/db.conf",
+			wantOverrideRefs: []string{"/srv/prod/db.conf"},
+			wantConfident:    true,
+		},
+		{
+			name:             "renamed keys do not change sensitivity",
+			args:             `{"a_path":"/srv/prod/db.conf","z_path":"/tmp/notes.txt"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "/srv/prod/db.conf",
+			wantOverrideRefs: []string{"/srv/prod/db.conf"},
+			wantConfident:    true,
+		},
+		{
+			name:             "secret-looking prose is not a target",
+			args:             `{"path":"/tmp/notes.txt","note":"do not touch ~/.ssh/id_rsa"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityNormal,
+			wantRef:          "/tmp/notes.txt",
+			wantOverrideRefs: []string{"/tmp/notes.txt"},
+			wantConfident:    true,
+		},
+		{
+			name:            "secret-looking prose alone is low confidence",
+			args:            `{"note":"do not touch ~/.ssh/id_rsa"}`,
+			wantClass:       session.ActionClassWrite,
+			wantSensitivity: session.SensitivityNormal,
+			wantRef:         "",
+			wantConfident:   false,
+		},
+		{
+			name:             "all secret targets constrain overrides",
+			args:             `{"path":"/home/developer/.ssh/id_rsa","archive_path":"/home/developer/.aws/credentials"}`,
+			wantClass:        session.ActionClassSecret,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "/home/developer/.aws/credentials",
+			wantOverrideRefs: []string{"/home/developer/.aws/credentials", "/home/developer/.ssh/id_rsa"},
+			wantConfident:    true,
+		},
+		{
+			name:             "prose-like key cannot hide standalone protected path",
+			args:             `{"payload":"/srv/prod/db archive.conf","note":"ordinary prose"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "/srv/prod/db archive.conf",
+			wantOverrideRefs: []string{"/srv/prod/db archive.conf"},
+			wantConfident:    true,
+		},
+		{
+			name:             "target role admits path containing spaces",
+			args:             `{"destinationPath":"srv/prod config.conf"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "srv/prod config.conf",
+			wantOverrideRefs: []string{"srv/prod config.conf"},
+			wantConfident:    true,
+		},
+		{
+			name:             "target array uses most restrictive member",
+			args:             `{"paths":["/tmp/notes.txt","/srv/prod/db.conf"]}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityProtected,
+			wantRef:          "/srv/prod/db.conf",
+			wantOverrideRefs: []string{"/srv/prod/db.conf"},
+			wantConfident:    true,
+		},
+		{
+			name:             "equally sensitive target preserves legacy reference",
+			args:             `{"path":"/tmp/current.txt","archive_path":"/tmp/archive.txt"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityNormal,
+			wantRef:          "/tmp/archive.txt",
+			wantOverrideRefs: []string{"/tmp/archive.txt", "/tmp/current.txt"},
+			wantConfident:    true,
+		},
+		{
+			name:             "malformed arguments preserve legacy reference",
+			args:             `/tmp/legacy.txt`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityNormal,
+			wantRef:          "/tmp/legacy.txt",
+			wantOverrideRefs: []string{"/tmp/legacy.txt"},
+			wantConfident:    true,
+		},
+		{
+			name:             "write URL preserves legacy target reference",
+			args:             `{"url":"https://api.vendor.example/resource"}`,
+			wantClass:        session.ActionClassWrite,
+			wantSensitivity:  session.SensitivityNormal,
+			wantRef:          "https://api.vendor.example/resource",
+			wantOverrideRefs: []string{"https://api.vendor.example/resource"},
+			wantConfident:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := session.ClassifyMCPToolCallWithOptions(
+				"write_file",
+				tt.args,
+				[]string{"/srv/prod/*", "srv/*"},
+				nil,
+				session.ClassificationOptions{},
+			)
+			if got.Class != tt.wantClass || got.Sensitivity != tt.wantSensitivity || got.ActionRef != tt.wantRef || got.Confident != tt.wantConfident {
+				t.Fatalf("classification = %+v, want class=%s sensitivity=%s actionRef=%q confident=%v",
+					got, tt.wantClass, tt.wantSensitivity, tt.wantRef, tt.wantConfident)
+			}
+			if !slices.Equal(got.OverrideRefs, tt.wantOverrideRefs) {
+				t.Fatalf("override refs = %q, want %q", got.OverrideRefs, tt.wantOverrideRefs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Tool arguments were flattened by ranging a decoded JSON object directly. Go does not specify map iteration order, so an MCP tool call carrying distinct candidate paths or URLs could select a different action reference between runs.

That reference is what an operator's taint trust override is matched against, so the same tool call could honor an override on one run and miss it on the next with no change to the input or the configuration.

The command line the exec path inspects was affected the same way. Its patterns span two tokens, and the walk emits each object key before its value, so an unordered walk could place a value next to a following key and form a pattern that the same input does not form on the next run. That moved identical arguments between protected and elevated sensitivity.

Object keys are now walked in sorted order, so both selections settle the same way every time.

Which candidate wins when a call carries several is unchanged in kind and is tracked separately. Selecting one target and ignoring the rest predates this change and needs a design that can tell an actual target argument apart from an incidental string.

The other JSON walker in this file is left as is. Its consumers are any-match predicates, so iteration order cannot change their result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when classifying MCP tool calls by ensuring action references are selected in a stable, predictable order.
  * Prevented classification results from varying between runs when processing nested data or shell command arguments.
  * Improved reliability of sensitivity and command classification results across repeated evaluations.

* **Tests**
  * Added coverage to verify deterministic classification across repeated runs and varied input structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->