### PR TITLE
feat(verifier): detect truncated evidence chains

### DIFF
--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -63,6 +63,7 @@ key.`,
 	cmd.Flags().StringVar(&opts.expectContractHash, "expect-contract", "", "EvidenceReceipt v2: require contract_hash")
 	cmd.Flags().StringVar(&opts.expectManifestHash, "expect-manifest", "", "EvidenceReceipt v2: require active_manifest_hash")
 	cmd.Flags().StringVar(&opts.expectPayloadKind, "expect-payload-kind", "", "EvidenceReceipt v2: require payload_kind")
+	cmd.Flags().StringVar(&opts.expectHeadHash, "expect-head", "", "EvidenceReceipt v2: require the chain tip to equal this receipt hash, which is the only check that detects dropped trailing entries; source it from trusted context outside the chain")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")
 	cmd.Flags().BoolVar(&opts.asDir, "dir", false, "treat PATH as a session directory rather than a single file")
 	cmd.Flags().BoolVar(&opts.allowUnpinned, "allow-unpinned", false, "allow structural-only verification without a trusted signer key")
@@ -80,6 +81,7 @@ type chainReport struct {
 	FinalSeq           uint64     `json:"final_seq"`
 	RootHash           string     `json:"root_hash,omitempty"`
 	SignaturesVerified bool       `json:"signatures_verified"`
+	HeadVerified       bool       `json:"head_verified"`
 	Unpinned           bool       `json:"unpinned,omitempty"`
 	SignerKeyID        string     `json:"signer_key_id,omitempty"`
 	Error              string     `json:"error,omitempty"`
@@ -225,6 +227,7 @@ func verifyEvidenceChain(stdout, stderr io.Writer, label string, receipts []cont
 		FinalSeq:           res.FinalSeq,
 		RootHash:           res.RootHash,
 		SignaturesVerified: res.SignaturesVerified,
+		HeadVerified:       res.HeadVerified,
 		Unpinned:           res.Valid && !res.SignaturesVerified,
 		SignerKeyID:        res.SignerKeyID,
 		Error:              res.Error,

--- a/cmd/pipelock-verifier/chain_head_test.go
+++ b/cmd/pipelock-verifier/chain_head_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -122,5 +124,38 @@ func TestChain_ExpectedHeadJSONField(t *testing.T) {
 	}
 	if !strings.Contains(pinned, `"head_verified": true`) {
 		t.Fatalf("json = %q, want head_verified true", pinned)
+	}
+}
+
+// TestReceipt_ExpectedHeadBindsASingleReceipt covers the single-receipt half of
+// the shared expect-head option. There is no omission to detect in one receipt,
+// so this binds identity: the file has to be the receipt the caller expected.
+// The option reaches this command through the shared evidenceBindingOptions, and
+// an option that is plumbed but unread is an inert security knob, so a mismatch
+// must be rejected rather than passed over.
+func TestReceipt_ExpectedHeadBindsASingleReceipt(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 1)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	data, marshalErr := json.Marshal(fix.receipts[0])
+	if marshalErr != nil {
+		t.Fatalf("marshal receipt: %v", marshalErr)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+	tip := evidenceTipHash(t, fix)
+
+	stdout, stderr, code := runRoot(t, "receipt", "--key", fix.keyHex, "--expect-head", tip, path)
+	if code != cliutil.ExitOK {
+		t.Fatalf("receipt with its own hash should verify, stdout=%q stderr=%q", stdout, stderr)
+	}
+
+	_, stderr, code = runRoot(t, "receipt", "--key", fix.keyHex, "--expect-head", strings.Repeat("0", 64), path)
+	if code == cliutil.ExitOK {
+		t.Fatalf("receipt verified against a head hash it does not have, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "does not match expected head") {
+		t.Fatalf("stderr = %q, want the expected-head mismatch named", stderr)
 	}
 }

--- a/cmd/pipelock-verifier/chain_head_test.go
+++ b/cmd/pipelock-verifier/chain_head_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+// evidenceTipHash returns the ReceiptHash of the fixture's final receipt, which
+// is what trusted external context would pin as the expected head.
+func evidenceTipHash(t *testing.T, fix *evidenceFixture) string {
+	t.Helper()
+	h, err := contractreceipt.ReceiptHash(fix.receipts[len(fix.receipts)-1])
+	if err != nil {
+		t.Fatalf("hash chain tip: %v", err)
+	}
+	return h
+}
+
+// writeTruncatedEvidence writes the fixture's chain with the last receipt
+// dropped, which is the omission every other check is blind to.
+func writeTruncatedEvidence(t *testing.T, fix *evidenceFixture, path string) {
+	t.Helper()
+	full := fix.receipts
+	fix.receipts = full[:len(full)-1]
+	fix.writeEvidenceJSONL(t, path)
+	fix.receipts = full
+}
+
+// TestChain_CompletenessNotProvenWithoutExpectedHead pins the reporting change.
+// A chain verified without an expected head is still VALID, because every check
+// but the head binding is satisfied by any prefix. Leaving that unsaid lets a
+// reader take "CHAIN VALID" as "nothing is missing", so the verdict has to say
+// which of the two it means.
+func TestChain_CompletenessNotProvenWithoutExpectedHead(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 3)
+	evidence := filepath.Join(t.TempDir(), "evidence.jsonl")
+	fix.writeEvidenceJSONL(t, evidence)
+
+	stdout, stderr, code := runRoot(t, "chain", "--key", fix.keyHex, evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("chain should verify, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "completeness: not proven") {
+		t.Fatalf("stdout = %q, want completeness reported as not proven", stdout)
+	}
+	if !strings.Contains(stdout, "--expect-head") {
+		t.Fatalf("stdout = %q, want the remediation flag named", stdout)
+	}
+}
+
+// TestChain_ExpectedHeadReportsVerified covers the other half: supplying the
+// real head both passes and says so.
+func TestChain_ExpectedHeadReportsVerified(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 3)
+	evidence := filepath.Join(t.TempDir(), "evidence.jsonl")
+	fix.writeEvidenceJSONL(t, evidence)
+
+	stdout, stderr, code := runRoot(t, "chain", "--key", fix.keyHex, "--expect-head", evidenceTipHash(t, fix), evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("chain with its own head should verify, stdout=%q stderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "completeness: head verified") {
+		t.Fatalf("stdout = %q, want completeness reported as head verified", stdout)
+	}
+}
+
+// TestChain_ExpectedHeadCatchesTruncation is the reason the flag exists. The
+// truncated chain passes every per-receipt check, so without a pinned head the
+// CLI reports it valid; with one it is rejected.
+func TestChain_ExpectedHeadCatchesTruncation(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 3)
+	evidence := filepath.Join(t.TempDir(), "truncated.jsonl")
+	writeTruncatedEvidence(t, fix, evidence)
+	tip := evidenceTipHash(t, fix)
+
+	stdout, _, code := runRoot(t, "chain", "--key", fix.keyHex, evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("a truncated chain still passes structurally; got exit %d stdout=%q", code, stdout)
+	}
+	if !strings.Contains(stdout, "completeness: not proven") {
+		t.Fatalf("stdout = %q, want the truncated chain flagged as completeness-unproven", stdout)
+	}
+
+	_, stderr, code := runRoot(t, "chain", "--key", fix.keyHex, "--expect-head", tip, evidence)
+	if code == cliutil.ExitOK {
+		t.Fatalf("truncated chain verified against the full-chain head, stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "truncated") {
+		t.Fatalf("stderr = %q, want the rejection to name truncation", stderr)
+	}
+}
+
+// TestChain_ExpectedHeadJSONField keeps the machine-readable verdict honest for
+// a consumer that never reads the human output.
+func TestChain_ExpectedHeadJSONField(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 2)
+	evidence := filepath.Join(t.TempDir(), "evidence.jsonl")
+	fix.writeEvidenceJSONL(t, evidence)
+
+	unpinned, _, code := runRoot(t, "chain", "--key", fix.keyHex, "--json", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("json chain should verify: %s", unpinned)
+	}
+	if !strings.Contains(unpinned, `"head_verified": false`) {
+		t.Fatalf("json = %q, want head_verified false with no expected head", unpinned)
+	}
+
+	pinned, _, code := runRoot(t, "chain", "--key", fix.keyHex, "--expect-head", evidenceTipHash(t, fix), "--json", evidence)
+	if code != cliutil.ExitOK {
+		t.Fatalf("json chain with head should verify: %s", pinned)
+	}
+	if !strings.Contains(pinned, `"head_verified": true`) {
+		t.Fatalf("json = %q, want head_verified true", pinned)
+	}
+}

--- a/cmd/pipelock-verifier/chain_head_test.go
+++ b/cmd/pipelock-verifier/chain_head_test.go
@@ -114,7 +114,13 @@ func TestChain_ExpectedHeadJSONField(t *testing.T) {
 	if code != cliutil.ExitOK {
 		t.Fatalf("json chain should verify: %s", unpinned)
 	}
-	if !strings.Contains(unpinned, `"head_verified": false`) {
+	var unpinnedReport struct {
+		HeadVerified *bool `json:"head_verified"`
+	}
+	if err := json.Unmarshal([]byte(unpinned), &unpinnedReport); err != nil {
+		t.Fatalf("decode json verdict: %v", err)
+	}
+	if unpinnedReport.HeadVerified == nil || *unpinnedReport.HeadVerified {
 		t.Fatalf("json = %q, want head_verified false with no expected head", unpinned)
 	}
 
@@ -122,7 +128,13 @@ func TestChain_ExpectedHeadJSONField(t *testing.T) {
 	if code != cliutil.ExitOK {
 		t.Fatalf("json chain with head should verify: %s", pinned)
 	}
-	if !strings.Contains(pinned, `"head_verified": true`) {
+	var pinnedReport struct {
+		HeadVerified *bool `json:"head_verified"`
+	}
+	if err := json.Unmarshal([]byte(pinned), &pinnedReport); err != nil {
+		t.Fatalf("decode json verdict: %v", err)
+	}
+	if pinnedReport.HeadVerified == nil || !*pinnedReport.HeadVerified {
 		t.Fatalf("json = %q, want head_verified true", pinned)
 	}
 }

--- a/cmd/pipelock-verifier/chain_head_test.go
+++ b/cmd/pipelock-verifier/chain_head_test.go
@@ -159,3 +159,58 @@ func TestReceipt_ExpectedHeadBindsASingleReceipt(t *testing.T) {
 		t.Fatalf("stderr = %q, want the expected-head mismatch named", stderr)
 	}
 }
+
+// TestReceipt_UnpinnedStillAppliesTheExpectBindings covers the path a pinned
+// test cannot reach. The receipt command verifies an unpinned receipt on its own
+// branch, which returned before the binding checks were reached, so every
+// Expect* flag was accepted and never compared when --key was omitted: the
+// command exited 0 with no error and no warning. An operator who pinned an
+// expectation and got silence had no way to tell the check never ran, which is
+// worse than the flag not existing.
+//
+// These bindings read the receipt's own declared fields, so none of them needs a
+// trusted key. Provenance is a separate question and the unpinned banner already
+// reports it.
+func TestReceipt_UnpinnedStillAppliesTheExpectBindings(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 1)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	data, marshalErr := json.Marshal(fix.receipts[0])
+	if marshalErr != nil {
+		t.Fatalf("marshal receipt: %v", marshalErr)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write receipt: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		flag   string
+		value  string
+		wantIn string
+	}{
+		{"expect_head", "--expect-head", strings.Repeat("0", 64), "does not match expected head"},
+		{"expect_signer_id", "--expect-signer-id", "not-the-signer", "signer_key_id"},
+		{"expect_contract", "--expect-contract", "sha256:not-the-contract", "contract_hash"},
+		{"expect_payload_kind", "--expect-payload-kind", "not_a_payload_kind", "payload_kind"},
+		{"expect_manifest", "--expect-manifest", "sha256:not-the-manifest", "active_manifest_hash"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, code := runRoot(t, "receipt", "--allow-unpinned", tc.flag, tc.value, path)
+			if code == cliutil.ExitOK {
+				t.Fatalf("%s mismatch accepted on the unpinned path, stderr=%q", tc.flag, stderr)
+			}
+			if !strings.Contains(stderr, tc.wantIn) {
+				t.Fatalf("stderr = %q, want it to name %s", stderr, tc.wantIn)
+			}
+		})
+	}
+
+	// The matching case must still pass, or the bindings would be refusing
+	// legitimate input rather than catching a mismatch.
+	stdout, stderr, code := runRoot(t, "receipt", "--allow-unpinned", "--expect-head", evidenceTipHash(t, fix), path)
+	if code != cliutil.ExitOK {
+		t.Fatalf("matching unpinned expected head rejected, stdout=%q stderr=%q", stdout, stderr)
+	}
+}

--- a/cmd/pipelock-verifier/evidence.go
+++ b/cmd/pipelock-verifier/evidence.go
@@ -112,6 +112,21 @@ func verifyEvidenceReceipt(r contractreceipt.EvidenceReceipt, keyHex string, opt
 	if opts.expectManifestHash != "" && r.ActiveManifestHash != opts.expectManifestHash {
 		return false, fmt.Errorf("active_manifest_hash does not match expected")
 	}
+	// Single-receipt binding for the same option the chain path uses. The field
+	// reaches here through the shared evidenceBindingOptions, so leaving it
+	// unread would make a plumbed security option silently do nothing the moment
+	// anyone exposed it on this command: an operator would pin a head, see no
+	// error, and believe it had been checked. There is no omission to detect in
+	// one receipt, so this binds identity rather than completeness.
+	if opts.expectHeadHash != "" {
+		h, hashErr := contractreceipt.ReceiptHash(r)
+		if hashErr != nil {
+			return false, hashErr
+		}
+		if h != opts.expectHeadHash {
+			return false, fmt.Errorf("receipt hash %s does not match expected head %s", h, opts.expectHeadHash)
+		}
+	}
 	if chainOpts.PinnedKey == nil {
 		if err := r.Validate(); err != nil {
 			return false, err

--- a/cmd/pipelock-verifier/evidence.go
+++ b/cmd/pipelock-verifier/evidence.go
@@ -50,6 +50,47 @@ func (opts evidenceBindingOptions) chainVerifyOptions(keyHex string) (contractre
 	}, nil
 }
 
+// checkBindings applies every Expect* binding to one receipt.
+//
+// It is a separate method because the receipt command verifies an UNPINNED
+// receipt on its own branch, which returns before verifyEvidenceReceipt is
+// reached. Every binding therefore used to be skipped whenever --key was
+// omitted: `--allow-unpinned --expect-signer-id WRONG` exited 0 with no error
+// and no warning, so an operator who pinned an expectation and got silence had
+// no way to tell it had never been compared. A binding that silently does
+// nothing is worse than one that is absent, because the operator believes the
+// check happened.
+//
+// These are checks on the receipt's own declared fields, so none of them needs
+// a trusted key and all of them are meaningful without one. Pinning provenance
+// is a separate question, and the unpinned banner already reports that.
+func (opts evidenceBindingOptions) checkBindings(r contractreceipt.EvidenceReceipt) error {
+	if opts.expectSignerKeyID != "" && r.Signature.SignerKeyID != opts.expectSignerKeyID {
+		return fmt.Errorf("signer_key_id %q does not match expected %q", r.Signature.SignerKeyID, opts.expectSignerKeyID)
+	}
+	if opts.expectPayloadKind != "" && r.PayloadKind != contractreceipt.PayloadKind(opts.expectPayloadKind) {
+		return fmt.Errorf("payload_kind %q does not match expected %q", r.PayloadKind, opts.expectPayloadKind)
+	}
+	if opts.expectContractHash != "" && r.ContractHash != opts.expectContractHash {
+		return fmt.Errorf("contract_hash does not match expected")
+	}
+	if opts.expectManifestHash != "" && r.ActiveManifestHash != opts.expectManifestHash {
+		return fmt.Errorf("active_manifest_hash does not match expected")
+	}
+	// One receipt has no trailing entries to drop, so the head binds identity
+	// rather than completeness: the file has to be the receipt the caller meant.
+	if opts.expectHeadHash != "" {
+		h, err := contractreceipt.ReceiptHash(r)
+		if err != nil {
+			return err
+		}
+		if h != opts.expectHeadHash {
+			return fmt.Errorf("receipt hash %s does not match expected head %s", h, opts.expectHeadHash)
+		}
+	}
+	return nil
+}
+
 func decodePinnedEvidenceKey(keyHex string) (ed25519.PublicKey, error) {
 	if keyHex == "" {
 		return nil, nil
@@ -100,32 +141,8 @@ func verifyEvidenceReceipt(r contractreceipt.EvidenceReceipt, keyHex string, opt
 	if err != nil {
 		return false, err
 	}
-	if opts.expectSignerKeyID != "" && r.Signature.SignerKeyID != opts.expectSignerKeyID {
-		return false, fmt.Errorf("signer_key_id %q does not match expected %q", r.Signature.SignerKeyID, opts.expectSignerKeyID)
-	}
-	if opts.expectPayloadKind != "" && r.PayloadKind != contractreceipt.PayloadKind(opts.expectPayloadKind) {
-		return false, fmt.Errorf("payload_kind %q does not match expected %q", r.PayloadKind, opts.expectPayloadKind)
-	}
-	if opts.expectContractHash != "" && r.ContractHash != opts.expectContractHash {
-		return false, fmt.Errorf("contract_hash does not match expected")
-	}
-	if opts.expectManifestHash != "" && r.ActiveManifestHash != opts.expectManifestHash {
-		return false, fmt.Errorf("active_manifest_hash does not match expected")
-	}
-	// Single-receipt binding for the same option the chain path uses. The field
-	// reaches here through the shared evidenceBindingOptions, so leaving it
-	// unread would make a plumbed security option silently do nothing the moment
-	// anyone exposed it on this command: an operator would pin a head, see no
-	// error, and believe it had been checked. There is no omission to detect in
-	// one receipt, so this binds identity rather than completeness.
-	if opts.expectHeadHash != "" {
-		h, hashErr := contractreceipt.ReceiptHash(r)
-		if hashErr != nil {
-			return false, hashErr
-		}
-		if h != opts.expectHeadHash {
-			return false, fmt.Errorf("receipt hash %s does not match expected head %s", h, opts.expectHeadHash)
-		}
+	if err := opts.checkBindings(r); err != nil {
+		return false, err
 	}
 	if chainOpts.PinnedKey == nil {
 		if err := r.Validate(); err != nil {

--- a/cmd/pipelock-verifier/evidence.go
+++ b/cmd/pipelock-verifier/evidence.go
@@ -24,13 +24,15 @@ type evidenceBindingOptions struct {
 	expectContractHash string
 	expectManifestHash string
 	expectPayloadKind  string
+	expectHeadHash     string
 }
 
 func (opts evidenceBindingOptions) anySet() bool {
 	return opts.expectSignerKeyID != "" ||
 		opts.expectContractHash != "" ||
 		opts.expectManifestHash != "" ||
-		opts.expectPayloadKind != ""
+		opts.expectPayloadKind != "" ||
+		opts.expectHeadHash != ""
 }
 
 func (opts evidenceBindingOptions) chainVerifyOptions(keyHex string) (contractreceipt.ChainVerifyOptions, error) {
@@ -44,6 +46,7 @@ func (opts evidenceBindingOptions) chainVerifyOptions(keyHex string) (contractre
 		ExpectContractHash: opts.expectContractHash,
 		ExpectManifestHash: opts.expectManifestHash,
 		ExpectPayloadKind:  contractreceipt.PayloadKind(opts.expectPayloadKind),
+		ExpectHeadHash:     opts.expectHeadHash,
 	}, nil
 }
 

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -94,6 +94,19 @@ func emitChainReport(stdout, stderr io.Writer, r chainReport, jsonMode bool) {
 			} else {
 				_, _ = fmt.Fprintln(stdout, "  signatures: not checked (self-consistency only; pass --key for provenance)")
 			}
+			// Completeness is reported, never enforced by default. Every other
+			// check passes on any valid PREFIX of a chain, so a VALID verdict
+			// alone cannot tell an operator that nothing was dropped from the
+			// end. Saying so is the point: an unstated limit reads as a
+			// guarantee. Unlike the unpinned-signature case this does not gate
+			// validity, because no head is available to pin until an external
+			// anchor ships, and failing every existing chain by default would
+			// be an outage rather than a safeguard.
+			if r.HeadVerified {
+				_, _ = fmt.Fprintln(stdout, "  completeness: head verified (no trailing entries dropped)")
+			} else {
+				_, _ = fmt.Fprintln(stdout, "  completeness: not proven (a truncated chain also verifies; pass --expect-head with a trusted head hash)")
+			}
 		}
 		if r.Scorecard != nil {
 			emitScorecard(stdout, *r.Scorecard)

--- a/cmd/pipelock-verifier/receipt.go
+++ b/cmd/pipelock-verifier/receipt.go
@@ -190,6 +190,15 @@ func runEvidenceReceipt(stdout, stderr io.Writer, clean string, data []byte, key
 			emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
 			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("validate evidence receipt: %w", err))
 		}
+		// The Expect* bindings apply here too. This branch returns before
+		// verifyEvidenceReceipt runs, so without this an expectation passed
+		// alongside --allow-unpinned was accepted and never compared.
+		if err := opts.checkBindings(r); err != nil {
+			report.Valid = false
+			report.Error = err.Error()
+			emitReceiptReport(stdout, stderr, report, opts.jsonOutput)
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("verify evidence receipt: %w", err))
+		}
 		if opts.recheckSource != "" {
 			result, recheckErr := recheckEvidenceReceiptSpan(r, opts.recheckSource, opts.recheckSpanIndex)
 			// No key was supplied on this path, so the producer is

--- a/cmd/pipelock-verifier/receipt.go
+++ b/cmd/pipelock-verifier/receipt.go
@@ -51,6 +51,7 @@ required unless --allow-unpinned is used for structural checks only.`,
 	cmd.Flags().StringVar(&opts.expectContractHash, "expect-contract", "", "EvidenceReceipt v2: require contract_hash")
 	cmd.Flags().StringVar(&opts.expectManifestHash, "expect-manifest", "", "EvidenceReceipt v2: require active_manifest_hash")
 	cmd.Flags().StringVar(&opts.expectPayloadKind, "expect-payload-kind", "", "EvidenceReceipt v2: require payload_kind")
+	cmd.Flags().StringVar(&opts.expectHeadHash, "expect-head", "", "EvidenceReceipt v2: require this receipt's hash to equal the given value")
 	cmd.Flags().StringVar(&opts.recheckSource, "recheck-source", "", "EvidenceReceipt v2 spans: source file containing the normalized/redacted source view input")
 	cmd.Flags().IntVar(&opts.recheckSpanIndex, "recheck-span-index", 0, "EvidenceReceipt v2 spans: source_spans index to recheck")
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit a structured JSON verdict on stdout")

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -497,6 +497,12 @@ pipelock-verifier chain evidence-proxy-0.jsonl \
   --expect-payload-kind shadow_delta \
   --expect-contract sha256:...
 
+# Verify an EvidenceReceipt v2 chain against a known head, which is the only
+# check that detects entries dropped from the end
+pipelock-verifier chain evidence-proxy-0.jsonl \
+  --key receipt-signing.pub \
+  --expect-head 8f84164e084b32e25d3cd4ca0421599ab6fbbda52d839457acf0894ee6f467ee
+
 # Verify an Audit Packet with a signer key obtained outside the packet
 pipelock-verifier audit-packet ./audit-packet --key ./trusted-signing-key.pub
 ```
@@ -505,6 +511,17 @@ For EvidenceReceipt v2, `--key` pins the trusted Ed25519 receipt-signing public
 key. Without `--key`, the verifier can check structure, hash linkage, sequence
 monotonicity, and signer-id consistency, but it reports signatures as not
 checked because v2 receipts do not embed public keys.
+
+**A valid chain is not a complete chain.** Structure, linkage, sequence, and
+signatures are all satisfied by any prefix of a chain, so a file with its
+trailing entries removed still verifies. The verifier reports this as
+`completeness: not proven` and returns `head_verified: false` in `--json`
+output. Pass `--expect-head` with the receipt hash of the entry the chain should
+end on to close it: a truncated or forked chain is then rejected, and the report
+reads `completeness: head verified`. Source that hash from trusted context
+outside the chain, such as a signed checkpoint or an anchored root. A head read
+from the same directory proves nothing on its own, because anyone able to remove
+entries can rewrite an unsigned value stored beside them.
 
 The standalone binary reads the same Audit Packet v0 schema and receipt signing
 conventions as the in-tree `pipelock verify-receipt` subcommand, plus the

--- a/internal/contract/receipt/chain.go
+++ b/internal/contract/receipt/chain.go
@@ -75,6 +75,31 @@ type ChainVerifyOptions struct {
 	// ExpectPayloadKind, when non-empty, requires every receipt's
 	// payload_kind to match (e.g. shadow_delta).
 	ExpectPayloadKind PayloadKind
+	// ExpectHeadHash, when non-empty, requires the chain tip (the
+	// ReceiptHash of the final receipt) to equal this value. It is the only
+	// option here that can detect OMISSION.
+	//
+	// Every other check in this type is satisfied by any valid PREFIX of a
+	// chain: linkage proves the receipts present form a sequence starting at
+	// genesis, so dropping every entry after some point leaves a chain that
+	// still verifies. Omission is the failure mode that matters most for
+	// evidence, because the dropped entries are exactly the ones a bad actor
+	// wants gone, and it is precisely the case a prefix check cannot see.
+	//
+	// Pinning the head closes that, and pinning the head alone is sufficient:
+	// because this is a hash chain, a matching tip determines every entry back
+	// to genesis, so no separate expected-count or sequence-range option is
+	// needed. The head hash must come from trusted context OUTSIDE the chain
+	// (a signed checkpoint, an anchored root, a transparency-log inclusion
+	// proof, or an authenticated manifest) — reading it from the same file
+	// proves nothing, since an attacker who truncates the chain can rewrite a
+	// head recorded beside it.
+	//
+	// Opt-in by construction: unset means structure-only verification, exactly
+	// as before, so existing callers and the other-language verifiers are
+	// unaffected. A caller that HAS trusted head context and omits this is
+	// choosing not to check completeness.
+	ExpectHeadHash string
 }
 
 // ChainResult describes the outcome of v2 evidence-chain verification.
@@ -88,6 +113,12 @@ type ChainResult struct {
 	// signature verified against it. When false, the verdict reflects
 	// self-consistency, not provenance.
 	SignaturesVerified bool `json:"signatures_verified"`
+	// HeadVerified is true only when ExpectHeadHash was supplied and matched.
+	// When false, the verdict covers the receipts PRESENT and says nothing
+	// about whether later ones were dropped, so a consumer must not report
+	// this chain as complete. It exists so "valid" cannot be read as
+	// "nothing is missing" by a caller that never pinned a head.
+	HeadVerified bool `json:"head_verified"`
 	// SignerKeyID is the common signer_key_id shared by every receipt.
 	SignerKeyID string `json:"signer_key_id,omitempty"`
 	Error       string `json:"error,omitempty"`
@@ -170,12 +201,25 @@ func VerifyChain(receipts []EvidenceReceipt, opts ChainVerifyOptions) ChainResul
 		tipHash = h
 	}
 
+	finalSeq := receipts[len(receipts)-1].ChainSeq
+
+	// Completeness, and the only check here that a valid prefix cannot pass.
+	// Deliberately last: a chain that is internally broken should report the
+	// broken link at its sequence rather than a head mismatch, which is the
+	// downstream symptom rather than the cause.
+	if opts.ExpectHeadHash != "" && tipHash != opts.ExpectHeadHash {
+		return brokenChain(finalSeq,
+			"chain head %s does not match expected %s: the chain is truncated, forked, or from a different session",
+			tipHash, opts.ExpectHeadHash)
+	}
+
 	return ChainResult{
 		Valid:              true,
 		ReceiptCount:       uint64(len(receipts)),
-		FinalSeq:           receipts[len(receipts)-1].ChainSeq,
+		FinalSeq:           finalSeq,
 		RootHash:           tipHash,
 		SignaturesVerified: opts.PinnedKey != nil,
+		HeadVerified:       opts.ExpectHeadHash != "",
 		SignerKeyID:        signerID,
 	}
 }

--- a/internal/contract/receipt/chain.go
+++ b/internal/contract/receipt/chain.go
@@ -86,14 +86,25 @@ type ChainVerifyOptions struct {
 	// evidence, because the dropped entries are exactly the ones a bad actor
 	// wants gone, and it is precisely the case a prefix check cannot see.
 	//
-	// Pinning the head closes that, and pinning the head alone is sufficient:
-	// because this is a hash chain, a matching tip determines every entry back
-	// to genesis, so no separate expected-count or sequence-range option is
-	// needed. The head hash must come from trusted context OUTSIDE the chain
-	// (a signed checkpoint, an anchored root, a transparency-log inclusion
-	// proof, or an authenticated manifest) — reading it from the same file
-	// proves nothing, since an attacker who truncates the chain can rewrite a
-	// head recorded beside it.
+	// For one accepted v2 receipt chain, pinning the head is sufficient under
+	// SHA-256 collision and second-preimage resistance: ReceiptHash covers the
+	// full canonical final receipt, whose chain_prev_hash recursively commits to
+	// every prior receipt back to genesis. A separate expected count or sequence
+	// range therefore cannot distinguish another valid prefix that the pinned
+	// head would accept.
+	//
+	// This commitment is only to the v2 receipt slice being verified. It does
+	// not cover recorder entry types skipped during extraction, authenticate a
+	// session label, or join independent genesis chains across process restarts.
+	// Those require whole-recorder verification and trusted session/segment
+	// metadata in addition to this option.
+	//
+	// The expected head must be authenticated independently of the chain bytes
+	// it validates (for example by a pinned-key signed checkpoint, an anchored
+	// root, a transparency-log inclusion proof, or an authenticated manifest).
+	// It may be stored in the same directory if its authentication is verified
+	// and its presence is required; an unsigned sibling value that an attacker
+	// can rewrite or delete with the chain proves nothing.
 	//
 	// Opt-in by construction: unset means structure-only verification, exactly
 	// as before, so existing callers and the other-language verifiers are

--- a/internal/contract/receipt/chain_truncation_test.go
+++ b/internal/contract/receipt/chain_truncation_test.go
@@ -4,6 +4,7 @@
 package receipt_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/contract/receipt"
@@ -119,4 +120,41 @@ func TestVerifyChain_BrokenLinkReportsTheLinkNotTheHead(t *testing.T) {
 	if res.BrokenAtSeq != 2 {
 		t.Fatalf("broken_at_seq = %d, want 2 (the broken link, not the head)", res.BrokenAtSeq)
 	}
+	if !strings.Contains(res.Error, "chain_prev_hash mismatch") {
+		t.Fatalf("error = %q, want the broken-link cause rather than signature or head mismatch", res.Error)
+	}
+}
+
+func TestVerifyChain_ExpectedHeadBoundaryOrdering(t *testing.T) {
+	t.Parallel()
+	priv, pub := testKey(t, 12)
+	chain := buildChain(t, priv, 3)
+	tip := chainTip(t, chain)
+
+	t.Run("empty chain", func(t *testing.T) {
+		res := receipt.VerifyChain(nil, receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: tip})
+		if res.Valid || res.HeadVerified || res.Error != "empty chain" {
+			t.Fatalf("empty result = %#v, want invalid unverified empty-chain error", res)
+		}
+	})
+
+	t.Run("single receipt", func(t *testing.T) {
+		singleTip := chainTip(t, chain[:1])
+		res := receipt.VerifyChain(chain[:1], receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: singleTip})
+		if !res.Valid || !res.HeadVerified || res.ReceiptCount != 1 || res.FinalSeq != 0 {
+			t.Fatalf("single result = %#v, want valid head-verified one-receipt chain", res)
+		}
+	})
+
+	t.Run("final signature failure precedes head", func(t *testing.T) {
+		broken := append([]receipt.EvidenceReceipt(nil), chain...)
+		broken[len(broken)-1].Signature.Signature = "ed25519:" + strings.Repeat("0", 128)
+		res := receipt.VerifyChain(broken, receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: tip})
+		if res.Valid || res.HeadVerified {
+			t.Fatalf("bad final signature result = %#v, want invalid and head unverified", res)
+		}
+		if res.BrokenAtSeq != 2 || !strings.Contains(res.Error, "signature") {
+			t.Fatalf("bad final signature result = %#v, want signature failure at seq 2 before head comparison", res)
+		}
+	})
 }

--- a/internal/contract/receipt/chain_truncation_test.go
+++ b/internal/contract/receipt/chain_truncation_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt_test
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+// chainTip returns the ReceiptHash of the final receipt in a chain, which is
+// the value trusted external context would pin as the expected head.
+func chainTip(t *testing.T, chain []receipt.EvidenceReceipt) string {
+	t.Helper()
+	h, err := receipt.ReceiptHash(chain[len(chain)-1])
+	if err != nil {
+		t.Fatalf("hash chain tip: %v", err)
+	}
+	return h
+}
+
+// TestVerifyChain_TruncationIsInvisibleWithoutAnExpectedHead pins the LIMIT
+// rather than blessing it. Every check other than ExpectHeadHash is satisfied
+// by any valid PREFIX of a chain: linkage only proves the receipts present form
+// a sequence starting at genesis. So dropping the tail leaves a chain that still
+// verifies, and omission is the failure mode that matters most for evidence,
+// because the dropped entries are exactly the ones worth dropping.
+//
+// The honest invariant, and what this asserts, is NOT "truncation is fine". It
+// is that an unpinned verdict must never claim completeness: Valid may be true,
+// but HeadVerified must be false, so no consumer can read "valid" as "nothing is
+// missing". If someone later makes an unpinned verification report completeness,
+// this fails.
+func TestVerifyChain_TruncationIsInvisibleWithoutAnExpectedHead(t *testing.T) {
+	t.Parallel()
+	priv, pub := testKey(t, 7)
+	chain := buildChain(t, priv, 5)
+
+	res := receipt.VerifyChain(chain[:2], receipt.ChainVerifyOptions{PinnedKey: pub})
+	if !res.Valid {
+		t.Fatalf("a valid prefix should still verify structurally: %s", res.Error)
+	}
+	if res.HeadVerified {
+		t.Fatal("unpinned verification claimed head verification; a truncated chain would read as complete")
+	}
+	if res.ReceiptCount != 2 {
+		t.Fatalf("receipt count = %d, want 2", res.ReceiptCount)
+	}
+}
+
+// TestVerifyChain_ExpectHeadHashDetectsTruncation is the closing half: with
+// trusted head context the same truncation is caught. This is the case the
+// evidence-provenance anchoring work must keep passing, which is why it is under
+// test now rather than assumed covered when that lands.
+func TestVerifyChain_ExpectHeadHashDetectsTruncation(t *testing.T) {
+	t.Parallel()
+	priv, pub := testKey(t, 8)
+	chain := buildChain(t, priv, 5)
+	tip := chainTip(t, chain)
+
+	full := receipt.VerifyChain(chain, receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: tip})
+	if !full.Valid {
+		t.Fatalf("complete chain rejected against its own head: %s", full.Error)
+	}
+	if !full.HeadVerified {
+		t.Fatal("HeadVerified false after a matching ExpectHeadHash")
+	}
+
+	// Drop the tail. Every per-receipt check still passes; only the head
+	// binding can see the omission.
+	for _, cut := range []int{1, 2, 4} {
+		res := receipt.VerifyChain(chain[:cut], receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: tip})
+		if res.Valid {
+			t.Fatalf("truncation to %d receipts verified against the full-chain head", cut)
+		}
+		if res.HeadVerified {
+			t.Fatalf("HeadVerified true on a rejected chain (cut=%d)", cut)
+		}
+	}
+}
+
+// TestVerifyChain_ExpectHeadHashRejectsAForeignHead guards the other direction:
+// the binding must not be satisfiable by a chain from a different session or
+// signer that happens to be internally consistent.
+func TestVerifyChain_ExpectHeadHashRejectsAForeignHead(t *testing.T) {
+	t.Parallel()
+	privA, pubA := testKey(t, 9)
+	privB, _ := testKey(t, 10)
+	mine := buildChain(t, privA, 3)
+	other := buildChain(t, privB, 3)
+
+	otherTip := chainTip(t, other)
+	if chainTip(t, mine) == otherTip {
+		t.Fatal("two independently keyed chains produced the same tip")
+	}
+	res := receipt.VerifyChain(mine, receipt.ChainVerifyOptions{PinnedKey: pubA, ExpectHeadHash: otherTip})
+	if res.Valid {
+		t.Fatal("chain verified against a head hash it does not have")
+	}
+}
+
+// TestVerifyChain_BrokenLinkReportsTheLinkNotTheHead pins the ordering choice.
+// The head check runs last so an internally broken chain reports the broken link
+// at its sequence, which is the cause, rather than the head mismatch it also
+// produces, which is only the downstream symptom and would send an operator
+// hunting for a truncation that did not happen.
+func TestVerifyChain_BrokenLinkReportsTheLinkNotTheHead(t *testing.T) {
+	t.Parallel()
+	priv, pub := testKey(t, 11)
+	chain := buildChain(t, priv, 4)
+	tip := chainTip(t, chain)
+	chain[2].ChainPrevHash = receipt.GenesisHash // break the middle link
+
+	res := receipt.VerifyChain(chain, receipt.ChainVerifyOptions{PinnedKey: pub, ExpectHeadHash: tip})
+	if res.Valid {
+		t.Fatal("chain with a broken link verified")
+	}
+	if res.BrokenAtSeq != 2 {
+		t.Fatalf("broken_at_seq = %d, want 2 (the broken link, not the head)", res.BrokenAtSeq)
+	}
+}


### PR DESCRIPTION
Chain verification proved that the receipts present form a sequence starting at genesis. It authenticated no expected head, so any valid prefix of a chain verified: a file with its trailing entries removed still reported valid. Omission is the failure mode that matters most for evidence, and it is the one a prefix check cannot see.

`VerifyChain` now takes an optional `ExpectHeadHash` that binds the chain tip to a head supplied by the caller. Pinning the head is enough on its own for one v2 receipt chain, because the final receipt hash commits recursively to every prior receipt back to genesis, so an expected count or sequence range adds nothing. The head has to be authenticated independently of the chain bytes it validates, through a signed checkpoint, an anchored root, a transparency-log proof, or an authenticated manifest. An unsigned value stored beside the chain proves nothing, since anyone able to remove entries can rewrite it.

`pipelock-verifier chain` takes `--expect-head`, carries `head_verified` in the JSON verdict, and prints a completeness line beside the existing signatures line. Without a pinned head it reads `completeness: not proven (a truncated chain also verifies)` and names the flag. With one it reads `completeness: head verified`.

Completeness is reported rather than enforced. A valid verdict alone cannot tell an operator that nothing was dropped from the end, and a limit that goes unstated reads as a guarantee. This does not gate validity the way an unpinned signature does, because no head is available to pin until an external anchor ships and failing every existing chain by default would be an outage rather than a safeguard.

Verification is unchanged when the option is unset, so existing callers and the other-language verifiers are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `--expect-head` option to verify EvidenceReceipt v2 chains and individual receipts against a trusted head hash.
  - Detects truncated, forked, or mismatched evidence during verification.
  - Reports whether chain completeness was proven in human-readable and JSON output.

- **Documentation**
  - Added guidance for expected-head verification, completeness reporting, and trusted checkpoints.

- **Bug Fixes**
  - Prevents incorrectly bound or incomplete evidence from being accepted during verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->