### PR TITLE
fix(proxy): bind the SSRF dial snapshot to the CONNECT port

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -92,6 +92,13 @@ func normalizeConnectTarget(target string) (normalized, host, port, scanURL stri
 	if err != nil || host == "" || port == "" {
 		return "", "", "", "", false
 	}
+	// CONNECT authorities carry a numeric TCP port. Accepting a service name or
+	// arbitrary text here would let policy and the dial disagree about what the
+	// port even is, and the dial resolver is not the right place to discover a
+	// malformed authority.
+	if n, convErr := strconv.Atoi(port); convErr != nil || n < 1 || n > 65535 {
+		return "", "", "", "", false
+	}
 	return target, host, port, "https://" + net.JoinHostPort(host, port) + "/", true
 }
 
@@ -185,6 +192,24 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 			"malformed target authority", http.StatusBadRequest)
 		return
 	}
+	// Contract evaluation for a RAW CONNECT tunnel deliberately keeps the legacy
+	// hostname-only projection while the rest of this path uses the exact
+	// authority. This divergence is intentional and temporary, not an oversight.
+	//
+	// Contract rules cannot express a port: selectors have no port field and
+	// inference drops it, so feeding the real port to the gate would make
+	// usesDefaultHTTPPort refuse every non-443 tunnel with no way for an
+	// operator to authorize the service they actually run. It would also apply
+	// HTTPS default-port semantics to what is an opaque TCP authority, so a
+	// legitimate CONNECT to :80 would be refused for being "non-default https".
+	//
+	// Whether raw CONNECT contract enforcement should become port-aware is a
+	// design decision that belongs with a CONNECT-authority rule shape, not with
+	// this change. Intercepted CONNECT already reconstructs inner requests with
+	// their real port and is unaffected by this projection.
+	// host is unbracketed here, so an IPv6 literal must be re-bracketed or the
+	// resulting URL does not parse and the gate would see a different authority.
+	contractURL := "https://" + hostForURL(host) + "/"
 	connectReceiptTarget := syntheticURL
 	emitConnectSessionDenyReceipt := func() {
 		emitConnectReceipt(receipt.EmitOpts{
@@ -492,7 +517,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	gate, gateErr := EvaluateGate(ContractGateInput{
 		Loader:           snapshotContractLoader,
 		Agent:            agent,
-		URL:              syntheticURL,
+		URL:              contractURL,
 		Method:           http.MethodConnect,
 		EffectiveAction:  scannerVerdictForGate(hasFinding),
 		ScannerVerdict:   scannerVerdictForGate(hasFinding),
@@ -2906,4 +2931,14 @@ func responseBundleRules(matches []scanner.ResponseMatch) []audit.BundleRuleHit 
 		}
 	}
 	return hits
+}
+
+// hostForURL re-brackets an IPv6 literal so it can be placed in a URL authority.
+// net.SplitHostPort strips the brackets, and an unbracketed IPv6 host produces a
+// URL that does not parse back to the same authority.
+func hostForURL(host string) string {
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -70,6 +70,18 @@ func getTunnelSemaphore() *tunnelSemaphore {
 	return tunnelSem
 }
 
+// normalizeConnectTarget applies CONNECT's sole default and produces the
+// host-and-port target used by both scanning and dialing.
+func normalizeConnectTarget(target string) (normalized, host, port, scanURL string) {
+	if _, _, err := net.SplitHostPort(target); err != nil {
+		bare := strings.TrimPrefix(strings.TrimSuffix(target, "]"), "[")
+		target = net.JoinHostPort(bare, "443")
+	}
+
+	host, port, _ = net.SplitHostPort(target)
+	return target, host, port, "https://" + net.JoinHostPort(host, port) + "/"
+}
+
 // handleConnect handles HTTP CONNECT tunnel requests. It scans the target
 // hostname through the full scanner pipeline, establishes a TCP connection
 // via the SSRF-safe dialer, and relays data bidirectionally.
@@ -153,29 +165,8 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure target has a port. CONNECT targets are always host:port.
-	// Strip brackets from bare IPv6 literals before JoinHostPort adds them back.
-	if _, _, err := net.SplitHostPort(target); err != nil {
-		bare := strings.TrimPrefix(strings.TrimSuffix(target, "]"), "[")
-		target = net.JoinHostPort(bare, "443")
-	}
-
-	// Synthesize a URL for scanner pipeline. The scanner expects a full URL,
-	// but CONNECT only gives us host:port. Use https:// as the tunnel is
-	// typically used for TLS traffic.
-	host, targetPort, _ := net.SplitHostPort(target)
-	syntheticHost := host
-	if strings.Contains(host, ":") { // IPv6 literal needs brackets in URL
-		syntheticHost = "[" + host + "]"
-	}
-	// The scanned/contract URL keeps its historical port-less form so the
-	// contract gate and scanner verdict are unchanged; the exact CONNECT port
-	// is bound to the dial snapshot below (from targetPort) and carried in the
-	// receipt target. Whether the CONNECT contract gate should also see the
-	// real port is a separate design question, tracked as a guard adjacent
-	// finding, not decided here.
-	syntheticURL := "https://" + syntheticHost + "/"
-	connectReceiptTarget := "https://" + net.JoinHostPort(host, targetPort) + "/"
+	target, host, targetPort, syntheticURL := normalizeConnectTarget(target)
+	connectReceiptTarget := syntheticURL
 	emitConnectSessionDenyReceipt := func() {
 		emitConnectReceipt(receipt.EmitOpts{
 			ActionID:  actionID,

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -71,15 +71,28 @@ func getTunnelSemaphore() *tunnelSemaphore {
 }
 
 // normalizeConnectTarget applies CONNECT's sole default and produces the
-// host-and-port target used by both scanning and dialing.
-func normalizeConnectTarget(target string) (normalized, host, port, scanURL string) {
+// host-and-port target used by both scanning and dialing. It reports whether
+// the authority was well formed.
+//
+// net.SplitHostPort accepts two shapes that must not reach the rest of this
+// path. ":443" and "" parse with an EMPTY HOST, which would produce a scan URL
+// with no host to match policy against. "host:" parses with an EMPTY PORT,
+// which is worse: the dial snapshot guard only compares ports when it has one,
+// so an empty port would silently disable the port binding for that request.
+// Both are rejected here rather than normalized to a guess, because inventing a
+// host or a port for a malformed authority decides policy on an address the
+// client never asked for.
+func normalizeConnectTarget(target string) (normalized, host, port, scanURL string, ok bool) {
 	if _, _, err := net.SplitHostPort(target); err != nil {
 		bare := strings.TrimPrefix(strings.TrimSuffix(target, "]"), "[")
 		target = net.JoinHostPort(bare, "443")
 	}
 
-	host, port, _ = net.SplitHostPort(target)
-	return target, host, port, "https://" + net.JoinHostPort(host, port) + "/"
+	host, port, err := net.SplitHostPort(target)
+	if err != nil || host == "" || port == "" {
+		return "", "", "", "", false
+	}
+	return target, host, port, "https://" + net.JoinHostPort(host, port) + "/", true
 }
 
 // handleConnect handles HTTP CONNECT tunnel requests. It scans the target
@@ -165,7 +178,13 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	target, host, targetPort, syntheticURL := normalizeConnectTarget(target)
+	target, host, targetPort, syntheticURL, targetOK := normalizeConnectTarget(target)
+	if !targetOK {
+		writeBlockedError(w,
+			blockInfoFor(blockreason.BadRequest, ""),
+			"malformed target authority", http.StatusBadRequest)
+		return
+	}
 	connectReceiptTarget := syntheticURL
 	emitConnectSessionDenyReceipt := func() {
 		emitConnectReceipt(receipt.EmitOpts{

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -96,7 +96,10 @@ func normalizeConnectTarget(target string) (normalized, host, port, scanURL stri
 	// arbitrary text here would let policy and the dial disagree about what the
 	// port even is, and the dial resolver is not the right place to discover a
 	// malformed authority.
-	if n, convErr := strconv.Atoi(port); convErr != nil || n < 1 || n > 65535 {
+	// ParseUint rather than Atoi: Atoi accepts a leading sign, so "+443" would be
+	// preserved verbatim in the authority while the dial read it as 443, leaving
+	// policy and the dial looking at different text for the same destination.
+	if n, convErr := strconv.ParseUint(port, 10, 16); convErr != nil || n == 0 {
 		return "", "", "", "", false
 	}
 	return target, host, port, "https://" + net.JoinHostPort(host, port) + "/", true

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3587,6 +3587,7 @@ func TestNormalizeConnectTargetPreservesPortForScanAndDial(t *testing.T) {
 		wantHost       string
 		wantPort       string
 		wantScanURL    string
+		wantBad        bool
 	}{
 		{
 			name:           "explicit port",
@@ -3620,11 +3621,39 @@ func TestNormalizeConnectTargetPreservesPortForScanAndDial(t *testing.T) {
 			wantPort:       "443",
 			wantScanURL:    "https://[2001:db8::1]:443/",
 		},
+		// net.SplitHostPort accepts all three of these, so without an explicit
+		// rejection they reach policy as an empty host or an empty port. An
+		// empty port is the dangerous one: the dial snapshot only compares
+		// ports when it has one, so it would silently stop binding.
+		{
+			name:    "empty port is rejected",
+			target:  "api.vendor.example:",
+			wantBad: true,
+		},
+		{
+			name:    "empty host is rejected",
+			target:  ":443",
+			wantBad: true,
+		},
+		{
+			name:    "empty authority is rejected",
+			target:  "",
+			wantBad: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			normalized, host, port, scanURL := normalizeConnectTarget(tt.target)
+			normalized, host, port, scanURL, ok := normalizeConnectTarget(tt.target)
+			if tt.wantBad {
+				if ok {
+					t.Fatalf("normalizeConnectTarget(%q) accepted a malformed authority as (%q, %q, %q, %q)", tt.target, normalized, host, port, scanURL)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("normalizeConnectTarget(%q) rejected a well-formed authority", tt.target)
+			}
 			if normalized != tt.wantNormalized || host != tt.wantHost || port != tt.wantPort || scanURL != tt.wantScanURL {
 				t.Fatalf("normalizeConnectTarget(%q) = (%q, %q, %q, %q), want (%q, %q, %q, %q)", tt.target, normalized, host, port, scanURL, tt.wantNormalized, tt.wantHost, tt.wantPort, tt.wantScanURL)
 			}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -6342,3 +6342,55 @@ func TestConnectMalformedAuthorityRejectedByHandler(t *testing.T) {
 		})
 	}
 }
+
+// TestConnectContractProjectionStaysHostnameOnly pins the deliberate divergence
+// between what raw CONNECT hands the contract gate and what it hands everything
+// else. Scanner, dial snapshot, and receipt must carry the exact authority, and
+// the contract gate must not, because contract rules cannot express a port yet
+// and would refuse every non-443 tunnel with no operator remedy.
+//
+// If someone later makes contract rules port-aware, this test should fail and be
+// replaced deliberately rather than quietly deleted.
+func TestConnectContractProjectionStaysHostnameOnly(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		target       string
+		wantScan     string
+		wantContract string
+	}{
+		{"high port", "api.vendor.example:8443", "https://api.vendor.example:8443/", "https://api.vendor.example/"},
+		{"explicit 443", "api.vendor.example:443", "https://api.vendor.example:443/", "https://api.vendor.example/"},
+		{"plain http port", "api.vendor.example:80", "https://api.vendor.example:80/", "https://api.vendor.example/"},
+		{"ipv6 high port", "[2001:db8::1]:8443", "https://[2001:db8::1]:8443/", "https://[2001:db8::1]/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, host, _, scanURL, ok := normalizeConnectTarget(tc.target)
+			if !ok {
+				t.Fatalf("normalizeConnectTarget(%q) rejected a well-formed authority", tc.target)
+			}
+			if scanURL != tc.wantScan {
+				t.Fatalf("scan URL = %q, want %q", scanURL, tc.wantScan)
+			}
+			contractURL := "https://" + hostForURL(host) + "/"
+			if contractURL != tc.wantContract {
+				t.Fatalf("contract URL = %q, want %q", contractURL, tc.wantContract)
+			}
+			if _, err := url.Parse(contractURL); err != nil {
+				t.Fatalf("contract URL %q does not parse: %v", contractURL, err)
+			}
+		})
+	}
+}
+
+// A CONNECT authority carries a numeric TCP port. A service name would leave
+// policy and the dial disagreeing about the destination.
+func TestConnectRejectsNonNumericPort(t *testing.T) {
+	t.Parallel()
+	for _, target := range []string{"api.vendor.example:https", "api.vendor.example:0", "api.vendor.example:65536", "api.vendor.example:-1"} {
+		if _, _, _, _, ok := normalizeConnectTarget(target); ok {
+			t.Fatalf("normalizeConnectTarget(%q) accepted a non-numeric or out-of-range port", target)
+		}
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -6388,9 +6388,19 @@ func TestConnectContractProjectionStaysHostnameOnly(t *testing.T) {
 // policy and the dial disagreeing about the destination.
 func TestConnectRejectsNonNumericPort(t *testing.T) {
 	t.Parallel()
-	for _, target := range []string{"api.vendor.example:https", "api.vendor.example:0", "api.vendor.example:65536", "api.vendor.example:-1"} {
-		if _, _, _, _, ok := normalizeConnectTarget(target); ok {
-			t.Fatalf("normalizeConnectTarget(%q) accepted a non-numeric or out-of-range port", target)
-		}
+	for _, target := range []string{
+		"api.vendor.example:https",
+		"api.vendor.example:0",
+		"api.vendor.example:65536",
+		"api.vendor.example:-1",
+		"api.vendor.example:+443",
+		"api.vendor.example:443 ",
+	} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			if _, _, _, scanURL, ok := normalizeConnectTarget(target); ok {
+				t.Fatalf("normalizeConnectTarget(%q) accepted a bad port and produced %q", target, scanURL)
+			}
+		})
 	}
 }

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -6308,3 +6308,37 @@ func TestForwardHTTP_CompressedSSE_GzipFailsClosed(t *testing.T) {
 		})
 	}
 }
+
+// TestConnectMalformedAuthorityRejectedByHandler drives the real handler rather
+// than the normalizer, because the normalizer returning a rejection only matters
+// if handleConnect acts on it. The empty-port form is the one that matters most:
+// net.SplitHostPort accepts it, and an empty port would leave the dial snapshot
+// with nothing to bind against.
+func TestConnectMalformedAuthorityRejectedByHandler(t *testing.T) {
+	t.Parallel()
+	proxyAddr, cleanup := setupForwardProxy(t, nil)
+	defer cleanup()
+
+	for _, tc := range []struct {
+		name      string
+		authority string
+	}{
+		{"empty port", "api.vendor.example:"},
+		{"empty host", ":443"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := dialProxy(t, proxyAddr)
+			defer func() { _ = conn.Close() }()
+
+			_, _ = conn.Write([]byte("CONNECT " + tc.authority + " HTTP/1.1\r\nHost: " + tc.authority + "\r\n\r\n"))
+			resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("CONNECT %q status = %d, want %d", tc.authority, resp.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -3579,6 +3579,59 @@ func TestConnectDefaultPort(t *testing.T) {
 	}
 }
 
+func TestNormalizeConnectTargetPreservesPortForScanAndDial(t *testing.T) {
+	tests := []struct {
+		name           string
+		target         string
+		wantNormalized string
+		wantHost       string
+		wantPort       string
+		wantScanURL    string
+	}{
+		{
+			name:           "explicit port",
+			target:         "api.vendor.example:6443",
+			wantNormalized: "api.vendor.example:6443",
+			wantHost:       "api.vendor.example",
+			wantPort:       "6443",
+			wantScanURL:    "https://api.vendor.example:6443/",
+		},
+		{
+			name:           "bare host defaults once",
+			target:         "api.vendor.example",
+			wantNormalized: "api.vendor.example:443",
+			wantHost:       "api.vendor.example",
+			wantPort:       "443",
+			wantScanURL:    "https://api.vendor.example:443/",
+		},
+		{
+			name:           "bracketed IPv6 explicit port",
+			target:         "[2001:db8::1]:6443",
+			wantNormalized: "[2001:db8::1]:6443",
+			wantHost:       "2001:db8::1",
+			wantPort:       "6443",
+			wantScanURL:    "https://[2001:db8::1]:6443/",
+		},
+		{
+			name:           "bracketed IPv6 defaults once",
+			target:         "[2001:db8::1]",
+			wantNormalized: "[2001:db8::1]:443",
+			wantHost:       "2001:db8::1",
+			wantPort:       "443",
+			wantScanURL:    "https://[2001:db8::1]:443/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, host, port, scanURL := normalizeConnectTarget(tt.target)
+			if normalized != tt.wantNormalized || host != tt.wantHost || port != tt.wantPort || scanURL != tt.wantScanURL {
+				t.Fatalf("normalizeConnectTarget(%q) = (%q, %q, %q, %q), want (%q, %q, %q, %q)", tt.target, normalized, host, port, scanURL, tt.wantNormalized, tt.wantHost, tt.wantPort, tt.wantScanURL)
+			}
+		})
+	}
+}
+
 func TestSSRFSafeDialContext_DirectIP(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}

--- a/internal/proxy/ssrf_dial_block_test.go
+++ b/internal/proxy/ssrf_dial_block_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestSSRFDialSnapshotMultiAddressIPv6Binding(t *testing.T) {
+	ctx := withSSRFDialScanSnapshot(context.Background(), "REbind.test.", "443", []string{
+		"203.0.113.10",
+		"2001:db8::10",
+	})
+	ctx = withSSRFDialPort(ctx, "443")
+
+	if isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("2001:db8::10")) {
+		t.Fatal("IPv6 address returned at scan time was treated as a DNS rebind")
+	}
+	if !isSSRFDNSRebind(ctx, "rebind.test", net.ParseIP("fd00::1")) {
+		t.Fatal("new IPv6 address after a multi-address scan did not fail as a DNS rebind")
+	}
+}


### PR DESCRIPTION
## What changed

A CONNECT destination is now carried as one normalized host and port from capture through scanning, receipt target, and the dial. The forward proxy previously built a synthetic URL that dropped the port, so the thing that was scanned and the thing that was connected to could differ on port.

The SSRF dial snapshot is bound to both the normalized host and the port. A snapshot taken for a host on 443 no longer authorizes a dial to the same host on another port.

Bare `CONNECT host` resolves to 443 in one place rather than being derived separately by the scan and the dial, and IPv6 literals stay bracketed in the scanned URL.

## Why it matters beyond CONNECT

Destination identity is the assumption every later authorization check rests on. If the scanned destination and the dialled destination can disagree on any field, a check that passes describes a destination that was never contacted.

## Notes for reviewers

Coverage spans explicit ports, bare CONNECT, IPv6 in both explicit and defaulted forms, multi-address DNS answers, and a resolution that changes between scan and dial. The dial still resolves independently and rejects private and metadata results, so the snapshot narrows what a permitted scan authorizes rather than replacing the dial-time check.

Legitimate round-robin answers observed during the scan remain valid, and only a newly resolved address is treated as a rebind, so this does not refuse traffic that was previously allowed.

Neutralizing only the port comparison makes the binding tests fail across CONNECT, absolute-URI forward, and fetch, so the guard is doing the work the tests claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS CONNECT handling when targets omit ports, defaulting securely to port 443.
  * Fixed handling of IPv6 targets, including bracketed and bare IPv6 addresses.
  * Preserved explicitly specified ports across connection, scanning, and generated HTTPS target URLs.
  * Rejected malformed CONNECT authorities and invalid ports with a clear bad-request response.
  * Improved SSRF protection consistency when validating IPv6 addresses returned through DNS resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->