### PR TITLE
fix(runtime): keep the contract trust anchor across config reload

### DIFF
--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -121,6 +121,18 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			s.logger.LogConfigReload("ignored", "conductor settings restart-only", attemptedHash)
 			newCfg.Conductor = oldCfg.Conductor
 		}
+		// The contract loader owns the roster root, active-store watcher, and
+		// enforcement mode. Proxy.Reload would otherwise rebuild and publish a
+		// loader from this new block, allowing a config reload to replace the
+		// root of trust after the gate has already enforced a contract. Keep the
+		// full block atomic and restart-only: its values are coupled loader inputs,
+		// not independently reloadable tuning knobs.
+		if oldCfg.LearnLock != newCfg.LearnLock {
+			attemptedHash := newCfg.Hash()
+			_, _ = fmt.Fprintln(s.opts.Stderr, "WARNING: config reload: learn_lock settings changed — contract loader trust and watcher require restart, ignoring")
+			s.logger.LogConfigReload("ignored", "learn_lock settings restart-only", attemptedHash)
+			newCfg.LearnLock = oldCfg.LearnLock
+		}
 		if oldCfg.EvidenceProvenance != newCfg.EvidenceProvenance {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: evidence_provenance.commitment_keyring_path changed — keyring is loaded at startup, ignoring (restart required)\n")
 			newCfg.EvidenceProvenance = oldCfg.EvidenceProvenance

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -3416,19 +3416,30 @@ func TestServer_Reload_PreservesLearnLockTrustAnchor(t *testing.T) {
 		"  minimum_signatures: 1",
 		"",
 	}, "\n"))
-	s, _ := newTestServer(t, func(opts *ServerOpts) { opts.ConfigFile = cfgPath })
+	s, buf := newTestServer(t, func(opts *ServerOpts) { opts.ConfigFile = cfgPath })
 	first := s.proxy.CurrentConfig().Clone()
 	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
 	assertLearnLockVerdict(t, s, "http://api-a.example.test/v1/chat", config.ActionAllow)
 
 	// Field removal must not clear a loader that has already made a successful
-	// decision. Current code rejects this malformed direct Reload input; the
-	// restart-only preservation path may instead accept it after restoring the
-	// live value. In either case, the gate must remain on the original anchor.
+	// decision. The reload is ACCEPTED and the restart-only path restores the live
+	// value, so the operator sees a warning rather than a failed reload, and the
+	// gate stays on the original anchor.
 	removed := s.proxy.CurrentConfig().Clone()
 	removed.LearnLock.PinnedRootFingerprint = ""
 	s.lastReloadAt = time.Time{} // exercise a real later reload, not dedup.
-	_ = s.Reload(removed)
+	if err := s.Reload(removed); err != nil {
+		t.Fatalf("removed learn_lock fingerprint reload: %v", err)
+	}
+	// The reload SUCCEEDING is the point. A rejected reload would also leave the
+	// gate on the original anchor, so without this the assertion below passes for
+	// the wrong reason and proves nothing about the preservation path.
+	if got := s.proxy.CurrentConfig().LearnLock; got != first.LearnLock {
+		t.Fatalf("learn_lock after removed-field reload = %+v, want the startup block %+v", got, first.LearnLock)
+	}
+	if out := buf.String(); !strings.Contains(out, "learn_lock settings changed") {
+		t.Fatalf("an ignored learn_lock reload must warn the operator, got: %s", out)
+	}
 	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
 
 	// An unrelated reload and an identical reload must retain the established

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/cli/runtimeconfig"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract"
+	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
 	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
@@ -3369,6 +3372,118 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 		if !buf.contains(want) {
 			t.Fatalf("stderr missing %q:\n%s", want, buf.String())
 		}
+	}
+}
+
+func TestServer_Reload_PreservesLearnLockTrustAnchor(t *testing.T) {
+	// Establish a real, already-successful lock run. The first loader trusts
+	// fixture A and permits only its destination. A later config reload must
+	// not be able to replace that trust anchor with fixture B.
+	fixtureA := contractruntimetest.NewFixture(t)
+	storeA := t.TempDir()
+	env := contractruntimetest.Env()
+	contractruntimetest.WriteSignedActiveStore(t, fixtureA, storeA, contractruntimetest.ActiveStoreOptions{
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: env,
+		Rules: []contract.Rule{
+			contractruntimetest.HTTPEnforceRule("allow-a", "api-a.example.test", "/v1/chat", http.MethodPost),
+		},
+	})
+	fixtureB := contractruntimetest.NewFixture(t)
+	storeB := t.TempDir()
+	contractruntimetest.WriteSignedActiveStore(t, fixtureB, storeB, contractruntimetest.ActiveStoreOptions{
+		Generation:  1,
+		PriorHash:   "sha256:genesis",
+		Environment: env,
+		Rules: []contract.Rule{
+			contractruntimetest.HTTPEnforceRule("allow-b", "api-b.example.test", "/v1/chat", http.MethodPost),
+		},
+	})
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"learn_lock:",
+		"  enabled: true",
+		"  mode: live",
+		"  store_dir: " + strconv.Quote(storeA),
+		"  roster_path: " + strconv.Quote(fixtureA.RosterPath()),
+		"  environment:",
+		"    id: " + strconv.Quote(env.ID),
+		"    tenant: \"\"",
+		"    deployment_id: \"\"",
+		"  pinned_root_fingerprint: " + strconv.Quote(fixtureA.RootFingerprint()),
+		"  minimum_signatures: 1",
+		"",
+	}, "\n"))
+	s, _ := newTestServer(t, func(opts *ServerOpts) { opts.ConfigFile = cfgPath })
+	first := s.proxy.CurrentConfig().Clone()
+	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
+	assertLearnLockVerdict(t, s, "http://api-a.example.test/v1/chat", config.ActionAllow)
+
+	// Field removal must not clear a loader that has already made a successful
+	// decision. Current code rejects this malformed direct Reload input; the
+	// restart-only preservation path may instead accept it after restoring the
+	// live value. In either case, the gate must remain on the original anchor.
+	removed := s.proxy.CurrentConfig().Clone()
+	removed.LearnLock.PinnedRootFingerprint = ""
+	s.lastReloadAt = time.Time{} // exercise a real later reload, not dedup.
+	_ = s.Reload(removed)
+	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
+
+	// An unrelated reload and an identical reload must retain the established
+	// trust anchor and its gate decision.
+	unrelated := s.proxy.CurrentConfig().Clone()
+	unrelated.Logging.IncludeAllowed = !unrelated.Logging.IncludeAllowed
+	s.lastReloadAt = time.Time{} // exercise a real later reload, not dedup.
+	if err := s.Reload(unrelated); err != nil {
+		t.Fatalf("unrelated reload: %v", err)
+	}
+	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
+	if err := s.Reload(s.proxy.CurrentConfig().Clone()); err != nil {
+		t.Fatalf("unchanged reload: %v", err)
+	}
+	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
+	assertLearnLockVerdict(t, s, "http://api-a.example.test/v1/chat", config.ActionAllow)
+
+	// This is the exploit-shaped case: the new pair is internally valid, but
+	// would replace the root of trust and make a previously denied destination
+	// pass the live contract gate without a restart.
+	rotated := s.proxy.CurrentConfig().Clone()
+	rotated.LearnLock.StoreDir = storeB
+	rotated.LearnLock.RosterPath = fixtureB.RosterPath()
+	rotated.LearnLock.PinnedRootFingerprint = fixtureB.RootFingerprint()
+	s.lastReloadAt = time.Time{} // exercise a real later reload, not dedup.
+	if err := s.Reload(rotated); err != nil {
+		t.Fatalf("trust-anchor-changing reload: %v", err)
+	}
+	assertLearnLockVerdict(t, s, "http://api-b.example.test/v1/chat", config.ActionBlock)
+	assertLearnLockVerdict(t, s, "http://api-a.example.test/v1/chat", config.ActionAllow)
+
+	live := s.proxy.CurrentConfig().LearnLock
+	if live != first.LearnLock {
+		t.Fatalf("learn_lock after reload = %+v, want startup trust anchor %+v", live, first.LearnLock)
+	}
+}
+
+// Both directions matter. A guard that pins the trust anchor so hard that the
+// originally permitted destination stops working would get the control switched
+// off, which costs as much as the fail-open it prevents.
+func assertLearnLockVerdict(t *testing.T, s *Server, target string, want string) {
+	t.Helper()
+	out, err := proxy.EvaluateGate(proxy.ContractGateInput{
+		Loader:         s.proxy.ContractLoaderPtr().Load(),
+		Agent:          "agent-a",
+		URL:            target,
+		Method:         http.MethodPost,
+		ScannerVerdict: config.ActionAllow,
+		Transport:      proxy.TransportForward,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateGate(%q): %v", target, err)
+	}
+	if out.Verdict != want {
+		t.Fatalf("gate verdict for %q = %q, want %q (reason=%q source=%q)", target, out.Verdict, want, out.Reason, out.WinningSource)
 	}
 }
 

--- a/internal/config/learn_lock_test.go
+++ b/internal/config/learn_lock_test.go
@@ -66,6 +66,25 @@ func TestLearnLock_EffectiveMinimumSignaturesDefaultsToOne(t *testing.T) {
 	}
 }
 
+func TestValidateReload_LearnLockTrustAnchorChangeWarns(t *testing.T) {
+	old := Defaults()
+	old.LearnLock = LearnLock{
+		Enabled:               true,
+		Mode:                  LockModeLive,
+		StoreDir:              "/var/lib/pipelock/contracts",
+		RosterPath:            "/etc/pipelock/roster.json",
+		Environment:           LearnLockEnvironment{ID: "production"},
+		PinnedRootFingerprint: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		MinimumSignatures:     1,
+	}
+	updated := old.Clone()
+	updated.LearnLock.PinnedRootFingerprint = "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
+	if !hasReloadWarning(ValidateReload(old, updated), "learn_lock") {
+		t.Fatal("pinned root fingerprint change did not produce learn_lock restart warning")
+	}
+}
+
 func TestValidate_LearnLockDisabledIgnoresOtherFields(t *testing.T) {
 	// When Enabled is false, no other field is required. This is important
 	// for the v2.3 → v2.4 upgrade path: an existing config without

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -685,6 +685,17 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	// The learn-lock block constructs one coupled runtime: its trust root,
+	// roster, active-store watcher, environment binding, signature threshold,
+	// and enforcement mode must all agree. Server reload preserves this block
+	// from the running configuration rather than rebuilding that runtime.
+	if old.LearnLock != updated.LearnLock {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "learn_lock",
+			Message: "learn_lock config changes require restart — ignored on reload",
+		})
+	}
+
 	// Sandbox config is startup-only. Warn if any sandbox fields changed
 	// so operators know the reload had no effect on the running sandbox.
 	if sandboxChanged(old, updated) {


### PR DESCRIPTION
## What changed

The contract gate's trust anchor now survives a configuration reload. A reload rebuilt the contract loader from the incoming configuration, so the pinned root fingerprint, roster, store directory, environment binding, signature threshold and enforcement mode could all be replaced while the process kept running. A gate that had already been enforcing against one root could be moved onto another one without a restart.

The block is now preserved from the running configuration and treated as restart-only, matching how the conductor and evidence provenance blocks are already handled. Operators get a reload warning on stderr, an ignored-reload audit entry, and a validation warning naming the field, so a changed setting that has no effect says so rather than appearing to apply.

## Notes for reviewers

The regression test drives a real locked runtime rather than asserting on configuration values. It stands up two independently rooted contract stores, confirms the running gate blocks the second one's destination, then attempts the reload. With the preservation removed, the gate allows that destination, so the test fails when the guard is disabled.

Both directions are covered. The destination the original contract permits is asserted to still be allowed after each reload attempt, since a guard that pinned the anchor hard enough to break legitimate traffic would end with the control turned off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Learn Lock settings now correctly require a restart when changed instead of being applied during a live reload.
  * Existing Learn Lock trust anchors and access rules are preserved across configuration reloads.
  * Reload warnings are reported when Learn Lock configuration changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->