### PR TITLE
fix(mcp): correlate HTTP response IDs

### DIFF
--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -140,6 +140,10 @@ func RunHTTPProxy(
 
 	// Request tracker for confused deputy protection.
 	tracker := NewRequestTracker()
+	// The background GET stream carries server requests and notifications. A
+	// JSON-RPC result/error on that channel is unsolicited even if it copies an
+	// ID currently outstanding on the POST response path.
+	getResponseTracker := NewStrictRequestTracker()
 
 	// Session-scoped opts: override Rec and ToolCfg from the caller's opts.
 	fwdOpts := opts
@@ -426,7 +430,7 @@ func RunHTTPProxy(
 		// the Once and permanently prevent the GET stream.
 		if httpClient.SessionID() != "" {
 			getStreamOnce.Do(func() {
-				startGETStream(ctx, httpClient, safeClientOut, safeLogW, fwdOpts, &wg)
+				startGETStream(ctx, httpClient, safeClientOut, safeLogW, fwdOpts, getResponseTracker, &wg)
 			})
 		}
 	}

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -125,12 +125,16 @@ func RunHTTPProxy(
 	// this invocation.
 	toolCfg := opts.toolCfg()
 	var fwdToolCfg *tools.ToolScanConfig
-	if toolCfg != nil && toolCfg.Action != "" {
+	if toolCfg != nil && (toolCfg.Action != "" ||
+		toolCfg.BindingUnknownAction != "" ||
+		toolCfg.BindingNoBaselineAction != "") {
 		fwdToolCfg = &tools.ToolScanConfig{
-			Baseline:    tools.NewToolBaseline(),
-			Action:      toolCfg.Action,
-			DetectDrift: toolCfg.DetectDrift,
-			ExtraPoison: toolCfg.ExtraPoison,
+			Baseline:                tools.NewToolBaseline(),
+			Action:                  toolCfg.Action,
+			DetectDrift:             toolCfg.DetectDrift,
+			ExtraPoison:             toolCfg.ExtraPoison,
+			BindingUnknownAction:    toolCfg.BindingUnknownAction,
+			BindingNoBaselineAction: toolCfg.BindingNoBaselineAction,
 		}
 	}
 

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -792,7 +792,7 @@ func RunHTTPListenerProxy(
 			if flusher, ok := w.(http.Flusher); ok {
 				streamWriter.flusher = flusher
 			}
-			foundInjection, scanErr := ForwardScanned(transport.NewSSEReader(upResp.Body), streamWriter, safeLogW, nil, reqOpts)
+			foundInjection, scanErr := ForwardScanned(transport.NewSSEReader(upResp.Body), streamWriter, safeLogW, NewStrictRequestTracker(), reqOpts)
 			if scanErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 			}
@@ -1241,8 +1241,10 @@ func RunHTTPListenerProxy(
 		// internal/mcp/transport/httpclient.go; this listener has its own
 		// hand-rolled HTTP request loop and so has to do it inline.
 		//
-		// nil tracker: HTTP reverse proxy pairs each request/response via HTTP
-		// semantics, so confused deputy tracking is handled at the transport level.
+		// HTTP attachment alone does not correlate the JSON-RPC envelope. A
+		// hostile upstream can answer request 1 with result 999, or inject a
+		// concurrent request's ID, so validate the exact client request ID.
+		responseTracker := NewStrictRequestTracker(frame.ID)
 		upstreamIsSSE := transport.HasSingleSSEContentType(upResp.Header)
 		var reader transport.MessageReader
 		if upstreamIsSSE {
@@ -1277,7 +1279,7 @@ func RunHTTPListenerProxy(
 			if flusher, ok := w.(http.Flusher); ok {
 				streamWriter.flusher = flusher
 			}
-			foundInjection, scanErr := ForwardScanned(reader, streamWriter, safeLogW, nil, reqOpts)
+			foundInjection, scanErr := ForwardScanned(reader, streamWriter, safeLogW, responseTracker, reqOpts)
 			if scanErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 			}
@@ -1303,7 +1305,7 @@ func RunHTTPListenerProxy(
 			}
 			return
 		}
-		foundInjection, scanErr := ForwardScanned(reader, bufWriter, safeLogW, nil, reqOpts)
+		foundInjection, scanErr := ForwardScanned(reader, bufWriter, safeLogW, responseTracker, reqOpts)
 		if scanErr != nil {
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: scan error: %v\n", scanErr)
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/mcp_sse_bridge.go
+++ b/internal/mcp/mcp_sse_bridge.go
@@ -76,6 +76,7 @@ func startGETStream(
 	safeClientOut *syncWriter,
 	safeLogW *syncWriter,
 	opts MCPProxyOpts,
+	tracker *RequestTracker,
 	wg *sync.WaitGroup,
 ) {
 	wg.Add(1)
@@ -131,9 +132,7 @@ func startGETStream(
 			// Reset backoff on successful connection.
 			backoff = time.Second
 
-			// nil tracker: GET stream carries server-initiated messages,
-			// not responses to client requests.
-			_, scanErr := ForwardScanned(reader, safeClientOut, safeLogW, nil, opts)
+			_, scanErr := ForwardScanned(reader, safeClientOut, safeLogW, tracker, opts)
 			if scanErr != nil {
 				_, _ = fmt.Fprintf(safeLogW, "pipelock: GET stream scan error: %v\n", scanErr)
 			}

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -295,6 +295,14 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		var hasTrackedOutcome bool
 		if tracker != nil && tracker.Seeded() && isResponse(line) {
 			rpcID := frame.ID
+			if rpcID == nil && tracker.Strict() {
+				_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: response has no correlatable ID\n", lineNum)
+				resp := blockResponseReason(nil, "response has no correlatable ID (confused deputy)")
+				if err := writer.WriteMessage(resp); err != nil {
+					return foundInjection, fmt.Errorf("writing confused deputy block: %w", err)
+				}
+				continue
+			}
 			if rpcID != nil {
 				var valid bool
 				trackedOutcome, valid = tracker.Consume(rpcID)

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -295,7 +295,7 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 		var hasTrackedOutcome bool
 		if tracker != nil && tracker.Seeded() && isResponse(line) {
 			rpcID := frame.ID
-			if rpcID == nil && tracker.Strict() {
+			if canonicalID(rpcID) == "" && tracker.Strict() {
 				_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: response has no correlatable ID\n", lineNum)
 				resp := blockResponseReason(nil, "response has no correlatable ID (confused deputy)")
 				if err := writer.WriteMessage(resp); err != nil {
@@ -309,7 +309,11 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 				if !valid {
 					_, _ = fmt.Fprintf(logW, "pipelock: line %d: confused deputy: unsolicited response ID %s\n",
 						lineNum, string(rpcID))
-					resp := blockResponseReason(rpcID, "unsolicited response ID (confused deputy)")
+					blockID := rpcID
+					if tracker.Strict() {
+						blockID = nil
+					}
+					resp := blockResponseReason(blockID, "unsolicited response ID (confused deputy)")
 					if err := writer.WriteMessage(resp); err != nil {
 						return foundInjection, fmt.Errorf("writing confused deputy block: %w", err)
 					}

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -1526,6 +1526,73 @@ func TestRunHTTPProxy_SessionDeleteOnEOF(t *testing.T) {
 	}
 }
 
+func TestRunHTTPProxy_SessionBindingActionsBlockBeforeForward(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		input          string
+		wantReason     string
+		wantListCalls  int32
+		unknownAction  string
+		baselineAction string
+	}{
+		{
+			name:           "no baseline with binding-only action",
+			input:          `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"safe","arguments":{}}}` + "\n",
+			wantReason:     bindingReasonNoBaseline,
+			baselineAction: config.ActionBlock,
+		},
+		{
+			name: "unknown after baseline with binding-only action",
+			input: `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}` + "\n" +
+				`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"unknown","arguments":{}}}` + "\n",
+			wantReason:    bindingReasonUnknownTool,
+			wantListCalls: 1,
+			unknownAction: config.ActionBlock,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var listCalls, toolCalls atomic.Int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("ReadAll(upstream): %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(string(body), `"method":"tools/list"`) {
+					listCalls.Add(1)
+					_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"safe","description":"Safe tool","inputSchema":{"type":"object"}}]}}`))
+					return
+				}
+				toolCalls.Add(1)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"unexpected"}]}}`))
+			}))
+			defer upstream.Close()
+
+			toolCfg := &tools.ToolScanConfig{
+				Baseline:                tools.NewToolBaseline(),
+				BindingUnknownAction:    tc.unknownAction,
+				BindingNoBaselineAction: tc.baselineAction,
+			}
+			var stdout, stderr bytes.Buffer
+			err := RunHTTPProxy(context.Background(), strings.NewReader(tc.input), &stdout, &stderr, upstream.URL, nil, MCPProxyOpts{
+				Scanner: testScannerForHTTP(t), ToolCfg: toolCfg,
+			})
+			if err != nil {
+				t.Fatalf("RunHTTPProxy: %v", err)
+			}
+			if !strings.Contains(stdout.String(), tc.wantReason) {
+				t.Fatalf("stdout = %s, want binding reason %q", stdout.String(), tc.wantReason)
+			}
+			if got := listCalls.Load(); got != tc.wantListCalls {
+				t.Fatalf("tools/list forwards = %d, want %d", got, tc.wantListCalls)
+			}
+			if got := toolCalls.Load(); got != 0 {
+				t.Fatalf("tools/call forwards = %d, want 0", got)
+			}
+		})
+	}
+}
+
 func TestScanHTTPInput_AskFallbackToBlock(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -734,6 +734,126 @@ func TestRunHTTPProxy_GETStreamRejectsResponseIDs(t *testing.T) {
 	}
 }
 
+func TestRunHTTPProxy_GETStreamWrongIDCannotCompleteOutstandingPOST(t *testing.T) {
+	getReady := make(chan struct{})
+	secondPOSTStarted := make(chan struct{})
+	attackSent := make(chan struct{})
+	allowSecondResponse := make(chan struct{})
+	var getReadyOnce, attackOnce, secondPOSTOnce sync.Once
+	var nonPOSTCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Error("test server does not support flushing")
+				return
+			}
+			flusher.Flush()
+			getReadyOnce.Do(func() { close(getReady) })
+			select {
+			case <-secondPOSTStarted:
+			case <-r.Context().Done():
+				return
+			}
+			attackOnce.Do(func() {
+				_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"owned\":\"cross-request\"}}\n\n"))
+				flusher.Flush()
+				close(attackSent)
+			})
+			<-r.Context().Done()
+			return
+		}
+		if r.Method != http.MethodPost {
+			nonPOSTCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll(request): %v", err)
+			return
+		}
+		requestID := ParseMCPFrame(requestBody).ID
+		w.Header().Set("Content-Type", "application/json")
+		if string(requestID) == "1" {
+			w.Header().Set("Mcp-Session-Id", "sess-cross-request")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`))
+			return
+		}
+		secondPOSTOnce.Do(func() { close(secondPOSTStarted) })
+		select {
+		case <-attackSent:
+		case <-r.Context().Done():
+			return
+		}
+		select {
+		case <-allowSecondResponse:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
+	}))
+	defer srv.Close()
+
+	stdinR, stdinW := io.Pipe()
+	var stdout, stderr lockedHTTPBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPProxy(context.Background(), stdinR, &stdout, &stderr, srv.URL, nil, MCPProxyOpts{Scanner: testScannerForHTTP(t)})
+	}()
+
+	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
+	select {
+	case <-getReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for GET stream")
+	}
+	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"))
+	testwait.For(t, 2*time.Second, func() bool {
+		return stdout.contains("unsolicited response ID")
+	}, "strict GET stream block")
+	close(allowSecondResponse)
+	_ = stdinW.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunHTTPProxy: %v", err)
+	}
+	if !stdout.contains(`"id":2,"result":{"tools":[]}`) {
+		t.Fatalf("legitimate POST response did not reach client: %s", stdout.String())
+	}
+	if got := nonPOSTCalls.Load(); got != 1 {
+		t.Fatalf("non-POST cleanup calls = %d, want 1 DELETE", got)
+	}
+
+	foundBlock := false
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		var response struct {
+			ID    json.RawMessage `json:"id"`
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &response); err != nil {
+			t.Fatalf("invalid JSON response %q: %v", line, err)
+		}
+		if !strings.Contains(response.Error.Message, "unsolicited response ID") {
+			continue
+		}
+		foundBlock = true
+		if canonicalID(response.ID) != "" {
+			t.Fatalf("strict GET block reused attacker-selected ID %s: %s", response.ID, line)
+		}
+	}
+	if !foundBlock {
+		t.Fatal("strict GET stream did not emit a confused-deputy block")
+	}
+	if stdout.contains(`"owned":"cross-request"`) {
+		t.Fatalf("hostile GET payload reached client: %s", stdout.String())
+	}
+}
+
 func TestRunHTTPProxy_InputDLPBlocking(t *testing.T) {
 	// Server should NOT be called - input is blocked before forwarding.
 	var serverCalled int32

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -689,6 +689,51 @@ func TestRunHTTPProxy_GETStreamReceivesServerNotifications(t *testing.T) {
 	}
 }
 
+func TestRunHTTPProxy_GETStreamRejectsResponseIDs(t *testing.T) {
+	getCalled := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"owned\":\"wrong-id\"}}\n\n" +
+				"data: {\"jsonrpc\":\"2.0\",\"id\":null,\"result\":{\"owned\":\"null-id\"}}\n\n" +
+				"data: {\"jsonrpc\":\"2.0\",\"result\":{\"owned\":\"missing-id\"}}\n\n"))
+			select {
+			case getCalled <- struct{}{}:
+			default:
+			}
+			return
+		}
+		w.Header().Set("Mcp-Session-Id", "sess-strict-get")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`))
+	}))
+	defer srv.Close()
+
+	stdinR, stdinW := io.Pipe()
+	var stdout, stderr lockedHTTPBuffer
+	done := make(chan error, 1)
+	sc := testScannerForHTTP(t)
+	go func() {
+		done <- RunHTTPProxy(context.Background(), stdinR, &stdout, &stderr, srv.URL, nil, MCPProxyOpts{Scanner: sc})
+	}()
+	_, _ = stdinW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"))
+	select {
+	case <-getCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for GET stream")
+	}
+	testwait.For(t, 2*time.Second, func() bool {
+		return stdout.contains("unsolicited response ID") && stdout.contains("no correlatable ID")
+	}, "GET response IDs rejected")
+	_ = stdinW.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunHTTPProxy: %v", err)
+	}
+	if stdout.contains(`"owned":`) {
+		t.Fatalf("GET response payload reached client: %s", stdout.String())
+	}
+}
+
 func TestRunHTTPProxy_InputDLPBlocking(t *testing.T) {
 	// Server should NOT be called - input is blocked before forwarding.
 	var serverCalled int32
@@ -2826,6 +2871,92 @@ func TestRunHTTPListenerProxy_SessionBindingBlocksNoBaseline(t *testing.T) {
 	}
 	if !strings.Contains(logBuf.String(), "before baseline established") {
 		t.Fatalf("expected binding diagnostic log, got: %s", logBuf.String())
+	}
+}
+
+func TestRunHTTPListenerProxy_RejectsMismatchedResponseID(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		reason      string
+	}{
+		{name: "json wrong ID", contentType: "application/json", body: `{"jsonrpc":"2.0","id":999,"result":{"owned":"attack"}}`, reason: "unsolicited response ID"},
+		{name: "json null ID", contentType: "application/json", body: `{"jsonrpc":"2.0","id":null,"result":{"owned":"attack"}}`, reason: "no correlatable ID"},
+		{name: "json missing ID", contentType: "application/json", body: `{"jsonrpc":"2.0","result":{"owned":"attack"}}`, reason: "no correlatable ID"},
+		{name: "sse wrong ID", contentType: "text/event-stream", body: "data: {\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"owned\":\"attack\"}}\n\n", reason: "unsolicited response ID"},
+		{name: "sse null ID", contentType: "text/event-stream", body: "data: {\"jsonrpc\":\"2.0\",\"id\":null,\"result\":{\"owned\":\"attack\"}}\n\n", reason: "no correlatable ID"},
+		{name: "sse missing ID", contentType: "text/event-stream", body: "data: {\"jsonrpc\":\"2.0\",\"result\":{\"owned\":\"attack\"}}\n\n", reason: "no correlatable ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer upstream.Close()
+			baseURL, _, _ := startListenerProxy(t, upstream.URL, testScannerForHTTP(t), nil, nil, nil)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("POST listener: %v", err)
+			}
+			payload, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll: %v", readErr)
+			}
+			if !bytes.Contains(payload, []byte(tc.reason)) {
+				t.Fatalf("response = %s, want confused-deputy block", payload)
+			}
+			if bytes.Contains(payload, []byte(`"owned":"attack"`)) {
+				t.Fatalf("mismatched response payload reached client: %s", payload)
+			}
+		})
+	}
+}
+
+func TestRunHTTPListenerProxy_GETRejectsJSONRPCResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name, event, reason string
+	}{
+		{name: "wrong ID", event: `{"jsonrpc":"2.0","id":999,"result":{"owned":"attack"}}`, reason: "unsolicited response ID"},
+		{name: "null ID", event: `{"jsonrpc":"2.0","id":null,"result":{"owned":"attack"}}`, reason: "no correlatable ID"},
+		{name: "missing ID", event: `{"jsonrpc":"2.0","result":{"owned":"attack"}}`, reason: "no correlatable ID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", tc.event)
+			}))
+			defer upstream.Close()
+			baseURL, _, _ := startListenerProxy(t, upstream.URL, testScannerForHTTP(t), nil, nil, nil)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+"/", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Accept", "text/event-stream")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET listener: %v", err)
+			}
+			payload, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll: %v", readErr)
+			}
+			if !bytes.Contains(payload, []byte(tc.reason)) {
+				t.Fatalf("response = %s, want confused-deputy block", payload)
+			}
+			if bytes.Contains(payload, []byte(`"owned":"attack"`)) {
+				t.Fatalf("GET response payload reached client: %s", payload)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/request_tracker.go
+++ b/internal/mcp/request_tracker.go
@@ -32,6 +32,10 @@ type RequestTracker struct {
 	// so responses arriving before any request tracking (e.g., during MCP
 	// server initialization) pass through instead of being blocked.
 	seeded bool
+	// strict rejects response envelopes whose ID is absent or null. It is used
+	// by HTTP response channels with an exact request set (including an empty
+	// set), while ordinary stdio/WS trackers retain JSON-RPC parse-error parity.
+	strict bool
 }
 
 // TrackedRequestOutcome carries the receipt metadata needed to emit a
@@ -52,6 +56,20 @@ func NewRequestTracker() *RequestTracker {
 	return &RequestTracker{
 		pending: make(map[string]TrackedRequestOutcome),
 	}
+}
+
+// NewStrictRequestTracker creates a tracker that rejects response IDs even
+// when no request ID is pending. Use it on HTTP response channels where the
+// corresponding client request is already known, or where responses are never
+// valid, so the initialization race exception cannot become a fail-open.
+func NewStrictRequestTracker(ids ...json.RawMessage) *RequestTracker {
+	t := NewRequestTracker()
+	t.seeded = true
+	t.strict = true
+	for _, id := range ids {
+		t.Track(id)
+	}
+	return t
 }
 
 // Track records a request ID as pending. Nil/null IDs are ignored
@@ -110,7 +128,7 @@ func (t *RequestTracker) Consume(id json.RawMessage) (TrackedRequestOutcome, boo
 	key := canonicalID(id)
 	if key == "" {
 		// Nil/null IDs: notifications and server-initiated requests.
-		return TrackedRequestOutcome{}, true
+		return TrackedRequestOutcome{}, !t.strict
 	}
 
 	t.mu.Lock()
@@ -142,6 +160,11 @@ func (t *RequestTracker) Seeded() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.seeded
+}
+
+// Strict reports whether response envelopes must carry an exact tracked ID.
+func (t *RequestTracker) Strict() bool {
+	return t != nil && t.strict
 }
 
 // DrainPending returns and removes all pending request IDs. Used when a

--- a/internal/mcp/request_tracker_test.go
+++ b/internal/mcp/request_tracker_test.go
@@ -52,11 +52,21 @@ func TestRequestTracker_NullID(t *testing.T) {
 }
 
 func TestStrictRequestTracker_RejectsUnkeyedIDs(t *testing.T) {
-	tr := NewStrictRequestTracker()
-	for _, id := range []json.RawMessage{nil, json.RawMessage(`null`), {}} {
-		if tr.Validate(id) {
-			t.Errorf("strict tracker accepted unkeyed ID %q", id)
-		}
+	tests := []struct {
+		name string
+		id   json.RawMessage
+	}{
+		{name: "nil", id: nil},
+		{name: "null", id: json.RawMessage(`null`)},
+		{name: "empty", id: json.RawMessage{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewStrictRequestTracker()
+			if tr.Validate(tc.id) {
+				t.Errorf("strict tracker accepted unkeyed ID %q", tc.id)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/request_tracker_test.go
+++ b/internal/mcp/request_tracker_test.go
@@ -51,6 +51,15 @@ func TestRequestTracker_NullID(t *testing.T) {
 	}
 }
 
+func TestStrictRequestTracker_RejectsUnkeyedIDs(t *testing.T) {
+	tr := NewStrictRequestTracker()
+	for _, id := range []json.RawMessage{nil, json.RawMessage(`null`), {}} {
+		if tr.Validate(id) {
+			t.Errorf("strict tracker accepted unkeyed ID %q", id)
+		}
+	}
+}
+
 func TestRequestTracker_EmptyID(t *testing.T) {
 	tr := NewRequestTracker()
 


### PR DESCRIPTION
## Summary

Adds strict response-ID correlation to reverse-listener JSON/SSE/GET paths and the stdio-to-HTTP background GET stream.

Mismatched, missing, and null response IDs are rejected while notifications, server-initiated requests, and correctly correlated responses continue to flow.

Stacked on #1203 because both changes touch the HTTP-forward path. Merge #1203 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked unsolicited, missing, null, or mismatched JSON-RPC responses from being forwarded.
  * Improved response correlation across HTTP, SSE, GET-stream, and listener paths.
  * Added diagnostics when responses cannot be matched to an originating request.

* **Tests**
  * Added coverage confirming invalid or uncorrelatable responses are rejected and not delivered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->