### PR TITLE
fix(taint): scan declared MCP command fields instead of a synthetic command line

### DIFF
--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -110,6 +110,7 @@ func evaluateMCPTaint(opts MCPProxyOpts, toolName, argsJSON string) taintDecisio
 	decision.ActionRef = classified.ActionRef
 	decision.ActionRef = mcpActionRef(toolName, decision.ActionRef)
 	decision.OverrideRefs = mcpOverrideRefs(toolName, classified.OverrideRefs, decision.ActionRef)
+	decision.ActionRef = mcpReportedActionRef(decision.OverrideRefs, decision.ActionRef)
 	if tp, ok := opts.Rec.(session.TaskContextProvider); ok {
 		decision.Task = tp.TaskSnapshot()
 		if taintRuntimeTrustOverrideApplies(tp.RuntimeTrustOverrides(), decision.Task, decision.Risk, decision.OverrideRefs) {
@@ -188,6 +189,16 @@ func mcpOverrideRefs(toolName string, targets []string, primary string) []string
 		}
 	}
 	return refs
+}
+
+// mcpReportedActionRef is a reporting value. Override matching uses
+// OverrideRefs, so a multi-target call cannot make one lexical candidate look
+// like the entire action to an audit reader or approver.
+func mcpReportedActionRef(refs []string, primary string) string {
+	if len(refs) <= 1 {
+		return primary
+	}
+	return strings.Join(refs, ", ")
 }
 
 func taintTrustOverrideApplies(overrides []config.TaintTrustOverride, risk session.SessionRisk, actionRefs []string) bool {

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -511,14 +511,14 @@ func TestEvaluateMCPTaint_TrustOverrideUsesControllingTarget(t *testing.T) {
 			args:        `{"path":"/srv/prod/db.conf","archive_path":"/srv/prod/archive.conf"}`,
 			actionMatch: "mcp:write_file:/srv/prod/db.conf",
 			want:        session.PolicyAsk,
-			wantRef:     "mcp:write_file:/srv/prod/archive.conf",
+			wantRef:     "mcp:write_file:/srv/prod/archive.conf, mcp:write_file:/srv/prod/db.conf",
 		},
 		{
 			name:        "wildcard can cover every equally protected target",
 			args:        `{"path":"/srv/prod/db.conf","archive_path":"/srv/prod/archive.conf"}`,
 			actionMatch: "mcp:write_file:/srv/prod/*",
 			want:        session.PolicyAllow,
-			wantRef:     "mcp:write_file:/srv/prod/archive.conf",
+			wantRef:     "mcp:write_file:/srv/prod/archive.conf, mcp:write_file:/srv/prod/db.conf",
 		},
 	}
 
@@ -550,6 +550,59 @@ func TestEvaluateMCPTaint_TrustOverrideUsesControllingTarget(t *testing.T) {
 			}
 			if decision.ActionRef != tt.wantRef {
 				t.Fatalf("action ref = %q, want %q", decision.ActionRef, tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestEvaluateMCPTaint_ReportedActionRefIncludesEveryTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	decision := evaluateMCPTaint(
+		MCPProxyOpts{TaintCfg: &cfg.Taint},
+		"fetch",
+		`{"trusted_url":"https://trusted.vendor.example/","metadata_url":"http://169.254.169.254/latest/meta-data/"}`,
+	)
+	const want = "mcp:fetch:http://169.254.169.254/latest/meta-data/, mcp:fetch:https://trusted.vendor.example/"
+	if decision.ActionRef != want {
+		t.Fatalf("reported action ref = %q, want %q", decision.ActionRef, want)
+	}
+}
+
+func TestMCPReportedActionRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		refs    []string
+		primary string
+		want    string
+	}{
+		{
+			name:    "single target remains byte identical",
+			refs:    []string{"mcp:fetch:https://trusted.vendor.example/"},
+			primary: "mcp:fetch:https://trusted.vendor.example/",
+			want:    "mcp:fetch:https://trusted.vendor.example/",
+		},
+		{
+			name:    "missing target retains the legacy tool reference",
+			primary: "mcp:shell",
+			want:    "mcp:shell",
+		},
+		{
+			name:    "multiple targets stay visible",
+			refs:    []string{"mcp:fetch:http://169.254.169.254/latest/meta-data/", "mcp:fetch:https://trusted.vendor.example/"},
+			primary: "mcp:fetch:http://169.254.169.254/latest/meta-data/",
+			want:    "mcp:fetch:http://169.254.169.254/latest/meta-data/, mcp:fetch:https://trusted.vendor.example/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mcpReportedActionRef(tt.refs, tt.primary); got != tt.want {
+				t.Fatalf("reported action ref = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -191,8 +191,7 @@ func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns
 	}
 
 	if looksLikeShellTool(name) || category == "exec" {
-		command := strings.Join(args, " ")
-		if isMutatingShellCommand(command) {
+		if command := firstMutatingMCPCommand(argsJSON); command != "" {
 			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 		}
 		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
@@ -222,8 +221,7 @@ func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns
 	}
 
 	if hasExecIntent(argsJSON) {
-		command := strings.Join(args, " ")
-		if isMutatingShellCommand(command) {
+		if command := firstMutatingMCPCommand(argsJSON); command != "" {
 			return ActionClassification{Class: ActionClassExec, Sensitivity: classifyShellSensitivity(command, targetPath, protectedPatterns, elevatedPatterns), ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
 		}
 		return ActionClassification{Class: ActionClassExec, Sensitivity: SensitivityProtected, ActionRef: targetPath, OverrideRefs: targets.refs, Confident: true}
@@ -234,6 +232,102 @@ func ClassifyMCPToolCallWithOptions(toolName, argsJSON string, protectedPatterns
 		sensitivity = SensitivityProtected
 	}
 	return ActionClassification{Class: ActionClassRead, Sensitivity: sensitivity, ActionRef: targetPath, OverrideRefs: pathClass.OverrideRefs, Confident: false}
+}
+
+// firstMutatingMCPCommand scans only declared command-bearing fields. It keeps
+// each vector separate, so values from unrelated fields cannot manufacture a
+// shell pattern merely by landing next to each other in a flattened string.
+func firstMutatingMCPCommand(raw string) string {
+	for _, command := range extractMCPCommands(raw) {
+		if isMutatingShellCommand(command) {
+			return command
+		}
+	}
+	return ""
+}
+
+// extractMCPCommands returns one synthetic command line for each declared
+// command vector. Object keys are used only to recognize a field's role; they
+// never become command text. A command/cmd/script/shell field is combined with
+// sibling args/argv vectors, which preserves the argument-vector boundary while
+// recognizing commands that split their executable and arguments across fields.
+func extractMCPCommands(raw string) []string {
+	decoded, ok := decodeJSONValue(raw)
+	if !ok {
+		return nil
+	}
+
+	var commands []string
+	var walk func(any)
+	walk = func(value any) {
+		switch tv := value.(type) {
+		case []any:
+			for _, item := range tv {
+				walk(item)
+			}
+		case map[string]any:
+			var bases, vectors []string
+			for _, key := range slices.Sorted(maps.Keys(tv)) {
+				switch mcpCommandFieldRole(key) {
+				case mcpCommandBase:
+					bases = append(bases, commandFieldVectors(tv[key])...)
+				case mcpCommandArgs:
+					vectors = append(vectors, commandFieldVectors(tv[key])...)
+				default:
+					walk(tv[key])
+				}
+			}
+			for _, base := range bases {
+				commands = append(commands, base)
+				for _, vector := range vectors {
+					commands = append(commands, strings.TrimSpace(base+" "+vector))
+				}
+			}
+			commands = append(commands, vectors...)
+		}
+	}
+	walk(decoded)
+	return commands
+}
+
+type mcpCommandRole uint8
+
+const (
+	mcpCommandNone mcpCommandRole = iota
+	mcpCommandBase
+	mcpCommandArgs
+)
+
+func mcpCommandFieldRole(key string) mcpCommandRole {
+	for _, token := range splitArgumentKey(key) {
+		switch token {
+		case "command", "cmd", "script", "shell":
+			return mcpCommandBase
+		case "args", "argv":
+			return mcpCommandArgs
+		}
+	}
+	return mcpCommandNone
+}
+
+func commandFieldVectors(value any) []string {
+	var values []string
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case string:
+			values = append(values, typed)
+		case []any:
+			for _, item := range typed {
+				walk(item)
+			}
+		}
+	}
+	walk(value)
+	if len(values) == 0 {
+		return nil
+	}
+	return []string{strings.Join(values, " ")}
 }
 
 type mcpActionTargets struct {

--- a/internal/session/taint_classify.go
+++ b/internal/session/taint_classify.go
@@ -268,7 +268,16 @@ func extractMCPCommands(raw string) []string {
 		case map[string]any:
 			var bases, vectors []string
 			for _, key := range slices.Sorted(maps.Keys(tv)) {
-				switch mcpCommandFieldRole(key) {
+				role := mcpCommandFieldRole(key)
+				if role != mcpCommandNone {
+					// A recognized field can still hold a nested container,
+					// for example {"command":{"cmd":"git","argv":[...]}}.
+					// commandFieldVectors only collects strings, so without
+					// this the whole subtree would go unscanned and a real
+					// command would never reach the matcher.
+					walk(tv[key])
+				}
+				switch role {
 				case mcpCommandBase:
 					bases = append(bases, commandFieldVectors(tv[key])...)
 				case mcpCommandArgs:
@@ -301,7 +310,10 @@ const (
 func mcpCommandFieldRole(key string) mcpCommandRole {
 	for _, token := range splitArgumentKey(key) {
 		switch token {
-		case "command", "cmd", "script", "shell":
+		// Keep this set aligned with hasExecIntent. A field that marks a call
+		// as an exec but is not recognized here would have its command go
+		// unscanned, which is how "program" was missed.
+		case "command", "cmd", "script", "shell", "program":
 			return mcpCommandBase
 		case "args", "argv":
 			return mcpCommandArgs

--- a/internal/session/taint_classify_determinism_test.go
+++ b/internal/session/taint_classify_determinism_test.go
@@ -138,6 +138,21 @@ func TestClassifyMCPToolCall_ShellCommandOrderIsStable(t *testing.T) {
 			argsJSON:        `{"command":"status","argv":[1,2,{"push":"origin"}]}`,
 			wantSensitivity: session.SensitivityProtected,
 		},
+		{
+			// A recognized field can hold a nested container. Without a
+			// recursive walk into it the command never reaches the matcher
+			// and a real mutation is scanned as if it were absent.
+			name:            "nested container under a recognized field is scanned",
+			argsJSON:        `{"command":{"cmd":"git","argv":["push","origin","main"]}}`,
+			wantSensitivity: session.SensitivityElevated,
+		},
+		{
+			// program marks an exec in hasExecIntent, so extraction has to
+			// recognize it too or its command goes unscanned.
+			name:            "program field is a command base",
+			argsJSON:        `{"program":"git","argv":["push","origin","main"]}`,
+			wantSensitivity: session.SensitivityElevated,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/session/taint_classify_determinism_test.go
+++ b/internal/session/taint_classify_determinism_test.go
@@ -89,40 +89,67 @@ func TestClassifyMCPToolCall_ActionRefIsStableAcrossRuns(t *testing.T) {
 	}
 }
 
-// TestClassifyMCPToolCall_ShellCommandOrderIsStable covers the second
-// consumer of the same flattened slice. The exec path joins every extracted
-// string into one command line and scans it for multi-token shell patterns
-// such as "git push", so an unordered walk can push two tokens together
-// across a join boundary and manufacture a match that the same input does not
-// produce on the next run.
-//
-// These arguments are built for exactly that. The walk emits each key before
-// its value, so the value "git" landing immediately before the key "push"
-// spells the pattern, and whether that adjacency happens depends entirely on
-// which key is visited first. Sorted keys settle it the same way every time.
+// TestClassifyMCPToolCall_ShellCommandOrderIsStable proves shell classification
+// scans declared command vectors, never object keys or a flattened mix of
+// unrelated values. It retains the repeated-run assertion because command
+// field extraction must remain deterministic.
 func TestClassifyMCPToolCall_ShellCommandOrderIsStable(t *testing.T) {
 	t.Parallel()
 
-	const argsJSON = `{"x":"git","push":"origin main"}`
+	tests := []struct {
+		name            string
+		argsJSON        string
+		wantSensitivity session.ActionSensitivity
+	}{
+		{
+			name:            "keys cannot manufacture a command",
+			argsJSON:        `{"a":"git","push":"origin main"}`,
+			wantSensitivity: session.SensitivityProtected,
+		},
+		{
+			name:            "command and argv form one vector despite unrelated fields",
+			argsJSON:        `{"argv":["push","origin","main"],"command":"git","decoy":"status"}`,
+			wantSensitivity: session.SensitivityElevated,
+		},
+		{
+			name:            "array command vector is scanned",
+			argsJSON:        `{"args":["git","push","origin","main"]}`,
+			wantSensitivity: session.SensitivityElevated,
+		},
+		{
+			// Arguments that are not JSON at all yield no command vector.
+			// The call must still be treated as a protected exec rather
+			// than read as benign for lack of a parseable command.
+			name:            "unparseable arguments stay protected",
+			argsJSON:        `{"command": "git push`,
+			wantSensitivity: session.SensitivityProtected,
+		},
+		{
+			// A top-level array still has to be walked, or a command
+			// nested one level up from an object would be missed.
+			name:            "top level array is walked",
+			argsJSON:        `[{"command":"git push origin main"}]`,
+			wantSensitivity: session.SensitivityElevated,
+		},
+		{
+			// A vector field holding no strings contributes nothing, and
+			// the base command alone decides the verdict.
+			name:            "non string vector contributes no command text",
+			argsJSON:        `{"command":"status","argv":[1,2,{"push":"origin"}]}`,
+			wantSensitivity: session.SensitivityProtected,
+		},
+	}
 
-	// Pinned, not taken from the first run. Using run zero as the oracle
-	// would let a deterministic regression that changes the verdict pass,
-	// because every later run would agree with the new wrong answer.
-	//
-	// Sorted keys emit push, origin main, x, git, which spells no mutating
-	// pattern, so this is a non-mutating exec and sensitivity stays
-	// protected. Unsorted, the value git can land before the key push and
-	// form "git push", which flips sensitivity to elevated.
-	const (
-		wantClass       = session.ActionClassExec
-		wantSensitivity = session.SensitivityProtected
-	)
-
-	for run := range classifyRuns {
-		class, sensitivity, _ := session.ClassifyMCPToolCall("shell", argsJSON, nil, nil)
-		if class != wantClass || sensitivity != wantSensitivity {
-			t.Fatalf("run %d: class/sensitivity = %v/%v, want %v/%v on every run",
-				run, class, sensitivity, wantClass, wantSensitivity)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for run := range classifyRuns {
+				class, sensitivity, _ := session.ClassifyMCPToolCall("shell", tt.argsJSON, nil, nil)
+				if class != session.ActionClassExec || sensitivity != tt.wantSensitivity {
+					t.Fatalf("run %d: class/sensitivity = %v/%v, want %v/%v on every run",
+						run, class, sensitivity, session.ActionClassExec, tt.wantSensitivity)
+				}
+			}
+		})
 	}
 }

--- a/internal/session/taint_classify_determinism_test.go
+++ b/internal/session/taint_classify_determinism_test.go
@@ -153,6 +153,14 @@ func TestClassifyMCPToolCall_ShellCommandOrderIsStable(t *testing.T) {
 			argsJSON:        `{"program":"git","argv":["push","origin","main"]}`,
 			wantSensitivity: session.SensitivityElevated,
 		},
+		{
+			// Two vector fields are two independent command candidates. A
+			// regression that flattened them back into one would spell a
+			// mutation out of tokens that were never one command.
+			name:            "separate vectors do not form one command",
+			argsJSON:        `{"args":["git"],"argv":["push"]}`,
+			wantSensitivity: session.SensitivityProtected,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Shell classification built the command it inspected by joining every flattened object key and string value, then scanned that synthetic line for multi-token patterns such as git push and sed -i. Object keys are supplied by the caller, so a call could spell a mutating pattern that matched no command the tool would run, and a real command split across fields could be separated so the pattern never formed.

Command content is now taken only from declared command-bearing fields, argument vectors keep their boundaries instead of being glued to unrelated values, and object keys never enter command text. A call with no recognizable command field stays classified as a protected exec rather than being read as benign.

The reported action reference on a call carrying several targets now names every candidate. Trust override matching already keys on the full candidate list, so this changes what an approver and an audit reader see and does not change any enforcement decision. A single-target call reports exactly as it did before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell-command detection to evaluate declared commands and arguments accurately, avoiding false positives caused by unrelated data.
  - Improved classification for shell tools and execution requests, including command vectors, argument arrays, malformed input, and other edge cases.
  - Trust-override results now report accurate action references for single- and multi-target decisions.
  - Multi-target references are deduplicated and displayed together for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->