### PR TITLE
feat(evidence): add reader support for writer namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Recorder readers accept the v3 outer-chain namespace fields
+  `chain_kind` and `writer_instance_id`. The recorder continues to emit v2
+  entries during the compatibility window.
+
 ## [3.3.0] - 2026-07-30
 
 ### Breaking Changes / Upgrade Notes

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -290,10 +290,12 @@ Fields:
 
 | Field | Description |
 |-------|-------------|
-| `v` | Schema version. Readers must reject unknown versions. |
+| `v` | Schema version. This release writes v2 and reads v1, v2, and v3. Readers reject other versions. |
 | `seq` | Monotonically increasing sequence number within the session. |
 | `ts` | RFC 3339 timestamp with nanosecond precision. |
 | `session_id` | Proxy session identifier. |
+| `chain_kind` | v3 chain namespace kind. Omitted from v1 and v2 records. |
+| `writer_instance_id` | v3 per-process namespace claim. Omitted from v1 and v2 records. This field separates cooperating writers; it does not authenticate the writer. |
 | `type` | Entry type: `decision`, `checkpoint`. |
 | `transport` | Proxy transport: `fetch`, `forward`, `connect`, `websocket`, `mcp-stdio`, `mcp-http`. |
 | `summary` | One-line human-readable description. |
@@ -304,11 +306,15 @@ Fields:
 
 ## Hash Chain
 
-The hash covers all entry fields joined with null-byte separators:
+Each schema version has a frozen field projection joined with null-byte separators. V1 uses:
 
 ```
 SHA256(v \0 seq \0 ts \0 session_id \0 trace_id \0 type \0 transport \0 summary \0 detail_json \0 raw_ref \0 prev_hash)
 ```
+
+V2 inserts `event_kind` after `type`. V3 inserts `chain_kind` and
+`writer_instance_id` after `session_id`. The recorder continues writing v2
+during the reader-first compatibility window.
 
 The first entry in a writer chain has `prev_hash: "genesis"`. Each subsequent entry's `prev_hash` must equal the `hash` of the previous entry from that writer. Any gap, deletion, modification, or concurrent-writer fork breaks the chain. Current releases do not reject multiple processes sharing a recorder directory; run `pipelock evidence doctor DIR` when a verifier reports a `prev_hash` mismatch to surface the structural damage for investigation. The doctor reports symptoms rather than causes; a concurrent-writer fork and a deliberate edit can produce the same structure.
 

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -308,7 +308,7 @@ Fields:
 
 Each schema version has a frozen field projection joined with null-byte separators. V1 uses:
 
-```
+```text
 SHA256(v \0 seq \0 ts \0 session_id \0 trace_id \0 type \0 transport \0 summary \0 detail_json \0 raw_ref \0 prev_hash)
 ```
 

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -331,7 +331,9 @@ follower keys are resolved first by exact org/fleet/instance and key ID.
 Accepted audit batches are written to a local SQLite raw-evidence store with
 idempotency on `(org, fleet, instance,
 batch_id)` and fork rejection on overlapping sequence ranges with divergent
-payload or segment-tail hashes. The storage directory is sensitive
+payload or segment-tail hashes within the same recorder chain namespace.
+Independent v3 writer namespaces may reuse sequence ranges without forming a
+fork. The storage directory is sensitive
 operator-controlled state. The MVP exposes
 `GET /api/v1/conductor/audit/batches` as an operator/admin metadata query
 endpoint; it requires audit-query authorization and at least `org_id`, returns
@@ -703,8 +705,8 @@ Conductor must:
 - Enforce created skew: default 60s, configurable max 300s with warning.
 - Verify schema version intersection.
 - Verify sequence range monotonicity.
-- Detect overlapping sequence ranges with different hashes as a compromise
-  indicator.
+- Detect overlapping sequence ranges with different hashes in the same recorder
+  chain namespace as a compromise indicator.
 - Verify v2 recorder entry hashes.
 - Verify checkpoint signature with enrolled receipt/checkpoint public key.
 - Stitch segment rotation using previous segment tail and current segment head.

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -638,8 +638,8 @@ metadata-only batch summaries. It does not export raw payload bytes.
 
 ## Audit Batch Schema
 
-Conductor-bound batches require recorder v2 entries. v1 entries are not accepted for
-Conductor-bound ingestion because v2 binds `event_kind` into the chain hash.
+Conductor-bound batches accept recorder v2 and v3 entries. v1 entries are not
+accepted because v2 and later bind `event_kind` into the chain hash.
 
 ```json
 {

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -708,8 +708,9 @@ Conductor must:
 - Detect overlapping sequence ranges with different hashes in the same recorder
   chain namespace as a compromise indicator.
 - Accept v2 and v3 recorder audit entries and verify each version with its own
-  hash projection. V3 entries require `chain_kind` and `writer_instance_id`,
-  which define the namespace used for continuity and fork detection.
+  hash projection. V3 entries require `session_id`, `chain_kind`, and
+  `writer_instance_id`, which together define the chain identity used for
+  continuity and fork detection.
 - Verify checkpoint signature with enrolled receipt/checkpoint public key.
 - Stitch segment rotation using previous segment tail and current segment head.
 - DLP-scan payload contents before storage.

--- a/docs/specs/pipelock-conductor-audit-sink.md
+++ b/docs/specs/pipelock-conductor-audit-sink.md
@@ -707,7 +707,9 @@ Conductor must:
 - Verify sequence range monotonicity.
 - Detect overlapping sequence ranges with different hashes in the same recorder
   chain namespace as a compromise indicator.
-- Verify v2 recorder entry hashes.
+- Accept v2 and v3 recorder audit entries and verify each version with its own
+  hash projection. V3 entries require `chain_kind` and `writer_instance_id`,
+  which define the namespace used for continuity and fork detection.
 - Verify checkpoint signature with enrolled receipt/checkpoint public key.
 - Stitch segment rotation using previous segment tail and current segment head.
 - DLP-scan payload contents before storage.

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -182,6 +182,16 @@ func (p *Producer) run() {
 	var pending []recorder.Entry
 	for entry := range p.entries {
 		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
+			if entry.Type == checkpointEntryType {
+				p.previousSegmentTail = entry.Hash
+			}
+			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
+			continue
+		}
+		if err := recorder.ValidateEntrySchema(entry); err != nil {
+			if entry.Type == checkpointEntryType {
+				p.previousSegmentTail = entry.Hash
+			}
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -307,7 +307,7 @@ func homogeneousRecorderNamespace(entries []recorder.Entry) bool {
 	}
 	first := entries[0]
 	for _, entry := range entries[1:] {
-		if entry.Version != first.Version || entry.ChainKind != first.ChainKind || entry.WriterInstanceID != first.WriterInstanceID {
+		if entry.Version != first.Version || entry.SessionID != first.SessionID || entry.ChainKind != first.ChainKind || entry.WriterInstanceID != first.WriterInstanceID {
 			return false
 		}
 	}
@@ -332,6 +332,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		Dropped:            dropped,
 		Chain: conductor.EvidenceChain{
 			EntryVersion:           entries[0].Version,
+			SessionID:              entries[0].SessionID,
 			ChainKind:              entries[0].ChainKind,
 			WriterInstanceID:       entries[0].WriterInstanceID,
 			SegmentID:              segmentID(entries[0], checkpoint.Sequence),
@@ -368,7 +369,7 @@ func recorderNamespaceKey(entry recorder.Entry) string {
 	if entry.Version == 1 || entry.Version == 2 {
 		return "legacy"
 	}
-	return fmt.Sprintf("v%d\x00%s\x00%s", entry.Version, entry.ChainKind, entry.WriterInstanceID)
+	return fmt.Sprintf("v%d\x00%s\x00%s\x00%s", entry.Version, entry.SessionID, entry.ChainKind, entry.WriterInstanceID)
 }
 
 func (p *Producer) previousSegmentTailFor(key string) string {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -302,7 +302,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 			EntryVersion:           entries[0].Version,
 			ChainKind:              entries[0].ChainKind,
 			WriterInstanceID:       entries[0].WriterInstanceID,
-			SegmentID:              segmentID(entries[0].SessionID, entries[0].Sequence, checkpoint.Sequence),
+			SegmentID:              segmentID(entries[0], checkpoint.Sequence),
 			SeqStart:               entries[0].Sequence,
 			SeqEnd:                 checkpoint.Sequence,
 			PreviousSegmentTail:    p.previousSegmentTail,
@@ -457,11 +457,16 @@ func ed25519SignatureString(hexSig string) string {
 	return conductor.SignaturePrefixEd25519 + hexSig
 }
 
-func segmentID(sessionID string, start, end uint64) string {
+func segmentID(entry recorder.Entry, end uint64) string {
+	sessionID := entry.SessionID
 	if sessionID == "" {
 		sessionID = "recorder"
 	}
-	return fmt.Sprintf("segment-%s-%020d-%020d", safeSegmentPart(sessionID), start, end)
+	prefix := "segment-" + safeSegmentPart(sessionID)
+	if recorder.EntryVersionHasNamespace(entry.Version) {
+		prefix += "-" + safeSegmentPart(entry.ChainKind) + "-" + safeSegmentPart(entry.WriterInstanceID)
+	}
+	return fmt.Sprintf("%s-%020d-%020d", prefix, entry.Sequence, end)
 }
 
 func safeSegmentPart(s string) string {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -62,6 +62,7 @@ type Producer struct {
 	dropMu               sync.Mutex
 	dropped              map[string]uint64
 	previousSegmentTail  string
+	previousSegmentTails map[string]string
 	emitAppliedState     bool
 	appliedStateProvider func() (conductor.FollowerAppliedState, bool)
 }
@@ -137,6 +138,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 		entries:              make(chan recorder.Entry, cfg.BufferSize),
 		done:                 make(chan struct{}),
 		dropped:              map[string]uint64{},
+		previousSegmentTails: map[string]string{},
 		emitAppliedState:     cfg.EmitAppliedState,
 		appliedStateProvider: cfg.AppliedStateProvider,
 	}
@@ -179,37 +181,40 @@ func (p *Producer) Close() error {
 
 func (p *Producer) run() {
 	defer close(p.done)
-	var pending []recorder.Entry
+	pending := make(map[string][]recorder.Entry)
 	for entry := range p.entries {
+		key := recorderNamespaceKey(entry)
 		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
 			if entry.Type == checkpointEntryType {
-				p.previousSegmentTail = entry.Hash
+				p.setPreviousSegmentTail(key, entry.Hash)
 			}
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
 		if err := recorder.ValidateEntrySchema(entry); err != nil {
 			if entry.Type == checkpointEntryType {
-				p.previousSegmentTail = entry.Hash
+				p.setPreviousSegmentTail(key, entry.Hash)
 			}
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
-		if len(pending) > 0 && entry.Sequence != pending[len(pending)-1].Sequence+1 {
-			p.drop(producerDropSequenceGap, droppedActionReceiptCount(pending))
-			pending = nil
+		chainPending := pending[key]
+		if len(chainPending) > 0 && entry.Sequence != chainPending[len(chainPending)-1].Sequence+1 {
+			p.drop(producerDropSequenceGap, droppedActionReceiptCount(chainPending))
+			chainPending = nil
 		}
-		pending = append(pending, entry)
+		chainPending = append(chainPending, entry)
+		pending[key] = chainPending
 		if entry.Type != checkpointEntryType {
 			continue
 		}
 		// enqueueSegment records its own drop accounting and metrics at
 		// each failure site, so the returned error is informational only.
-		_ = p.enqueueSegment(pending)
-		pending = nil
+		_ = p.enqueueSegment(chainPending)
+		delete(pending, key)
 	}
-	if len(pending) > 0 {
-		p.drop(producerDropShutdownPartial, droppedActionReceiptCount(pending))
+	for _, chainPending := range pending {
+		p.drop(producerDropShutdownPartial, droppedActionReceiptCount(chainPending))
 	}
 }
 
@@ -228,7 +233,8 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	// drop path left the tail un-advanced, the next segment would claim
 	// continuity across a checkpoint the recorder actually wrote, and a
 	// verifier replaying the local recorder file would reject the chain.
-	defer func() { p.previousSegmentTail = checkpoint.Hash }()
+	key := recorderNamespaceKey(checkpoint)
+	defer func() { p.setPreviousSegmentTail(key, checkpoint.Hash) }()
 	if !homogeneousRecorderNamespace(entries) {
 		droppedActions := droppedActionReceiptCount(entries)
 		p.drop(producerDropInvalidCheckpoint, droppedActions)
@@ -250,7 +256,7 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 		return fmt.Errorf("%s: payload=%d max=%d", producerDropPayloadTooLarge, len(payload), conductor.MaxAuditPayloadBytes)
 	}
 	includedDrops := p.droppedAccounting()
-	envelope := p.envelope(entries, checkpoint, cp, payload, includedDrops)
+	envelope := p.envelope(entries, checkpoint, cp, payload, includedDrops, p.previousSegmentTailFor(key))
 	signed, err := SignEnvelope(envelope, p.auditSignerKeyID, p.auditSigner)
 	if err != nil {
 		p.drop(producerDropEnqueueError, droppedActions)
@@ -282,7 +288,7 @@ func homogeneousRecorderNamespace(entries []recorder.Entry) bool {
 	return true
 }
 
-func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte, dropped conductor.DroppedAccounting) conductor.AuditBatchEnvelope {
+func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte, dropped conductor.DroppedAccounting, previousSegmentTail string) conductor.AuditBatchEnvelope {
 	sum := sha256.Sum256(payload)
 	env := conductor.AuditBatchEnvelope{
 		SchemaVersion:      conductor.SchemaVersion,
@@ -305,7 +311,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 			SegmentID:              segmentID(entries[0], checkpoint.Sequence),
 			SeqStart:               entries[0].Sequence,
 			SeqEnd:                 checkpoint.Sequence,
-			PreviousSegmentTail:    p.previousSegmentTail,
+			PreviousSegmentTail:    previousSegmentTail,
 			SegmentHeadHash:        entries[0].Hash,
 			SegmentTailHash:        checkpoint.Hash,
 			CheckpointSeq:          checkpoint.Sequence,
@@ -330,6 +336,28 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		}
 	}
 	return env
+}
+
+func recorderNamespaceKey(entry recorder.Entry) string {
+	if entry.Version == 1 || entry.Version == 2 {
+		return "legacy"
+	}
+	return fmt.Sprintf("v%d\x00%s\x00%s", entry.Version, entry.ChainKind, entry.WriterInstanceID)
+}
+
+func (p *Producer) previousSegmentTailFor(key string) string {
+	if key == "legacy" {
+		return p.previousSegmentTail
+	}
+	return p.previousSegmentTails[key]
+}
+
+func (p *Producer) setPreviousSegmentTail(key, tail string) {
+	if key == "legacy" {
+		p.previousSegmentTail = tail
+		return
+	}
+	p.previousSegmentTails[key] = tail
 }
 
 func (p *Producer) nextBatchID() string {
@@ -464,7 +492,8 @@ func segmentID(entry recorder.Entry, end uint64) string {
 	}
 	prefix := "segment-" + safeSegmentPart(sessionID)
 	if recorder.EntryVersionHasNamespace(entry.Version) {
-		prefix += "-" + safeSegmentPart(entry.ChainKind) + "-" + safeSegmentPart(entry.WriterInstanceID)
+		namespace := sha256.Sum256([]byte(sessionID + "\x00" + entry.ChainKind + "\x00" + entry.WriterInstanceID))
+		prefix += "-" + hex.EncodeToString(namespace[:8])
 	}
 	return fmt.Sprintf("%s-%020d-%020d", prefix, entry.Sequence, end)
 }

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -202,12 +202,18 @@ func (p *Producer) run() {
 		}
 		if err := recorder.ValidateEntrySchema(entry); err != nil {
 			if recorder.ValidateEntryNamespace(entry.Version, entry.ChainKind, entry.WriterInstanceID) != nil {
-				for pendingKey, chainPending := range pending {
-					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(chainPending))
-					delete(pending, pendingKey)
+				if entry.Version == 1 || entry.Version == 2 {
+					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
+					delete(pending, key)
+					blocked[key] = true
+				} else {
+					for pendingKey, chainPending := range pending {
+						p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(chainPending))
+						delete(pending, pendingKey)
+					}
+					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
+					blockedAll = true
 				}
-				p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
-				blockedAll = true
 			} else {
 				p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
 				delete(pending, key)
@@ -228,6 +234,9 @@ func (p *Producer) run() {
 		// enqueueSegment records its own drop accounting and metrics at
 		// each failure site, so the returned error is informational only.
 		_ = p.enqueueSegment(chainPending)
+		if p.previousSegmentTailFor(key) != entry.Hash {
+			blocked[key] = true
+		}
 		delete(pending, key)
 	}
 	for _, chainPending := range pending {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -181,7 +181,7 @@ func (p *Producer) run() {
 	defer close(p.done)
 	var pending []recorder.Entry
 	for entry := range p.entries {
-		if entry.Version != recorder.EntryVersion {
+		if !recorder.IsAcceptedEntryVersion(entry.Version) {
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
@@ -210,6 +210,11 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	checkpoint := entries[len(entries)-1]
 	if checkpoint.Type != checkpointEntryType {
 		return nil
+	}
+	if !homogeneousRecorderNamespace(entries) {
+		droppedActions := droppedActionReceiptCount(entries)
+		p.drop(producerDropInvalidCheckpoint, droppedActions)
+		return fmt.Errorf("%s: recorder entry version or namespace changed within segment", producerDropInvalidCheckpoint)
 	}
 	// The recorder committed this checkpoint to its local hash chain before
 	// we observed it, so advance the chain tail unconditionally - even on a
@@ -255,6 +260,19 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	return nil
 }
 
+func homogeneousRecorderNamespace(entries []recorder.Entry) bool {
+	if len(entries) == 0 {
+		return true
+	}
+	first := entries[0]
+	for _, entry := range entries[1:] {
+		if entry.Version != first.Version || entry.ChainKind != first.ChainKind || entry.WriterInstanceID != first.WriterInstanceID {
+			return false
+		}
+	}
+	return true
+}
+
 func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry, cp recorder.CheckpointDetail, payload []byte, dropped conductor.DroppedAccounting) conductor.AuditBatchEnvelope {
 	sum := sha256.Sum256(payload)
 	env := conductor.AuditBatchEnvelope{
@@ -263,7 +281,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		OrgID:              p.orgID,
 		FleetID:            p.fleetID,
 		InstanceID:         p.instanceID,
-		AuditSchemaVersion: recorder.EntryVersion,
+		AuditSchemaVersion: entries[0].Version,
 		EmittedAt:          p.now().UTC(),
 		SeqStart:           entries[0].Sequence,
 		SeqEnd:             checkpoint.Sequence,
@@ -272,7 +290,9 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		PayloadBytes:       uint64(len(payload)),
 		Dropped:            dropped,
 		Chain: conductor.EvidenceChain{
-			EntryVersion:           recorder.EntryVersion,
+			EntryVersion:           entries[0].Version,
+			ChainKind:              entries[0].ChainKind,
+			WriterInstanceID:       entries[0].WriterInstanceID,
 			SegmentID:              segmentID(entries[0].SessionID, entries[0].Sequence, checkpoint.Sequence),
 			SeqStart:               entries[0].Sequence,
 			SeqEnd:                 checkpoint.Sequence,

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -182,20 +182,37 @@ func (p *Producer) Close() error {
 func (p *Producer) run() {
 	defer close(p.done)
 	pending := make(map[string][]recorder.Entry)
+	blocked := make(map[string]bool)
+	blockedAll := false
 	for entry := range p.entries {
 		key := recorderNamespaceKey(entry)
-		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
-			if entry.Type == checkpointEntryType {
-				p.setPreviousSegmentTail(key, entry.Hash)
-			}
+		if blockedAll || blocked[key] {
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
-		if err := recorder.ValidateEntrySchema(entry); err != nil {
-			if entry.Type == checkpointEntryType {
-				p.setPreviousSegmentTail(key, entry.Hash)
+		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
+			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
+			delete(pending, key)
+			if entry.Version == 1 || entry.Version == 2 {
+				blocked[key] = true
+			} else {
+				blockedAll = true
 			}
-			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
+			continue
+		}
+		if err := recorder.ValidateEntrySchema(entry); err != nil {
+			if recorder.ValidateEntryNamespace(entry.Version, entry.ChainKind, entry.WriterInstanceID) != nil {
+				for pendingKey, chainPending := range pending {
+					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(chainPending))
+					delete(pending, pendingKey)
+				}
+				p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
+				blockedAll = true
+			} else {
+				p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
+				delete(pending, key)
+				blocked[key] = true
+			}
 			continue
 		}
 		chainPending := pending[key]
@@ -233,8 +250,6 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	// drop path left the tail un-advanced, the next segment would claim
 	// continuity across a checkpoint the recorder actually wrote, and a
 	// verifier replaying the local recorder file would reject the chain.
-	key := recorderNamespaceKey(checkpoint)
-	defer func() { p.setPreviousSegmentTail(key, checkpoint.Hash) }()
 	if !homogeneousRecorderNamespace(entries) {
 		droppedActions := droppedActionReceiptCount(entries)
 		p.drop(producerDropInvalidCheckpoint, droppedActions)
@@ -246,6 +261,8 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 		p.drop(producerDropInvalidCheckpoint, droppedActions)
 		return fmt.Errorf("%s: %w", producerDropInvalidCheckpoint, err)
 	}
+	key := recorderNamespaceKey(checkpoint)
+	defer func() { p.setPreviousSegmentTail(key, checkpoint.Hash) }()
 	payload, err := marshalEntriesJSONL(entries)
 	if err != nil {
 		p.drop(producerDropEnqueueError, droppedActions)

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	defaultProducerBuffer = 4096
+	defaultProducerBuffer       = 4096
+	maxActiveRecorderNamespaces = 1024
 
 	actionReceiptEntryType = "action_receipt"
 	checkpointEntryType    = "checkpoint"
@@ -183,21 +184,21 @@ func (p *Producer) run() {
 	defer close(p.done)
 	pending := make(map[string][]recorder.Entry)
 	blocked := make(map[string]bool)
-	blockedAll := false
+	knownNamespaces := make(map[string]struct{})
 	for entry := range p.entries {
 		key := recorderNamespaceKey(entry)
-		if blockedAll || blocked[key] {
+		if !admitRecorderNamespace(knownNamespaces, key) {
+			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
+			continue
+		}
+		if blocked[key] {
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
 		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
 			delete(pending, key)
-			if entry.Version == 1 || entry.Version == 2 {
-				blocked[key] = true
-			} else {
-				blockedAll = true
-			}
+			blocked[key] = true
 			continue
 		}
 		if err := recorder.ValidateEntrySchema(entry); err != nil {
@@ -207,12 +208,9 @@ func (p *Producer) run() {
 					delete(pending, key)
 					blocked[key] = true
 				} else {
-					for pendingKey, chainPending := range pending {
-						p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(chainPending))
-						delete(pending, pendingKey)
-					}
-					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
-					blockedAll = true
+					p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
+					delete(pending, key)
+					blocked[key] = true
 				}
 			} else {
 				p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount(append(pending[key], entry)))
@@ -242,6 +240,20 @@ func (p *Producer) run() {
 	for _, chainPending := range pending {
 		p.drop(producerDropShutdownPartial, droppedActionReceiptCount(chainPending))
 	}
+}
+
+func admitRecorderNamespace(known map[string]struct{}, key string) bool {
+	if key == "legacy" {
+		return true
+	}
+	if _, ok := known[key]; ok {
+		return true
+	}
+	if len(known) >= maxActiveRecorderNamespaces {
+		return false
+	}
+	known[key] = struct{}{}
+	return true
 }
 
 func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
@@ -332,7 +344,7 @@ func (p *Producer) envelope(entries []recorder.Entry, checkpoint recorder.Entry,
 		Dropped:            dropped,
 		Chain: conductor.EvidenceChain{
 			EntryVersion:           entries[0].Version,
-			SessionID:              entries[0].SessionID,
+			SessionID:              namespacedSessionID(entries[0]),
 			ChainKind:              entries[0].ChainKind,
 			WriterInstanceID:       entries[0].WriterInstanceID,
 			SegmentID:              segmentID(entries[0], checkpoint.Sequence),
@@ -370,6 +382,13 @@ func recorderNamespaceKey(entry recorder.Entry) string {
 		return "legacy"
 	}
 	return fmt.Sprintf("v%d\x00%s\x00%s\x00%s", entry.Version, entry.SessionID, entry.ChainKind, entry.WriterInstanceID)
+}
+
+func namespacedSessionID(entry recorder.Entry) string {
+	if recorder.EntryVersionHasNamespace(entry.Version) {
+		return entry.SessionID
+	}
+	return ""
 }
 
 func (p *Producer) previousSegmentTailFor(key string) string {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -181,7 +181,7 @@ func (p *Producer) run() {
 	defer close(p.done)
 	var pending []recorder.Entry
 	for entry := range p.entries {
-		if !recorder.IsAcceptedEntryVersion(entry.Version) {
+		if !conductor.IsSupportedAuditEntryVersion(entry.Version) {
 			p.drop(producerDropInvalidCheckpoint, droppedActionReceiptCount([]recorder.Entry{entry}))
 			continue
 		}
@@ -211,11 +211,6 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	if checkpoint.Type != checkpointEntryType {
 		return nil
 	}
-	if !homogeneousRecorderNamespace(entries) {
-		droppedActions := droppedActionReceiptCount(entries)
-		p.drop(producerDropInvalidCheckpoint, droppedActions)
-		return fmt.Errorf("%s: recorder entry version or namespace changed within segment", producerDropInvalidCheckpoint)
-	}
 	// The recorder committed this checkpoint to its local hash chain before
 	// we observed it, so advance the chain tail unconditionally - even on a
 	// drop. The next segment's PreviousSegmentTail must reflect the true
@@ -224,7 +219,11 @@ func (p *Producer) enqueueSegment(entries []recorder.Entry) error {
 	// continuity across a checkpoint the recorder actually wrote, and a
 	// verifier replaying the local recorder file would reject the chain.
 	defer func() { p.previousSegmentTail = checkpoint.Hash }()
-
+	if !homogeneousRecorderNamespace(entries) {
+		droppedActions := droppedActionReceiptCount(entries)
+		p.drop(producerDropInvalidCheckpoint, droppedActions)
+		return fmt.Errorf("%s: recorder entry version or namespace changed within segment", producerDropInvalidCheckpoint)
+	}
 	droppedActions := droppedActionReceiptCount(entries)
 	cp, err := checkpointDetail(checkpoint)
 	if err != nil {

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -26,12 +26,13 @@ import (
 )
 
 func TestHomogeneousRecorderNamespace(t *testing.T) {
-	base := recorder.Entry{Version: recorder.LatestEntryVersion, ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a"}
+	base := recorder.Entry{Version: recorder.LatestEntryVersion, SessionID: "session-a", ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a"}
 	for _, tc := range []struct {
 		name   string
 		mutate func(*recorder.Entry)
 	}{
 		{"version", func(e *recorder.Entry) { e.Version = recorder.CurrentWriteEntryVersion }},
+		{"session_id", func(e *recorder.Entry) { e.SessionID = "session-b" }},
 		{"chain_kind", func(e *recorder.Entry) { e.ChainKind = "receipt" }},
 		{"writer_instance_id", func(e *recorder.Entry) { e.WriterInstanceID = "writer-b" }},
 	} {
@@ -511,6 +512,42 @@ func TestProducer_IsolatesInterleavedV3Namespaces(t *testing.T) {
 		chain := lease.Batch.Envelope.Chain
 		if chain.WriterInstanceID != wantWriters[i] || chain.PreviousSegmentTail != wantPrevious[i] {
 			t.Fatalf("batch %d writer/tail = %q/%q, want %q/%q", i, chain.WriterInstanceID, chain.PreviousSegmentTail, wantWriters[i], wantPrevious[i])
+		}
+	}
+}
+
+func TestProducer_IsolatesInterleavedV3Sessions(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+
+	first := namespacedCheckpointSegment(0, "writer-a")
+	second := namespacedCheckpointSegment(0, "writer-a")
+	for i := range first {
+		first[i].SessionID = "session-a"
+		second[i].SessionID = "session-b"
+	}
+	for _, entry := range []recorder.Entry{first[0], second[0], first[1], second[1]} {
+		p.ObserveRecorderEntry(entry)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, wantSession := range []string{"session-a", "session-b"} {
+		lease, err := q.Claim()
+		if err != nil {
+			t.Fatalf("Claim batch %d: %v", i, err)
+		}
+		chain := lease.Batch.Envelope.Chain
+		if chain.SessionID != wantSession || chain.PreviousSegmentTail != "" {
+			t.Fatalf("batch %d session/tail = %q/%q, want %q/empty", i, chain.SessionID, chain.PreviousSegmentTail, wantSession)
 		}
 	}
 }

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -70,6 +70,9 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	for _, entry := range checkpointSegment(2) {
 		p.ObserveRecorderEntry(entry)
 	}
+	for _, entry := range namespacedCheckpointSegment(0, "writer-a") {
+		p.ObserveRecorderEntry(entry)
+	}
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -77,8 +80,8 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Pending != 0 || p.previousSegmentTail != "" {
-		t.Fatalf("v1 segment pending=%d tail=%q, want quarantined namespace with no accepted tail", stats.Pending, p.previousSegmentTail)
+	if stats.Pending != 1 || p.previousSegmentTail != "" {
+		t.Fatalf("v1 segment pending=%d tail=%q, want legacy quarantined and v3 pending", stats.Pending, p.previousSegmentTail)
 	}
 }
 
@@ -101,6 +104,9 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 	for _, entry := range checkpointSegment(2) {
 		p.ObserveRecorderEntry(entry)
 	}
+	for _, entry := range namespacedCheckpointSegment(0, "writer-a") {
+		p.ObserveRecorderEntry(entry)
+	}
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -108,8 +114,15 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Pending != 0 || p.previousSegmentTail != "" {
-		t.Fatalf("invalid namespace pending=%d tail=%q, want quarantined namespace with no accepted tail", stats.Pending, p.previousSegmentTail)
+	if stats.Pending != 1 || p.previousSegmentTail != "" {
+		t.Fatalf("invalid namespace pending=%d tail=%q, want legacy quarantined and v3 pending", stats.Pending, p.previousSegmentTail)
+	}
+	lease, err := q.Claim()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lease.Batch.Envelope.Chain.WriterInstanceID; got != "writer-a" {
+		t.Fatalf("independent v3 writer = %q, want writer-a", got)
 	}
 }
 
@@ -401,11 +414,10 @@ func TestProducer_AdvancesChainTailOnDroppedSegment(t *testing.T) {
 	}
 }
 
-// TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint covers the
-// invalid-checkpoint drop path: the tail still advances (the recorder wrote
-// the checkpoint) and the drop metric carries the right reason. Nothing is
-// enqueued.
-func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) {
+// TestProducer_QuarantinesInvalidCheckpoint covers the fail-closed boundary:
+// an invalid checkpoint cannot become a trusted tail, and later entries in the
+// same namespace cannot be emitted with stale continuity.
+func TestProducer_QuarantinesInvalidCheckpoint(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
@@ -416,25 +428,27 @@ func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) 
 	}
 	metrics := &transportMetricsRecorder{}
 	p := newTestProducer(t, q, metrics, priv)
-	defer func() { _ = p.Close() }()
 
 	seg := checkpointSegment(0)
 	seg[1].Detail = recorder.CheckpointDetail{} // strip the checkpoint signature
-	if err := p.enqueueSegment(seg); err == nil {
-		t.Fatal("expected invalid checkpoint error")
+	for _, entry := range append(seg, checkpointSegment(2)...) {
+		p.ObserveRecorderEntry(entry)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
 	}
 	if p.previousSegmentTail != "" {
 		t.Fatalf("tail advanced from invalid checkpoint: %q", p.previousSegmentTail)
 	}
-	if got := metrics.delivery["drop:invalid_checkpoint"]; got != 1 {
-		t.Fatalf("invalid_checkpoint drop metric = %d, want 1", got)
+	if got := metrics.delivery["drop:invalid_checkpoint"]; got != 2 {
+		t.Fatalf("invalid_checkpoint drop metric = %d, want 2", got)
 	}
 	stats, err := q.Stats()
 	if err != nil {
 		t.Fatalf("Stats: %v", err)
 	}
 	if stats.Pending != 0 {
-		t.Fatalf("pending = %d, want 0 (nothing enqueued)", stats.Pending)
+		t.Fatalf("pending = %d, want 0 after namespace quarantine", stats.Pending)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -62,8 +62,12 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
-	const tail = "unsupported-v1-checkpoint"
-	p.ObserveRecorderEntry(recorder.Entry{Version: 1, Type: checkpointEntryType, Hash: tail})
+	segment := checkpointSegment(0)
+	for i := range segment {
+		segment[i].Version = 1
+		p.ObserveRecorderEntry(segment[i])
+	}
+	tail := segment[1].Hash
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -86,11 +90,13 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
-	const tail = "invalid-v2-namespace-checkpoint"
-	p.ObserveRecorderEntry(recorder.Entry{
-		Version: recorder.CurrentWriteEntryVersion, Type: checkpointEntryType,
-		ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "unhashed", Hash: tail,
-	})
+	segment := checkpointSegment(0)
+	for i := range segment {
+		segment[i].ChainKind = recorder.ChainKindRecorder
+		segment[i].WriterInstanceID = "unhashed"
+		p.ObserveRecorderEntry(segment[i])
+	}
+	tail := segment[1].Hash
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -446,8 +452,48 @@ func TestProducer_AdvancesTailOnMixedNamespaceRejection(t *testing.T) {
 	if err := p.enqueueSegment(seg); err == nil {
 		t.Fatal("mixed namespace segment accepted")
 	}
-	if p.previousSegmentTail != seg[1].Hash {
-		t.Fatalf("tail after mixed namespace rejection = %q, want %q", p.previousSegmentTail, seg[1].Hash)
+	key := recorderNamespaceKey(seg[1])
+	if got := p.previousSegmentTailFor(key); got != seg[1].Hash {
+		t.Fatalf("tail after mixed namespace rejection = %q, want %q", got, seg[1].Hash)
+	}
+}
+
+func TestProducer_IsolatesInterleavedV3Namespaces(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+
+	firstA := namespacedCheckpointSegment(0, "writer-a")
+	firstB := namespacedCheckpointSegment(0, "writer-b")
+	for _, entry := range []recorder.Entry{firstA[0], firstB[0], firstA[1], firstB[1]} {
+		p.ObserveRecorderEntry(entry)
+	}
+	secondA := namespacedCheckpointSegment(2, "writer-a")
+	secondB := namespacedCheckpointSegment(2, "writer-b")
+	for _, entry := range append(secondA, secondB...) {
+		p.ObserveRecorderEntry(entry)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	wantPrevious := []string{"", "", firstA[1].Hash, firstB[1].Hash}
+	wantWriters := []string{"writer-a", "writer-b", "writer-a", "writer-b"}
+	for i := range wantPrevious {
+		lease, err := q.Claim()
+		if err != nil {
+			t.Fatalf("Claim batch %d: %v", i, err)
+		}
+		chain := lease.Batch.Envelope.Chain
+		if chain.WriterInstanceID != wantWriters[i] || chain.PreviousSegmentTail != wantPrevious[i] {
+			t.Fatalf("batch %d writer/tail = %q/%q, want %q/%q", i, chain.WriterInstanceID, chain.PreviousSegmentTail, wantWriters[i], wantPrevious[i])
+		}
 	}
 }
 
@@ -565,7 +611,7 @@ func TestProducerHelpers(t *testing.T) {
 		Version: recorder.LatestEntryVersion, SessionID: "proxy", Sequence: 1,
 		ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a",
 	}
-	if got := segmentID(entry, 2); got != "segment-proxy-recorder-writer-a-00000000000000000001-00000000000000000002" {
+	if got := segmentID(entry, 2); got != "segment-proxy-840f4f71315f14ee-00000000000000000001-00000000000000000002" {
 		t.Fatalf("segmentID(v3) = %q", got)
 	}
 	if got := safeSegmentPart("a/b:c"); got != "abc" {
@@ -622,6 +668,16 @@ func checkpointSegment(start uint64) []recorder.Entry {
 		},
 	}
 	return []recorder.Entry{reg, cp}
+}
+
+func namespacedCheckpointSegment(start uint64, writer string) []recorder.Entry {
+	segment := checkpointSegment(start)
+	for i := range segment {
+		segment[i].Version = 3
+		segment[i].ChainKind = recorder.ChainKindRecorder
+		segment[i].WriterInstanceID = writer
+	}
+	return segment
 }
 
 func segmentHashHex(seed string) string {

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -53,6 +53,21 @@ func TestHomogeneousRecorderNamespace(t *testing.T) {
 	}
 }
 
+func TestRecorderNamespaceLimit(t *testing.T) {
+	known := make(map[string]struct{})
+	for i := 0; i < maxActiveRecorderNamespaces; i++ {
+		if !admitRecorderNamespace(known, fmt.Sprintf("v3-%d", i)) {
+			t.Fatalf("namespace %d rejected below limit", i)
+		}
+	}
+	if admitRecorderNamespace(known, "overflow") {
+		t.Fatal("namespace above limit accepted")
+	}
+	if !admitRecorderNamespace(known, "v3-0") {
+		t.Fatal("known namespace rejected at limit")
+	}
+}
+
 func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -127,6 +142,37 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 	}
 }
 
+func TestProducerQuarantinesOnlyInvalidV3Namespace(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+	invalid := namespacedCheckpointSegment(0, "writer-bad")
+	for i := range invalid {
+		invalid[i].WriterInstanceID = ""
+		invalid[i].Hash = recorder.ComputeHash(invalid[i])
+		p.ObserveRecorderEntry(invalid[i])
+	}
+	for _, entry := range namespacedCheckpointSegment(0, "writer-good") {
+		p.ObserveRecorderEntry(entry)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Pending != 1 {
+		t.Fatalf("pending = %d, want independent valid namespace queued", stats.Pending)
+	}
+}
+
 func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 	auditPub, auditPriv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -179,6 +225,9 @@ func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 		t.Fatalf("Claim: %v", err)
 	}
 	batch := lease.Batch
+	if batch.Envelope.Chain.SessionID != "" {
+		t.Fatalf("v2 chain session_id = %q, want omitted for wire compatibility", batch.Envelope.Chain.SessionID)
+	}
 	if err := batch.Envelope.VerifySignatures(func(id string) (conductor.SignatureKey, error) {
 		if id != "audit-key-1" {
 			return conductor.SignatureKey{}, errors.New("unknown key")

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -67,7 +67,9 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 		segment[i].Version = 1
 		p.ObserveRecorderEntry(segment[i])
 	}
-	tail := segment[1].Hash
+	for _, entry := range checkpointSegment(2) {
+		p.ObserveRecorderEntry(entry)
+	}
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -75,8 +77,8 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Pending != 0 || p.previousSegmentTail != tail {
-		t.Fatalf("v1 segment pending=%d tail=%q, want 0 and %q", stats.Pending, p.previousSegmentTail, tail)
+	if stats.Pending != 0 || p.previousSegmentTail != "" {
+		t.Fatalf("v1 segment pending=%d tail=%q, want quarantined namespace with no accepted tail", stats.Pending, p.previousSegmentTail)
 	}
 }
 
@@ -96,7 +98,9 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 		segment[i].WriterInstanceID = "unhashed"
 		p.ObserveRecorderEntry(segment[i])
 	}
-	tail := segment[1].Hash
+	for _, entry := range checkpointSegment(2) {
+		p.ObserveRecorderEntry(entry)
+	}
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -104,8 +108,8 @@ func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Pending != 0 || p.previousSegmentTail != tail {
-		t.Fatalf("invalid namespace pending=%d tail=%q, want 0 and %q", stats.Pending, p.previousSegmentTail, tail)
+	if stats.Pending != 0 || p.previousSegmentTail != "" {
+		t.Fatalf("invalid namespace pending=%d tail=%q, want quarantined namespace with no accepted tail", stats.Pending, p.previousSegmentTail)
 	}
 }
 
@@ -419,8 +423,8 @@ func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) 
 	if err := p.enqueueSegment(seg); err == nil {
 		t.Fatal("expected invalid checkpoint error")
 	}
-	if p.previousSegmentTail != seg[1].Hash {
-		t.Fatalf("tail not advanced on invalid checkpoint: %q", p.previousSegmentTail)
+	if p.previousSegmentTail != "" {
+		t.Fatalf("tail advanced from invalid checkpoint: %q", p.previousSegmentTail)
 	}
 	if got := metrics.delivery["drop:invalid_checkpoint"]; got != 1 {
 		t.Fatalf("invalid_checkpoint drop metric = %d, want 1", got)
@@ -453,8 +457,8 @@ func TestProducer_AdvancesTailOnMixedNamespaceRejection(t *testing.T) {
 		t.Fatal("mixed namespace segment accepted")
 	}
 	key := recorderNamespaceKey(seg[1])
-	if got := p.previousSegmentTailFor(key); got != seg[1].Hash {
-		t.Fatalf("tail after mixed namespace rejection = %q, want %q", got, seg[1].Hash)
+	if got := p.previousSegmentTailFor(key); got != "" {
+		t.Fatalf("tail advanced after mixed namespace rejection: %q", got)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -46,6 +46,34 @@ func TestHomogeneousRecorderNamespace(t *testing.T) {
 	if !homogeneousRecorderNamespace([]recorder.Entry{base, base}) {
 		t.Fatal("homogeneousRecorderNamespace() = false for identical namespace")
 	}
+	legacy := recorder.Entry{Version: recorder.CurrentWriteEntryVersion}
+	if !homogeneousRecorderNamespace([]recorder.Entry{legacy, legacy}) {
+		t.Fatal("homogeneousRecorderNamespace() = false for v2 entries without namespace")
+	}
+}
+
+func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := &transportMetricsRecorder{}
+	p := newTestProducer(t, q, metrics, priv)
+	p.ObserveRecorderEntry(recorder.Entry{Version: 1, Type: "action_receipt"})
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Pending != 0 || metrics.delivery["drop:invalid_checkpoint"] != 1 {
+		t.Fatalf("v1 segment pending=%d invalid drops=%d, want 0 and 1", stats.Pending, metrics.delivery["drop:invalid_checkpoint"])
+	}
 }
 
 func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
@@ -370,6 +398,29 @@ func TestProducer_AdvancesTailAndRecordsMetricOnInvalidCheckpoint(t *testing.T) 
 	}
 	if stats.Pending != 0 {
 		t.Fatalf("pending = %d, want 0 (nothing enqueued)", stats.Pending)
+	}
+}
+
+func TestProducer_AdvancesTailOnMixedNamespaceRejection(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+	defer func() { _ = p.Close() }()
+	seg := checkpointSegment(0)
+	seg[1].Version = recorder.LatestEntryVersion
+	seg[1].ChainKind = recorder.ChainKindRecorder
+	seg[1].WriterInstanceID = "writer-a"
+	if err := p.enqueueSegment(seg); err == nil {
+		t.Fatal("mixed namespace segment accepted")
+	}
+	if p.previousSegmentTail != seg[1].Hash {
+		t.Fatalf("tail after mixed namespace rejection = %q, want %q", p.previousSegmentTail, seg[1].Hash)
 	}
 }
 

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -558,8 +558,15 @@ func TestProducerHelpers(t *testing.T) {
 	if got := ed25519SignatureString("abc"); got != "ed25519:abc" {
 		t.Fatalf("unprefixed signature = %q", got)
 	}
-	if got := segmentID("", 1, 2); got != "segment-recorder-00000000000000000001-00000000000000000002" {
+	if got := segmentID(recorder.Entry{Sequence: 1}, 2); got != "segment-recorder-00000000000000000001-00000000000000000002" {
 		t.Fatalf("segmentID(empty) = %q", got)
+	}
+	entry := recorder.Entry{
+		Version: recorder.LatestEntryVersion, SessionID: "proxy", Sequence: 1,
+		ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a",
+	}
+	if got := segmentID(entry, 2); got != "segment-proxy-recorder-writer-a-00000000000000000001-00000000000000000002" {
+		t.Fatalf("segmentID(v3) = %q", got)
 	}
 	if got := safeSegmentPart("a/b:c"); got != "abc" {
 		t.Fatalf("safeSegmentPart() = %q", got)

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -25,6 +25,29 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
+func TestHomogeneousRecorderNamespace(t *testing.T) {
+	base := recorder.Entry{Version: recorder.LatestEntryVersion, ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a"}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*recorder.Entry)
+	}{
+		{"version", func(e *recorder.Entry) { e.Version = recorder.CurrentWriteEntryVersion }},
+		{"chain_kind", func(e *recorder.Entry) { e.ChainKind = "receipt" }},
+		{"writer_instance_id", func(e *recorder.Entry) { e.WriterInstanceID = "writer-b" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := base
+			tc.mutate(&changed)
+			if homogeneousRecorderNamespace([]recorder.Entry{base, changed}) {
+				t.Fatalf("homogeneousRecorderNamespace() = true after %s change", tc.name)
+			}
+		})
+	}
+	if !homogeneousRecorderNamespace([]recorder.Entry{base, base}) {
+		t.Fatal("homogeneousRecorderNamespace() = false for identical namespace")
+	}
+}
+
 func TestProducer_EnqueuesSignedCheckpointSegment(t *testing.T) {
 	auditPub, auditPriv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/enterprise/conductor/auditbatcher/producer_test.go
+++ b/enterprise/conductor/auditbatcher/producer_test.go
@@ -61,9 +61,9 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	metrics := &transportMetricsRecorder{}
-	p := newTestProducer(t, q, metrics, priv)
-	p.ObserveRecorderEntry(recorder.Entry{Version: 1, Type: "action_receipt"})
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+	const tail = "unsupported-v1-checkpoint"
+	p.ObserveRecorderEntry(recorder.Entry{Version: 1, Type: checkpointEntryType, Hash: tail})
 	if err := p.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -71,8 +71,35 @@ func TestProducerRejectsTransportUnsupportedV1Segment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Pending != 0 || metrics.delivery["drop:invalid_checkpoint"] != 1 {
-		t.Fatalf("v1 segment pending=%d invalid drops=%d, want 0 and 1", stats.Pending, metrics.delivery["drop:invalid_checkpoint"])
+	if stats.Pending != 0 || p.previousSegmentTail != tail {
+		t.Fatalf("v1 segment pending=%d tail=%q, want 0 and %q", stats.Pending, p.previousSegmentTail, tail)
+	}
+}
+
+func TestProducerRejectsLegacyNamespaceBeforeEnvelope(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := testOpen(t, Config{Dir: filepath.Join(t.TempDir(), "queue")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newTestProducer(t, q, &transportMetricsRecorder{}, priv)
+	const tail = "invalid-v2-namespace-checkpoint"
+	p.ObserveRecorderEntry(recorder.Entry{
+		Version: recorder.CurrentWriteEntryVersion, Type: checkpointEntryType,
+		ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "unhashed", Hash: tail,
+	})
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := q.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Pending != 0 || p.previousSegmentTail != tail {
+		t.Fatalf("invalid namespace pending=%d tail=%q, want 0 and %q", stats.Pending, p.previousSegmentTail, tail)
 	}
 }
 

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -464,7 +464,7 @@ func DefaultCapabilities(conductorID string) conductor.CapabilitiesResponse {
 		RemoteKill:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		RollbackAuthorization:  conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		AuditBatch:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.AuditEnvelopeSchemaVersion},
-		ReceiptEntryVersions:   []int{2, 3},
+		ReceiptEntryVersions:   conductor.SupportedAuditEntryVersions(),
 		MaxCreatedSkewSeconds:  int(conductor.DefaultAuditMaxSkew / time.Second),
 		EmergencyStream:        false,
 		RemoteKillThreshold:    conductor.RequiredCatastrophicSigners,

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -464,7 +464,7 @@ func DefaultCapabilities(conductorID string) conductor.CapabilitiesResponse {
 		RemoteKill:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		RollbackAuthorization:  conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		AuditBatch:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.AuditEnvelopeSchemaVersion},
-		ReceiptEntryVersions:   []int{2},
+		ReceiptEntryVersions:   []int{2, 3},
 		MaxCreatedSkewSeconds:  int(conductor.DefaultAuditMaxSkew / time.Second),
 		EmergencyStream:        false,
 		RemoteKillThreshold:    conductor.RequiredCatastrophicSigners,

--- a/enterprise/conductor/fleetreport/report.go
+++ b/enterprise/conductor/fleetreport/report.go
@@ -312,7 +312,9 @@ func verifySegment(batchID string, chain conductorcore.EvidenceChain, entries []
 		if err := recorder.ValidateEntrySchema(entry); err != nil {
 			return fmt.Errorf("fleet report: audit batch %s seq %d invalid recorder entry: %w", batchID, entry.Sequence, err)
 		}
-		if entry.Version != chain.EntryVersion || entry.ChainKind != chain.ChainKind || entry.WriterInstanceID != chain.WriterInstanceID {
+		if entry.Version != chain.EntryVersion ||
+			(recorder.EntryVersionHasNamespace(entry.Version) && entry.SessionID != chain.SessionID) ||
+			entry.ChainKind != chain.ChainKind || entry.WriterInstanceID != chain.WriterInstanceID {
 			return fmt.Errorf("fleet report: audit batch %s seq %d chain namespace mismatch", batchID, entry.Sequence)
 		}
 	}

--- a/enterprise/conductor/fleetreport/report.go
+++ b/enterprise/conductor/fleetreport/report.go
@@ -116,7 +116,7 @@ func Build(ctx context.Context, source EvidenceSource, opts Options) (Result, er
 		if uint64(len(entries)) != ev.Envelope.EventCount {
 			return Result{}, fmt.Errorf("fleet report: audit batch %s event count=%d want %d", ev.Envelope.BatchID, len(entries), ev.Envelope.EventCount)
 		}
-		if err := verifySegment(ev.Envelope.BatchID, ev.Envelope.SeqStart, ev.Envelope.SeqEnd, ev.Envelope.Chain.SegmentHeadHash, ev.Envelope.Chain.SegmentTailHash, entries); err != nil {
+		if err := verifySegment(ev.Envelope.BatchID, ev.Envelope.Chain, entries); err != nil {
 			return Result{}, err
 		}
 		if err := agg.addBatch(ev, entries, auditKey); err != nil {
@@ -295,19 +295,22 @@ func decodeReceiptDetail(detail any) (receipt.Receipt, error) {
 	return receipt.Unmarshal(raw)
 }
 
-func verifySegment(batchID string, seqStart, seqEnd uint64, headHash, tailHash string, entries []recorder.Entry) error {
+func verifySegment(batchID string, chain conductorcore.EvidenceChain, entries []recorder.Entry) error {
 	if len(entries) == 0 {
 		return fmt.Errorf("fleet report: audit batch %s has empty payload", batchID)
 	}
-	if entries[0].Sequence != seqStart || entries[len(entries)-1].Sequence != seqEnd {
+	if entries[0].Sequence != chain.SeqStart || entries[len(entries)-1].Sequence != chain.SeqEnd {
 		return fmt.Errorf("fleet report: audit batch %s sequence range mismatch", batchID)
 	}
-	if entries[0].Hash != headHash || entries[len(entries)-1].Hash != tailHash {
+	if entries[0].Hash != chain.SegmentHeadHash || entries[len(entries)-1].Hash != chain.SegmentTailHash {
 		return fmt.Errorf("fleet report: audit batch %s chain head/tail mismatch", batchID)
 	}
 	for i, entry := range entries {
 		if !recorder.IsAcceptedEntryVersion(entry.Version) {
 			return fmt.Errorf("fleet report: audit batch %s seq %d unsupported recorder entry version %d", batchID, entry.Sequence, entry.Version)
+		}
+		if entry.Version != chain.EntryVersion || entry.ChainKind != chain.ChainKind || entry.WriterInstanceID != chain.WriterInstanceID {
+			return fmt.Errorf("fleet report: audit batch %s seq %d chain namespace mismatch", batchID, entry.Sequence)
 		}
 		if i == 0 {
 			continue

--- a/enterprise/conductor/fleetreport/report.go
+++ b/enterprise/conductor/fleetreport/report.go
@@ -305,16 +305,19 @@ func verifySegment(batchID string, chain conductorcore.EvidenceChain, entries []
 	if entries[0].Hash != chain.SegmentHeadHash || entries[len(entries)-1].Hash != chain.SegmentTailHash {
 		return fmt.Errorf("fleet report: audit batch %s chain head/tail mismatch", batchID)
 	}
-	for i, entry := range entries {
+	for _, entry := range entries {
 		if !recorder.IsAcceptedEntryVersion(entry.Version) {
 			return fmt.Errorf("fleet report: audit batch %s seq %d unsupported recorder entry version %d", batchID, entry.Sequence, entry.Version)
+		}
+		if err := recorder.ValidateEntrySchema(entry); err != nil {
+			return fmt.Errorf("fleet report: audit batch %s seq %d invalid recorder entry: %w", batchID, entry.Sequence, err)
 		}
 		if entry.Version != chain.EntryVersion || entry.ChainKind != chain.ChainKind || entry.WriterInstanceID != chain.WriterInstanceID {
 			return fmt.Errorf("fleet report: audit batch %s seq %d chain namespace mismatch", batchID, entry.Sequence)
 		}
-		if i == 0 {
-			continue
-		}
+	}
+	for i := 1; i < len(entries); i++ {
+		entry := entries[i]
 		prev := entries[i-1]
 		if entry.Sequence != prev.Sequence+1 {
 			return fmt.Errorf("fleet report: audit batch %s seq gap at %d", batchID, entry.Sequence)

--- a/enterprise/conductor/fleetreport/report_test.go
+++ b/enterprise/conductor/fleetreport/report_test.go
@@ -428,6 +428,25 @@ func TestVerifySegmentRejectsVersionInappropriateNamespace(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("valid_v3_namespace_mismatch", func(t *testing.T) {
+		entry := recorder.Entry{
+			Version: recorder.LatestEntryVersion, Sequence: 0, Timestamp: testWindowStart,
+			SessionID: "proxy", ChainKind: recorder.ChainKindRecorder, WriterInstanceID: "writer-a",
+			Type: "checkpoint", Transport: "recorder", Summary: "fixture",
+			PrevHash: recorder.GenesisHash,
+		}
+		entry.Hash = recorder.ComputeHash(entry)
+		chain := conductorcore.EvidenceChain{
+			EntryVersion: recorder.LatestEntryVersion, ChainKind: recorder.ChainKindRecorder,
+			WriterInstanceID: "writer-b", SeqStart: 0, SeqEnd: 0,
+			SegmentHeadHash: entry.Hash, SegmentTailHash: entry.Hash,
+		}
+		err := verifySegment("audit-namespace", chain, []recorder.Entry{entry})
+		if err == nil || !strings.Contains(err.Error(), "chain namespace mismatch") {
+			t.Fatalf("verifySegment() error = %v, want chain namespace mismatch", err)
+		}
+	})
 }
 
 func TestValueOrUnspecified(t *testing.T) {

--- a/enterprise/conductor/fleetreport/report_test.go
+++ b/enterprise/conductor/fleetreport/report_test.go
@@ -382,7 +382,7 @@ func TestVerifySegmentRejectsMalformedSegments(t *testing.T) {
 			entries := append([]recorder.Entry(nil), valid...)
 			entries[1].WriterInstanceID = "unexpected"
 			return entries
-		}(), "chain namespace mismatch"},
+		}(), "invalid recorder entry"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -396,6 +396,35 @@ func TestVerifySegmentRejectsMalformedSegments(t *testing.T) {
 			err := verifySegment("audit-1", chain, tc.entries)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("verifySegment() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifySegmentRejectsVersionInappropriateNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		version int
+		kind    string
+		writer  string
+	}{
+		{"legacy_with_namespace", recorder.CurrentWriteEntryVersion, recorder.ChainKindRecorder, "writer-a"},
+		{"v3_without_namespace", recorder.LatestEntryVersion, "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := recorder.Entry{
+				Version: tc.version, Sequence: 0, Timestamp: testWindowStart,
+				SessionID: "proxy", ChainKind: tc.kind, WriterInstanceID: tc.writer,
+				Type: "checkpoint", Transport: "recorder", Summary: "fixture",
+				PrevHash: recorder.GenesisHash,
+			}
+			entry.Hash = recorder.ComputeHash(entry)
+			chain := conductorcore.EvidenceChain{
+				EntryVersion: tc.version, ChainKind: tc.kind, WriterInstanceID: tc.writer,
+				SeqStart: 0, SeqEnd: 0, SegmentHeadHash: entry.Hash, SegmentTailHash: entry.Hash,
+			}
+			if err := verifySegment("audit-namespace", chain, []recorder.Entry{entry}); err == nil {
+				t.Fatal("verifySegment() accepted version-inappropriate namespace")
 			}
 		})
 	}

--- a/enterprise/conductor/fleetreport/report_test.go
+++ b/enterprise/conductor/fleetreport/report_test.go
@@ -378,10 +378,22 @@ func TestVerifySegmentRejectsMalformedSegments(t *testing.T) {
 			entries[1].PrevHash = recorder.GenesisHash
 			return entries
 		}(), "chain link mismatch"},
+		{"namespace", 10, 11, first.Hash, second.Hash, func() []recorder.Entry {
+			entries := append([]recorder.Entry(nil), valid...)
+			entries[1].WriterInstanceID = "unexpected"
+			return entries
+		}(), "chain namespace mismatch"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := verifySegment("audit-1", tc.start, tc.end, tc.head, tc.tail, tc.entries)
+			chain := conductorcore.EvidenceChain{
+				EntryVersion:    recorder.CurrentWriteEntryVersion,
+				SeqStart:        tc.start,
+				SeqEnd:          tc.end,
+				SegmentHeadHash: tc.head,
+				SegmentTailHash: tc.tail,
+			}
+			err := verifySegment("audit-1", chain, tc.entries)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("verifySegment() error = %v, want %q", err, tc.want)
 			}

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1405,6 +1405,9 @@ func (c EvidenceChain) Validate(seqStart, seqEnd uint64) error {
 			return err
 		}
 	}
+	if err := recorder.ValidateEntryNamespace(c.EntryVersion, c.ChainKind, c.WriterInstanceID); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidSequenceRange, err)
+	}
 	if err := validateIdentifier("chain.segment_id", c.SegmentID); err != nil {
 		return err
 	}

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -403,6 +403,7 @@ type StreamSwitchAuthorization struct {
 
 type EvidenceChain struct {
 	EntryVersion           int    `json:"entry_version"`
+	SessionID              string `json:"session_id,omitempty"`
 	ChainKind              string `json:"chain_kind,omitempty"`
 	WriterInstanceID       string `json:"writer_instance_id,omitempty"`
 	SegmentID              string `json:"segment_id"`
@@ -1397,7 +1398,7 @@ func auditChainIdentityEqual(a, b EvidenceChain) bool {
 	if !aNamespaced {
 		return true
 	}
-	return a.EntryVersion == b.EntryVersion && a.ChainKind == b.ChainKind && a.WriterInstanceID == b.WriterInstanceID
+	return a.EntryVersion == b.EntryVersion && a.SessionID == b.SessionID && a.ChainKind == b.ChainKind && a.WriterInstanceID == b.WriterInstanceID
 }
 
 // IsSupportedAuditEntryVersion reports whether audit transport accepts version.
@@ -1413,6 +1414,9 @@ func (c EvidenceChain) Validate(seqStart, seqEnd uint64) error {
 		return fmt.Errorf("%w: entry_version=%d", ErrInvalidSequenceRange, c.EntryVersion)
 	}
 	if recorder.EntryVersionHasNamespace(c.EntryVersion) {
+		if err := validateIdentifier("chain.session_id", c.SessionID); err != nil {
+			return err
+		}
 		if err := validateIdentifier("chain.chain_kind", c.ChainKind); err != nil {
 			return err
 		}

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -403,6 +403,8 @@ type StreamSwitchAuthorization struct {
 
 type EvidenceChain struct {
 	EntryVersion           int    `json:"entry_version"`
+	ChainKind              string `json:"chain_kind,omitempty"`
+	WriterInstanceID       string `json:"writer_instance_id,omitempty"`
 	SegmentID              string `json:"segment_id"`
 	SeqStart               uint64 `json:"seq_start"`
 	SeqEnd                 uint64 `json:"seq_end"`
@@ -1384,8 +1386,16 @@ func (a AuditBatchEnvelope) ForksWith(other AuditBatchEnvelope) bool {
 }
 
 func (c EvidenceChain) Validate(seqStart, seqEnd uint64) error {
-	if c.EntryVersion != 2 {
+	if c.EntryVersion != 2 && c.EntryVersion != recorder.LatestEntryVersion {
 		return fmt.Errorf("%w: entry_version=%d", ErrInvalidSequenceRange, c.EntryVersion)
+	}
+	if c.EntryVersion == recorder.LatestEntryVersion {
+		if err := validateIdentifier("chain.chain_kind", c.ChainKind); err != nil {
+			return err
+		}
+		if err := validateIdentifier("chain.writer_instance_id", c.WriterInstanceID); err != nil {
+			return err
+		}
 	}
 	if err := validateIdentifier("chain.segment_id", c.SegmentID); err != nil {
 		return err
@@ -1452,13 +1462,13 @@ func (c CapabilitiesResponse) ValidateWithLocalThresholdCap(maxThreshold int) er
 			return err
 		}
 	}
-	// Couple to recorder.EntryVersion - the version the local recorder
-	// actively WRITES - so a recorder bump (v2→v3) automatically tightens
-	// the handshake instead of leaving this stranded on a hardcoded "2".
+	// Couple to the version the local recorder actively writes, not the latest
+	// version its readers accept. A reader-first bump must not strand older
+	// conductors during a rolling upgrade.
 	// Conductor must advertise that version or the follower can never produce
 	// ingestable batches.
-	if !slices.Contains(c.ReceiptEntryVersions, recorder.EntryVersion) {
-		return fmt.Errorf("%w: receipt_entry_versions must include recorder write version %d", ErrInvalidState, recorder.EntryVersion)
+	if !slices.Contains(c.ReceiptEntryVersions, recorder.CurrentWriteEntryVersion) {
+		return fmt.Errorf("%w: receipt_entry_versions must include recorder write version %d", ErrInvalidState, recorder.CurrentWriteEntryVersion)
 	}
 	if c.MaxCreatedSkewSeconds <= 0 || time.Duration(c.MaxCreatedSkewSeconds)*time.Second > MaxAllowedAuditSkew {
 		return fmt.Errorf("%w: max_created_skew_seconds=%d", ErrSkewExceeded, c.MaxCreatedSkewSeconds)

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1379,14 +1379,25 @@ func (a AuditBatchEnvelope) ForksWith(other AuditBatchEnvelope) bool {
 	if a.OrgID != other.OrgID || a.FleetID != other.FleetID || a.InstanceID != other.InstanceID {
 		return false
 	}
+	if !auditChainIdentityEqual(a.Chain, other.Chain) {
+		return false
+	}
 	if a.SeqEnd < other.SeqStart || other.SeqEnd < a.SeqStart {
 		return false
 	}
-	return a.PayloadSHA256 != other.PayloadSHA256 ||
-		a.Chain.SegmentTailHash != other.Chain.SegmentTailHash ||
-		a.Chain.EntryVersion != other.Chain.EntryVersion ||
-		a.Chain.ChainKind != other.Chain.ChainKind ||
-		a.Chain.WriterInstanceID != other.Chain.WriterInstanceID
+	return a.PayloadSHA256 != other.PayloadSHA256 || a.Chain.SegmentTailHash != other.Chain.SegmentTailHash
+}
+
+func auditChainIdentityEqual(a, b EvidenceChain) bool {
+	aNamespaced := recorder.EntryVersionHasNamespace(a.EntryVersion)
+	bNamespaced := recorder.EntryVersionHasNamespace(b.EntryVersion)
+	if aNamespaced != bNamespaced {
+		return false
+	}
+	if !aNamespaced {
+		return true
+	}
+	return a.EntryVersion == b.EntryVersion && a.ChainKind == b.ChainKind && a.WriterInstanceID == b.WriterInstanceID
 }
 
 // IsSupportedAuditEntryVersion reports whether audit transport accepts version.

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1382,7 +1382,11 @@ func (a AuditBatchEnvelope) ForksWith(other AuditBatchEnvelope) bool {
 	if a.SeqEnd < other.SeqStart || other.SeqEnd < a.SeqStart {
 		return false
 	}
-	return a.PayloadSHA256 != other.PayloadSHA256 || a.Chain.SegmentTailHash != other.Chain.SegmentTailHash
+	return a.PayloadSHA256 != other.PayloadSHA256 ||
+		a.Chain.SegmentTailHash != other.Chain.SegmentTailHash ||
+		a.Chain.EntryVersion != other.Chain.EntryVersion ||
+		a.Chain.ChainKind != other.Chain.ChainKind ||
+		a.Chain.WriterInstanceID != other.Chain.WriterInstanceID
 }
 
 // IsSupportedAuditEntryVersion reports whether audit transport accepts version.

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1385,11 +1385,19 @@ func (a AuditBatchEnvelope) ForksWith(other AuditBatchEnvelope) bool {
 	return a.PayloadSHA256 != other.PayloadSHA256 || a.Chain.SegmentTailHash != other.Chain.SegmentTailHash
 }
 
+// IsSupportedAuditEntryVersion reports whether audit transport accepts version.
+func IsSupportedAuditEntryVersion(version int) bool {
+	return version == 2 || recorder.EntryVersionHasNamespace(version)
+}
+
+// SupportedAuditEntryVersions returns the versions advertised to followers.
+func SupportedAuditEntryVersions() []int { return []int{2, 3} }
+
 func (c EvidenceChain) Validate(seqStart, seqEnd uint64) error {
-	if c.EntryVersion != 2 && c.EntryVersion != recorder.LatestEntryVersion {
+	if !IsSupportedAuditEntryVersion(c.EntryVersion) {
 		return fmt.Errorf("%w: entry_version=%d", ErrInvalidSequenceRange, c.EntryVersion)
 	}
-	if c.EntryVersion == recorder.LatestEntryVersion {
+	if recorder.EntryVersionHasNamespace(c.EntryVersion) {
 		if err := validateIdentifier("chain.chain_kind", c.ChainKind); err != nil {
 			return err
 		}

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/presets"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"gopkg.in/yaml.v3"
 )
@@ -162,6 +163,41 @@ func TestAuditBatchEnvelope_ValidateV2ChainAndForkDetection(t *testing.T) {
 	nonOverlap.SeqEnd = batch.SeqEnd + 10
 	if batch.ForksWith(nonOverlap) {
 		t.Fatal("ForksWith() = true for non-overlapping seq range")
+	}
+}
+
+func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
+	chain := testAuditBatch().Chain
+	chain.EntryVersion = recorder.LatestEntryVersion
+	chain.ChainKind = recorder.ChainKindRecorder
+	chain.WriterInstanceID = "writer-a"
+	if err := chain.Validate(10, 20); err != nil {
+		t.Fatalf("Validate(v3) = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		edit func(*EvidenceChain)
+	}{
+		{"missing_chain_kind", func(c *EvidenceChain) { c.ChainKind = "" }},
+		{"missing_writer_instance_id", func(c *EvidenceChain) { c.WriterInstanceID = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invalid := chain
+			tc.edit(&invalid)
+			if err := invalid.Validate(10, 20); !errors.Is(err, ErrMissingField) {
+				t.Fatalf("Validate() = %v, want ErrMissingField", err)
+			}
+		})
+	}
+
+	first := testAuditBatch()
+	first.Chain = chain
+	second := first
+	second.PayloadSHA256 = testHash("20")
+	second.Chain.WriterInstanceID = "writer-b"
+	if !first.ForksWith(second) {
+		t.Fatal("ForksWith() = false after follower-controlled namespace change")
 	}
 }
 
@@ -1752,7 +1788,7 @@ func TestEvidenceChain_ValidateErrors(t *testing.T) {
 		edit func(*EvidenceChain)
 		want error
 	}{
-		{"wrong_entry_version", func(c *EvidenceChain) { c.EntryVersion = 3 }, ErrInvalidSequenceRange},
+		{"wrong_entry_version", func(c *EvidenceChain) { c.EntryVersion = 4 }, ErrInvalidSequenceRange},
 		{"missing_segment", func(c *EvidenceChain) { c.SegmentID = "" }, ErrMissingField},
 		{"seq_mismatch", func(c *EvidenceChain) { c.SeqStart++ }, ErrInvalidSequenceRange},
 		{"bad_hash", func(c *EvidenceChain) { c.CheckpointHash = "bad" }, ErrInvalidHash},

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -191,13 +191,23 @@ func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 		})
 	}
 
-	first := testAuditBatch()
-	first.Chain = chain
-	second := first
-	second.PayloadSHA256 = testHash("20")
-	second.Chain.WriterInstanceID = "writer-b"
-	if !first.ForksWith(second) {
-		t.Fatal("ForksWith() = false after follower-controlled namespace change")
+	for _, tc := range []struct {
+		name string
+		edit func(*EvidenceChain)
+	}{
+		{"entry_version", func(c *EvidenceChain) { c.EntryVersion = recorder.CurrentWriteEntryVersion }},
+		{"chain_kind", func(c *EvidenceChain) { c.ChainKind = "import" }},
+		{"writer_instance_id", func(c *EvidenceChain) { c.WriterInstanceID = "writer-b" }},
+	} {
+		t.Run("fork_"+tc.name, func(t *testing.T) {
+			first := testAuditBatch()
+			first.Chain = chain
+			second := first
+			tc.edit(&second.Chain)
+			if !first.ForksWith(second) {
+				t.Fatalf("ForksWith() = false after %s change", tc.name)
+			}
+		})
 	}
 }
 

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -201,6 +201,24 @@ func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 	}
 }
 
+func TestEvidenceChainRejectsVersionInappropriateNamespace(t *testing.T) {
+	legacy := testAuditBatch().Chain
+	legacy.EntryVersion = recorder.CurrentWriteEntryVersion
+	legacy.ChainKind = recorder.ChainKindRecorder
+	legacy.WriterInstanceID = "writer-a"
+	if err := legacy.Validate(legacy.SeqStart, legacy.SeqEnd); err == nil {
+		t.Fatal("EvidenceChain.Validate() accepted unhashed namespace on v2")
+	}
+
+	v3 := testAuditBatch().Chain
+	v3.EntryVersion = recorder.LatestEntryVersion
+	v3.ChainKind = ""
+	v3.WriterInstanceID = ""
+	if err := v3.Validate(v3.SeqStart, v3.SeqEnd); err == nil {
+		t.Fatal("EvidenceChain.Validate() accepted incomplete v3 namespace")
+	}
+}
+
 func TestAuditBatchEnvelope_DroppedAccounting(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		batch := testAuditBatch()

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -169,6 +169,7 @@ func TestAuditBatchEnvelope_ValidateV2ChainAndForkDetection(t *testing.T) {
 func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 	chain := testAuditBatch().Chain
 	chain.EntryVersion = recorder.LatestEntryVersion
+	chain.SessionID = "session-a"
 	chain.ChainKind = recorder.ChainKindRecorder
 	chain.WriterInstanceID = "writer-a"
 	if err := chain.Validate(10, 20); err != nil {
@@ -196,6 +197,7 @@ func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 		edit func(*EvidenceChain)
 	}{
 		{"entry_version", func(c *EvidenceChain) { c.EntryVersion = recorder.CurrentWriteEntryVersion }},
+		{"session_id", func(c *EvidenceChain) { c.SessionID = "session-b" }},
 		{"chain_kind", func(c *EvidenceChain) { c.ChainKind = "import" }},
 		{"writer_instance_id", func(c *EvidenceChain) { c.WriterInstanceID = "writer-b" }},
 	} {

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -211,6 +211,17 @@ func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("same_namespaced_chain_detects_fork", func(t *testing.T) {
+		first := testAuditBatch()
+		first.Chain = chain
+		second := first
+		second.PayloadSHA256 = testHash("20")
+		second.Chain.SegmentTailHash = testHash("21")
+		if !first.ForksWith(second) {
+			t.Fatal("ForksWith() = false for conflicting batches in the same v3 namespace")
+		}
+	})
 }
 
 func TestEvidenceChainRejectsVersionInappropriateNamespace(t *testing.T) {

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -199,13 +199,15 @@ func TestEvidenceChainAcceptsNamespacedV3AndForksPerWriter(t *testing.T) {
 		{"chain_kind", func(c *EvidenceChain) { c.ChainKind = "import" }},
 		{"writer_instance_id", func(c *EvidenceChain) { c.WriterInstanceID = "writer-b" }},
 	} {
-		t.Run("fork_"+tc.name, func(t *testing.T) {
+		t.Run("separate_chain_"+tc.name, func(t *testing.T) {
 			first := testAuditBatch()
 			first.Chain = chain
 			second := first
 			tc.edit(&second.Chain)
-			if !first.ForksWith(second) {
-				t.Fatalf("ForksWith() = false after %s change", tc.name)
+			second.PayloadSHA256 = testHash("20")
+			second.Chain.SegmentTailHash = testHash("21")
+			if first.ForksWith(second) {
+				t.Fatalf("ForksWith() = true across separate %s identity", tc.name)
 			}
 		})
 	}

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -178,6 +178,9 @@ func parseRecorderEntry(line []byte) (recorder.Entry, error) {
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return recorder.Entry{}, err
 	}
+	if err := recorder.ValidateEntryJSONSchema(line, raw.Version); err != nil {
+		return recorder.Entry{}, err
+	}
 
 	detail := json.RawMessage("null")
 	if raw.Detail != nil && string(raw.Detail) != "null" {

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -87,9 +87,9 @@ func newStreamState(opts StreamOptions) streamState {
 		allowedVersions:  make(map[int]bool),
 	}
 	if len(opts.AllowSchemaVersion) == 0 {
-		state.allowedVersions[1] = true
-		state.allowedVersions[2] = true
-		state.allowedVersions[recorder.LatestEntryVersion] = true
+		for _, version := range recorder.AcceptedEntryVersions() {
+			state.allowedVersions[version] = true
+		}
 		return state
 	}
 	for _, version := range opts.AllowSchemaVersion {
@@ -126,11 +126,11 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 			return
 		}
 		if seenEntry {
-			if (rec.Version == recorder.LatestEntryVersion) != (chainVersion == recorder.LatestEntryVersion) {
+			if recorder.EntryVersionHasNamespace(rec.Version) != recorder.EntryVersionHasNamespace(chainVersion) {
 				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder namespace version changed", ErrHashChainBroken, lineNo, rec.Sequence)
 				return
 			}
-			if rec.Version == recorder.LatestEntryVersion && (rec.ChainKind != chainKind || rec.WriterInstanceID != writerID) {
+			if recorder.EntryVersionHasNamespace(rec.Version) && (rec.ChainKind != chainKind || rec.WriterInstanceID != writerID) {
 				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder chain namespace changed", ErrHashChainBroken, lineNo, rec.Sequence)
 				return
 			}
@@ -207,10 +207,8 @@ func (s streamState) verifyRecorderEntry(rec recorder.Entry, lineNo int, previou
 	if !s.allowedVersions[rec.Version] || !hashSupportedVersion(rec.Version) {
 		return fmt.Errorf("%w (line=%d, seq=%d, version=%d)", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence, rec.Version)
 	}
-	if rec.Version == recorder.LatestEntryVersion {
-		if rec.ChainKind == "" || rec.WriterInstanceID == "" {
-			return fmt.Errorf("%w (line=%d, seq=%d): v3 chain namespace incomplete", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence)
-		}
+	if err := recorder.ValidateEntryNamespace(rec.Version, rec.ChainKind, rec.WriterInstanceID); err != nil {
+		return fmt.Errorf("%w (line=%d, seq=%d): %w", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence, err)
 	}
 
 	computedHash := recorder.ComputeHash(rec)

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -108,6 +108,7 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 		previousHash string
 		seenEntry    bool
 		chainVersion int
+		sessionID    string
 		chainKind    string
 		writerID     string
 	)
@@ -130,12 +131,12 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder namespace version changed", ErrHashChainBroken, lineNo, rec.Sequence)
 				return
 			}
-			if recorder.EntryVersionHasNamespace(rec.Version) && (rec.ChainKind != chainKind || rec.WriterInstanceID != writerID) {
+			if recorder.EntryVersionHasNamespace(rec.Version) && (rec.SessionID != sessionID || rec.ChainKind != chainKind || rec.WriterInstanceID != writerID) {
 				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder chain namespace changed", ErrHashChainBroken, lineNo, rec.Sequence)
 				return
 			}
 		} else {
-			chainVersion, chainKind, writerID = rec.Version, rec.ChainKind, rec.WriterInstanceID
+			chainVersion, sessionID, chainKind, writerID = rec.Version, rec.SessionID, rec.ChainKind, rec.WriterInstanceID
 		}
 		previousHash = rec.Hash
 		seenEntry = true

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -43,7 +43,7 @@ type StreamOptions struct {
 	EscrowPrivateKey []byte
 
 	// AllowSchemaVersion gates recorder.Entry.Version. The zero value allows
-	// recorder v1 and the current recorder.EntryVersion.
+	// recorder v1 plus every recorder version understood by this reader.
 	AllowSchemaVersion []int
 }
 
@@ -88,7 +88,8 @@ func newStreamState(opts StreamOptions) streamState {
 	}
 	if len(opts.AllowSchemaVersion) == 0 {
 		state.allowedVersions[1] = true
-		state.allowedVersions[recorder.EntryVersion] = true
+		state.allowedVersions[2] = true
+		state.allowedVersions[recorder.LatestEntryVersion] = true
 		return state
 	}
 	for _, version := range opts.AllowSchemaVersion {
@@ -106,6 +107,9 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 		lineNo       int
 		previousHash string
 		seenEntry    bool
+		chainVersion int
+		chainKind    string
+		writerID     string
 	)
 
 	for scanner.Scan() {
@@ -120,6 +124,18 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 		if err := s.verifyRecorderEntry(rec, lineNo, previousHash, seenEntry); err != nil {
 			errs <- err
 			return
+		}
+		if seenEntry {
+			if (rec.Version == recorder.LatestEntryVersion) != (chainVersion == recorder.LatestEntryVersion) {
+				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder namespace version changed", ErrHashChainBroken, lineNo, rec.Sequence)
+				return
+			}
+			if rec.Version == recorder.LatestEntryVersion && (rec.ChainKind != chainKind || rec.WriterInstanceID != writerID) {
+				errs <- fmt.Errorf("%w (line=%d, seq=%d): recorder chain namespace changed", ErrHashChainBroken, lineNo, rec.Sequence)
+				return
+			}
+		} else {
+			chainVersion, chainKind, writerID = rec.Version, rec.ChainKind, rec.WriterInstanceID
 		}
 		previousHash = rec.Hash
 		seenEntry = true
@@ -140,19 +156,21 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 }
 
 type rawRecorderEntry struct {
-	Version   int             `json:"v"`
-	Sequence  uint64          `json:"seq"`
-	Timestamp time.Time       `json:"ts"`
-	SessionID string          `json:"session_id"`
-	TraceID   string          `json:"trace_id,omitempty"`
-	Type      string          `json:"type"`
-	EventKind string          `json:"event_kind,omitempty"`
-	Transport string          `json:"transport"`
-	Summary   string          `json:"summary"`
-	Detail    json.RawMessage `json:"detail"`
-	RawRef    string          `json:"raw_ref,omitempty"`
-	PrevHash  string          `json:"prev_hash"`
-	Hash      string          `json:"hash"`
+	Version          int             `json:"v"`
+	Sequence         uint64          `json:"seq"`
+	Timestamp        time.Time       `json:"ts"`
+	SessionID        string          `json:"session_id"`
+	ChainKind        string          `json:"chain_kind,omitempty"`
+	WriterInstanceID string          `json:"writer_instance_id,omitempty"`
+	TraceID          string          `json:"trace_id,omitempty"`
+	Type             string          `json:"type"`
+	EventKind        string          `json:"event_kind,omitempty"`
+	Transport        string          `json:"transport"`
+	Summary          string          `json:"summary"`
+	Detail           json.RawMessage `json:"detail"`
+	RawRef           string          `json:"raw_ref,omitempty"`
+	PrevHash         string          `json:"prev_hash"`
+	Hash             string          `json:"hash"`
 }
 
 func parseRecorderEntry(line []byte) (recorder.Entry, error) {
@@ -167,25 +185,32 @@ func parseRecorderEntry(line []byte) (recorder.Entry, error) {
 	}
 
 	return recorder.Entry{
-		Version:   raw.Version,
-		Sequence:  raw.Sequence,
-		Timestamp: raw.Timestamp,
-		SessionID: raw.SessionID,
-		TraceID:   raw.TraceID,
-		Type:      raw.Type,
-		EventKind: raw.EventKind,
-		Transport: raw.Transport,
-		Summary:   raw.Summary,
-		Detail:    detail,
-		RawRef:    raw.RawRef,
-		PrevHash:  raw.PrevHash,
-		Hash:      raw.Hash,
+		Version:          raw.Version,
+		Sequence:         raw.Sequence,
+		Timestamp:        raw.Timestamp,
+		SessionID:        raw.SessionID,
+		ChainKind:        raw.ChainKind,
+		WriterInstanceID: raw.WriterInstanceID,
+		TraceID:          raw.TraceID,
+		Type:             raw.Type,
+		EventKind:        raw.EventKind,
+		Transport:        raw.Transport,
+		Summary:          raw.Summary,
+		Detail:           detail,
+		RawRef:           raw.RawRef,
+		PrevHash:         raw.PrevHash,
+		Hash:             raw.Hash,
 	}, nil
 }
 
 func (s streamState) verifyRecorderEntry(rec recorder.Entry, lineNo int, previousHash string, seenEntry bool) error {
 	if !s.allowedVersions[rec.Version] || !hashSupportedVersion(rec.Version) {
 		return fmt.Errorf("%w (line=%d, seq=%d, version=%d)", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence, rec.Version)
+	}
+	if rec.Version == recorder.LatestEntryVersion {
+		if rec.ChainKind == "" || rec.WriterInstanceID == "" {
+			return fmt.Errorf("%w (line=%d, seq=%d): v3 chain namespace incomplete", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence)
+		}
 	}
 
 	computedHash := recorder.ComputeHash(rec)

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -207,7 +207,7 @@ func (s streamState) verifyRecorderEntry(rec recorder.Entry, lineNo int, previou
 	if !s.allowedVersions[rec.Version] || !hashSupportedVersion(rec.Version) {
 		return fmt.Errorf("%w (line=%d, seq=%d, version=%d)", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence, rec.Version)
 	}
-	if err := recorder.ValidateEntryNamespace(rec.Version, rec.ChainKind, rec.WriterInstanceID); err != nil {
+	if err := recorder.ValidateEntrySchema(rec); err != nil {
 		return fmt.Errorf("%w (line=%d, seq=%d): %w", ErrUnsupportedSchemaVersion, lineNo, rec.Sequence, err)
 	}
 

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -232,6 +232,17 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
 	})
 
+	t.Run("legacy entries reject unhashed chain namespace", func(t *testing.T) {
+		rec := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
+		rec.ChainKind = recorder.ChainKindRecorder
+		rec.Hash = recorder.ComputeHash(rec)
+		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})
+		if len(entries) != 0 {
+			t.Fatalf("entries len = %d, want 0", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
+	})
+
 	t.Run("v3 namespace cannot change within a stream", func(t *testing.T) {
 		first := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
 		second := testEntry(t, recorder.LatestEntryVersion, 2, first.Hash, "checkpoint", map[string]any{"version": 3})
@@ -321,7 +332,7 @@ func testEntry(t *testing.T, version int, seq int, prevHash, entryType string, d
 		Detail:    detail,
 		PrevHash:  prevHash,
 	}
-	if version == recorder.LatestEntryVersion {
+	if recorder.EntryVersionHasNamespace(version) {
 		rec.ChainKind = recorder.ChainKindRecorder
 		rec.WriterInstanceID = "writer-test"
 	}

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -64,9 +64,19 @@ func TestStreamTypesCaptureSummary(t *testing.T) {
 }
 
 func TestParseRecorderEntryRejectsExplicitNullV3ProjectedField(t *testing.T) {
-	line := []byte(`{"v":3,"seq":0,"ts":null,"session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}`)
-	if _, err := parseRecorderEntry(line); err == nil || !strings.Contains(err.Error(), "ts must be a string") {
-		t.Fatalf("parseRecorderEntry() error = %v, want v3 ts type error", err)
+	for _, tc := range []struct {
+		name string
+		line string
+		want string
+	}{
+		{"null", `{"v":3,"seq":0,"ts":null,"session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}`, "ts must be a string"},
+		{"missing", `{"v":3,"seq":0,"session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}`, "ts required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseRecorderEntry([]byte(tc.line)); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseRecorderEntry() error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -256,6 +256,28 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 		requireOneErrorIs(t, errs, ErrHashChainBroken)
 	})
 
+	t.Run("v3 chain kind cannot change within a stream", func(t *testing.T) {
+		first := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		second := testEntry(t, recorder.LatestEntryVersion, 2, first.Hash, "checkpoint", map[string]any{"version": 3})
+		second.ChainKind = "receipt"
+		second.Hash = recorder.ComputeHash(second)
+		entries, errs := collectStream(t, mustJSONLines(t, first, second), StreamOptions{})
+		if len(entries) != 1 {
+			t.Fatalf("entries len = %d, want 1", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrHashChainBroken)
+	})
+
+	t.Run("legacy stream cannot transition to v3", func(t *testing.T) {
+		legacy := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
+		v3 := testEntry(t, recorder.LatestEntryVersion, 2, legacy.Hash, "checkpoint", map[string]any{"version": 3})
+		entries, errs := collectStream(t, mustJSONLines(t, legacy, v3), StreamOptions{})
+		if len(entries) != 1 {
+			t.Fatalf("entries len = %d, want 1", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrHashChainBroken)
+	})
+
 	t.Run("explicit allow list rejects omitted recorder versions", func(t *testing.T) {
 		v1 := testEntry(t, 1, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 1})
 

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -63,6 +63,13 @@ func TestStreamTypesCaptureSummary(t *testing.T) {
 	}
 }
 
+func TestParseRecorderEntryRejectsExplicitNullV3ProjectedField(t *testing.T) {
+	line := []byte(`{"v":3,"seq":0,"ts":null,"session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}`)
+	if _, err := parseRecorderEntry(line); err == nil || !strings.Contains(err.Error(), "ts must be a string") {
+		t.Fatalf("parseRecorderEntry() error = %v, want v3 ts type error", err)
+	}
+}
+
 func TestStreamExplicitNullDetailHashesAsNull(t *testing.T) {
 	rec := recorder.Entry{
 		Version:   recorder.EntryVersion,

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -232,9 +232,33 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
 	})
 
+	t.Run("v3 requires chain kind", func(t *testing.T) {
+		rec := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		rec.ChainKind = ""
+		rec.Hash = recorder.ComputeHash(rec)
+
+		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})
+
+		if len(entries) != 0 {
+			t.Fatalf("entries len = %d, want 0", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
+	})
+
 	t.Run("legacy entries reject unhashed chain namespace", func(t *testing.T) {
 		rec := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
 		rec.ChainKind = recorder.ChainKindRecorder
+		rec.Hash = recorder.ComputeHash(rec)
+		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})
+		if len(entries) != 0 {
+			t.Fatalf("entries len = %d, want 0", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
+	})
+
+	t.Run("legacy entries reject unhashed writer namespace", func(t *testing.T) {
+		rec := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
+		rec.WriterInstanceID = "writer-a"
 		rec.Hash = recorder.ComputeHash(rec)
 		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})
 		if len(entries) != 0 {

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -314,6 +314,18 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 		requireOneErrorIs(t, errs, ErrHashChainBroken)
 	})
 
+	t.Run("v3 session cannot change within a stream", func(t *testing.T) {
+		first := testEntry(t, v3EntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		second := testEntry(t, v3EntryVersion, 2, first.Hash, "checkpoint", map[string]any{"version": 3})
+		second.SessionID = "session-other"
+		second.Hash = recorder.ComputeHash(second)
+		entries, errs := collectStream(t, mustJSONLines(t, first, second), StreamOptions{})
+		if len(entries) != 1 {
+			t.Fatalf("entries len = %d, want 1", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrHashChainBroken)
+	})
+
 	t.Run("legacy stream cannot transition to v3", func(t *testing.T) {
 		legacy := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
 		v3 := testEntry(t, recorder.LatestEntryVersion, 2, legacy.Hash, "checkpoint", map[string]any{"version": 3})

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
+const (
+	v2EntryVersion = 2
+	v3EntryVersion = 3
+)
+
 func TestStreamTypesCaptureSummary(t *testing.T) {
 	rec := testEntry(t, recorder.EntryVersion, 1, recorder.GenesisHash, capture.EntryTypeCapture, capture.CaptureSummary{
 		CaptureSchemaVersion: capture.CaptureSchemaV1,
@@ -233,7 +238,7 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 	})
 
 	t.Run("v3 requires chain kind", func(t *testing.T) {
-		rec := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		rec := testEntry(t, v3EntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
 		rec.ChainKind = ""
 		rec.Hash = recorder.ComputeHash(rec)
 
@@ -257,7 +262,7 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 	})
 
 	t.Run("legacy entries reject unhashed writer namespace", func(t *testing.T) {
-		rec := testEntry(t, recorder.CurrentWriteEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
+		rec := testEntry(t, v2EntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 2})
 		rec.WriterInstanceID = "writer-a"
 		rec.Hash = recorder.ComputeHash(rec)
 		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -197,9 +197,9 @@ func TestStreamDetectsHashChainBreaks(t *testing.T) {
 }
 
 func TestStreamSchemaVersionGating(t *testing.T) {
-	t.Run("zero options allow v1 and current recorder versions", func(t *testing.T) {
+	t.Run("zero options allow mixed legacy recorder versions", func(t *testing.T) {
 		v1 := testEntry(t, 1, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 1})
-		v2 := testEntry(t, recorder.EntryVersion, 2, v1.Hash, "checkpoint", map[string]any{"version": recorder.EntryVersion})
+		v2 := testEntry(t, 2, 2, v1.Hash, "checkpoint", map[string]any{"version": 2})
 
 		entries, errs := collectStream(t, mustJSONLines(t, v1, v2), StreamOptions{})
 
@@ -209,6 +209,40 @@ func TestStreamSchemaVersionGating(t *testing.T) {
 		if len(entries) != 2 {
 			t.Fatalf("entries len = %d, want 2", len(entries))
 		}
+	})
+
+	t.Run("zero options allow a namespaced v3 stream", func(t *testing.T) {
+		v3 := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		entries, errs := collectStream(t, mustJSONLines(t, v3), StreamOptions{})
+		if len(errs) != 0 || len(entries) != 1 {
+			t.Fatalf("entries = %d, errs = %v, want one v3 entry", len(entries), errs)
+		}
+	})
+
+	t.Run("v3 requires complete chain namespace", func(t *testing.T) {
+		rec := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		rec.WriterInstanceID = ""
+		rec.Hash = recorder.ComputeHash(rec)
+
+		entries, errs := collectStream(t, mustJSONLines(t, rec), StreamOptions{})
+
+		if len(entries) != 0 {
+			t.Fatalf("entries len = %d, want 0", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrUnsupportedSchemaVersion)
+	})
+
+	t.Run("v3 namespace cannot change within a stream", func(t *testing.T) {
+		first := testEntry(t, recorder.LatestEntryVersion, 1, recorder.GenesisHash, "checkpoint", map[string]any{"version": 3})
+		second := testEntry(t, recorder.LatestEntryVersion, 2, first.Hash, "checkpoint", map[string]any{"version": 3})
+		second.WriterInstanceID = "writer-other"
+		second.Hash = recorder.ComputeHash(second)
+
+		entries, errs := collectStream(t, mustJSONLines(t, first, second), StreamOptions{})
+		if len(entries) != 1 {
+			t.Fatalf("entries len = %d, want 1", len(entries))
+		}
+		requireOneErrorIs(t, errs, ErrHashChainBroken)
 	})
 
 	t.Run("explicit allow list rejects omitted recorder versions", func(t *testing.T) {
@@ -286,6 +320,10 @@ func testEntry(t *testing.T, version int, seq int, prevHash, entryType string, d
 		Summary:   "test entry",
 		Detail:    detail,
 		PrevHash:  prevHash,
+	}
+	if version == recorder.LatestEntryVersion {
+		rec.ChainKind = recorder.ChainKindRecorder
+		rec.WriterInstanceID = "writer-test"
 	}
 	rec.Hash = recorder.ComputeHash(rec)
 	return rec

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -23,10 +23,20 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 )
 
-// EntryVersion is the current schema version for new writes. Readers MUST
-// reject versions outside acceptedEntryVersions; v1 chains continue to
-// verify with the v1 hash projection so pre-upgrade audit logs stay valid.
-const EntryVersion = 2
+const (
+	// CurrentWriteEntryVersion is the schema version emitted by the recorder.
+	// Keep this at v2 during the reader-first rollout.
+	CurrentWriteEntryVersion = 2
+	// LatestEntryVersion is the newest schema version understood by readers.
+	LatestEntryVersion = 3
+	// EntryVersion is retained for source compatibility. New code must choose
+	// CurrentWriteEntryVersion or LatestEntryVersion according to its role.
+	EntryVersion = CurrentWriteEntryVersion
+
+	// ChainKindRecorder identifies the outer recorder hash chain. It is bound
+	// into v3 hashes with WriterInstanceID to form the chain namespace.
+	ChainKindRecorder = "recorder"
+)
 
 // MaxEntryLineBytes is the maximum JSONL line payload accepted by recorder
 // entry readers.
@@ -50,7 +60,7 @@ func defaultEntryReadLimits() entryReadLimits {
 // and VerifyChain will load. New writes always use EntryVersion; v1 entries
 // keep verifying via computeHashV1 so the chain integrity guarantee survives
 // the schema bump.
-var acceptedEntryVersions = map[int]bool{1: true, 2: true}
+var acceptedEntryVersions = map[int]bool{1: true, 2: true, 3: true}
 
 // GenesisHash is the PrevHash of the first entry in a chain.
 const GenesisHash = "genesis"
@@ -71,20 +81,25 @@ func IsAcceptedEntryVersion(version int) bool {
 // classification debt) drive their behavior off this field; the recorder
 // itself only stamps it through and binds it into the v2 chain hash.
 type Entry struct {
-	Version   int             `json:"v"`
-	Sequence  uint64          `json:"seq"`
-	Timestamp time.Time       `json:"ts"`
-	SessionID string          `json:"session_id"`
-	TraceID   string          `json:"trace_id,omitempty"`
-	Type      string          `json:"type"`
-	EventKind string          `json:"event_kind,omitempty"`
-	Transport string          `json:"transport"`
-	Summary   string          `json:"summary"`
-	Detail    any             `json:"detail"`
-	RawDetail json.RawMessage `json:"-"`
-	RawRef    string          `json:"raw_ref,omitempty"`
-	PrevHash  string          `json:"prev_hash"`
-	Hash      string          `json:"hash"`
+	Version   int       `json:"v"`
+	Sequence  uint64    `json:"seq"`
+	Timestamp time.Time `json:"ts"`
+	SessionID string    `json:"session_id"`
+	ChainKind string    `json:"chain_kind,omitempty"`
+	// WriterInstanceID is an unauthenticated per-process namespace claim. It
+	// prevents cooperating writers from accidentally sharing sequence space;
+	// checkpoint and receipt signatures remain the authenticity boundary.
+	WriterInstanceID string          `json:"writer_instance_id,omitempty"`
+	TraceID          string          `json:"trace_id,omitempty"`
+	Type             string          `json:"type"`
+	EventKind        string          `json:"event_kind,omitempty"`
+	Transport        string          `json:"transport"`
+	Summary          string          `json:"summary"`
+	Detail           any             `json:"detail"`
+	RawDetail        json.RawMessage `json:"-"`
+	RawRef           string          `json:"raw_ref,omitempty"`
+	PrevHash         string          `json:"prev_hash"`
+	Hash             string          `json:"hash"`
 }
 
 // CheckpointDetail is the structured payload for checkpoint entries.
@@ -110,6 +125,8 @@ func ComputeHash(e Entry) string {
 		return computeHashV1(e)
 	case 2:
 		return computeHashV2(e)
+	case 3:
+		return computeHashV3(e)
 	default:
 		return ""
 	}
@@ -180,6 +197,38 @@ func computeHashV2(e Entry) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
+// computeHashV3 is the frozen v3 canonical projection. It extends v2 by
+// inserting ChainKind and WriterInstanceID after SessionID. These fields form
+// the per-writer chain namespace and must never be removed or reordered.
+func computeHashV3(e Entry) string {
+	detailJSON := detailJSONForHash(e)
+
+	h := sha256.New()
+	fields := []string{
+		strconv.Itoa(e.Version),
+		strconv.FormatUint(e.Sequence, 10),
+		e.Timestamp.UTC().Format(time.RFC3339Nano),
+		e.SessionID,
+		e.ChainKind,
+		e.WriterInstanceID,
+		e.TraceID,
+		e.Type,
+		e.EventKind,
+		e.Transport,
+		e.Summary,
+		string(detailJSON),
+		e.RawRef,
+		e.PrevHash,
+	}
+	for i, f := range fields {
+		if i > 0 {
+			_, _ = h.Write([]byte{0})
+		}
+		_, _ = h.Write([]byte(f))
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
 func detailJSONForHash(e Entry) []byte {
 	if e.RawDetail != nil {
 		return e.RawDetail
@@ -198,9 +247,33 @@ func detailJSONForHash(e Entry) []byte {
 // across the version boundary.
 // If pubKey is provided, checkpoint entry signatures are also verified.
 func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
+	var v3ChainKind, v3WriterInstanceID string
 	for i, e := range entries {
 		if !acceptedEntryVersions[e.Version] {
-			return fmt.Errorf("entry seq %d: unsupported version %d (accepted: 1, 2)", e.Sequence, e.Version)
+			return fmt.Errorf("entry seq %d: unsupported version %d (accepted: 1, 2, 3)", e.Sequence, e.Version)
+		}
+		if e.Version == LatestEntryVersion {
+			if e.ChainKind == "" {
+				return fmt.Errorf("entry seq %d: v3 chain_kind required", e.Sequence)
+			}
+			if e.WriterInstanceID == "" {
+				return fmt.Errorf("entry seq %d: v3 writer_instance_id required", e.Sequence)
+			}
+			if i > 0 && entries[i-1].Version != LatestEntryVersion {
+				return fmt.Errorf("entry seq %d: v3 chain cannot continue a legacy recorder namespace", e.Sequence)
+			}
+			if v3ChainKind == "" {
+				v3ChainKind, v3WriterInstanceID = e.ChainKind, e.WriterInstanceID
+			} else if e.ChainKind != v3ChainKind || e.WriterInstanceID != v3WriterInstanceID {
+				return fmt.Errorf("entry seq %d: v3 chain namespace changed", e.Sequence)
+			}
+		} else {
+			if e.ChainKind != "" || e.WriterInstanceID != "" {
+				return fmt.Errorf("entry seq %d: legacy entry cannot carry v3 recorder namespace fields", e.Sequence)
+			}
+			if v3ChainKind != "" {
+				return fmt.Errorf("entry seq %d: legacy entry cannot continue a v3 recorder namespace", e.Sequence)
+			}
 		}
 		computed := ComputeHash(e)
 		if computed != e.Hash {
@@ -365,36 +438,40 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		}
 
 		var raw struct {
-			Version   int             `json:"v"`
-			Sequence  uint64          `json:"seq"`
-			Timestamp time.Time       `json:"ts"`
-			SessionID string          `json:"session_id"`
-			TraceID   string          `json:"trace_id,omitempty"`
-			Type      string          `json:"type"`
-			EventKind string          `json:"event_kind,omitempty"`
-			Transport string          `json:"transport"`
-			Summary   string          `json:"summary"`
-			Detail    json.RawMessage `json:"detail"`
-			RawRef    string          `json:"raw_ref,omitempty"`
-			PrevHash  string          `json:"prev_hash"`
-			Hash      string          `json:"hash"`
+			Version          int             `json:"v"`
+			Sequence         uint64          `json:"seq"`
+			Timestamp        time.Time       `json:"ts"`
+			SessionID        string          `json:"session_id"`
+			ChainKind        string          `json:"chain_kind,omitempty"`
+			WriterInstanceID string          `json:"writer_instance_id,omitempty"`
+			TraceID          string          `json:"trace_id,omitempty"`
+			Type             string          `json:"type"`
+			EventKind        string          `json:"event_kind,omitempty"`
+			Transport        string          `json:"transport"`
+			Summary          string          `json:"summary"`
+			Detail           json.RawMessage `json:"detail"`
+			RawRef           string          `json:"raw_ref,omitempty"`
+			PrevHash         string          `json:"prev_hash"`
+			Hash             string          `json:"hash"`
 		}
 		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
 			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
 		e := Entry{
-			Version:   raw.Version,
-			Sequence:  raw.Sequence,
-			Timestamp: raw.Timestamp,
-			SessionID: raw.SessionID,
-			TraceID:   raw.TraceID,
-			Type:      raw.Type,
-			EventKind: raw.EventKind,
-			Transport: raw.Transport,
-			Summary:   raw.Summary,
-			RawRef:    raw.RawRef,
-			PrevHash:  raw.PrevHash,
-			Hash:      raw.Hash,
+			Version:          raw.Version,
+			Sequence:         raw.Sequence,
+			Timestamp:        raw.Timestamp,
+			SessionID:        raw.SessionID,
+			ChainKind:        raw.ChainKind,
+			WriterInstanceID: raw.WriterInstanceID,
+			TraceID:          raw.TraceID,
+			Type:             raw.Type,
+			EventKind:        raw.EventKind,
+			Transport:        raw.Transport,
+			Summary:          raw.Summary,
+			RawRef:           raw.RawRef,
+			PrevHash:         raw.PrevHash,
+			Hash:             raw.Hash,
 		}
 		if raw.Detail != nil {
 			e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
@@ -405,7 +482,17 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 			e.Detail = detail
 		}
 		if !acceptedEntryVersions[e.Version] {
-			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2)", lineNum, e.Version)
+			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2, 3)", lineNum, e.Version)
+		}
+		if e.Version == LatestEntryVersion {
+			if e.ChainKind == "" {
+				return nil, false, bytesRead, fmt.Errorf("line %d: v3 chain_kind required", lineNum)
+			}
+			if e.WriterInstanceID == "" {
+				return nil, false, bytesRead, fmt.Errorf("line %d: v3 writer_instance_id required", lineNum)
+			}
+		} else if e.ChainKind != "" || e.WriterInstanceID != "" {
+			return nil, false, bytesRead, fmt.Errorf("line %d: legacy entry cannot carry v3 recorder namespace fields", lineNum)
 		}
 		entries = append(entries, e)
 		if errors.Is(err, io.EOF) {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -145,6 +145,17 @@ func ValidateEntryJSONSchema(rawJSON []byte, version int) error {
 	if err := json.Unmarshal(rawJSON, &projected); err != nil {
 		return fmt.Errorf("parse v3 projected fields: %w", err)
 	}
+	seq, ok := projected["seq"]
+	if !ok {
+		return errors.New("v3 seq required")
+	}
+	seqText := string(bytes.TrimSpace(seq))
+	if seqText == "" || strings.Trim(seqText, "0123456789") != "" {
+		return errors.New("v3 seq must be an unsigned integer")
+	}
+	if _, err := strconv.ParseUint(seqText, 10, 64); err != nil {
+		return errors.New("v3 seq must be an unsigned 64-bit integer")
+	}
 	required := map[string]bool{"ts": true, "session_id": true, "type": true, "transport": true, "summary": true, "prev_hash": true}
 	for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
 		value, ok := projected[field]
@@ -341,7 +352,7 @@ func detailJSONForHash(e Entry) []byte {
 // across the version boundary.
 // If pubKey is provided, checkpoint entry signatures are also verified.
 func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
-	var v3ChainKind, v3WriterInstanceID string
+	var v3SessionID, v3ChainKind, v3WriterInstanceID string
 	for i, e := range entries {
 		if !acceptedEntryVersions[e.Version] {
 			return fmt.Errorf("entry seq %d: unsupported version %d (accepted: 1, 2, 3)", e.Sequence, e.Version)
@@ -354,8 +365,8 @@ func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
 				return fmt.Errorf("entry seq %d: v3 chain cannot continue a legacy recorder namespace", e.Sequence)
 			}
 			if v3ChainKind == "" {
-				v3ChainKind, v3WriterInstanceID = e.ChainKind, e.WriterInstanceID
-			} else if e.ChainKind != v3ChainKind || e.WriterInstanceID != v3WriterInstanceID {
+				v3SessionID, v3ChainKind, v3WriterInstanceID = e.SessionID, e.ChainKind, e.WriterInstanceID
+			} else if e.SessionID != v3SessionID || e.ChainKind != v3ChainKind || e.WriterInstanceID != v3WriterInstanceID {
 				return fmt.Errorf("entry seq %d: v3 chain namespace changed", e.Sequence)
 			}
 		} else {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -70,6 +70,29 @@ func IsAcceptedEntryVersion(version int) bool {
 	return acceptedEntryVersions[version]
 }
 
+// AcceptedEntryVersions returns the recorder schema versions readers accept.
+func AcceptedEntryVersions() []int { return []int{1, 2, 3} }
+
+// EntryVersionHasNamespace reports whether version binds a recorder namespace.
+func EntryVersionHasNamespace(version int) bool { return version == 3 }
+
+// ValidateEntryNamespace enforces the namespace fields appropriate to version.
+func ValidateEntryNamespace(version int, chainKind, writerInstanceID string) error {
+	if EntryVersionHasNamespace(version) {
+		if chainKind == "" {
+			return errors.New("v3 chain_kind required")
+		}
+		if writerInstanceID == "" {
+			return errors.New("v3 writer_instance_id required")
+		}
+		return nil
+	}
+	if chainKind != "" || writerInstanceID != "" {
+		return errors.New("legacy entry cannot carry v3 recorder namespace fields")
+	}
+	return nil
+}
+
 // Entry is a single evidence record in the hash chain.
 //
 // EventKind is informational at the recorder layer. Empty for envelope
@@ -252,14 +275,11 @@ func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
 		if !acceptedEntryVersions[e.Version] {
 			return fmt.Errorf("entry seq %d: unsupported version %d (accepted: 1, 2, 3)", e.Sequence, e.Version)
 		}
-		if e.Version == LatestEntryVersion {
-			if e.ChainKind == "" {
-				return fmt.Errorf("entry seq %d: v3 chain_kind required", e.Sequence)
-			}
-			if e.WriterInstanceID == "" {
-				return fmt.Errorf("entry seq %d: v3 writer_instance_id required", e.Sequence)
-			}
-			if i > 0 && entries[i-1].Version != LatestEntryVersion {
+		if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
+			return fmt.Errorf("entry seq %d: %w", e.Sequence, err)
+		}
+		if EntryVersionHasNamespace(e.Version) {
+			if i > 0 && !EntryVersionHasNamespace(entries[i-1].Version) {
 				return fmt.Errorf("entry seq %d: v3 chain cannot continue a legacy recorder namespace", e.Sequence)
 			}
 			if v3ChainKind == "" {
@@ -268,9 +288,6 @@ func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
 				return fmt.Errorf("entry seq %d: v3 chain namespace changed", e.Sequence)
 			}
 		} else {
-			if e.ChainKind != "" || e.WriterInstanceID != "" {
-				return fmt.Errorf("entry seq %d: legacy entry cannot carry v3 recorder namespace fields", e.Sequence)
-			}
 			if v3ChainKind != "" {
 				return fmt.Errorf("entry seq %d: legacy entry cannot continue a v3 recorder namespace", e.Sequence)
 			}
@@ -484,15 +501,8 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		if !acceptedEntryVersions[e.Version] {
 			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2, 3)", lineNum, e.Version)
 		}
-		if e.Version == LatestEntryVersion {
-			if e.ChainKind == "" {
-				return nil, false, bytesRead, fmt.Errorf("line %d: v3 chain_kind required", lineNum)
-			}
-			if e.WriterInstanceID == "" {
-				return nil, false, bytesRead, fmt.Errorf("line %d: v3 writer_instance_id required", lineNum)
-			}
-		} else if e.ChainKind != "" || e.WriterInstanceID != "" {
-			return nil, false, bytesRead, fmt.Errorf("line %d: legacy entry cannot carry v3 recorder namespace fields", lineNum)
+		if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
+			return nil, false, bytesRead, fmt.Errorf("line %d: %w", lineNum, err)
 		}
 		entries = append(entries, e)
 		if errors.Is(err, io.EOF) {

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -131,6 +131,24 @@ func ValidateEntrySchema(e Entry) error {
 	return nil
 }
 
+// ValidateEntryJSONSchema rejects raw JSON representations that typed Go
+// decoding would otherwise collapse into the same zero value.
+func ValidateEntryJSONSchema(rawJSON []byte, version int) error {
+	if version != 3 {
+		return nil
+	}
+	var projected map[string]json.RawMessage
+	if err := json.Unmarshal(rawJSON, &projected); err != nil {
+		return fmt.Errorf("parse v3 projected fields: %w", err)
+	}
+	for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
+		if value, ok := projected[field]; ok && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return fmt.Errorf("v3 %s must be a string", field)
+		}
+	}
+	return nil
+}
+
 // EntryVersionsCanShareChain reports whether a writer may resume a tail
 // without crossing between legacy and namespaced hash-chain families.
 func EntryVersionsCanShareChain(tailVersion, writeVersion int) bool {
@@ -518,16 +536,8 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
 			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
 		}
-		if raw.Version == 3 {
-			var projected map[string]json.RawMessage
-			if err := json.Unmarshal([]byte(trimmed), &projected); err != nil {
-				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry fields: %w", lineNum, err)
-			}
-			for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
-				if value, ok := projected[field]; ok && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
-					return nil, false, bytesRead, fmt.Errorf("line %d: v3 %s must be a string", lineNum, field)
-				}
-			}
+		if err := ValidateEntryJSONSchema([]byte(trimmed), raw.Version); err != nil {
+			return nil, false, bytesRead, fmt.Errorf("line %d: %w", lineNum, err)
 		}
 		e := Entry{
 			Version:          raw.Version,

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -60,7 +60,15 @@ func defaultEntryReadLimits() entryReadLimits {
 // and VerifyChain will load. New writes always use EntryVersion; v1 entries
 // keep verifying via computeHashV1 so the chain integrity guarantee survives
 // the schema bump.
-var acceptedEntryVersions = map[int]bool{1: true, 2: true, 3: true}
+var acceptedEntryVersionList = []int{1, 2, 3}
+
+var acceptedEntryVersions = func() map[int]bool {
+	versions := make(map[int]bool, len(acceptedEntryVersionList))
+	for _, version := range acceptedEntryVersionList {
+		versions[version] = true
+	}
+	return versions
+}()
 
 // GenesisHash is the PrevHash of the first entry in a chain.
 const GenesisHash = "genesis"
@@ -71,7 +79,7 @@ func IsAcceptedEntryVersion(version int) bool {
 }
 
 // AcceptedEntryVersions returns the recorder schema versions readers accept.
-func AcceptedEntryVersions() []int { return []int{1, 2, 3} }
+func AcceptedEntryVersions() []int { return append([]int(nil), acceptedEntryVersionList...) }
 
 // EntryVersionHasNamespace reports whether version binds a recorder namespace.
 func EntryVersionHasNamespace(version int) bool { return version == 3 }

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -85,12 +85,47 @@ func ValidateEntryNamespace(version int, chainKind, writerInstanceID string) err
 		if writerInstanceID == "" {
 			return errors.New("v3 writer_instance_id required")
 		}
+		if strings.ContainsRune(chainKind, '\x00') {
+			return errors.New("v3 chain_kind cannot contain NUL")
+		}
+		if strings.ContainsRune(writerInstanceID, '\x00') {
+			return errors.New("v3 writer_instance_id cannot contain NUL")
+		}
 		return nil
 	}
 	if chainKind != "" || writerInstanceID != "" {
 		return errors.New("legacy entry cannot carry v3 recorder namespace fields")
 	}
 	return nil
+}
+
+// ValidateEntrySchema rejects fields that the version's hash projection cannot
+// bind unambiguously. V3 retains the frozen null-delimited projection, so its
+// string fields cannot contain the delimiter.
+func ValidateEntrySchema(e Entry) error {
+	if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
+		return err
+	}
+	if !EntryVersionHasNamespace(e.Version) {
+		return nil
+	}
+	for name, value := range map[string]string{
+		"session_id": e.SessionID, "chain_kind": e.ChainKind,
+		"writer_instance_id": e.WriterInstanceID, "trace_id": e.TraceID,
+		"type": e.Type, "event_kind": e.EventKind, "transport": e.Transport,
+		"summary": e.Summary, "raw_ref": e.RawRef, "prev_hash": e.PrevHash,
+	} {
+		if strings.ContainsRune(value, '\x00') {
+			return fmt.Errorf("v3 %s cannot contain NUL", name)
+		}
+	}
+	return nil
+}
+
+// EntryVersionsCanShareChain reports whether a writer may resume a tail
+// without crossing between legacy and namespaced hash-chain families.
+func EntryVersionsCanShareChain(tailVersion, writeVersion int) bool {
+	return EntryVersionHasNamespace(tailVersion) == EntryVersionHasNamespace(writeVersion)
 }
 
 // Entry is a single evidence record in the hash chain.
@@ -275,7 +310,7 @@ func VerifyChain(entries []Entry, pubKey ...ed25519.PublicKey) error {
 		if !acceptedEntryVersions[e.Version] {
 			return fmt.Errorf("entry seq %d: unsupported version %d (accepted: 1, 2, 3)", e.Sequence, e.Version)
 		}
-		if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
+		if err := ValidateEntrySchema(e); err != nil {
 			return fmt.Errorf("entry seq %d: %w", e.Sequence, err)
 		}
 		if EntryVersionHasNamespace(e.Version) {
@@ -501,7 +536,7 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		if !acceptedEntryVersions[e.Version] {
 			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2, 3)", lineNum, e.Version)
 		}
-		if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
+		if err := ValidateEntrySchema(e); err != nil {
 			return nil, false, bytesRead, fmt.Errorf("line %d: %w", lineNum, err)
 		}
 		entries = append(entries, e)

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -7,6 +7,7 @@ package recorder
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
@@ -516,6 +517,17 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 		}
 		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
 			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+		}
+		if raw.Version == 3 {
+			var projected map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(trimmed), &projected); err != nil {
+				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry fields: %w", lineNum, err)
+			}
+			for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
+				if value, ok := projected[field]; ok && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+					return nil, false, bytesRead, fmt.Errorf("line %d: v3 %s must be a string", lineNum, field)
+				}
+			}
 		}
 		e := Entry{
 			Version:          raw.Version,

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -115,17 +115,21 @@ func ValidateEntrySchema(e Entry) error {
 	if err := ValidateEntryNamespace(e.Version, e.ChainKind, e.WriterInstanceID); err != nil {
 		return err
 	}
-	if !EntryVersionHasNamespace(e.Version) {
-		return nil
-	}
-	for name, value := range map[string]string{
-		"session_id": e.SessionID, "chain_kind": e.ChainKind,
-		"writer_instance_id": e.WriterInstanceID, "trace_id": e.TraceID,
-		"type": e.Type, "event_kind": e.EventKind, "transport": e.Transport,
+	fields := map[string]string{
+		"session_id": e.SessionID, "trace_id": e.TraceID,
+		"type": e.Type, "transport": e.Transport,
 		"summary": e.Summary, "raw_ref": e.RawRef, "prev_hash": e.PrevHash,
-	} {
+	}
+	if e.Version >= 2 {
+		fields["event_kind"] = e.EventKind
+	}
+	if EntryVersionHasNamespace(e.Version) {
+		fields["chain_kind"] = e.ChainKind
+		fields["writer_instance_id"] = e.WriterInstanceID
+	}
+	for name, value := range fields {
 		if strings.ContainsRune(value, '\x00') {
-			return fmt.Errorf("v3 %s cannot contain NUL", name)
+			return fmt.Errorf("v%d %s cannot contain NUL", e.Version, name)
 		}
 	}
 	return nil
@@ -141,8 +145,13 @@ func ValidateEntryJSONSchema(rawJSON []byte, version int) error {
 	if err := json.Unmarshal(rawJSON, &projected); err != nil {
 		return fmt.Errorf("parse v3 projected fields: %w", err)
 	}
+	required := map[string]bool{"ts": true, "session_id": true, "type": true, "transport": true, "summary": true, "prev_hash": true}
 	for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
-		if value, ok := projected[field]; ok && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+		value, ok := projected[field]
+		if !ok && required[field] {
+			return fmt.Errorf("v3 %s required", field)
+		}
+		if ok && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
 			return fmt.Errorf("v3 %s must be a string", field)
 		}
 	}

--- a/internal/recorder/entry_test.go
+++ b/internal/recorder/entry_test.go
@@ -121,7 +121,7 @@ func TestComputeHash_FieldChange(t *testing.T) {
 }
 
 func TestIsAcceptedEntryVersion(t *testing.T) {
-	for _, version := range []int{1, recorder.EntryVersion} {
+	for _, version := range []int{1, 2, recorder.LatestEntryVersion} {
 		if !recorder.IsAcceptedEntryVersion(version) {
 			t.Fatalf("IsAcceptedEntryVersion(%d) = false, want true", version)
 		}

--- a/internal/recorder/entry_test.go
+++ b/internal/recorder/entry_test.go
@@ -121,10 +121,15 @@ func TestComputeHash_FieldChange(t *testing.T) {
 }
 
 func TestIsAcceptedEntryVersion(t *testing.T) {
-	for _, version := range []int{1, 2, recorder.LatestEntryVersion} {
+	versions := recorder.AcceptedEntryVersions()
+	for _, version := range versions {
 		if !recorder.IsAcceptedEntryVersion(version) {
 			t.Fatalf("IsAcceptedEntryVersion(%d) = false, want true", version)
 		}
+	}
+	versions[0] = 99
+	if recorder.IsAcceptedEntryVersion(99) || !recorder.IsAcceptedEntryVersion(1) {
+		t.Fatal("AcceptedEntryVersions exposed mutable internal version state")
 	}
 	for _, version := range []int{0, 99} {
 		if recorder.IsAcceptedEntryVersion(version) {

--- a/internal/recorder/entry_v2_test.go
+++ b/internal/recorder/entry_v2_test.go
@@ -281,7 +281,7 @@ func TestReadEntries_RejectsUnknownVersionInRange(t *testing.T) {
 	if !strings.Contains(err.Error(), v2UnsupportedVersionFence) {
 		t.Errorf("error = %q, want substring %q", err.Error(), v2UnsupportedVersionFence)
 	}
-	if !strings.Contains(err.Error(), "accepted: 1, 2") {
+	if !strings.Contains(err.Error(), "accepted: 1, 2, 3") {
 		t.Errorf("error = %q, want accepted-range hint", err.Error())
 	}
 }

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -74,7 +74,7 @@ func TestComputeHashV3BindsNamespace(t *testing.T) {
 }
 
 func TestReadEntriesV3RejectsExplicitNullProjectedStrings(t *testing.T) {
-	for _, field := range []string{"ts", "trace_id", "summary", "prev_hash"} {
+	for _, field := range []string{"ts", "session_id", "chain_kind", "writer_instance_id", "trace_id", "type", "event_kind", "transport", "summary", "raw_ref", "prev_hash"} {
 		t.Run(field, func(t *testing.T) {
 			e := v3Entry()
 			e.Hash = recorder.ComputeHash(e)
@@ -96,6 +96,27 @@ func TestReadEntriesV3RejectsExplicitNullProjectedStrings(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("missing_ts", func(t *testing.T) {
+		e := v3Entry()
+		e.Hash = recorder.ComputeHash(e)
+		encoded, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(encoded, &raw); err != nil {
+			t.Fatal(err)
+		}
+		delete(raw, "ts")
+		encoded, err = json.Marshal(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := recorder.ReadEntriesFromReader(strings.NewReader(string(encoded) + "\n")); err == nil || !strings.Contains(err.Error(), "ts required") {
+			t.Fatalf("ReadEntriesFromReader() error = %v, want missing v3 ts error", err)
+		}
+	})
 }
 
 func TestV3RejectsNullDelimiterCollision(t *testing.T) {
@@ -111,6 +132,28 @@ func TestV3RejectsNullDelimiterCollision(t *testing.T) {
 	for _, entry := range []recorder.Entry{left, right} {
 		if err := recorder.ValidateEntrySchema(entry); err == nil || !strings.Contains(err.Error(), "cannot contain NUL") {
 			t.Fatalf("ValidateEntrySchema() error = %v, want NUL rejection", err)
+		}
+	}
+}
+
+func TestLegacyRejectsNullDelimiterCollision(t *testing.T) {
+	for _, version := range []int{1, 2} {
+		left := v3Entry()
+		left.Version = version
+		left.ChainKind = ""
+		left.WriterInstanceID = ""
+		left.SessionID = "x\x00y"
+		left.TraceID = "z"
+		right := left
+		right.SessionID = "x"
+		right.TraceID = "y\x00z"
+		if recorder.ComputeHash(left) != recorder.ComputeHash(right) {
+			t.Fatalf("v%d fixture does not reproduce delimiter collision", version)
+		}
+		for _, entry := range []recorder.Entry{left, right} {
+			if err := recorder.ValidateEntrySchema(entry); err == nil || !strings.Contains(err.Error(), "cannot contain NUL") {
+				t.Fatalf("ValidateEntrySchema(v%d) error = %v, want NUL rejection", version, err)
+			}
 		}
 	}
 }

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -73,6 +73,31 @@ func TestComputeHashV3BindsNamespace(t *testing.T) {
 	}
 }
 
+func TestReadEntriesV3RejectsExplicitNullProjectedStrings(t *testing.T) {
+	for _, field := range []string{"ts", "trace_id", "summary", "prev_hash"} {
+		t.Run(field, func(t *testing.T) {
+			e := v3Entry()
+			e.Hash = recorder.ComputeHash(e)
+			encoded, err := json.Marshal(e)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(encoded, &raw); err != nil {
+				t.Fatal(err)
+			}
+			raw[field] = nil
+			encoded, err = json.Marshal(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := recorder.ReadEntriesFromReader(strings.NewReader(string(encoded) + "\n")); err == nil || !strings.Contains(err.Error(), field+" must be a string") {
+				t.Fatalf("ReadEntriesFromReader() error = %v, want %s type error", err, field)
+			}
+		})
+	}
+}
+
 func TestV3RejectsNullDelimiterCollision(t *testing.T) {
 	left := v3Entry()
 	left.ChainKind = "recorder"

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -71,6 +71,42 @@ func TestComputeHashV3BindsNamespace(t *testing.T) {
 	}
 }
 
+func TestV3RejectsNullDelimiterCollision(t *testing.T) {
+	left := v3Entry()
+	left.ChainKind = "recorder"
+	left.WriterInstanceID = "a\x00b"
+	right := left
+	right.ChainKind = "recorder\x00a"
+	right.WriterInstanceID = "b"
+	if recorder.ComputeHash(left) != recorder.ComputeHash(right) {
+		t.Fatal("fixture does not reproduce the frozen v3 delimiter collision")
+	}
+	for _, entry := range []recorder.Entry{left, right} {
+		if err := recorder.ValidateEntrySchema(entry); err == nil || !strings.Contains(err.Error(), "cannot contain NUL") {
+			t.Fatalf("ValidateEntrySchema() error = %v, want NUL rejection", err)
+		}
+	}
+}
+
+func TestEntryVersionsCanShareChain(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tail, write int
+		want        bool
+	}{
+		{"v1_to_v2", 1, 2, true},
+		{"v2_to_v3", 2, 3, false},
+		{"v3_to_v2", 3, 2, false},
+		{"v3_to_v3", 3, 3, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := recorder.EntryVersionsCanShareChain(tc.tail, tc.write); got != tc.want {
+				t.Fatalf("EntryVersionsCanShareChain(%d, %d) = %v, want %v", tc.tail, tc.write, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestVerifyChainV3RequiresNamespace(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
+const v3EntryVersion = 3
+
 func v3Entry() recorder.Entry {
 	return recorder.Entry{
-		Version:          recorder.LatestEntryVersion,
+		Version:          v3EntryVersion,
 		Sequence:         7,
 		Timestamp:        time.Date(2026, 8, 7, 12, 34, 56, 789, time.UTC),
 		SessionID:        "proxy",

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -138,23 +138,25 @@ func TestV3RejectsNullDelimiterCollision(t *testing.T) {
 
 func TestLegacyRejectsNullDelimiterCollision(t *testing.T) {
 	for _, version := range []int{1, 2} {
-		left := v3Entry()
-		left.Version = version
-		left.ChainKind = ""
-		left.WriterInstanceID = ""
-		left.SessionID = "x\x00y"
-		left.TraceID = "z"
-		right := left
-		right.SessionID = "x"
-		right.TraceID = "y\x00z"
-		if recorder.ComputeHash(left) != recorder.ComputeHash(right) {
-			t.Fatalf("v%d fixture does not reproduce delimiter collision", version)
-		}
-		for _, entry := range []recorder.Entry{left, right} {
-			if err := recorder.ValidateEntrySchema(entry); err == nil || !strings.Contains(err.Error(), "cannot contain NUL") {
-				t.Fatalf("ValidateEntrySchema(v%d) error = %v, want NUL rejection", version, err)
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			left := v3Entry()
+			left.Version = version
+			left.ChainKind = ""
+			left.WriterInstanceID = ""
+			left.SessionID = "x\x00y"
+			left.TraceID = "z"
+			right := left
+			right.SessionID = "x"
+			right.TraceID = "y\x00z"
+			if recorder.ComputeHash(left) != recorder.ComputeHash(right) {
+				t.Fatalf("fixture does not reproduce delimiter collision")
 			}
-		}
+			for _, entry := range []recorder.Entry{left, right} {
+				if err := recorder.ValidateEntrySchema(entry); err == nil || !strings.Contains(err.Error(), "cannot contain NUL") {
+					t.Fatalf("ValidateEntrySchema() error = %v, want NUL rejection", err)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -119,6 +119,50 @@ func TestReadEntriesV3RejectsExplicitNullProjectedStrings(t *testing.T) {
 	})
 }
 
+func TestReadEntriesV3RejectsInvalidSequenceRepresentations(t *testing.T) {
+	for _, seq := range []string{"null", "-1", "1.5", "18446744073709551616"} {
+		t.Run(seq, func(t *testing.T) {
+			e := v3Entry()
+			encoded, err := json.Marshal(e)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &raw); err != nil {
+				t.Fatal(err)
+			}
+			raw["seq"] = json.RawMessage(seq)
+			encoded, err = json.Marshal(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := recorder.ReadEntriesFromReader(strings.NewReader(string(encoded) + "\n")); err == nil || !strings.Contains(err.Error(), "seq") {
+				t.Fatalf("ReadEntriesFromReader() error = %v, want seq rejection", err)
+			}
+		})
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		e := v3Entry()
+		encoded, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(encoded, &raw); err != nil {
+			t.Fatal(err)
+		}
+		delete(raw, "seq")
+		encoded, err = json.Marshal(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := recorder.ReadEntriesFromReader(strings.NewReader(string(encoded) + "\n")); err == nil || !strings.Contains(err.Error(), "seq required") {
+			t.Fatalf("ReadEntriesFromReader() error = %v, want missing seq rejection", err)
+		}
+	})
+}
+
 func TestV3RejectsNullDelimiterCollision(t *testing.T) {
 	left := v3Entry()
 	left.ChainKind = "recorder"
@@ -231,6 +275,7 @@ func TestVerifyChainRejectsNamespaceTransitions(t *testing.T) {
 	}{
 		{"writer_change", func(e *recorder.Entry) { e.WriterInstanceID = "writer-b" }, "namespace changed"},
 		{"kind_change", func(e *recorder.Entry) { e.ChainKind = "receipt" }, "namespace changed"},
+		{"session_change", func(e *recorder.Entry) { e.SessionID = "session-b" }, "namespace changed"},
 		{"legacy_after_v3", func(e *recorder.Entry) {
 			e.Version = recorder.CurrentWriteEntryVersion
 			e.ChainKind = ""

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -161,6 +161,23 @@ func TestReadEntriesV3RejectsInvalidSequenceRepresentations(t *testing.T) {
 			t.Fatalf("ReadEntriesFromReader() error = %v, want missing seq rejection", err)
 		}
 	})
+
+	t.Run("max uint64", func(t *testing.T) {
+		e := v3Entry()
+		e.Sequence = ^uint64(0)
+		e.Hash = recorder.ComputeHash(e)
+		encoded, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, err := recorder.ReadEntriesFromReader(strings.NewReader(string(encoded) + "\n"))
+		if err != nil {
+			t.Fatalf("ReadEntriesFromReader() error = %v", err)
+		}
+		if len(entries) != 1 || entries[0].Sequence != e.Sequence {
+			t.Fatalf("decoded sequence = %d, want %d", entries[0].Sequence, e.Sequence)
+		}
+	})
 }
 
 func TestV3RejectsNullDelimiterCollision(t *testing.T) {

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package recorder_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func v3Entry() recorder.Entry {
+	return recorder.Entry{
+		Version:          recorder.LatestEntryVersion,
+		Sequence:         7,
+		Timestamp:        time.Date(2026, 8, 7, 12, 34, 56, 789, time.UTC),
+		SessionID:        "proxy",
+		ChainKind:        recorder.ChainKindRecorder,
+		WriterInstanceID: "writer-0123456789abcdef",
+		TraceID:          "trace-7",
+		Type:             "request",
+		EventKind:        "write",
+		Transport:        "fetch",
+		Summary:          "v3 reader fixture",
+		Detail:           map[string]any{"a": "b"},
+		RawRef:           "evidence.raw.enc",
+		PrevHash:         recorder.GenesisHash,
+	}
+}
+
+func TestComputeHashV3FrozenProjection(t *testing.T) {
+	e := v3Entry()
+	const want = "86cf558b8504031e857711860383f0b2badd0cff5c06761a3f29ae507c1d4292"
+	if got := recorder.ComputeHash(e); got != want {
+		t.Fatalf("ComputeHash(v3) = %q, want frozen %q", got, want)
+	}
+}
+
+func TestComputeHashV3BindsNamespace(t *testing.T) {
+	base := v3Entry()
+	baseHash := recorder.ComputeHash(base)
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*recorder.Entry)
+	}{
+		{"chain_kind", func(e *recorder.Entry) { e.ChainKind = "receipt" }},
+		{"writer_instance_id", func(e *recorder.Entry) { e.WriterInstanceID = "writer-fedcba9876543210" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := base
+			tc.mutate(&changed)
+			if got := recorder.ComputeHash(changed); got == baseHash {
+				t.Fatalf("changing %s did not change v3 hash", tc.name)
+			}
+		})
+	}
+
+	v2 := base
+	v2.Version = recorder.CurrentWriteEntryVersion
+	v2.ChainKind = ""
+	v2.WriterInstanceID = ""
+	if recorder.ComputeHash(v2) == baseHash {
+		t.Fatal("v2 and v3 hashes collide for equivalent record")
+	}
+}
+
+func TestVerifyChainV3RequiresNamespace(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*recorder.Entry)
+		want   string
+	}{
+		{"missing_chain_kind", func(e *recorder.Entry) { e.ChainKind = "" }, "chain_kind required"},
+		{"missing_writer_instance_id", func(e *recorder.Entry) { e.WriterInstanceID = "" }, "writer_instance_id required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := v3Entry()
+			tc.mutate(&e)
+			e.Hash = recorder.ComputeHash(e)
+			err := recorder.VerifyChain([]recorder.Entry{e})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("VerifyChain() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyChainAcceptsMixedV1V2(t *testing.T) {
+	entries := make([]recorder.Entry, 2)
+	prevHash := recorder.GenesisHash
+	for i, version := range []int{1, 2} {
+		entries[i] = v3Entry()
+		entries[i].Version = version
+		entries[i].Sequence = uint64(i)
+		entries[i].ChainKind = ""
+		entries[i].WriterInstanceID = ""
+		entries[i].PrevHash = prevHash
+		entries[i].Hash = recorder.ComputeHash(entries[i])
+		prevHash = entries[i].Hash
+	}
+	if err := recorder.VerifyChain(entries); err != nil {
+		t.Fatalf("VerifyChain(v1/v2) = %v", err)
+	}
+}
+
+func TestVerifyChainRejectsNamespaceTransitions(t *testing.T) {
+	first := v3Entry()
+	first.Sequence = 0
+	first.PrevHash = recorder.GenesisHash
+	first.Hash = recorder.ComputeHash(first)
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*recorder.Entry)
+		want   string
+	}{
+		{"writer_change", func(e *recorder.Entry) { e.WriterInstanceID = "writer-b" }, "namespace changed"},
+		{"kind_change", func(e *recorder.Entry) { e.ChainKind = "receipt" }, "namespace changed"},
+		{"legacy_after_v3", func(e *recorder.Entry) {
+			e.Version = recorder.CurrentWriteEntryVersion
+			e.ChainKind = ""
+			e.WriterInstanceID = ""
+		}, "legacy entry cannot continue"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			second := first
+			second.Sequence = 1
+			second.PrevHash = first.Hash
+			tc.mutate(&second)
+			second.Hash = recorder.ComputeHash(second)
+			err := recorder.VerifyChain([]recorder.Entry{first, second})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("VerifyChain() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	legacy := first
+	legacy.Version = recorder.CurrentWriteEntryVersion
+	legacy.ChainKind = ""
+	legacy.WriterInstanceID = ""
+	legacy.Hash = recorder.ComputeHash(legacy)
+	newChain := first
+	newChain.Sequence = 1
+	newChain.PrevHash = legacy.Hash
+	newChain.Hash = recorder.ComputeHash(newChain)
+	if err := recorder.VerifyChain([]recorder.Entry{legacy, newChain}); err == nil || !strings.Contains(err.Error(), "cannot continue a legacy") {
+		t.Fatalf("VerifyChain(v2/v3) error = %v, want namespace transition rejection", err)
+	}
+}
+
+func TestReadEntriesPreservesV3Namespace(t *testing.T) {
+	e := v3Entry()
+	e.Hash = recorder.ComputeHash(e)
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "evidence-proxy-7.jsonl")
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := recorder.ReadEntries(path)
+	if err != nil {
+		t.Fatalf("ReadEntries() = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ReadEntries() count = %d, want 1", len(entries))
+	}
+	if entries[0].ChainKind != e.ChainKind || entries[0].WriterInstanceID != e.WriterInstanceID {
+		t.Fatalf("namespace = (%q, %q), want (%q, %q)", entries[0].ChainKind, entries[0].WriterInstanceID, e.ChainKind, e.WriterInstanceID)
+	}
+	if err := recorder.VerifyChain(entries); err != nil {
+		t.Fatalf("VerifyChain(ReadEntries()) = %v", err)
+	}
+}
+
+func TestReadEntriesRejectsIncompleteV3Namespace(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*recorder.Entry)
+		want   string
+	}{
+		{"missing_chain_kind", func(e *recorder.Entry) { e.ChainKind = "" }, "chain_kind required"},
+		{"missing_writer_instance_id", func(e *recorder.Entry) { e.WriterInstanceID = "" }, "writer_instance_id required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := v3Entry()
+			tc.mutate(&e)
+			e.Hash = recorder.ComputeHash(e)
+			data, err := json.Marshal(e)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "v3.jsonl")
+			if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := recorder.ReadEntries(path); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ReadEntries() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLegacyEntriesRejectV3NamespaceFields(t *testing.T) {
+	for _, version := range []int{1, recorder.CurrentWriteEntryVersion} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			e := v3Entry()
+			e.Version = version
+			e.Hash = recorder.ComputeHash(e)
+
+			if err := recorder.VerifyChain([]recorder.Entry{e}); err == nil || !strings.Contains(err.Error(), "legacy entry cannot carry") {
+				t.Fatalf("VerifyChain() error = %v, want legacy namespace rejection", err)
+			}
+
+			data, err := json.Marshal(e)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "legacy.jsonl")
+			if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := recorder.ReadEntries(path); err == nil || !strings.Contains(err.Error(), "legacy entry cannot carry") {
+				t.Fatalf("ReadEntries() error = %v, want legacy namespace rejection", err)
+			}
+		})
+	}
+}
+
+func TestRecorderStillWritesV2DuringReaderFirstRollout(t *testing.T) {
+	if recorder.CurrentWriteEntryVersion != 2 {
+		t.Fatalf("CurrentWriteEntryVersion = %d, want 2 during reader-first rollout", recorder.CurrentWriteEntryVersion)
+	}
+	if recorder.LatestEntryVersion != 3 {
+		t.Fatalf("LatestEntryVersion = %d, want 3", recorder.LatestEntryVersion)
+	}
+}
+
+func TestRecorderStripsNamespaceFieldsWhileWritingV2(t *testing.T) {
+	dir := t.TempDir()
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, SignCheckpoints: false}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Record(recorder.Entry{
+		SessionID:        "proxy",
+		ChainKind:        recorder.ChainKindRecorder,
+		WriterInstanceID: "caller-controlled",
+		Type:             "capture",
+		Transport:        "fetch",
+		Summary:          "reader-first",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("evidence files = %v, err = %v", files, err)
+	}
+	entries, err := recorder.ReadEntries(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no recorder entries")
+	}
+	if entries[0].Version != recorder.CurrentWriteEntryVersion || entries[0].ChainKind != "" || entries[0].WriterInstanceID != "" {
+		t.Fatalf("written namespace = v%d (%q, %q), want v2 with empty namespace", entries[0].Version, entries[0].ChainKind, entries[0].WriterInstanceID)
+	}
+}

--- a/internal/recorder/entry_v3_test.go
+++ b/internal/recorder/entry_v3_test.go
@@ -237,6 +237,7 @@ func TestLegacyEntriesRejectV3NamespaceFields(t *testing.T) {
 	}
 }
 
+// Remove this rollout tripwire when the recorder advances its writer to v3.
 func TestRecorderStillWritesV2DuringReaderFirstRollout(t *testing.T) {
 	if recorder.CurrentWriteEntryVersion != 2 {
 		t.Fatalf("CurrentWriteEntryVersion = %d, want 2 during reader-first rollout", recorder.CurrentWriteEntryVersion)

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -491,7 +491,12 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 		return Entry{}, fmt.Errorf("recorder: session_id mismatch (expected %q, got %q)", r.sessionID, e.SessionID)
 	}
 
-	e.Version = EntryVersion
+	e.Version = CurrentWriteEntryVersion
+	// Namespace fields are authenticated only by the v3 projection. Strip any
+	// caller-supplied values while this binary emits v2 so unhashed metadata
+	// cannot leak into the evidence file or an enterprise audit envelope.
+	e.ChainKind = ""
+	e.WriterInstanceID = ""
 	e.Sequence = r.seq
 	e.Timestamp = time.Now().UTC()
 	e.PrevHash = r.prevHash
@@ -681,7 +686,7 @@ func (r *Recorder) checkpointLocked() error {
 
 	// Build the checkpoint entry
 	e := Entry{
-		Version:   EntryVersion,
+		Version:   CurrentWriteEntryVersion,
 		Sequence:  r.seq,
 		Timestamp: time.Now().UTC(),
 		SessionID: r.sessionID,
@@ -972,6 +977,16 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 			return fmt.Errorf(
 				"evidence file %s: tail entry seq %d belongs to session %q, not %q; refusing to adopt a foreign chain head",
 				candidate.base, last.Sequence, last.SessionID, wantSession)
+		}
+
+		// Reader support may lead writer support during a rolling upgrade. Never
+		// append the current writer format to a tail produced by another format:
+		// that transition would make the entire shard unverifiable. Refuse the
+		// write so an operator can preserve the existing evidence intact.
+		if last.Version != CurrentWriteEntryVersion {
+			return fmt.Errorf(
+				"evidence file %s: tail entry seq %d uses version %d, current writer uses version %d; refusing to mix recorder versions",
+				candidate.base, last.Sequence, last.Version, CurrentWriteEntryVersion)
 		}
 
 		// A uint64 at its maximum wraps to zero on increment, which would

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -980,12 +980,12 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 		}
 
 		// Reader support may lead writer support during a rolling upgrade. Never
-		// append the current writer format to a tail produced by a newer format:
-		// that downgrade would make the entire shard unverifiable. Older legacy
-		// tails remain appendable because VerifyChain accepts v1-to-v2 upgrades.
-		if last.Version > CurrentWriteEntryVersion {
+		// Never cross between legacy and namespaced chain families. Numeric
+		// ordering is insufficient: after the writer advances to v3, appending
+		// it to a v2 tail would be the inverse form of the same corruption.
+		if !EntryVersionsCanShareChain(last.Version, CurrentWriteEntryVersion) {
 			return fmt.Errorf(
-				"evidence file %s: tail entry seq %d uses version %d, newer than current writer version %d; refusing to mix recorder versions",
+				"evidence file %s: tail entry seq %d uses version %d, incompatible with current writer version %d; refusing to mix recorder versions",
 				candidate.base, last.Sequence, last.Version, CurrentWriteEntryVersion)
 		}
 

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -980,12 +980,12 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 		}
 
 		// Reader support may lead writer support during a rolling upgrade. Never
-		// append the current writer format to a tail produced by another format:
-		// that transition would make the entire shard unverifiable. Refuse the
-		// write so an operator can preserve the existing evidence intact.
-		if last.Version != CurrentWriteEntryVersion {
+		// append the current writer format to a tail produced by a newer format:
+		// that downgrade would make the entire shard unverifiable. Older legacy
+		// tails remain appendable because VerifyChain accepts v1-to-v2 upgrades.
+		if last.Version > CurrentWriteEntryVersion {
 			return fmt.Errorf(
-				"evidence file %s: tail entry seq %d uses version %d, current writer uses version %d; refusing to mix recorder versions",
+				"evidence file %s: tail entry seq %d uses version %d, newer than current writer version %d; refusing to mix recorder versions",
 				candidate.base, last.Sequence, last.Version, CurrentWriteEntryVersion)
 		}
 

--- a/internal/recorder/resume_availability_test.go
+++ b/internal/recorder/resume_availability_test.go
@@ -471,6 +471,35 @@ func TestRecorder_ResumeRefusesTailFromDifferentEntryVersion(t *testing.T) {
 	}
 }
 
+func TestRecorder_ResumeAllowsOlderLegacyTail(t *testing.T) {
+	dir := t.TempDir()
+	entry := recorder.Entry{
+		Version: recorder.AcceptedEntryVersions()[0], Sequence: 0,
+		Timestamp: time.Unix(1712345678, 0).UTC(), SessionID: "upgrade",
+		Type: testType, Transport: testTransport, Summary: "v1 tail",
+		Detail: map[string]string{"safe": "value"}, PrevHash: recorder.GenesisHash,
+	}
+	entry.Hash = recorder.ComputeHash(entry)
+	line, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-upgrade-0.jsonl"), append(line, '\n'), filePermissions); err != nil {
+		t.Fatal(err)
+	}
+	rec := newResumeRecorder(t, dir)
+	if err := rec.Record(recorder.Entry{
+		SessionID: "upgrade", Type: testType, Transport: testTransport,
+		Summary: "v2 continuation", Detail: map[string]string{"safe": "value"},
+	}); err != nil {
+		t.Fatalf("Record() after v1 tail = %v", err)
+	}
+	entries := readAllEntriesForSession(t, dir, "upgrade")
+	if len(entries) != 2 || entries[1].Version != recorder.CurrentWriteEntryVersion {
+		t.Fatalf("resumed entries = %+v, want v1 tail followed by v2", entries)
+	}
+}
+
 // The candidate scan has two I/O error branches. Both must surface the wrapped
 // directory-read context rather than being mistaken for an empty directory,
 // which would resume at genesis and fork the chain.

--- a/internal/recorder/resume_availability_test.go
+++ b/internal/recorder/resume_availability_test.go
@@ -419,6 +419,58 @@ func TestRecorder_ResumeRefusesShardWhoseEntriesBelongToAnotherSession(t *testin
 	}
 }
 
+// A reader-capable v2 writer must not append to a v3 tail during rollback. The
+// resulting v3-to-v2 transition is invalid, so refusing before the write keeps
+// the existing evidence verifiable and makes the operator-visible failure local.
+//
+// Neutralization: drop the last.Version check in resumeSessionLocked and this
+// fails because Record appends a v2 entry to the v3 shard.
+func TestRecorder_ResumeRefusesTailFromDifferentEntryVersion(t *testing.T) {
+	dir := t.TempDir()
+	entry := recorder.Entry{
+		Version:          recorder.LatestEntryVersion,
+		Sequence:         0,
+		Timestamp:        time.Unix(1712345678, 0).UTC(),
+		SessionID:        "rollback",
+		ChainKind:        recorder.ChainKindRecorder,
+		WriterInstanceID: "writer-before-rollback",
+		Type:             testType,
+		Transport:        testTransport,
+		Summary:          "v3 tail",
+		Detail:           map[string]string{"safe": "value"},
+		PrevHash:         recorder.GenesisHash,
+	}
+	entry.Hash = recorder.ComputeHash(entry)
+	line, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "evidence-rollback-0.jsonl")
+	if err := os.WriteFile(path, append(line, '\n'), filePermissions); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := newResumeRecorder(t, dir)
+	err = rec.Record(recorder.Entry{
+		SessionID: "rollback",
+		Type:      testType,
+		Transport: testTransport,
+		Summary:   "must not cross the version boundary",
+		Detail:    map[string]string{"safe": "value"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "refusing to mix recorder versions") {
+		t.Fatalf("Record() error = %v, want version-mismatch refusal", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(strings.TrimSpace(string(data)), "\n") + 1; got != 1 {
+		t.Fatalf("shard contains %d entries after refused resume, want 1", got)
+	}
+}
+
 // The candidate scan has two I/O error branches. Both must surface the wrapped
 // directory-read context rather than being mistaken for an empty directory,
 // which would resume at genesis and fork the chain.

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -40,6 +40,19 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
         }
         if version == Some(3) {
             require_v3_namespace(&entry, index + 1)?;
+        } else if entry
+            .get("chain_kind")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.is_empty())
+            || entry
+                .get("writer_instance_id")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+        {
+            return Err(VerifierError::Invalid(format!(
+                "line {}: legacy entry cannot carry v3 recorder namespace fields",
+                index + 1
+            )));
         }
         entries.push(entry);
     }

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -35,8 +35,11 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
         reject_duplicate_keys(line)
             .map_err(|err| VerifierError::Invalid(format!("line {}: {}", index + 1, err)))?;
         let version = entry.get("v").and_then(serde_json::Value::as_u64);
-        if version != Some(1) && version != Some(2) {
+        if version != Some(1) && version != Some(2) && version != Some(3) {
             errors_unsupported(index + 1, version)?;
+        }
+        if version == Some(3) {
+            require_v3_namespace(&entry, index + 1)?;
         }
         entries.push(entry);
     }
@@ -152,9 +155,24 @@ fn seq_start(path: &Path) -> Result<u64> {
 
 fn errors_unsupported(line: usize, version: Option<u64>) -> Result<()> {
     Err(VerifierError::Runtime(format!(
-        "line {line}: unsupported entry version {} (accepted: 1, 2)",
+        "line {line}: unsupported entry version {} (accepted: 1, 2, 3)",
         version.map_or_else(|| "null".to_string(), |value| value.to_string())
     )))
+}
+
+fn require_v3_namespace(entry: &serde_json::Value, line: usize) -> Result<()> {
+    for field in ["chain_kind", "writer_instance_id"] {
+        if entry
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .is_none_or(str::is_empty)
+        {
+            return Err(VerifierError::Runtime(format!(
+                "line {line}: v3 {field} required"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn display_path(path: &Path) -> String {

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -38,10 +38,10 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
         if version != Some(1) && version != Some(2) && version != Some(3) {
             errors_unsupported(index + 1, version)?;
         }
-        if version == Some(3) {
-            validate_v3_projected_strings(&entry, index + 1)?;
-        } else if legacy_namespace_field_is_set(&entry, "chain_kind")
-            || legacy_namespace_field_is_set(&entry, "writer_instance_id")
+        validate_projected_strings(&entry, index + 1, version.unwrap_or_default())?;
+        if version != Some(3)
+            && (legacy_namespace_field_is_set(&entry, "chain_kind")
+                || legacy_namespace_field_is_set(&entry, "writer_instance_id"))
         {
             return Err(VerifierError::Invalid(format!(
                 "line {}: legacy entry cannot carry v3 recorder namespace fields",
@@ -175,12 +175,10 @@ fn errors_unsupported(line: usize, version: Option<u64>) -> Result<()> {
     )))
 }
 
-fn validate_v3_projected_strings(entry: &serde_json::Value, line: usize) -> Result<()> {
-    for field in [
+fn validate_projected_strings(entry: &serde_json::Value, line: usize, version: u64) -> Result<()> {
+    let mut fields = vec![
         "ts",
         "session_id",
-        "chain_kind",
-        "writer_instance_id",
         "trace_id",
         "type",
         "event_kind",
@@ -188,24 +186,41 @@ fn validate_v3_projected_strings(entry: &serde_json::Value, line: usize) -> Resu
         "summary",
         "raw_ref",
         "prev_hash",
-    ] {
+    ];
+    if version == 3 {
+        fields.extend(["chain_kind", "writer_instance_id"]);
+    }
+    for field in fields {
+        let missing = entry.get(field).is_none();
         let value = match entry.get(field) {
             None => "",
             Some(value) => value.as_str().ok_or_else(|| {
                 VerifierError::Runtime(format!("line {line}: v3 {field} must be a string"))
             })?,
         };
-        if (field == "chain_kind" || field == "writer_instance_id") && value.is_empty() {
+        let required = version == 3
+            && matches!(
+                field,
+                "ts" | "session_id"
+                    | "chain_kind"
+                    | "writer_instance_id"
+                    | "type"
+                    | "transport"
+                    | "summary"
+                    | "prev_hash"
+            );
+        let namespace_required = field == "chain_kind" || field == "writer_instance_id";
+        if (required && missing) || (version == 3 && namespace_required && value.is_empty()) {
             return Err(VerifierError::Runtime(format!(
                 "line {line}: v3 {field} required"
             )));
         }
         if value.contains('\0') {
             return Err(VerifierError::Runtime(format!(
-                "line {line}: v3 {field} cannot contain NUL"
+                "line {line}: v{version} {field} cannot contain NUL"
             )));
         }
-        if field == "ts" {
+        if version == 3 && field == "ts" {
             crate::aarp::envelope::validate_timestamp(value, "recorder ts")
                 .map_err(|err| VerifierError::Runtime(format!("line {line}: {err}")))?;
         }

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -40,14 +40,8 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
         }
         if version == Some(3) {
             require_v3_namespace(&entry, index + 1)?;
-        } else if entry
-            .get("chain_kind")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.is_empty())
-            || entry
-                .get("writer_instance_id")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.is_empty())
+        } else if legacy_namespace_field_is_set(&entry, "chain_kind")
+            || legacy_namespace_field_is_set(&entry, "writer_instance_id")
         {
             return Err(VerifierError::Invalid(format!(
                 "line {}: legacy entry cannot carry v3 recorder namespace fields",
@@ -57,6 +51,14 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
         entries.push(entry);
     }
     Ok(entries)
+}
+
+fn legacy_namespace_field_is_set(entry: &serde_json::Value, field: &str) -> bool {
+    match entry.get(field) {
+        None | Some(serde_json::Value::Null) => false,
+        Some(serde_json::Value::String(value)) => !value.is_empty(),
+        Some(_) => true,
+    }
 }
 
 pub fn extract_receipts(path: &Path) -> Result<Vec<Receipt>> {
@@ -175,13 +177,14 @@ fn errors_unsupported(line: usize, version: Option<u64>) -> Result<()> {
 
 fn require_v3_namespace(entry: &serde_json::Value, line: usize) -> Result<()> {
     for field in ["chain_kind", "writer_instance_id"] {
-        if entry
+        let value = entry
             .get(field)
             .and_then(serde_json::Value::as_str)
-            .is_none_or(str::is_empty)
-        {
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| VerifierError::Runtime(format!("line {line}: v3 {field} required")))?;
+        if value.contains('\0') {
             return Err(VerifierError::Runtime(format!(
-                "line {line}: v3 {field} required"
+                "line {line}: v3 {field} cannot contain NUL"
             )));
         }
     }

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -205,6 +205,10 @@ fn validate_v3_projected_strings(entry: &serde_json::Value, line: usize) -> Resu
                 "line {line}: v3 {field} cannot contain NUL"
             )));
         }
+        if field == "ts" {
+            crate::aarp::envelope::validate_timestamp(value, "recorder ts")
+                .map_err(|err| VerifierError::Runtime(format!("line {line}: {err}")))?;
+        }
     }
     Ok(())
 }

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -39,7 +39,7 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
             errors_unsupported(index + 1, version)?;
         }
         if version == Some(3) {
-            require_v3_namespace(&entry, index + 1)?;
+            validate_v3_projected_strings(&entry, index + 1)?;
         } else if legacy_namespace_field_is_set(&entry, "chain_kind")
             || legacy_namespace_field_is_set(&entry, "writer_instance_id")
         {
@@ -175,13 +175,31 @@ fn errors_unsupported(line: usize, version: Option<u64>) -> Result<()> {
     )))
 }
 
-fn require_v3_namespace(entry: &serde_json::Value, line: usize) -> Result<()> {
-    for field in ["chain_kind", "writer_instance_id"] {
-        let value = entry
-            .get(field)
-            .and_then(serde_json::Value::as_str)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| VerifierError::Runtime(format!("line {line}: v3 {field} required")))?;
+fn validate_v3_projected_strings(entry: &serde_json::Value, line: usize) -> Result<()> {
+    for field in [
+        "ts",
+        "session_id",
+        "chain_kind",
+        "writer_instance_id",
+        "trace_id",
+        "type",
+        "event_kind",
+        "transport",
+        "summary",
+        "raw_ref",
+        "prev_hash",
+    ] {
+        let value = match entry.get(field) {
+            None => "",
+            Some(value) => value.as_str().ok_or_else(|| {
+                VerifierError::Runtime(format!("line {line}: v3 {field} must be a string"))
+            })?,
+        };
+        if (field == "chain_kind" || field == "writer_instance_id") && value.is_empty() {
+            return Err(VerifierError::Runtime(format!(
+                "line {line}: v3 {field} required"
+            )));
+        }
         if value.contains('\0') {
             return Err(VerifierError::Runtime(format!(
                 "line {line}: v3 {field} cannot contain NUL"

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -39,6 +39,17 @@ pub fn read_entries(path: &Path) -> Result<Vec<serde_json::Value>> {
             errors_unsupported(index + 1, version)?;
         }
         validate_projected_strings(&entry, index + 1, version.unwrap_or_default())?;
+        if version == Some(3)
+            && entry
+                .get("seq")
+                .and_then(serde_json::Value::as_u64)
+                .is_none()
+        {
+            return Err(VerifierError::Runtime(format!(
+                "line {}: v3 seq must be an unsigned 64-bit integer",
+                index + 1
+            )));
+        }
         if version != Some(3)
             && (legacy_namespace_field_is_set(&entry, "chain_kind")
                 || legacy_namespace_field_is_set(&entry, "writer_instance_id"))

--- a/sdk/verifiers/rust/src/recorder.rs
+++ b/sdk/verifiers/rust/src/recorder.rs
@@ -194,9 +194,15 @@ fn validate_projected_strings(entry: &serde_json::Value, line: usize, version: u
         let missing = entry.get(field).is_none();
         let value = match entry.get(field) {
             None => "",
-            Some(value) => value.as_str().ok_or_else(|| {
-                VerifierError::Runtime(format!("line {line}: v3 {field} must be a string"))
-            })?,
+            Some(value) => match value.as_str() {
+                Some(value) => value,
+                None if version != 3 => continue,
+                None => {
+                    return Err(VerifierError::Runtime(format!(
+                        "line {line}: v3 {field} must be a string"
+                    )))
+                }
+            },
         };
         let required = version == 3
             && matches!(

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -794,6 +794,21 @@ fn recorder_reader_rejects_nul_in_legacy_projected_strings() {
 }
 
 #[test]
+fn recorder_reader_preserves_legacy_null_compatibility() {
+    for version in [1, 2] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v{version}-null")));
+        let path = &fixture.0;
+        let entry = serde_json::json!({
+            "v": version, "seq": 0, "ts": "2026-08-07T00:00:00Z", "session_id": "s",
+            "trace_id": null, "type": "checkpoint", "transport": "x", "summary": "",
+            "detail": {}, "prev_hash": "genesis", "hash": "h"
+        });
+        fs::write(path, format!("{}\n", entry)).expect("write JSONL");
+        extract_receipts(path).expect("legacy null should remain accepted");
+    }
+}
+
+#[test]
 fn recorder_reader_rejects_malformed_legacy_namespace_types() {
     for (name, value) in [
         ("object", "{}"),

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -724,6 +724,52 @@ fn recorder_extraction_rejects_duplicate_keys_inside_receipt_detail() {
     assert!(err.to_string().contains("duplicate object key"));
 }
 
+#[test]
+fn recorder_reader_accepts_namespaced_v3_entries() {
+    let path = recorder_fixture_path("v3-valid");
+    let line = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
+    fs::write(&path, format!("{line}\n")).expect("write JSONL");
+    let receipts = extract_receipts(&path).expect("v3 entry should parse");
+    let _ = fs::remove_file(&path);
+    assert!(receipts.is_empty());
+}
+
+#[test]
+fn recorder_reader_rejects_v3_entries_without_complete_namespace() {
+    for (name, namespace, expected) in [
+        (
+            "v3-missing-kind",
+            r#""writer_instance_id":"writer-a","#,
+            "chain_kind required",
+        ),
+        (
+            "v3-missing-writer",
+            r#""chain_kind":"recorder","#,
+            "writer_instance_id required",
+        ),
+    ] {
+        let path = recorder_fixture_path(name);
+        let line = format!(
+            r#"{{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s",{namespace}"type":"checkpoint","transport":"x","summary":"","detail":{{}},"prev_hash":"genesis","hash":"h"}}"#
+        );
+        fs::write(&path, format!("{line}\n")).expect("write JSONL");
+        let err = extract_receipts(&path).expect_err("incomplete v3 namespace should reject");
+        let _ = fs::remove_file(&path);
+        assert!(err.to_string().contains(expected), "{err}");
+    }
+}
+
+fn recorder_fixture_path(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "pipelock-rs-verifier-{name}-{}-{suffix}.jsonl",
+        std::process::id()
+    ))
+}
+
 fn build_evidence_chain(count: usize) -> Vec<Value> {
     let root = common::repo_root();
     let base: Value =

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -737,8 +737,8 @@ fn recorder_reader_accepts_namespaced_v3_entries() {
     let fixture = TempFixture(recorder_fixture_path("v3-valid"));
     let path = &fixture.0;
     let line = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
-    fs::write(&path, format!("{line}\n")).expect("write JSONL");
-    let receipts = extract_receipts(&path).expect("v3 entry should parse");
+    fs::write(path, format!("{line}\n")).expect("write JSONL");
+    let receipts = extract_receipts(path).expect("v3 entry should parse");
     assert!(receipts.is_empty());
 }
 
@@ -761,8 +761,8 @@ fn recorder_reader_rejects_v3_entries_without_complete_namespace() {
         let line = format!(
             r#"{{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s",{namespace}"type":"checkpoint","transport":"x","summary":"","detail":{{}},"prev_hash":"genesis","hash":"h"}}"#
         );
-        fs::write(&path, format!("{line}\n")).expect("write JSONL");
-        let err = extract_receipts(&path).expect_err("incomplete v3 namespace should reject");
+        fs::write(path, format!("{line}\n")).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("incomplete v3 namespace should reject");
         assert!(err.to_string().contains(expected), "{err}");
     }
 }
@@ -775,6 +775,35 @@ fn recorder_reader_rejects_namespace_fields_on_legacy_entries() {
     fs::write(path, format!("{line}\n")).expect("write JSONL");
     let err = extract_receipts(path).expect_err("legacy namespace should reject");
     assert!(err.to_string().contains("legacy entry cannot carry"));
+}
+
+#[test]
+fn recorder_reader_rejects_malformed_legacy_namespace_types() {
+    for (name, value) in [
+        ("object", "{}"),
+        ("array", "[]"),
+        ("number", "1"),
+        ("boolean", "true"),
+    ] {
+        let fixture = TempFixture(recorder_fixture_path(name));
+        let path = &fixture.0;
+        let line = format!(
+            r#"{{"v":2,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":{value},"type":"checkpoint","transport":"x","summary":"","detail":{{}},"prev_hash":"genesis","hash":"h"}}"#
+        );
+        fs::write(path, format!("{line}\n")).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("malformed legacy namespace should reject");
+        assert!(err.to_string().contains("legacy entry cannot carry"));
+    }
+}
+
+#[test]
+fn recorder_reader_rejects_nul_in_v3_namespace() {
+    let fixture = TempFixture(recorder_fixture_path("v3-nul"));
+    let path = &fixture.0;
+    let line = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"a\u0000b","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
+    fs::write(path, format!("{line}\n")).expect("write JSONL");
+    let err = extract_receipts(path).expect_err("NUL namespace should reject");
+    assert!(err.to_string().contains("cannot contain NUL"));
 }
 
 fn recorder_fixture_path(name: &str) -> std::path::PathBuf {

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -844,15 +844,38 @@ fn recorder_reader_rejects_non_string_v3_projected_fields() {
         let fixture = TempFixture(recorder_fixture_path(&format!("v3-type-{field}")));
         let path = &fixture.0;
         let mut entry = serde_json::json!({
-            "v": 3, "seq": 0, "chain_kind": "recorder", "writer_instance_id": "writer-a",
+            "v": 3, "seq": 0, "ts": "2026-08-07T00:00:00Z", "chain_kind": "recorder", "writer_instance_id": "writer-a",
             "type": "checkpoint"
         });
         entry[field] = serde_json::json!(1);
         fs::write(path, format!("{}\n", entry)).expect("write JSONL");
         let err = extract_receipts(path).expect_err("non-string projected field should reject");
-        assert!(err
-            .to_string()
-            .contains(&format!("{field} must be a string")));
+        let message = err.to_string();
+        assert!(
+            message.contains(&format!("{field} must be a string")),
+            "field {field}: {message}"
+        );
+    }
+}
+
+#[test]
+fn recorder_reader_rejects_null_and_malformed_v3_timestamps() {
+    for (name, timestamp) in [
+        ("null", serde_json::Value::Null),
+        ("malformed", serde_json::json!("not-a-time")),
+    ] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v3-ts-{name}")));
+        let path = &fixture.0;
+        let entry = serde_json::json!({
+            "v": 3, "seq": 0, "ts": timestamp, "chain_kind": "recorder",
+            "writer_instance_id": "writer-a", "type": "checkpoint"
+        });
+        fs::write(path, format!("{}\n", entry)).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("invalid timestamp should reject");
+        assert!(
+            err.to_string().contains("timestamp")
+                || err.to_string().contains("ts must be a string")
+        );
     }
 }
 

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -917,6 +917,35 @@ fn recorder_reader_rejects_null_and_malformed_v3_timestamps() {
     }
 }
 
+#[test]
+fn recorder_reader_rejects_invalid_v3_sequences() {
+    for (name, seq) in [
+        ("missing", None),
+        ("null", Some("null")),
+        ("negative", Some("-1")),
+        ("fractional", Some("1.5")),
+        ("overflow", Some("18446744073709551616")),
+    ] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v3-seq-{name}")));
+        let path = &fixture.0;
+        let seq_field = seq.map_or_else(String::new, |value| format!(r#""seq":{value},"#));
+        let line = format!(
+            r#"{{"v":3,{seq_field}"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","prev_hash":"genesis"}}"#
+        );
+        fs::write(path, format!("{line}\n")).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("invalid v3 seq should reject");
+        assert!(
+            err.to_string().contains("seq")
+                || (name == "overflow"
+                    && (err.to_string().contains("number out of range")
+                        || err
+                            .to_string()
+                            .contains("exceeds cross-language exact range"))),
+            "{name}: {err}"
+        );
+    }
+}
+
 fn recorder_fixture_path(name: &str) -> std::path::PathBuf {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -797,13 +797,63 @@ fn recorder_reader_rejects_malformed_legacy_namespace_types() {
 }
 
 #[test]
-fn recorder_reader_rejects_nul_in_v3_namespace() {
-    let fixture = TempFixture(recorder_fixture_path("v3-nul"));
+fn recorder_reader_rejects_nul_in_every_v3_projected_string() {
+    for field in [
+        "ts",
+        "session_id",
+        "chain_kind",
+        "writer_instance_id",
+        "trace_id",
+        "type",
+        "event_kind",
+        "transport",
+        "summary",
+        "raw_ref",
+        "prev_hash",
+    ] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v3-nul-{field}")));
+        let path = &fixture.0;
+        let mut entry = serde_json::json!({
+            "v": 3, "seq": 0, "ts": "2026-08-07T00:00:00Z", "session_id": "s",
+            "chain_kind": "recorder", "writer_instance_id": "writer-a", "type": "checkpoint",
+            "transport": "x", "summary": "", "detail": {}, "prev_hash": "genesis", "hash": "h"
+        });
+        entry[field] = serde_json::Value::String("a\0b".to_string());
+        fs::write(path, format!("{}\n", entry)).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("NUL projected field should reject");
+        assert!(err
+            .to_string()
+            .contains(&format!("{field} cannot contain NUL")));
+    }
+}
+
+#[test]
+fn recorder_reader_rejects_v3_delimiter_collision_pair() {
+    let fixture = TempFixture(recorder_fixture_path("v3-collision"));
     let path = &fixture.0;
-    let line = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"a\u0000b","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
-    fs::write(path, format!("{line}\n")).expect("write JSONL");
-    let err = extract_receipts(path).expect_err("NUL namespace should reject");
-    assert!(err.to_string().contains("cannot contain NUL"));
+    let first = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","trace_id":"x\u0000y","type":"z","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
+    let second = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","trace_id":"x","type":"y\u0000z","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
+    fs::write(path, format!("{first}\n{second}\n")).expect("write JSONL");
+    let err = extract_receipts(path).expect_err("delimiter collision should reject");
+    assert!(err.to_string().contains("trace_id cannot contain NUL"));
+}
+
+#[test]
+fn recorder_reader_rejects_non_string_v3_projected_fields() {
+    for field in ["ts", "session_id", "trace_id", "type", "prev_hash"] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v3-type-{field}")));
+        let path = &fixture.0;
+        let mut entry = serde_json::json!({
+            "v": 3, "seq": 0, "chain_kind": "recorder", "writer_instance_id": "writer-a",
+            "type": "checkpoint"
+        });
+        entry[field] = serde_json::json!(1);
+        fs::write(path, format!("{}\n", entry)).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("non-string projected field should reject");
+        assert!(err
+            .to_string()
+            .contains(&format!("{field} must be a string")));
+    }
 }
 
 fn recorder_fixture_path(name: &str) -> std::path::PathBuf {

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -17,6 +17,14 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+struct TempFixture(std::path::PathBuf);
+
+impl Drop for TempFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
 const V2_GOLDEN_PUBLIC_KEY: &str =
     "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
 const V2_PRIVATE_SEED_HEX: &str = concat!(
@@ -726,11 +734,11 @@ fn recorder_extraction_rejects_duplicate_keys_inside_receipt_detail() {
 
 #[test]
 fn recorder_reader_accepts_namespaced_v3_entries() {
-    let path = recorder_fixture_path("v3-valid");
+    let fixture = TempFixture(recorder_fixture_path("v3-valid"));
+    let path = &fixture.0;
     let line = r#"{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
     fs::write(&path, format!("{line}\n")).expect("write JSONL");
     let receipts = extract_receipts(&path).expect("v3 entry should parse");
-    let _ = fs::remove_file(&path);
     assert!(receipts.is_empty());
 }
 
@@ -748,15 +756,25 @@ fn recorder_reader_rejects_v3_entries_without_complete_namespace() {
             "writer_instance_id required",
         ),
     ] {
-        let path = recorder_fixture_path(name);
+        let fixture = TempFixture(recorder_fixture_path(name));
+        let path = &fixture.0;
         let line = format!(
             r#"{{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s",{namespace}"type":"checkpoint","transport":"x","summary":"","detail":{{}},"prev_hash":"genesis","hash":"h"}}"#
         );
         fs::write(&path, format!("{line}\n")).expect("write JSONL");
         let err = extract_receipts(&path).expect_err("incomplete v3 namespace should reject");
-        let _ = fs::remove_file(&path);
         assert!(err.to_string().contains(expected), "{err}");
     }
+}
+
+#[test]
+fn recorder_reader_rejects_namespace_fields_on_legacy_entries() {
+    let fixture = TempFixture(recorder_fixture_path("v2-namespace"));
+    let path = &fixture.0;
+    let line = r#"{"v":2,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}"#;
+    fs::write(path, format!("{line}\n")).expect("write JSONL");
+    let err = extract_receipts(path).expect_err("legacy namespace should reject");
+    assert!(err.to_string().contains("legacy entry cannot carry"));
 }
 
 fn recorder_fixture_path(name: &str) -> std::path::PathBuf {

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -778,6 +778,22 @@ fn recorder_reader_rejects_namespace_fields_on_legacy_entries() {
 }
 
 #[test]
+fn recorder_reader_rejects_nul_in_legacy_projected_strings() {
+    for version in [1, 2] {
+        let fixture = TempFixture(recorder_fixture_path(&format!("v{version}-nul")));
+        let path = &fixture.0;
+        let entry = serde_json::json!({
+            "v": version, "seq": 0, "ts": "2026-08-07T00:00:00Z", "session_id": "x\0y",
+            "type": "checkpoint", "transport": "x", "summary": "", "detail": {},
+            "prev_hash": "genesis", "hash": "h"
+        });
+        fs::write(path, format!("{}\n", entry)).expect("write JSONL");
+        let err = extract_receipts(path).expect_err("legacy NUL should reject");
+        assert!(err.to_string().contains("cannot contain NUL"));
+    }
+}
+
+#[test]
 fn recorder_reader_rejects_malformed_legacy_namespace_types() {
     for (name, value) in [
         ("object", "{}"),
@@ -844,8 +860,9 @@ fn recorder_reader_rejects_non_string_v3_projected_fields() {
         let fixture = TempFixture(recorder_fixture_path(&format!("v3-type-{field}")));
         let path = &fixture.0;
         let mut entry = serde_json::json!({
-            "v": 3, "seq": 0, "ts": "2026-08-07T00:00:00Z", "chain_kind": "recorder", "writer_instance_id": "writer-a",
-            "type": "checkpoint"
+            "v": 3, "seq": 0, "ts": "2026-08-07T00:00:00Z", "session_id": "s",
+            "chain_kind": "recorder", "writer_instance_id": "writer-a", "type": "checkpoint",
+            "transport": "x", "summary": "", "prev_hash": "genesis"
         });
         entry[field] = serde_json::json!(1);
         fs::write(path, format!("{}\n", entry)).expect("write JSONL");
@@ -861,19 +878,25 @@ fn recorder_reader_rejects_non_string_v3_projected_fields() {
 #[test]
 fn recorder_reader_rejects_null_and_malformed_v3_timestamps() {
     for (name, timestamp) in [
-        ("null", serde_json::Value::Null),
-        ("malformed", serde_json::json!("not-a-time")),
+        ("omitted", None),
+        ("null", Some(serde_json::Value::Null)),
+        ("malformed", Some(serde_json::json!("not-a-time"))),
     ] {
         let fixture = TempFixture(recorder_fixture_path(&format!("v3-ts-{name}")));
         let path = &fixture.0;
-        let entry = serde_json::json!({
-            "v": 3, "seq": 0, "ts": timestamp, "chain_kind": "recorder",
-            "writer_instance_id": "writer-a", "type": "checkpoint"
+        let mut entry = serde_json::json!({
+            "v": 3, "seq": 0, "session_id": "s", "chain_kind": "recorder",
+            "writer_instance_id": "writer-a", "type": "checkpoint", "transport": "x",
+            "summary": "", "prev_hash": "genesis"
         });
+        if let Some(timestamp) = timestamp {
+            entry["ts"] = timestamp;
+        }
         fs::write(path, format!("{}\n", entry)).expect("write JSONL");
         let err = extract_receipts(path).expect_err("invalid timestamp should reject");
         assert!(
-            err.to_string().contains("timestamp")
+            err.to_string().contains("ts required")
+                || err.to_string().contains("timestamp")
                 || err.to_string().contains("ts must be a string")
         );
     }

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -38,11 +38,11 @@ export function readEntries(file: string): RecorderEntry[] {
         `line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2, 3)`,
       );
     }
-    if (entry.v === 3) {
-      validateV3ProjectedStrings(entry, i + 1);
-    } else if (
-      legacyNamespaceFieldIsSet(entry.chain_kind) ||
-      legacyNamespaceFieldIsSet(entry.writer_instance_id)
+    validateProjectedStrings(entry, i + 1, entry.v);
+    if (
+      entry.v !== 3 &&
+      (legacyNamespaceFieldIsSet(entry.chain_kind) ||
+        legacyNamespaceFieldIsSet(entry.writer_instance_id))
     ) {
       throw new RuntimeError(
         `line ${i + 1}: legacy entry cannot carry v3 recorder namespace fields`,
@@ -53,12 +53,10 @@ export function readEntries(file: string): RecorderEntry[] {
   return entries;
 }
 
-function validateV3ProjectedStrings(entry: RecorderEntry, line: number): void {
-  for (const field of [
+function validateProjectedStrings(entry: RecorderEntry, line: number, version: number): void {
+  const fields: (keyof RecorderEntry)[] = [
     "ts",
     "session_id",
-    "chain_kind",
-    "writer_instance_id",
     "trace_id",
     "type",
     "event_kind",
@@ -66,21 +64,33 @@ function validateV3ProjectedStrings(entry: RecorderEntry, line: number): void {
     "summary",
     "raw_ref",
     "prev_hash",
-  ] as const) {
+  ];
+  if (version === 3) fields.push("chain_kind", "writer_instance_id");
+  for (const field of fields) {
     const value = entry[field];
     if (value !== undefined && typeof value !== "string") {
       throw new RuntimeError(`line ${line}: v3 ${field} must be a string`);
     }
-    if (
-      (field === "chain_kind" || field === "writer_instance_id") &&
-      (value === undefined || value === "")
-    ) {
+    const required =
+      version === 3 &&
+      [
+        "ts",
+        "session_id",
+        "chain_kind",
+        "writer_instance_id",
+        "type",
+        "transport",
+        "summary",
+        "prev_hash",
+      ].includes(field);
+    const namespaceRequired = field === "chain_kind" || field === "writer_instance_id";
+    if ((required && value === undefined) || (version === 3 && namespaceRequired && value === "")) {
       throw new RuntimeError(`line ${line}: v3 ${field} required`);
     }
     if (typeof value === "string" && value.includes("\0")) {
-      throw new RuntimeError(`line ${line}: v3 ${field} cannot contain NUL`);
+      throw new RuntimeError(`line ${line}: v${version} ${field} cannot contain NUL`);
     }
-    if (field === "ts" && typeof value === "string") {
+    if (version === 3 && field === "ts" && typeof value === "string") {
       try {
         validateTimestamp(value);
       } catch (err) {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -38,18 +38,7 @@ export function readEntries(file: string): RecorderEntry[] {
       );
     }
     if (entry.v === 3) {
-      if (typeof entry.chain_kind !== "string" || entry.chain_kind === "") {
-        throw new RuntimeError(`line ${i + 1}: v3 chain_kind required`);
-      }
-      if (entry.chain_kind.includes("\0")) {
-        throw new RuntimeError(`line ${i + 1}: v3 chain_kind cannot contain NUL`);
-      }
-      if (typeof entry.writer_instance_id !== "string" || entry.writer_instance_id === "") {
-        throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id required`);
-      }
-      if (entry.writer_instance_id.includes("\0")) {
-        throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id cannot contain NUL`);
-      }
+      validateV3ProjectedStrings(entry, i + 1);
     } else if (
       legacyNamespaceFieldIsSet(entry.chain_kind) ||
       legacyNamespaceFieldIsSet(entry.writer_instance_id)
@@ -61,6 +50,36 @@ export function readEntries(file: string): RecorderEntry[] {
     entries.push(entry);
   }
   return entries;
+}
+
+function validateV3ProjectedStrings(entry: RecorderEntry, line: number): void {
+  for (const field of [
+    "ts",
+    "session_id",
+    "chain_kind",
+    "writer_instance_id",
+    "trace_id",
+    "type",
+    "event_kind",
+    "transport",
+    "summary",
+    "raw_ref",
+    "prev_hash",
+  ] as const) {
+    const value = entry[field];
+    if (value !== undefined && typeof value !== "string") {
+      throw new RuntimeError(`line ${line}: v3 ${field} must be a string`);
+    }
+    if (
+      (field === "chain_kind" || field === "writer_instance_id") &&
+      (value === undefined || value === "")
+    ) {
+      throw new RuntimeError(`line ${line}: v3 ${field} required`);
+    }
+    if (typeof value === "string" && value.includes("\0")) {
+      throw new RuntimeError(`line ${line}: v3 ${field} cannot contain NUL`);
+    }
+  }
 }
 
 function legacyNamespaceFieldIsSet(value: unknown): boolean {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -41,12 +41,18 @@ export function readEntries(file: string): RecorderEntry[] {
       if (typeof entry.chain_kind !== "string" || entry.chain_kind === "") {
         throw new RuntimeError(`line ${i + 1}: v3 chain_kind required`);
       }
+      if (entry.chain_kind.includes("\0")) {
+        throw new RuntimeError(`line ${i + 1}: v3 chain_kind cannot contain NUL`);
+      }
       if (typeof entry.writer_instance_id !== "string" || entry.writer_instance_id === "") {
         throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id required`);
       }
+      if (entry.writer_instance_id.includes("\0")) {
+        throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id cannot contain NUL`);
+      }
     } else if (
-      (typeof entry.chain_kind === "string" && entry.chain_kind !== "") ||
-      (typeof entry.writer_instance_id === "string" && entry.writer_instance_id !== "")
+      legacyNamespaceFieldIsSet(entry.chain_kind) ||
+      legacyNamespaceFieldIsSet(entry.writer_instance_id)
     ) {
       throw new RuntimeError(
         `line ${i + 1}: legacy entry cannot carry v3 recorder namespace fields`,
@@ -55,6 +61,10 @@ export function readEntries(file: string): RecorderEntry[] {
     entries.push(entry);
   }
   return entries;
+}
+
+function legacyNamespaceFieldIsSet(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== "";
 }
 
 export function extractReceipts(file: string): Receipt[] {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import type { Receipt, RecorderEntry } from "./types.js";
 import { validateV1Receipt } from "./strict.js";
 import { validateTimestamp } from "./aarp/numbers.js";
+import { parseJSONStrict, RawNumber } from "./aarp/strictjson.js";
 import { InvalidError, RuntimeError, decodeUTF8, parseJSON, rejectDuplicateKeys } from "./util.js";
 
 const actionReceiptType = "action_receipt";
@@ -38,6 +39,7 @@ export function readEntries(file: string): RecorderEntry[] {
         `line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2, 3)`,
       );
     }
+    if (entry.v === 3) validateV3Sequence(line, i + 1);
     validateProjectedStrings(entry, i + 1, entry.v);
     if (
       entry.v !== 3 &&
@@ -51,6 +53,17 @@ export function readEntries(file: string): RecorderEntry[] {
     entries.push(entry);
   }
   return entries;
+}
+
+function validateV3Sequence(rawLine: string, line: number): void {
+  const raw = parseJSONStrict(rawLine) as Record<string, unknown>;
+  const seq = raw.seq;
+  if (!(seq instanceof RawNumber) || !/^(?:0|[1-9][0-9]*)$/u.test(seq.literal)) {
+    throw new RuntimeError(`line ${line}: v3 seq must be an unsigned 64-bit integer`);
+  }
+  if (BigInt(seq.literal) > 18446744073709551615n) {
+    throw new RuntimeError(`line ${line}: v3 seq must be an unsigned 64-bit integer`);
+  }
 }
 
 function validateProjectedStrings(entry: RecorderEntry, line: number, version: number): void {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -32,10 +32,18 @@ export function readEntries(file: string): RecorderEntry[] {
     if (line === "") continue;
     const entry = parseJSON<RecorderEntry>(line, `line ${i + 1}`);
     rejectDuplicateKeys(line);
-    if (entry.v !== 1 && entry.v !== 2) {
+    if (entry.v !== 1 && entry.v !== 2 && entry.v !== 3) {
       throw new RuntimeError(
-        `line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2)`,
+        `line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2, 3)`,
       );
+    }
+    if (entry.v === 3) {
+      if (typeof entry.chain_kind !== "string" || entry.chain_kind === "") {
+        throw new RuntimeError(`line ${i + 1}: v3 chain_kind required`);
+      }
+      if (typeof entry.writer_instance_id !== "string" || entry.writer_instance_id === "") {
+        throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id required`);
+      }
     }
     entries.push(entry);
   }

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -33,13 +33,16 @@ export function readEntries(file: string): RecorderEntry[] {
     const line = lines[i]?.trim() ?? "";
     if (line === "") continue;
     const entry = parseJSON<RecorderEntry>(line, `line ${i + 1}`);
-    rejectDuplicateKeys(line);
     if (entry.v !== 1 && entry.v !== 2 && entry.v !== 3) {
       throw new RuntimeError(
         `line ${i + 1}: unsupported entry version ${String(entry.v)} (accepted: 1, 2, 3)`,
       );
     }
-    if (entry.v === 3) validateV3Sequence(line, i + 1);
+    if (entry.v === 3) {
+      entry.seq = validateV3Sequence(line, i + 1);
+    } else {
+      rejectDuplicateKeys(line);
+    }
     validateProjectedStrings(entry, i + 1, entry.v);
     if (
       entry.v !== 3 &&
@@ -55,7 +58,7 @@ export function readEntries(file: string): RecorderEntry[] {
   return entries;
 }
 
-function validateV3Sequence(rawLine: string, line: number): void {
+function validateV3Sequence(rawLine: string, line: number): string {
   const raw = parseJSONStrict(rawLine) as Record<string, unknown>;
   const seq = raw.seq;
   if (!(seq instanceof RawNumber) || !/^(?:0|[1-9][0-9]*)$/u.test(seq.literal)) {
@@ -64,6 +67,7 @@ function validateV3Sequence(rawLine: string, line: number): void {
   if (BigInt(seq.literal) > 18446744073709551615n) {
     throw new RuntimeError(`line ${line}: v3 seq must be an unsigned 64-bit integer`);
   }
+  return seq.literal;
 }
 
 function validateProjectedStrings(entry: RecorderEntry, line: number, version: number): void {

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -69,6 +69,7 @@ function validateProjectedStrings(entry: RecorderEntry, line: number, version: n
   for (const field of fields) {
     const value = entry[field];
     if (value !== undefined && typeof value !== "string") {
+      if (version !== 3) continue;
       throw new RuntimeError(`line ${line}: v3 ${field} must be a string`);
     }
     const required =

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -44,6 +44,13 @@ export function readEntries(file: string): RecorderEntry[] {
       if (typeof entry.writer_instance_id !== "string" || entry.writer_instance_id === "") {
         throw new RuntimeError(`line ${i + 1}: v3 writer_instance_id required`);
       }
+    } else if (
+      (typeof entry.chain_kind === "string" && entry.chain_kind !== "") ||
+      (typeof entry.writer_instance_id === "string" && entry.writer_instance_id !== "")
+    ) {
+      throw new RuntimeError(
+        `line ${i + 1}: legacy entry cannot carry v3 recorder namespace fields`,
+      );
     }
     entries.push(entry);
   }

--- a/sdk/verifiers/ts/src/recorder.ts
+++ b/sdk/verifiers/ts/src/recorder.ts
@@ -5,6 +5,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import * as path from "node:path";
 import type { Receipt, RecorderEntry } from "./types.js";
 import { validateV1Receipt } from "./strict.js";
+import { validateTimestamp } from "./aarp/numbers.js";
 import { InvalidError, RuntimeError, decodeUTF8, parseJSON, rejectDuplicateKeys } from "./util.js";
 
 const actionReceiptType = "action_receipt";
@@ -78,6 +79,13 @@ function validateV3ProjectedStrings(entry: RecorderEntry, line: number): void {
     }
     if (typeof value === "string" && value.includes("\0")) {
       throw new RuntimeError(`line ${line}: v3 ${field} cannot contain NUL`);
+    }
+    if (field === "ts" && typeof value === "string") {
+      try {
+        validateTimestamp(value);
+      } catch (err) {
+        throw new RuntimeError(`line ${line}: recorder ts ${(err as Error).message}`);
+      }
     }
   }
 }

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -139,7 +139,13 @@ export interface RecorderEntry {
   session_id?: string;
   chain_kind?: string;
   writer_instance_id?: string;
+  trace_id?: string;
   type?: string;
+  event_kind?: string;
+  transport?: string;
+  summary?: string;
+  raw_ref?: string;
+  prev_hash?: string;
   detail?: unknown;
 }
 

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -137,6 +137,8 @@ export interface RecorderEntry {
   seq?: number;
   ts?: string;
   session_id?: string;
+  chain_kind?: string;
+  writer_instance_id?: string;
   type?: string;
   detail?: unknown;
 }

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -134,7 +134,7 @@ export interface ShieldSummary {
 
 export interface RecorderEntry {
   v?: number;
-  seq?: number;
+  seq?: number | string;
   ts?: string;
   session_id?: string;
   chain_kind?: string;

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -654,16 +654,93 @@ test("JSONL recorder reader rejects malformed legacy namespace field types", () 
   }
 });
 
-test("JSONL recorder reader rejects NUL in v3 namespace", () => {
+test("JSONL recorder reader rejects NUL in every v3 projected string", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
-  const file = join(dir, "v3-nul.jsonl");
   try {
-    writeFileSync(
-      file,
-      '{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"a\\u0000b","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n',
-      { mode: 0o600 },
-    );
-    assert.throws(() => extractReceipts(file), /cannot contain NUL/u);
+    for (const field of [
+      "ts",
+      "session_id",
+      "chain_kind",
+      "writer_instance_id",
+      "trace_id",
+      "type",
+      "event_kind",
+      "transport",
+      "summary",
+      "raw_ref",
+      "prev_hash",
+    ]) {
+      const file = join(dir, `v3-nul-${field}.jsonl`);
+      const entry: Record<string, unknown> = {
+        v: 3,
+        seq: 0,
+        ts: "2026-08-07T00:00:00Z",
+        session_id: "s",
+        chain_kind: "recorder",
+        writer_instance_id: "writer-a",
+        type: "checkpoint",
+        transport: "x",
+        summary: "",
+        detail: {},
+        prev_hash: "genesis",
+        hash: "h",
+      };
+      entry[field] = "a\0b";
+      writeFileSync(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+      assert.throws(() => extractReceipts(file), new RegExp(`${field} cannot contain NUL`, "u"));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JSONL recorder reader rejects v3 delimiter-collision pair", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "v3-collision.jsonl");
+  try {
+    const base = {
+      v: 3,
+      seq: 0,
+      ts: "2026-08-07T00:00:00Z",
+      session_id: "s",
+      chain_kind: "recorder",
+      writer_instance_id: "writer-a",
+      type: "z",
+      transport: "x",
+      summary: "",
+      detail: {},
+      prev_hash: "genesis",
+      hash: "h",
+    };
+    const colliding = [
+      { ...base, trace_id: "x\0y", type: "z" },
+      { ...base, trace_id: "x", type: "y\0z" },
+    ];
+    writeFileSync(file, `${colliding.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+      mode: 0o600,
+    });
+    assert.throws(() => extractReceipts(file), /trace_id cannot contain NUL/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JSONL recorder reader rejects non-string v3 projected fields", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const field of ["ts", "session_id", "trace_id", "type", "prev_hash"]) {
+      const file = join(dir, `v3-type-${field}.jsonl`);
+      const entry: Record<string, unknown> = {
+        v: 3,
+        seq: 0,
+        chain_kind: "recorder",
+        writer_instance_id: "writer-a",
+        type: "checkpoint",
+      };
+      entry[field] = 1;
+      writeFileSync(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+      assert.throws(() => extractReceipts(file), new RegExp(`${field} must be a string`, "u"));
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -582,6 +582,41 @@ test("malformed JSONL raises an error", () => {
   }
 });
 
+test("JSONL recorder reader accepts namespaced v3 entries", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "v3.jsonl");
+  try {
+    writeFileSync(
+      file,
+      '{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n',
+      { mode: 0o600 },
+    );
+    assert.equal(extractReceipts(file).length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JSONL recorder reader rejects v3 entries without a complete namespace", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const [name, namespace] of [
+      ["missing-kind", '"writer_instance_id":"writer-a",'],
+      ["missing-writer", '"chain_kind":"recorder",'],
+    ]) {
+      const file = join(dir, `${name}.jsonl`);
+      writeFileSync(
+        file,
+        `{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s",${namespace}"type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(() => extractReceipts(file), /v3 (chain_kind|writer_instance_id) required/u);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder extraction rejects duplicate keys inside receipt detail", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   const file = join(dir, "duplicate-key.jsonl");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -632,6 +632,23 @@ test("JSONL recorder reader rejects namespace fields on legacy entries", () => {
   }
 });
 
+test("JSONL recorder reader rejects NUL in legacy projected strings", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const version of [1, 2]) {
+      const file = join(dir, `v${version}-nul.jsonl`);
+      writeFileSync(
+        file,
+        `${JSON.stringify({ v: version, seq: 0, ts: "2026-08-07T00:00:00Z", session_id: "x\0y", type: "checkpoint", transport: "x", summary: "", detail: {}, prev_hash: "genesis", hash: "h" })}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(() => extractReceipts(file), /cannot contain NUL/u);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder reader rejects malformed legacy namespace field types", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   try {
@@ -734,9 +751,13 @@ test("JSONL recorder reader rejects non-string v3 projected fields", () => {
         v: 3,
         seq: 0,
         ts: "2026-08-07T00:00:00Z",
+        session_id: "s",
         chain_kind: "recorder",
         writer_instance_id: "writer-a",
         type: "checkpoint",
+        transport: "x",
+        summary: "",
+        prev_hash: "genesis",
       };
       entry[field] = 1;
       writeFileSync(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
@@ -751,16 +772,17 @@ test("JSONL recorder reader rejects null and malformed v3 timestamps", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   try {
     for (const [name, ts] of [
+      ["omitted", undefined],
       ["null", null],
       ["malformed", "not-a-time"],
     ]) {
       const file = join(dir, `v3-ts-${name}.jsonl`);
       writeFileSync(
         file,
-        `${JSON.stringify({ v: 3, seq: 0, ts, chain_kind: "recorder", writer_instance_id: "writer-a", type: "checkpoint" })}\n`,
+        `${JSON.stringify({ v: 3, seq: 0, ts, session_id: "s", chain_kind: "recorder", writer_instance_id: "writer-a", type: "checkpoint", transport: "x", summary: "", prev_hash: "genesis" })}\n`,
         { mode: 0o600 },
       );
-      assert.throws(() => extractReceipts(file), /recorder ts|ts must be a string/u);
+      assert.throws(() => extractReceipts(file), /ts required|recorder ts|ts must be a string/u);
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import * as ed25519 from "@noble/ed25519";
 import { canonicalizeBytes } from "../src/aarp/canonical.js";
 import { canonicalizeActionRecord } from "../src/canonical.js";
-import { extractReceipts } from "../src/recorder.js";
+import { extractReceipts, readEntries } from "../src/recorder.js";
 import { computeSessionOpenGenesis, receiptHash, verifyChain } from "../src/chain.js";
 import {
   loadRotationEndorsementFile,
@@ -838,7 +838,9 @@ test("JSONL recorder reader preserves maximum uint64 v3 sequence", () => {
       '{"v":3,"seq":18446744073709551615,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","prev_hash":"genesis"}\n',
       { mode: 0o600 },
     );
-    assert.doesNotThrow(() => extractReceipts(file));
+    const entries = readEntries(file);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.seq, "18446744073709551615");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -617,6 +617,21 @@ test("JSONL recorder reader rejects v3 entries without a complete namespace", ()
   }
 });
 
+test("JSONL recorder reader rejects namespace fields on legacy entries", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "v2-namespace.jsonl");
+  try {
+    writeFileSync(
+      file,
+      '{"v":2,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n',
+      { mode: 0o600 },
+    );
+    assert.throws(() => extractReceipts(file), /legacy entry cannot carry/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder extraction rejects duplicate keys inside receipt detail", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   const file = join(dir, "duplicate-key.jsonl");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -632,6 +632,43 @@ test("JSONL recorder reader rejects namespace fields on legacy entries", () => {
   }
 });
 
+test("JSONL recorder reader rejects malformed legacy namespace field types", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const [name, value] of [
+      ["object", "{}"],
+      ["array", "[]"],
+      ["number", "1"],
+      ["boolean", "true"],
+    ]) {
+      const file = join(dir, `${name}.jsonl`);
+      writeFileSync(
+        file,
+        `{"v":2,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":${value},"type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(() => extractReceipts(file), /legacy entry cannot carry/u);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JSONL recorder reader rejects NUL in v3 namespace", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "v3-nul.jsonl");
+  try {
+    writeFileSync(
+      file,
+      '{"v":3,"seq":0,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"a\\u0000b","type":"checkpoint","transport":"x","summary":"","detail":{},"prev_hash":"genesis","hash":"h"}\n',
+      { mode: 0o600 },
+    );
+    assert.throws(() => extractReceipts(file), /cannot contain NUL/u);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder extraction rejects duplicate keys inside receipt detail", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   const file = join(dir, "duplicate-key.jsonl");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -806,6 +806,29 @@ test("JSONL recorder reader rejects null and malformed v3 timestamps", () => {
   }
 });
 
+test("JSONL recorder reader rejects invalid v3 sequences", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const [name, seqField] of [
+      ["missing", ""],
+      ["null", '"seq":null,'],
+      ["negative", '"seq":-1,'],
+      ["fractional", '"seq":1.5,'],
+      ["overflow", '"seq":18446744073709551616,'],
+    ]) {
+      const file = join(dir, `v3-seq-${name}.jsonl`);
+      writeFileSync(
+        file,
+        `{"v":3,${seqField}"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","prev_hash":"genesis"}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(() => extractReceipts(file), /v3 seq|exceeds cross-language exact range/u);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder extraction rejects duplicate keys inside receipt detail", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   const file = join(dir, "duplicate-key.jsonl");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -829,6 +829,21 @@ test("JSONL recorder reader rejects invalid v3 sequences", () => {
   }
 });
 
+test("JSONL recorder reader preserves maximum uint64 v3 sequence", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  const file = join(dir, "v3-seq-max.jsonl");
+  try {
+    writeFileSync(
+      file,
+      '{"v":3,"seq":18446744073709551615,"ts":"2026-08-07T00:00:00Z","session_id":"s","chain_kind":"recorder","writer_instance_id":"writer-a","type":"checkpoint","transport":"x","summary":"","prev_hash":"genesis"}\n',
+      { mode: 0o600 },
+    );
+    assert.doesNotThrow(() => extractReceipts(file));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder extraction rejects duplicate keys inside receipt detail", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   const file = join(dir, "duplicate-key.jsonl");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -733,6 +733,7 @@ test("JSONL recorder reader rejects non-string v3 projected fields", () => {
       const entry: Record<string, unknown> = {
         v: 3,
         seq: 0,
+        ts: "2026-08-07T00:00:00Z",
         chain_kind: "recorder",
         writer_instance_id: "writer-a",
         type: "checkpoint",
@@ -740,6 +741,26 @@ test("JSONL recorder reader rejects non-string v3 projected fields", () => {
       entry[field] = 1;
       writeFileSync(file, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
       assert.throws(() => extractReceipts(file), new RegExp(`${field} must be a string`, "u"));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("JSONL recorder reader rejects null and malformed v3 timestamps", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const [name, ts] of [
+      ["null", null],
+      ["malformed", "not-a-time"],
+    ]) {
+      const file = join(dir, `v3-ts-${name}.jsonl`);
+      writeFileSync(
+        file,
+        `${JSON.stringify({ v: 3, seq: 0, ts, chain_kind: "recorder", writer_instance_id: "writer-a", type: "checkpoint" })}\n`,
+        { mode: 0o600 },
+      );
+      assert.throws(() => extractReceipts(file), /recorder ts|ts must be a string/u);
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -649,6 +649,23 @@ test("JSONL recorder reader rejects NUL in legacy projected strings", () => {
   }
 });
 
+test("JSONL recorder reader preserves legacy null compatibility", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
+  try {
+    for (const version of [1, 2]) {
+      const file = join(dir, `v${version}-null.jsonl`);
+      writeFileSync(
+        file,
+        `${JSON.stringify({ v: version, seq: 0, ts: "2026-08-07T00:00:00Z", session_id: "s", trace_id: null, type: "checkpoint", transport: "x", summary: "", detail: {}, prev_hash: "genesis", hash: "h" })}\n`,
+        { mode: 0o600 },
+      );
+      assert.doesNotThrow(() => extractReceipts(file));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("JSONL recorder reader rejects malformed legacy namespace field types", () => {
   const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-"));
   try {


### PR DESCRIPTION
Adds reader support for recorder entry v3 with chain_kind and writer_instance_id bound into the frozen hash projection. Production recording remains on v2 during the compatibility window.

Updates Go, TypeScript, Rust, inference, and enterprise readers. Enterprise ingestion keeps existing fork detection and rejects payload/envelope namespace mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recorder readers and verifiers support evidence versions 1–3.
  * Version 3 entries include chain kind and writer identity metadata.
  * Independent recorder namespaces are processed without false fork detection.

* **Bug Fixes**
  * Rejects incomplete, unsupported, or inconsistent chains.
  * Prevents resuming from incompatible newer-format shards.
  * Continues writing version 2 entries during compatibility rollout.

* **Documentation**
  * Documented supported versions, metadata, hashing, and compatibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->