### PR TITLE
fix(verifier): report evidence lifecycle completeness where chain validity was standing in for it

### DIFF
--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
@@ -86,18 +87,20 @@ and --key (or the packet's own signer_key) must match.`,
 // auditPacketReport is the structured form emitted by --json. Field names are
 // deliberately stable so external CI checks can grep them.
 type auditPacketReport struct {
-	Path        string         `json:"path"`
-	Verdict     string         `json:"verdict"`
-	Trusted     bool           `json:"trusted"`
-	Valid       bool           `json:"valid"`
-	Summary     auditPktDigest `json:"summary"`
-	Posture     posturePeek    `json:"posture"`
-	Run         runPeek        `json:"run"`
-	Errors      []string       `json:"errors,omitempty"`
-	Warnings    []string       `json:"warnings,omitempty"`
-	SchemaCheck string         `json:"schema_check"`
-	ChainCheck  string         `json:"chain_check"`
-	CrossCheck  string         `json:"cross_check"`
+	Path            string              `json:"path"`
+	Verdict         string              `json:"verdict"`
+	Trusted         bool                `json:"trusted"`
+	Valid           bool                `json:"valid"`
+	Summary         auditPktDigest      `json:"summary"`
+	Posture         posturePeek         `json:"posture"`
+	Run             runPeek             `json:"run"`
+	Errors          []string            `json:"errors,omitempty"`
+	Warnings        []string            `json:"warnings,omitempty"`
+	SchemaCheck     string              `json:"schema_check"`
+	ChainCheck      string              `json:"chain_check"`
+	CrossCheck      string              `json:"cross_check"`
+	LifecycleStatus completeness.Status `json:"lifecycle_status,omitempty"`
+	LifecycleReason completeness.Reason `json:"lifecycle_reason,omitempty"`
 }
 
 type auditPktDigest struct {
@@ -196,6 +199,9 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, chainErr)
 	}
 	report.ChainCheck = chainStatusLabel(chainResult)
+	lifecycle := completeness.Analyze(chainReceipts, chainResult)
+	report.LifecycleStatus = lifecycle.Status
+	report.LifecycleReason = lifecycle.Reason
 
 	if crossErrs := crossCheck(&packet, chainResult, chainReceipts); len(crossErrs) > 0 {
 		report.CrossCheck = statusFail

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -30,6 +30,14 @@ const (
 	statusSkipped = "skipped"
 )
 
+// Stable values for the lifecycle_assessment field.
+const (
+	lifecycleAssessed          = "assessed"
+	lifecycleNotAssessed       = "not_assessed"
+	lifecycleReasonOffline     = "offline mode skips chain re-verification"
+	lifecycleReasonChainFailed = "chain re-verification did not complete"
+)
+
 // auditPacketOptions holds resolved CLI flags for the audit-packet command.
 type auditPacketOptions struct {
 	signerKey   string
@@ -101,6 +109,14 @@ type auditPacketReport struct {
 	CrossCheck      string              `json:"cross_check"`
 	LifecycleStatus completeness.Status `json:"lifecycle_status,omitempty"`
 	LifecycleReason completeness.Reason `json:"lifecycle_reason,omitempty"`
+	// LifecycleAssessment states whether completeness was evaluated at all, and
+	// is always emitted. An absent LifecycleStatus alone cannot carry this: it
+	// is equally produced by offline mode, by a chain re-verification that
+	// failed before the analysis could run, and by an older report that had no
+	// lifecycle field. A consumer that cannot tell those apart will read the
+	// same silence as a passing lifecycle.
+	LifecycleAssessment       string `json:"lifecycle_assessment"`
+	LifecycleAssessmentReason string `json:"lifecycle_assessment_reason,omitempty"`
 }
 
 type auditPktDigest struct {
@@ -127,10 +143,12 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 	}
 
 	report := auditPacketReport{
-		Path:        packetPath,
-		SchemaCheck: statusSkipped,
-		ChainCheck:  statusSkipped,
-		CrossCheck:  statusSkipped,
+		Path:                      packetPath,
+		SchemaCheck:               statusSkipped,
+		ChainCheck:                statusSkipped,
+		CrossCheck:                statusSkipped,
+		LifecycleAssessment:       lifecycleNotAssessed,
+		LifecycleAssessmentReason: lifecycleReasonChainFailed,
 	}
 
 	rawPacket, err := readVerifierFile(packetPath)
@@ -176,6 +194,7 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 	report.SchemaCheck = statusPass
 
 	if opts.offline {
+		report.LifecycleAssessmentReason = lifecycleReasonOffline
 		report.Valid = trustVerdict(&packet, opts)
 		emitReport(stdout, stderr, report, opts.jsonOutput)
 		if !report.Valid {
@@ -202,6 +221,8 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 	lifecycle := completeness.Analyze(chainReceipts, chainResult)
 	report.LifecycleStatus = lifecycle.Status
 	report.LifecycleReason = lifecycle.Reason
+	report.LifecycleAssessment = lifecycleAssessed
+	report.LifecycleAssessmentReason = ""
 
 	if crossErrs := crossCheck(&packet, chainResult, chainReceipts); len(crossErrs) > 0 {
 		report.CrossCheck = statusFail

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -104,15 +106,12 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 		}
 		clean = location.Dir
 		label = fmt.Sprintf("%s (session %s)", clean, opts.sessionID)
+		if handled, handleErr := runEvidenceChainFromDir(stdout, stderr, location, label, keyHex, opts); handled || handleErr != nil {
+			return handleErr
+		}
 		receipts, extractErr := actionreceipt.ExtractReceiptsFromResolvedSessionDir(location, opts.sessionID)
 		if extractErr != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
-		}
-		if len(receipts) > 0 {
-			return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
-		}
-		if handled, handleErr := runEvidenceChainFromDir(stdout, stderr, location, label, keyHex, opts); handled || handleErr != nil {
-			return handleErr
 		}
 		return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
 	} else {
@@ -128,18 +127,55 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%q is a directory; pass --dir to verify a session directory", target))
 		}
 		label = clean
-		receipts, extractErr := actionreceipt.ExtractReceipts(clean)
-		if extractErr != nil {
-			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
+		isBareV1, detectErr := isBareActionReceiptJSONL(clean)
+		if detectErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, detectErr)
 		}
-		if len(receipts) > 0 {
+		if isBareV1 {
+			receipts, extractErr := actionreceipt.ExtractReceipts(clean)
+			if extractErr != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
+			}
 			return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
 		}
 		if handled, handleErr := runEvidenceChainFromFile(stdout, stderr, clean, label, keyHex, opts); handled || handleErr != nil {
 			return handleErr
 		}
+		receipts, extractErr := actionreceipt.ExtractReceipts(clean)
+		if extractErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
+		}
 		return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
 	}
+}
+
+// isBareActionReceiptJSONL identifies the legacy compatibility format without
+// treating malformed or mixed input as an action chain. Recorder-backed v1 and
+// all v2 input keep the v2-first route below, which preserves its strict
+// recorder validation before the v1 fallback.
+func isBareActionReceiptJSONL(path string) (bool, error) {
+	data, err := readVerifierFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read evidence file: %w", err)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64<<10), 10<<20)
+	found := false
+	for scanner.Scan() {
+		raw := bytes.TrimSpace(scanner.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		r, unmarshalErr := actionreceipt.Unmarshal(raw)
+		if unmarshalErr != nil || r.Version != actionreceipt.ReceiptVersion || r.Signature == "" || r.SignerKey == "" {
+			return false, nil
+		}
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("scan evidence file: %w", err)
+	}
+	return found, nil
 }
 
 func verifyActionChain(stdout, stderr io.Writer, label string, receipts []actionreceipt.Receipt, keyHex string, opts chainOptions) error {

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -104,12 +104,15 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 		}
 		clean = location.Dir
 		label = fmt.Sprintf("%s (session %s)", clean, opts.sessionID)
-		if handled, handleErr := runEvidenceChainFromDir(stdout, stderr, location, label, keyHex, opts); handled || handleErr != nil {
-			return handleErr
-		}
 		receipts, extractErr := actionreceipt.ExtractReceiptsFromResolvedSessionDir(location, opts.sessionID)
 		if extractErr != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
+		}
+		if len(receipts) > 0 {
+			return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
+		}
+		if handled, handleErr := runEvidenceChainFromDir(stdout, stderr, location, label, keyHex, opts); handled || handleErr != nil {
+			return handleErr
 		}
 		return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
 	} else {
@@ -125,12 +128,15 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%q is a directory; pass --dir to verify a session directory", target))
 		}
 		label = clean
-		if handled, handleErr := runEvidenceChainFromFile(stdout, stderr, clean, label, keyHex, opts); handled || handleErr != nil {
-			return handleErr
-		}
 		receipts, extractErr := actionreceipt.ExtractReceipts(clean)
 		if extractErr != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
+		}
+		if len(receipts) > 0 {
+			return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
+		}
+		if handled, handleErr := runEvidenceChainFromFile(stdout, stderr, clean, label, keyHex, opts); handled || handleErr != nil {
+			return handleErr
 		}
 		return verifyActionChain(stdout, stderr, label, receipts, keyHex, opts)
 	}

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -127,12 +127,15 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 			return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%q is a directory; pass --dir to verify a session directory", target))
 		}
 		label = clean
-		isBareV1, detectErr := isBareActionReceiptJSONL(clean)
+		isBareV1, bareData, detectErr := isBareActionReceiptJSONL(clean)
 		if detectErr != nil {
 			return cliutil.ExitCodeError(cliutil.ExitConfig, detectErr)
 		}
 		if isBareV1 {
-			receipts, extractErr := actionreceipt.ExtractReceipts(clean)
+			// Verify the exact bytes the routing decision was made on. Reopening
+			// the path here would let a file replaced between the two reads be
+			// verified under a decision taken about different evidence.
+			receipts, extractErr := actionreceipt.ExtractReceiptsBytes(bareData)
 			if extractErr != nil {
 				return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("extract receipts: %w", extractErr))
 			}
@@ -153,10 +156,12 @@ func runChain(stdout, stderr io.Writer, target string, opts chainOptions) error 
 // treating malformed or mixed input as an action chain. Recorder-backed v1 and
 // all v2 input keep the v2-first route below, which preserves its strict
 // recorder validation before the v1 fallback.
-func isBareActionReceiptJSONL(path string) (bool, error) {
+// It returns the bytes it classified so the caller can verify those exact bytes
+// rather than reopening the path.
+func isBareActionReceiptJSONL(path string) (bool, []byte, error) {
 	data, err := readVerifierFile(path)
 	if err != nil {
-		return false, fmt.Errorf("read evidence file: %w", err)
+		return false, nil, fmt.Errorf("read evidence file: %w", err)
 	}
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	scanner.Buffer(make([]byte, 0, 64<<10), 10<<20)
@@ -168,14 +173,18 @@ func isBareActionReceiptJSONL(path string) (bool, error) {
 		}
 		r, unmarshalErr := actionreceipt.Unmarshal(raw)
 		if unmarshalErr != nil || r.Version != actionreceipt.ReceiptVersion || r.Signature == "" || r.SignerKey == "" {
-			return false, nil
+			return false, nil, nil
 		}
 		found = true
 	}
+	// Defensive only while readVerifierFile's total-size bound stays below this
+	// scanner's per-line bound: a single line cannot exceed the line limit when
+	// the whole file is already capped lower. It is kept so that raising the
+	// reader's cap cannot silently turn an oversized line into a parse attempt.
 	if err := scanner.Err(); err != nil {
-		return false, fmt.Errorf("scan evidence file: %w", err)
+		return false, nil, fmt.Errorf("scan evidence file: %w", err)
 	}
-	return found, nil
+	return found, data, nil
 }
 
 func verifyActionChain(stdout, stderr io.Writer, label string, receipts []actionreceipt.Receipt, keyHex string, opts chainOptions) error {

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -565,6 +565,56 @@ func writeChainRecorderJSONL(t *testing.T, receipts []receipt.Receipt) string {
 	return path
 }
 
+func TestChainAndCompletenessAcceptSameBareV1JSONL(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		fixture.open("run-bare-v1", "open-bare-v1"),
+		fixture.close("run-bare-v1", "open-bare-v1"),
+	})
+
+	for _, command := range []string{"chain", "completeness"} {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			stdout, stderr, code := runRoot(t, command, "--json", "--key", fixture.keyHex, path)
+			if code != cliutil.ExitOK {
+				t.Fatalf("bare v1 %s should verify: code=%d stdout=%q stderr=%q", command, code, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestChainAndCompletenessRejectMalformedBareV1JSONL(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		fixture.open("run-malformed-bare-v1", "open-malformed-bare-v1"),
+	})
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	if _, err := file.WriteString(`{"record_type":"evidence_receipt_v2"}` + "\n"); err != nil {
+		_ = file.Close()
+		t.Fatalf("append mixed record: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+
+	for _, command := range []string{"chain", "completeness"} {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			stdout, stderr, code := runRoot(t, command, "--json", "--key", fixture.keyHex, path)
+			if code == cliutil.ExitOK {
+				t.Fatalf("mixed bare v1 %s input accepted: stdout=%q stderr=%q", command, stdout, stderr)
+			}
+		})
+	}
+}
+
 // TestChainCLIShowsCompletenessReasonForATailDroppedChain proves the PATH, not
 // the formatter. The sibling unit test hands emitScorecard a reason and checks
 // it prints; that cannot fail if the analyzer stopped classifying a missing

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -591,7 +591,7 @@ func TestChainAndCompletenessRejectMalformedBareV1JSONL(t *testing.T) {
 	path := writeCompletenessJSONL(t, []receipt.Receipt{
 		fixture.open("run-malformed-bare-v1", "open-malformed-bare-v1"),
 	})
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	file, err := os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		t.Fatalf("open fixture: %v", err)
 	}

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -673,3 +673,67 @@ func TestChainCLIShowsCompletenessReasonForATailDroppedChain(t *testing.T) {
 		t.Fatalf("a bounded chain and a tail-dropped one print the same completeness line: %s", closedLine)
 	}
 }
+
+// The bare-v1 detector reads the whole file before deciding a route, so its
+// failure paths decide whether an unreadable or oversized file is refused or
+// silently falls through to the v2 route. Each case below drives the real
+// command so the exit path is proven, not just the helper.
+
+func TestChainRefusesUnreadableBareV1JSONL(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		fixture.open("run-unreadable", "open-unreadable"),
+		fixture.close("run-unreadable", "open-unreadable"),
+	})
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code == cliutil.ExitOK {
+		t.Fatalf("unreadable evidence file accepted: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestChainRefusesOversizedBareV1Line(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oversized.jsonl")
+	line := append(bytes.Repeat([]byte("a"), 11<<20), '\n')
+	if err := os.WriteFile(path, line, 0o600); err != nil {
+		t.Fatalf("write oversized fixture: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code == cliutil.ExitOK {
+		t.Fatalf("oversized evidence line accepted: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestChainAcceptsBareV1JSONLWithBlankLines(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		fixture.open("run-blank-lines", "open-blank-lines"),
+		fixture.close("run-blank-lines", "open-blank-lines"),
+	})
+	file, err := os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	if _, err := file.WriteString("\n   \n"); err != nil {
+		_ = file.Close()
+		t.Fatalf("append blank lines: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code != cliutil.ExitOK {
+		t.Fatalf("blank-line bare v1 chain should verify: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -679,25 +679,7 @@ func TestChainCLIShowsCompletenessReasonForATailDroppedChain(t *testing.T) {
 // silently falls through to the v2 route. Each case below drives the real
 // command so the exit path is proven, not just the helper.
 
-func TestChainRefusesUnreadableBareV1JSONL(t *testing.T) {
-	t.Parallel()
-	fixture := newCompletenessFixture(t)
-	path := writeCompletenessJSONL(t, []receipt.Receipt{
-		fixture.open("run-unreadable", "open-unreadable"),
-		fixture.close("run-unreadable", "open-unreadable"),
-	})
-	if err := os.Chmod(path, 0o000); err != nil {
-		t.Fatalf("chmod fixture: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
-
-	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
-	if code == cliutil.ExitOK {
-		t.Fatalf("unreadable evidence file accepted: stdout=%q stderr=%q", stdout, stderr)
-	}
-}
-
-func TestChainRefusesOversizedBareV1Line(t *testing.T) {
+func TestChainRefusesOversizedEvidenceFile(t *testing.T) {
 	t.Parallel()
 	fixture := newCompletenessFixture(t)
 	dir := t.TempDir()
@@ -707,9 +689,23 @@ func TestChainRefusesOversizedBareV1Line(t *testing.T) {
 		t.Fatalf("write oversized fixture: %v", err)
 	}
 
-	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
-	if code == cliutil.ExitOK {
-		t.Fatalf("oversized evidence line accepted: stdout=%q stderr=%q", stdout, stderr)
+	var stdout, stderr bytes.Buffer
+	err := runChain(&stdout, &stderr, path, chainOptions{signerKey: fixture.keyHex})
+	if err == nil {
+		t.Fatalf("oversized evidence line accepted: stdout=%q", stdout.String())
+	}
+	// Ordinary malformed input is classified as not-bare-v1 and refused later on
+	// a different route. Pinning the detector scan error is what proves this test
+	// exercises the line-length bound rather than generic rejection.
+	// The detector reads the whole file before classifying it, so the reader's
+	// total-size bound is what stops an oversized input from being buffered.
+	// Pinning that message is what proves this test exercises the size bound
+	// rather than ordinary malformed-input rejection.
+	if !strings.Contains(err.Error(), "input exceeds") {
+		t.Fatalf("oversized file must fail on the reader size bound: err=%v", err)
+	}
+	if got := exitCodeFor(err); got != cliutil.ExitConfig {
+		t.Fatalf("oversized line exit=%d, want %d", got, cliutil.ExitConfig)
 	}
 }
 

--- a/cmd/pipelock-verifier/completeness_unix_test.go
+++ b/cmd/pipelock-verifier/completeness_unix_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+// The detector reads the whole file before choosing a route, so an unreadable
+// file must be refused rather than falling through to the other route. The
+// assertion depends on Unix permission semantics, and root bypasses them, so
+// both conditions are checked rather than assumed.
+func TestChainRefusesUnreadableBareV1JSONL(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permission bits, so an unreadable fixture cannot be built")
+	}
+	fixture := newCompletenessFixture(t)
+	path := writeCompletenessJSONL(t, []receipt.Receipt{
+		fixture.open("run-unreadable", "open-unreadable"),
+		fixture.close("run-unreadable", "open-unreadable"),
+	})
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if _, err := os.ReadFile(filepath.Clean(path)); err == nil {
+		t.Skip("fixture remained readable after chmod, so the permission path cannot be exercised")
+	}
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code == cliutil.ExitOK {
+		t.Fatalf("unreadable evidence file accepted: stdout=%q stderr=%q", stdout, stderr)
+	}
+}

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -346,6 +346,29 @@ func TestAuditPacket_HappyPath(t *testing.T) {
 	}
 }
 
+func TestAuditPacketReportsInFlightLifecycleCompleteness(t *testing.T) {
+	t.Parallel()
+	lifecycle := newCompletenessFixture(t)
+	fix := &fixture{
+		pub:  lifecycle.priv.Public().(ed25519.PublicKey),
+		priv: lifecycle.priv,
+		receipts: []receipt.Receipt{
+			lifecycle.open("run-audit-packet", "open-audit-packet"),
+		},
+		keyHex: lifecycle.keyHex,
+	}
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+
+	stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, dir)
+	if code != cliutil.ExitOK {
+		t.Fatalf("valid in-flight packet should verify: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "lifecycle:    LIMITED (abnormal_end)") {
+		t.Fatalf("packet report must name missing session_close: %s", stdout)
+	}
+}
+
 func TestAuditPacket_ValidVerdictRequiresExternalTrustAnchor(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -2612,3 +2612,101 @@ func TestChain_EvidenceV2WithExpectFlagsOnV1Fails(t *testing.T) {
 		t.Fatalf("v2 expect flags on v1 chain should fail")
 	}
 }
+
+// An absent lifecycle status is produced by three different situations, and an
+// operator reading the report cannot tell them apart from the status alone. The
+// report therefore carries an explicit assessment field, and these cases pin
+// each situation to its own reason rather than letting one stand in for all.
+func TestAuditPacketLifecycleAssessmentDistinguishesOfflineFromFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("offline_says_offline", func(t *testing.T) {
+		t.Parallel()
+		fix := newFixture(t, 2)
+		dir := t.TempDir()
+		fix.writePacketDir(t, dir, nil)
+
+		stdout, stderr, _ := runRoot(t, "audit-packet", "--offline", "--json", "--key", fix.keyHex, dir)
+		var report auditPacketReport
+		if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+			t.Fatalf("unmarshal report: %v stdout=%q stderr=%q", err, stdout, stderr)
+		}
+		if report.LifecycleAssessment != lifecycleNotAssessed {
+			t.Fatalf("offline assessment = %q, want %q", report.LifecycleAssessment, lifecycleNotAssessed)
+		}
+		if report.LifecycleAssessmentReason != lifecycleReasonOffline {
+			t.Fatalf("offline reason = %q, want %q", report.LifecycleAssessmentReason, lifecycleReasonOffline)
+		}
+	})
+
+	t.Run("chain_failure_does_not_claim_offline", func(t *testing.T) {
+		t.Parallel()
+		fix := newFixture(t, 2)
+		dir := t.TempDir()
+		fix.writePacketDir(t, dir, nil)
+		// Remove the evidence the packet points at so re-verification fails
+		// before completeness can run. This is the path that previously
+		// reported offline mode while the command was online.
+		if err := os.Remove(filepath.Join(dir, "evidence.jsonl")); err != nil {
+			t.Fatalf("remove evidence: %v", err)
+		}
+
+		stdout, _, code := runAuditPacketWithKey(t, fix.keyHex, "--json", dir)
+		if code == cliutil.ExitOK {
+			t.Fatalf("packet with missing evidence should not verify: stdout=%q", stdout)
+		}
+		var report auditPacketReport
+		if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+			t.Fatalf("unmarshal report: %v stdout=%q", err, stdout)
+		}
+		if report.LifecycleAssessment != lifecycleNotAssessed {
+			t.Fatalf("failed-chain assessment = %q, want %q", report.LifecycleAssessment, lifecycleNotAssessed)
+		}
+		if report.LifecycleAssessmentReason == lifecycleReasonOffline {
+			t.Fatalf("a failed online re-verification must not report offline mode")
+		}
+	})
+
+	t.Run("human_output_names_the_real_reason", func(t *testing.T) {
+		t.Parallel()
+		fix := newFixture(t, 2)
+		dir := t.TempDir()
+		fix.writePacketDir(t, dir, nil)
+		if err := os.Remove(filepath.Join(dir, "evidence.jsonl")); err != nil {
+			t.Fatalf("remove evidence: %v", err)
+		}
+
+		stdout, _, code := runAuditPacketWithKey(t, fix.keyHex, dir)
+		if code == cliutil.ExitOK {
+			t.Fatalf("packet with missing evidence should not verify: stdout=%q", stdout)
+		}
+		if strings.Contains(stdout, lifecycleReasonOffline) {
+			t.Fatalf("an online run that failed re-verification must not blame offline mode: %s", stdout)
+		}
+		if !strings.Contains(stdout, lifecycleReasonChainFailed) {
+			t.Fatalf("report must name why lifecycle was not assessed: %s", stdout)
+		}
+	})
+
+	t.Run("verified_chain_is_assessed", func(t *testing.T) {
+		t.Parallel()
+		fix := newFixture(t, 2)
+		dir := t.TempDir()
+		fix.writePacketDir(t, dir, nil)
+
+		stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, "--json", dir)
+		if code != cliutil.ExitOK {
+			t.Fatalf("valid packet should verify: code=%d stdout=%q stderr=%q", code, stdout, stderr)
+		}
+		var report auditPacketReport
+		if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+			t.Fatalf("unmarshal report: %v stdout=%q", err, stdout)
+		}
+		if report.LifecycleAssessment != lifecycleAssessed {
+			t.Fatalf("assessment = %q, want %q", report.LifecycleAssessment, lifecycleAssessed)
+		}
+		if report.LifecycleStatus == "" {
+			t.Fatalf("an assessed report must carry a lifecycle status: %+v", report)
+		}
+	})
+}

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -37,6 +37,11 @@ func emitReport(stdout, stderr io.Writer, r auditPacketReport, jsonMode bool) {
 	_, _ = fmt.Fprintf(stdout, "  verdict:      %s\n", verdict)
 	_, _ = fmt.Fprintf(stdout, "  trusted:      %t\n", r.Trusted)
 	_, _ = fmt.Fprintf(stdout, "  receipts:     %d\n", r.Summary.ReceiptCount)
+	if r.LifecycleStatus == "" {
+		_, _ = fmt.Fprintln(stdout, "  lifecycle:    not assessed (offline mode skips chain re-verification)")
+	} else {
+		_, _ = fmt.Fprintf(stdout, "  lifecycle:    %s (%s)\n", r.LifecycleStatus, r.LifecycleReason)
+	}
 	if r.Run.Provider != "" {
 		_, _ = fmt.Fprintf(stdout, "  provider:     %s\n", r.Run.Provider)
 	}

--- a/cmd/pipelock-verifier/output.go
+++ b/cmd/pipelock-verifier/output.go
@@ -37,8 +37,12 @@ func emitReport(stdout, stderr io.Writer, r auditPacketReport, jsonMode bool) {
 	_, _ = fmt.Fprintf(stdout, "  verdict:      %s\n", verdict)
 	_, _ = fmt.Fprintf(stdout, "  trusted:      %t\n", r.Trusted)
 	_, _ = fmt.Fprintf(stdout, "  receipts:     %d\n", r.Summary.ReceiptCount)
-	if r.LifecycleStatus == "" {
-		_, _ = fmt.Fprintln(stdout, "  lifecycle:    not assessed (offline mode skips chain re-verification)")
+	if r.LifecycleAssessment != lifecycleAssessed {
+		reason := r.LifecycleAssessmentReason
+		if reason == "" {
+			reason = lifecycleReasonChainFailed
+		}
+		_, _ = fmt.Fprintf(stdout, "  lifecycle:    not assessed (%s)\n", reason)
 	} else {
 		_, _ = fmt.Fprintf(stdout, "  lifecycle:    %s (%s)\n", r.LifecycleStatus, r.LifecycleReason)
 	}

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -507,6 +507,13 @@ pipelock-verifier chain evidence-proxy-0.jsonl \
 pipelock-verifier audit-packet ./audit-packet --key ./trusted-signing-key.pub
 ```
 
+An Audit Packet report separates chain integrity from run lifecycle evidence.
+After chain re-verification, its `lifecycle` line reports the lifecycle status
+and reason, such as `LIMITED (abnormal_end)` when a valid in-flight chain has
+no signed `session_close`. That status does not change the packet's integrity
+verdict. With `--offline`, the report says lifecycle was not assessed because
+it did not re-read the receipt chain.
+
 For EvidenceReceipt v2, `--key` pins the trusted Ed25519 receipt-signing public
 key. Without `--key`, the verifier can check structure, hash linkage, sequence
 monotonicity, and signer-id consistency, but it reports signatures as not

--- a/internal/evidenceview/scorecard.go
+++ b/internal/evidenceview/scorecard.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
@@ -221,23 +222,28 @@ func anchorState(_ string) (state, chip, detail, sub string) {
 
 func completenessLine(chain receipt.ChainResult, receipts []receipt.Receipt) Line {
 	receiptCount := len(receipts)
+	lifecycle := completeness.Analyze(receipts, chain)
 	gaps := 0
 	detail := fmt.Sprintf(
-		"%d receipts, %d chain gaps. Covers mediated egress inside the declared Pipelock boundary.",
+		"%d receipts, %d chain gaps; lifecycle: %s (%s). Covers mediated egress inside the declared Pipelock boundary.",
 		receiptCount,
 		gaps,
+		lifecycle.Status,
+		lifecycle.Reason,
 	)
 	if !chain.Valid || chain.BrokenAtSeq != 0 {
 		gaps = 1
 		lost := receiptsAtOrAfterBreak(receipts, chain.BrokenAtIndex)
 		verifiable := receiptCount - lost
 		detail = fmt.Sprintf(
-			"%d of %d receipts verifiable; %d lost to the break. %d receipts, %d chain gaps. Covers mediated egress inside the declared Pipelock boundary.",
+			"%d of %d receipts verifiable; %d lost to the break. %d receipts, %d chain gaps; lifecycle: %s (%s). Covers mediated egress inside the declared Pipelock boundary.",
 			verifiable,
 			receiptCount,
 			lost,
 			receiptCount,
 			gaps,
+			lifecycle.Status,
+			lifecycle.Reason,
 		)
 	}
 	return Line{

--- a/internal/evidenceview/scorecard_ported_test.go
+++ b/internal/evidenceview/scorecard_ported_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
+
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
@@ -419,5 +421,38 @@ func assertPortedNotVerify(t *testing.T, got, name string) {
 	t.Helper()
 	if got == StateVerify {
 		t.Fatalf("%s returned %q for an unknown signer", name, StateVerify)
+	}
+}
+
+// A broken chain takes the second branch of completenessLine, which rewrites
+// the detail string around the lost receipts. That branch carries its own copy
+// of the lifecycle clause, so it can silently lose the lifecycle reason while
+// the in-flight test above still passes.
+func TestComputeScorecard_BrokenChainStillReportsLifecycle(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generatePortedKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildPortedChain(t, priv, 4)
+	chain[1].ActionRecord.Target = "https://api.vendor.example/tampered"
+
+	evidence := SessionEvidenceOf(portedTestSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: portedTrustedKeySource},
+	}, false, DashboardReceiptReadLimit, DashboardTimelineLimit)
+	if evidence.Chain.Valid {
+		t.Fatalf("tampered chain should not verify")
+	}
+	if evidence.Scorecard.Completeness.State != StateLimited {
+		t.Fatalf("Completeness.State = %q, want %q", evidence.Scorecard.Completeness.State, StateLimited)
+	}
+	detail := evidence.Scorecard.Completeness.Detail
+	if !strings.Contains(detail, "lost to the break") {
+		t.Fatalf("broken-chain completeness must name the lost receipts: %q", detail)
+	}
+	if !strings.Contains(detail, "lifecycle: ") {
+		t.Fatalf("broken-chain completeness must still carry a lifecycle clause: %q", detail)
+	}
+	if !strings.Contains(detail, string(completeness.ReasonChainBroken)) {
+		t.Fatalf("broken-chain completeness must name the chain-broken reason: %q", detail)
 	}
 }

--- a/internal/evidenceview/scorecard_ported_test.go
+++ b/internal/evidenceview/scorecard_ported_test.go
@@ -274,6 +274,12 @@ func TestComputeScorecard_BoundSessionOpenGenesis(t *testing.T) {
 	if evidence.Scorecard.Untampered.State != StateVerify {
 		t.Fatalf("Untampered.State = %q, want %q", evidence.Scorecard.Untampered.State, StateVerify)
 	}
+	if evidence.Scorecard.Completeness.State != StateLimited {
+		t.Fatalf("in-flight Completeness.State = %q, want %q", evidence.Scorecard.Completeness.State, StateLimited)
+	}
+	if !strings.Contains(evidence.Scorecard.Completeness.Detail, "lifecycle: LIMITED (abnormal_end)") {
+		t.Fatalf("in-flight completeness must name the missing close: %q", evidence.Scorecard.Completeness.Detail)
+	}
 	if evidence.Timeline[0].Seq != 0 || evidence.Timeline[0].Unverifiable {
 		t.Fatalf("first bound-g1 timeline item = %+v, want verifiable seq 0", evidence.Timeline[0])
 	}


### PR DESCRIPTION
## What changed

An intact receipt chain proves the records were not tampered with. It does not prove the run reached a clean end. Three surfaces reported the first and let a reader infer the second.

`pipelock-verifier chain` now reads a bare v1 receipt file, which `completeness` already accepted. The two commands took different routes over the same input, so one refused a file the other verified. Malformed and mixed input stays refused on both.

The dashboard scorecard now reports lifecycle status and the reason behind it, so a bounded run that closed normally reads differently from a valid prefix whose close record never arrived. A valid in-flight chain stays passing and gains the reason rather than a failure.

The audit packet report now prints lifecycle status and reason, or states plainly that offline mode did not assess it. Chain integrity and receipt counts alone no longer stand in for a completeness verdict.

Docs cover what the audit packet output means for an operator reading it.

## Notes for reviewers

Each new report path has a test that fails when the analysis call is removed, so a passing suite means the path is live rather than present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit reports now show lifecycle completeness status and explanations.
  * Reports distinguish chain integrity from lifecycle evidence, including in-flight sessions with missing close events.
  * Legacy signed receipt JSONL files can be verified directly when all records are valid.

* **Bug Fixes**
  * Improved handling of malformed, mixed, oversized, and unreadable receipt files.

* **Documentation**
  * Added guidance explaining lifecycle status, offline verification, and integrity verdicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->