### PR TITLE
feat(verifiers): align lifecycle evidence verdicts

### DIFF
--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -218,6 +218,24 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, chainErr)
 	}
 	report.ChainCheck = chainStatusLabel(chainResult)
+	if !chainResult.Valid {
+		if len(chainReceipts) == 0 {
+			// Empty evidence has no chain whose integrity can be assessed, but it
+			// does have a useful completeness verdict for compatibility with the
+			// cross-language verifier contract.
+			lifecycle := completeness.Analyze(chainReceipts, chainResult)
+			report.LifecycleStatus = lifecycle.Status
+			report.LifecycleReason = lifecycle.Reason
+			report.LifecycleAssessment = lifecycleAssessed
+			report.LifecycleAssessmentReason = ""
+		}
+		// Completeness findings describe a chain whose integrity has already
+		// passed. Do not relabel a concrete signature, hash, trust, or sequence
+		// rejection as a lifecycle failure.
+		report.Errors = append(report.Errors, fmt.Sprintf("chain: %s", chainResult.Error))
+		emitReport(stdout, stderr, report, opts.jsonOutput)
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("packet chain rejected at seq %d: %s", chainResult.BrokenAtSeq, chainResult.Error))
+	}
 	lifecycle := completeness.Analyze(chainReceipts, chainResult)
 	report.LifecycleStatus = lifecycle.Status
 	report.LifecycleReason = lifecycle.Reason

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -346,13 +346,17 @@ func reverifyChain(baseDir string, packet *auditpacket.Packet, signerOverride st
 	if err != nil {
 		return receipt.ChainResult{}, nil, fmt.Errorf("extract receipts: %w", err)
 	}
-	if len(receipts) == 0 {
-		return receipt.ChainResult{}, nil, errors.New("empty chain")
-	}
 	keyHex := strings.TrimSpace(signerOverride)
 	resolvedKey, err := resolveSignerKey(keyHex)
 	if err != nil {
 		return receipt.ChainResult{}, nil, fmt.Errorf("resolve signer key: %w", err)
+	}
+	if len(receipts) == 0 {
+		// Empty evidence is a completed, failed chain verification rather than
+		// an inability to run verification. Keep it invalid while allowing the
+		// lifecycle analyzer to report UNVERIFIED/no_receipts, matching the
+		// TypeScript verifier's assessment contract.
+		return receipt.ChainResult{Valid: false, Error: "empty chain"}, receipts, nil
 	}
 	return receipt.VerifyChain(receipts, resolvedKey), receipts, nil
 }

--- a/cmd/pipelock-verifier/auditpacket.go
+++ b/cmd/pipelock-verifier/auditpacket.go
@@ -234,9 +234,15 @@ func runAuditPacket(stdout, stderr io.Writer, target string, opts auditPacketOpt
 	}
 	report.CrossCheck = statusPass
 
-	report.Valid = chainResult.Valid && trustVerdict(&packet, opts)
+	report.Valid = chainResult.Valid && lifecycle.Status != completeness.StatusBroken && trustVerdict(&packet, opts)
+	if lifecycle.Status == completeness.StatusBroken {
+		report.Errors = append(report.Errors, fmt.Sprintf("lifecycle: %s", lifecycle.Reason))
+	}
 	emitReport(stdout, stderr, report, opts.jsonOutput)
 	if !report.Valid {
+		if lifecycle.Status == completeness.StatusBroken {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("packet lifecycle broken: %s", lifecycle.Error))
+		}
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.New("packet not trusted"))
 	}
 	return nil

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -219,7 +219,7 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 		report.Error = unpinnedReceiptBanner
 		report.Valid = opts.allowUnpinned
 	}
-	if completenessReport.Status == completeness.StatusBroken {
+	if res.Valid && completenessReport.Status == completeness.StatusBroken {
 		report.Valid = false
 		report.Unpinned = false
 		report.Error = "lifecycle: " + string(completenessReport.Reason)

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -222,6 +222,7 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 	if res.Valid && completenessReport.Status == completeness.StatusBroken {
 		report.Valid = false
 		report.Unpinned = false
+		report.BrokenAtSeq = completenessReport.BrokenAtSeq
 		report.Error = "lifecycle: " + string(completenessReport.Reason)
 		if completenessReport.Error != "" {
 			report.Error += ": " + completenessReport.Error

--- a/cmd/pipelock-verifier/chain.go
+++ b/cmd/pipelock-verifier/chain.go
@@ -219,6 +219,14 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 		report.Error = unpinnedReceiptBanner
 		report.Valid = opts.allowUnpinned
 	}
+	if completenessReport.Status == completeness.StatusBroken {
+		report.Valid = false
+		report.Unpinned = false
+		report.Error = "lifecycle: " + string(completenessReport.Reason)
+		if completenessReport.Error != "" {
+			report.Error += ": " + completenessReport.Error
+		}
+	}
 	if res.Valid {
 		if lintErr := lintDeferredCascadeReceipts(receipts); lintErr != nil {
 			report.Valid = false
@@ -230,6 +238,9 @@ func verifyActionChain(stdout, stderr io.Writer, label string, receipts []action
 	emitChainReport(stdout, stderr, report, opts.jsonOutput)
 	if !res.Valid {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain rejected at seq %d: %s", res.BrokenAtSeq, res.Error))
+	}
+	if completenessReport.Status == completeness.StatusBroken {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain lifecycle broken: %s", completenessReport.Error))
 	}
 	if keyHex == "" && !opts.allowUnpinned {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("chain verification unpinned"))

--- a/cmd/pipelock-verifier/completeness.go
+++ b/cmd/pipelock-verifier/completeness.go
@@ -37,10 +37,9 @@ Pipelock can bound mediated egress it observed, but cannot prove the agent had
 no egress path outside that boundary.
 
 Exit-code contract:
-  0  analysis ran and the chain was not classified BROKEN; LIMITED and
-     UNVERIFIED are successful analyses
-  1  BROKEN chain/completeness evidence, unpinned non-empty chain without
-     --allow-unpinned, or another verifier failure
+  0  LIMITED bounded-completeness result
+  1  BROKEN or UNVERIFIED completeness evidence, unpinned non-empty chain
+     without --allow-unpinned, or another verifier failure
   2  tool, IO, extraction, or key-resolution error
  64  command-line usage error`,
 		Args:          exactOneArg,
@@ -108,6 +107,9 @@ func runCompleteness(stdout, stderr io.Writer, target string, opts completenessO
 	emitCompletenessReport(stdout, stderr, report, opts.jsonOutput)
 	if report.Status == completeness.StatusBroken {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("completeness broken: %s", report.Error))
+	}
+	if report.Status == completeness.StatusUnverified {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("completeness unverified: %s", report.Reason))
 	}
 	if report.Unpinned && !opts.allowUnpinned {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("completeness verification unpinned"))

--- a/cmd/pipelock-verifier/completeness.go
+++ b/cmd/pipelock-verifier/completeness.go
@@ -87,7 +87,11 @@ func runCompleteness(stdout, stderr io.Writer, target string, opts completenessO
 	chainResult := actionreceipt.VerifyChain(receipts, keyHex)
 	report := completeness.Analyze(receipts, chainResult)
 	report.Path = label
-	report.SignaturesVerified = chainResult.IntegrityVerified && keyHex != ""
+	// An empty chain has no signatures to verify. VerifyChain reports its
+	// integrity result separately so that lifecycle-only failures can retain
+	// their provenance detail, but that must not turn no evidence into a
+	// signatures-verified claim.
+	report.SignaturesVerified = len(receipts) > 0 && chainResult.IntegrityVerified && keyHex != ""
 	report.Unpinned = len(receipts) > 0 && chainResult.IntegrityVerified && keyHex == ""
 	if report.Unpinned && !opts.allowUnpinned {
 		// Append rather than overwrite: a report can be both Unpinned and

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -252,7 +252,7 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("lifecycle_no_open_exits_nonzero", func(t *testing.T) {
+	t.Run("integrity_verified_no_open_is_unverified", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -260,12 +260,12 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 			f.close(runNonce, openNonce),
 		})
 		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
-		if code != cliutil.ExitGeneral {
-			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+		if code != cliutil.ExitOK {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
 		}
 		report := parseCompletenessReport(t, stdout)
-		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken {
-			t.Fatalf("report=%s/%s, want BROKEN/chain_broken", report.Status, report.Reason)
+		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen {
+			t.Fatalf("report=%s/%s, want UNVERIFIED/no_open", report.Status, report.Reason)
 		}
 		if !report.SignaturesVerified {
 			t.Fatalf("signatures_verified=false, want true for signed malformed lifecycle: %#v", report)
@@ -294,7 +294,7 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("broken_no_open_without_key_stays_nonzero_with_unpinned_flag", func(t *testing.T) {
+	t.Run("unverified_no_open_requires_unpinned_opt_in", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -311,12 +311,12 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 
 		stdout, stderr, code = runRoot(t, "completeness", "--json", "--allow-unpinned", path)
-		if code != cliutil.ExitGeneral {
-			t.Fatalf("allow-unpinned code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+		if code != cliutil.ExitOK {
+			t.Fatalf("allow-unpinned code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
 		}
 		report = parseCompletenessReport(t, stdout)
-		if report.Status != completeness.StatusBroken || report.Reason != completeness.ReasonChainBroken || !report.Unpinned {
-			t.Fatalf("allow-unpinned report=%s/%s unpinned=%t, want BROKEN/chain_broken unpinned", report.Status, report.Reason, report.Unpinned)
+		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen || !report.Unpinned {
+			t.Fatalf("allow-unpinned report=%s/%s unpinned=%t, want UNVERIFIED/no_open unpinned", report.Status, report.Reason, report.Unpinned)
 		}
 	})
 

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -238,6 +238,20 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
+	t.Run("empty_chain_never_claims_signatures_verified", func(t *testing.T) {
+		t.Parallel()
+		f := newCompletenessFixture(t)
+		path := writeCompletenessJSONL(t, nil)
+		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
+		if code != cliutil.ExitOK {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
+		}
+		report := parseCompletenessReport(t, stdout)
+		if report.SignaturesVerified {
+			t.Fatalf("empty chain claimed signatures_verified: %#v", report)
+		}
+	})
+
 	t.Run("lifecycle_no_open_exits_nonzero", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
@@ -671,6 +685,33 @@ func TestChainCLIShowsCompletenessReasonForATailDroppedChain(t *testing.T) {
 	droppedLine := scorecardLine(t, droppedOut)
 	if closedLine == droppedLine {
 		t.Fatalf("a bounded chain and a tail-dropped one print the same completeness line: %s", closedLine)
+	}
+}
+
+func TestChainCLIRejectsLifecycleBrokenChain(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	path := writeChainRecorderJSONL(t, []receipt.Receipt{
+		fixture.open("run-chain-broken", "open-chain-broken"),
+		fixture.outcome("run-chain-broken", "outcome-without-intent"),
+	})
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code != cliutil.ExitGeneral {
+		t.Fatalf("lifecycle-broken chain code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+	}
+	var report chainReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout)
+	}
+	if report.Valid || report.Scorecard == nil {
+		t.Fatalf("lifecycle-broken chain accepted or omitted scorecard: %+v", report)
+	}
+	if report.Scorecard.Authentic.Status != "FAIL" || report.Scorecard.Untampered.Status != "FAIL" {
+		t.Fatalf("lifecycle-broken scorecard left a pass: %+v", report.Scorecard)
+	}
+	if !strings.Contains(report.Error, "lifecycle: chain_broken") {
+		t.Fatalf("missing lifecycle error: %q", report.Error)
 	}
 }
 

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -238,21 +238,24 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("empty_chain_never_claims_signatures_verified", func(t *testing.T) {
+	t.Run("empty_chain_is_unverified_and_exits_nonzero", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, nil)
 		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
-		if code != cliutil.ExitOK {
-			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 		}
 		report := parseCompletenessReport(t, stdout)
+		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoReceipts {
+			t.Fatalf("report=%s/%s, want UNVERIFIED/no_receipts", report.Status, report.Reason)
+		}
 		if report.SignaturesVerified {
 			t.Fatalf("empty chain claimed signatures_verified: %#v", report)
 		}
 	})
 
-	t.Run("integrity_verified_no_open_is_unverified", func(t *testing.T) {
+	t.Run("integrity_verified_no_open_is_unverified_and_exits_nonzero", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -260,8 +263,8 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 			f.close(runNonce, openNonce),
 		})
 		stdout, stderr, code := runRoot(t, "completeness", "--json", "--key", f.keyHex, path)
-		if code != cliutil.ExitOK {
-			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 		}
 		report := parseCompletenessReport(t, stdout)
 		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen {
@@ -294,7 +297,7 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("unverified_no_open_requires_unpinned_opt_in", func(t *testing.T) {
+	t.Run("unverified_no_open_remains_nonzero_with_unpinned_opt_in", func(t *testing.T) {
 		t.Parallel()
 		f := newCompletenessFixture(t)
 		path := writeCompletenessJSONL(t, []receipt.Receipt{
@@ -311,8 +314,8 @@ func TestCompletenessCLIJSONVerdictsAndExitCodes(t *testing.T) {
 		}
 
 		stdout, stderr, code = runRoot(t, "completeness", "--json", "--allow-unpinned", path)
-		if code != cliutil.ExitOK {
-			t.Fatalf("allow-unpinned code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitOK, stdout, stderr)
+		if code != cliutil.ExitGeneral {
+			t.Fatalf("allow-unpinned code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
 		}
 		report = parseCompletenessReport(t, stdout)
 		if report.Status != completeness.StatusUnverified || report.Reason != completeness.ReasonNoOpen || !report.Unpinned {
@@ -712,6 +715,13 @@ func TestChainCLIRejectsLifecycleBrokenChain(t *testing.T) {
 	}
 	if !strings.Contains(report.Error, "lifecycle: chain_broken") {
 		t.Fatalf("missing lifecycle error: %q", report.Error)
+	}
+	if report.BrokenAtSeq == 0 {
+		t.Fatalf("lifecycle break sequence omitted: %+v", report)
+	}
+	if report.Scorecard.Untampered.BrokenAtSeq != report.BrokenAtSeq {
+		t.Fatalf("scorecard break sequence = %d, want lifecycle break sequence %d: %+v",
+			report.Scorecard.Untampered.BrokenAtSeq, report.BrokenAtSeq, report.Scorecard.Untampered)
 	}
 }
 

--- a/cmd/pipelock-verifier/completeness_test.go
+++ b/cmd/pipelock-verifier/completeness_test.go
@@ -715,6 +715,29 @@ func TestChainCLIRejectsLifecycleBrokenChain(t *testing.T) {
 	}
 }
 
+func TestChainCLIPreservesIntegrityFailureInsteadOfRelabelingItAsLifecycle(t *testing.T) {
+	t.Parallel()
+	fixture := newCompletenessFixture(t)
+	chain := []receipt.Receipt{
+		fixture.open("run-integrity-broken", "open-integrity-broken"),
+		fixture.close("run-integrity-broken", "open-integrity-broken"),
+	}
+	chain[1].ActionRecord.Target = "https://api.vendor.example/forged"
+	path := writeChainRecorderJSONL(t, chain)
+
+	stdout, stderr, code := runRoot(t, "chain", "--json", "--key", fixture.keyHex, path)
+	if code != cliutil.ExitGeneral {
+		t.Fatalf("integrity-broken chain code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+	}
+	var report chainReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout)
+	}
+	if strings.Contains(report.Error, "lifecycle:") || !strings.Contains(report.Error, "signature") {
+		t.Fatalf("integrity error relabeled as lifecycle: %q", report.Error)
+	}
+}
+
 // The bare-v1 detector reads the whole file before deciding a route, so its
 // failure paths decide whether an unreadable or oversized file is refused or
 // silently falls through to the v2 route. Each case below drives the real

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -25,6 +25,7 @@ import (
 	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	auditpacket "github.com/luckyPipewrench/pipelock/sdk/audit-packet"
@@ -572,12 +573,24 @@ func TestAuditPacket_RejectsEmptyChain(t *testing.T) {
 	fix := newFixture(t, 0)
 	pkt := fix.writePacketDir(t, t.TempDir(), nil)
 
-	_, stderr, code := runRoot(t, "audit-packet", "--key", fix.keyHex, pkt)
+	stdout, stderr, code := runRoot(t, "audit-packet", "--json", "--key", fix.keyHex, pkt)
 	if code == cliutil.ExitOK {
 		t.Fatalf("empty audit-packet chain should fail, stderr=%q", stderr)
 	}
-	if !strings.Contains(stderr, "empty chain") {
-		t.Fatalf("expected empty-chain error, got %q", stderr)
+	var report auditPacketReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout)
+	}
+	if !strings.Contains(strings.Join(report.Errors, "\n"), "empty chain") {
+		t.Fatalf("expected empty-chain error, got report errors %q and stderr %q", report.Errors, stderr)
+	}
+	if report.LifecycleAssessment != lifecycleAssessed ||
+		report.LifecycleStatus != completeness.StatusUnverified ||
+		report.LifecycleReason != completeness.ReasonNoReceipts {
+		t.Fatalf("empty-chain lifecycle = assessment %q, status %q, reason %q; "+
+			"want assessed/%s/%s to match the TypeScript verifier",
+			report.LifecycleAssessment, report.LifecycleStatus, report.LifecycleReason,
+			completeness.StatusUnverified, completeness.ReasonNoReceipts)
 	}
 }
 

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -406,6 +406,66 @@ func TestAuditPacketRejectsLifecycleBrokenChain(t *testing.T) {
 	}
 }
 
+func TestAuditPacketPreservesChainFailureInsteadOfRelabelingItAsLifecycle(t *testing.T) {
+	t.Parallel()
+	fix := newFixture(t, 2)
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+	evidence := filepath.Join(dir, "evidence.jsonl")
+	raw, err := os.ReadFile(filepath.Clean(evidence))
+	if err != nil {
+		t.Fatalf("read evidence: %v", err)
+	}
+	// Flip one signature nibble after the packet is written. The recorder
+	// envelope and signature encoding remain valid, so this reaches
+	// cryptographic signature verification rather than the parser.
+	const signaturePrefix = `"signature":"ed25519:`
+	signatureOffset := bytes.Index(raw, []byte(signaturePrefix))
+	if signatureOffset < 0 {
+		t.Fatal("signature prefix not found in evidence")
+	}
+	tampered := append([]byte(nil), raw...)
+	signatureOffset += len(signaturePrefix)
+	if tampered[signatureOffset] == '0' {
+		tampered[signatureOffset] = '1'
+	} else {
+		tampered[signatureOffset] = '0'
+	}
+	if err := os.WriteFile(evidence, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered evidence: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = runAuditPacket(&stdout, &stderr, dir, auditPacketOptions{
+		signerKey:  fix.keyHex,
+		jsonOutput: true,
+	})
+	code := exitCodeFor(err)
+	if code != cliutil.ExitGeneral {
+		t.Fatalf("tampered packet code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout.String(), stderr.String())
+	}
+	var report auditPacketReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.ChainCheck != statusFail || report.Valid {
+		t.Fatalf("tampered chain report = %+v, want failed chain and invalid packet", report)
+	}
+	errorsText := strings.Join(report.Errors, "\n")
+	if !strings.Contains(errorsText, "signature verification failed") ||
+		strings.Contains(errorsText, "lifecycle:") {
+		t.Fatalf("chain failure must preserve signature detail without lifecycle label: %q", errorsText)
+	}
+	if report.LifecycleAssessment != lifecycleNotAssessed || report.LifecycleStatus != "" || report.LifecycleReason != "" {
+		t.Fatalf("invalid chain must not receive lifecycle assessment: %+v", report)
+	}
+	if err == nil || !strings.Contains(err.Error(), "packet chain rejected") ||
+		!strings.Contains(err.Error(), "signature verification failed") ||
+		strings.Contains(err.Error(), "packet lifecycle broken") {
+		t.Fatalf("terminal error must preserve chain failure without lifecycle label: %v", err)
+	}
+}
+
 func TestAuditPacket_ValidVerdictRequiresExternalTrustAnchor(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -370,6 +370,42 @@ func TestAuditPacketReportsInFlightLifecycleCompleteness(t *testing.T) {
 	}
 }
 
+func TestAuditPacketRejectsLifecycleBrokenChain(t *testing.T) {
+	t.Parallel()
+	lifecycle := newCompletenessFixture(t)
+	fix := &fixture{
+		pub:  lifecycle.priv.Public().(ed25519.PublicKey),
+		priv: lifecycle.priv,
+		receipts: []receipt.Receipt{
+			lifecycle.open("run-audit-broken", "open-audit-broken"),
+			// The outcome deliberately has no matching intent. Its signature and
+			// chain link are valid, so this proves the lifecycle boundary itself.
+			lifecycle.outcome("run-audit-broken", "outcome-without-intent"),
+		},
+		keyHex: lifecycle.keyHex,
+	}
+	dir := t.TempDir()
+	fix.writePacketDir(t, dir, nil)
+
+	stdout, stderr, code := runAuditPacketWithKey(t, fix.keyHex, "--json", dir)
+	if code != cliutil.ExitGeneral {
+		t.Fatalf("lifecycle-broken packet code=%d, want %d stdout=%q stderr=%q", code, cliutil.ExitGeneral, stdout, stderr)
+	}
+	var report auditPacketReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout)
+	}
+	if report.Valid || report.ChainCheck != statusPass || report.CrossCheck != statusPass {
+		t.Fatalf("lifecycle-broken packet must fail after otherwise passing checks: %+v", report)
+	}
+	if report.LifecycleStatus != completeness.StatusBroken || report.LifecycleReason != completeness.ReasonChainBroken {
+		t.Fatalf("lifecycle = %s/%s, want BROKEN/chain_broken", report.LifecycleStatus, report.LifecycleReason)
+	}
+	if !strings.Contains(strings.Join(report.Errors, "\n"), "lifecycle: chain_broken") {
+		t.Fatalf("missing lifecycle failure detail: %+v", report.Errors)
+	}
+}
+
 func TestAuditPacket_ValidVerdictRequiresExternalTrustAnchor(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 2)

--- a/cmd/pipelock-verifier/scorecard.go
+++ b/cmd/pipelock-verifier/scorecard.go
@@ -78,6 +78,9 @@ func newActionScorecard(res actionreceipt.ChainResult, keyPinned bool, report co
 		authentic.Status = "FAIL"
 		authentic.Detail = appendScorecardDetail(authentic.Detail, detail)
 		untampered.Status = "FAIL"
+		if untampered.BrokenAtSeq == 0 {
+			untampered.BrokenAtSeq = report.BrokenAtSeq
+		}
 		untampered.Reason = appendScorecardDetail(untampered.Reason, detail)
 	}
 	gaps := uint64(0)

--- a/cmd/pipelock-verifier/scorecard.go
+++ b/cmd/pipelock-verifier/scorecard.go
@@ -67,6 +67,18 @@ func newActionScorecard(res actionreceipt.ChainResult, keyPinned bool, report co
 	if res.Valid || res.IntegrityVerified {
 		untampered = scorecardUntampered{Status: "PASS"}
 	}
+	if report.Status == completeness.StatusBroken {
+		// A signature-valid receipt stream can still be structurally impossible
+		// as lifecycle evidence (for example, an orphaned outcome). Neither
+		// authenticity nor tamper-evidence is safe to present as passing then.
+		detail := "lifecycle: " + string(report.Reason)
+		if report.Error != "" {
+			detail += ": " + report.Error
+		}
+		authentic.Status = "FAIL"
+		authentic.Detail = detail
+		untampered = scorecardUntampered{Status: "FAIL", Reason: detail}
+	}
 	gaps := uint64(0)
 	heartbeat := "continuous"
 	for _, run := range report.Runs {

--- a/cmd/pipelock-verifier/scorecard.go
+++ b/cmd/pipelock-verifier/scorecard.go
@@ -76,8 +76,9 @@ func newActionScorecard(res actionreceipt.ChainResult, keyPinned bool, report co
 			detail += ": " + report.Error
 		}
 		authentic.Status = "FAIL"
-		authentic.Detail = detail
-		untampered = scorecardUntampered{Status: "FAIL", Reason: detail}
+		authentic.Detail = appendScorecardDetail(authentic.Detail, detail)
+		untampered.Status = "FAIL"
+		untampered.Reason = appendScorecardDetail(untampered.Reason, detail)
 	}
 	gaps := uint64(0)
 	heartbeat := "continuous"
@@ -111,6 +112,13 @@ func newActionScorecard(res actionreceipt.ChainResult, keyPinned bool, report co
 			},
 		},
 	}
+}
+
+func appendScorecardDetail(existing, addition string) string {
+	if existing == "" {
+		return addition
+	}
+	return existing + "; " + addition
 }
 
 func emitScorecard(out io.Writer, sc scorecard) {

--- a/cmd/pipelock-verifier/scorecard_test.go
+++ b/cmd/pipelock-verifier/scorecard_test.go
@@ -212,6 +212,25 @@ func TestNewActionScorecardStatusMapping(t *testing.T) {
 	}
 }
 
+func TestNewActionScorecardPreservesChainFailureDetailWhenLifecycleIsBroken(t *testing.T) {
+	sc := newActionScorecard(actionreceipt.ChainResult{
+		ReceiptCount:  3,
+		BrokenAtSeq:   2,
+		Error:         "hash link mismatch",
+		FailureKind:   actionreceipt.ChainFailureIntegrity,
+		BrokenAtIndex: 2,
+	}, false, completeness.Report{Status: completeness.StatusBroken, Reason: completeness.ReasonChainBroken})
+
+	if !strings.Contains(sc.Authentic.Detail, "no trusted signer key pinned") ||
+		!strings.Contains(sc.Authentic.Detail, "lifecycle: chain_broken") {
+		t.Fatalf("authentic detail lost evidence: %q", sc.Authentic.Detail)
+	}
+	if sc.Untampered.BrokenAtSeq != 2 || !strings.Contains(sc.Untampered.Reason, "hash link mismatch") ||
+		!strings.Contains(sc.Untampered.Reason, "lifecycle: chain_broken") {
+		t.Fatalf("untampered detail lost evidence: %+v", sc.Untampered)
+	}
+}
+
 func scorecardLine(t *testing.T, out string) string {
 	t.Helper()
 	for _, line := range strings.Split(out, "\n") {

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -128,6 +128,15 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 	if !chainResult.Valid && !isLifecycleOnlyChainFailure(chainResult) {
 		return brokenReport(report, chainResult)
 	}
+	if isLifecycleOnlyChainFailure(chainResult) {
+		// The chain verifier proved signatures and linkage, but it could not
+		// establish the run's opening boundary. That is incomplete evidence, not
+		// a forged or contradictory transcript.
+		report.Status = StatusUnverified
+		report.Reason = ReasonNoOpen
+		report.Error = chainResult.Error
+		return report
+	}
 
 	if !hasSessionControl(chain) {
 		report.Status = StatusUnverified

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -92,6 +92,9 @@ type runState struct {
 	hasOpen  bool
 	intents  map[string]int
 	outcomes map[string]int
+	// firstOutcomeSeq records the first outcome for each action so a
+	// terminal outcome-without-intent finding can retain the failing receipt.
+	firstOutcomeSeq map[string]uint64
 
 	lastBeat uint64
 	sawBeat  bool
@@ -167,8 +170,9 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 				Reason:              ReasonBoundedClosed,
 				DurabilityMonotonic: true,
 			},
-			intents:  make(map[string]int),
-			outcomes: make(map[string]int),
+			intents:         make(map[string]int),
+			outcomes:        make(map[string]int),
+			firstOutcomeSeq: make(map[string]uint64),
 		}
 		states[runNonce] = st
 		order = append(order, runNonce)
@@ -178,6 +182,20 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 	var previous receipt.ActionRecord
 	hasPrevious := false
 	var segmentPrefixCount uint64
+	type observedRecord struct {
+		seq   uint64
+		index int
+	}
+	firstRecordByRun := make(map[string]observedRecord)
+	structuralBrokenAtSeqSet := false
+	markStructural := func(st *runState, violation string, seq uint64, index int) {
+		markStructuralViolation(st, violation)
+		if !structuralBrokenAtSeqSet {
+			report.BrokenAtSeq = seq
+			report.BrokenAtIndex = index
+			structuralBrokenAtSeqSet = true
+		}
+	}
 	for i := range chain {
 		ar := chain[i].ActionRecord
 		// session_close carries the emitter's SEGMENT-LOCAL FinalSeq/ReceiptCount,
@@ -201,10 +219,15 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		hasPrevious = true
 
 		runNonce := effectiveRunNonce(ar)
+		if runNonce != "" {
+			if _, ok := firstRecordByRun[runNonce]; !ok {
+				firstRecordByRun[runNonce] = observedRecord{seq: ar.ChainSeq, index: i}
+			}
+		}
 		if ar.SessionControl == nil {
 			if violation := validateLifecycleAction(lifecycle, ar); violation != "" {
 				st := getRun(runNonce)
-				markStructuralViolation(st, violation)
+				markStructural(st, violation, ar.ChainSeq, i)
 				segmentPrefixCount++
 				continue
 			}
@@ -212,7 +235,7 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		if runNonce != "" || ar.SessionControl != nil {
 			st := getRun(runNonce)
 			if violation := applyRecord(st, ar, ctx); violation != "" {
-				markStructuralViolation(st, violation)
+				markStructural(st, violation, ar.ChainSeq, i)
 			}
 			updateLifecycleState(lifecycle, ar)
 		}
@@ -223,12 +246,31 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		if runNonce == "(missing)" || lifecycle.opened[runNonce] {
 			continue
 		}
-		markStructuralViolation(states[runNonce], "receipt run_nonce has no matching session_open")
+		first := firstRecordByRun[runNonce]
+		markStructural(states[runNonce], "receipt run_nonce has no matching session_open", first.seq, first.index)
 	}
 
 	for _, runNonce := range order {
 		st := states[runNonce]
 		finalizeRun(st)
+		if st.report.Status == StatusBroken && !structuralBrokenAtSeqSet {
+			var firstOrphanSeq uint64
+			foundOrphan := false
+			for actionID := range st.outcomes {
+				if st.intents[actionID] != 0 {
+					continue
+				}
+				seq := st.firstOutcomeSeq[actionID]
+				if !foundOrphan || seq < firstOrphanSeq {
+					firstOrphanSeq = seq
+					foundOrphan = true
+				}
+			}
+			if foundOrphan {
+				report.BrokenAtSeq = firstOrphanSeq
+				structuralBrokenAtSeqSet = true
+			}
+		}
 		report.Runs = append(report.Runs, st.report)
 		report.Status, report.Reason = worse(report.Status, report.Reason, st.report.Status, st.report.Reason)
 	}
@@ -346,6 +388,12 @@ func applyRecord(st *runState, ar receipt.ActionRecord, ctx recordContext) strin
 	case receipt.DecisionPhaseOutcome:
 		st.report.Outcomes++
 		st.outcomes[ar.ActionID]++
+		if st.firstOutcomeSeq == nil {
+			st.firstOutcomeSeq = make(map[string]uint64)
+		}
+		if _, ok := st.firstOutcomeSeq[ar.ActionID]; !ok {
+			st.firstOutcomeSeq[ar.ActionID] = ar.ChainSeq
+		}
 	}
 
 	ctrl := ar.SessionControl

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -8,6 +8,8 @@ package completeness
 
 import "github.com/luckyPipewrench/pipelock/internal/receipt"
 
+const maxSafeLifecycleInteger uint64 = 9_007_199_254_740_991
+
 // Status is the top-level completeness status vocabulary.
 type Status string
 
@@ -403,6 +405,11 @@ func applyHeartbeat(st *runState, ar receipt.ActionRecord, heartbeat *receipt.Se
 	if heartbeat == nil {
 		return "heartbeat kind missing heartbeat payload"
 	}
+	if heartbeat.Beat > maxSafeLifecycleInteger ||
+		heartbeat.FsyncErrorsGated > maxSafeLifecycleInteger ||
+		heartbeat.DurabilityBlocks > maxSafeLifecycleInteger {
+		return "heartbeat lifecycle counter exceeds the cross-language safe integer range"
+	}
 	if ar.RunNonce == "" || heartbeat.RunNonce != ar.RunNonce {
 		return "heartbeat run_nonce does not match receipt run_nonce"
 	}
@@ -441,6 +448,10 @@ func applyHeartbeat(st *runState, ar receipt.ActionRecord, heartbeat *receipt.Se
 func applyClose(st *runState, ar receipt.ActionRecord, closeRecord *receipt.SessionClose, ctx recordContext) string {
 	if closeRecord == nil {
 		return "session_close kind missing close payload"
+	}
+	if closeRecord.FsyncErrorsGated > maxSafeLifecycleInteger ||
+		closeRecord.DurabilityBlocks > maxSafeLifecycleInteger {
+		return "session_close lifecycle counter exceeds the cross-language safe integer range"
 	}
 	if ar.RunNonce == "" || closeRecord.RunNonce != ar.RunNonce {
 		return "session_close run_nonce does not match receipt run_nonce"

--- a/internal/evidence/completeness/completeness.go
+++ b/internal/evidence/completeness/completeness.go
@@ -95,6 +95,10 @@ type runState struct {
 	// firstOutcomeSeq records the first outcome for each action so a
 	// terminal outcome-without-intent finding can retain the failing receipt.
 	firstOutcomeSeq map[string]uint64
+	// firstOutcomeIndex is the receipt's position in the supplied chain. Chain
+	// sequence numbers restart at a key transition, so this is the stable way
+	// to select the first orphan outcome across segments.
+	firstOutcomeIndex map[string]int
 
 	lastBeat uint64
 	sawBeat  bool
@@ -170,9 +174,10 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 				Reason:              ReasonBoundedClosed,
 				DurabilityMonotonic: true,
 			},
-			intents:         make(map[string]int),
-			outcomes:        make(map[string]int),
-			firstOutcomeSeq: make(map[string]uint64),
+			intents:           make(map[string]int),
+			outcomes:          make(map[string]int),
+			firstOutcomeSeq:   make(map[string]uint64),
+			firstOutcomeIndex: make(map[string]int),
 		}
 		states[runNonce] = st
 		order = append(order, runNonce)
@@ -234,7 +239,7 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		}
 		if runNonce != "" || ar.SessionControl != nil {
 			st := getRun(runNonce)
-			if violation := applyRecord(st, ar, ctx); violation != "" {
+			if violation := applyRecordAt(st, ar, ctx, i); violation != "" {
 				markStructural(st, violation, ar.ChainSeq, i)
 			}
 			updateLifecycleState(lifecycle, ar)
@@ -254,20 +259,24 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 		st := states[runNonce]
 		finalizeRun(st)
 		if st.report.Status == StatusBroken && !structuralBrokenAtSeqSet {
-			var firstOrphanSeq uint64
+			var firstOrphan observedRecord
 			foundOrphan := false
 			for actionID := range st.outcomes {
 				if st.intents[actionID] != 0 {
 					continue
 				}
-				seq := st.firstOutcomeSeq[actionID]
-				if !foundOrphan || seq < firstOrphanSeq {
-					firstOrphanSeq = seq
+				orphan := observedRecord{
+					seq:   st.firstOutcomeSeq[actionID],
+					index: st.firstOutcomeIndex[actionID],
+				}
+				if !foundOrphan || orphan.index < firstOrphan.index {
+					firstOrphan = orphan
 					foundOrphan = true
 				}
 			}
 			if foundOrphan {
-				report.BrokenAtSeq = firstOrphanSeq
+				report.BrokenAtSeq = firstOrphan.seq
+				report.BrokenAtIndex = firstOrphan.index
 				structuralBrokenAtSeqSet = true
 			}
 		}
@@ -280,10 +289,10 @@ func Analyze(chain []receipt.Receipt, chainResult receipt.ChainResult) Report {
 	}
 	if report.Status == StatusBroken {
 		report.Error = firstBrokenRunError(report.Runs, chainResult.Error)
-		if report.BrokenAtSeq == 0 {
+		if !structuralBrokenAtSeqSet {
 			report.BrokenAtSeq = chainResult.BrokenAtSeq
+			report.BrokenAtIndex = chainResult.BrokenAtIndex
 		}
-		report.BrokenAtIndex = chainResult.BrokenAtIndex
 		return report
 	}
 	if !chainResult.Valid {
@@ -377,6 +386,10 @@ func markStructuralViolation(st *runState, violation string) {
 }
 
 func applyRecord(st *runState, ar receipt.ActionRecord, ctx recordContext) string {
+	return applyRecordAt(st, ar, ctx, -1)
+}
+
+func applyRecordAt(st *runState, ar receipt.ActionRecord, ctx recordContext, index int) string {
 	if st.report.Closed {
 		return "record observed after session_close"
 	}
@@ -391,8 +404,14 @@ func applyRecord(st *runState, ar receipt.ActionRecord, ctx recordContext) strin
 		if st.firstOutcomeSeq == nil {
 			st.firstOutcomeSeq = make(map[string]uint64)
 		}
+		if st.firstOutcomeIndex == nil {
+			st.firstOutcomeIndex = make(map[string]int)
+		}
 		if _, ok := st.firstOutcomeSeq[ar.ActionID]; !ok {
 			st.firstOutcomeSeq[ar.ActionID] = ar.ChainSeq
+			if index >= 0 {
+				st.firstOutcomeIndex[ar.ActionID] = index
+			}
 		}
 	}
 

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -414,7 +414,7 @@ func TestAnalyzeReasons(t *testing.T) {
 	}
 }
 
-func TestAnalyzeNoOpenIsBroken(t *testing.T) {
+func TestAnalyzeIntegrityVerifiedNoOpenIsUnverified(t *testing.T) {
 	t.Parallel()
 	b := newChainBuilder(t)
 	chain := []receipt.Receipt{
@@ -426,9 +426,8 @@ func TestAnalyzeNoOpenIsBroken(t *testing.T) {
 		t.Fatal("fixture should trigger the existing chain verifier no-open rejection")
 	}
 	report := Analyze(chain, res)
-	run := requireOneRun(t, report, StatusBroken, ReasonChainBroken)
-	if run.StructuralViolation != "heartbeat observed before session_open" {
-		t.Fatalf("structural_violation = %q, want heartbeat before open: %#v", run.StructuralViolation, run)
+	if report.Status != StatusUnverified || report.Reason != ReasonNoOpen {
+		t.Fatalf("report = %s/%s, want UNVERIFIED/no_open: %#v", report.Status, report.Reason, report)
 	}
 }
 
@@ -861,8 +860,8 @@ func TestAnalyzeOnlyMissingOpenIntegrityFailureDowngrades(t *testing.T) {
 		},
 		"missing_open_with_integrity": {
 			chainResult: receipt.ChainResult{FailureKind: receipt.ChainFailureLifecycleOpen, IntegrityVerified: true, Error: "missing open"},
-			wantStatus:  StatusBroken,
-			wantReason:  ReasonChainBroken,
+			wantStatus:  StatusUnverified,
+			wantReason:  ReasonNoOpen,
 		},
 	}
 

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -706,6 +706,107 @@ func TestAnalyzeHeartbeatClaimsMustMatchObservedPrefix(t *testing.T) {
 	}
 }
 
+func TestAnalyzeLifecycleCountersRespectCrossLanguageSafeIntegerBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		build          func(*chainBuilder, uint64) []receipt.Receipt
+		wantViolation  string
+		assertAccepted func(*testing.T, RunReport)
+	}{
+		{
+			name: "heartbeat_beat",
+			build: func(b *chainBuilder, value uint64) []receipt.Receipt {
+				return []receipt.Receipt{b.open(), b.heartbeat(value, 0, 1), b.close(0, 1)}
+			},
+			wantViolation: "heartbeat lifecycle counter exceeds the cross-language safe integer range",
+			assertAccepted: func(t *testing.T, run RunReport) {
+				t.Helper()
+				if run.Heartbeats != 1 {
+					t.Fatalf("heartbeats = %d, want 1: %#v", run.Heartbeats, run)
+				}
+			},
+		},
+		{
+			name: "heartbeat_fsync_errors_gated",
+			build: func(b *chainBuilder, value uint64) []receipt.Receipt {
+				return []receipt.Receipt{b.open(), b.heartbeat(1, value, 1), b.close(value, 1)}
+			},
+			wantViolation: "heartbeat lifecycle counter exceeds the cross-language safe integer range",
+			assertAccepted: func(t *testing.T, run RunReport) {
+				t.Helper()
+				if run.LastHeartbeat == nil || run.LastHeartbeat.FsyncErrorsGated != maxSafeLifecycleInteger {
+					t.Fatalf("last heartbeat = %#v, want fsync_errors_gated=%d", run.LastHeartbeat, maxSafeLifecycleInteger)
+				}
+			},
+		},
+		{
+			name: "heartbeat_durability_blocks",
+			build: func(b *chainBuilder, value uint64) []receipt.Receipt {
+				return []receipt.Receipt{b.open(), b.heartbeat(1, 0, value), b.close(0, value)}
+			},
+			wantViolation: "heartbeat lifecycle counter exceeds the cross-language safe integer range",
+			assertAccepted: func(t *testing.T, run RunReport) {
+				t.Helper()
+				if run.LastHeartbeat == nil || run.LastHeartbeat.DurabilityBlocks != maxSafeLifecycleInteger {
+					t.Fatalf("last heartbeat = %#v, want durability_blocks=%d", run.LastHeartbeat, maxSafeLifecycleInteger)
+				}
+			},
+		},
+		{
+			name: "session_close_fsync_errors_gated",
+			build: func(b *chainBuilder, value uint64) []receipt.Receipt {
+				return []receipt.Receipt{b.open(), b.heartbeat(1, 0, 1), b.close(value, 1)}
+			},
+			wantViolation: "session_close lifecycle counter exceeds the cross-language safe integer range",
+			assertAccepted: func(t *testing.T, run RunReport) {
+				t.Helper()
+				if run.Close == nil || run.Close.FsyncErrorsGated != maxSafeLifecycleInteger {
+					t.Fatalf("close = %#v, want fsync_errors_gated=%d", run.Close, maxSafeLifecycleInteger)
+				}
+			},
+		},
+		{
+			name: "session_close_durability_blocks",
+			build: func(b *chainBuilder, value uint64) []receipt.Receipt {
+				return []receipt.Receipt{b.open(), b.heartbeat(1, 0, 1), b.close(0, value)}
+			},
+			wantViolation: "session_close lifecycle counter exceeds the cross-language safe integer range",
+			assertAccepted: func(t *testing.T, run RunReport) {
+				t.Helper()
+				if run.Close == nil || run.Close.DurabilityBlocks != maxSafeLifecycleInteger {
+					t.Fatalf("close = %#v, want durability_blocks=%d", run.Close, maxSafeLifecycleInteger)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			acceptedBuilder := newChainBuilder(t)
+			accepted := analyzeBuiltIntegrityOnly(tc.build(acceptedBuilder, maxSafeLifecycleInteger), acceptedBuilder.keyHex)
+			acceptedRun := requireOneRun(t, accepted, StatusLimited, accepted.Reason)
+			if acceptedRun.StructuralViolation != "" {
+				t.Fatalf("max safe integer was rejected: %#v", acceptedRun)
+			}
+			tc.assertAccepted(t, acceptedRun)
+
+			rejectedBuilder := newChainBuilder(t)
+			rejected := analyzeBuiltIntegrityOnly(tc.build(rejectedBuilder, maxSafeLifecycleInteger+1), rejectedBuilder.keyHex)
+			rejectedRun := requireOneRun(t, rejected, StatusBroken, ReasonChainBroken)
+			if rejectedRun.StructuralViolation != tc.wantViolation {
+				t.Fatalf("structural_violation = %q, want %q", rejectedRun.StructuralViolation, tc.wantViolation)
+			}
+			if rejected.BrokenAtSeq == 0 {
+				t.Fatalf("rejected report omitted the nonzero break sequence: %#v", rejected)
+			}
+		})
+	}
+}
+
 func TestAnalyzeDurabilityCountersArePerRun(t *testing.T) {
 	t.Parallel()
 
@@ -891,6 +992,9 @@ func TestAnalyzeOutcomeWithoutIntentIsBroken(t *testing.T) {
 	}
 	if run.StructuralViolation != "outcome without matching intent" {
 		t.Fatalf("structural_violation = %q", run.StructuralViolation)
+	}
+	if report.BrokenAtSeq != chain[1].ActionRecord.ChainSeq {
+		t.Fatalf("broken_at_seq = %d, want orphan outcome seq %d", report.BrokenAtSeq, chain[1].ActionRecord.ChainSeq)
 	}
 }
 

--- a/internal/evidence/completeness/completeness_test.go
+++ b/internal/evidence/completeness/completeness_test.go
@@ -671,6 +671,9 @@ func TestAnalyzeLifecycleChainRejectsActionsOutsideOpenedRun(t *testing.T) {
 			if run.StructuralViolation != tc.wantViolation {
 				t.Fatalf("structural_violation = %q, want %q: %#v", run.StructuralViolation, tc.wantViolation, run)
 			}
+			if name == "pre_open_action" && report.BrokenAtIndex != 0 {
+				t.Fatalf("pre-open action broken_at_index = %d, want index 0 preserved: %#v", report.BrokenAtIndex, report)
+			}
 		})
 	}
 }
@@ -995,6 +998,9 @@ func TestAnalyzeOutcomeWithoutIntentIsBroken(t *testing.T) {
 	}
 	if report.BrokenAtSeq != chain[1].ActionRecord.ChainSeq {
 		t.Fatalf("broken_at_seq = %d, want orphan outcome seq %d", report.BrokenAtSeq, chain[1].ActionRecord.ChainSeq)
+	}
+	if report.BrokenAtIndex != 1 {
+		t.Fatalf("broken_at_index = %d, want first orphan outcome index 1", report.BrokenAtIndex)
 	}
 }
 

--- a/internal/evidence/completeness/lifecycle_vectors_test.go
+++ b/internal/evidence/completeness/lifecycle_vectors_test.go
@@ -59,40 +59,47 @@ func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
 		"durability_decrease": false, "missing_run_nonce": false,
 		"null_session_control": false,
 	}
+	sawGoDecodeError := false
 
 	for i := range file.Vectors {
 		vector := &file.Vectors[i]
-		if _, ok := required[vector.Name]; ok {
-			required[vector.Name] = true
-		}
-		receipts, err := decodeLifecycleVectorReceipts(vector.Receipts)
-		if vector.GoDecodeError {
-			if err == nil {
-				t.Fatalf("%s decoded successfully, want Go parser rejection", vector.Name)
+		t.Run(vector.Name, func(t *testing.T) {
+			if _, ok := required[vector.Name]; ok {
+				required[vector.Name] = true
 			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("%s: decode receipts: %v", vector.Name, err)
-		}
-		report := Analyze(receipts, receipt.ChainResult{
-			Valid:             vector.ChainResult.Valid,
-			IntegrityVerified: vector.ChainResult.IntegrityVerified,
-			FailureKind:       receipt.ChainFailureKind(vector.ChainResult.FailureKind),
+			receipts, err := decodeLifecycleVectorReceipts(vector.Receipts)
+			if vector.GoDecodeError {
+				sawGoDecodeError = true
+				if err == nil {
+					t.Fatalf("decoded successfully, want Go parser rejection")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decode receipts: %v", err)
+			}
+			report := Analyze(receipts, receipt.ChainResult{
+				Valid:             vector.ChainResult.Valid,
+				IntegrityVerified: vector.ChainResult.IntegrityVerified,
+				FailureKind:       receipt.ChainFailureKind(vector.ChainResult.FailureKind),
+			})
+			actual := lifecycleExpected{Status: report.Status, Reason: report.Reason}
+			if *updateLifecycleVectors {
+				vector.Expected = actual
+				return
+			}
+			if actual != vector.Expected {
+				t.Fatalf("got %s/%s, want %s/%s", actual.Status, actual.Reason, vector.Expected.Status, vector.Expected.Reason)
+			}
 		})
-		actual := lifecycleExpected{Status: report.Status, Reason: report.Reason}
-		if *updateLifecycleVectors {
-			vector.Expected = actual
-			continue
-		}
-		if actual != vector.Expected {
-			t.Fatalf("%s = %s/%s, want %s/%s", vector.Name, actual.Status, actual.Reason, vector.Expected.Status, vector.Expected.Reason)
-		}
 	}
 	for name, present := range required {
 		if !present {
 			t.Fatalf("lifecycle vector %q is missing", name)
 		}
+	}
+	if !sawGoDecodeError {
+		t.Fatal("lifecycle vector file has no Go parser rejection vector")
 	}
 	if !*updateLifecycleVectors {
 		return

--- a/internal/evidence/completeness/lifecycle_vectors_test.go
+++ b/internal/evidence/completeness/lifecycle_vectors_test.go
@@ -40,7 +40,7 @@ type lifecycleExpected struct {
 
 func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
 	path := filepath.Join("..", "..", "..", "sdk", "conformance", "testdata", "lifecycle-verdict-vectors.json")
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		t.Fatalf("read lifecycle vectors: %v", err)
 	}

--- a/internal/evidence/completeness/lifecycle_vectors_test.go
+++ b/internal/evidence/completeness/lifecycle_vectors_test.go
@@ -21,10 +21,11 @@ type lifecycleVectorFile struct {
 }
 
 type lifecycleVector struct {
-	Name        string            `json:"name"`
-	Receipts    []json.RawMessage `json:"receipts"`
-	ChainResult lifecycleChain    `json:"chain_result"`
-	Expected    lifecycleExpected `json:"expected"`
+	Name          string            `json:"name"`
+	Receipts      []json.RawMessage `json:"receipts"`
+	ChainResult   lifecycleChain    `json:"chain_result"`
+	Expected      lifecycleExpected `json:"expected"`
+	GoDecodeError bool              `json:"go_decode_error,omitempty"`
 }
 
 type lifecycleChain struct {
@@ -64,7 +65,16 @@ func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
 		if _, ok := required[vector.Name]; ok {
 			required[vector.Name] = true
 		}
-		receipts := decodeLifecycleVectorReceipts(t, vector.Receipts)
+		receipts, err := decodeLifecycleVectorReceipts(vector.Receipts)
+		if vector.GoDecodeError {
+			if err == nil {
+				t.Fatalf("%s decoded successfully, want Go parser rejection", vector.Name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: decode receipts: %v", vector.Name, err)
+		}
 		report := Analyze(receipts, receipt.ChainResult{
 			Valid:             vector.ChainResult.Valid,
 			IntegrityVerified: vector.ChainResult.IntegrityVerified,
@@ -97,13 +107,12 @@ func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
 	}
 }
 
-func decodeLifecycleVectorReceipts(t *testing.T, raw []json.RawMessage) []receipt.Receipt {
-	t.Helper()
+func decodeLifecycleVectorReceipts(raw []json.RawMessage) ([]receipt.Receipt, error) {
 	receipts := make([]receipt.Receipt, len(raw))
 	for i := range raw {
 		if err := json.Unmarshal(raw[i], &receipts[i]); err != nil {
-			t.Fatalf("decode receipt %d: %v", i, err)
+			return nil, err
 		}
 	}
-	return receipts
+	return receipts, nil
 }

--- a/internal/evidence/completeness/lifecycle_vectors_test.go
+++ b/internal/evidence/completeness/lifecycle_vectors_test.go
@@ -55,7 +55,8 @@ func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
 		"no_receipts": false, "no_lifecycle": false, "no_open": false,
 		"bounded_closed": false, "abnormal_end": false, "open_action": false,
 		"heartbeat_gap": false, "orphan_outcome": false, "duplicate_outcome": false,
-		"durability_decrease": false,
+		"durability_decrease": false, "missing_run_nonce": false,
+		"null_session_control": false,
 	}
 
 	for i := range file.Vectors {

--- a/internal/evidence/completeness/lifecycle_vectors_test.go
+++ b/internal/evidence/completeness/lifecycle_vectors_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package completeness
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+var updateLifecycleVectors = flag.Bool("update-lifecycle-vectors", false, "write lifecycle vector verdicts computed by Go")
+
+type lifecycleVectorFile struct {
+	GeneratedBy string            `json:"generated_by"`
+	Vectors     []lifecycleVector `json:"vectors"`
+}
+
+type lifecycleVector struct {
+	Name        string            `json:"name"`
+	Receipts    []json.RawMessage `json:"receipts"`
+	ChainResult lifecycleChain    `json:"chain_result"`
+	Expected    lifecycleExpected `json:"expected"`
+}
+
+type lifecycleChain struct {
+	Valid             bool   `json:"valid"`
+	IntegrityVerified bool   `json:"integrity_verified,omitempty"`
+	FailureKind       string `json:"failure_kind,omitempty"`
+}
+
+type lifecycleExpected struct {
+	Status Status `json:"status"`
+	Reason Reason `json:"reason"`
+}
+
+func TestLifecycleVerdictVectorsMatchGo(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "sdk", "conformance", "testdata", "lifecycle-verdict-vectors.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read lifecycle vectors: %v", err)
+	}
+	var file lifecycleVectorFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		t.Fatalf("decode lifecycle vectors: %v", err)
+	}
+	if len(file.Vectors) == 0 {
+		t.Fatal("lifecycle vector file is empty")
+	}
+	required := map[string]bool{
+		"no_receipts": false, "no_lifecycle": false, "no_open": false,
+		"bounded_closed": false, "abnormal_end": false, "open_action": false,
+		"heartbeat_gap": false, "orphan_outcome": false, "duplicate_outcome": false,
+		"durability_decrease": false,
+	}
+
+	for i := range file.Vectors {
+		vector := &file.Vectors[i]
+		if _, ok := required[vector.Name]; ok {
+			required[vector.Name] = true
+		}
+		receipts := decodeLifecycleVectorReceipts(t, vector.Receipts)
+		report := Analyze(receipts, receipt.ChainResult{
+			Valid:             vector.ChainResult.Valid,
+			IntegrityVerified: vector.ChainResult.IntegrityVerified,
+			FailureKind:       receipt.ChainFailureKind(vector.ChainResult.FailureKind),
+		})
+		actual := lifecycleExpected{Status: report.Status, Reason: report.Reason}
+		if *updateLifecycleVectors {
+			vector.Expected = actual
+			continue
+		}
+		if actual != vector.Expected {
+			t.Fatalf("%s = %s/%s, want %s/%s", vector.Name, actual.Status, actual.Reason, vector.Expected.Status, vector.Expected.Reason)
+		}
+	}
+	for name, present := range required {
+		if !present {
+			t.Fatalf("lifecycle vector %q is missing", name)
+		}
+	}
+	if !*updateLifecycleVectors {
+		return
+	}
+	file.GeneratedBy = "go test ./internal/evidence/completeness -run TestLifecycleVerdictVectorsMatchGo -update-lifecycle-vectors"
+	encoded, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		t.Fatalf("encode generated lifecycle vectors: %v", err)
+	}
+	if err := os.WriteFile(path, append(encoded, '\n'), 0o600); err != nil {
+		t.Fatalf("write generated lifecycle vectors: %v", err)
+	}
+}
+
+func decodeLifecycleVectorReceipts(t *testing.T, raw []json.RawMessage) []receipt.Receipt {
+	t.Helper()
+	receipts := make([]receipt.Receipt, len(raw))
+	for i := range raw {
+		if err := json.Unmarshal(raw[i], &receipts[i]); err != nil {
+			t.Fatalf("decode receipt %d: %v", i, err)
+		}
+	}
+	return receipts
+}

--- a/internal/evidence/completeness/malformed_evidence_security_test.go
+++ b/internal/evidence/completeness/malformed_evidence_security_test.go
@@ -412,7 +412,7 @@ func TestLifecycleOnlyIntegrityWarningIsPreserved(t *testing.T) {
 		IntegrityVerified: true,
 		Error:             "lifecycle verifier warning",
 	})
-	if report.Status != StatusLimited || report.Reason != ReasonAbnormalEnd {
+	if report.Status != StatusUnverified || report.Reason != ReasonNoOpen {
 		t.Fatalf("continued lifecycle analysis = %s/%s: %#v", report.Status, report.Reason, report)
 	}
 	if report.Error != "lifecycle verifier warning" {

--- a/internal/evidenceview/scorecard.go
+++ b/internal/evidenceview/scorecard.go
@@ -252,6 +252,14 @@ func completenessLine(chain receipt.ChainResult, receipts []receipt.Receipt) Lin
 			lifecycle.Reason,
 		)
 	}
+	if !chain.Valid {
+		return Line{
+			State:  StateFail,
+			Chip:   chipChainBroken,
+			Detail: detail,
+			Sub:    "Chain integrity verification failed; lifecycle evidence cannot be assessed.",
+		}
+	}
 	if lifecycle.Status == completeness.StatusBroken {
 		return Line{
 			State:  StateFail,

--- a/internal/evidenceview/scorecard.go
+++ b/internal/evidenceview/scorecard.go
@@ -84,14 +84,20 @@ func ComputeScorecard(receipts []receipt.Receipt, trustedKeys map[string]Trusted
 	}
 
 	anchoredState, anchoredChip, anchoredDetail, anchoredSub := anchorState(sessionID)
+	scorecard := Scorecard{
+		Authentic:    authentic,
+		Untampered:   untamperedLine(chain, len(receipts)),
+		Anchored:     Line{State: anchoredState, Chip: anchoredChip, Detail: anchoredDetail, Sub: anchoredSub},
+		Completeness: completenessLine(chain, receipts),
+	}
+	if lifecycle := completeness.Analyze(receipts, chain); chain.Valid && lifecycle.Status == completeness.StatusBroken {
+		detail := fmt.Sprintf("Lifecycle evidence is broken (%s); this session cannot be treated as authenticated or untampered.", lifecycle.Reason)
+		scorecard.Authentic = Line{State: StateFail, Chip: "Lifecycle broken", Detail: detail}
+		scorecard.Untampered = Line{State: StateFail, Chip: "Lifecycle broken", Detail: detail}
+	}
 	return scorecardResult{
-		Scorecard: Scorecard{
-			Authentic:    authentic,
-			Untampered:   untamperedLine(chain, len(receipts)),
-			Anchored:     Line{State: anchoredState, Chip: anchoredChip, Detail: anchoredDetail, Sub: anchoredSub},
-			Completeness: completenessLine(chain, receipts),
-		},
-		Chain: chain,
+		Scorecard: scorecard,
+		Chain:     chain,
 	}
 }
 
@@ -245,6 +251,14 @@ func completenessLine(chain receipt.ChainResult, receipts []receipt.Receipt) Lin
 			lifecycle.Status,
 			lifecycle.Reason,
 		)
+	}
+	if lifecycle.Status == completeness.StatusBroken {
+		return Line{
+			State:  StateFail,
+			Chip:   "Lifecycle broken",
+			Detail: detail,
+			Sub:    "Lifecycle evidence is structurally inconsistent; do not treat this session as authenticated or untampered.",
+		}
 	}
 	return Line{
 		State:  StateLimited,

--- a/internal/evidenceview/scorecard_ported_test.go
+++ b/internal/evidenceview/scorecard_ported_test.go
@@ -442,8 +442,8 @@ func TestComputeScorecard_BrokenChainStillReportsLifecycle(t *testing.T) {
 	if evidence.Chain.Valid {
 		t.Fatalf("tampered chain should not verify")
 	}
-	if evidence.Scorecard.Completeness.State != StateLimited {
-		t.Fatalf("Completeness.State = %q, want %q", evidence.Scorecard.Completeness.State, StateLimited)
+	if evidence.Scorecard.Completeness.State != StateFail {
+		t.Fatalf("Completeness.State = %q, want %q", evidence.Scorecard.Completeness.State, StateFail)
 	}
 	detail := evidence.Scorecard.Completeness.Detail
 	if !strings.Contains(detail, "lost to the break") {
@@ -454,5 +454,35 @@ func TestComputeScorecard_BrokenChainStillReportsLifecycle(t *testing.T) {
 	}
 	if !strings.Contains(detail, string(completeness.ReasonChainBroken)) {
 		t.Fatalf("broken-chain completeness must name the chain-broken reason: %q", detail)
+	}
+}
+
+func TestComputeScorecardRejectsLifecycleBrokenValidChain(t *testing.T) {
+	t.Parallel()
+	pub, priv := generatePortedKey(t)
+	keyHex := hex.EncodeToString(pub)
+	chain := buildBoundPortedChain(t, priv, keyHex)
+	chain[1].ActionRecord.DecisionPhase = receipt.DecisionPhaseOutcome
+	chain[1].ActionRecord.ActionID = "outcome-without-intent"
+	var err error
+	chain[1], err = receipt.Sign(chain[1].ActionRecord, priv)
+	if err != nil {
+		t.Fatalf("sign orphan outcome: %v", err)
+	}
+
+	evidence := SessionEvidenceOf(portedTestSessionID, chain, map[string]TrustedKey{
+		keyHex: {Source: portedTrustedKeySource},
+	}, false, DashboardReceiptReadLimit, DashboardTimelineLimit)
+	if !evidence.Chain.Valid {
+		t.Fatalf("orphan outcome must retain a valid signed chain: %+v", evidence.Chain)
+	}
+	for name, line := range map[string]Line{
+		"authentic":    evidence.Scorecard.Authentic,
+		"untampered":   evidence.Scorecard.Untampered,
+		"completeness": evidence.Scorecard.Completeness,
+	} {
+		if line.State != StateFail || line.Chip != "Lifecycle broken" {
+			t.Fatalf("%s = %+v, want lifecycle failure", name, line)
+		}
 	}
 }

--- a/internal/evidenceview/scorecard_ported_test.go
+++ b/internal/evidenceview/scorecard_ported_test.go
@@ -445,6 +445,9 @@ func TestComputeScorecard_BrokenChainStillReportsLifecycle(t *testing.T) {
 	if evidence.Scorecard.Completeness.State != StateFail {
 		t.Fatalf("Completeness.State = %q, want %q", evidence.Scorecard.Completeness.State, StateFail)
 	}
+	if evidence.Scorecard.Completeness.Chip != chipChainBroken {
+		t.Fatalf("Completeness.Chip = %q, want %q", evidence.Scorecard.Completeness.Chip, chipChainBroken)
+	}
 	detail := evidence.Scorecard.Completeness.Detail
 	if !strings.Contains(detail, "lost to the break") {
 		t.Fatalf("broken-chain completeness must name the lost receipts: %q", detail)

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -367,6 +367,75 @@
       }
     },
     {
+      "name": "lifecycle_counter_exceeds_safe_integer",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-counter-range",
+            "chain_seq": 0,
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-counter-range",
+                "open_nonce": "open-counter-range",
+                "chain_open_seq": 0
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-counter-range",
+            "chain_seq": 1,
+            "chain_prev_hash": "root-counter-range",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-counter-range",
+                "open_nonce": "open-counter-range",
+                "beat": 9007199254740992,
+                "chain_head": "root-counter-range",
+                "chain_seq_head": 0
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "negative_heartbeat_beat",
+      "go_decode_error": true,
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-negative-beat",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-negative-beat",
+                "open_nonce": "open-negative-beat",
+                "beat": -1
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
       "name": "null_session_control",
       "receipts": [
         {

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -1,66 +1,324 @@
-[
-  {
-    "name": "orphan_outcome",
-    "receipts": [
-      {
-        "action_record": {
-          "run_nonce": "run-orphan",
-          "session_control": {
-            "kind": "session_open",
-            "open": { "run_nonce": "run-orphan" }
-          }
-        }
+{
+  "generated_by": "go test ./internal/evidence/completeness -run TestLifecycleVerdictVectorsMatchGo -update-lifecycle-vectors",
+  "vectors": [
+    {
+      "name": "no_receipts",
+      "receipts": [],
+      "chain_result": {
+        "valid": true
       },
-      {
-        "action_record": {
-          "run_nonce": "run-orphan",
-          "decision_phase": "outcome",
-          "action_id": "outcome-without-intent"
-        }
+      "expected": {
+        "status": "UNVERIFIED",
+        "reason": "no_receipts"
       }
-    ],
-    "expected": { "status": "BROKEN", "reason": "chain_broken" }
-  },
-  {
-    "name": "durability_decrease",
-    "receipts": [
-      {
-        "action_record": {
-          "run_nonce": "run-durability",
-          "session_control": {
-            "kind": "session_open",
-            "open": { "run_nonce": "run-durability" }
-          }
+    },
+    {
+      "name": "no_lifecycle",
+      "receipts": [
+        {
+          "action_record": {}
         }
+      ],
+      "chain_result": {
+        "valid": true
       },
-      {
-        "action_record": {
-          "run_nonce": "run-durability",
-          "session_control": {
-            "kind": "heartbeat",
-            "heartbeat": {
-              "run_nonce": "run-durability",
-              "beat": 1,
-              "fsync_errors_gated": 2,
-              "durability_blocks": 2
+      "expected": {
+        "status": "UNVERIFIED",
+        "reason": "no_lifecycle"
+      }
+    },
+    {
+      "name": "no_open",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-no-open",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-no-open",
+                "open_nonce": "open-no-open",
+                "beat": 1
+              }
             }
           }
         }
+      ],
+      "chain_result": {
+        "valid": false,
+        "integrity_verified": true,
+        "failure_kind": "lifecycle_missing_open"
       },
-      {
-        "action_record": {
-          "run_nonce": "run-durability",
-          "session_control": {
-            "kind": "session_close",
-            "close": {
-              "run_nonce": "run-durability",
-              "fsync_errors_gated": 1,
-              "durability_blocks": 1
+      "expected": {
+        "status": "UNVERIFIED",
+        "reason": "no_open"
+      }
+    },
+    {
+      "name": "bounded_closed",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-closed",
+            "chain_seq": 0,
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-closed",
+                "open_nonce": "open-closed",
+                "chain_open_seq": 0
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-closed",
+            "chain_seq": 1,
+            "chain_prev_hash": "root-closed",
+            "session_control": {
+              "kind": "session_close",
+              "close": {
+                "run_nonce": "run-closed",
+                "open_nonce": "open-closed",
+                "final_seq": 1,
+                "root_hash": "root-closed",
+                "receipt_count": 2
+              }
             }
           }
         }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "bounded_closed"
       }
-    ],
-    "expected": { "status": "BROKEN", "reason": "chain_broken" }
-  }
-]
+    },
+    {
+      "name": "abnormal_end",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-open",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-open",
+                "open_nonce": "open-open"
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "abnormal_end"
+      }
+    },
+    {
+      "name": "open_action",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-action",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-action",
+                "open_nonce": "open-action"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-action",
+            "decision_phase": "intent",
+            "action_id": "unresolved"
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "open_action"
+      }
+    },
+    {
+      "name": "heartbeat_gap",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-heartbeat",
+            "chain_seq": 0,
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-heartbeat",
+                "open_nonce": "open-heartbeat",
+                "chain_open_seq": 0
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-heartbeat",
+            "chain_seq": 1,
+            "chain_prev_hash": "root-heartbeat",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-heartbeat",
+                "open_nonce": "open-heartbeat",
+                "beat": 2,
+                "chain_head": "root-heartbeat",
+                "chain_seq_head": 0
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "heartbeat_gap"
+      }
+    },
+    {
+      "name": "orphan_outcome",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-orphan",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-orphan"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-orphan",
+            "decision_phase": "outcome",
+            "action_id": "outcome-without-intent"
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "duplicate_outcome",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-duplicate",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-duplicate",
+                "open_nonce": "open-duplicate"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-duplicate",
+            "decision_phase": "intent",
+            "action_id": "duplicate"
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-duplicate",
+            "decision_phase": "outcome",
+            "action_id": "duplicate"
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-duplicate",
+            "decision_phase": "outcome",
+            "action_id": "duplicate"
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "abnormal_end"
+      }
+    },
+    {
+      "name": "durability_decrease",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-durability",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-durability"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-durability",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-durability",
+                "beat": 1,
+                "fsync_errors_gated": 2,
+                "durability_blocks": 2
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-durability",
+            "session_control": {
+              "kind": "session_close",
+              "close": {
+                "run_nonce": "run-durability",
+                "fsync_errors_gated": 1,
+                "durability_blocks": 1
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    }
+  ]
+}

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -204,7 +204,8 @@
             "session_control": {
               "kind": "session_open",
               "open": {
-                "run_nonce": "run-orphan"
+                "run_nonce": "run-orphan",
+                "open_nonce": "open-orphan"
               }
             }
           }
@@ -279,7 +280,8 @@
             "session_control": {
               "kind": "session_open",
               "open": {
-                "run_nonce": "run-durability"
+                "run_nonce": "run-durability",
+                "open_nonce": "open-durability"
               }
             }
           }
@@ -291,6 +293,7 @@
               "kind": "heartbeat",
               "heartbeat": {
                 "run_nonce": "run-durability",
+                "open_nonce": "open-durability",
                 "beat": 1,
                 "fsync_errors_gated": 2,
                 "durability_blocks": 2
@@ -305,6 +308,7 @@
               "kind": "session_close",
               "close": {
                 "run_nonce": "run-durability",
+                "open_nonce": "open-durability",
                 "fsync_errors_gated": 1,
                 "durability_blocks": 1
               }
@@ -318,6 +322,78 @@
       "expected": {
         "status": "BROKEN",
         "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "missing_run_nonce",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-missing-nonce",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-missing-nonce",
+                "open_nonce": "open-missing-nonce"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-missing-nonce",
+            "session_control": {
+              "kind": "session_close",
+              "close": {
+                "run_nonce": "run-missing-nonce",
+                "open_nonce": "open-missing-nonce"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "decision_phase": "intent",
+            "action_id": "post-close-without-run"
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "null_session_control",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-null-control",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-null-control",
+                "open_nonce": "open-null-control"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-null-control",
+            "session_control": null
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "LIMITED",
+        "reason": "abnormal_end"
       }
     }
   ]

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "orphan_outcome",
+    "receipts": [
+      {
+        "action_record": {
+          "run_nonce": "run-orphan",
+          "session_control": {
+            "kind": "session_open",
+            "open": { "run_nonce": "run-orphan" }
+          }
+        }
+      },
+      {
+        "action_record": {
+          "run_nonce": "run-orphan",
+          "decision_phase": "outcome",
+          "action_id": "outcome-without-intent"
+        }
+      }
+    ],
+    "expected": { "status": "BROKEN", "reason": "chain_broken" }
+  },
+  {
+    "name": "durability_decrease",
+    "receipts": [
+      {
+        "action_record": {
+          "run_nonce": "run-durability",
+          "session_control": {
+            "kind": "session_open",
+            "open": { "run_nonce": "run-durability" }
+          }
+        }
+      },
+      {
+        "action_record": {
+          "run_nonce": "run-durability",
+          "session_control": {
+            "kind": "heartbeat",
+            "heartbeat": {
+              "run_nonce": "run-durability",
+              "beat": 1,
+              "fsync_errors_gated": 2,
+              "durability_blocks": 2
+            }
+          }
+        }
+      },
+      {
+        "action_record": {
+          "run_nonce": "run-durability",
+          "session_control": {
+            "kind": "session_close",
+            "close": {
+              "run_nonce": "run-durability",
+              "fsync_errors_gated": 1,
+              "durability_blocks": 1
+            }
+          }
+        }
+      }
+    ],
+    "expected": { "status": "BROKEN", "reason": "chain_broken" }
+  }
+]

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -464,6 +464,246 @@
         "status": "LIMITED",
         "reason": "abnormal_end"
       }
+    },
+    {
+      "name": "missing_heartbeat_payload",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-missing-heartbeat",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-missing-heartbeat",
+                "open_nonce": "open-missing-heartbeat"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-missing-heartbeat",
+            "session_control": {
+              "kind": "heartbeat"
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "null_heartbeat_payload",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-null-heartbeat",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-null-heartbeat",
+                "open_nonce": "open-null-heartbeat"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-null-heartbeat",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": null
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "missing_close_payload",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-missing-close",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-missing-close",
+                "open_nonce": "open-missing-close"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-missing-close",
+            "session_control": {
+              "kind": "session_close"
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "null_close_payload",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-null-close",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-null-close",
+                "open_nonce": "open-null-close"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-null-close",
+            "session_control": {
+              "kind": "session_close",
+              "close": null
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "heartbeat_run_nonce_mismatch",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-heartbeat-match",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-heartbeat-match",
+                "open_nonce": "open-heartbeat-match"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-heartbeat-match",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "other-run",
+                "open_nonce": "open-heartbeat-match",
+                "beat": 1
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "close_run_nonce_mismatch",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-close-match",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-close-match",
+                "open_nonce": "open-close-match"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-close-match",
+            "session_control": {
+              "kind": "session_close",
+              "close": {
+                "run_nonce": "other-run",
+                "open_nonce": "open-close-match"
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
+      "name": "missing_beat_with_malformed_durability_counter",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-missing-beat",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-missing-beat",
+                "open_nonce": "open-missing-beat"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-missing-beat",
+            "session_control": {
+              "kind": "heartbeat",
+              "heartbeat": {
+                "run_nonce": "run-missing-beat",
+                "open_nonce": "open-missing-beat",
+                "fsync_errors_gated": 9007199254740992
+              }
+            }
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
     }
   ]
 }

--- a/sdk/conformance/testdata/lifecycle-verdict-vectors.json
+++ b/sdk/conformance/testdata/lifecycle-verdict-vectors.json
@@ -55,6 +55,37 @@
       }
     },
     {
+      "name": "opened_run_a_plus_unopened_run_b",
+      "receipts": [
+        {
+          "action_record": {
+            "run_nonce": "run-opened-a",
+            "session_control": {
+              "kind": "session_open",
+              "open": {
+                "run_nonce": "run-opened-a",
+                "open_nonce": "open-a"
+              }
+            }
+          }
+        },
+        {
+          "action_record": {
+            "run_nonce": "run-unopened-b",
+            "decision_phase": "intent",
+            "action_id": "action-b"
+          }
+        }
+      ],
+      "chain_result": {
+        "valid": true
+      },
+      "expected": {
+        "status": "BROKEN",
+        "reason": "chain_broken"
+      }
+    },
+    {
       "name": "bounded_closed",
       "receipts": [
         {

--- a/sdk/verifiers/rust/Cargo.lock
+++ b/sdk/verifiers/rust/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipelock-verifier-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "data-encoding",

--- a/sdk/verifiers/rust/Cargo.toml
+++ b/sdk/verifiers/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipelock-verifier-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -139,15 +139,6 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
     report.lifecycle_reason = Some(lifecycle.reason);
     report.lifecycle_assessment = "assessed".to_string();
     report.lifecycle_assessment_reason = None;
-    let cross_errors = cross_check(&packet, &chain, &receipts);
-    if !cross_errors.is_empty() {
-        report.cross_check = "fail".to_string();
-        for err in cross_errors {
-            push_error(&mut report, format!("cross-check: {err}"));
-        }
-        return Ok(report);
-    }
-    report.cross_check = "pass".to_string();
     if !chain.valid {
         push_error(
             &mut report,
@@ -157,6 +148,15 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
             ),
         );
     }
+    let cross_errors = cross_check(&packet, &chain, &receipts);
+    if !cross_errors.is_empty() {
+        report.cross_check = "fail".to_string();
+        for err in cross_errors {
+            push_error(&mut report, format!("cross-check: {err}"));
+        }
+        return Ok(report);
+    }
+    report.cross_check = "pass".to_string();
     report.valid = chain.valid && !lifecycle_broken && trust_verdict(&packet, opts);
     if lifecycle_broken {
         push_error(&mut report, format!("lifecycle: {lifecycle_reason}"));

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -133,21 +133,12 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
     let chain = verify_chain_with_options(&receipts, &key_hex, opts.allow_self_consistent_only);
     report.chain_check = if chain.valid { "pass" } else { "fail" }.to_string();
     let lifecycle = analyze_lifecycle(&receipts, &chain);
+    let lifecycle_broken = lifecycle.status == "BROKEN";
+    let lifecycle_reason = lifecycle.reason.clone();
     report.lifecycle_status = Some(lifecycle.status);
     report.lifecycle_reason = Some(lifecycle.reason);
     report.lifecycle_assessment = "assessed".to_string();
     report.lifecycle_assessment_reason = None;
-    if !chain.valid {
-        push_error(
-            &mut report,
-            format!(
-                "chain: {}",
-                chain.error.as_deref().unwrap_or("verification failed")
-            ),
-        );
-        return Ok(report);
-    }
-
     let cross_errors = cross_check(&packet, &chain, &receipts);
     if !cross_errors.is_empty() {
         report.cross_check = "fail".to_string();
@@ -157,7 +148,19 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
         return Ok(report);
     }
     report.cross_check = "pass".to_string();
-    report.valid = chain.valid && trust_verdict(&packet, opts);
+    if !chain.valid {
+        push_error(
+            &mut report,
+            format!(
+                "chain: {}",
+                chain.error.as_deref().unwrap_or("verification failed")
+            ),
+        );
+    }
+    report.valid = chain.valid && !lifecycle_broken && trust_verdict(&packet, opts);
+    if lifecycle_broken {
+        push_error(&mut report, format!("lifecycle: {lifecycle_reason}"));
+    }
     if !report.valid {
         push_error(&mut report, "packet not trusted".to_string());
     }

--- a/sdk/verifiers/rust/src/audit_packet.rs
+++ b/sdk/verifiers/rust/src/audit_packet.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chain::{compute_totals, verify_chain_with_options};
+use crate::lifecycle::analyze_lifecycle;
 use crate::recorder::extract_receipts;
 use crate::schema::validate_audit_packet;
 use crate::types::{
@@ -78,6 +79,8 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
     report.schema_check = "pass".to_string();
 
     if opts.offline {
+        report.lifecycle_assessment_reason =
+            Some("offline mode skips chain re-verification".to_string());
         report.valid = trust_verdict(&packet, opts);
         return Ok(report);
     }
@@ -129,6 +132,11 @@ pub fn verify_audit_packet(target: &str, opts: &AuditPacketOptions) -> Result<Au
     };
     let chain = verify_chain_with_options(&receipts, &key_hex, opts.allow_self_consistent_only);
     report.chain_check = if chain.valid { "pass" } else { "fail" }.to_string();
+    let lifecycle = analyze_lifecycle(&receipts, &chain);
+    report.lifecycle_status = Some(lifecycle.status);
+    report.lifecycle_reason = Some(lifecycle.reason);
+    report.lifecycle_assessment = "assessed".to_string();
+    report.lifecycle_assessment_reason = None;
     if !chain.valid {
         push_error(
             &mut report,
@@ -203,6 +211,10 @@ pub fn report_from_packet(path: &str, packet: Option<&AuditPacket>) -> AuditPack
         schema_check: "skipped".to_string(),
         chain_check: "skipped".to_string(),
         cross_check: "skipped".to_string(),
+        lifecycle_status: None,
+        lifecycle_reason: None,
+        lifecycle_assessment: "not_assessed".to_string(),
+        lifecycle_assessment_reason: Some("chain re-verification did not complete".to_string()),
     }
 }
 

--- a/sdk/verifiers/rust/src/chain.rs
+++ b/sdk/verifiers/rust/src/chain.rs
@@ -42,9 +42,34 @@ pub fn verify_chain_with_options(
     expected_key_hex: &str,
     allow_unpinned: bool,
 ) -> ChainResult {
+    let result = verify_chain_inner(receipts, expected_key_hex, allow_unpinned, false);
+    if result.failure_kind.as_deref() != Some("lifecycle_missing_open") {
+        return result;
+    }
+    let integrity = verify_chain_inner(receipts, expected_key_hex, allow_unpinned, true);
+    if !integrity.valid {
+        return integrity;
+    }
+    ChainResult {
+        integrity_verified: true,
+        receipt_count: integrity.receipt_count,
+        final_seq: integrity.final_seq,
+        root_hash: integrity.root_hash,
+        ..result
+    }
+}
+
+fn verify_chain_inner(
+    receipts: &[Receipt],
+    expected_key_hex: &str,
+    allow_unpinned: bool,
+    skip_lifecycle: bool,
+) -> ChainResult {
     if receipts.is_empty() {
         return ChainResult {
             valid: false,
+            integrity_verified: false,
+            failure_kind: None,
             receipt_count: 0,
             final_seq: 0,
             root_hash: String::new(),
@@ -166,32 +191,40 @@ pub fn verify_chain_with_options(
             return broken(seq, format!("seq gap: expected {expected_seq}, got {seq}"));
         }
         state.segment_receipt_count += 1;
-        if let Some(result) = validate_closed_run(receipt, seq, &state) {
-            return result;
-        }
-        if let Some(result) = validate_session_control_state(receipt, seq, index as u64, &mut state)
-        {
-            return result;
-        }
-        if let Some(open) = session_open(receipt) {
-            state.active_run_nonce = open
-                .get("run_nonce")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-            state.active_open_nonce = open
-                .get("open_nonce")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-            if let Some(run_nonce) = state.active_run_nonce.clone() {
-                state.opened_runs.insert(run_nonce.clone());
-                state.closed_runs.remove(&run_nonce);
+        if !skip_lifecycle {
+            if let Some(mut result) = validate_closed_run(receipt, seq, &state) {
+                if result.error.as_deref().is_some_and(|error| {
+                    error.contains("first receipt is not a matching session_open")
+                }) {
+                    result.failure_kind = Some("lifecycle_missing_open".to_string());
+                }
+                return result;
             }
-        } else if session_close(receipt).is_some() {
-            if let Some(run_nonce) = state.active_run_nonce.clone() {
-                state.closed_runs.insert(run_nonce);
+            if let Some(result) =
+                validate_session_control_state(receipt, seq, index as u64, &mut state)
+            {
+                return result;
             }
-            state.active_run_nonce = None;
-            state.active_open_nonce = None;
+            if let Some(open) = session_open(receipt) {
+                state.active_run_nonce = open
+                    .get("run_nonce")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                state.active_open_nonce = open
+                    .get("open_nonce")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                if let Some(run_nonce) = state.active_run_nonce.clone() {
+                    state.opened_runs.insert(run_nonce.clone());
+                    state.closed_runs.remove(&run_nonce);
+                }
+            } else if session_close(receipt).is_some() {
+                if let Some(run_nonce) = state.active_run_nonce.clone() {
+                    state.closed_runs.insert(run_nonce);
+                }
+                state.active_run_nonce = None;
+                state.active_open_nonce = None;
+            }
         }
         state.prev_hash = receipt_hash(receipt);
         state.prior_segment_seq = Some(seq);
@@ -199,6 +232,8 @@ pub fn verify_chain_with_options(
 
     ChainResult {
         valid: true,
+        integrity_verified: true,
+        failure_kind: None,
         receipt_count: receipts.len(),
         final_seq: receipts
             .last()
@@ -752,6 +787,8 @@ fn verify_evidence_chain(
 
     ChainResult {
         valid: true,
+        integrity_verified: true,
+        failure_kind: None,
         receipt_count: receipts.len(),
         final_seq: receipts
             .last()
@@ -789,6 +826,8 @@ pub fn compute_totals(receipts: &[Receipt]) -> Totals {
 fn broken(seq: u64, error: String) -> ChainResult {
     ChainResult {
         valid: false,
+        integrity_verified: false,
+        failure_kind: None,
         receipt_count: 0,
         final_seq: 0,
         root_hash: String::new(),

--- a/sdk/verifiers/rust/src/cli.rs
+++ b/sdk/verifiers/rust/src/cli.rs
@@ -3,6 +3,7 @@
 
 use crate::audit_packet::{verify_audit_packet, AuditPacketOptions};
 use crate::chain::verify_chain_with_options;
+use crate::lifecycle::analyze_lifecycle;
 use crate::output::{emit_audit_packet, emit_chain, emit_receipt};
 use crate::provenance_proof::run_provenance;
 use crate::receipt::run_receipt;
@@ -142,16 +143,23 @@ fn run_chain_command(args: &[String]) -> Result<i32> {
     } else {
         verify_chain_with_endorsements(&receipts, &parsed.session_id, &endorsements, &key_hex)
     };
+    let lifecycle = analyze_lifecycle(&receipts, &result);
+    let lifecycle_broken = lifecycle.status == "BROKEN";
     let report = ChainCommandReport {
         path: label,
-        valid: result.valid,
+        valid: result.valid && !lifecycle_broken,
         unpinned: (key_hex.is_empty()
-            && (result.valid || result.error.as_deref().unwrap_or("").contains("UNPINNED")))
-        .then_some(true),
+            && (result.error.as_deref().unwrap_or("").contains("UNPINNED")
+                || (result.valid && !lifecycle_broken)))
+            .then_some(true),
         receipt_count: result.receipt_count,
         final_seq: result.final_seq,
         root_hash: (!result.root_hash.is_empty()).then_some(result.root_hash),
-        error: result.error,
+        error: if lifecycle_broken {
+            Some(format!("lifecycle: {}", lifecycle.reason))
+        } else {
+            result.error
+        },
         broken_at_seq: result.broken_at_seq,
     };
     emit_chain(&report, parsed.json)?;

--- a/sdk/verifiers/rust/src/cli.rs
+++ b/sdk/verifiers/rust/src/cli.rs
@@ -155,7 +155,10 @@ fn run_chain_command(args: &[String]) -> Result<i32> {
         receipt_count: result.receipt_count,
         final_seq: result.final_seq,
         root_hash: (!result.root_hash.is_empty()).then_some(result.root_hash),
-        error: if lifecycle_broken {
+        // Preserve the verifier's concrete cryptographic, hash, trust, or
+        // sequence failure. Lifecycle is a supplemental gate only when the
+        // chain itself verified successfully.
+        error: if lifecycle_broken && result.valid {
             Some(format!("lifecycle: {}", lifecycle.reason))
         } else {
             result.error

--- a/sdk/verifiers/rust/src/lib.rs
+++ b/sdk/verifiers/rust/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit_packet;
 pub mod canonical;
 pub mod chain;
 pub mod cli;
+pub mod lifecycle;
 pub mod output;
 pub mod provenance;
 pub(crate) mod provenance_proof;

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -241,7 +241,10 @@ fn increment(values: &mut HashMap<String, u64>, key: &str) {
 
 fn assess_run(state: &RunState) -> LifecycleReport {
     if !state.opened {
-        return report("UNVERIFIED", "no_open");
+        // An observed run nonce without its own session_open contradicts the
+        // transcript. UNVERIFIED/no_open is reserved for the chain verifier's
+        // explicit, integrity-proven lifecycle_missing_open failure kind above.
+        return report("BROKEN", "chain_broken");
     }
     if state.outcomes.iter().any(|(action_id, outcomes)| {
         *outcomes > 0 && state.intents.get(action_id).unwrap_or(&0) == &0

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -61,7 +61,7 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
         let control = session_control(receipt);
         let run_nonce = run_nonce_for(record, control);
         if run_nonce.is_empty() {
-            continue;
+            return report("BROKEN", "chain_broken");
         }
         let state = runs.entry(run_nonce).or_default();
         match record

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -1,0 +1,212 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::{ChainResult, Receipt};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleReport {
+    pub status: String,
+    pub reason: String,
+}
+
+#[derive(Default)]
+struct RunState {
+    opened: bool,
+    closed: bool,
+    intents: HashMap<String, u64>,
+    outcomes: HashMap<String, u64>,
+    saw_heartbeat: bool,
+    last_heartbeat: u64,
+    heartbeat_gap: bool,
+}
+
+// analyze_lifecycle mirrors the Go verifier's packet-level lifecycle verdict.
+// It deliberately reports an open but otherwise valid run as LIMITED rather
+// than rejecting the packet: integrity and a clean session close answer
+// different questions.
+pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> LifecycleReport {
+    if receipts.is_empty() {
+        return report("UNVERIFIED", "no_receipts");
+    }
+    if !chain.valid {
+        return report("BROKEN", "chain_broken");
+    }
+    if !receipts
+        .iter()
+        .any(|receipt| session_control(receipt).is_some())
+    {
+        return report("UNVERIFIED", "no_lifecycle");
+    }
+
+    let mut runs = HashMap::<String, RunState>::new();
+    for receipt in receipts {
+        let Some(record) = receipt.get("action_record") else {
+            continue;
+        };
+        let control = session_control(receipt);
+        let run_nonce = run_nonce_for(record, control);
+        if run_nonce.is_empty() {
+            continue;
+        }
+        let state = runs.entry(run_nonce).or_default();
+        match record
+            .get("decision_phase")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("intent") => increment(
+                &mut state.intents,
+                record
+                    .get("action_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            ),
+            Some("outcome") => increment(
+                &mut state.outcomes,
+                record
+                    .get("action_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            ),
+            _ => {}
+        }
+
+        let Some(control) = control else {
+            continue;
+        };
+        match control.get("kind").and_then(serde_json::Value::as_str) {
+            Some("session_open") => {
+                state.opened = true;
+                state.closed = false;
+            }
+            Some("session_close") => state.closed = true,
+            Some("session_heartbeat") => {
+                if let Some(beat) = control
+                    .get("heartbeat")
+                    .and_then(serde_json::Value::as_object)
+                    .and_then(|heartbeat| heartbeat.get("beat"))
+                    .and_then(serde_json::Value::as_u64)
+                {
+                    if (state.saw_heartbeat && beat != state.last_heartbeat + 1)
+                        || (!state.saw_heartbeat && beat != 1)
+                    {
+                        state.heartbeat_gap = true;
+                    }
+                    state.saw_heartbeat = true;
+                    state.last_heartbeat = beat;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    runs.values()
+        .map(assess_run)
+        .reduce(worse)
+        .unwrap_or_else(|| report("UNVERIFIED", "no_lifecycle"))
+}
+
+fn session_control(receipt: &Receipt) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    receipt
+        .get("action_record")
+        .and_then(|record| record.get("session_control"))
+        .and_then(serde_json::Value::as_object)
+}
+
+fn run_nonce_for(
+    record: &serde_json::Value,
+    control: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> String {
+    if let Some(run_nonce) = record.get("run_nonce").and_then(serde_json::Value::as_str) {
+        if !run_nonce.is_empty() {
+            return run_nonce.to_string();
+        }
+    }
+    let Some(control) = control else {
+        return String::new();
+    };
+    let payload = match control.get("kind").and_then(serde_json::Value::as_str) {
+        Some("session_open") => control.get("open"),
+        Some("session_heartbeat") => control.get("heartbeat"),
+        Some("session_close") => control.get("close"),
+        _ => None,
+    };
+    payload
+        .and_then(|payload| payload.get("run_nonce"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn increment(values: &mut HashMap<String, u64>, key: &str) {
+    *values.entry(key.to_string()).or_default() += 1;
+}
+
+fn assess_run(state: &RunState) -> LifecycleReport {
+    if !state.opened {
+        return report("UNVERIFIED", "no_open");
+    }
+    if state
+        .outcomes
+        .iter()
+        .any(|(action_id, outcomes)| state.intents.get(action_id).unwrap_or(&0) < outcomes)
+    {
+        return report("BROKEN", "chain_broken");
+    }
+    if state
+        .intents
+        .iter()
+        .any(|(action_id, intents)| state.outcomes.get(action_id).unwrap_or(&0) < intents)
+    {
+        return report("LIMITED", "open_action");
+    }
+    if state.heartbeat_gap {
+        return report("LIMITED", "heartbeat_gap");
+    }
+    if !state.closed {
+        return report("LIMITED", "abnormal_end");
+    }
+    report("LIMITED", "bounded_closed")
+}
+
+fn report(status: &str, reason: &str) -> LifecycleReport {
+    LifecycleReport {
+        status: status.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn worse(current: LifecycleReport, next: LifecycleReport) -> LifecycleReport {
+    let current_key = (
+        status_severity(&current.status),
+        reason_severity(&current.reason),
+    );
+    let next_key = (status_severity(&next.status), reason_severity(&next.reason));
+    if next_key > current_key {
+        next
+    } else {
+        current
+    }
+}
+
+fn status_severity(status: &str) -> u8 {
+    match status {
+        "BROKEN" => 3,
+        "UNVERIFIED" => 2,
+        "LIMITED" => 1,
+        _ => 0,
+    }
+}
+
+fn reason_severity(reason: &str) -> u8 {
+    match reason {
+        "chain_broken" => 100,
+        "no_open" => 80,
+        "no_lifecycle" | "recorder_disabled" | "no_receipts" => 70,
+        "open_action" => 50,
+        "heartbeat_gap" => 40,
+        "abnormal_end" => 30,
+        "bounded_closed" => 10,
+        _ => 0,
+    }
+}

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -96,27 +96,49 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
                 state.closed = false;
             }
             Some("session_close") => {
+                let Some(close) = control.get("close").and_then(serde_json::Value::as_object)
+                else {
+                    return report("BROKEN", "chain_broken");
+                };
+                let action_run_nonce = record
+                    .get("run_nonce")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if action_run_nonce.is_empty()
+                    || close.get("run_nonce").and_then(serde_json::Value::as_str)
+                        != Some(action_run_nonce)
+                {
+                    return report("BROKEN", "chain_broken");
+                }
                 state.closed = true;
                 if !apply_durability(state, control.get("close")) {
                     return report("BROKEN", "chain_broken");
                 }
             }
             Some("heartbeat") | Some("session_heartbeat") => {
-                let beat = control
+                let Some(heartbeat) = control
                     .get("heartbeat")
                     .and_then(serde_json::Value::as_object)
-                    .and_then(|heartbeat| heartbeat.get("beat"))
-                    .map(lifecycle_counter);
+                else {
+                    return report("BROKEN", "chain_broken");
+                };
+                let action_run_nonce = record
+                    .get("run_nonce")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                if action_run_nonce.is_empty()
+                    || heartbeat
+                        .get("run_nonce")
+                        .and_then(serde_json::Value::as_str)
+                        != Some(action_run_nonce)
+                {
+                    return report("BROKEN", "chain_broken");
+                }
+                let beat = heartbeat.get("beat").map(lifecycle_counter);
                 let Some(beat) = beat else {
-                    if control
-                        .get("heartbeat")
-                        .and_then(serde_json::Value::as_object)
-                        .and_then(|heartbeat| heartbeat.get("beat"))
-                        .is_some()
-                    {
+                    if !apply_durability(state, control.get("heartbeat")) {
                         return report("BROKEN", "chain_broken");
                     }
-                    apply_durability(state, control.get("heartbeat"));
                     continue;
                 };
                 let Some(beat) = beat else {

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -4,6 +4,8 @@
 use crate::types::{ChainResult, Receipt};
 use std::collections::HashMap;
 
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LifecycleReport {
     pub status: String,
@@ -25,8 +27,8 @@ struct RunState {
 
 #[derive(Clone, Copy)]
 struct DurabilitySnapshot {
-    fsync_errors_gated: u64,
-    durability_blocks: u64,
+    fsync_errors_gated: Option<u64>,
+    durability_blocks: Option<u64>,
 }
 
 // analyze_lifecycle mirrors the Go verifier's packet-level lifecycle verdict.
@@ -95,24 +97,41 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
             }
             Some("session_close") => {
                 state.closed = true;
-                apply_durability(state, control.get("close"));
+                if !apply_durability(state, control.get("close")) {
+                    return report("BROKEN", "chain_broken");
+                }
             }
             Some("heartbeat") | Some("session_heartbeat") => {
-                if let Some(beat) = control
+                let beat = control
                     .get("heartbeat")
                     .and_then(serde_json::Value::as_object)
                     .and_then(|heartbeat| heartbeat.get("beat"))
-                    .and_then(serde_json::Value::as_u64)
-                {
-                    if (state.saw_heartbeat && beat != state.last_heartbeat + 1)
-                        || (!state.saw_heartbeat && beat != 1)
+                    .map(lifecycle_counter);
+                let Some(beat) = beat else {
+                    if control
+                        .get("heartbeat")
+                        .and_then(serde_json::Value::as_object)
+                        .and_then(|heartbeat| heartbeat.get("beat"))
+                        .is_some()
                     {
-                        state.heartbeat_gap = true;
+                        return report("BROKEN", "chain_broken");
                     }
-                    state.saw_heartbeat = true;
-                    state.last_heartbeat = beat;
+                    apply_durability(state, control.get("heartbeat"));
+                    continue;
+                };
+                let Some(beat) = beat else {
+                    return report("BROKEN", "chain_broken");
+                };
+                if (state.saw_heartbeat && beat != state.last_heartbeat + 1)
+                    || (!state.saw_heartbeat && beat != 1)
+                {
+                    state.heartbeat_gap = true;
                 }
-                apply_durability(state, control.get("heartbeat"));
+                state.saw_heartbeat = true;
+                state.last_heartbeat = beat;
+                if !apply_durability(state, control.get("heartbeat")) {
+                    return report("BROKEN", "chain_broken");
+                }
             }
             _ => {}
         }
@@ -124,25 +143,42 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
         .unwrap_or_else(|| report("UNVERIFIED", "no_lifecycle"))
 }
 
-fn apply_durability(state: &mut RunState, value: Option<&serde_json::Value>) {
+fn apply_durability(state: &mut RunState, value: Option<&serde_json::Value>) -> bool {
     let snapshot = DurabilitySnapshot {
-        fsync_errors_gated: value
-            .and_then(|value| value.get("fsync_errors_gated"))
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0),
-        durability_blocks: value
-            .and_then(|value| value.get("durability_blocks"))
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0),
+        fsync_errors_gated: match value.and_then(|value| value.get("fsync_errors_gated")) {
+            Some(value) => match lifecycle_counter(value) {
+                Some(value) => Some(value),
+                None => return false,
+            },
+            None => None,
+        },
+        durability_blocks: match value.and_then(|value| value.get("durability_blocks")) {
+            Some(value) => match lifecycle_counter(value) {
+                Some(value) => Some(value),
+                None => return false,
+            },
+            None => None,
+        },
     };
     if let Some(previous) = state.last_durability {
-        if snapshot.fsync_errors_gated < previous.fsync_errors_gated
-            || snapshot.durability_blocks < previous.durability_blocks
+        if snapshot
+            .fsync_errors_gated
+            .zip(previous.fsync_errors_gated)
+            .is_some_and(|(current, previous)| current < previous)
+            || snapshot
+                .durability_blocks
+                .zip(previous.durability_blocks)
+                .is_some_and(|(current, previous)| current < previous)
         {
             state.durability_drop = true;
         }
     }
     state.last_durability = Some(snapshot);
+    true
+}
+
+fn lifecycle_counter(value: &serde_json::Value) -> Option<u64> {
+    value.as_u64().filter(|value| *value <= MAX_SAFE_INTEGER)
 }
 
 fn session_control(receipt: &Receipt) -> Option<&serde_json::Map<String, serde_json::Value>> {

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -19,6 +19,14 @@ struct RunState {
     saw_heartbeat: bool,
     last_heartbeat: u64,
     heartbeat_gap: bool,
+    last_durability: Option<DurabilitySnapshot>,
+    durability_drop: bool,
+}
+
+#[derive(Clone, Copy)]
+struct DurabilitySnapshot {
+    fsync_errors_gated: u64,
+    durability_blocks: u64,
 }
 
 // analyze_lifecycle mirrors the Go verifier's packet-level lifecycle verdict.
@@ -79,8 +87,11 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
                 state.opened = true;
                 state.closed = false;
             }
-            Some("session_close") => state.closed = true,
-            Some("session_heartbeat") => {
+            Some("session_close") => {
+                state.closed = true;
+                apply_durability(state, control.get("close"));
+            }
+            Some("heartbeat") | Some("session_heartbeat") => {
                 if let Some(beat) = control
                     .get("heartbeat")
                     .and_then(serde_json::Value::as_object)
@@ -95,6 +106,7 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
                     state.saw_heartbeat = true;
                     state.last_heartbeat = beat;
                 }
+                apply_durability(state, control.get("heartbeat"));
             }
             _ => {}
         }
@@ -104,6 +116,27 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
         .map(assess_run)
         .reduce(worse)
         .unwrap_or_else(|| report("UNVERIFIED", "no_lifecycle"))
+}
+
+fn apply_durability(state: &mut RunState, value: Option<&serde_json::Value>) {
+    let snapshot = DurabilitySnapshot {
+        fsync_errors_gated: value
+            .and_then(|value| value.get("fsync_errors_gated"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        durability_blocks: value
+            .and_then(|value| value.get("durability_blocks"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+    };
+    if let Some(previous) = state.last_durability {
+        if snapshot.fsync_errors_gated < previous.fsync_errors_gated
+            || snapshot.durability_blocks < previous.durability_blocks
+        {
+            state.durability_drop = true;
+        }
+    }
+    state.last_durability = Some(snapshot);
 }
 
 fn session_control(receipt: &Receipt) -> Option<&serde_json::Map<String, serde_json::Value>> {
@@ -159,6 +192,9 @@ fn assess_run(state: &RunState) -> LifecycleReport {
         .any(|(action_id, intents)| state.outcomes.get(action_id).unwrap_or(&0) < intents)
     {
         return report("LIMITED", "open_action");
+    }
+    if state.durability_drop {
+        return report("BROKEN", "chain_broken");
     }
     if state.heartbeat_gap {
         return report("LIMITED", "heartbeat_gap");

--- a/sdk/verifiers/rust/src/lifecycle.rs
+++ b/sdk/verifiers/rust/src/lifecycle.rs
@@ -37,8 +37,14 @@ pub fn analyze_lifecycle(receipts: &[Receipt], chain: &ChainResult) -> Lifecycle
     if receipts.is_empty() {
         return report("UNVERIFIED", "no_receipts");
     }
-    if !chain.valid {
+    let missing_open = !chain.valid
+        && chain.integrity_verified
+        && chain.failure_kind.as_deref() == Some("lifecycle_missing_open");
+    if !chain.valid && !missing_open {
         return report("BROKEN", "chain_broken");
+    }
+    if missing_open {
+        return report("UNVERIFIED", "no_open");
     }
     if !receipts
         .iter()
@@ -160,7 +166,7 @@ fn run_nonce_for(
     };
     let payload = match control.get("kind").and_then(serde_json::Value::as_str) {
         Some("session_open") => control.get("open"),
-        Some("session_heartbeat") => control.get("heartbeat"),
+        Some("heartbeat") | Some("session_heartbeat") => control.get("heartbeat"),
         Some("session_close") => control.get("close"),
         _ => None,
     };
@@ -179,11 +185,9 @@ fn assess_run(state: &RunState) -> LifecycleReport {
     if !state.opened {
         return report("UNVERIFIED", "no_open");
     }
-    if state
-        .outcomes
-        .iter()
-        .any(|(action_id, outcomes)| state.intents.get(action_id).unwrap_or(&0) < outcomes)
-    {
+    if state.outcomes.iter().any(|(action_id, outcomes)| {
+        *outcomes > 0 && state.intents.get(action_id).unwrap_or(&0) == &0
+    }) {
         return report("BROKEN", "chain_broken");
     }
     if state

--- a/sdk/verifiers/rust/src/output.rs
+++ b/sdk/verifiers/rust/src/output.rs
@@ -24,6 +24,21 @@ pub fn emit_audit_packet(report: &AuditPacketReport, json: bool) -> Result<()> {
     println!("  schema:       {}", report.schema_check);
     println!("  chain:        {}", report.chain_check);
     println!("  cross-check:  {}", report.cross_check);
+    if report.lifecycle_assessment != "assessed" {
+        println!(
+            "  lifecycle:    not assessed ({})",
+            report
+                .lifecycle_assessment_reason
+                .as_deref()
+                .unwrap_or("chain re-verification did not complete")
+        );
+    } else {
+        println!(
+            "  lifecycle:    {} ({})",
+            report.lifecycle_status.as_deref().unwrap_or(""),
+            report.lifecycle_reason.as_deref().unwrap_or("")
+        );
+    }
     println!("  verdict:      {verdict}");
     println!("  trusted:      {}", report.trusted);
     println!("  receipts:     {}", report.summary.receipt_count);

--- a/sdk/verifiers/rust/src/rotation.rs
+++ b/sdk/verifiers/rust/src/rotation.rs
@@ -281,6 +281,8 @@ pub fn verify_chain_with_endorsements(
     if session_id.trim().is_empty() {
         return ChainResult {
             valid: false,
+            integrity_verified: false,
+            failure_kind: None,
             receipt_count: receipts.len(),
             final_seq: 0,
             root_hash: String::new(),
@@ -293,6 +295,8 @@ pub fn verify_chain_with_endorsements(
     if receipts.is_empty() {
         return ChainResult {
             valid: false,
+            integrity_verified: false,
+            failure_kind: None,
             receipt_count: 0,
             final_seq: 0,
             root_hash: String::new(),
@@ -322,6 +326,8 @@ pub fn verify_chain_with_endorsements(
         if !transition && signer != authorized_signer {
             return ChainResult {
                 valid: false,
+                integrity_verified: false,
+                failure_kind: None,
                 receipt_count: receipts.len(),
                 final_seq: 0,
                 root_hash: String::new(),

--- a/sdk/verifiers/rust/src/rotation.rs
+++ b/sdk/verifiers/rust/src/rotation.rs
@@ -226,6 +226,7 @@ pub fn load_rotation_endorsement_file(path: &Path) -> Result<RotationEndorsement
 
 fn fail(mut base: ChainResult, message: impl Into<String>) -> ChainResult {
     base.valid = false;
+    base.failure_kind = None;
     base.error = Some(message.into());
     base
 }
@@ -348,7 +349,10 @@ pub fn verify_chain_with_endorsements(
         .collect::<Vec<_>>()
         .join(",");
     let base = verify_chain(receipts, &all_keys);
-    if !base.valid {
+    let lifecycle_only_failure = !base.valid
+        && base.integrity_verified
+        && base.failure_kind.as_deref() == Some("lifecycle_missing_open");
+    if !base.valid && !lifecycle_only_failure {
         return base;
     }
     let roots = root_key_hex

--- a/sdk/verifiers/rust/src/types.rs
+++ b/sdk/verifiers/rust/src/types.rs
@@ -106,6 +106,13 @@ pub struct AuditPacketReport {
     pub schema_check: String,
     pub chain_check: String,
     pub cross_check: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_reason: Option<String>,
+    pub lifecycle_assessment: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_assessment_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/sdk/verifiers/rust/src/types.rs
+++ b/sdk/verifiers/rust/src/types.rs
@@ -81,6 +81,9 @@ impl Totals {
 #[derive(Debug, Clone, Serialize)]
 pub struct ChainResult {
     pub valid: bool,
+    pub integrity_verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<String>,
     pub receipt_count: usize,
     pub final_seq: u64,
     pub root_hash: String,

--- a/sdk/verifiers/rust/tests/audit_packet.rs
+++ b/sdk/verifiers/rust/tests/audit_packet.rs
@@ -306,7 +306,13 @@ fn audit_packet_reports_chain_failure_reason() {
     assert_eq!(report.lifecycle_assessment, "assessed");
     assert_eq!(report.lifecycle_status.as_deref(), Some("BROKEN"));
     assert_eq!(report.lifecycle_reason.as_deref(), Some("chain_broken"));
-    assert!(has_error(&report.errors, "chain_prev_hash mismatch"));
+    assert!(report.errors.as_ref().is_some_and(|errors| errors
+        .iter()
+        .any(|error| error.starts_with("chain: ") && error.contains("chain_prev_hash mismatch"))));
+    assert!(report.errors.as_ref().is_some_and(|errors| errors
+        .iter()
+        .any(|error| error.starts_with("cross-check: ")
+            && error.contains("chain_prev_hash mismatch"))));
 }
 
 #[test]

--- a/sdk/verifiers/rust/tests/audit_packet.rs
+++ b/sdk/verifiers/rust/tests/audit_packet.rs
@@ -4,6 +4,8 @@
 mod common;
 
 use pipelock_verifier_rs::audit_packet::{verify_audit_packet, AuditPacketOptions};
+use pipelock_verifier_rs::chain::{compute_totals, verify_chain};
+use pipelock_verifier_rs::recorder::extract_receipts;
 use pipelock_verifier_rs::util::sha256_hex;
 use serde_json::{json, Value};
 use std::fs;
@@ -44,6 +46,56 @@ fn audit_packet_verifies_end_to_end() {
     assert_eq!(report.schema_check, "pass");
     assert_eq!(report.chain_check, "pass");
     assert_eq!(report.cross_check, "pass");
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("UNVERIFIED"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("no_lifecycle"));
+}
+
+#[test]
+fn audit_packet_reports_lifecycle_structure_separately_from_chain_validity() {
+    let packet_dir = write_packet_with_evidence("g1-valid-chain.jsonl", None);
+    let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("BROKEN"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("chain_broken"));
+}
+
+#[test]
+fn audit_packet_keeps_an_in_progress_lifecycle_valid_but_names_it() {
+    let packet_dir = write_packet_with_evidence("g1-restart-chain.jsonl", None);
+    let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("LIMITED"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("open_action"));
+}
+
+#[test]
+fn audit_packet_keeps_an_open_session_valid_but_marks_its_missing_close() {
+    let packet_dir = write_packet_with_evidence("g1-valid-chain.jsonl", Some(1));
+    let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
+    assert!(report.valid, "{:?}", report.errors);
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("LIMITED"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("abnormal_end"));
+}
+
+#[test]
+fn audit_packet_reports_a_malformed_lifecycle_chain_as_assessed_and_broken() {
+    let root = common::repo_root();
+    let packet_dir = write_packet(None);
+    fs::copy(
+        root.join("sdk/conformance/testdata/g1-inconsistent-close.jsonl"),
+        packet_dir.join("evidence.jsonl"),
+    )
+    .unwrap();
+    let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
+    assert!(!report.valid);
+    assert_eq!(report.chain_check, "fail");
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("BROKEN"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("chain_broken"));
 }
 
 #[test]
@@ -274,6 +326,11 @@ fn offline_skips_chain_verification() {
     assert!(report.valid, "{:?}", report.errors);
     assert_eq!(report.chain_check, "skipped");
     assert_eq!(report.cross_check, "skipped");
+    assert_eq!(report.lifecycle_assessment, "not_assessed");
+    assert_eq!(
+        report.lifecycle_assessment_reason.as_deref(),
+        Some("offline mode skips chain re-verification")
+    );
 }
 
 fn base_packet() -> Value {
@@ -345,6 +402,45 @@ fn write_packet(mutator: Option<fn(&mut Value)>) -> PathBuf {
     fs::copy(
         root.join("sdk/conformance/testdata/valid-chain.jsonl"),
         dir.join("evidence.jsonl"),
+    )
+    .unwrap();
+    fs::write(dir.join("verifier.txt"), "ok\n").unwrap();
+    dir
+}
+
+fn write_packet_with_evidence(name: &str, lines: Option<usize>) -> PathBuf {
+    let root = common::repo_root();
+    let evidence = root.join("sdk/conformance/testdata").join(name);
+    let id = NEXT_DIR.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("pipelock-rust-verifier-lifecycle-{id}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir(&dir).unwrap();
+    let raw_evidence = fs::read_to_string(&evidence).unwrap();
+    let evidence_text = match lines {
+        Some(lines) => format!(
+            "{}\n",
+            raw_evidence
+                .trim_end()
+                .lines()
+                .take(lines)
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+        None => raw_evidence,
+    };
+    fs::write(dir.join("evidence.jsonl"), evidence_text).unwrap();
+    let receipts = extract_receipts(&dir.join("evidence.jsonl")).unwrap();
+    let chain = verify_chain(&receipts, PUBLIC_KEY);
+    assert!(chain.valid, "{name}: {:?}", chain.error);
+    let mut packet = base_packet();
+    packet["summary"]["receipt_count"] = Value::from(chain.receipt_count as u64);
+    packet["summary"]["totals"] = serde_json::to_value(compute_totals(&receipts)).unwrap();
+    packet["verifier"]["receipt_count"] = Value::from(chain.receipt_count as u64);
+    packet["verifier"]["root_hash"] = Value::from(chain.root_hash);
+    packet["verifier"]["final_seq"] = Value::from(chain.final_seq);
+    fs::write(
+        dir.join("packet.json"),
+        format!("{}\n", serde_json::to_string_pretty(&packet).unwrap()),
     )
     .unwrap();
     fs::write(dir.join("verifier.txt"), "ok\n").unwrap();

--- a/sdk/verifiers/rust/tests/audit_packet.rs
+++ b/sdk/verifiers/rust/tests/audit_packet.rs
@@ -52,10 +52,13 @@ fn audit_packet_verifies_end_to_end() {
 }
 
 #[test]
-fn audit_packet_reports_lifecycle_structure_separately_from_chain_validity() {
+fn audit_packet_rejects_an_orphan_outcome_in_an_otherwise_valid_chain() {
     let packet_dir = write_packet_with_evidence("g1-valid-chain.jsonl", None);
     let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
-    assert!(report.valid, "{:?}", report.errors);
+    assert!(!report.valid);
+    assert_eq!(report.chain_check, "pass");
+    assert_eq!(report.cross_check, "pass");
+    assert!(has_error(&report.errors, "lifecycle: chain_broken"));
     assert_eq!(report.lifecycle_assessment, "assessed");
     assert_eq!(report.lifecycle_status.as_deref(), Some("BROKEN"));
     assert_eq!(report.lifecycle_reason.as_deref(), Some("chain_broken"));
@@ -202,7 +205,11 @@ fn audit_packet_rejects_empty_chain() {
     let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
     assert!(!report.valid);
     assert_eq!(report.chain_check, "fail");
+    assert_eq!(report.cross_check, "fail");
     assert!(has_error(&report.errors, "empty chain"));
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("UNVERIFIED"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("no_receipts"));
 }
 
 #[test]
@@ -295,7 +302,10 @@ fn audit_packet_reports_chain_failure_reason() {
     .unwrap();
     let report = verify_audit_packet(packet_dir.to_str().unwrap(), &default_options()).unwrap();
     assert_eq!(report.chain_check, "fail");
-    assert_eq!(report.cross_check, "skipped");
+    assert_eq!(report.cross_check, "fail");
+    assert_eq!(report.lifecycle_assessment, "assessed");
+    assert_eq!(report.lifecycle_status.as_deref(), Some("BROKEN"));
+    assert_eq!(report.lifecycle_reason.as_deref(), Some("chain_broken"));
     assert!(has_error(&report.errors, "chain_prev_hash mismatch"));
 }
 

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -535,6 +535,28 @@ fn g1_close_without_open_fixture_is_rejected() {
 }
 
 #[test]
+fn endorsement_verification_does_not_skip_root_trust_after_lifecycle_only_failure() {
+    let root = common::repo_root();
+    let receipts =
+        extract_receipts(&root.join("sdk/conformance/testdata/g1-close-without-open.jsonl"))
+            .unwrap();
+
+    let result =
+        verify_chain_with_endorsements(&receipts, "conformance-session", &[], &"0".repeat(64));
+
+    assert!(!result.valid);
+    assert_ne!(
+        result.failure_kind.as_deref(),
+        Some("lifecycle_missing_open"),
+        "failed endorsement verification must not preserve a lifecycle-only failure kind"
+    );
+    assert!(result
+        .error
+        .unwrap_or_default()
+        .contains("genesis signer key is not in the trusted root set"));
+}
+
+#[test]
 fn g1_new_session_after_close_fixture_verifies() {
     let root = common::repo_root();
     let receipts =

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -15,6 +15,7 @@ use pipelock_verifier_rs::rotation::{
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::fs;
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 struct TempFixture(std::path::PathBuf);
@@ -78,6 +79,30 @@ fn g1_go_generated_chain_verifies_with_pinned_key() {
     assert!(result.valid, "{:?}", result.error);
     assert_eq!(result.receipt_count, 5);
     assert_eq!(result.final_seq, 4);
+}
+
+#[test]
+fn chain_cli_rejects_a_lifecycle_broken_but_signature_valid_chain() {
+    let root = common::repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_pipelock-verifier-rs"))
+        .args([
+            "chain",
+            root.join("sdk/conformance/testdata/g1-valid-chain.jsonl")
+                .to_str()
+                .unwrap(),
+            "--key",
+            &conformance_key(),
+            "--json",
+        ])
+        .output()
+        .expect("run chain CLI");
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("chain JSON report");
+    assert_eq!(report["valid"], Value::Bool(false));
+    assert!(report["error"]
+        .as_str()
+        .unwrap_or("")
+        .contains("lifecycle: chain_broken"));
 }
 
 #[test]

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -8,7 +8,7 @@ use pipelock_verifier_rs::canonical::{canonicalize_action_record, canonicalize_j
 use pipelock_verifier_rs::chain::{
     compute_session_open_genesis, receipt_hash, verify_chain, verify_chain_with_options,
 };
-use pipelock_verifier_rs::recorder::extract_receipts;
+use pipelock_verifier_rs::recorder::{extract_receipts, read_entries};
 use pipelock_verifier_rs::rotation::{
     load_rotation_endorsement_file, verify_chain_with_endorsements, verify_rotation_endorsement,
 };
@@ -103,6 +103,29 @@ fn chain_cli_rejects_a_lifecycle_broken_but_signature_valid_chain() {
         .as_str()
         .unwrap_or("")
         .contains("lifecycle: chain_broken"));
+}
+
+#[test]
+fn chain_cli_preserves_a_chain_trust_failure_over_lifecycle_assessment() {
+    let root = common::repo_root();
+    let output = Command::new(env!("CARGO_BIN_EXE_pipelock-verifier-rs"))
+        .args([
+            "chain",
+            root.join("sdk/conformance/testdata/g1-valid-chain.jsonl")
+                .to_str()
+                .unwrap(),
+            "--key",
+            &"00".repeat(32),
+            "--json",
+        ])
+        .output()
+        .expect("run chain CLI");
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let report: Value = serde_json::from_slice(&output.stdout).expect("chain JSON report");
+    assert_eq!(report["valid"], Value::Bool(false));
+    let error = report["error"].as_str().unwrap_or("");
+    assert!(error.contains("not in the trusted set"), "{error}");
+    assert!(!error.contains("lifecycle:"), "{error}");
 }
 
 #[test]
@@ -641,6 +664,142 @@ fn g1_session_control_missing_record_run_nonce_is_rejected_with_valid_signature(
 }
 
 #[test]
+fn signed_malformed_lifecycle_controls_fail_closed_through_the_chain_cli() {
+    type ControlCase = (
+        &'static str,
+        fn(&mut [Value]),
+        Option<&'static str>,
+        &'static str,
+    );
+    let cases: &[ControlCase] = &[
+        (
+            "missing heartbeat payload",
+            |receipts| {
+                receipts[3]["action_record"]["session_control"]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("heartbeat");
+            },
+            Some("session_control must carry exactly one payload"),
+            "session_control must carry exactly one payload",
+        ),
+        (
+            "null heartbeat payload",
+            |receipts| {
+                receipts[3]["action_record"]["session_control"]["heartbeat"] = Value::Null;
+            },
+            Some("session_control must carry exactly one payload"),
+            "session_control must carry exactly one payload",
+        ),
+        (
+            "missing close payload",
+            |receipts| {
+                receipts[4]["action_record"]["session_control"]
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("close");
+            },
+            Some("session_control must carry exactly one payload"),
+            "session_control must carry exactly one payload",
+        ),
+        (
+            "null close payload",
+            |receipts| {
+                receipts[4]["action_record"]["session_control"]["close"] = Value::Null;
+            },
+            Some("session_control must carry exactly one payload"),
+            "session_control must carry exactly one payload",
+        ),
+        (
+            "heartbeat run_nonce mismatch",
+            |receipts| {
+                receipts[3]["action_record"]["session_control"]["heartbeat"]["run_nonce"] =
+                    json!("other-run");
+            },
+            Some("session_control run_nonce mismatch"),
+            "session_control run_nonce mismatch",
+        ),
+        (
+            "close run_nonce mismatch",
+            |receipts| {
+                receipts[4]["action_record"]["session_control"]["close"]["run_nonce"] =
+                    json!("other-run");
+            },
+            Some("session_control run_nonce mismatch"),
+            "session_control run_nonce mismatch",
+        ),
+        (
+            "missing beat with malformed durability counter",
+            |receipts| {
+                let heartbeat = receipts[3]["action_record"]["session_control"]["heartbeat"]
+                    .as_object_mut()
+                    .unwrap();
+                heartbeat.remove("beat");
+                heartbeat.insert("fsync_errors_gated".to_string(), json!("malformed-counter"));
+            },
+            None,
+            "lifecycle: chain_broken",
+        ),
+    ];
+    let root = common::repo_root();
+    let key = conformance_key();
+    for (name, mutate, direct_error, cli_error) in cases {
+        let mut entries =
+            read_entries(&root.join("sdk/conformance/testdata/g1-valid-chain.jsonl")).unwrap();
+        let mut receipts = entries
+            .iter()
+            .map(|entry| entry["detail"].clone())
+            .collect::<Vec<_>>();
+        mutate(&mut receipts);
+        resign_g1_tail(&mut receipts, 3);
+        for (entry, receipt) in entries.iter_mut().zip(receipts.iter()) {
+            entry["detail"] = receipt.clone();
+        }
+        let fixture = TempFixture(recorder_fixture_path("signed-malformed-control"));
+        fs::write(
+            &fixture.0,
+            format!(
+                "{}\n",
+                entries
+                    .iter()
+                    .map(serde_json::Value::to_string)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+        )
+        .unwrap();
+
+        let direct = verify_chain(&extract_receipts(&fixture.0).unwrap(), &key);
+        if let Some(expected) = direct_error {
+            assert!(!direct.valid, "{name} unexpectedly verified");
+            let error = direct.error.unwrap_or_default();
+            assert!(error.contains(expected), "{name}: {error}");
+            assert!(!error.contains("signature"), "{name}: {error}");
+        } else {
+            assert!(direct.valid, "{name}: {:?}", direct.error);
+        }
+
+        let output = Command::new(env!("CARGO_BIN_EXE_pipelock-verifier-rs"))
+            .args([
+                "chain",
+                fixture.0.to_str().unwrap(),
+                "--key",
+                &key,
+                "--json",
+            ])
+            .output()
+            .expect("run chain CLI");
+        assert_eq!(output.status.code(), Some(1), "{name}: {output:?}");
+        let report: Value = serde_json::from_slice(&output.stdout).expect("chain JSON report");
+        assert_eq!(report["valid"], Value::Bool(false), "{name}");
+        assert!(
+            report["error"].as_str().unwrap_or("").contains(cli_error),
+            "{name}: {report}"
+        );
+    }
+}
+
+#[test]
 fn g1_signed_field_tampering_is_rejected() {
     let root = common::repo_root();
     let key = conformance_key();
@@ -1061,6 +1220,21 @@ fn sign_evidence_receipt(receipt: &mut Value) {
 
 fn sign_action_receipt_with_conformance_key(receipt: &mut Value) {
     sign_action_receipt_with_conformance_key_fields(receipt, "seed_hex", "public_key_hex");
+}
+
+fn resign_g1_tail(receipts: &mut [Value], start: usize) {
+    let mut previous_hash = receipt_hash(&receipts[start - 1]);
+    for receipt in &mut receipts[start..] {
+        receipt["action_record"]["chain_prev_hash"] = json!(previous_hash);
+        if receipt["action_record"]["session_control"]["kind"] == "session_close"
+            && receipt["action_record"]["session_control"]["close"].is_object()
+        {
+            receipt["action_record"]["session_control"]["close"]["root_hash"] =
+                json!(previous_hash);
+        }
+        sign_action_receipt_with_conformance_key(receipt);
+        previous_hash = receipt_hash(receipt);
+    }
 }
 
 fn sign_action_receipt_with_conformance_key_fields(

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -523,6 +523,11 @@ fn g1_close_without_open_fixture_is_rejected() {
     let key = conformance_key();
     let result = verify_chain(&receipts, &key);
     assert!(!result.valid);
+    assert!(result.integrity_verified);
+    assert_eq!(
+        result.failure_kind.as_deref(),
+        Some("lifecycle_missing_open")
+    );
     assert!(result
         .error
         .unwrap_or_default()

--- a/sdk/verifiers/rust/tests/lifecycle.rs
+++ b/sdk/verifiers/rust/tests/lifecycle.rs
@@ -18,27 +18,46 @@ struct Expected {
 struct LifecycleVector {
     name: String,
     receipts: Vec<Receipt>,
+    chain_result: LifecycleChain,
     expected: Expected,
+}
+
+#[derive(Deserialize)]
+struct LifecycleVectorFile {
+    generated_by: String,
+    vectors: Vec<LifecycleVector>,
+}
+
+#[derive(Deserialize, Default)]
+struct LifecycleChain {
+    valid: bool,
+    #[serde(default)]
+    integrity_verified: bool,
+    #[serde(default)]
+    failure_kind: Option<String>,
 }
 
 #[test]
 fn lifecycle_verdict_vectors_match_go() {
-    let vectors: Vec<LifecycleVector> = serde_json::from_str(
+    let file: LifecycleVectorFile = serde_json::from_str(
         &fs::read_to_string(
             common::repo_root().join("sdk/conformance/testdata/lifecycle-verdict-vectors.json"),
         )
         .expect("read lifecycle verdict vectors"),
     )
     .expect("parse lifecycle verdict vectors");
-    let chain = ChainResult {
-        valid: true,
-        receipt_count: 3,
-        final_seq: 2,
-        root_hash: "test-root".to_string(),
-        error: None,
-        broken_at_seq: None,
-    };
-    for vector in vectors {
+    assert!(file.generated_by.starts_with("go test "));
+    for vector in file.vectors {
+        let chain = ChainResult {
+            valid: vector.chain_result.valid,
+            integrity_verified: vector.chain_result.integrity_verified,
+            failure_kind: vector.chain_result.failure_kind,
+            receipt_count: vector.receipts.len(),
+            final_seq: vector.receipts.len().saturating_sub(1) as u64,
+            root_hash: "test-root".to_string(),
+            error: None,
+            broken_at_seq: None,
+        };
         let actual = analyze_lifecycle(&vector.receipts, &chain);
         assert_eq!(
             actual.status, vector.expected.status,

--- a/sdk/verifiers/rust/tests/lifecycle.rs
+++ b/sdk/verifiers/rust/tests/lifecycle.rs
@@ -6,6 +6,7 @@ mod common;
 use pipelock_verifier_rs::lifecycle::analyze_lifecycle;
 use pipelock_verifier_rs::types::{ChainResult, Receipt};
 use serde::Deserialize;
+use serde_json::json;
 use std::fs;
 
 #[derive(Deserialize)]
@@ -47,6 +48,7 @@ fn lifecycle_verdict_vectors_match_go() {
     )
     .expect("parse lifecycle verdict vectors");
     assert!(file.generated_by.starts_with("go test "));
+    assert!(!file.vectors.is_empty(), "lifecycle vector file is empty");
     for vector in file.vectors {
         let chain = ChainResult {
             valid: vector.chain_result.valid,
@@ -70,4 +72,32 @@ fn lifecycle_verdict_vectors_match_go() {
             vector.name
         );
     }
+}
+
+#[test]
+fn missing_durability_fields_remain_unknown_instead_of_resetting_counters() {
+    let receipts = vec![
+        json!({"action_record":{"run_nonce":"run-missing-durability","session_control":{"kind":"session_open","open":{"run_nonce":"run-missing-durability","open_nonce":"open"}}}}),
+        json!({"action_record":{"run_nonce":"run-missing-durability","session_control":{"kind":"heartbeat","heartbeat":{"run_nonce":"run-missing-durability","open_nonce":"open","beat":1,"fsync_errors_gated":2,"durability_blocks":2}}}}),
+        json!({"action_record":{"run_nonce":"run-missing-durability","session_control":{"kind":"heartbeat","heartbeat":{"run_nonce":"run-missing-durability","open_nonce":"open","beat":2}}}}),
+        json!({"action_record":{"run_nonce":"run-missing-durability","session_control":{"kind":"session_close","close":{"run_nonce":"run-missing-durability","open_nonce":"open"}}}}),
+    ];
+    let chain = ChainResult {
+        valid: true,
+        integrity_verified: false,
+        failure_kind: None,
+        receipt_count: receipts.len(),
+        final_seq: 3,
+        root_hash: "test-root".to_string(),
+        error: None,
+        broken_at_seq: None,
+    };
+
+    assert_eq!(
+        analyze_lifecycle(&receipts, &chain),
+        pipelock_verifier_rs::lifecycle::LifecycleReport {
+            status: "LIMITED".to_string(),
+            reason: "bounded_closed".to_string(),
+        }
+    );
 }

--- a/sdk/verifiers/rust/tests/lifecycle.rs
+++ b/sdk/verifiers/rust/tests/lifecycle.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod common;
+
+use pipelock_verifier_rs::lifecycle::analyze_lifecycle;
+use pipelock_verifier_rs::types::{ChainResult, Receipt};
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize)]
+struct Expected {
+    status: String,
+    reason: String,
+}
+
+#[derive(Deserialize)]
+struct LifecycleVector {
+    name: String,
+    receipts: Vec<Receipt>,
+    expected: Expected,
+}
+
+#[test]
+fn lifecycle_verdict_vectors_match_go() {
+    let vectors: Vec<LifecycleVector> = serde_json::from_str(
+        &fs::read_to_string(
+            common::repo_root().join("sdk/conformance/testdata/lifecycle-verdict-vectors.json"),
+        )
+        .expect("read lifecycle verdict vectors"),
+    )
+    .expect("parse lifecycle verdict vectors");
+    let chain = ChainResult {
+        valid: true,
+        receipt_count: 3,
+        final_seq: 2,
+        root_hash: "test-root".to_string(),
+        error: None,
+        broken_at_seq: None,
+    };
+    for vector in vectors {
+        let actual = analyze_lifecycle(&vector.receipts, &chain);
+        assert_eq!(
+            actual.status, vector.expected.status,
+            "{} status",
+            vector.name
+        );
+        assert_eq!(
+            actual.reason, vector.expected.reason,
+            "{} reason",
+            vector.name
+        );
+    }
+}

--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipelock/verifier-ts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipelock/verifier-ts",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "3.1.0",

--- a/sdk/verifiers/ts/package.json
+++ b/sdk/verifiers/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipelock/verifier-ts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript reference verifier for Pipelock signed agent-egress receipts (Audit Packet v0, ActionReceipt v1, EvidenceReceipt v2).",
   "license": "Apache-2.0",
   "author": "Pipelab",

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import type { AuditPacket, AuditPacketReport, ChainResult, Receipt, Totals } from "./types.js";
 import { computeTotals, verifyChain } from "./chain.js";
+import { analyzeLifecycle } from "./lifecycle.js";
 import { extractReceipts } from "./recorder.js";
 import { validateAuditPacket } from "./schema.js";
 import {
@@ -57,6 +58,8 @@ function reportFromPacket(packetPath: string, packet?: AuditPacket): AuditPacket
     schema_check: "skipped",
     chain_check: "skipped",
     cross_check: "skipped",
+    lifecycle_assessment: "not_assessed",
+    lifecycle_assessment_reason: "chain re-verification did not complete",
   };
 }
 
@@ -154,6 +157,7 @@ export async function verifyAuditPacket(
   report.schema_check = "pass";
 
   if (opts.offline) {
+    report.lifecycle_assessment_reason = "offline mode skips chain re-verification";
     report.valid = trustVerdict(packet, opts);
     return report;
   }
@@ -186,6 +190,11 @@ export async function verifyAuditPacket(
     return report;
   }
   report.chain_check = chain.valid ? "pass" : "fail";
+  const lifecycle = analyzeLifecycle(receipts, chain);
+  report.lifecycle_status = lifecycle.status;
+  report.lifecycle_reason = lifecycle.reason;
+  report.lifecycle_assessment = "assessed";
+  delete report.lifecycle_assessment_reason;
 
   const crossErrors = crossCheck(packet, chain, receipts);
   if (crossErrors.length > 0) {

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -203,7 +203,8 @@ export async function verifyAuditPacket(
     return report;
   }
   report.cross_check = "pass";
-  report.valid = chain.valid && trustVerdict(packet, opts);
+  report.valid = chain.valid && lifecycle.status !== "BROKEN" && trustVerdict(packet, opts);
+  if (lifecycle.status === "BROKEN") pushError(report, `lifecycle: ${lifecycle.reason}`);
   if (!report.valid) pushError(report, "packet not trusted");
   return report;
 }

--- a/sdk/verifiers/ts/src/audit-packet.ts
+++ b/sdk/verifiers/ts/src/audit-packet.ts
@@ -190,6 +190,7 @@ export async function verifyAuditPacket(
     return report;
   }
   report.chain_check = chain.valid ? "pass" : "fail";
+  if (!chain.valid) pushError(report, `chain: ${chain.error ?? "verification failed"}`);
   const lifecycle = analyzeLifecycle(receipts, chain);
   report.lifecycle_status = lifecycle.status;
   report.lifecycle_reason = lifecycle.reason;

--- a/sdk/verifiers/ts/src/chain.ts
+++ b/sdk/verifiers/ts/src/chain.ts
@@ -29,6 +29,25 @@ export async function verifyChain(
   expectedKeyHex = "",
   options: VerifyChainOptions = {},
 ): Promise<ChainResult> {
+  const result = await verifyChainInternal(receipts, expectedKeyHex, options, false);
+  if (result.failure_kind !== "lifecycle_missing_open") return result;
+  const integrity = await verifyChainInternal(receipts, expectedKeyHex, options, true);
+  if (!integrity.valid) return integrity;
+  return {
+    ...result,
+    integrity_verified: true,
+    receipt_count: integrity.receipt_count,
+    final_seq: integrity.final_seq,
+    root_hash: integrity.root_hash,
+  };
+}
+
+async function verifyChainInternal(
+  receipts: Receipt[],
+  expectedKeyHex: string,
+  options: VerifyChainOptions,
+  skipLifecycle: boolean,
+): Promise<ChainResult> {
   if (receipts.length === 0) {
     return broken(0, "empty chain");
   }
@@ -111,23 +130,31 @@ export async function verifyChain(
       return broken(seq, `seq gap: expected ${expectedSeq}, got ${seq}`);
     }
     state.segmentReceiptCount++;
-    const closedRunResult = validateClosedRun(receipt, seq, state);
-    if (closedRunResult !== undefined) return closedRunResult;
-    const sessionControlResult = validateSessionControlState(receipt, seq, i, state);
-    if (sessionControlResult !== undefined) return sessionControlResult;
-    const open = sessionOpen(receipt);
-    if (open !== undefined) {
-      state.activeRunNonce = typeof open["run_nonce"] === "string" ? open["run_nonce"] : undefined;
-      state.activeOpenNonce =
-        typeof open["open_nonce"] === "string" ? open["open_nonce"] : undefined;
-      if (state.activeRunNonce !== undefined) {
-        state.openedRuns.add(state.activeRunNonce);
-        state.closedRuns.delete(state.activeRunNonce);
+    if (!skipLifecycle) {
+      const closedRunResult = validateClosedRun(receipt, seq, state);
+      if (closedRunResult !== undefined) {
+        if (closedRunResult.error?.includes("first receipt is not a matching session_open")) {
+          closedRunResult.failure_kind = "lifecycle_missing_open";
+        }
+        return closedRunResult;
       }
-    } else if (sessionClose(receipt) !== undefined) {
-      if (state.activeRunNonce !== undefined) state.closedRuns.add(state.activeRunNonce);
-      state.activeRunNonce = undefined;
-      state.activeOpenNonce = undefined;
+      const sessionControlResult = validateSessionControlState(receipt, seq, i, state);
+      if (sessionControlResult !== undefined) return sessionControlResult;
+      const open = sessionOpen(receipt);
+      if (open !== undefined) {
+        state.activeRunNonce =
+          typeof open["run_nonce"] === "string" ? open["run_nonce"] : undefined;
+        state.activeOpenNonce =
+          typeof open["open_nonce"] === "string" ? open["open_nonce"] : undefined;
+        if (state.activeRunNonce !== undefined) {
+          state.openedRuns.add(state.activeRunNonce);
+          state.closedRuns.delete(state.activeRunNonce);
+        }
+      } else if (sessionClose(receipt) !== undefined) {
+        if (state.activeRunNonce !== undefined) state.closedRuns.add(state.activeRunNonce);
+        state.activeRunNonce = undefined;
+        state.activeOpenNonce = undefined;
+      }
     }
     state.prevHash = receiptHash(receipt);
     state.priorSegmentSeq = seq;
@@ -510,7 +537,11 @@ function unpinnedChainResult(seq: number): ChainResult {
   return broken(seq, unpinnedReceiptBanner);
 }
 
-function broken(seq: number, error: string): ChainResult {
+function broken(
+  seq: number,
+  error: string,
+  failureKind?: ChainResult["failure_kind"],
+): ChainResult {
   return {
     valid: false,
     receipt_count: 0,
@@ -518,6 +549,7 @@ function broken(seq: number, error: string): ChainResult {
     root_hash: "",
     broken_at_seq: seq,
     error,
+    failure_kind: failureKind,
   };
 }
 

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { parseArgs } from "node:util";
 import { verifyAuditPacket } from "./audit-packet.js";
 import { verifyChain } from "./chain.js";
+import { analyzeLifecycle } from "./lifecycle.js";
 import { emitAuditPacket, emitChain, emitReceipt } from "./output.js";
 import { extractReceipts, extractReceiptsFromSessionDir } from "./recorder.js";
 import { runReceipt } from "./receipt.js";
@@ -139,18 +140,22 @@ async function runChainCommand(args: string[]): Promise<number> {
           endorsements,
         })
       : await verifyChain(receipts, keyHex, { allowUnpinned });
+  const lifecycle = analyzeLifecycle(receipts, result);
+  const lifecycleBroken = lifecycle.status === "BROKEN";
   const report: ChainCommandReport = {
     path: label,
-    valid: result.valid,
-    unpinned: keyHex === "" && (result.valid || result.error?.includes("UNPINNED")),
+    valid: result.valid && !lifecycleBroken,
+    unpinned:
+      keyHex === "" &&
+      (result.error?.includes("UNPINNED") === true || (result.valid && !lifecycleBroken)),
     receipt_count: result.receipt_count,
     final_seq: result.final_seq,
     root_hash: result.root_hash || undefined,
-    error: result.error,
+    error: lifecycleBroken ? `lifecycle: ${lifecycle.reason}` : result.error,
     broken_at_seq: result.broken_at_seq,
   };
   emitChain(report, parsed.values.json === true);
-  return result.valid ? 0 : 1;
+  return report.valid ? 0 : 1;
 }
 
 async function runReceiptCommand(args: string[]): Promise<number> {

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -153,7 +153,10 @@ async function runChainCommand(args: string[]): Promise<number> {
     receipt_count: result.receipt_count,
     final_seq: result.final_seq,
     root_hash: result.root_hash || undefined,
-    error: lifecycleBroken ? `lifecycle: ${lifecycle.reason}` : result.error,
+    // Preserve the verifier's concrete cryptographic, hash, trust, or
+    // sequence failure. Lifecycle is a supplemental gate only when the chain
+    // itself verified successfully.
+    error: lifecycleBroken && result.valid ? `lifecycle: ${lifecycle.reason}` : result.error,
     broken_at_seq: result.broken_at_seq,
   };
   emitChain(report, parsed.values.json === true);

--- a/sdk/verifiers/ts/src/cli.ts
+++ b/sdk/verifiers/ts/src/cli.ts
@@ -147,7 +147,9 @@ async function runChainCommand(args: string[]): Promise<number> {
     valid: result.valid && !lifecycleBroken,
     unpinned:
       keyHex === "" &&
-      (result.error?.includes("UNPINNED") === true || (result.valid && !lifecycleBroken)),
+      (result.error?.includes("UNPINNED") === true || (result.valid && !lifecycleBroken))
+        ? true
+        : undefined,
     receipt_count: result.receipt_count,
     final_seq: result.final_seq,
     root_hash: result.root_hash || undefined,

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -1,0 +1,178 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ChainResult, LifecycleReason, LifecycleStatus, Receipt } from "./types.js";
+
+export interface LifecycleReport {
+  status: LifecycleStatus;
+  reason: LifecycleReason;
+}
+
+interface RunState {
+  opened: boolean;
+  closed: boolean;
+  intents: Map<string, number>;
+  outcomes: Map<string, number>;
+  sawHeartbeat: boolean;
+  lastHeartbeat: number;
+  heartbeatGap: boolean;
+}
+
+const limited: LifecycleStatus = "LIMITED";
+const broken: LifecycleStatus = "BROKEN";
+const unverified: LifecycleStatus = "UNVERIFIED";
+
+// analyzeLifecycle mirrors the Go verifier's packet-level lifecycle verdict.
+// It deliberately reports an open but otherwise valid run as LIMITED rather
+// than rejecting the packet: integrity and a clean session close answer
+// different questions.
+export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): LifecycleReport {
+  if (receipts.length === 0) return { status: unverified, reason: "no_receipts" };
+  if (!chain.valid) return { status: broken, reason: "chain_broken" };
+  const controls = receipts.filter((receipt) => sessionControl(receipt) !== undefined);
+  if (controls.length === 0) return { status: unverified, reason: "no_lifecycle" };
+
+  const runs = new Map<string, RunState>();
+  const stateFor = (runNonce: string): RunState => {
+    let state = runs.get(runNonce);
+    if (state === undefined) {
+      state = {
+        opened: false,
+        closed: false,
+        intents: new Map<string, number>(),
+        outcomes: new Map<string, number>(),
+        sawHeartbeat: false,
+        lastHeartbeat: 0,
+        heartbeatGap: false,
+      };
+      runs.set(runNonce, state);
+    }
+    return state;
+  };
+
+  for (const receipt of receipts) {
+    const record = receipt.action_record;
+    if (record === undefined) continue;
+    const control = sessionControl(receipt);
+    const runNonce = runNonceFor(record, control);
+    if (runNonce === "") continue;
+    const state = stateFor(runNonce);
+
+    if (record.decision_phase === "intent") increment(state.intents, record.action_id ?? "");
+    if (record.decision_phase === "outcome") increment(state.outcomes, record.action_id ?? "");
+
+    if (control === undefined) continue;
+    const kind = control["kind"];
+    if (kind === "session_open") {
+      state.opened = true;
+      state.closed = false;
+      continue;
+    }
+    if (kind === "session_close") {
+      state.closed = true;
+      continue;
+    }
+    if (kind === "session_heartbeat") {
+      const heartbeat = objectField(control, "heartbeat");
+      const beat = heartbeat?.["beat"];
+      if (typeof beat === "number" && Number.isInteger(beat)) {
+        if (
+          (state.sawHeartbeat && beat !== state.lastHeartbeat + 1) ||
+          (!state.sawHeartbeat && beat !== 1)
+        ) {
+          state.heartbeatGap = true;
+        }
+        state.sawHeartbeat = true;
+        state.lastHeartbeat = beat;
+      }
+    }
+  }
+
+  let report: LifecycleReport | undefined;
+  for (const state of runs.values()) {
+    report = worse(report, assessRun(state));
+  }
+  return report ?? { status: unverified, reason: "no_lifecycle" };
+}
+
+function sessionControl(receipt: Receipt): Record<string, unknown> | undefined {
+  const value = receipt.action_record?.session_control;
+  return value !== undefined && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function objectField(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const field = value[key];
+  return field !== null && typeof field === "object" && !Array.isArray(field)
+    ? (field as Record<string, unknown>)
+    : undefined;
+}
+
+function runNonceFor(
+  record: NonNullable<Receipt["action_record"]>,
+  control: Record<string, unknown> | undefined,
+): string {
+  if (typeof record.run_nonce === "string" && record.run_nonce !== "") return record.run_nonce;
+  if (control === undefined) return "";
+  const kind = control["kind"];
+  const payload =
+    kind === "session_open"
+      ? objectField(control, "open")
+      : kind === "session_heartbeat"
+        ? objectField(control, "heartbeat")
+        : kind === "session_close"
+          ? objectField(control, "close")
+          : undefined;
+  return typeof payload?.["run_nonce"] === "string" ? (payload["run_nonce"] as string) : "";
+}
+
+function increment(values: Map<string, number>, key: string): void {
+  values.set(key, (values.get(key) ?? 0) + 1);
+}
+
+function assessRun(state: RunState): LifecycleReport {
+  if (!state.opened) return { status: unverified, reason: "no_open" };
+  for (const [actionID, outcomes] of state.outcomes) {
+    if ((state.intents.get(actionID) ?? 0) < outcomes)
+      return { status: broken, reason: "chain_broken" };
+  }
+  for (const [actionID, intents] of state.intents) {
+    if ((state.outcomes.get(actionID) ?? 0) < intents)
+      return { status: limited, reason: "open_action" };
+  }
+  if (state.heartbeatGap) return { status: limited, reason: "heartbeat_gap" };
+  if (!state.closed) return { status: limited, reason: "abnormal_end" };
+  return { status: limited, reason: "bounded_closed" };
+}
+
+function worse(current: LifecycleReport | undefined, next: LifecycleReport): LifecycleReport {
+  if (current === undefined) return next;
+  const statusOrder: Record<LifecycleStatus, number> = {
+    LIMITED: 1,
+    UNVERIFIED: 2,
+    BROKEN: 3,
+  };
+  const reasonOrder: Record<LifecycleReason, number> = {
+    chain_broken: 100,
+    no_open: 80,
+    no_lifecycle: 70,
+    recorder_disabled: 70,
+    no_receipts: 70,
+    open_action: 50,
+    heartbeat_gap: 40,
+    abnormal_end: 30,
+    bounded_closed: 10,
+  };
+  if (statusOrder[next.status] > statusOrder[current.status]) return next;
+  if (
+    statusOrder[next.status] === statusOrder[current.status] &&
+    reasonOrder[next.reason] > reasonOrder[current.reason]
+  ) {
+    return next;
+  }
+  return current;
+}

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -82,14 +82,31 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
       continue;
     }
     if (kind === "session_close") {
+      const close = objectField(control, "close");
+      if (
+        close === undefined ||
+        typeof record.run_nonce !== "string" ||
+        record.run_nonce === "" ||
+        close["run_nonce"] !== record.run_nonce
+      ) {
+        return { status: broken, reason: "chain_broken" };
+      }
       state.closed = true;
-      if (!applyDurability(state, objectField(control, "close"))) {
+      if (!applyDurability(state, close)) {
         return { status: broken, reason: "chain_broken" };
       }
       continue;
     }
     if (kind === "heartbeat" || kind === "session_heartbeat") {
       const heartbeat = objectField(control, "heartbeat");
+      if (
+        heartbeat === undefined ||
+        typeof record.run_nonce !== "string" ||
+        record.run_nonce === "" ||
+        heartbeat["run_nonce"] !== record.run_nonce
+      ) {
+        return { status: broken, reason: "chain_broken" };
+      }
       const beat = heartbeat?.["beat"];
       if (beat !== undefined && !validCounter(beat)) {
         return { status: broken, reason: "chain_broken" };

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -21,8 +21,8 @@ interface RunState {
 }
 
 interface DurabilitySnapshot {
-  fsyncErrorsGated: number;
-  durabilityBlocks: number;
+  fsyncErrorsGated?: number;
+  durabilityBlocks?: number;
 }
 
 const limited: LifecycleStatus = "LIMITED";
@@ -83,13 +83,18 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
     }
     if (kind === "session_close") {
       state.closed = true;
-      applyDurability(state, objectField(control, "close"));
+      if (!applyDurability(state, objectField(control, "close"))) {
+        return { status: broken, reason: "chain_broken" };
+      }
       continue;
     }
     if (kind === "heartbeat" || kind === "session_heartbeat") {
       const heartbeat = objectField(control, "heartbeat");
       const beat = heartbeat?.["beat"];
-      if (typeof beat === "number" && Number.isInteger(beat)) {
+      if (beat !== undefined && !validCounter(beat)) {
+        return { status: broken, reason: "chain_broken" };
+      }
+      if (beat !== undefined) {
         if (
           (state.sawHeartbeat && beat !== state.lastHeartbeat + 1) ||
           (!state.sawHeartbeat && beat !== 1)
@@ -99,7 +104,7 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
         state.sawHeartbeat = true;
         state.lastHeartbeat = beat;
       }
-      applyDurability(state, heartbeat);
+      if (!applyDurability(state, heartbeat)) return { status: broken, reason: "chain_broken" };
     }
   }
 
@@ -110,23 +115,36 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
   return report ?? { status: unverified, reason: "no_lifecycle" };
 }
 
-function applyDurability(state: RunState, value: Record<string, unknown> | undefined): void {
+function applyDurability(state: RunState, value: Record<string, unknown> | undefined): boolean {
+  const fsyncErrorsGated = counter(value?.["fsync_errors_gated"]);
+  const durabilityBlocks = counter(value?.["durability_blocks"]);
+  if (fsyncErrorsGated === null || durabilityBlocks === null) return false;
   const snapshot: DurabilitySnapshot = {
-    fsyncErrorsGated: counter(value?.["fsync_errors_gated"]),
-    durabilityBlocks: counter(value?.["durability_blocks"]),
+    fsyncErrorsGated,
+    durabilityBlocks,
   };
   if (
     state.lastDurability !== undefined &&
-    (snapshot.fsyncErrorsGated < state.lastDurability.fsyncErrorsGated ||
-      snapshot.durabilityBlocks < state.lastDurability.durabilityBlocks)
+    ((snapshot.fsyncErrorsGated !== undefined &&
+      state.lastDurability.fsyncErrorsGated !== undefined &&
+      snapshot.fsyncErrorsGated < state.lastDurability.fsyncErrorsGated) ||
+      (snapshot.durabilityBlocks !== undefined &&
+        state.lastDurability.durabilityBlocks !== undefined &&
+        snapshot.durabilityBlocks < state.lastDurability.durabilityBlocks))
   ) {
     state.durabilityDrop = true;
   }
   state.lastDurability = snapshot;
+  return true;
 }
 
-function counter(value: unknown): number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : 0;
+function validCounter(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function counter(value: unknown): number | undefined | null {
+  if (value === undefined) return undefined;
+  return validCounter(value) ? value : null;
 }
 
 function sessionControl(receipt: Receipt): Record<string, unknown> | undefined {

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -68,7 +68,7 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
     if (record === undefined) continue;
     const control = sessionControl(receipt);
     const runNonce = runNonceFor(record, control);
-    if (runNonce === "") continue;
+    if (runNonce === "") return { status: broken, reason: "chain_broken" };
     const state = stateFor(runNonce);
 
     if (record.decision_phase === "intent") increment(state.intents, record.action_id ?? "");
@@ -131,7 +131,7 @@ function counter(value: unknown): number {
 
 function sessionControl(receipt: Receipt): Record<string, unknown> | undefined {
   const value = receipt.action_record?.session_control;
-  return value !== undefined && typeof value === "object" && !Array.isArray(value)
+  return value !== null && value !== undefined && typeof value === "object" && !Array.isArray(value)
     ? value
     : undefined;
 }

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -16,6 +16,13 @@ interface RunState {
   sawHeartbeat: boolean;
   lastHeartbeat: number;
   heartbeatGap: boolean;
+  lastDurability?: DurabilitySnapshot;
+  durabilityDrop: boolean;
+}
+
+interface DurabilitySnapshot {
+  fsyncErrorsGated: number;
+  durabilityBlocks: number;
 }
 
 const limited: LifecycleStatus = "LIMITED";
@@ -44,6 +51,7 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
         sawHeartbeat: false,
         lastHeartbeat: 0,
         heartbeatGap: false,
+        durabilityDrop: false,
       };
       runs.set(runNonce, state);
     }
@@ -70,9 +78,10 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
     }
     if (kind === "session_close") {
       state.closed = true;
+      applyDurability(state, objectField(control, "close"));
       continue;
     }
-    if (kind === "session_heartbeat") {
+    if (kind === "heartbeat" || kind === "session_heartbeat") {
       const heartbeat = objectField(control, "heartbeat");
       const beat = heartbeat?.["beat"];
       if (typeof beat === "number" && Number.isInteger(beat)) {
@@ -85,6 +94,7 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
         state.sawHeartbeat = true;
         state.lastHeartbeat = beat;
       }
+      applyDurability(state, heartbeat);
     }
   }
 
@@ -93,6 +103,25 @@ export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): Lifec
     report = worse(report, assessRun(state));
   }
   return report ?? { status: unverified, reason: "no_lifecycle" };
+}
+
+function applyDurability(state: RunState, value: Record<string, unknown> | undefined): void {
+  const snapshot: DurabilitySnapshot = {
+    fsyncErrorsGated: counter(value?.["fsync_errors_gated"]),
+    durabilityBlocks: counter(value?.["durability_blocks"]),
+  };
+  if (
+    state.lastDurability !== undefined &&
+    (snapshot.fsyncErrorsGated < state.lastDurability.fsyncErrorsGated ||
+      snapshot.durabilityBlocks < state.lastDurability.durabilityBlocks)
+  ) {
+    state.durabilityDrop = true;
+  }
+  state.lastDurability = snapshot;
+}
+
+function counter(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : 0;
 }
 
 function sessionControl(receipt: Receipt): Record<string, unknown> | undefined {
@@ -144,6 +173,7 @@ function assessRun(state: RunState): LifecycleReport {
     if ((state.outcomes.get(actionID) ?? 0) < intents)
       return { status: limited, reason: "open_action" };
   }
+  if (state.durabilityDrop) return { status: broken, reason: "chain_broken" };
   if (state.heartbeatGap) return { status: limited, reason: "heartbeat_gap" };
   if (!state.closed) return { status: limited, reason: "abnormal_end" };
   return { status: limited, reason: "bounded_closed" };

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -204,7 +204,10 @@ function increment(values: Map<string, number>, key: string): void {
 }
 
 function assessRun(state: RunState): LifecycleReport {
-  if (!state.opened) return { status: unverified, reason: "no_open" };
+  // An observed run nonce without its own session_open contradicts the
+  // transcript. UNVERIFIED/no_open is reserved for the chain verifier's
+  // explicit, integrity-proven lifecycle_missing_open failure kind above.
+  if (!state.opened) return { status: broken, reason: "chain_broken" };
   for (const [actionID, outcomes] of state.outcomes) {
     if ((state.intents.get(actionID) ?? 0) === 0 && outcomes > 0)
       return { status: broken, reason: "chain_broken" };

--- a/sdk/verifiers/ts/src/lifecycle.ts
+++ b/sdk/verifiers/ts/src/lifecycle.ts
@@ -35,7 +35,12 @@ const unverified: LifecycleStatus = "UNVERIFIED";
 // different questions.
 export function analyzeLifecycle(receipts: Receipt[], chain: ChainResult): LifecycleReport {
   if (receipts.length === 0) return { status: unverified, reason: "no_receipts" };
-  if (!chain.valid) return { status: broken, reason: "chain_broken" };
+  const missingOpen =
+    !chain.valid &&
+    chain.integrity_verified === true &&
+    chain.failure_kind === "lifecycle_missing_open";
+  if (!chain.valid && !missingOpen) return { status: broken, reason: "chain_broken" };
+  if (missingOpen) return { status: unverified, reason: "no_open" };
   const controls = receipts.filter((receipt) => sessionControl(receipt) !== undefined);
   if (controls.length === 0) return { status: unverified, reason: "no_lifecycle" };
 
@@ -151,7 +156,7 @@ function runNonceFor(
   const payload =
     kind === "session_open"
       ? objectField(control, "open")
-      : kind === "session_heartbeat"
+      : kind === "heartbeat" || kind === "session_heartbeat"
         ? objectField(control, "heartbeat")
         : kind === "session_close"
           ? objectField(control, "close")
@@ -166,7 +171,7 @@ function increment(values: Map<string, number>, key: string): void {
 function assessRun(state: RunState): LifecycleReport {
   if (!state.opened) return { status: unverified, reason: "no_open" };
   for (const [actionID, outcomes] of state.outcomes) {
-    if ((state.intents.get(actionID) ?? 0) < outcomes)
+    if ((state.intents.get(actionID) ?? 0) === 0 && outcomes > 0)
       return { status: broken, reason: "chain_broken" };
   }
   for (const [actionID, intents] of state.intents) {

--- a/sdk/verifiers/ts/src/output.ts
+++ b/sdk/verifiers/ts/src/output.ts
@@ -19,6 +19,15 @@ export function emitAuditPacket(report: AuditPacketReport, json: boolean): void 
   process.stdout.write(`  schema:       ${report.schema_check}\n`);
   process.stdout.write(`  chain:        ${report.chain_check}\n`);
   process.stdout.write(`  cross-check:  ${report.cross_check}\n`);
+  if (report.lifecycle_assessment !== "assessed") {
+    process.stdout.write(
+      `  lifecycle:    not assessed (${report.lifecycle_assessment_reason ?? "chain re-verification did not complete"})\n`,
+    );
+  } else {
+    process.stdout.write(
+      `  lifecycle:    ${report.lifecycle_status} (${report.lifecycle_reason})\n`,
+    );
+  }
   process.stdout.write(`  verdict:      ${verdict}\n`);
   process.stdout.write(`  trusted:      ${String(report.trusted)}\n`);
   process.stdout.write(`  receipts:     ${report.summary.receipt_count}\n`);

--- a/sdk/verifiers/ts/src/rotation.ts
+++ b/sdk/verifiers/ts/src/rotation.ts
@@ -41,7 +41,7 @@ export interface EndorsedChainOptions {
 }
 
 function broken(base: ChainResult, message: string): ChainResult {
-  return { ...base, valid: false, error: message };
+  return { ...base, valid: false, failure_kind: undefined, error: message };
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -327,7 +327,11 @@ export async function verifyChainWithEndorsements(
     ),
   ];
   const base = await verifyChain(receipts, allKeys.join(","));
-  if (!base.valid) return base;
+  const lifecycleOnlyFailure =
+    !base.valid &&
+    base.integrity_verified === true &&
+    base.failure_kind === "lifecycle_missing_open";
+  if (!base.valid && !lifecycleOnlyFailure) return base;
   const roots = new Set(
     rootKeyHex
       .split(",")

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -75,6 +75,8 @@ export interface ActionRecord {
   chain_prev_hash?: string;
   chain_seq?: number;
   run_nonce?: string;
+  decision_phase?: string;
+  session_control?: Record<string, unknown>;
   key_transition?: KeyTransition;
   venue?: string;
   jurisdiction?: string;
@@ -239,4 +241,23 @@ export interface AuditPacketReport {
   schema_check: "pass" | "fail" | "skipped";
   chain_check: "pass" | "fail" | "skipped";
   cross_check: "pass" | "fail" | "skipped";
+  lifecycle_status?: LifecycleStatus;
+  lifecycle_reason?: LifecycleReason;
+  lifecycle_assessment: LifecycleAssessment;
+  lifecycle_assessment_reason?: string;
 }
+
+export type LifecycleStatus = "LIMITED" | "BROKEN" | "UNVERIFIED";
+
+export type LifecycleReason =
+  | "bounded_closed"
+  | "abnormal_end"
+  | "open_action"
+  | "heartbeat_gap"
+  | "no_open"
+  | "no_lifecycle"
+  | "recorder_disabled"
+  | "no_receipts"
+  | "chain_broken";
+
+export type LifecycleAssessment = "assessed" | "not_assessed";

--- a/sdk/verifiers/ts/src/types.ts
+++ b/sdk/verifiers/ts/src/types.ts
@@ -210,6 +210,8 @@ export interface AuditPacket {
 
 export interface ChainResult {
   valid: boolean;
+  integrity_verified?: boolean;
+  failure_kind?: "integrity" | "trust" | "lifecycle" | "lifecycle_missing_open";
   receipt_count: number;
   final_seq: number;
   root_hash: string;

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -245,6 +245,9 @@ test("audit packet rejects an empty chain", async () => {
   assert.equal(report.valid, false);
   assert.equal(report.chain_check, "fail");
   assert.ok(report.errors?.some((err) => err.includes("empty chain")));
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "UNVERIFIED");
+  assert.equal(report.lifecycle_reason, "no_receipts");
 });
 
 test("literal signer key wins over a same-named cwd file", () => {

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -8,6 +8,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { verifyAuditPacket } from "../src/audit-packet.js";
+import { computeTotals, verifyChain } from "../src/chain.js";
+import { extractReceipts } from "../src/recorder.js";
 import type { AuditPacket } from "../src/types.js";
 import { resolveSignerKey, sha256Hex } from "../src/util.js";
 
@@ -83,6 +85,30 @@ function writePacket(mutator?: (packet: AuditPacket) => void): string {
   return dir;
 }
 
+async function writePacketWithEvidence(source: string, lines?: number): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "pipelock-ts-verifier-lifecycle-"));
+  const rawEvidence = readFileSync(source, "utf8");
+  const evidence =
+    lines === undefined
+      ? rawEvidence
+      : `${rawEvidence.trimEnd().split("\n").slice(0, lines).join("\n")}\n`;
+  writeFileSync(path.join(dir, "evidence.jsonl"), evidence, { mode: 0o600 });
+  const receipts = extractReceipts(path.join(dir, "evidence.jsonl"));
+  const chain = await verifyChain(receipts, publicKey);
+  assert.equal(chain.valid, true, chain.error);
+  const packet = basePacket();
+  packet.summary!.receipt_count = chain.receipt_count;
+  packet.summary!.totals = computeTotals(receipts);
+  packet.verifier!.receipt_count = chain.receipt_count;
+  packet.verifier!.root_hash = chain.root_hash;
+  packet.verifier!.final_seq = chain.final_seq;
+  writeFileSync(path.join(dir, "packet.json"), `${JSON.stringify(packet, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  writeFileSync(path.join(dir, "verifier.txt"), "ok\n", { mode: 0o600 });
+  return dir;
+}
+
 const defaultOptions = {
   signerKey: publicKey,
   offline: false,
@@ -97,6 +123,57 @@ test("audit packet verifies end to end", async () => {
   assert.equal(report.schema_check, "pass");
   assert.equal(report.chain_check, "pass");
   assert.equal(report.cross_check, "pass");
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "UNVERIFIED");
+  assert.equal(report.lifecycle_reason, "no_lifecycle");
+});
+
+test("audit packet reports lifecycle structure separately from chain validity", async () => {
+  const report = await verifyAuditPacket(
+    await writePacketWithEvidence("../../conformance/testdata/g1-valid-chain.jsonl"),
+    defaultOptions,
+  );
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "BROKEN");
+  assert.equal(report.lifecycle_reason, "chain_broken");
+});
+
+test("audit packet keeps an in-progress lifecycle valid but names it", async () => {
+  const report = await verifyAuditPacket(
+    await writePacketWithEvidence("../../conformance/testdata/g1-restart-chain.jsonl"),
+    defaultOptions,
+  );
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "LIMITED");
+  assert.equal(report.lifecycle_reason, "open_action");
+});
+
+test("audit packet keeps an open session valid but marks its missing close", async () => {
+  const report = await verifyAuditPacket(
+    await writePacketWithEvidence("../../conformance/testdata/g1-valid-chain.jsonl", 1),
+    defaultOptions,
+  );
+  assert.equal(report.valid, true, JSON.stringify(report.errors));
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "LIMITED");
+  assert.equal(report.lifecycle_reason, "abnormal_end");
+});
+
+test("audit packet reports a malformed lifecycle chain as assessed and broken", async () => {
+  const dir = writePacket();
+  writeFileSync(
+    path.join(dir, "evidence.jsonl"),
+    readFileSync("../../conformance/testdata/g1-inconsistent-close.jsonl"),
+    { mode: 0o600 },
+  );
+  const report = await verifyAuditPacket(dir, defaultOptions);
+  assert.equal(report.valid, false);
+  assert.equal(report.chain_check, "fail");
+  assert.equal(report.lifecycle_assessment, "assessed");
+  assert.equal(report.lifecycle_status, "BROKEN");
+  assert.equal(report.lifecycle_reason, "chain_broken");
 });
 
 test("audit packet requires external trust for valid verdict", async () => {
@@ -285,6 +362,8 @@ test("--offline skips chain verification", async () => {
   assert.equal(report.valid, true);
   assert.equal(report.chain_check, "skipped");
   assert.equal(report.cross_check, "skipped");
+  assert.equal(report.lifecycle_assessment, "not_assessed");
+  assert.equal(report.lifecycle_assessment_reason, "offline mode skips chain re-verification");
 });
 
 test("CLI missing argument exits 64", () => {

--- a/sdk/verifiers/ts/tests/audit-packet.test.ts
+++ b/sdk/verifiers/ts/tests/audit-packet.test.ts
@@ -128,12 +128,15 @@ test("audit packet verifies end to end", async () => {
   assert.equal(report.lifecycle_reason, "no_lifecycle");
 });
 
-test("audit packet reports lifecycle structure separately from chain validity", async () => {
+test("audit packet rejects an orphan outcome in an otherwise valid chain", async () => {
   const report = await verifyAuditPacket(
     await writePacketWithEvidence("../../conformance/testdata/g1-valid-chain.jsonl"),
     defaultOptions,
   );
-  assert.equal(report.valid, true, JSON.stringify(report.errors));
+  assert.equal(report.valid, false);
+  assert.equal(report.chain_check, "pass");
+  assert.equal(report.cross_check, "pass");
+  assert.ok(report.errors?.some((error) => error.includes("lifecycle: chain_broken")));
   assert.equal(report.lifecycle_assessment, "assessed");
   assert.equal(report.lifecycle_status, "BROKEN");
   assert.equal(report.lifecycle_reason, "chain_broken");

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -422,6 +422,8 @@ test("g1 close without open fixture is rejected", async () => {
     .public_key_hex;
   const result = await verifyChain(extractReceipts(g1CloseWithoutOpen), key);
   assert.equal(result.valid, false);
+  assert.equal(result.integrity_verified, true);
+  assert.equal(result.failure_kind, "lifecycle_missing_open");
   assert.match(result.error ?? "", /first receipt is not a matching session_open/u);
 });
 

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -394,6 +394,19 @@ test("chain CLI rejects a lifecycle-broken but signature-valid chain", () => {
   assert.match(report.error ?? "", /lifecycle: chain_broken/u);
 });
 
+test("chain CLI preserves a chain trust failure over lifecycle assessment", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["dist/src/cli.js", "chain", g1ValidChain, "--key", "00".repeat(32), "--json"],
+    { encoding: "utf8", timeout: 10_000 },
+  );
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stdout) as { valid: boolean; error?: string };
+  assert.equal(report.valid, false);
+  assert.match(report.error ?? "", /not in the trusted set/u);
+  assert.doesNotMatch(report.error ?? "", /lifecycle:/u);
+});
+
 test("g1 plain action after close fixture is rejected", async () => {
   const key = (JSON.parse(readFileSync(testKey, "utf8")) as { public_key_hex: string })
     .public_key_hex;
@@ -465,6 +478,120 @@ test("g1 session_control missing record run_nonce is rejected with valid signatu
   assert.equal(result.valid, false);
   assert.equal(result.broken_at_seq, 3);
   assert.match(result.error ?? "", /session_control receipt missing run_nonce/u);
+});
+
+test("signed malformed lifecycle controls fail closed through the chain CLI", async () => {
+  type ControlCase = {
+    name: string;
+    mutate: (receipts: Receipt[]) => void;
+    directError?: RegExp;
+    cliError: RegExp;
+  };
+  const cases: ControlCase[] = [
+    {
+      name: "missing heartbeat payload",
+      mutate: (receipts) => {
+        delete (receipts[3]!.action_record!.session_control as Record<string, unknown>)[
+          "heartbeat"
+        ];
+      },
+      directError: /session_control must carry exactly one payload/u,
+      cliError: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "null heartbeat payload",
+      mutate: (receipts) => {
+        (receipts[3]!.action_record!.session_control as Record<string, unknown>)["heartbeat"] =
+          null;
+      },
+      directError: /session_control must carry exactly one payload/u,
+      cliError: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "missing close payload",
+      mutate: (receipts) => {
+        delete (receipts[4]!.action_record!.session_control as Record<string, unknown>)["close"];
+      },
+      directError: /session_control must carry exactly one payload/u,
+      cliError: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "null close payload",
+      mutate: (receipts) => {
+        (receipts[4]!.action_record!.session_control as Record<string, unknown>)["close"] = null;
+      },
+      directError: /session_control must carry exactly one payload/u,
+      cliError: /session_control must carry exactly one payload/u,
+    },
+    {
+      name: "heartbeat run_nonce mismatch",
+      mutate: (receipts) => {
+        const heartbeat = (receipts[3]!.action_record!.session_control as Record<string, unknown>)[
+          "heartbeat"
+        ] as Record<string, unknown>;
+        heartbeat["run_nonce"] = "other-run";
+      },
+      directError: /session_control run_nonce mismatch/u,
+      cliError: /session_control run_nonce mismatch/u,
+    },
+    {
+      name: "close run_nonce mismatch",
+      mutate: (receipts) => {
+        const close = (receipts[4]!.action_record!.session_control as Record<string, unknown>)[
+          "close"
+        ] as Record<string, unknown>;
+        close["run_nonce"] = "other-run";
+      },
+      directError: /session_control run_nonce mismatch/u,
+      cliError: /session_control run_nonce mismatch/u,
+    },
+    {
+      name: "missing beat with malformed durability counter",
+      mutate: (receipts) => {
+        const heartbeat = (receipts[3]!.action_record!.session_control as Record<string, unknown>)[
+          "heartbeat"
+        ] as Record<string, unknown>;
+        delete heartbeat["beat"];
+        heartbeat["fsync_errors_gated"] = "malformed-counter";
+      },
+      cliError: /lifecycle: chain_broken/u,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const dir = mkdtempSync(join(tmpdir(), "pipelock-ts-verifier-signed-control-"));
+    try {
+      const entries = readEntries(g1ValidChain);
+      const receipts = entries.map((entry) => entry.detail as Receipt);
+      testCase.mutate(receipts);
+      await resignG1Tail(receipts, 3);
+      const file = join(dir, "evidence.jsonl");
+      writeFileSync(file, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, {
+        mode: 0o600,
+      });
+
+      const direct = await verifyChain(extractReceipts(file), trustedKeys().split(",")[0]!);
+      if (testCase.directError === undefined) {
+        assert.equal(direct.valid, true, `${testCase.name}: ${direct.error}`);
+      } else {
+        assert.equal(direct.valid, false, `${testCase.name} unexpectedly verified`);
+        assert.match(direct.error ?? "", testCase.directError, testCase.name);
+        assert.doesNotMatch(direct.error ?? "", /signature/u, testCase.name);
+      }
+
+      const cli = spawnSync(
+        process.execPath,
+        ["dist/src/cli.js", "chain", file, "--key", trustedKeys().split(",")[0]!, "--json"],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+      assert.equal(cli.status, 1, `${testCase.name}: ${cli.stderr}`);
+      const report = JSON.parse(cli.stdout) as { valid: boolean; error?: string };
+      assert.equal(report.valid, false, testCase.name);
+      assert.match(report.error ?? "", testCase.cliError, testCase.name);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
 });
 
 test("g1 signed field tampering is rejected", async () => {
@@ -940,6 +1067,24 @@ async function signActionReceiptWithTestKey(receipt: Receipt): Promise<void> {
     seed_hex: string;
   };
   await signActionReceiptWithKey(receipt, keyInfo.seed_hex, keyInfo.public_key_hex);
+}
+
+async function resignG1Tail(receipts: Receipt[], start: number): Promise<void> {
+  let previousHash = receiptHash(receipts[start - 1]!);
+  for (let i = start; i < receipts.length; i++) {
+    const receipt = receipts[i]!;
+    const record = receipt.action_record!;
+    record.chain_prev_hash = previousHash;
+    const control = record.session_control as Record<string, unknown> | undefined;
+    if (control?.["kind"] === "session_close") {
+      const close = control["close"];
+      if (typeof close === "object" && close !== null && !Array.isArray(close)) {
+        (close as Record<string, unknown>)["root_hash"] = previousHash;
+      }
+    }
+    await signActionReceiptWithTestKey(receipt);
+    previousHash = receiptHash(receipt);
+  }
 }
 
 async function signActionReceiptWithKey(

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -382,6 +382,18 @@ test("g1 rotated close receipt_count invalid fixture is rejected", async () => {
   assert.match(result.error ?? "", /session_close receipt_count mismatch/u);
 });
 
+test("chain CLI rejects a lifecycle-broken but signature-valid chain", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["dist/src/cli.js", "chain", g1ValidChain, "--key", trustedKeys().split(",")[0]!, "--json"],
+    { encoding: "utf8", timeout: 10_000 },
+  );
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stdout) as { valid: boolean; error?: string };
+  assert.equal(report.valid, false);
+  assert.match(report.error ?? "", /lifecycle: chain_broken/u);
+});
+
 test("g1 plain action after close fixture is rejected", async () => {
   const key = (JSON.parse(readFileSync(testKey, "utf8")) as { public_key_hex: string })
     .public_key_hex;

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -427,6 +427,18 @@ test("g1 close without open fixture is rejected", async () => {
   assert.match(result.error ?? "", /first receipt is not a matching session_open/u);
 });
 
+test("endorsement verification does not skip root trust after lifecycle-only failure", async () => {
+  const result = await verifyChainWithEndorsements(
+    extractReceipts(g1CloseWithoutOpen),
+    "0".repeat(64),
+    { sessionID: "conformance-session", endorsements: [] },
+  );
+
+  assert.equal(result.valid, false);
+  assert.notEqual(result.failure_kind, "lifecycle_missing_open");
+  assert.match(result.error ?? "", /genesis signer key is not in the trusted root set/u);
+});
+
 test("g1 new session after close fixture verifies", async () => {
   const key = (JSON.parse(readFileSync(testKey, "utf8")) as { public_key_hex: string })
     .public_key_hex;

--- a/sdk/verifiers/ts/tests/lifecycle.test.ts
+++ b/sdk/verifiers/ts/tests/lifecycle.test.ts
@@ -31,8 +31,39 @@ test("lifecycle verdict vectors match the Go verifier", () => {
     readFileSync("../../conformance/testdata/lifecycle-verdict-vectors.json", "utf8"),
   ) as LifecycleVectorFile;
   assert.match(file.generated_by, /^go test /u);
+  assert.ok(file.vectors.length > 0, "lifecycle vector file is empty");
   for (const vector of file.vectors) {
     const actual = analyzeLifecycle(vector.receipts, { ...defaultChain, ...vector.chain_result });
     assert.deepEqual(actual, vector.expected, vector.name);
   }
+});
+
+test("missing durability fields remain unknown instead of resetting cumulative counters", () => {
+  const record = (kind: string, payload: Record<string, unknown>) => ({
+    action_record: {
+      run_nonce: "run-missing-durability",
+      session_control: {
+        kind,
+        [kind === "session_open" ? "open" : kind === "session_close" ? "close" : "heartbeat"]:
+          payload,
+      },
+    },
+  });
+  const receipts = [
+    record("session_open", { run_nonce: "run-missing-durability", open_nonce: "open" }),
+    record("heartbeat", {
+      run_nonce: "run-missing-durability",
+      open_nonce: "open",
+      beat: 1,
+      fsync_errors_gated: 2,
+      durability_blocks: 2,
+    }),
+    record("heartbeat", { run_nonce: "run-missing-durability", open_nonce: "open", beat: 2 }),
+    record("session_close", { run_nonce: "run-missing-durability", open_nonce: "open" }),
+  ] as Receipt[];
+
+  assert.deepEqual(analyzeLifecycle(receipts, defaultChain), {
+    status: "LIMITED",
+    reason: "bounded_closed",
+  });
 });

--- a/sdk/verifiers/ts/tests/lifecycle.test.ts
+++ b/sdk/verifiers/ts/tests/lifecycle.test.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { analyzeLifecycle } from "../src/lifecycle.js";
+import type { ChainResult, Receipt } from "../src/types.js";
+
+interface LifecycleVector {
+  name: string;
+  receipts: Receipt[];
+  expected: { status: string; reason: string };
+}
+
+const validChain: ChainResult = {
+  valid: true,
+  receipt_count: 3,
+  final_seq: 2,
+  root_hash: "test-root",
+};
+
+test("lifecycle verdict vectors match the Go verifier", () => {
+  const vectors = JSON.parse(
+    readFileSync("../../conformance/testdata/lifecycle-verdict-vectors.json", "utf8"),
+  ) as LifecycleVector[];
+  for (const vector of vectors) {
+    const actual = analyzeLifecycle(vector.receipts, validChain);
+    assert.deepEqual(actual, vector.expected, vector.name);
+  }
+});

--- a/sdk/verifiers/ts/tests/lifecycle.test.ts
+++ b/sdk/verifiers/ts/tests/lifecycle.test.ts
@@ -10,10 +10,16 @@ import type { ChainResult, Receipt } from "../src/types.js";
 interface LifecycleVector {
   name: string;
   receipts: Receipt[];
+  chain_result: Partial<ChainResult>;
   expected: { status: string; reason: string };
 }
 
-const validChain: ChainResult = {
+interface LifecycleVectorFile {
+  generated_by: string;
+  vectors: LifecycleVector[];
+}
+
+const defaultChain: ChainResult = {
   valid: true,
   receipt_count: 3,
   final_seq: 2,
@@ -21,11 +27,12 @@ const validChain: ChainResult = {
 };
 
 test("lifecycle verdict vectors match the Go verifier", () => {
-  const vectors = JSON.parse(
+  const file = JSON.parse(
     readFileSync("../../conformance/testdata/lifecycle-verdict-vectors.json", "utf8"),
-  ) as LifecycleVector[];
-  for (const vector of vectors) {
-    const actual = analyzeLifecycle(vector.receipts, validChain);
+  ) as LifecycleVectorFile;
+  assert.match(file.generated_by, /^go test /u);
+  for (const vector of file.vectors) {
+    const actual = analyzeLifecycle(vector.receipts, { ...defaultChain, ...vector.chain_result });
     assert.deepEqual(actual, vector.expected, vector.name);
   }
 });


### PR DESCRIPTION
Adds one shared lifecycle-verdict corpus generated from the Go verifier and applies the same result across the Go, Rust, and TypeScript verifier surfaces.

Broken lifecycle evidence now fails verification and cannot appear authentic or untampered. Incomplete evidence continues to report a distinct limited or unverified state so operators can see the boundary of the proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle validation for receipt chains across verifier tools and SDKs.
  * Reports and audit output now include lifecycle status, reason, and assessment details.
  * Added detection for missing session opens, unmatched outcomes, incomplete actions, heartbeat gaps, and durability issues.

* **Bug Fixes**
  * Lifecycle-broken evidence is now marked invalid with a specific error.
  * Empty evidence no longer reports as signature-verified.
  * Integrity-valid but incomplete chains are reported as unverified rather than broken.

* **Tests**
  * Added cross-language lifecycle conformance and CLI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->