### PR TITLE
fix(contain): verify the running service image

### DIFF
--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -945,20 +945,21 @@ func TestProbeBinaryIntegrity_UppercasePinIsMalformedNotMismatch(t *testing.T) {
 	}
 }
 
-// A stat failure leaves file identity unknown rather than different. Reporting a
-// difference there would assert something unverified, which is the exact class of
-// overstatement this probe was changed to stop making. Each lookup is failed
-// independently, because either one alone is enough to leave identity unknown.
-func TestProbeBinaryIntegrity_StatFailureReportsUnknownNotDifference(t *testing.T) {
+// A failure to stat the deployed file makes running-image verification
+// incomplete and fails the probe. A failure to stat only the optional invoking
+// binary remains a note: it cannot change the deployed or running image proof.
+func TestProbeBinaryIntegrity_StatFailurePreservesRequiredRuntimeIdentity(t *testing.T) {
 	digest := "cc" + strings.Repeat("0", 62)
 
 	tests := []struct {
-		name string
-		fail string // which path's stat fails
+		name       string
+		fail       string // which path's stat fails
+		wantStatus string
+		wantDetail string
 	}{
-		{name: "deployed binary stat fails", fail: "target"},
-		{name: "invoking binary stat fails", fail: "self"},
-		{name: "both stats fail", fail: "both"},
+		{name: "deployed binary stat fails", fail: "target", wantStatus: statusFail, wantDetail: "stat deployed binary"},
+		{name: "invoking binary stat fails", fail: "self", wantStatus: statusPass, wantDetail: "could not compare"},
+		{name: "both stats fail", fail: "both", wantStatus: statusFail, wantDetail: "stat deployed binary"},
 	}
 
 	for _, tt := range tests {
@@ -1000,13 +1001,14 @@ func TestProbeBinaryIntegrity_StatFailureReportsUnknownNotDifference(t *testing.
 				}
 				return os.Stat(path)
 			}
+			configureMatchingServiceBinary(t, env)
 
 			status, detail := probeBinaryIntegrity(context.Background(), env)
-			if status != statusPass {
-				t.Fatalf("status = %s, want pass (the deployed binary still matches its pin)", status)
+			if status != tt.wantStatus {
+				t.Fatalf("status = %s, want %s (detail=%q)", status, tt.wantStatus, detail)
 			}
-			if !strings.Contains(detail, "could not compare") {
-				t.Errorf("detail = %q, want it to say the comparison was unavailable", detail)
+			if !strings.Contains(detail, tt.wantDetail) {
+				t.Errorf("detail = %q, want it to contain %q", detail, tt.wantDetail)
 			}
 			if strings.Contains(detail, "differs") {
 				t.Errorf("detail = %q, must not assert a difference it did not verify", detail)

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -339,6 +339,14 @@ func allProbes() []probe {
 
 func probesForEnv(env *probeEnv) []probe {
 	probes := allProbes()
+	if !env.verifyRunningImage {
+		for i := range probes {
+			if probes[i].name == "binary_integrity_pin" {
+				probes[i].desc = "deployed pipelock binary matches TOFU pin; running-service image is not verified"
+				break
+			}
+		}
+	}
 	if len(env.workspacePaths) > 0 {
 		probes = append(probes, probe{13, "workspace_access", "pipelock-agent can read configured workspace paths", probeWorkspaceAccess})
 	}
@@ -526,11 +534,12 @@ func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string)
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
-// confirms all three identities agree: the deployed install path, the
+// normally confirms all three identities agree: the deployed install path, the
 // effective systemd ExecStart path, and the executable mapped by the service's
-// current MainPID. Skipped when the needed host state is unavailable to the
-// caller (for example, /proc access requires root); it never reports a pass
-// without all three checks.
+// current MainPID. In enforcement-only mode it checks the deployed path and pin
+// only, and reports that running-service image verification was not performed.
+// Running-image checks skip when the needed host state is unavailable to the
+// caller (for example, /proc access requires root).
 //
 // This is still trust-on-first-use drift detection. It does not survive an
 // attacker able to rewrite the binary, pin, unit, and running process as root.
@@ -567,7 +576,7 @@ func probeBinaryIntegrity(ctx context.Context, env *probeEnv) (string, string) {
 			shortHash(pinned), shortHash(got))
 	}
 	if !env.verifyRunningImage {
-		return statusPass, binaryIntegrityDetail(env, target, pinned)
+		return statusPass, fmt.Sprintf("deployed %s (running service image not verified)", binaryIntegrityDetail(env, target, pinned))
 	}
 
 	// The installed pathname alone is not the running service identity. An
@@ -804,11 +813,13 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	previousVerifyRunningImage := env.verifyRunningImage
+	// Mode policy is per invocation. Callers can share a probe environment in
+	// tests and embedders, so never toggle a field on their environment while a
+	// verification is running.
+	runEnv := *env
 	if opts.enforcementOnly {
-		env.verifyRunningImage = false
+		runEnv.verifyRunningImage = false
 	}
-	defer func() { env.verifyRunningImage = previousVerifyRunningImage }()
 
 	w := cmd.OutOrStdout()
 	var textWriter *errorTrackingWriter
@@ -829,14 +840,14 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 		}
 	}
 
-	probes := probesForEnv(env)
+	probes := probesForEnv(&runEnv)
 	if opts.enforcementOnly {
 		probes = enforcementProbes(probes)
 	}
 	var passN, failN, skipN, unknownN int
 
 	for _, p := range probes {
-		status, detail := p.fn(ctx, env)
+		status, detail := p.fn(ctx, &runEnv)
 		switch status {
 		case statusPass:
 			passN++

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -145,6 +145,7 @@ type probeEnv struct {
 	toolsListPath      string
 	workspacePaths     []string
 	pipelockTarget     string
+	verifyRunningImage bool
 	// postureProofPath is the resolved path the current `contain run` writes its
 	// signed posture capsule to. It is exported into the contained launch env as
 	// PIPELOCK_POSTURE_PROOF so an in-child emitter binds the exact capsule this
@@ -159,6 +160,7 @@ type probeEnv struct {
 	groupIDs    groupIDsFunc
 	stat        func(path string) (os.FileInfo, error)
 	readFile    func(path string) ([]byte, error)
+	readLink    func(path string) (string, error)
 	selfPath    func() (string, error)
 	hashFile    func(path string) (string, error)
 }
@@ -189,6 +191,7 @@ func defaultProbeEnv() *probeEnv {
 		wrapperInvPath:     defaultWrapperInvPath,
 		toolsListPath:      defaultToolsListPath,
 		pipelockTarget:     defaultPipelockTarget,
+		verifyRunningImage: true,
 		runCmd:             realRunCommand,
 		dropCounter:        readContainmentDropCounter,
 		dialCtx:            realDial,
@@ -197,6 +200,7 @@ func defaultProbeEnv() *probeEnv {
 		groupIDs:           realGroupIDs,
 		stat:               os.Stat,
 		readFile:           os.ReadFile,
+		readLink:           os.Readlink,
 		selfPath:           os.Executable,
 		hashFile:           sha256HexOfFile,
 	}
@@ -327,7 +331,7 @@ func allProbes() []probe {
 		{7, "no_proxy_env_correct", "NO_PROXY in plk-launch matches policy", probeNoProxyEnv},
 		{8, "cc_agent_egress_denied", "pipelock-agent cannot reach the internet directly", probeCCAgentEgressDenied},
 		{9, "operator_egress_reachable", "operator user can still reach the internet", probeOperatorEgress},
-		{10, "binary_integrity_pin", "installed pipelock binary matches TOFU pin", probeBinaryIntegrity},
+		{10, "binary_integrity_pin", "deployed and running pipelock binary match TOFU pin", probeBinaryIntegrity},
 		{11, "cc_launch_allow_list_enforced", "plk-launch rejects tools missing from the allow-list", probeCCLaunchAllowList},
 		{12, "listed_tool_targets_resolvable", "tools.list entries resolve for pipelock-agent", probeListedToolTargets},
 	}
@@ -522,19 +526,15 @@ func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string)
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
-// compares it against the SHA-256 of the binary at the deployed install path.
-// Skipped when the pin file is missing (install never happened) or
-// unreadable to this user (run as root to verify). Failure means either
-// the deployed binary was swapped after install or cannot be verified.
+// confirms all three identities agree: the deployed install path, the
+// effective systemd ExecStart path, and the executable mapped by the service's
+// current MainPID. Skipped when the needed host state is unavailable to the
+// caller (for example, /proc access requires root); it never reports a pass
+// without all three checks.
 //
-// Two limits, stated because a probe should not imply more than it checks.
-// Nothing here reads the unit's effective ExecStart, so this establishes that
-// the binary at the install path is unchanged, not that the running service
-// has that binary mapped; proving the latter needs the live process image.
-// And the pin is written by our own installer, so this is trust-on-first-use
-// drift detection. It does not survive anyone able to rewrite both the binary
-// and the pin, which root can do.
-func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
+// This is still trust-on-first-use drift detection. It does not survive an
+// attacker able to rewrite the binary, pin, unit, and running process as root.
+func probeBinaryIntegrity(ctx context.Context, env *probeEnv) (string, string) {
 	data, err := env.readFile(env.pinPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -566,7 +566,79 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("binary hash mismatch: pin=%s got=%s (deployed binary swapped after install)",
 			shortHash(pinned), shortHash(got))
 	}
+	if !env.verifyRunningImage {
+		detail, status := binaryIntegrityDetail(env, target, pinned)
+		return status, detail
+	}
 
+	// The installed pathname alone is not the running service identity. An
+	// atomic upgrade can replace and re-pin the file while the old executable
+	// remains mapped by the current service process until restart.
+	out, code, err := env.runCmd(ctx, "systemctl", "show", env.serviceName, "--property=ExecStart,MainPID")
+	if err != nil {
+		return statusSkip, fmt.Sprintf("systemctl unavailable for running binary verification: %v", err)
+	}
+	if code != 0 {
+		return statusFail, fmt.Sprintf("systemctl exit=%d while reading ExecStart/MainPID: %s", code, oneLine(out))
+	}
+
+	fields := parseSystemdShow(out)
+	execPath, err := systemdExecStartPath(fields["ExecStart"])
+	if err != nil {
+		return statusFail, fmt.Sprintf("parse effective ExecStart: %v", err)
+	}
+	if filepath.Clean(execPath) != target {
+		return statusFail, fmt.Sprintf("effective ExecStart path %s does not match deployed binary %s", oneLine(execPath), oneLine(target))
+	}
+
+	pid, err := systemdMainPID(fields["MainPID"])
+	if err != nil {
+		return statusFail, fmt.Sprintf("parse service MainPID: %v", err)
+	}
+	procExe := serviceProcessExePath(pid)
+	runningPath, err := env.readLink(procExe)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return statusSkip, fmt.Sprintf("read running service image %s: %v (rerun as root)", procExe, err)
+		}
+		return statusFail, fmt.Sprintf("read running service image %s: %v", procExe, err)
+	}
+
+	targetInfo, err := env.stat(target)
+	if err != nil {
+		return statusFail, fmt.Sprintf("stat deployed binary %s: %v", target, err)
+	}
+	runningInfo, err := env.stat(procExe)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return statusSkip, fmt.Sprintf("stat running service image %s: %v (rerun as root)", procExe, err)
+		}
+		return statusFail, fmt.Sprintf("stat running service image %s: %v", procExe, err)
+	}
+	if !os.SameFile(targetInfo, runningInfo) {
+		return statusFail, fmt.Sprintf("running service image %s differs from deployed binary %s", oneLine(runningPath), oneLine(target))
+	}
+
+	runningHash, err := env.hashFile(procExe)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return statusSkip, fmt.Sprintf("hash running service image %s: %v (rerun as root)", procExe, err)
+		}
+		return statusFail, fmt.Sprintf("hash running service image %s: %v", procExe, err)
+	}
+	if runningHash != pinned {
+		return statusFail, fmt.Sprintf("running service image hash mismatch: pin=%s got=%s", shortHash(pinned), shortHash(runningHash))
+	}
+
+	detail, status := binaryIntegrityDetail(env, target, pinned)
+	if status != statusPass {
+		return status, detail
+	}
+	detail = fmt.Sprintf("deployed and running service %s", detail)
+	return statusPass, detail
+}
+
+func binaryIntegrityDetail(env *probeEnv, target, pinned string) (string, string) {
 	detail := fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
 	if self, err := env.selfPath(); err == nil && filepath.Clean(self) != target {
 		self = filepath.Clean(self)
@@ -582,7 +654,48 @@ func probeBinaryIntegrity(_ context.Context, env *probeEnv) (string, string) {
 			detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", self, target)
 		}
 	}
-	return statusPass, detail
+	return detail, statusPass
+}
+
+// systemdExecStartPath extracts the one executable path from systemctl show's
+// stable ExecStart representation. Pipelock's managed service is Type=simple
+// with exactly one command; accepting multiple commands here would leave its
+// running program ambiguous.
+func systemdExecStartPath(raw string) (string, error) {
+	var paths []string
+	for _, segment := range strings.Split(raw, ";") {
+		segment = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(segment), "{"))
+		if !strings.HasPrefix(segment, "path=") {
+			continue
+		}
+		path := strings.TrimPrefix(segment, "path=")
+		if path == "" || !filepath.IsAbs(path) {
+			return "", fmt.Errorf("invalid executable path %q", path)
+		}
+		paths = append(paths, path)
+	}
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no executable path in %q", raw)
+	}
+	if len(paths) != 1 {
+		return "", fmt.Errorf("expected one executable path, found %d", len(paths))
+	}
+	return paths[0], nil
+}
+
+func systemdMainPID(raw string) (int, error) {
+	if raw == "" {
+		return 0, errors.New("missing MainPID")
+	}
+	pid, err := strconv.Atoi(raw)
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("invalid MainPID %q", raw)
+	}
+	return pid, nil
+}
+
+func serviceProcessExePath(pid int) string {
+	return filepath.Join("/proc", strconv.Itoa(pid), "exe")
 }
 
 const sha256HexLen = 64
@@ -637,13 +750,13 @@ Probes inspect system users, the pipelock systemd unit, nftables rules,
 wrapper scripts, the CA bundle, the pipelock loopback bind, the NO_PROXY
 policy, run two egress canaries (pipelock-agent must NOT reach the internet
 directly; the operator user must still reach the internet), verify the
-installed binary matches the TOFU integrity pin written at install
-time, and exercise plk-launch end-to-end with a sentinel tool to confirm
+deployed and running service binaries match the TOFU integrity pin written at
+install time, and exercise plk-launch end-to-end with a sentinel tool to confirm
 the allow-list enforcement path actually fires. Pass --workspace to also
 verify that pipelock-agent can read/traverse real project directories.
 Pass --enforcement-only when another process owns the proxy lifecycle;
-that mode verifies the kernel/user/wrapper controls while skipping proxy
-liveness probes before making plk wrappers the default entry point.
+that mode verifies the kernel/user/wrapper controls and the pinned file at the
+deployed path, while skipping proxy liveness and running-service-image checks.
 
 verify never mutates state. Probes that require root visibility
 (nft list ruleset) record skip when run unprivileged.
@@ -668,7 +781,7 @@ Exit codes:
 	}
 
 	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit newline-delimited JSON instead of text")
-	cmd.Flags().BoolVar(&opts.enforcementOnly, "enforcement-only", false, "skip service and loopback listener liveness probes")
+	cmd.Flags().BoolVar(&opts.enforcementOnly, "enforcement-only", false, "skip service, loopback, and running-service-image checks")
 	cmd.Flags().IntVar(&opts.port, "port", defaultProxyPort, "pipelock listen port to probe on loopback")
 	cmd.Flags().StringArrayVar(&opts.workspacePaths, "workspace", nil, "workspace path that pipelock-agent must be able to read/traverse (repeatable)")
 
@@ -690,6 +803,11 @@ func runVerify(cmd *cobra.Command, env *probeEnv, opts verifyOpts) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	previousVerifyRunningImage := env.verifyRunningImage
+	if opts.enforcementOnly {
+		env.verifyRunningImage = false
+	}
+	defer func() { env.verifyRunningImage = previousVerifyRunningImage }()
 
 	w := cmd.OutOrStdout()
 	var textWriter *errorTrackingWriter

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -567,23 +567,21 @@ func probeBinaryIntegrity(ctx context.Context, env *probeEnv) (string, string) {
 			shortHash(pinned), shortHash(got))
 	}
 	if !env.verifyRunningImage {
-		detail, status := binaryIntegrityDetail(env, target, pinned)
-		return status, detail
+		return statusPass, binaryIntegrityDetail(env, target, pinned)
 	}
 
 	// The installed pathname alone is not the running service identity. An
 	// atomic upgrade can replace and re-pin the file while the old executable
 	// remains mapped by the current service process until restart.
-	out, code, err := env.runCmd(ctx, "systemctl", "show", env.serviceName, "--property=ExecStart,MainPID")
+	execStart, code, err := env.runCmd(ctx, "systemctl", "show", env.serviceName, "--property=ExecStart", "--value")
 	if err != nil {
 		return statusSkip, fmt.Sprintf("systemctl unavailable for running binary verification: %v", err)
 	}
 	if code != 0 {
-		return statusFail, fmt.Sprintf("systemctl exit=%d while reading ExecStart/MainPID: %s", code, oneLine(out))
+		return statusFail, fmt.Sprintf("systemctl exit=%d while reading ExecStart: %s", code, oneLine(execStart))
 	}
 
-	fields := parseSystemdShow(out)
-	execPath, err := systemdExecStartPath(fields["ExecStart"])
+	execPath, err := systemdExecStartPath(execStart)
 	if err != nil {
 		return statusFail, fmt.Sprintf("parse effective ExecStart: %v", err)
 	}
@@ -591,7 +589,15 @@ func probeBinaryIntegrity(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("effective ExecStart path %s does not match deployed binary %s", oneLine(execPath), oneLine(target))
 	}
 
-	pid, err := systemdMainPID(fields["MainPID"])
+	mainPID, code, err := env.runCmd(ctx, "systemctl", "show", env.serviceName, "--property=MainPID", "--value")
+	if err != nil {
+		return statusSkip, fmt.Sprintf("systemctl unavailable for running binary verification: %v", err)
+	}
+	if code != 0 {
+		return statusFail, fmt.Sprintf("systemctl exit=%d while reading MainPID: %s", code, oneLine(mainPID))
+	}
+
+	pid, err := systemdMainPID(strings.TrimSpace(mainPID))
 	if err != nil {
 		return statusFail, fmt.Sprintf("parse service MainPID: %v", err)
 	}
@@ -630,15 +636,10 @@ func probeBinaryIntegrity(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("running service image hash mismatch: pin=%s got=%s", shortHash(pinned), shortHash(runningHash))
 	}
 
-	detail, status := binaryIntegrityDetail(env, target, pinned)
-	if status != statusPass {
-		return status, detail
-	}
-	detail = fmt.Sprintf("deployed and running service %s", detail)
-	return statusPass, detail
+	return statusPass, fmt.Sprintf("deployed and running service %s", binaryIntegrityDetail(env, target, pinned))
 }
 
-func binaryIntegrityDetail(env *probeEnv, target, pinned string) (string, string) {
+func binaryIntegrityDetail(env *probeEnv, target, pinned string) string {
 	detail := fmt.Sprintf("binary hash %s matches pin", shortHash(pinned))
 	if self, err := env.selfPath(); err == nil && filepath.Clean(self) != target {
 		self = filepath.Clean(self)
@@ -654,7 +655,7 @@ func binaryIntegrityDetail(env *probeEnv, target, pinned string) (string, string
 			detail += fmt.Sprintf(" (note: invoking binary %s differs from deployed binary %s)", self, target)
 		}
 	}
-	return detail, statusPass
+	return detail
 }
 
 // systemdExecStartPath extracts the one executable path from systemctl show's

--- a/internal/cli/contain/verify_lifecycle_failures_test.go
+++ b/internal/cli/contain/verify_lifecycle_failures_test.go
@@ -531,17 +531,24 @@ func TestProbeBinaryIntegrity_VerifiesEffectiveServiceCommandAndRunningImage(t *
 			mustWriteFile(t, pinPath, pinned+"\n")
 
 			execPath, mainPID, runningImage, readLinkErr := tc.setup(t, target, pinPath)
-			procExe := serviceProcessExePath(4242)
+			procExe := serviceProcessExePath(testServicePID)
 			env := makeProbeEnv(t, func(env *probeEnv) {
 				env.pipelockTarget = target
 				env.pinPath = pinPath
 				env.readFile = os.ReadFile
 				env.selfPath = func() (string, error) { return target, nil }
 				env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
-					if name != testSystemctl || !containsArg(args, "--property=ExecStart,MainPID") {
+					if name != testSystemctl || !containsArg(args, "--value") {
 						return "", -1, fmt.Errorf("unexpected command %s %v", name, args)
 					}
-					return fmt.Sprintf("MainPID=%s\nExecStart={ path=%s ; argv[]=%s run ; }\n", mainPID, execPath, execPath), 0, nil
+					switch {
+					case containsArg(args, "--property=ExecStart"):
+						return fmt.Sprintf("{ path=%s ; argv[]=%s run ; }\n", execPath, execPath), 0, nil
+					case containsArg(args, "--property=MainPID"):
+						return mainPID + "\n", 0, nil
+					default:
+						return "", -1, fmt.Errorf("unexpected systemctl property %v", args)
+					}
 				}
 				env.readLink = func(path string) (string, error) {
 					if path != procExe {
@@ -684,7 +691,7 @@ func TestProbeBinaryIntegrity_RunningImageVerificationFailures(t *testing.T) {
 				t.Fatalf("hash target: %v", err)
 			}
 			mustWriteFile(t, pinPath, pinned+"\n")
-			procExe := serviceProcessExePath(4242)
+			procExe := serviceProcessExePath(testServicePID)
 			env := makeProbeEnv(t, func(env *probeEnv) {
 				env.pipelockTarget = target
 				env.pinPath = pinPath
@@ -699,6 +706,32 @@ func TestProbeBinaryIntegrity_RunningImageVerificationFailures(t *testing.T) {
 				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
 			}
 		})
+	}
+}
+
+func TestProbeBinaryIntegrity_EnforcementOnlySkipsRunningImage(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pipelock")
+	pinPath := filepath.Join(dir, "binary-pin.sha256")
+	mustWriteFile(t, target, "service image")
+	pinned, err := sha256HexOfFile(target)
+	if err != nil {
+		t.Fatalf("hash target: %v", err)
+	}
+	mustWriteFile(t, pinPath, pinned+"\n")
+
+	env := makeProbeEnv(t, func(env *probeEnv) {
+		env.pipelockTarget = target
+		env.pinPath = pinPath
+		env.readFile = os.ReadFile
+		env.selfPath = func() (string, error) { return target, nil }
+		env.hashFile = sha256HexOfFile
+		env.verifyRunningImage = false
+	})
+
+	status, detail := probeBinaryIntegrity(context.Background(), env)
+	if status != statusPass || !strings.Contains(detail, "binary hash") {
+		t.Fatalf("probe = (%q, %q), want deployed-pin pass", status, detail)
 	}
 }
 

--- a/internal/cli/contain/verify_lifecycle_failures_test.go
+++ b/internal/cli/contain/verify_lifecycle_failures_test.go
@@ -6,6 +6,7 @@ package contain
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -289,6 +290,12 @@ func TestVerificationMetadataFailuresAreVisible(t *testing.T) {
 				env.selfPath = tc.selfPath
 				env.hashFile = tc.hashFile
 			})
+			if tc.wantStatus == statusPass {
+				target := filepath.Join(t.TempDir(), "pipelock")
+				mustWriteFile(t, target, "deployed binary")
+				env.pipelockTarget = target
+				configureMatchingServiceBinary(t, env)
+			}
 			status, detail := probeBinaryIntegrity(context.Background(), env)
 			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
 				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
@@ -368,6 +375,7 @@ func TestProbeBinaryIntegrityVerifiesDeployedBinary(t *testing.T) {
 				env.selfPath = func() (string, error) { return invoking, nil }
 				env.hashFile = sha256HexOfFile
 			})
+			configureMatchingServiceBinary(t, env)
 			status, detail := probeBinaryIntegrity(context.Background(), env)
 			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
 				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
@@ -420,12 +428,275 @@ func TestProbeBinaryIntegrity_DoesNotMisreportAliasedInvokingBinary(t *testing.T
 				env.selfPath = func() (string, error) { return invoking, nil }
 				env.hashFile = sha256HexOfFile
 			})
+			configureMatchingServiceBinary(t, env)
 			status, detail := probeBinaryIntegrity(context.Background(), env)
 			if status != statusPass {
 				t.Fatalf("status = %q, want pass: %s", status, detail)
 			}
 			if strings.Contains(detail, "note: invoking binary") {
 				t.Fatalf("detail = %q, must not report a path alias as a different binary", detail)
+			}
+		})
+	}
+}
+
+func TestProbeBinaryIntegrity_VerifiesEffectiveServiceCommandAndRunningImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, target, pinPath string) (execPath, mainPID, runningImage string, readLinkErr error)
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name: "clean deployed command and running image match",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				return target, "4242", target, nil
+			},
+			wantStatus: statusPass,
+			wantDetail: "deployed and running service binary hash",
+		},
+		{
+			name: "effective ExecStart points at a different binary",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				other := filepath.Join(t.TempDir(), "other-pipelock")
+				mustWriteFile(t, other, "other executable")
+				return other, "4242", target, nil
+			},
+			wantStatus: statusFail,
+			wantDetail: "effective ExecStart path",
+		},
+		{
+			name: "deployed file was atomically replaced but service still maps the old image",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				oldImage := target + ".old"
+				if err := os.Rename(target, oldImage); err != nil {
+					t.Fatalf("preserve running image: %v", err)
+				}
+				mustWriteFile(t, target+".new", "new deployed executable")
+				if err := os.Rename(target+".new", target); err != nil {
+					t.Fatalf("atomically replace deployed image: %v", err)
+				}
+				pinned, err := sha256HexOfFile(target)
+				if err != nil {
+					t.Fatalf("hash replacement: %v", err)
+				}
+				mustWriteFile(t, pinPath, pinned+"\n")
+				return target, "4242", oldImage, nil
+			},
+			wantStatus: statusFail,
+			wantDetail: "running service image",
+		},
+		{
+			name: "systemd reports no main process",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				return target, "0", target, nil
+			},
+			wantStatus: statusFail,
+			wantDetail: "invalid MainPID",
+		},
+		{
+			name: "MainPID is stale",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				return target, "4242", "", os.ErrNotExist
+			},
+			wantStatus: statusFail,
+			wantDetail: "read running service image",
+		},
+		{
+			name: "running image is not visible without root",
+			setup: func(t *testing.T, target, pinPath string) (string, string, string, error) {
+				t.Helper()
+				return target, "4242", "", os.ErrPermission
+			},
+			wantStatus: statusSkip,
+			wantDetail: "rerun as root",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "pipelock")
+			pinPath := filepath.Join(dir, "binary-pin.sha256")
+			mustWriteFile(t, target, "original executable")
+			pinned, err := sha256HexOfFile(target)
+			if err != nil {
+				t.Fatalf("hash deployed image: %v", err)
+			}
+			mustWriteFile(t, pinPath, pinned+"\n")
+
+			execPath, mainPID, runningImage, readLinkErr := tc.setup(t, target, pinPath)
+			procExe := serviceProcessExePath(4242)
+			env := makeProbeEnv(t, func(env *probeEnv) {
+				env.pipelockTarget = target
+				env.pinPath = pinPath
+				env.readFile = os.ReadFile
+				env.selfPath = func() (string, error) { return target, nil }
+				env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+					if name != testSystemctl || !containsArg(args, "--property=ExecStart,MainPID") {
+						return "", -1, fmt.Errorf("unexpected command %s %v", name, args)
+					}
+					return fmt.Sprintf("MainPID=%s\nExecStart={ path=%s ; argv[]=%s run ; }\n", mainPID, execPath, execPath), 0, nil
+				}
+				env.readLink = func(path string) (string, error) {
+					if path != procExe {
+						return "", fmt.Errorf("unexpected readLink %s", path)
+					}
+					if readLinkErr != nil {
+						return "", readLinkErr
+					}
+					return runningImage, nil
+				}
+				env.stat = func(path string) (os.FileInfo, error) {
+					if path == procExe {
+						return os.Stat(runningImage)
+					}
+					return os.Stat(path)
+				}
+				env.hashFile = func(path string) (string, error) {
+					if path == procExe {
+						return sha256HexOfFile(runningImage)
+					}
+					return sha256HexOfFile(path)
+				}
+			})
+
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestProbeBinaryIntegrity_RunningImageVerificationFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(env *probeEnv, target, procExe string)
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name: "systemctl reports a failed show command",
+			configure: func(env *probeEnv, _, _ string) {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+					return "unit not loaded\nextra detail", 5, nil
+				}
+			},
+			wantStatus: statusFail,
+			wantDetail: "systemctl exit=5",
+		},
+		{
+			name: "systemctl reports a malformed effective command",
+			configure: func(env *probeEnv, _, _ string) {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+					return "MainPID=4242\nExecStart={ path=pipelock ; argv[]=pipelock run ; }\n", 0, nil
+				}
+			},
+			wantStatus: statusFail,
+			wantDetail: "parse effective ExecStart",
+		},
+		{
+			name: "running image stat permission denied",
+			configure: func(env *probeEnv, _, procExe string) {
+				originalStat := env.stat
+				env.stat = func(path string) (os.FileInfo, error) {
+					if path == procExe {
+						return nil, os.ErrPermission
+					}
+					return originalStat(path)
+				}
+			},
+			wantStatus: statusSkip,
+			wantDetail: "stat running service image",
+		},
+		{
+			name: "running image stat stale process",
+			configure: func(env *probeEnv, _, procExe string) {
+				originalStat := env.stat
+				env.stat = func(path string) (os.FileInfo, error) {
+					if path == procExe {
+						return nil, os.ErrNotExist
+					}
+					return originalStat(path)
+				}
+			},
+			wantStatus: statusFail,
+			wantDetail: "stat running service image",
+		},
+		{
+			name: "running image hash permission denied",
+			configure: func(env *probeEnv, _, procExe string) {
+				originalHash := env.hashFile
+				env.hashFile = func(path string) (string, error) {
+					if path == procExe {
+						return "", os.ErrPermission
+					}
+					return originalHash(path)
+				}
+			},
+			wantStatus: statusSkip,
+			wantDetail: "hash running service image",
+		},
+		{
+			name: "running image hash stale process",
+			configure: func(env *probeEnv, _, procExe string) {
+				originalHash := env.hashFile
+				env.hashFile = func(path string) (string, error) {
+					if path == procExe {
+						return "", os.ErrNotExist
+					}
+					return originalHash(path)
+				}
+			},
+			wantStatus: statusFail,
+			wantDetail: "hash running service image",
+		},
+		{
+			name: "running image hash differs from pin",
+			configure: func(env *probeEnv, _, procExe string) {
+				originalHash := env.hashFile
+				env.hashFile = func(path string) (string, error) {
+					if path == procExe {
+						return strings.Repeat("b", sha256HexLen), nil
+					}
+					return originalHash(path)
+				}
+			},
+			wantStatus: statusFail,
+			wantDetail: "running service image hash mismatch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "pipelock")
+			pinPath := filepath.Join(dir, "binary-pin.sha256")
+			mustWriteFile(t, target, "service image")
+			pinned, err := sha256HexOfFile(target)
+			if err != nil {
+				t.Fatalf("hash target: %v", err)
+			}
+			mustWriteFile(t, pinPath, pinned+"\n")
+			procExe := serviceProcessExePath(4242)
+			env := makeProbeEnv(t, func(env *probeEnv) {
+				env.pipelockTarget = target
+				env.pinPath = pinPath
+				env.readFile = os.ReadFile
+				env.selfPath = func() (string, error) { return target, nil }
+				env.hashFile = sha256HexOfFile
+				configureMatchingServiceBinary(t, env)
+			})
+			tc.configure(env, target, procExe)
+			status, detail := probeBinaryIntegrity(context.Background(), env)
+			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("probe = (%q, %q), want (%q, containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
 			}
 		})
 	}
@@ -452,6 +723,30 @@ func TestVerificationParsersRejectIncompleteSafetyEvidence(t *testing.T) {
 		fields := parseSystemdShow("noise without separator\nActiveState=active\n")
 		if len(fields) != 1 || fields["ActiveState"] != "active" {
 			t.Fatalf("fields = %v", fields)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "relative ExecStart path", raw: "{ path=pipelock ; argv[]=pipelock run ; }", want: "invalid executable path"},
+		{name: "missing ExecStart path", raw: "{ argv[]=/usr/local/bin/pipelock run ; }", want: "no executable path"},
+		{name: "multiple ExecStart paths", raw: "{ path=/usr/local/bin/pipelock ; }; { path=/usr/bin/other ; }", want: "expected one executable path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := systemdExecStartPath(tc.raw)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing systemd MainPID", func(t *testing.T) {
+		_, err := systemdMainPID("")
+		if err == nil || !strings.Contains(err.Error(), "missing MainPID") {
+			t.Fatalf("error = %v", err)
 		}
 	})
 

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -41,6 +41,7 @@ const (
 	testSudoCmd      = "sudo"
 	testOperatorUser = "operator"
 	testSystemctl    = "systemctl"
+	testServicePID   = 4242
 	testNFT          = "nft"
 	testUserDel      = "userdel"
 	testRustup       = "rustup"
@@ -263,15 +264,21 @@ func rejectAllReadLink(path string) (string, error) {
 // invoking-binary setup under its control.
 func configureMatchingServiceBinary(t *testing.T, env *probeEnv) {
 	t.Helper()
-	const pid = 4242
-	procExe := serviceProcessExePath(pid)
+	procExe := serviceProcessExePath(testServicePID)
 	originalStat := env.stat
 	originalHash := env.hashFile
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
-		if name != testSystemctl || !containsArg(args, "--property=ExecStart,MainPID") {
+		if name != testSystemctl || !containsArg(args, "--value") {
 			return "", -1, fmt.Errorf("unexpected command %s %v", name, args)
 		}
-		return fmt.Sprintf("MainPID=%d\nExecStart={ path=%s ; argv[]=%s run ; }\n", pid, env.pipelockTarget, env.pipelockTarget), 0, nil
+		switch {
+		case containsArg(args, "--property=ExecStart"):
+			return fmt.Sprintf("{ path=%s ; argv[]=%s run ; }\n", env.pipelockTarget, env.pipelockTarget), 0, nil
+		case containsArg(args, "--property=MainPID"):
+			return fmt.Sprintf("%d\n", testServicePID), 0, nil
+		default:
+			return "", -1, fmt.Errorf("unexpected systemctl property %v", args)
+		}
 	}
 	env.readLink = func(path string) (string, error) {
 		if path != procExe {
@@ -3335,8 +3342,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 	const allPassHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
 	deployed := filepath.Join(t.TempDir(), "pipelock")
 	writeFakeWrapper(t, deployed, 0o755)
-	const servicePID = 4242
-	procExe := serviceProcessExePath(servicePID)
+	procExe := serviceProcessExePath(testServicePID)
 	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
 		return defaultRunForAllPass(name, args)
 	}
@@ -3381,7 +3387,15 @@ func allPassEnv(t *testing.T) *probeEnv {
 func defaultRunForAllPass(name string, args []string) (string, int, error) {
 	switch name {
 	case testSystemctl:
-		return "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\nMainPID=4242\nExecStart={ path=/usr/local/bin/pipelock ; argv[]=/usr/local/bin/pipelock run ; ignore_errors=no ; }\n", 0, nil
+		if containsArg(args, "--value") {
+			switch {
+			case containsArg(args, "--property=ExecStart"):
+				return "{ path=/usr/local/bin/pipelock ; argv[]=/usr/local/bin/pipelock run ; ignore_errors=no ; }\n", 0, nil
+			case containsArg(args, "--property=MainPID"):
+				return fmt.Sprintf("%d\n", testServicePID), 0, nil
+			}
+		}
+		return fmt.Sprintf("ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\nMainPID=%d\nExecStart={ path=/usr/local/bin/pipelock ; argv[]=/usr/local/bin/pipelock run ; ignore_errors=no ; }\n", testServicePID), 0, nil
 	case testNFT:
 		return goodNFTContainmentOutput, 0, nil
 	case testSudoCmd:

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -191,24 +191,25 @@ func TestProbeListedToolTargets_AgentContextFailuresSkip(t *testing.T) {
 func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 	t.Helper()
 	env := &probeEnv{
-		port:           8888,
-		operatorUser:   "",
-		proxyUserName:  testProxyUser,
-		agentUserName:  testAgentUser,
-		wrapperDir:     t.TempDir(),
-		toolWrappers:   []string{"plk-claude", "plk-codex"},
-		caBundlePath:   filepath.Join(t.TempDir(), "combined-ca.pem"),
-		launchPath:     "", // populated below
-		nftTable:       testTable,
-		nftChain:       testChain,
-		nftPath:        testNFT,
-		serviceName:    testService,
-		pinPath:        filepath.Join(t.TempDir(), "binary-pin.sha256"),
-		toolsListPath:  filepath.Join(t.TempDir(), "tools.list"),
-		pipelockTarget: defaultPipelockTarget,
-		runCmd:         rejectAllRun,
-		dropCounter:    rejectAllDropCounter,
-		dialCtx:        rejectAllDial,
+		port:               8888,
+		operatorUser:       "",
+		proxyUserName:      testProxyUser,
+		agentUserName:      testAgentUser,
+		wrapperDir:         t.TempDir(),
+		toolWrappers:       []string{"plk-claude", "plk-codex"},
+		caBundlePath:       filepath.Join(t.TempDir(), "combined-ca.pem"),
+		launchPath:         "", // populated below
+		nftTable:           testTable,
+		nftChain:           testChain,
+		nftPath:            testNFT,
+		serviceName:        testService,
+		pinPath:            filepath.Join(t.TempDir(), "binary-pin.sha256"),
+		toolsListPath:      filepath.Join(t.TempDir(), "tools.list"),
+		pipelockTarget:     defaultPipelockTarget,
+		verifyRunningImage: true,
+		runCmd:             rejectAllRun,
+		dropCounter:        rejectAllDropCounter,
+		dialCtx:            rejectAllDial,
 		wait: func(context.Context, time.Duration) error {
 			return nil
 		},
@@ -216,6 +217,7 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		groupIDs:   rejectAllGroupIDs,
 		stat:       os.Stat,
 		readFile:   rejectAllReadFile,
+		readLink:   rejectAllReadLink,
 		selfPath:   rejectAllSelfPath,
 		hashFile:   rejectAllHashFile,
 	}
@@ -250,6 +252,45 @@ func rejectAllLookup(name string) (*user.User, error) {
 
 func rejectAllReadFile(path string) ([]byte, error) {
 	return nil, fmt.Errorf("unstubbed readFile: %s", path)
+}
+
+func rejectAllReadLink(path string) (string, error) {
+	return "", fmt.Errorf("unstubbed readLink: %s", path)
+}
+
+// configureMatchingServiceBinary makes the running-process half of probe 10
+// point at env.pipelockTarget while leaving the test's deployed-file and
+// invoking-binary setup under its control.
+func configureMatchingServiceBinary(t *testing.T, env *probeEnv) {
+	t.Helper()
+	const pid = 4242
+	procExe := serviceProcessExePath(pid)
+	originalStat := env.stat
+	originalHash := env.hashFile
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name != testSystemctl || !containsArg(args, "--property=ExecStart,MainPID") {
+			return "", -1, fmt.Errorf("unexpected command %s %v", name, args)
+		}
+		return fmt.Sprintf("MainPID=%d\nExecStart={ path=%s ; argv[]=%s run ; }\n", pid, env.pipelockTarget, env.pipelockTarget), 0, nil
+	}
+	env.readLink = func(path string) (string, error) {
+		if path != procExe {
+			return "", fmt.Errorf("unexpected readLink %s", path)
+		}
+		return env.pipelockTarget, nil
+	}
+	env.stat = func(path string) (os.FileInfo, error) {
+		if path == procExe {
+			return originalStat(env.pipelockTarget)
+		}
+		return originalStat(path)
+	}
+	env.hashFile = func(path string) (string, error) {
+		if path == procExe {
+			return originalHash(env.pipelockTarget)
+		}
+		return originalHash(path)
+	}
 }
 
 func rejectAllSelfPath() (string, error) {
@@ -2984,14 +3025,14 @@ func TestRunVerify_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
 				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &agg); err != nil {
 					t.Fatalf("decode aggregate: %v\n%s", err, out)
 				}
-				if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 1 ||
-					agg.Aggregate.Skip != 1 || agg.Aggregate.Unknown != 1 ||
+				if agg.Aggregate.Pass != 8 || agg.Aggregate.Fail != 1 ||
+					agg.Aggregate.Skip != 2 || agg.Aggregate.Unknown != 1 ||
 					agg.Aggregate.ExitCode != cliutil.ExitGeneral {
-					t.Fatalf("mixed aggregate = %+v, want 9 pass / 1 fail / 1 skip / 1 unknown / exit 1", agg.Aggregate)
+					t.Fatalf("mixed aggregate = %+v, want 8 pass / 1 fail / 2 skip / 1 unknown / exit 1", agg.Aggregate)
 				}
 				return
 			}
-			if !strings.Contains(out, "9 PASS / 1 FAIL / 1 SKIP / 1 UNKNOWN — exit 1") {
+			if !strings.Contains(out, "8 PASS / 1 FAIL / 2 SKIP / 1 UNKNOWN — exit 1") {
 				t.Fatalf("text lost a mixed outcome or fail precedence:\n%s", out)
 			}
 		})
@@ -3269,10 +3310,6 @@ func allPassEnv(t *testing.T) *probeEnv {
 		return &fakeConn{}, nil
 	}
 
-	// Probes 2, 3, 8, 9: subprocess stubs.
-	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
-		return defaultRunForAllPass(name, args)
-	}
 	var counterReads uint64
 	env.dropCounter = func(_ context.Context, _ *probeEnv) (uint64, error) {
 		counterReads++
@@ -3291,10 +3328,18 @@ func allPassEnv(t *testing.T) *probeEnv {
 	}
 	writeFakePEMBundle(t, env.caBundlePath, "Pipelock Test CA")
 
-	// Probe 10: deployed binary integrity. allPassEnv emits matching pin + hash so
-	// the probe returns pass. Tests that want to exercise mismatch override
-	// hashFile or readFile after calling allPassEnv.
+	// Probe 10: deployed and running binary integrity. allPassEnv emits matching
+	// pin + hashes and maps the synthetic process image to the deployed file.
+	// Tests that want to exercise mismatch override hashFile or readFile after
+	// calling allPassEnv.
 	const allPassHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+	deployed := filepath.Join(t.TempDir(), "pipelock")
+	writeFakeWrapper(t, deployed, 0o755)
+	const servicePID = 4242
+	procExe := serviceProcessExePath(servicePID)
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		return defaultRunForAllPass(name, args)
+	}
 	env.readFile = func(path string) ([]byte, error) {
 		if path == env.pinPath {
 			return []byte(allPassHash + "\n"), nil
@@ -3307,9 +3352,22 @@ func allPassEnv(t *testing.T) *probeEnv {
 		}
 		return nil, fmt.Errorf("unexpected readFile %s", path)
 	}
+	env.readLink = func(path string) (string, error) {
+		if path != procExe {
+			return "", fmt.Errorf("unexpected readLink %s", path)
+		}
+		return defaultPipelockTarget, nil
+	}
+	originalStat := env.stat
+	env.stat = func(path string) (os.FileInfo, error) {
+		if path == procExe || path == defaultPipelockTarget {
+			return originalStat(deployed)
+		}
+		return originalStat(path)
+	}
 	env.selfPath = func() (string, error) { return defaultPipelockTarget, nil }
 	env.hashFile = func(path string) (string, error) {
-		if path == defaultPipelockTarget {
+		if path == defaultPipelockTarget || path == procExe {
 			return allPassHash, nil
 		}
 		return "", fmt.Errorf("unexpected hashFile %s", path)
@@ -3323,7 +3381,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 func defaultRunForAllPass(name string, args []string) (string, int, error) {
 	switch name {
 	case testSystemctl:
-		return "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\n", 0, nil
+		return "ActiveState=active\nSubState=running\nUser=pipelock-proxy\nType=simple\nMainPID=4242\nExecStart={ path=/usr/local/bin/pipelock ; argv[]=/usr/local/bin/pipelock run ; ignore_errors=no ; }\n", 0, nil
 	case testNFT:
 		return goodNFTContainmentOutput, 0, nil
 	case testSudoCmd:

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -22,6 +22,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2880,6 +2881,120 @@ func TestRunVerify_EnforcementOnlySkipsProxyLiveness(t *testing.T) {
 	}
 	if !strings.Contains(out, "10 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing enforcement-only aggregate: %q", out)
+	}
+	if !strings.Contains(out, "probe 10: deployed pipelock binary matches TOFU pin; running-service image is not verified") ||
+		!strings.Contains(out, "running service image not verified") {
+		t.Errorf("enforcement-only probe 10 did not describe its limited evidence: %q", out)
+	}
+	if strings.Contains(out, "deployed and running pipelock binary match TOFU pin") {
+		t.Errorf("enforcement-only probe 10 claimed running-image verification: %q", out)
+	}
+}
+
+func TestRunVerify_EnforcementOnlyJSONReportsLimitedBinaryEvidence(t *testing.T) {
+	env := allPassEnv(t)
+	cmd := newVerifyCmd(t)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := runVerify(cmd, env, verifyOpts{enforcementOnly: true, jsonOutput: true}); err != nil {
+		t.Fatalf("runVerify returned err: %v", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var rec probeRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue // The aggregate record has a different JSON shape.
+		}
+		if rec.Name != "binary_integrity_pin" {
+			continue
+		}
+		if rec.Status != statusPass || !strings.Contains(rec.Detail, "running service image not verified") {
+			t.Fatalf("binary-integrity JSON record = %+v, want deployed-only pass evidence", rec)
+		}
+		return
+	}
+	t.Fatalf("binary-integrity JSON record missing from %q", buf.String())
+}
+
+func TestRunVerify_ConcurrentModesKeepRunningImagePolicyIsolated(t *testing.T) {
+	env := allPassEnv(t)
+	originalRun := env.runCmd
+
+	enforcementAtBarrier := make(chan struct{})
+	runtimeImageChecks := make(chan struct{}, 2)
+	releaseEnforcement := make(chan struct{})
+	var barrierOnce sync.Once
+	var releaseOnce sync.Once
+	unblockEnforcement := func() { releaseOnce.Do(func() { close(releaseEnforcement) }) }
+	t.Cleanup(unblockEnforcement)
+
+	var counterMu sync.Mutex
+	var counter uint64
+	env.dropCounter = func(_ context.Context, runEnv *probeEnv) (uint64, error) {
+		if !runEnv.verifyRunningImage {
+			barrierOnce.Do(func() {
+				close(enforcementAtBarrier)
+				<-releaseEnforcement
+			})
+		}
+		counterMu.Lock()
+		defer counterMu.Unlock()
+		counter++
+		return counter, nil
+	}
+	env.runCmd = func(ctx context.Context, name string, args ...string) (string, int, error) {
+		if name == testSystemctl && containsArg(args, "--property=ExecStart") && containsArg(args, "--value") {
+			runtimeImageChecks <- struct{}{}
+		}
+		return originalRun(ctx, name, args...)
+	}
+
+	type verifyResult struct {
+		err error
+		out string
+	}
+	run := func(opts verifyOpts) <-chan verifyResult {
+		result := make(chan verifyResult, 1)
+		go func() {
+			cmd := newVerifyCmd(t)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			result <- verifyResult{err: runVerify(cmd, env, opts), out: buf.String()}
+		}()
+		return result
+	}
+
+	enforcement := run(verifyOpts{enforcementOnly: true})
+	select {
+	case <-enforcementAtBarrier:
+	case <-time.After(time.Second):
+		t.Fatal("enforcement-only verification did not reach the barrier")
+	}
+
+	normal := run(verifyOpts{})
+	select {
+	case <-runtimeImageChecks:
+	case <-time.After(time.Second):
+		unblockEnforcement()
+		normalResult := <-normal
+		enforcementResult := <-enforcement
+		t.Fatalf("normal verification skipped its running-image check while enforcement-only was active: normal=%+v enforcement=%+v", normalResult, enforcementResult)
+	}
+
+	normalResult := <-normal
+	unblockEnforcement()
+	enforcementResult := <-enforcement
+	if normalResult.err != nil || enforcementResult.err != nil {
+		t.Fatalf("concurrent verification errors: normal=%+v enforcement=%+v", normalResult, enforcementResult)
+	}
+	select {
+	case <-runtimeImageChecks:
+		t.Fatal("enforcement-only verification ran the running-image check")
+	default:
+	}
+	if !env.verifyRunningImage {
+		t.Fatal("runVerify mutated the caller-owned running-image policy")
 	}
 }
 


### PR DESCRIPTION
Containment verification now checks that the installed binary, managed service command, and live service image agree with the integrity pin.

The enforcement-only mode keeps the installed-file check while skipping service-image inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Expanded binary integrity checks to verify the configured service command, running process, executable identity, and image hash.
  * Detects replacement binaries, stale processes, permission issues, hash mismatches, and invalid service metadata.
  * Running-image verification is enabled by default, with enforcement-only mode available to disable it.
* **Reliability**
  * Improved handling of unavailable binary metadata by distinguishing required checks from optional comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->