### PR TITLE
ci(release): prove container artifacts before promotion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -264,12 +264,43 @@ jobs:
             done
           done
 
+      # Keep the release builder as reproducible as the artifacts it emits. The
+      # action's convenient `~> v2` selector silently moved the release tool
+      # underneath us. Download the exact upstream archive, check the digest
+      # published by GoReleaser, then ask the binary what version it is before
+      # it can publish anything.
+      - name: Install and verify GoReleaser
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GORELEASER_VERSION: v2.17.1
+          GORELEASER_LINUX_AMD64_SHA256: a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/goreleaser-${GORELEASER_VERSION}"
+          mkdir -p "$tool_dir"
+          gh release download "$GORELEASER_VERSION" \
+            --repo goreleaser/goreleaser \
+            --pattern goreleaser_Linux_x86_64.tar.gz \
+            --dir "$tool_dir"
+          printf '%s  %s\n' \
+            "$GORELEASER_LINUX_AMD64_SHA256" \
+            "$tool_dir/goreleaser_Linux_x86_64.tar.gz" | sha256sum --check
+          tar -xzf "$tool_dir/goreleaser_Linux_x86_64.tar.gz" -C "$tool_dir"
+          got="$($tool_dir/goreleaser --version | awk '/^GitVersion:/ { print $2 }')"
+          expected="${GORELEASER_VERSION#v}"
+          test "$got" = "$expected" || {
+            echo "::error::GoReleaser reports $got, expected $expected"
+            exit 1
+          }
+          echo "GoReleaser version: $got"
+          echo "$tool_dir" >> "$GITHUB_PATH"
+
+      # Keep the GitHub Release private while the artifact set is assembled and
+      # checked. GoReleaser still publishes container images and updates
+      # Homebrew through their separate public endpoints; a draft only prevents
+      # an incomplete GitHub Release page or its assets from becoming public.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
-        with:
-          distribution: goreleaser
-          version: '~> v2'
-          args: release --clean
+        run: goreleaser release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -299,6 +330,94 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" sbom.cdx.json --clobber
 
+      # Resolve the index AND its Linux children. An attestation against only a
+      # multi-architecture index does not prove the amd64 or arm64 image an
+      # operator actually runs. Matching the direct per-architecture tag to the
+      # index child prevents an image from being attested under a look-alike tag.
+      - name: Resolve release image platform digests
+        id: platform-digests
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          go install github.com/google/go-containerregistry/cmd/crane@v0.20.7
+          resolve_image() {
+            local name="$1"
+            local repository="$2"
+            local index_digest child_digest direct_digest arch
+
+            index_digest="$(crane digest "${repository}:${TAG#v}")"
+            printf '%s_index=%s\n' "$name" "$index_digest" >> "$GITHUB_OUTPUT"
+            for arch in amd64 arm64; do
+              child_digest="$(crane manifest "${repository}:${TAG#v}" | jq -er --arg arch "$arch" '
+                [.manifests[] | select(
+                  .platform.os == "linux" and
+                  .platform.architecture == $arch
+                ) | .digest] | if length == 1 then .[0] else error("expected one linux/" + $arch + " child") end
+              ')"
+              direct_digest="$(crane digest "${repository}:${TAG#v}-${arch}")"
+              test "$child_digest" = "$direct_digest" || {
+                echo "::error::${repository}:${TAG#v}-${arch} is not the index child"
+                exit 1
+              }
+              printf '%s_%s=%s\n' "$name" "$arch" "$child_digest" >> "$GITHUB_OUTPUT"
+            done
+          }
+
+          resolve_image pipelock ghcr.io/luckypipewrench/pipelock
+          resolve_image pipelock_init ghcr.io/luckypipewrench/pipelock-init
+          resolve_image license_service ghcr.io/luckypipewrench/pipelock-license-service
+
+      # Attach a CycloneDX SBOM for every platform-specific image, not a source
+      # dependency list that says nothing about the image base or architecture.
+      # The generator follows the same exact-version, exact-digest rule as the
+      # release builder; a bare Syft version is not enough to make the published
+      # inventory reproducible.
+      - name: Generate and publish platform image SBOMs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SYFT_VERSION: v1.50.0
+          SYFT_LINUX_AMD64_SHA256: bf7b29ff57f06da30918266a0e1c2885a8f99784798d1bdb1628886aa015d788
+          PIPELOCK_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
+          PIPELOCK_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
+          PIPELOCK_INIT_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
+          PIPELOCK_INIT_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
+          LICENSE_SERVICE_AMD64_DIGEST: ${{ steps.platform-digests.outputs.license_service_amd64 }}
+          LICENSE_SERVICE_ARM64_DIGEST: ${{ steps.platform-digests.outputs.license_service_arm64 }}
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/syft-${SYFT_VERSION}"
+          mkdir -p "$tool_dir"
+          gh release download "$SYFT_VERSION" \
+            --repo anchore/syft \
+            --pattern syft_1.50.0_linux_amd64.tar.gz \
+            --dir "$tool_dir"
+          printf '%s  %s\n' \
+            "$SYFT_LINUX_AMD64_SHA256" \
+            "$tool_dir/syft_1.50.0_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf "$tool_dir/syft_1.50.0_linux_amd64.tar.gz" -C "$tool_dir"
+          got="$($tool_dir/syft version | awk '/^Version:/ { print $2 }')"
+          expected="${SYFT_VERSION#v}"
+          test "$got" = "$expected" || {
+            echo "::error::Syft reports $got, expected $expected"
+            exit 1
+          }
+          echo "Syft version: $got"
+          publish_sbom() {
+            local image="$1"
+            local digest="$2"
+            local output="$3"
+            "$tool_dir/syft" "${image}@${digest}" -o "cyclonedx-json=${output}"
+            gh release upload "$GITHUB_REF_NAME" "$output" --clobber
+          }
+
+          publish_sbom ghcr.io/luckypipewrench/pipelock "$PIPELOCK_AMD64_DIGEST" sbom-pipelock-linux-amd64.cdx.json
+          publish_sbom ghcr.io/luckypipewrench/pipelock "$PIPELOCK_ARM64_DIGEST" sbom-pipelock-linux-arm64.cdx.json
+          publish_sbom ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_AMD64_DIGEST" sbom-pipelock-init-linux-amd64.cdx.json
+          publish_sbom ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_ARM64_DIGEST" sbom-pipelock-init-linux-arm64.cdx.json
+          publish_sbom ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_AMD64_DIGEST" sbom-pipelock-license-service-linux-amd64.cdx.json
+          publish_sbom ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_ARM64_DIGEST" sbom-pipelock-license-service-linux-arm64.cdx.json
+
       # Attestation steps use continue-on-error so one failure doesn't
       # cascade and kill the rest. The final verification step checks
       # that ALL attestation steps succeeded (binaries, checksums,
@@ -325,68 +444,85 @@ jobs:
           subject-path: dist/pipelock_*.tar.gz
           sbom-path: sbom.cdx.json
 
-      - name: Get container digest
-        id: digest
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.7
-          if ! DIGEST=$(crane digest "ghcr.io/luckypipewrench/pipelock:${TAG}" 2>/dev/null); then
-            echo "::warning::Failed to resolve container digest for tag ${TAG}"
-            echo "digest=" >> "$GITHUB_OUTPUT"
-          else
-            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Attest container image
         id: attest-pipelock-container
-        if: steps.digest.outputs.digest != ''
         continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock
-          subject-digest: ${{ steps.digest.outputs.digest }}
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_index }}
           push-to-registry: true
-
-      - name: Get pipelock-init container digest
-        id: init-digest
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          if ! DIGEST=$(crane digest "ghcr.io/luckypipewrench/pipelock-init:${TAG}" 2>/dev/null); then
-            echo "::warning::Failed to resolve pipelock-init container digest for tag ${TAG}"
-            echo "digest=" >> "$GITHUB_OUTPUT"
-          else
-            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Attest pipelock-init container image
         id: attest-pipelock-init-container
-        if: steps.init-digest.outputs.digest != ''
         continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-init
-          subject-digest: ${{ steps.init-digest.outputs.digest }}
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_index }}
           push-to-registry: true
-
-      - name: Get license-service container digest
-        id: license-service-digest
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          if ! DIGEST=$(crane digest "ghcr.io/luckypipewrench/pipelock-license-service:${TAG}" 2>/dev/null); then
-            echo "::warning::Failed to resolve license-service container digest for tag ${TAG}"
-            echo "digest=" >> "$GITHUB_OUTPUT"
-          else
-            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Attest license-service container image
         id: attest-license-service-container
-        if: steps.license-service-digest.outputs.digest != ''
         continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-license-service
-          subject-digest: ${{ steps.license-service-digest.outputs.digest }}
+          subject-digest: ${{ steps.platform-digests.outputs.license_service_index }}
+          push-to-registry: true
+
+      - name: Attest pipelock linux amd64 image
+        id: attest-pipelock-amd64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
+          push-to-registry: true
+
+      - name: Attest pipelock linux arm64 image
+        id: attest-pipelock-arm64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
+          push-to-registry: true
+
+      - name: Attest pipelock-init linux amd64 image
+        id: attest-pipelock-init-amd64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-init
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
+          push-to-registry: true
+
+      - name: Attest pipelock-init linux arm64 image
+        id: attest-pipelock-init-arm64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-init
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
+          push-to-registry: true
+
+      - name: Attest license-service linux amd64 image
+        id: attest-license-service-amd64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-license-service
+          subject-digest: ${{ steps.platform-digests.outputs.license_service_amd64 }}
+          push-to-registry: true
+
+      - name: Attest license-service linux arm64 image
+        id: attest-license-service-arm64
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-license-service
+          subject-digest: ${{ steps.platform-digests.outputs.license_service_arm64 }}
           push-to-registry: true
 
       # Fail closed: any attestation that did not SUCCEED blocks the release.
@@ -403,10 +539,34 @@ jobs:
           steps.attest-sbom.outcome != 'success' ||
           steps.attest-pipelock-container.outcome != 'success' ||
           steps.attest-pipelock-init-container.outcome != 'success' ||
-          steps.attest-license-service-container.outcome != 'success' )
+          steps.attest-license-service-container.outcome != 'success' ||
+          steps.attest-pipelock-amd64.outcome != 'success' ||
+          steps.attest-pipelock-arm64.outcome != 'success' ||
+          steps.attest-pipelock-init-amd64.outcome != 'success' ||
+          steps.attest-pipelock-init-arm64.outcome != 'success' ||
+          steps.attest-license-service-amd64.outcome != 'success' ||
+          steps.attest-license-service-arm64.outcome != 'success' )
         run: |
           echo "::error::Attestation failed — release provenance is incomplete"
           exit 1
+
+      # Build the operator-facing bundle only after every child image has its
+      # own SBOM and provenance proof. The bundle contains index digests because
+      # Kubernetes selects the matching platform child from that signed index.
+      - name: Build Kubernetes image digest bundle
+        run: |
+          go run ./cmd/pipelock-release-images \
+            -tag "$GITHUB_REF_NAME" \
+            -commit "$GITHUB_SHA" \
+            -out dist/release-images.json \
+            -image "pipelock=ghcr.io/luckypipewrench/pipelock@${{ steps.platform-digests.outputs.pipelock_index }}" \
+            -image "pipelock-init=ghcr.io/luckypipewrench/pipelock-init@${{ steps.platform-digests.outputs.pipelock_init_index }}" \
+            -image "pipelock-license-service=ghcr.io/luckypipewrench/pipelock-license-service@${{ steps.platform-digests.outputs.license_service_index }}"
+
+      - name: Upload Kubernetes image digest bundle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/release-images.json --clobber
 
       # Deliberately placed after the attestation gate. The chart is the least
       # critical artifact in the release, and an earlier position would let a
@@ -483,6 +643,15 @@ jobs:
             echo "\`helm install oci://ghcr.io/luckypipewrench/charts/pipelock\` fails for"
             echo "everyone until it is made public once under Package settings."
           } >>"$GITHUB_STEP_SUMMARY"
+
+      # Promote only after the proof gate, Kubernetes digest bundle, and chart
+      # have all succeeded. The draft kept GitHub Release assets private while
+      # those checks ran. Container images and Homebrew remain separate
+      # publication surfaces and are not made atomic by this promotion.
+      - name: Publish GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
 
       # Move the v2 floating tag so `uses: luckyPipewrench/pipelock@v2`
       # always resolves to the latest release. Safe because the trigger requires

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -582,7 +582,8 @@ jobs:
       # GoReleaser writes only staging tags, so an attestation failure leaves
       # no consumer version or latest image manifest. Promote the verified index
       # by digest. Version tags never overwrite an existing different digest;
-      # latest deliberately advances to the newly verified release.
+      # latest advances only for a newer stable release, never for a prerelease
+      # or an older-line backport.
       - name: Promote verified image manifests
         env:
           TAG: ${{ github.ref_name }}
@@ -595,7 +596,7 @@ jobs:
             local repository="$1"
             local index_digest="$2"
             local version="${TAG#v}"
-            local tags existing
+            local tags existing current_stable newest_stable promote_latest=false
 
             tags="$(crane ls "$repository")" || {
               echo "::error::could not list tags for ${repository}; refusing image promotion"
@@ -613,10 +614,26 @@ jobs:
             else
               crane copy --no-clobber "${repository}@${index_digest}" "${repository}:${version}"
             fi
-            crane copy "${repository}@${index_digest}" "${repository}:latest"
+
+            if [[ "$version" != *-* ]]; then
+              current_stable="$(printf '%s\n' "$tags" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+              if [[ -z "$current_stable" ]]; then
+                promote_latest=true
+              else
+                newest_stable="$(printf '%s\n%s\n' "$current_stable" "$version" | sort -V | tail -n 1)"
+                if [[ "$newest_stable" = "$version" && "$current_stable" != "$version" ]]; then
+                  promote_latest=true
+                fi
+              fi
+            fi
+            if [[ "$promote_latest" = true ]]; then
+              crane copy "${repository}@${index_digest}" "${repository}:latest"
+              test "$(crane digest "${repository}:latest")" = "$index_digest"
+            else
+              echo "Not moving ${repository}:latest for non-newer or prerelease version ${version}"
+            fi
 
             test "$(crane digest "${repository}:${version}")" = "$index_digest"
-            test "$(crane digest "${repository}:latest")" = "$index_digest"
           }
 
           promote_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_INDEX_DIGEST"
@@ -707,13 +724,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "$GITHUB_REF_NAME" --draft=false
 
-      # Move the v2 floating tag so `uses: luckyPipewrench/pipelock@v2`
-      # always resolves to the latest release. Safe because the trigger requires
-      # two dotted components, so a bare `v2` push cannot re-fire this workflow.
+      # Move the v2 floating tag only for the newest stable product release.
+      # A prerelease or an older-line backport still publishes its immutable
+      # version, but cannot move this consumer-facing pointer backward.
       - name: Update v2 floating tag for GitHub Action
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+          latest_stable_tag="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+          if [[ "$TAG_NAME" != "$latest_stable_tag" ]]; then
+            echo "Not moving v2 for non-latest or prerelease tag ${TAG_NAME}"
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # The ^{} suffix dereferences TAG_NAME (annotated tag) to its commit.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,24 +168,46 @@ jobs:
         run: make reproducible-build-check
 
       - name: Login to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          # GoReleaser still emits separate checksums.txt.sig/.pem assets.
-          # Cosign v3 requires the new bundle format and rejects those flags.
-          cosign-release: 'v2.6.1'
+      # GoReleaser signs the legacy detached signature and certificate pair.
+      # Cosign v3 requires bundle output, so use the newest maintained v2
+      # release and verify its archive digest before it reaches GoReleaser.
+      - name: Install and verify cosign
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COSIGN_VERSION: v2.6.5
+          COSIGN_LINUX_AMD64_SHA256: c3b4f5410e608af03a5eb0aaac84a4313d8da131248e08ff1759ac70c79d1644
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/cosign-${COSIGN_VERSION}"
+          mkdir -p "$tool_dir"
+          gh release download "$COSIGN_VERSION" \
+            --repo sigstore/cosign \
+            --pattern cosign-linux-amd64 \
+            --dir "$tool_dir"
+          printf '%s  %s\n' \
+            "$COSIGN_LINUX_AMD64_SHA256" \
+            "$tool_dir/cosign-linux-amd64" | sha256sum --check
+          install -m 0755 "$tool_dir/cosign-linux-amd64" "$tool_dir/cosign"
+          got="$($tool_dir/cosign version | awk '/^GitVersion:/ { print $2 }')"
+          expected="$COSIGN_VERSION"
+          test "$got" = "$expected" || {
+            echo "::error::cosign reports $got, expected $expected"
+            exit 1
+          }
+          echo "cosign version: $got"
+          echo "$tool_dir" >> "$GITHUB_PATH"
 
       - name: Set GOVERSION
         run: echo "GOVERSION=$(go env GOVERSION)" >> "$GITHUB_ENV"
@@ -321,9 +343,30 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" dist/release.json --clobber
 
       - name: Generate SBOM
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CYCLONEDX_GOMOD_VERSION: v1.10.0
+          CYCLONEDX_GOMOD_LINUX_AMD64_SHA256: 5cce8ae99a5181be6a610ea5ed9ca9d596937cc04dc1a8f6f6b5e462d8c9900e
         run: |
-          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.9.0
-          cyclonedx-gomod mod -json -output sbom.cdx.json
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/cyclonedx-gomod-${CYCLONEDX_GOMOD_VERSION}"
+          archive="cyclonedx-gomod_${CYCLONEDX_GOMOD_VERSION#v}_linux_amd64.tar.gz"
+          mkdir -p "$tool_dir"
+          gh release download "$CYCLONEDX_GOMOD_VERSION" \
+            --repo CycloneDX/cyclonedx-gomod \
+            --pattern "$archive" \
+            --dir "$tool_dir"
+          printf '%s  %s\n' \
+            "$CYCLONEDX_GOMOD_LINUX_AMD64_SHA256" \
+            "$tool_dir/$archive" | sha256sum --check
+          tar -xzf "$tool_dir/$archive" -C "$tool_dir"
+          got="$($tool_dir/cyclonedx-gomod version | awk '/^Version:/ { print $2 }')"
+          expected="$CYCLONEDX_GOMOD_VERSION"
+          test "$got" = "$expected" || {
+            echo "::error::cyclonedx-gomod reports $got, expected $expected"
+            exit 1
+          }
+          "$tool_dir/cyclonedx-gomod" mod -json -output sbom.cdx.json
 
       - name: Upload SBOM to release
         env:
@@ -338,25 +381,46 @@ jobs:
         id: platform-digests
         env:
           TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          CRANE_VERSION: v0.21.9
+          CRANE_LINUX_AMD64_SHA256: 5c16d8ddb971cb1d5e6ed8b1e743da8224414eeba2c2762d8f1a61b2f095699e
         run: |
           set -euo pipefail
-          go install github.com/google/go-containerregistry/cmd/crane@v0.20.7
+          tool_dir="$RUNNER_TEMP/crane-${CRANE_VERSION}"
+          archive="go-containerregistry_Linux_x86_64.tar.gz"
+          mkdir -p "$tool_dir"
+          gh release download "$CRANE_VERSION" \
+            --repo google/go-containerregistry \
+            --pattern "$archive" \
+            --dir "$tool_dir"
+          printf '%s  %s\n' \
+            "$CRANE_LINUX_AMD64_SHA256" \
+            "$tool_dir/$archive" | sha256sum --check
+          tar -xzf "$tool_dir/$archive" -C "$tool_dir"
+          got="$($tool_dir/crane version)"
+          expected="${CRANE_VERSION#v}"
+          test "$got" = "$expected" || {
+            echo "::error::crane reports $got, expected $expected"
+            exit 1
+          }
+          echo "crane version: $got"
+          echo "$tool_dir" >> "$GITHUB_PATH"
           resolve_image() {
             local name="$1"
             local repository="$2"
             local staging_tag index_digest child_digest direct_digest arch
 
             staging_tag="${TAG#v}-staging"
-            index_digest="$(crane digest "${repository}:${staging_tag}")"
+            index_digest="$("$tool_dir/crane" digest "${repository}:${staging_tag}")"
             printf '%s_index=%s\n' "$name" "$index_digest" >> "$GITHUB_OUTPUT"
             for arch in amd64 arm64; do
-              child_digest="$(crane manifest "${repository}:${staging_tag}" | jq -er --arg arch "$arch" '
+              child_digest="$("$tool_dir/crane" manifest "${repository}:${staging_tag}" | jq -er --arg arch "$arch" '
                 [.manifests[] | select(
                   .platform.os == "linux" and
                   .platform.architecture == $arch
                 ) | .digest] | if length == 1 then .[0] else error("expected one linux/" + $arch + " child") end
               ')"
-              direct_digest="$(crane digest "${repository}:${staging_tag}-${arch}")"
+              direct_digest="$("$tool_dir/crane" digest "${repository}:${staging_tag}-${arch}")"
               test "$child_digest" = "$direct_digest" || {
                 echo "::error::${repository}:${staging_tag}-${arch} is not the index child"
                 exit 1
@@ -426,14 +490,14 @@ jobs:
       - name: Attest binary archives
         id: attest-binaries
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/pipelock_*.tar.gz
 
       - name: Attest checksums
         id: attest-checksums
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/checksums.txt
 
@@ -448,7 +512,7 @@ jobs:
       - name: Attest container image
         id: attest-pipelock-container
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_index }}
@@ -457,7 +521,7 @@ jobs:
       - name: Attest pipelock-init container image
         id: attest-pipelock-init-container
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-init
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_index }}
@@ -466,7 +530,7 @@ jobs:
       - name: Attest license-service container image
         id: attest-license-service-container
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-license-service
           subject-digest: ${{ steps.platform-digests.outputs.license_service_index }}
@@ -475,7 +539,7 @@ jobs:
       - name: Attest pipelock linux amd64 image
         id: attest-pipelock-amd64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
@@ -484,7 +548,7 @@ jobs:
       - name: Attest pipelock linux arm64 image
         id: attest-pipelock-arm64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
@@ -493,7 +557,7 @@ jobs:
       - name: Attest pipelock-init linux amd64 image
         id: attest-pipelock-init-amd64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-init
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
@@ -502,7 +566,7 @@ jobs:
       - name: Attest pipelock-init linux arm64 image
         id: attest-pipelock-init-arm64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-init
           subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
@@ -511,7 +575,7 @@ jobs:
       - name: Attest license-service linux amd64 image
         id: attest-license-service-amd64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-license-service
           subject-digest: ${{ steps.platform-digests.outputs.license_service_amd64 }}
@@ -520,7 +584,7 @@ jobs:
       - name: Attest license-service linux arm64 image
         id: attest-license-service-arm64
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/luckypipewrench/pipelock-license-service
           subject-digest: ${{ steps.platform-digests.outputs.license_service_arm64 }}
@@ -552,9 +616,9 @@ jobs:
           exit 1
 
       - name: Set up Helm
-        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: v3.20.2
+          version: v3.21.3
 
       # Refuse a re-pushed release tag before moving any consumer image tag.
       # Without this preflight, replaying an older tag could roll :latest back

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -296,9 +296,9 @@ jobs:
           echo "$tool_dir" >> "$GITHUB_PATH"
 
       # Keep the GitHub Release private while the artifact set is assembled and
-      # checked. GoReleaser still publishes container images and updates
-      # Homebrew through their separate public endpoints; a draft only prevents
-      # an incomplete GitHub Release page or its assets from becoming public.
+      # checked. GoReleaser publishes only staging image tags; the consumer
+      # version and latest manifests are promoted after attestation completes.
+      # Homebrew remains a separate publication surface.
       - name: Run GoReleaser
         run: goreleaser release --clean --draft
         env:
@@ -344,20 +344,21 @@ jobs:
           resolve_image() {
             local name="$1"
             local repository="$2"
-            local index_digest child_digest direct_digest arch
+            local staging_tag index_digest child_digest direct_digest arch
 
-            index_digest="$(crane digest "${repository}:${TAG#v}")"
+            staging_tag="${TAG#v}-staging"
+            index_digest="$(crane digest "${repository}:${staging_tag}")"
             printf '%s_index=%s\n' "$name" "$index_digest" >> "$GITHUB_OUTPUT"
             for arch in amd64 arm64; do
-              child_digest="$(crane manifest "${repository}:${TAG#v}" | jq -er --arg arch "$arch" '
+              child_digest="$(crane manifest "${repository}:${staging_tag}" | jq -er --arg arch "$arch" '
                 [.manifests[] | select(
                   .platform.os == "linux" and
                   .platform.architecture == $arch
                 ) | .digest] | if length == 1 then .[0] else error("expected one linux/" + $arch + " child") end
               ')"
-              direct_digest="$(crane digest "${repository}:${TAG#v}-${arch}")"
+              direct_digest="$(crane digest "${repository}:${staging_tag}-${arch}")"
               test "$child_digest" = "$direct_digest" || {
-                echo "::error::${repository}:${TAG#v}-${arch} is not the index child"
+                echo "::error::${repository}:${staging_tag}-${arch} is not the index child"
                 exit 1
               }
               printf '%s_%s=%s\n' "$name" "$arch" "$child_digest" >> "$GITHUB_OUTPUT"
@@ -550,6 +551,78 @@ jobs:
           echo "::error::Attestation failed — release provenance is incomplete"
           exit 1
 
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
+      # Refuse a re-pushed release tag before moving any consumer image tag.
+      # Without this preflight, replaying an older tag could roll :latest back
+      # and only then fail when chart publication discovers the version exists.
+      - name: Verify Helm chart version is unpublished
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
+          test -n "$chart_version" || {
+            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
+            exit 1
+          }
+          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
+          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          if chart_lookup_output="$(helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" 2>&1)"; then
+            echo "::error::chart ${chart_version} is already published; refusing to replay a release tag"
+            exit 1
+          elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
+            echo "::error::could not determine whether chart ${chart_version} already exists; refusing image promotion"
+            exit 1
+          fi
+
+      # GoReleaser writes only staging tags, so an attestation failure leaves
+      # no consumer version or latest image manifest. Promote the verified index
+      # by digest. Version tags never overwrite an existing different digest;
+      # latest deliberately advances to the newly verified release.
+      - name: Promote verified image manifests
+        env:
+          TAG: ${{ github.ref_name }}
+          PIPELOCK_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_index }}
+          PIPELOCK_INIT_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_index }}
+          LICENSE_SERVICE_INDEX_DIGEST: ${{ steps.platform-digests.outputs.license_service_index }}
+        run: |
+          set -euo pipefail
+          promote_image() {
+            local repository="$1"
+            local index_digest="$2"
+            local version="${TAG#v}"
+            local tags existing
+
+            tags="$(crane ls "$repository")" || {
+              echo "::error::could not list tags for ${repository}; refusing image promotion"
+              exit 1
+            }
+            if grep -Fxq "$version" <<<"$tags"; then
+              existing="$(crane digest "${repository}:${version}")" || {
+                echo "::error::could not resolve existing ${repository}:${version}"
+                exit 1
+              }
+              test "$existing" = "$index_digest" || {
+                echo "::error::${repository}:${version} already resolves to a different digest"
+                exit 1
+              }
+            else
+              crane copy --no-clobber "${repository}@${index_digest}" "${repository}:${version}"
+            fi
+            crane copy "${repository}@${index_digest}" "${repository}:latest"
+
+            test "$(crane digest "${repository}:${version}")" = "$index_digest"
+            test "$(crane digest "${repository}:latest")" = "$index_digest"
+          }
+
+          promote_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_INDEX_DIGEST"
+          promote_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_INDEX_DIGEST"
+          promote_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_INDEX_DIGEST"
+
       # Build the operator-facing bundle only after every child image has its
       # own SBOM and provenance proof. The bundle contains index digests because
       # Kubernetes selects the matching platform child from that signed index.
@@ -590,11 +663,6 @@ jobs:
       # by default, so the chart is not installable until that package is made
       # public once in the GitHub UI. There is no REST endpoint for that, and it
       # is irreversible, so it stays a deliberate human step.
-      - name: Set up Helm
-        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.20.2
-
       - name: Package and publish Helm chart
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -610,20 +678,6 @@ jobs:
           helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
-
-          # Refuse to overwrite a published tag. The release gate keeps the chart
-          # version equal to the release version, so this can only trigger when
-          # the same version is released twice, which a re-pushed tag allows.
-          # An OCI registry accepts a re-push silently, so without this the
-          # second run would change what an already-published version means for
-          # anyone who pinned it.
-          if chart_lookup_output="$(helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" 2>&1)"; then
-            echo "::error::chart ${chart_version} is already published; refusing to overwrite a published tag"
-            exit 1
-          elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
-            echo "::error::could not determine whether chart ${chart_version} already exists; refusing to publish"
-            exit 1
-          fi
 
           helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -336,10 +336,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
         run: |
+          release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{}")"
           go run ./cmd/pipelock-release-manifest \
             -dist dist \
             -tag "$GITHUB_REF_NAME" \
-            -commit "$GITHUB_SHA"
+            -commit "$release_commit"
           gh release upload "$GITHUB_REF_NAME" dist/release.json --clobber
 
       - name: Generate SBOM
@@ -452,15 +453,16 @@ jobs:
         run: |
           set -euo pipefail
           tool_dir="$RUNNER_TEMP/syft-${SYFT_VERSION}"
+          archive="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
           mkdir -p "$tool_dir"
           gh release download "$SYFT_VERSION" \
             --repo anchore/syft \
-            --pattern syft_1.50.0_linux_amd64.tar.gz \
+            --pattern "$archive" \
             --dir "$tool_dir"
           printf '%s  %s\n' \
             "$SYFT_LINUX_AMD64_SHA256" \
-            "$tool_dir/syft_1.50.0_linux_amd64.tar.gz" | sha256sum --check
-          tar -xzf "$tool_dir/syft_1.50.0_linux_amd64.tar.gz" -C "$tool_dir"
+            "$tool_dir/$archive" | sha256sum --check
+          tar -xzf "$tool_dir/$archive" -C "$tool_dir"
           got="$($tool_dir/syft version | awk '/^Version:/ { print $2 }')"
           expected="${SYFT_VERSION#v}"
           test "$got" = "$expected" || {
@@ -590,6 +592,66 @@ jobs:
           subject-digest: ${{ steps.platform-digests.outputs.license_service_arm64 }}
           push-to-registry: true
 
+      - name: Attest pipelock linux amd64 SBOM
+        id: attest-pipelock-amd64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
+          sbom-path: sbom-pipelock-linux-amd64.cdx.json
+          push-to-registry: true
+
+      - name: Attest pipelock linux arm64 SBOM
+        id: attest-pipelock-arm64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
+          sbom-path: sbom-pipelock-linux-arm64.cdx.json
+          push-to-registry: true
+
+      - name: Attest pipelock-init linux amd64 SBOM
+        id: attest-pipelock-init-amd64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-init
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
+          sbom-path: sbom-pipelock-init-linux-amd64.cdx.json
+          push-to-registry: true
+
+      - name: Attest pipelock-init linux arm64 SBOM
+        id: attest-pipelock-init-arm64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-init
+          subject-digest: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
+          sbom-path: sbom-pipelock-init-linux-arm64.cdx.json
+          push-to-registry: true
+
+      - name: Attest license-service linux amd64 SBOM
+        id: attest-license-service-amd64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-license-service
+          subject-digest: ${{ steps.platform-digests.outputs.license_service_amd64 }}
+          sbom-path: sbom-pipelock-license-service-linux-amd64.cdx.json
+          push-to-registry: true
+
+      - name: Attest license-service linux arm64 SBOM
+        id: attest-license-service-arm64-sbom
+        continue-on-error: true
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/luckypipewrench/pipelock-license-service
+          subject-digest: ${{ steps.platform-digests.outputs.license_service_arm64 }}
+          sbom-path: sbom-pipelock-license-service-linux-arm64.cdx.json
+          push-to-registry: true
+
       # Fail closed: any attestation that did not SUCCEED blocks the release.
       # `!= 'success'` (not `== 'failure'`) also catches a SKIPPED container
       # attest step, which happens when its digest step could not resolve the
@@ -610,7 +672,13 @@ jobs:
           steps.attest-pipelock-init-amd64.outcome != 'success' ||
           steps.attest-pipelock-init-arm64.outcome != 'success' ||
           steps.attest-license-service-amd64.outcome != 'success' ||
-          steps.attest-license-service-arm64.outcome != 'success' )
+          steps.attest-license-service-arm64.outcome != 'success' ||
+          steps.attest-pipelock-amd64-sbom.outcome != 'success' ||
+          steps.attest-pipelock-arm64-sbom.outcome != 'success' ||
+          steps.attest-pipelock-init-amd64-sbom.outcome != 'success' ||
+          steps.attest-pipelock-init-arm64-sbom.outcome != 'success' ||
+          steps.attest-license-service-amd64-sbom.outcome != 'success' ||
+          steps.attest-license-service-arm64-sbom.outcome != 'success' )
         run: |
           echo "::error::Attestation failed — release provenance is incomplete"
           exit 1
@@ -620,27 +688,42 @@ jobs:
         with:
           version: v3.21.3
 
-      # Refuse a re-pushed release tag before moving any consumer image tag.
-      # Without this preflight, replaying an older tag could roll :latest back
-      # and only then fail when chart publication discovers the version exists.
-      - name: Verify Helm chart version is unpublished
+      # A retry after publishing the chart must not fail halfway through the
+      # release. Compare a pre-existing chart with this run's packaged chart and
+      # skip its immutable upload only when their contents are identical.
+      - name: Package and verify Helm chart version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          app_version="${TAG_NAME#v}"
           chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
           test -n "$chart_version" || {
             echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
             exit 1
           }
+          helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
-          if chart_lookup_output="$(helm show chart "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" 2>&1)"; then
-            echo "::error::chart ${chart_version} is already published; refusing to replay a release tag"
-            exit 1
+          existing_dir="$RUNNER_TEMP/published-chart-${chart_version}"
+          candidate_dir="$RUNNER_TEMP/candidate-chart-${chart_version}"
+          mkdir -p "$existing_dir"
+          if chart_lookup_output="$(helm pull "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" --destination "$existing_dir" 2>&1)"; then
+            mkdir -p "$candidate_dir"
+            tar -xzf "dist-chart/pipelock-${chart_version}.tgz" -C "$candidate_dir"
+            tar -xzf "$existing_dir/pipelock-${chart_version}.tgz" -C "$existing_dir"
+            diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock" || {
+              echo "::error::published chart ${chart_version} differs from this release; refusing to overwrite it"
+              exit 1
+            }
+            echo "CHART_ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+            echo "Chart ${chart_version} already matches this release; skipping its immutable upload"
           elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
             echo "::error::could not determine whether chart ${chart_version} already exists; refusing image promotion"
             exit 1
+          else
+            echo "CHART_ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
           fi
 
       # GoReleaser writes only staging tags, so an attestation failure leaves
@@ -654,13 +737,19 @@ jobs:
           PIPELOCK_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_index }}
           PIPELOCK_INIT_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_index }}
           LICENSE_SERVICE_INDEX_DIGEST: ${{ steps.platform-digests.outputs.license_service_index }}
+          PIPELOCK_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
+          PIPELOCK_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
+          PIPELOCK_INIT_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
+          PIPELOCK_INIT_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
+          LICENSE_SERVICE_AMD64_DIGEST: ${{ steps.platform-digests.outputs.license_service_amd64 }}
+          LICENSE_SERVICE_ARM64_DIGEST: ${{ steps.platform-digests.outputs.license_service_arm64 }}
         run: |
           set -euo pipefail
           promote_image() {
             local repository="$1"
             local index_digest="$2"
             local version="${TAG#v}"
-            local tags existing current_stable newest_stable promote_latest=false
+            local tags existing latest_digest newest_stable
 
             tags="$(crane ls "$repository")" || {
               echo "::error::could not list tags for ${repository}; refusing image promotion"
@@ -680,42 +769,82 @@ jobs:
             fi
 
             if [[ "$version" != *-* ]]; then
-              current_stable="$(printf '%s\n' "$tags" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
-              if [[ -z "$current_stable" ]]; then
-                promote_latest=true
-              else
-                newest_stable="$(printf '%s\n%s\n' "$current_stable" "$version" | sort -V | tail -n 1)"
-                if [[ "$newest_stable" = "$version" && "$current_stable" != "$version" ]]; then
-                  promote_latest=true
+              newest_stable="$(printf '%s\n%s\n' "$tags" "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+              if [[ "$newest_stable" = "$version" ]]; then
+                latest_digest="$(crane digest "${repository}:latest" 2>/dev/null || true)"
+                if [[ "$latest_digest" != "$index_digest" ]]; then
+                  crane copy "${repository}@${index_digest}" "${repository}:latest"
                 fi
+                test "$(crane digest "${repository}:latest")" = "$index_digest"
+              else
+                echo "Not moving ${repository}:latest for non-newer or prerelease version ${version}"
               fi
-            fi
-            if [[ "$promote_latest" = true ]]; then
-              crane copy "${repository}@${index_digest}" "${repository}:latest"
-              test "$(crane digest "${repository}:latest")" = "$index_digest"
             else
-              echo "Not moving ${repository}:latest for non-newer or prerelease version ${version}"
+              echo "Not moving ${repository}:latest for prerelease version ${version}"
             fi
 
             test "$(crane digest "${repository}:${version}")" = "$index_digest"
           }
 
+          promote_platform_image() {
+            local repository="$1"
+            local digest="$2"
+            local arch="$3"
+            local version="${TAG#v}"
+            local target="${repository}:${version}-${arch}"
+            local existing
+
+            if existing="$(crane digest "$target" 2>/dev/null)"; then
+              test "$existing" = "$digest" || {
+                echo "::error::${target} already resolves to a different digest"
+                exit 1
+              }
+            else
+              crane copy --no-clobber "${repository}@${digest}" "$target"
+            fi
+            test "$(crane digest "$target")" = "$digest"
+          }
+
           promote_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_INDEX_DIGEST"
           promote_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_INDEX_DIGEST"
           promote_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_INDEX_DIGEST"
+          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_ARM64_DIGEST" arm64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_ARM64_DIGEST" arm64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_ARM64_DIGEST" arm64
 
       # Build the operator-facing bundle only after every child image has its
       # own SBOM and provenance proof. The bundle contains index digests because
       # Kubernetes selects the matching platform child from that signed index.
       - name: Build Kubernetes image digest bundle
+        env:
+          PIPELOCK_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_index }}
+          PIPELOCK_INIT_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_index }}
+          LICENSE_SERVICE_INDEX_DIGEST: ${{ steps.platform-digests.outputs.license_service_index }}
         run: |
+          release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{}")"
           go run ./cmd/pipelock-release-images \
             -tag "$GITHUB_REF_NAME" \
-            -commit "$GITHUB_SHA" \
+            -commit "$release_commit" \
             -out dist/release-images.json \
-            -image "pipelock=ghcr.io/luckypipewrench/pipelock@${{ steps.platform-digests.outputs.pipelock_index }}" \
-            -image "pipelock-init=ghcr.io/luckypipewrench/pipelock-init@${{ steps.platform-digests.outputs.pipelock_init_index }}" \
-            -image "pipelock-license-service=ghcr.io/luckypipewrench/pipelock-license-service@${{ steps.platform-digests.outputs.license_service_index }}"
+            -image "pipelock=ghcr.io/luckypipewrench/pipelock@${PIPELOCK_INDEX_DIGEST}" \
+            -image "pipelock-init=ghcr.io/luckypipewrench/pipelock-init@${PIPELOCK_INIT_INDEX_DIGEST}" \
+            -image "pipelock-license-service=ghcr.io/luckypipewrench/pipelock-license-service@${LICENSE_SERVICE_INDEX_DIGEST}"
+
+      - name: Attest Kubernetes image digest bundle
+        id: attest-release-images
+        continue-on-error: true
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/release-images.json
+
+      - name: Verify Kubernetes image digest bundle attestation
+        if: always() && steps.attest-release-images.outcome != 'success'
+        run: |
+          echo "::error::Kubernetes image digest bundle attestation failed"
+          exit 1
 
       - name: Upload Kubernetes image digest bundle
         env:
@@ -744,7 +873,7 @@ jobs:
       # by default, so the chart is not installable until that package is made
       # public once in the GitHub UI. There is no REST endpoint for that, and it
       # is irreversible, so it stays a deliberate human step.
-      - name: Package and publish Helm chart
+      - name: Publish Helm chart
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -756,11 +885,12 @@ jobs:
             echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
             exit 1
           }
-          helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
 
-          helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          if [[ "$CHART_ALREADY_PUBLISHED" != true ]]; then
+            helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          fi
 
           # A brand-new GHCR package is private, and the install command in the
           # READMEs fails with an authorization error until it is made public.
@@ -796,9 +926,9 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          latest_stable_tag="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
+          latest_stable_tag="$(git tag --list | grep -E '^v2\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
           if [[ "$TAG_NAME" != "$latest_stable_tag" ]]; then
-            echo "Not moving v2 for non-latest or prerelease tag ${TAG_NAME}"
+            echo "Not moving v2 for non-latest, off-major, or prerelease tag ${TAG_NAME}"
             exit 0
           fi
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -474,7 +474,7 @@ jobs:
             local image="$1"
             local digest="$2"
             local output="$3"
-            "$tool_dir/syft" "${image}@${digest}" -o "cyclonedx-json=${output}"
+            "$tool_dir/syft" "registry:${image}@${digest}" -o "cyclonedx-json=${output}"
             gh release upload "$GITHUB_REF_NAME" "$output" --clobber
           }
 
@@ -703,6 +703,7 @@ jobs:
             echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
             exit 1
           }
+          echo "CHART_VERSION=$chart_version" >> "$GITHUB_ENV"
           helm package charts/pipelock --app-version "$app_version" --destination dist-chart
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
@@ -880,9 +881,9 @@ jobs:
         run: |
           set -euo pipefail
           app_version="${TAG_NAME#v}"
-          chart_version="$(helm show chart charts/pipelock | awk '$1 == "version:" { print $2 }')"
+          chart_version="$CHART_VERSION"
           test -n "$chart_version" || {
-            echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
+            echo "::error::chart version was not established before publication"
             exit 1
           }
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -187,7 +187,7 @@ brews:
 
 dockers:
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-staging-amd64"
     ids: [pipelock]
     use: buildx
     build_flag_templates:
@@ -205,7 +205,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
 
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-staging-arm64"
     ids: [pipelock]
     use: buildx
     build_flag_templates:
@@ -226,7 +226,7 @@ dockers:
   # Init container image for K8s sidecar deployments (MCP stdio wrapping).
   # Alpine-based so `cp` is available for copying the binary to shared volumes.
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-amd64"
+      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-staging-amd64"
     ids: [pipelock]
     use: buildx
     build_flag_templates:
@@ -244,7 +244,7 @@ dockers:
     dockerfile: Dockerfile.init
 
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-staging-arm64"
     ids: [pipelock]
     use: buildx
     build_flag_templates:
@@ -265,7 +265,7 @@ dockers:
   # License service: webhook handler for Polar subscription events.
   # Alpine-based (needs writable fs for SQLite + audit ledger).
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-amd64"
+      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-staging-amd64"
     ids: [license-service]
     use: buildx
     build_flag_templates:
@@ -283,7 +283,7 @@ dockers:
     dockerfile: Dockerfile.license-service
 
   - image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-staging-arm64"
     ids: [license-service]
     use: buildx
     build_flag_templates:
@@ -302,32 +302,17 @@ dockers:
     dockerfile: Dockerfile.license-service
 
 docker_manifests:
-  - name_template: "ghcr.io/luckypipewrench/pipelock:{{ .Version }}"
+  - name_template: "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-staging"
     image_templates:
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-staging-amd64"
+      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-staging-arm64"
 
-  - name_template: "ghcr.io/luckypipewrench/pipelock:latest"
+  - name_template: "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-staging"
     image_templates:
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-staging-amd64"
+      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-staging-arm64"
 
-  - name_template: "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}"
+  - name_template: "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-staging"
     image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/luckypipewrench/pipelock-init:latest"
-    image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock-init:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/luckypipewrench/pipelock-license-service:latest"
-    image_templates:
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-amd64"
-      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-arm64"
+      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-staging-amd64"
+      - "ghcr.io/luckypipewrench/pipelock-license-service:{{ .Version }}-staging-arm64"

--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ Full docs directory: [docs/](docs/)
 | [False Positive Tuning](docs/false-positive-tuning.md) | Identifying, suppressing, and tuning scanner findings |
 | [Scan API](docs/scan-api.md) | Evaluation endpoint for programmatic scanning |
 | [Deployment Recipes](docs/guides/deployment-recipes.md) | Docker Compose, K8s sidecar, iptables, macOS PF |
+| [Kubernetes Image Upgrades](docs/guides/kubernetes-image-upgrades.md) | Digest-pinned releases, live image-ID checks, and rollback |
 | [`pipelock doctor`](docs/cli/doctor.md) | Configured-vs-enforceable deployment diagnostics for proxy, TLS, MCP, file_sentry, telemetry, and containment signals |
 | [`pipelock dashboard`](docs/cli/dashboard.md) | Operator dashboard setup: auth modes, RBAC permissions, evidence, exemptions, budgets, trust and keys, fleet views, backup/restore, and coverage certificates |
 | [`pipelock verify-install`](docs/cli/verify-install.md) | Deterministic scanning, local proof, and direct-egress smoke checks |

--- a/cmd/pipelock-release-images/main.go
+++ b/cmd/pipelock-release-images/main.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// pipelock-release-images writes the exact container image digests that belong
+// to one Pipelock release. It runs in the release workflow after all three
+// published images resolve to immutable manifest digests.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const schema = "pipelock-release-images-v1"
+
+var (
+	tagRE    = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$`)
+	commitRE = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	digestRE = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+)
+
+var expectedImages = map[string]string{
+	"pipelock":                 "ghcr.io/luckypipewrench/pipelock",
+	"pipelock-init":            "ghcr.io/luckypipewrench/pipelock-init",
+	"pipelock-license-service": "ghcr.io/luckypipewrench/pipelock-license-service",
+}
+
+type imageFlag []string
+
+func (f *imageFlag) String() string { return strings.Join(*f, ",") }
+
+func (f *imageFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+type releaseImages struct {
+	Schema string         `json:"schema"`
+	Tag    string         `json:"tag"`
+	Commit string         `json:"commit"`
+	Images []releaseImage `json:"images"`
+}
+
+type releaseImage struct {
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	Digest     string `json:"digest"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "pipelock-release-images: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("pipelock-release-images", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	tag := fs.String("tag", "", "release tag, e.g. v3.4.0")
+	commit := fs.String("commit", "", "release commit SHA")
+	out := fs.String("out", "", "output path for release-images.json")
+	var images imageFlag
+	fs.Var(&images, "image", "required image as name=repository@sha256:<64 lowercase hex chars>; repeat for every release image")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("unexpected positional arguments")
+	}
+	manifest, err := buildManifest(*tag, *commit, images)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal release image bundle: %w", err)
+	}
+	data = append(data, '\n')
+	if *out == "" {
+		if _, err := stdout.Write(data); err != nil {
+			return fmt.Errorf("write release image bundle: %w", err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(filepath.Clean(*out), data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", *out, err)
+	}
+	return nil
+}
+
+func buildManifest(tag, commit string, values []string) (releaseImages, error) {
+	tag = strings.TrimSpace(tag)
+	if !tagRE.MatchString(tag) {
+		return releaseImages{}, errors.New("--tag must be a release tag such as v3.4.0")
+	}
+	commit = strings.TrimSpace(commit)
+	if !commitRE.MatchString(commit) {
+		return releaseImages{}, errors.New("--commit must be a 40-character lowercase Git SHA")
+	}
+	if len(values) > len(expectedImages) {
+		return releaseImages{}, fmt.Errorf("exactly %d --image flags are required", len(expectedImages))
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	images := make([]releaseImage, 0, len(values))
+	for _, value := range values {
+		image, err := parseImage(value)
+		if err != nil {
+			return releaseImages{}, err
+		}
+		if _, ok := seen[image.Name]; ok {
+			return releaseImages{}, fmt.Errorf("duplicate --image %q", image.Name)
+		}
+		seen[image.Name] = struct{}{}
+		wantRepository, ok := expectedImages[image.Name]
+		if !ok {
+			return releaseImages{}, fmt.Errorf("unknown --image name %q", image.Name)
+		}
+		if image.Repository != wantRepository {
+			return releaseImages{}, fmt.Errorf("--image %q repository = %q, want %q", image.Name, image.Repository, wantRepository)
+		}
+		images = append(images, image)
+	}
+	for name := range expectedImages {
+		if _, ok := seen[name]; !ok {
+			return releaseImages{}, fmt.Errorf("missing required --image %q", name)
+		}
+	}
+	sort.Slice(images, func(i, j int) bool { return images[i].Name < images[j].Name })
+	return releaseImages{Schema: schema, Tag: tag, Commit: commit, Images: images}, nil
+}
+
+func parseImage(value string) (releaseImage, error) {
+	name, reference, ok := strings.Cut(strings.TrimSpace(value), "=")
+	if !ok || name == "" || reference == "" {
+		return releaseImage{}, fmt.Errorf("--image %q must use name=repository@sha256:<64 lowercase hex chars>", value)
+	}
+	repository, digest, ok := strings.Cut(reference, "@")
+	if !ok || repository == "" {
+		return releaseImage{}, fmt.Errorf("--image %q must use a lowercase sha256 manifest digest", value)
+	}
+	if strings.Contains(repository, "@") || strings.Contains(digest, "@") {
+		return releaseImage{}, fmt.Errorf("--image %q has more than one @ separator", value)
+	}
+	if !digestRE.MatchString(digest) {
+		return releaseImage{}, fmt.Errorf("--image %q must use a lowercase sha256 manifest digest", value)
+	}
+	return releaseImage{Name: name, Repository: repository, Digest: digest}, nil
+}

--- a/cmd/pipelock-release-images/main.go
+++ b/cmd/pipelock-release-images/main.go
@@ -145,10 +145,13 @@ func parseImage(value string) (releaseImage, error) {
 		return releaseImage{}, fmt.Errorf("--image %q must use name=repository@sha256:<64 lowercase hex chars>", value)
 	}
 	repository, digest, ok := strings.Cut(reference, "@")
-	if !ok || repository == "" {
+	if !ok {
 		return releaseImage{}, fmt.Errorf("--image %q must use a lowercase sha256 manifest digest", value)
 	}
-	if strings.Contains(repository, "@") || strings.Contains(digest, "@") {
+	if repository == "" {
+		return releaseImage{}, fmt.Errorf("--image %q must name a repository before @", value)
+	}
+	if strings.Contains(digest, "@") {
 		return releaseImage{}, fmt.Errorf("--image %q has more than one @ separator", value)
 	}
 	if !digestRE.MatchString(digest) {

--- a/cmd/pipelock-release-images/main_test.go
+++ b/cmd/pipelock-release-images/main_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -39,6 +40,15 @@ func TestRunWritesStableImageBundle(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "release-images.json")
 	if err := run(validArgs(out), io.Discard, io.Discard); err != nil {
 		t.Fatalf("run: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(out)
+		if err != nil {
+			t.Fatalf("stat output: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("output permissions = %04o, want 0600", got)
+		}
 	}
 	data, err := os.ReadFile(out) // #nosec G304 -- test reads its own temp output
 	if err != nil {

--- a/cmd/pipelock-release-images/main_test.go
+++ b/cmd/pipelock-release-images/main_test.go
@@ -166,7 +166,7 @@ func TestParseImageRejectsMalformedReferences(t *testing.T) {
 		{name: "empty name", value: "=ghcr.io/luckypipewrench/pipelock@" + testDigest, want: "must use name"},
 		{name: "empty reference", value: "pipelock=", want: "must use name"},
 		{name: "missing digest separator", value: "pipelock=ghcr.io/luckypipewrench/pipelock", want: "lowercase sha256"},
-		{name: "empty repository", value: "pipelock=@" + testDigest, want: "lowercase sha256"},
+		{name: "empty repository", value: "pipelock=@" + testDigest, want: "must name a repository"},
 		{name: "repeated digest separator", value: "pipelock=ghcr.io/luckypipewrench/pipelock@" + testDigest + "@again", want: "more than one @"},
 	}
 	for _, tc := range tests {

--- a/cmd/pipelock-release-images/main_test.go
+++ b/cmd/pipelock-release-images/main_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+type failWriter struct{ err error }
+
+func (w failWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func validArgs(out string) []string {
+	args := []string{
+		"-tag", "v3.4.0",
+		"-commit", strings.Repeat("a", 40),
+	}
+	if out != "" {
+		args = append(args, "-out", out)
+	}
+	return append(args,
+		"-image", "pipelock=ghcr.io/luckypipewrench/pipelock@"+testDigest,
+		"-image", "pipelock-init=ghcr.io/luckypipewrench/pipelock-init@"+testDigest,
+		"-image", "pipelock-license-service=ghcr.io/luckypipewrench/pipelock-license-service@"+testDigest,
+	)
+}
+
+func TestRunWritesStableImageBundle(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "release-images.json")
+	if err := run(validArgs(out), io.Discard, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(out) // #nosec G304 -- test reads its own temp output
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got releaseImages
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got.Schema != schema || got.Tag != "v3.4.0" || got.Commit != strings.Repeat("a", 40) {
+		t.Fatalf("bundle identity = %+v", got)
+	}
+	if len(got.Images) != 3 || got.Images[0].Name != "pipelock" || got.Images[1].Name != "pipelock-init" || got.Images[2].Name != "pipelock-license-service" {
+		t.Fatalf("images = %+v", got.Images)
+	}
+	for _, image := range got.Images {
+		if image.Digest != testDigest {
+			t.Fatalf("digest for %s = %q", image.Name, image.Digest)
+		}
+	}
+}
+
+func TestRunWritesBundleToStdout(t *testing.T) {
+	var stdout bytes.Buffer
+	if err := run(validArgs(""), &stdout, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"schema": "pipelock-release-images-v1"`) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunRejectsFlagAndOutputFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		stdout io.Writer
+		want   string
+	}{
+		{
+			name: "unknown flag",
+			args: []string{"--unknown"},
+			want: "flag provided but not defined",
+		},
+		{
+			name:   "positional argument",
+			args:   append(validArgs(""), "unexpected"),
+			stdout: io.Discard,
+			want:   "unexpected positional arguments",
+		},
+		{
+			name:   "stdout write failure",
+			args:   validArgs(""),
+			stdout: failWriter{err: errors.New("stdout unavailable")},
+			want:   "write release image bundle: stdout unavailable",
+		},
+		{
+			name:   "output path is directory",
+			args:   validArgs(t.TempDir()),
+			stdout: io.Discard,
+			want:   "write ",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := run(tc.args, tc.stdout, io.Discard); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildManifestRejectsWrongOrMissingInputs(t *testing.T) {
+	validImages := []string{
+		"pipelock=ghcr.io/luckypipewrench/pipelock@" + testDigest,
+		"pipelock-init=ghcr.io/luckypipewrench/pipelock-init@" + testDigest,
+		"pipelock-license-service=ghcr.io/luckypipewrench/pipelock-license-service@" + testDigest,
+	}
+	tests := []struct {
+		name   string
+		tag    string
+		commit string
+		images []string
+		want   string
+	}{
+		{name: "bad tag", tag: "release-3.4.0", commit: strings.Repeat("a", 40), images: validImages, want: "--tag"},
+		{name: "bad commit", tag: "v3.4.0", commit: "ABC", images: validImages, want: "--commit"},
+		{name: "missing image", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: validImages[:2], want: "missing required"},
+		{name: "duplicate image", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: append(validImages[:2], validImages[0]), want: "duplicate"},
+		{name: "too many images", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: append(validImages, validImages[0]), want: "exactly"},
+		{name: "unknown image", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: []string{
+			"other=ghcr.io/luckypipewrench/other@" + testDigest,
+			validImages[1], validImages[2],
+		}, want: "unknown"},
+		{name: "wrong repository", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: []string{
+			"pipelock=registry.example/pipelock@" + testDigest,
+			validImages[1], validImages[2],
+		}, want: "repository"},
+		{name: "tagged reference", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: []string{
+			"pipelock=ghcr.io/luckypipewrench/pipelock:3.4.0@" + testDigest,
+			validImages[1], validImages[2],
+		}, want: "repository"},
+		{name: "uppercase digest", tag: "v3.4.0", commit: strings.Repeat("a", 40), images: []string{
+			"pipelock=ghcr.io/luckypipewrench/pipelock@sha256:0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef",
+			validImages[1], validImages[2],
+		}, want: "lowercase"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildManifest(tc.tag, tc.commit, tc.images)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("buildManifest error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseImageRejectsMalformedReferences(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "missing name separator", value: "pipelock", want: "must use name"},
+		{name: "empty name", value: "=ghcr.io/luckypipewrench/pipelock@" + testDigest, want: "must use name"},
+		{name: "empty reference", value: "pipelock=", want: "must use name"},
+		{name: "missing digest separator", value: "pipelock=ghcr.io/luckypipewrench/pipelock", want: "lowercase sha256"},
+		{name: "empty repository", value: "pipelock=@" + testDigest, want: "lowercase sha256"},
+		{name: "repeated digest separator", value: "pipelock=ghcr.io/luckypipewrench/pipelock@" + testDigest + "@again", want: "more than one @"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseImage(tc.value); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseImage error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/docs/guides/kubernetes-image-upgrades.md
+++ b/docs/guides/kubernetes-image-upgrades.md
@@ -24,21 +24,35 @@ gh release download v3.4.0 --repo luckyPipewrench/pipelock --pattern release-ima
 cat pipelock-v3.4.0/release-images.json
 ```
 
-Verify the provenance for each image before you put its digest in a workload.
-This command verifies the main Pipelock image named in the bundle. It pins the
-attestation to the release workflow, tag, and commit recorded in that bundle;
-it requires a current GitHub CLI login and registry access when the image is
-not public:
+Verify the bundle before you use an image from it. This checks the selected
+release tag against the remote repository, verifies the bundle attestation, and
+then verifies the main Pipelock image named in the bundle. It requires a current
+GitHub CLI login and registry access when the image is not public:
 
 ```bash
-PIPELOCK_BUNDLE=pipelock-v3.4.0/release-images.json
-PIPELOCK_TAG="$(jq -er '.tag' "$PIPELOCK_BUNDLE")"
-PIPELOCK_COMMIT="$(jq -er '.commit' "$PIPELOCK_BUNDLE")"
+PIPELOCK_RELEASE=v3.4.0
+PIPELOCK_BUNDLE="pipelock-${PIPELOCK_RELEASE}/release-images.json"
+PIPELOCK_COMMIT="$(git ls-remote https://github.com/luckyPipewrench/pipelock.git \
+  "refs/tags/${PIPELOCK_RELEASE}" "refs/tags/${PIPELOCK_RELEASE}^{}" \
+  | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }')"
+test -n "$PIPELOCK_COMMIT"
+
+gh attestation verify "$PIPELOCK_BUNDLE" \
+  --repo luckyPipewrench/pipelock \
+  --signer-workflow luckyPipewrench/pipelock/.github/workflows/release.yaml \
+  --source-ref "refs/tags/${PIPELOCK_RELEASE}" \
+  --source-digest "$PIPELOCK_COMMIT" \
+  --deny-self-hosted-runners
+
+jq -e --arg tag "$PIPELOCK_RELEASE" --arg commit "$PIPELOCK_COMMIT" \
+  '.schema == "pipelock-release-images-v1" and .tag == $tag and .commit == $commit' \
+  "$PIPELOCK_BUNDLE" >/dev/null
+
 PIPELOCK_IMAGE="$(jq -er '.images[] | select(.name == "pipelock") | "\(.repository)@\(.digest)"' "$PIPELOCK_BUNDLE")"
 gh attestation verify "oci://${PIPELOCK_IMAGE}" \
   --repo luckyPipewrench/pipelock \
   --signer-workflow luckyPipewrench/pipelock/.github/workflows/release.yaml \
-  --source-ref "refs/tags/${PIPELOCK_TAG}" \
+  --source-ref "refs/tags/${PIPELOCK_RELEASE}" \
   --source-digest "$PIPELOCK_COMMIT" \
   --deny-self-hosted-runners
 ```

--- a/docs/guides/kubernetes-image-upgrades.md
+++ b/docs/guides/kubernetes-image-upgrades.md
@@ -25,11 +25,22 @@ cat pipelock-v3.4.0/release-images.json
 ```
 
 Verify the provenance for each image before you put its digest in a workload.
-This command verifies the main Pipelock image named in the bundle:
+This command verifies the main Pipelock image named in the bundle. It pins the
+attestation to the release workflow, tag, and commit recorded in that bundle;
+it requires a current GitHub CLI login and registry access when the image is
+not public:
 
 ```bash
-PIPELOCK_IMAGE="$(jq -r '.images[] | select(.name == "pipelock") | "\(.repository)@\(.digest)"' pipelock-v3.4.0/release-images.json)"
-gh attestation verify "oci://${PIPELOCK_IMAGE}" --repo luckyPipewrench/pipelock
+PIPELOCK_BUNDLE=pipelock-v3.4.0/release-images.json
+PIPELOCK_TAG="$(jq -er '.tag' "$PIPELOCK_BUNDLE")"
+PIPELOCK_COMMIT="$(jq -er '.commit' "$PIPELOCK_BUNDLE")"
+PIPELOCK_IMAGE="$(jq -er '.images[] | select(.name == "pipelock") | "\(.repository)@\(.digest)"' "$PIPELOCK_BUNDLE")"
+gh attestation verify "oci://${PIPELOCK_IMAGE}" \
+  --repo luckyPipewrench/pipelock \
+  --signer-workflow luckyPipewrench/pipelock/.github/workflows/release.yaml \
+  --source-ref "refs/tags/${PIPELOCK_TAG}" \
+  --source-digest "$PIPELOCK_COMMIT" \
+  --deny-self-hosted-runners
 ```
 
 Run the same command for `pipelock-init` and `pipelock-license-service` when
@@ -46,7 +57,7 @@ The file has this shape:
     {
       "name": "pipelock",
       "repository": "ghcr.io/luckypipewrench/pipelock",
-      "digest": "sha256:..."
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   ]
 }

--- a/docs/guides/kubernetes-image-upgrades.md
+++ b/docs/guides/kubernetes-image-upgrades.md
@@ -1,0 +1,139 @@
+# Kubernetes image upgrades
+
+Every Pipelock release publishes `release-images.json`. It lists the immutable
+manifest digest for each image built from that release commit:
+
+| Bundle entry | Use it for |
+| --- | --- |
+| `pipelock` | The proxy, Conductor, and `pipelock dashboard serve` workloads |
+| `pipelock-init` | Init containers that copy the Pipelock binary into a shared volume |
+| `pipelock-license-service` | The separately deployed license service |
+
+The bundle is an upgrade input, not a signature. Verify the release's image
+provenance before applying it, then keep the exact file with the change that
+updates your cluster.
+
+## Get the exact image set
+
+This downloads the immutable image set for v3.4.0 into the current directory.
+Replace the version only after selecting a released version.
+
+```bash
+mkdir -p pipelock-v3.4.0
+gh release download v3.4.0 --repo luckyPipewrench/pipelock --pattern release-images.json --dir pipelock-v3.4.0
+cat pipelock-v3.4.0/release-images.json
+```
+
+Verify the provenance for each image before you put its digest in a workload.
+This command verifies the main Pipelock image named in the bundle:
+
+```bash
+PIPELOCK_IMAGE="$(jq -r '.images[] | select(.name == "pipelock") | "\(.repository)@\(.digest)"' pipelock-v3.4.0/release-images.json)"
+gh attestation verify "oci://${PIPELOCK_IMAGE}" --repo luckyPipewrench/pipelock
+```
+
+Run the same command for `pipelock-init` and `pipelock-license-service` when
+your upgrade uses those images.
+
+The file has this shape:
+
+```json
+{
+  "schema": "pipelock-release-images-v1",
+  "tag": "v3.4.0",
+  "commit": "the release commit",
+  "images": [
+    {
+      "name": "pipelock",
+      "repository": "ghcr.io/luckypipewrench/pipelock",
+      "digest": "sha256:..."
+    }
+  ]
+}
+```
+
+Use a `repository@digest` reference. A tag such as `:3.4.0` can be moved; a
+manifest digest cannot.
+
+## Helm chart
+
+The Pipelock chart accepts a digest directly. Put the `pipelock` repository and
+digest from `release-images.json` in a values file. Leave `tag` empty. The same
+value applies to proxy and Conductor chart modes because both run the Pipelock
+image.
+
+```yaml
+image:
+  repository: ghcr.io/luckypipewrench/pipelock
+  tag: ""
+  digest: "sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098"
+```
+
+That digest only shows the required shape. Replace it with the `pipelock`
+digest from the release bundle you verified.
+
+Render the exact values before applying them:
+
+```bash
+helm lint charts/pipelock -f values-pipelock-v3.4.0.yaml
+helm template pipelock charts/pipelock -f values-pipelock-v3.4.0.yaml > rendered-pipelock-v3.4.0.yaml
+grep 'image:' rendered-pipelock-v3.4.0.yaml
+```
+
+The output must contain `ghcr.io/luckypipewrench/pipelock@sha256:`. It must not
+contain a tag beside the digest.
+
+## Other Kubernetes workloads
+
+Use the same `pipelock` digest for a standalone dashboard deployment. For an
+init-copy container, use `pipelock-init` from the bundle. For the license
+service, use `pipelock-license-service` from the bundle. Those two images are
+separate on purpose and are not configured by the Pipelock Helm chart.
+
+```yaml
+initContainers:
+  - name: pipelock-init
+    image: ghcr.io/luckypipewrench/pipelock-init@sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098
+    args: ["cp", "/pipelock", "/shared-bin/pipelock"]
+
+containers:
+  - name: license-service
+    image: ghcr.io/luckypipewrench/pipelock-license-service@sha256:e8e249d2dd1b579f995f0f5a75cfab13fb8505a8ffc33c2cec7a6418290d9098
+```
+
+Those digests also show shape only. Replace each with its matching entry from
+the release bundle.
+
+## Prove the cluster changed
+
+Run these commands against the namespace and workload you changed. They check
+four different things: the desired pod template, a completed rollout, ready
+pods, and the digest the node reported after pulling the image.
+
+```bash
+kubectl -n pipelock get deployment pipelock -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\t"}{.image}{"\n"}{end}'
+kubectl -n pipelock rollout status deployment/pipelock --timeout=5m
+kubectl -n pipelock wait --for=condition=Ready pod -l app.kubernetes.io/name=pipelock --timeout=5m
+kubectl -n pipelock get pods -l app.kubernetes.io/name=pipelock -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .status.initContainerStatuses[*]}{.name}{"\t"}{.imageID}{"\n"}{end}{range .status.containerStatuses[*]}{.name}{"\t"}{.imageID}{"\n"}{end}{end}'
+```
+
+Compare every desired `image:` reference and every reported `imageID` to the
+matching digest in `release-images.json`. `imageID` often starts with
+`containerd://`; the digest after that prefix is the part that must match.
+
+Repeat the same check for each standalone dashboard, init-copy workload, and
+license-service Deployment or StatefulSet. A green rollout only proves a pod
+started. It does not prove the node pulled the image you meant to deploy.
+
+## Drift and rollback
+
+Keep the previous release's `release-images.json` beside the new one. Compare
+the desired pod templates and live image IDs after every GitOps reconciliation
+or manual Helm upgrade. A mismatch means the cluster is running a different
+image from the release you approved.
+
+For a normal rollback, change the same values or GitOps image references back
+to the previous bundle, apply through the same path, then repeat the four
+checks above. `kubectl rollout undo` is an emergency tool for a Deployment;
+it does not roll back separate StatefulSets, Helm values, or GitOps state, so
+use it only to stop a bad rollout while you restore the declared configuration.

--- a/scripts/check-release-ready.sh
+++ b/scripts/check-release-ready.sh
@@ -62,7 +62,7 @@ echo "release-ready gate: version=$VER"
 # exactly the shards accepted by ci_test_packages.py. Ordinary CI and release CI
 # are separate workflow surfaces; keeping this assertion in the preflight stops
 # a stale release-only shard name before the tag workflow fans out.
-(cd "$REPO_ROOT" && python3 -m unittest scripts.test_ci_test_packages)
+(cd "$REPO_ROOT" && python3 -m unittest scripts.test_ci_test_packages scripts.test_release_artifacts)
 
 # 1. CHANGELOG: a "## [<ver>] - <YYYY-MM-DD>" heading must exist with a real date.
 # Match the version LITERALLY (grep -F) so metacharacters in a version string

--- a/scripts/test_ci_test_packages.py
+++ b/scripts/test_ci_test_packages.py
@@ -108,8 +108,8 @@ class TestPackageSharding(unittest.TestCase):
         workflow = (root / ".github/workflows/release.yaml").read_text(encoding="utf-8")
         goreleaser = (root / ".goreleaser.yaml").read_text(encoding="utf-8")
 
-        version_match = re.search(r"^\s*cosign-release:\s*['\"]v(\d+)\.", workflow, re.MULTILINE)
-        self.assertIsNotNone(version_match, "release workflow cosign version not found")
+        version_match = re.search(r"^\s*COSIGN_VERSION:\s*v(\d+)\.", workflow, re.MULTILINE)
+        self.assertIsNotNone(version_match, "release workflow COSIGN_VERSION not found")
 
         uses_legacy_outputs = (
             "--output-certificate=" in goreleaser and "--output-signature=" in goreleaser

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/release.yaml"
+GORELEASER = ROOT / ".goreleaser.yaml"
 
 GORELEASER_VERSION = "v2.17.1"
 GORELEASER_LINUX_AMD64_SHA256 = "a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80"
@@ -39,12 +40,19 @@ BUNDLE_NAMES = {
     "pipelock_init": "pipelock-init",
     "license_service": "pipelock-license-service",
 }
+INDEX_ATTESTATION_IDS = (
+    "attest-pipelock-container",
+    "attest-pipelock-init-container",
+    "attest-license-service-container",
+)
+ARCHIVE_ATTESTATION_IDS = ("attest-binaries", "attest-checksums", "attest-sbom")
 
 
 class TestReleaseArtifacts(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.goreleaser = GORELEASER.read_text(encoding="utf-8")
 
     def test_goreleaser_is_exactly_pinned_and_self_reports(self) -> None:
         self.assertIn(f"GORELEASER_VERSION: {GORELEASER_VERSION}", self.workflow)
@@ -60,11 +68,19 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn("run: goreleaser release --clean --draft", self.workflow)
         self.assertNotIn("version: '~> v2'", self.workflow)
 
-    def test_every_platform_is_resolved_from_the_published_index(self) -> None:
+        for repository in PLATFORM_ARTIFACTS.values():
+            self.assertIn(f'"{repository}:{{{{ .Version }}}}-staging-amd64"', self.goreleaser)
+            self.assertIn(f'"{repository}:{{{{ .Version }}}}-staging-arm64"', self.goreleaser)
+            self.assertIn(f'name_template: "{repository}:{{{{ .Version }}}}-staging"', self.goreleaser)
+            self.assertNotIn(f'name_template: "{repository}:{{{{ .Version }}}}"', self.goreleaser)
+            self.assertNotIn(f'name_template: "{repository}:latest"', self.goreleaser)
+
+    def test_every_platform_is_resolved_from_the_staging_index(self) -> None:
         self.assertIn("Resolve release image platform digests", self.workflow)
         self.assertIn('for arch in amd64 arm64; do', self.workflow)
-        self.assertIn('crane manifest "${repository}:${TAG#v}"', self.workflow)
-        self.assertIn('crane digest "${repository}:${TAG#v}-${arch}"', self.workflow)
+        self.assertIn('staging_tag="${TAG#v}-staging"', self.workflow)
+        self.assertIn('crane manifest "${repository}:${staging_tag}"', self.workflow)
+        self.assertIn('crane digest "${repository}:${staging_tag}-${arch}"', self.workflow)
         self.assertIn('is not the index child', self.workflow)
         for name, repository in PLATFORM_ARTIFACTS.items():
             self.assertIn(f"resolve_image {name} {repository}", self.workflow)
@@ -95,10 +111,18 @@ class TestReleaseArtifacts(unittest.TestCase):
                     self.workflow,
                 )
 
-    def test_every_platform_child_has_provenance_and_is_fail_closed(self) -> None:
+    def test_every_attestation_dependency_is_fail_closed(self) -> None:
+        proof_gate = self.workflow.index("- name: Verify attestation")
+        attestation_ids = [*ARCHIVE_ATTESTATION_IDS, *INDEX_ATTESTATION_IDS]
+        for attestation_id in attestation_ids:
+            self.assertIn(f"id: {attestation_id}", self.workflow)
+            self.assertIn(f"steps.{attestation_id}.outcome != 'success'", self.workflow)
+            self.assertLess(self.workflow.index(f"id: {attestation_id}"), proof_gate)
+
         for name, repository in PLATFORM_ARTIFACTS.items():
             for arch in ("amd64", "arm64"):
                 attestation_id = f"attest-{ATTESTATION_NAMES[name]}-{arch}"
+                attestation_ids.append(attestation_id)
                 self.assertIn(f"id: {attestation_id}", self.workflow)
                 self.assertIn(
                     f"subject-digest: ${{{{ steps.platform-digests.outputs.{name}_{arch} }}}}",
@@ -108,6 +132,41 @@ class TestReleaseArtifacts(unittest.TestCase):
                     f"steps.{attestation_id}.outcome != 'success'",
                     self.workflow,
                 )
+                self.assertLess(self.workflow.index(f"id: {attestation_id}"), proof_gate)
+
+        gate_end = self.workflow.index("run: |", proof_gate)
+        normalized_gate = " ".join(self.workflow[proof_gate:gate_end].split())
+        expected_condition = "always() && ( " + " || ".join(
+            f"steps.{attestation_id}.outcome != 'success'"
+            for attestation_id in attestation_ids
+        ) + " )"
+        self.assertIn(expected_condition, normalized_gate)
+        self.assertNotIn("== 'failure'", normalized_gate)
+
+    def test_verified_staging_indexes_promote_after_the_proof_gate(self) -> None:
+        resolution = self.workflow.index("- name: Resolve release image platform digests")
+        proof_gate = self.workflow.index("- name: Verify attestation")
+        chart_preflight = self.workflow.index("- name: Verify Helm chart version is unpublished")
+        promotion = self.workflow.index("- name: Promote verified image manifests")
+        bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
+        self.assertLess(resolution, proof_gate)
+        self.assertLess(proof_gate, chart_preflight)
+        self.assertLess(chart_preflight, promotion)
+        self.assertLess(proof_gate, promotion)
+        self.assertLess(promotion, bundle)
+        self.assertIn('crane copy --no-clobber "${repository}@${index_digest}"', self.workflow)
+        self.assertIn('"${repository}:latest"', self.workflow)
+
+        digest_vars = {
+            "pipelock": "PIPELOCK_INDEX_DIGEST",
+            "pipelock_init": "PIPELOCK_INIT_INDEX_DIGEST",
+            "license_service": "LICENSE_SERVICE_INDEX_DIGEST",
+        }
+        for name, repository in PLATFORM_ARTIFACTS.items():
+            self.assertIn(
+                f'promote_image {repository} "${digest_vars[name]}"',
+                self.workflow,
+            )
 
     def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
         goreleaser = self.workflow.index("- name: Run GoReleaser")

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -24,6 +24,12 @@ GORELEASER_VERSION = "v2.17.1"
 GORELEASER_LINUX_AMD64_SHA256 = "a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80"
 SYFT_VERSION = "v1.50.0"
 SYFT_LINUX_AMD64_SHA256 = "bf7b29ff57f06da30918266a0e1c2885a8f99784798d1bdb1628886aa015d788"
+COSIGN_VERSION = "v2.6.5"
+COSIGN_LINUX_AMD64_SHA256 = "c3b4f5410e608af03a5eb0aaac84a4313d8da131248e08ff1759ac70c79d1644"
+CYCLONEDX_GOMOD_VERSION = "v1.10.0"
+CYCLONEDX_GOMOD_LINUX_AMD64_SHA256 = "5cce8ae99a5181be6a610ea5ed9ca9d596937cc04dc1a8f6f6b5e462d8c9900e"
+CRANE_VERSION = "v0.21.9"
+CRANE_LINUX_AMD64_SHA256 = "5c16d8ddb971cb1d5e6ed8b1e743da8224414eeba2c2762d8f1a61b2f095699e"
 
 PLATFORM_ARTIFACTS = {
     "pipelock": "ghcr.io/luckypipewrench/pipelock",
@@ -75,12 +81,50 @@ class TestReleaseArtifacts(unittest.TestCase):
             self.assertNotIn(f'name_template: "{repository}:{{{{ .Version }}}}"', self.goreleaser)
             self.assertNotIn(f'name_template: "{repository}:latest"', self.goreleaser)
 
+    def test_other_release_tools_are_exactly_pinned_and_verified(self) -> None:
+        expected_tools = (
+            (
+                "COSIGN",
+                COSIGN_VERSION,
+                COSIGN_LINUX_AMD64_SHA256,
+                "sigstore/cosign",
+                "cosign-linux-amd64",
+                'got="$($tool_dir/cosign version',
+            ),
+            (
+                "CYCLONEDX_GOMOD",
+                CYCLONEDX_GOMOD_VERSION,
+                CYCLONEDX_GOMOD_LINUX_AMD64_SHA256,
+                "CycloneDX/cyclonedx-gomod",
+                "cyclonedx-gomod_",
+                'got="$($tool_dir/cyclonedx-gomod version',
+            ),
+            (
+                "CRANE",
+                CRANE_VERSION,
+                CRANE_LINUX_AMD64_SHA256,
+                "google/go-containerregistry",
+                "go-containerregistry_Linux_x86_64.tar.gz",
+                'got="$($tool_dir/crane version)',
+            ),
+        )
+        for prefix, version, digest, repository, asset, version_check in expected_tools:
+            self.assertIn(f"{prefix}_VERSION: {version}", self.workflow)
+            self.assertIn(f"{prefix}_LINUX_AMD64_SHA256: {digest}", self.workflow)
+            self.assertIn(f"--repo {repository}", self.workflow)
+            self.assertIn(asset, self.workflow)
+            self.assertIn("sha256sum --check", self.workflow)
+            self.assertIn(version_check, self.workflow)
+
+        self.assertNotIn("go install github.com/CycloneDX", self.workflow)
+        self.assertNotIn("go install github.com/google/go-containerregistry", self.workflow)
+
     def test_every_platform_is_resolved_from_the_staging_index(self) -> None:
         self.assertIn("Resolve release image platform digests", self.workflow)
         self.assertIn('for arch in amd64 arm64; do', self.workflow)
         self.assertIn('staging_tag="${TAG#v}-staging"', self.workflow)
-        self.assertIn('crane manifest "${repository}:${staging_tag}"', self.workflow)
-        self.assertIn('crane digest "${repository}:${staging_tag}-${arch}"', self.workflow)
+        self.assertIn('"$tool_dir/crane" manifest "${repository}:${staging_tag}"', self.workflow)
+        self.assertIn('"$tool_dir/crane" digest "${repository}:${staging_tag}-${arch}"', self.workflow)
         self.assertIn('is not the index child', self.workflow)
         for name, repository in PLATFORM_ARTIFACTS.items():
             self.assertIn(f"resolve_image {name} {repository}", self.workflow)

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -149,7 +149,7 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn('archive="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"', self.workflow)
         self.assertIn('got="$($tool_dir/syft version', self.workflow)
         self.assertIn('test "$got" = "$expected"', self.workflow)
-        self.assertIn('"$tool_dir/syft" "${image}@${digest}"', self.workflow)
+        self.assertIn('"$tool_dir/syft" "registry:${image}@${digest}"', self.workflow)
         self.assertIn('gh release upload "$GITHUB_REF_NAME" "$output" --clobber', self.workflow)
 
         for name, repository in PLATFORM_ARTIFACTS.items():
@@ -190,6 +190,7 @@ class TestReleaseArtifacts(unittest.TestCase):
                 self.assertLess(self.workflow.index(f"id: {attestation_id}"), proof_gate)
                 sbom_attestation_id = f"{attestation_id}-sbom"
                 self.assertIn(f"id: {sbom_attestation_id}", self.workflow)
+                self.assertLess(self.workflow.index(f"id: {sbom_attestation_id}"), proof_gate)
                 self.assertIn(
                     f"sbom-{repository.rsplit('/', maxsplit=1)[-1]}-linux-{arch}.cdx.json",
                     self.workflow,
@@ -267,6 +268,8 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn('steps.attest-release-images.outcome != \'success\'', self.workflow)
         self.assertIn('if [[ "$CHART_ALREADY_PUBLISHED" != true ]]; then', self.workflow)
         self.assertIn('diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock"', self.workflow)
+        self.assertIn('echo "CHART_VERSION=$chart_version" >> "$GITHUB_ENV"', self.workflow)
+        self.assertIn('chart_version="$CHART_VERSION"', self.workflow)
         digest_vars = {
             "pipelock": "PIPELOCK_INDEX_DIGEST",
             "pipelock_init": "PIPELOCK_INIT_INDEX_DIGEST",

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -156,6 +156,12 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertLess(promotion, bundle)
         self.assertIn('crane copy --no-clobber "${repository}@${index_digest}"', self.workflow)
         self.assertIn('"${repository}:latest"', self.workflow)
+        self.assertIn('if [[ "$version" != *-* ]]; then', self.workflow)
+        self.assertIn("grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$'", self.workflow)
+        self.assertIn('if [[ "$promote_latest" = true ]]; then', self.workflow)
+        self.assertIn('"$newest_stable" = "$version"', self.workflow)
+        self.assertIn('latest_stable_tag="$(git tag --list', self.workflow)
+        self.assertIn('if [[ "$TAG_NAME" != "$latest_stable_tag" ]]; then', self.workflow)
 
         digest_vars = {
             "pipelock": "PIPELOCK_INDEX_DIGEST",

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -52,6 +52,14 @@ INDEX_ATTESTATION_IDS = (
     "attest-license-service-container",
 )
 ARCHIVE_ATTESTATION_IDS = ("attest-binaries", "attest-checksums", "attest-sbom")
+IMAGE_SBOM_ATTESTATION_IDS = (
+    "attest-pipelock-amd64-sbom",
+    "attest-pipelock-arm64-sbom",
+    "attest-pipelock-init-amd64-sbom",
+    "attest-pipelock-init-arm64-sbom",
+    "attest-license-service-amd64-sbom",
+    "attest-license-service-arm64-sbom",
+)
 
 
 class TestReleaseArtifacts(unittest.TestCase):
@@ -109,12 +117,14 @@ class TestReleaseArtifacts(unittest.TestCase):
             ),
         )
         for prefix, version, digest, repository, asset, version_check in expected_tools:
-            self.assertIn(f"{prefix}_VERSION: {version}", self.workflow)
-            self.assertIn(f"{prefix}_LINUX_AMD64_SHA256: {digest}", self.workflow)
-            self.assertIn(f"--repo {repository}", self.workflow)
-            self.assertIn(asset, self.workflow)
-            self.assertIn("sha256sum --check", self.workflow)
-            self.assertIn(version_check, self.workflow)
+            start = self.workflow.index(f"{prefix}_VERSION: {version}")
+            end = self.workflow.find("\n      - name:", start)
+            block = self.workflow[start : end if end != -1 else len(self.workflow)]
+            self.assertIn(f"{prefix}_LINUX_AMD64_SHA256: {digest}", block)
+            self.assertIn(f"--repo {repository}", block)
+            self.assertIn(asset, block)
+            self.assertIn("sha256sum --check", block)
+            self.assertIn(version_check, block)
 
         self.assertNotIn("go install github.com/CycloneDX", self.workflow)
         self.assertNotIn("go install github.com/google/go-containerregistry", self.workflow)
@@ -136,6 +146,7 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn(f"SYFT_LINUX_AMD64_SHA256: {SYFT_LINUX_AMD64_SHA256}", self.workflow)
         self.assertIn('gh release download "$SYFT_VERSION"', self.workflow)
         self.assertIn("--repo anchore/syft", self.workflow)
+        self.assertIn('archive="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"', self.workflow)
         self.assertIn('got="$($tool_dir/syft version', self.workflow)
         self.assertIn('test "$got" = "$expected"', self.workflow)
         self.assertIn('"$tool_dir/syft" "${image}@${digest}"', self.workflow)
@@ -177,6 +188,14 @@ class TestReleaseArtifacts(unittest.TestCase):
                     self.workflow,
                 )
                 self.assertLess(self.workflow.index(f"id: {attestation_id}"), proof_gate)
+                sbom_attestation_id = f"{attestation_id}-sbom"
+                self.assertIn(f"id: {sbom_attestation_id}", self.workflow)
+                self.assertIn(
+                    f"sbom-{repository.rsplit('/', maxsplit=1)[-1]}-linux-{arch}.cdx.json",
+                    self.workflow,
+                )
+
+        attestation_ids.extend(IMAGE_SBOM_ATTESTATION_IDS)
 
         gate_end = self.workflow.index("run: |", proof_gate)
         normalized_gate = " ".join(self.workflow[proof_gate:gate_end].split())
@@ -190,7 +209,7 @@ class TestReleaseArtifacts(unittest.TestCase):
     def test_verified_staging_indexes_promote_after_the_proof_gate(self) -> None:
         resolution = self.workflow.index("- name: Resolve release image platform digests")
         proof_gate = self.workflow.index("- name: Verify attestation")
-        chart_preflight = self.workflow.index("- name: Verify Helm chart version is unpublished")
+        chart_preflight = self.workflow.index("- name: Package and verify Helm chart version")
         promotion = self.workflow.index("- name: Promote verified image manifests")
         bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
         self.assertLess(resolution, proof_gate)
@@ -199,12 +218,13 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertLess(proof_gate, promotion)
         self.assertLess(promotion, bundle)
         self.assertIn('crane copy --no-clobber "${repository}@${index_digest}"', self.workflow)
+        self.assertIn('crane copy --no-clobber "${repository}@${digest}" "$target"', self.workflow)
         self.assertIn('"${repository}:latest"', self.workflow)
         self.assertIn('if [[ "$version" != *-* ]]; then', self.workflow)
         self.assertIn("grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$'", self.workflow)
-        self.assertIn('if [[ "$promote_latest" = true ]]; then', self.workflow)
-        self.assertIn('"$newest_stable" = "$version"', self.workflow)
-        self.assertIn('latest_stable_tag="$(git tag --list', self.workflow)
+        self.assertIn('if [[ "$newest_stable" = "$version" ]]; then', self.workflow)
+        self.assertIn('if [[ "$latest_digest" != "$index_digest" ]]; then', self.workflow)
+        self.assertIn("grep -E '^v2\\.[0-9]+\\.[0-9]+$'", self.workflow)
         self.assertIn('if [[ "$TAG_NAME" != "$latest_stable_tag" ]]; then', self.workflow)
 
         digest_vars = {
@@ -217,25 +237,44 @@ class TestReleaseArtifacts(unittest.TestCase):
                 f'promote_image {repository} "${digest_vars[name]}"',
                 self.workflow,
             )
+            for arch in ("amd64", "arm64"):
+                self.assertIn(
+                    f'promote_platform_image {repository} "${name.upper()}_{arch.upper()}_DIGEST" {arch}',
+                    self.workflow,
+                )
 
     def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
         goreleaser = self.workflow.index("- name: Run GoReleaser")
         proof_gate = self.workflow.index("- name: Verify attestation")
         bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
+        bundle_attestation = self.workflow.index("- name: Attest Kubernetes image digest bundle")
+        bundle_gate = self.workflow.index("- name: Verify Kubernetes image digest bundle attestation")
         upload = self.workflow.index("- name: Upload Kubernetes image digest bundle")
-        chart = self.workflow.index("- name: Package and publish Helm chart")
+        chart = self.workflow.index("- name: Publish Helm chart")
         promotion = self.workflow.index("- name: Publish GitHub release")
         self.assertIn('gh release edit "$GITHUB_REF_NAME" --draft=false', self.workflow)
 
         self.assertLess(goreleaser, proof_gate)
         self.assertLess(proof_gate, bundle)
-        self.assertLess(bundle, upload)
+        self.assertLess(bundle, bundle_attestation)
+        self.assertLess(bundle_attestation, bundle_gate)
+        self.assertLess(bundle_gate, upload)
         self.assertLess(upload, chart)
         self.assertLess(chart, promotion)
 
+        self.assertIn('release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{}")"', self.workflow)
+        self.assertNotIn('-commit "$GITHUB_SHA"', self.workflow)
+        self.assertIn('steps.attest-release-images.outcome != \'success\'', self.workflow)
+        self.assertIn('if [[ "$CHART_ALREADY_PUBLISHED" != true ]]; then', self.workflow)
+        self.assertIn('diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock"', self.workflow)
+        digest_vars = {
+            "pipelock": "PIPELOCK_INDEX_DIGEST",
+            "pipelock_init": "PIPELOCK_INIT_INDEX_DIGEST",
+            "license_service": "LICENSE_SERVICE_INDEX_DIGEST",
+        }
         for name, repository in PLATFORM_ARTIFACTS.items():
             self.assertIn(
-                f'-image "{BUNDLE_NAMES[name]}={repository}@${{{{ steps.platform-digests.outputs.{name}_index }}}}"',
+                f'-image "{BUNDLE_NAMES[name]}={repository}@${{{digest_vars[name]}}}"',
                 self.workflow,
             )
         self.assertIn("dist/release-images.json", self.workflow)

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed structural checks for the tag-release artifact contract.
+
+These run in the tag preflight job, before GoReleaser can upload a release. The
+checks intentionally inspect the workflow source rather than relying on a
+successful prior run: a future edit that drops one architecture, swaps a tool
+for a floating version, or stops publishing an image SBOM must block the tag
+that introduced the drift.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/release.yaml"
+
+GORELEASER_VERSION = "v2.17.1"
+GORELEASER_LINUX_AMD64_SHA256 = "a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80"
+SYFT_VERSION = "v1.50.0"
+SYFT_LINUX_AMD64_SHA256 = "bf7b29ff57f06da30918266a0e1c2885a8f99784798d1bdb1628886aa015d788"
+
+PLATFORM_ARTIFACTS = {
+    "pipelock": "ghcr.io/luckypipewrench/pipelock",
+    "pipelock_init": "ghcr.io/luckypipewrench/pipelock-init",
+    "license_service": "ghcr.io/luckypipewrench/pipelock-license-service",
+}
+ATTESTATION_NAMES = {
+    "pipelock": "pipelock",
+    "pipelock_init": "pipelock-init",
+    "license_service": "license-service",
+}
+BUNDLE_NAMES = {
+    "pipelock": "pipelock",
+    "pipelock_init": "pipelock-init",
+    "license_service": "pipelock-license-service",
+}
+
+
+class TestReleaseArtifacts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_goreleaser_is_exactly_pinned_and_self_reports(self) -> None:
+        self.assertIn(f"GORELEASER_VERSION: {GORELEASER_VERSION}", self.workflow)
+        self.assertIn(
+            f"GORELEASER_LINUX_AMD64_SHA256: {GORELEASER_LINUX_AMD64_SHA256}",
+            self.workflow,
+        )
+        self.assertIn('gh release download "$GORELEASER_VERSION"', self.workflow)
+        self.assertIn("--repo goreleaser/goreleaser", self.workflow)
+        self.assertIn("sha256sum --check", self.workflow)
+        self.assertIn('got="$($tool_dir/goreleaser --version', self.workflow)
+        self.assertIn('test "$got" = "$expected"', self.workflow)
+        self.assertIn("run: goreleaser release --clean --draft", self.workflow)
+        self.assertNotIn("version: '~> v2'", self.workflow)
+
+    def test_every_platform_is_resolved_from_the_published_index(self) -> None:
+        self.assertIn("Resolve release image platform digests", self.workflow)
+        self.assertIn('for arch in amd64 arm64; do', self.workflow)
+        self.assertIn('crane manifest "${repository}:${TAG#v}"', self.workflow)
+        self.assertIn('crane digest "${repository}:${TAG#v}-${arch}"', self.workflow)
+        self.assertIn('is not the index child', self.workflow)
+        for name, repository in PLATFORM_ARTIFACTS.items():
+            self.assertIn(f"resolve_image {name} {repository}", self.workflow)
+            for arch in ("amd64", "arm64"):
+                self.assertIn(f"{name}_{arch}", self.workflow)
+
+    def test_every_platform_image_gets_a_published_sbom(self) -> None:
+        self.assertIn(f"SYFT_VERSION: {SYFT_VERSION}", self.workflow)
+        self.assertIn(f"SYFT_LINUX_AMD64_SHA256: {SYFT_LINUX_AMD64_SHA256}", self.workflow)
+        self.assertIn('gh release download "$SYFT_VERSION"', self.workflow)
+        self.assertIn("--repo anchore/syft", self.workflow)
+        self.assertIn('got="$($tool_dir/syft version', self.workflow)
+        self.assertIn('test "$got" = "$expected"', self.workflow)
+        self.assertIn('"$tool_dir/syft" "${image}@${digest}"', self.workflow)
+        self.assertIn('gh release upload "$GITHUB_REF_NAME" "$output" --clobber', self.workflow)
+
+        for name, repository in PLATFORM_ARTIFACTS.items():
+            stem = repository.rsplit("/", maxsplit=1)[-1]
+            for arch in ("amd64", "arm64"):
+                digest_var = f"{name.upper()}_{arch.upper()}_DIGEST"
+                self.assertIn(
+                    f"{digest_var}: ${{{{ steps.platform-digests.outputs.{name}_{arch} }}}}",
+                    self.workflow,
+                )
+                output = f"sbom-{stem}-linux-{arch}.cdx.json"
+                self.assertIn(
+                    f"publish_sbom {repository} \"${digest_var}\" {output}",
+                    self.workflow,
+                )
+
+    def test_every_platform_child_has_provenance_and_is_fail_closed(self) -> None:
+        for name, repository in PLATFORM_ARTIFACTS.items():
+            for arch in ("amd64", "arm64"):
+                attestation_id = f"attest-{ATTESTATION_NAMES[name]}-{arch}"
+                self.assertIn(f"id: {attestation_id}", self.workflow)
+                self.assertIn(
+                    f"subject-digest: ${{{{ steps.platform-digests.outputs.{name}_{arch} }}}}",
+                    self.workflow,
+                )
+                self.assertIn(
+                    f"steps.{attestation_id}.outcome != 'success'",
+                    self.workflow,
+                )
+
+    def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
+        goreleaser = self.workflow.index("- name: Run GoReleaser")
+        proof_gate = self.workflow.index("- name: Verify attestation")
+        bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
+        upload = self.workflow.index("- name: Upload Kubernetes image digest bundle")
+        chart = self.workflow.index("- name: Package and publish Helm chart")
+        promotion = self.workflow.index("- name: Publish GitHub release")
+        self.assertIn('gh release edit "$GITHUB_REF_NAME" --draft=false', self.workflow)
+
+        self.assertLess(goreleaser, proof_gate)
+        self.assertLess(proof_gate, bundle)
+        self.assertLess(bundle, upload)
+        self.assertLess(upload, chart)
+        self.assertLess(chart, promotion)
+
+        for name, repository in PLATFORM_ARTIFACTS.items():
+            self.assertIn(
+                f'-image "{BUNDLE_NAMES[name]}={repository}@${{{{ steps.platform-digests.outputs.{name}_index }}}}"',
+                self.workflow,
+            )
+        self.assertIn("dist/release-images.json", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Build, verify, and attest each platform image before the workflow exposes release tags. Publish a digest bundle for Kubernetes upgrades.
- Pin release tools to verified upstream archives and document image proof with rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verified release image bundles with immutable digest references for safer deployments.
  * Added provenance attestations, SBOMs, and Helm chart publication for releases.
  * Added a release-image validation command for generating standardized image manifests.
  * Release images now use staging tags until verification is complete.

* **Documentation**
  * Added a Kubernetes image-upgrade guide covering digest pinning, verification, rollout checks, drift detection, and rollback.

* **Bug Fixes**
  * Improved release safeguards to prevent publishing incomplete or conflicting artifacts.
  * Added checks to ensure platform images and release artifacts are consistently verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->