### PR TITLE
fix(proxy): stop carrying action authority across redirect hops

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -845,10 +845,32 @@ func (p *Proxy) refreshEnvelopeForRedirect(req *http.Request, via []*http.Reques
 		prev    envelope.Envelope
 		rawPrev string
 	)
+	// Read every value, not just the first. Header.Get returns only the
+	// first, so a sequence like ["", "not a dictionary ((("] would read as
+	// empty and take the no-prior-envelope path, silently reclassifying a
+	// malformed mediation header as an absent one and skipping the block
+	// below. A genuinely absent header is still the legitimate first-hop
+	// case; a header that is PRESENT but empty or repeated is ambiguous
+	// about which envelope governs this chain, so it fails closed.
+	priorHeader := envelope.HeaderName
+	var priorValues []string
 	if len(via) > 0 {
-		rawPrev = via[0].Header.Get(envelope.HeaderName)
+		priorValues = via[0].Header.Values(priorHeader)
 	} else {
-		rawPrev = req.Header.Get(envelope.HeaderName)
+		priorValues = req.Header.Values(priorHeader)
+	}
+	if len(priorValues) > 1 {
+		return newRedirectEnvelopeBlockedRequest(
+			fmt.Errorf("prior envelope header repeated %d times", len(priorValues)),
+		)
+	}
+	if len(priorValues) == 1 {
+		rawPrev = priorValues[0]
+		if strings.TrimSpace(rawPrev) == "" {
+			return newRedirectEnvelopeBlockedRequest(
+				errors.New("prior envelope header present but empty"),
+			)
+		}
 	}
 	if rawPrev != "" {
 		parsed, parseErr := envelope.Parse(rawPrev)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -791,7 +791,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 // Steps:
 //  1. Parse the inbound Pipelock-Mediation header to recover the
 //     original envelope fields we want to preserve (Actor, ActorAuth,
-//     ReceiptID, AuthorityKind, SessionTaint, TaskID, Action).
+//     ReceiptID, SessionTaint, TaskID, RequiresReauth, Verdict).
 //  2. Increment Hop.
 //  3. Derive fresh body bytes via req.GetBody when the redirect
 //     preserves method + body (307/308). On method-switching
@@ -828,7 +828,7 @@ func (p *Proxy) refreshEnvelopeForRedirect(req *http.Request, via []*http.Reques
 	actx := newHTTPAuditContext(p.logger, req.Method, req.URL.String(), clientIP, requestID, agentName)
 
 	// 1. Parse the ORIGINAL envelope. Identity fields (Actor,
-	//    ActorAuth, ReceiptID, Authority, Taint, TaskID, RequiresReauth)
+	//    ActorAuth, ReceiptID, Taint, TaskID, RequiresReauth)
 	//    are immutable across a redirect chain, so we always read
 	//    them from the first request in the chain. In the live
 	//    CheckRedirect path via[] is always non-empty and via[0] is
@@ -855,8 +855,9 @@ func (p *Proxy) refreshEnvelopeForRedirect(req *http.Request, via []*http.Reques
 		if parseErr != nil {
 			p.logger.LogAnomaly(actx, "",
 				fmt.Sprintf("envelope refresh: parsing prior envelope failed: %v", parseErr), 0.1)
-			// Fall through with zero-value prev - the refresh will
-			// still install a new envelope.
+			return newRedirectEnvelopeBlockedRequest(
+				fmt.Errorf("parsing prior envelope: %w", parseErr),
+			)
 		} else {
 			prev = parsed
 		}
@@ -918,9 +919,11 @@ func (p *Proxy) refreshEnvelopeForRedirect(req *http.Request, via []*http.Reques
 	req.Header.Del("Content-Digest")
 
 	// 5. Rebuild BuildOpts from prev + redirect context. Preserve
-	//    Actor / ActorAuth / ReceiptID / AuthorityKind / SessionTaint
-	//    / TaskID from the original envelope so the redirect chain
-	//    threads through as one logical action. Recompute Action
+	//    Actor / ActorAuth / ReceiptID / SessionTaint / TaskID from
+	//    the original envelope so the redirect chain threads through
+	//    as one logical action. Do not carry authority: it grants
+	//    permission for the original action and destination, neither
+	//    of which describes this redirected hop. Recompute Action
 	//    from the new method because the redirect could have
 	//    downgraded a POST to a GET (303).
 	actionID := prev.ReceiptID
@@ -938,8 +941,6 @@ func (p *Proxy) refreshEnvelopeForRedirect(req *http.Request, via []*http.Reques
 		ActorAuth:      prev.ActorAuth,
 		SessionTaint:   prev.SessionTaint,
 		TaskID:         prev.TaskID,
-		AuthorityKind:  prev.AuthorityKind,
-		AuthorityRef:   prev.AuthorityRef,
 		RequiresReauth: prev.RequiresReauth,
 		PolicyHash:     envelope.PolicyHashFromHex(cfg.CanonicalPolicyHash()),
 	}

--- a/internal/proxy/redirect_refresh_test.go
+++ b/internal/proxy/redirect_refresh_test.go
@@ -380,13 +380,27 @@ func TestCheckRedirect_MalformedPriorEnvelopeBlocks(t *testing.T) {
 		// Values-based read a malformed later value reads as absent and
 		// skips the block entirely.
 		extra []string
+		// validFirst makes the FIRST header value a genuinely valid signed
+		// envelope. Without it a repeated-header case proves nothing about
+		// the repeated-header guard, because an incomplete first value is
+		// rejected by envelope.Parse whether or not that guard exists.
+		validFirst bool
 	}{
 		{name: "invalid structured field", raw: "not a valid dictionary ((("},
 		{name: "missing required verdict", raw: "v=1, act=\"read\", rid=\"01961f3a-7b2c-7000-8000-000000000023\", ts=1"},
 		{name: "present but empty", raw: ""},
 		{name: "present but whitespace only", raw: "   "},
 		{name: "empty then malformed", raw: "", extra: []string{"not a valid dictionary ((("}},
-		{name: "valid then malformed", raw: "v=1", extra: []string{"not a valid dictionary ((("}},
+		{
+			name:       "valid then malformed",
+			validFirst: true,
+			extra:      []string{"not a valid dictionary ((("},
+		},
+		{
+			name:       "valid then valid",
+			validFirst: true,
+			extra:      []string{"v=1, act=\"read\", rid=\"01961f3a-7b2c-7000-8000-000000000024\", ts=1, vd=\"allow\""},
+		},
 	}
 
 	for _, tt := range tests {
@@ -395,7 +409,27 @@ func TestCheckRedirect_MalformedPriorEnvelopeBlocks(t *testing.T) {
 
 			p := newSigningProxyForTest(t)
 			original := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://origin.example/start", nil)
-			original.Header.Set(envelope.HeaderName, tt.raw)
+			if tt.validFirst {
+				em := p.envelopeEmitterPtr.Load()
+				if em == nil {
+					t.Fatal("expected startup signing emitter")
+				}
+				prev, err := em.Build(envelope.BuildOpts{
+					ActionID:  "01961f3a-7b2c-7000-8000-000000000025",
+					Action:    "read",
+					Verdict:   config.ActionAllow,
+					Actor:     "agent",
+					ActorAuth: envelope.ActorAuthBound,
+				})
+				if err != nil {
+					t.Fatalf("build valid first envelope: %v", err)
+				}
+				if err := envelope.InjectHTTP(original.Header, prev); err != nil {
+					t.Fatalf("inject valid first envelope: %v", err)
+				}
+			} else {
+				original.Header.Set(envelope.HeaderName, tt.raw)
+			}
 			for _, value := range tt.extra {
 				original.Header.Add(envelope.HeaderName, value)
 			}

--- a/internal/proxy/redirect_refresh_test.go
+++ b/internal/proxy/redirect_refresh_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -322,6 +323,20 @@ func TestCheckRedirect_DropsAuthorityOnRedirect(t *testing.T) {
 				t.Fatalf("inject previous envelope: %v", err)
 			}
 
+			// Prove authority actually crossed the serialized boundary
+			// before asserting the redirect removed it. Without this, an
+			// emitter that silently dropped authority would make the
+			// removal assertion below pass even with the carry-over
+			// restored, so the test would prove nothing about redirects.
+			injected, err := envelope.Parse(original.Header.Get(envelope.HeaderName))
+			if err != nil {
+				t.Fatalf("parse injected envelope: %v", err)
+			}
+			if injected.AuthorityKind != tt.authorityKind || injected.AuthorityRef != tt.authorityRef {
+				t.Fatalf("injected authority = %q/%q, want %q/%q",
+					injected.AuthorityKind, injected.AuthorityRef, tt.authorityKind, tt.authorityRef)
+			}
+
 			redirected := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirected.example/final", nil)
 			if err := p.refreshEnvelopeForRedirect(redirected, []*http.Request{original}, p.cfgPtr.Load()); err != nil {
 				t.Fatalf("refreshEnvelopeForRedirect: %v", err)
@@ -333,6 +348,13 @@ func TestCheckRedirect_DropsAuthorityOnRedirect(t *testing.T) {
 			}
 			if refreshed.AuthorityKind != "" || refreshed.AuthorityRef != "" {
 				t.Fatalf("redirected authority = %q/%q, want empty", refreshed.AuthorityKind, refreshed.AuthorityRef)
+			}
+			// The redirect switched POST to GET, so the action must be
+			// recomputed from the new method rather than carried over.
+			// Preserving "write" here would misreport the hop.
+			if wantAction := string(receipt.ClassifyHTTP(http.MethodGet)); refreshed.Action != wantAction {
+				t.Fatalf("refreshed Action = %q, want %q recomputed from the redirected method",
+					refreshed.Action, wantAction)
 			}
 			if refreshed.Actor != prev.Actor || refreshed.ActorAuth != prev.ActorAuth ||
 				refreshed.ReceiptID != prev.ReceiptID || refreshed.SessionTaint != prev.SessionTaint ||
@@ -353,9 +375,18 @@ func TestCheckRedirect_MalformedPriorEnvelopeBlocks(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  string
+		// extra values are Added after raw, so the header carries more
+		// than one value. Header.Get reads only the first, so without a
+		// Values-based read a malformed later value reads as absent and
+		// skips the block entirely.
+		extra []string
 	}{
 		{name: "invalid structured field", raw: "not a valid dictionary ((("},
 		{name: "missing required verdict", raw: "v=1, act=\"read\", rid=\"01961f3a-7b2c-7000-8000-000000000023\", ts=1"},
+		{name: "present but empty", raw: ""},
+		{name: "present but whitespace only", raw: "   "},
+		{name: "empty then malformed", raw: "", extra: []string{"not a valid dictionary ((("}},
+		{name: "valid then malformed", raw: "v=1", extra: []string{"not a valid dictionary ((("}},
 	}
 
 	for _, tt := range tests {
@@ -365,6 +396,9 @@ func TestCheckRedirect_MalformedPriorEnvelopeBlocks(t *testing.T) {
 			p := newSigningProxyForTest(t)
 			original := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://origin.example/start", nil)
 			original.Header.Set(envelope.HeaderName, tt.raw)
+			for _, value := range tt.extra {
+				original.Header.Add(envelope.HeaderName, value)
+			}
 			redirected := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirected.example/final", nil)
 
 			err := p.refreshEnvelopeForRedirect(redirected, []*http.Request{original}, p.cfgPtr.Load())

--- a/internal/proxy/redirect_refresh_test.go
+++ b/internal/proxy/redirect_refresh_test.go
@@ -273,6 +273,115 @@ func TestCheckRedirect_PreservesRequiresReauth(t *testing.T) {
 	}
 }
 
+func TestCheckRedirect_DropsAuthorityOnRedirect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		authorityKind string
+		authorityRef  string
+	}{
+		{
+			name:          "kind and reference",
+			authorityKind: "user-exact",
+			authorityRef:  "grant-123",
+		},
+		{
+			name:          "kind only",
+			authorityKind: "delegated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := newSigningProxyForTest(t)
+			em := p.envelopeEmitterPtr.Load()
+			if em == nil {
+				t.Fatal("expected startup signing emitter")
+			}
+
+			original := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "https://origin.example/start", nil)
+			prev, err := em.Build(envelope.BuildOpts{
+				ActionID:       "01961f3a-7b2c-7000-8000-000000000022",
+				Action:         "write",
+				Verdict:        config.ActionAllow,
+				Actor:          "agent",
+				ActorAuth:      envelope.ActorAuthBound,
+				SessionTaint:   "restricted",
+				TaskID:         "task-123",
+				AuthorityKind:  tt.authorityKind,
+				AuthorityRef:   tt.authorityRef,
+				RequiresReauth: true,
+			})
+			if err != nil {
+				t.Fatalf("build previous envelope: %v", err)
+			}
+			if err := envelope.InjectHTTP(original.Header, prev); err != nil {
+				t.Fatalf("inject previous envelope: %v", err)
+			}
+
+			redirected := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirected.example/final", nil)
+			if err := p.refreshEnvelopeForRedirect(redirected, []*http.Request{original}, p.cfgPtr.Load()); err != nil {
+				t.Fatalf("refreshEnvelopeForRedirect: %v", err)
+			}
+
+			refreshed, err := envelope.Parse(redirected.Header.Get(envelope.HeaderName))
+			if err != nil {
+				t.Fatalf("parse refreshed envelope: %v", err)
+			}
+			if refreshed.AuthorityKind != "" || refreshed.AuthorityRef != "" {
+				t.Fatalf("redirected authority = %q/%q, want empty", refreshed.AuthorityKind, refreshed.AuthorityRef)
+			}
+			if refreshed.Actor != prev.Actor || refreshed.ActorAuth != prev.ActorAuth ||
+				refreshed.ReceiptID != prev.ReceiptID || refreshed.SessionTaint != prev.SessionTaint ||
+				refreshed.TaskID != prev.TaskID || refreshed.RequiresReauth != prev.RequiresReauth {
+				t.Fatalf("redirect lost identity metadata: got %+v, want actor=%q actor_auth=%q receipt=%q taint=%q task=%q reauth=%t",
+					refreshed, prev.Actor, prev.ActorAuth, prev.ReceiptID, prev.SessionTaint, prev.TaskID, prev.RequiresReauth)
+			}
+			if refreshed.Hop != 1 {
+				t.Errorf("Hop = %d, want 1", refreshed.Hop)
+			}
+		})
+	}
+}
+
+func TestCheckRedirect_MalformedPriorEnvelopeBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "invalid structured field", raw: "not a valid dictionary ((("},
+		{name: "missing required verdict", raw: "v=1, act=\"read\", rid=\"01961f3a-7b2c-7000-8000-000000000023\", ts=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := newSigningProxyForTest(t)
+			original := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://origin.example/start", nil)
+			original.Header.Set(envelope.HeaderName, tt.raw)
+			redirected := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://redirected.example/final", nil)
+
+			err := p.refreshEnvelopeForRedirect(redirected, []*http.Request{original}, p.cfgPtr.Load())
+			if err == nil {
+				t.Fatal("malformed prior envelope was allowed")
+			}
+			blocked, ok := blockedRequestErrorFrom(err)
+			if !ok {
+				t.Fatalf("expected blockedRequestError, got %T", err)
+			}
+			if blocked.layer != blockLayerMediationEnvelope {
+				t.Fatalf("blocked layer = %q, want %q", blocked.layer, blockLayerMediationEnvelope)
+			}
+		})
+	}
+}
+
 func TestCheckRedirect_ExplicitNilEmitterSnapshotDoesNotFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The mediation envelope is rebuilt on each redirect hop, and it preserved the action authority fields from the first request in the chain along with the identity fields. Identity being stable across a chain is correct, because the whole chain is one logical action. Authority is different: it describes permission for a specific action against a specific destination, and a later hop is a destination the original grant never described.

Authority is now cleared past the first hop. Actor, actor auth, receipt ID, session taint, task ID, reauth state and the hop counter still thread through unchanged.

A prior envelope that fails to parse now blocks the redirect instead of continuing with zero-valued metadata. Minting a fresh signed envelope from fields that could not be read is the wrong direction to fail on a hop that carries enforcement state.

The authority fields are inert today, so this is not a live bypass. It is removed now so the carry-over does not exist if a future change makes those fields load-bearing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redirected requests no longer retain authority metadata from earlier hops.
  * Redirect refreshes now stop safely when mediation envelope data is missing, empty, malformed, or duplicated, preventing unintended continuation.
  * Identity, authentication, receipt, task, taint, and reauthentication information continue to be preserved during redirects.
  * Redirect actions are recalculated correctly after each hop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->