### PR TITLE
fix(filesentry): fail closed on missing required coverage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2237,9 +2237,10 @@ Real-time filesystem monitoring for agent subprocesses. Detects secrets written 
 ```yaml
 file_sentry:
   enabled: false
+  best_effort: false             # false: fail startup on any skipped subtree
   watch_paths:
-    - "."                         # required:false; degraded if unavailable
-    - path: "/var/agent-secrets"  # required:true; startup fails if unavailable
+    - "."                         # strict by default
+    - path: "/var/agent-secrets"  # remains strict even with best_effort: true
       required: true
   scan_content: true
   max_file_bytes: 0             # 0 = built-in 10 MiB default
@@ -2253,13 +2254,14 @@ file_sentry:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `enabled` | `false` | Enable filesystem monitoring. Opt-in. |
-| `watch_paths` | `[]` | Directories to monitor recursively. Relative paths are resolved against the config file directory (not CWD). Required when enabled. Entries may be bare strings or `{path, required}` mappings. Bare strings default to `required: false`. |
+| `best_effort` | `false` | Keep accessible directories armed when a configured root or descendant cannot be watched. Startup still fails if no directory can be armed. |
+| `watch_paths` | `[]` | Directories to monitor recursively. Relative paths are resolved against the config file directory (not CWD). Required when enabled. Entries may be bare strings or `{path, required}` mappings. `required: true` keeps that root strict even when `best_effort` is enabled. |
 | `scan_content` | `true` | Run DLP scanner on modified file content. |
 | `max_file_bytes` | `0` | Max watched-file bytes to read for content scanning. `0` uses the built-in 10 MiB default; negative values are rejected. |
 | `ignore_patterns` | `[]` | Glob patterns for files and directories to skip. |
 | `action` | `warn` | Enforcement response when an agent-attributed write matches a DLP pattern. `warn` logs the finding + records a metric (current default). `block` additionally cancels the proxy context so the MCP child terminates, preventing the agent from continuing after a detected leak. Non-agent writes (editor saves, build output) never trigger the block path. |
 
-When a `watch_paths` entry is `required: false`, startup records a degraded path and continues if that watch cannot be installed. Set `required: true` on paths that are part of the security boundary; startup fails closed if those watches cannot be installed. Unknown fields in mapping entries are rejected so typos such as `require: true` do not silently disable the hard-fail opt-in.
+File sentry setup is strict by default: any root or descendant subtree that cannot be watched fails startup after Pipelock reports every skipped subtree. Set `best_effort: true` to keep accessible siblings armed while reporting each skipped root or subtree. Startup still fails when nothing can be armed. `required: true` keeps a configured root strict even in best-effort mode. Root symlinks are rejected and child symlinks are not followed. Unknown fields in mapping entries are rejected so typos such as `require: true` do not silently change the requested behavior.
 
 Findings are reported as stderr warnings and Prometheus metrics (`pipelock_file_sentry_findings_total`). Structured audit log emission (`file_sentry_dlp` event type) is defined but not yet wired to the webhook/syslog pipeline. On Linux, process lineage tracking attributes file writes to the agent's process tree via `PR_SET_CHILD_SUBREAPER` and `/proc` walking.
 

--- a/docs/guides/filesystem-sentinel.md
+++ b/docs/guides/filesystem-sentinel.md
@@ -20,11 +20,12 @@ File sentry detects writes; it does not intercept them. The write reaches disk b
 ```yaml
 file_sentry:
   enabled: true
+  best_effort: false        # false: fail startup on any skipped subtree
   action: warn               # warn (default) or block
   watch_paths:
-    - "/workspace"           # optional by default; degraded if unavailable
+    - "/workspace"           # strict by default
     - path: "/tmp/agent-output"
-      required: true         # startup fails if this watch cannot be installed
+      required: true         # remains strict when best_effort is true
   scan_content: true
   max_file_bytes: 0           # 0 = built-in 10 MiB default
   ignore_patterns:
@@ -48,12 +49,12 @@ Each entry can be either a bare string or a mapping:
 
 ```yaml
 watch_paths:
-  - "/workspace"             # required:false
+  - "/workspace"             # strict by default
   - path: "/var/agent-secrets"
     required: true
 ```
 
-Bare string entries default to `required: false`. If a non-required watch cannot be installed, pipelock logs a degraded path and continues arming the remaining paths. Use `required: true` for directories whose monitoring is part of the security boundary; startup fails closed if that watch cannot be installed. Unknown mapping fields are rejected so typos do not silently disable the hard-fail opt-in.
+Setup is strict by default. If Pipelock cannot watch any configured root or descendant subtree, it reports every skipped subtree and fails startup. Set `best_effort: true` to keep accessible siblings armed while reporting the gaps. Startup still fails if no directory can be armed. Use `required: true` for a root that must stay strict while best-effort is enabled. Root symlinks are rejected and child symlinks are not followed. Unknown mapping fields are rejected so typos do not silently change the requested behavior.
 
 ### Ignore Patterns
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1637,15 +1637,7 @@ Key-free evidence capture:
 						_ = watcher.Close()
 						waitConsumer()
 					}()
-					configuredPaths := len(cfg.FileSentry.WatchPaths)
-					degradedPaths := len(watcher.DegradedPaths())
-					if degradedPaths > 0 {
-						_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d configured path(s) (action=%s; %d skipped/unarmed subtree(s))\n",
-							configuredPaths, cfg.FileSentry.Action, degradedPaths)
-					} else {
-						_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d configured path(s) (action=%s)\n",
-							configuredPaths, cfg.FileSentry.Action)
-					}
+					reportFileSentryCoverage(logW, len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action, watcher.DegradedPathCount())
 
 					// onChildReady: called by RunProxy after cmd.Start() + TrackPID.
 					// Starts the file sentry event loop AFTER the child PID is registered,

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1593,13 +1593,9 @@ Key-free evidence capture:
 				onErr := func(err error) {
 					_, _ = fmt.Fprintf(logW, "pipelock: [file_sentry] %v\n", err)
 				}
-				watcher, watchErr := filesentry.NewWatcher(&cfg.FileSentry, sc, lin, onErr)
+				watcher, watchErr := newFileSentryWatcher(&cfg.FileSentry, sc, lin, onErr)
 				if watchErr != nil {
-					if cfg.FileSentry.BestEffort {
-						_, _ = fmt.Fprintf(logW, "pipelock: file sentry init failed (best_effort: continuing without file monitoring): %v\n", watchErr)
-					} else {
-						return fmt.Errorf("file sentry init failed (feature is enabled): %w", watchErr)
-					}
+					return fmt.Errorf("file sentry init failed (feature is enabled): %w", watchErr)
 				}
 				// Arm synchronously before child launch.
 				if watcher != nil {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1605,7 +1605,7 @@ Key-free evidence capture:
 				if watcher != nil {
 					if armErr := watcher.Arm(); armErr != nil {
 						_ = watcher.Close()
-						if cfg.FileSentry.BestEffort {
+						if cfg.FileSentry.BestEffort && !fileSentryArmErrorMustFailClosed(armErr) {
 							_, _ = fmt.Fprintf(logW, "pipelock: file sentry failed to arm watches (best_effort: continuing without file monitoring): %v\n", armErr)
 							watcher = nil
 						} else {
@@ -1637,8 +1637,15 @@ Key-free evidence capture:
 						_ = watcher.Close()
 						waitConsumer()
 					}()
-					_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d path(s) (action=%s)\n",
-						len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action)
+					configuredPaths := len(cfg.FileSentry.WatchPaths)
+					degradedPaths := len(watcher.DegradedPaths())
+					if degradedPaths > 0 {
+						_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d configured path(s) (action=%s; %d skipped/unarmed subtree(s))\n",
+							configuredPaths, cfg.FileSentry.Action, degradedPaths)
+					} else {
+						_, _ = fmt.Fprintf(logW, "pipelock: file sentry watching %d configured path(s) (action=%s)\n",
+							configuredPaths, cfg.FileSentry.Action)
+					}
 
 					// onChildReady: called by RunProxy after cmd.Start() + TrackPID.
 					// Starts the file sentry event loop AFTER the child PID is registered,

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
 	"github.com/luckyPipewrench/pipelock/internal/deferred"
+	"github.com/luckyPipewrench/pipelock/internal/filesentry"
 	"github.com/luckyPipewrench/pipelock/internal/mcp"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -88,6 +89,15 @@ func writeMCPFileSentryConfig(t *testing.T, bestEffort bool, paths ...string) st
 	return configPath
 }
 
+func failFileSentryWatcher(t *testing.T, watchErr error) {
+	t.Helper()
+	old := newFileSentryWatcher
+	newFileSentryWatcher = func(*config.FileSentry, filesentry.DLPScanner, filesentry.Lineage, func(error)) (filesentry.Watcher, error) {
+		return nil, watchErr
+	}
+	t.Cleanup(func() { newFileSentryWatcher = old })
+}
+
 func TestMcpProxyCmd_FileSentryFailsWhenNoPathsArm(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "nonexistent-zero-armed")
 	configPath := writeMCPFileSentryConfig(t, false, missing)
@@ -111,6 +121,16 @@ func TestMcpProxyCmd_FileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no watch paths armed") {
 		t.Fatalf("mcp proxy error = %v, want zero-armed file-sentry failure; stderr:\n%s", err, stderr)
+	}
+}
+
+func TestMcpProxyCmd_FileSentryBestEffortRejectsInitializationFailure(t *testing.T) {
+	failFileSentryWatcher(t, errors.New("watcher setup failed"))
+	configPath := writeMCPFileSentryConfig(t, true, t.TempDir())
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err == nil || !strings.Contains(err.Error(), "file sentry init failed") {
+		t.Fatalf("mcp proxy error = %v, want initialization failure; stderr:\n%s", err, stderr)
 	}
 }
 

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -158,6 +158,21 @@ func TestMcpProxyCmd_FileSentryBestEffortRejectsRequiredPathFailure(t *testing.T
 	}
 }
 
+func TestMcpProxyCmd_FileSentryBestEffortRejectsNormalizedRequiredDuplicate(t *testing.T) {
+	watchDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "nonexistent-required-duplicate")
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	configBody := fmt.Sprintf("mode: balanced\nfile_sentry:\n  enabled: true\n  best_effort: true\n  watch_paths:\n    - %q\n    - %q\n    - path: %q\n      required: true\n  scan_content: true\n", watchDir, missing, missing+string(filepath.Separator))
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err == nil || !strings.Contains(err.Error(), "required watch coverage unavailable") {
+		t.Fatalf("mcp proxy error = %v, want required duplicate file-sentry failure; stderr:\n%s", err, stderr)
+	}
+}
+
 func TestMCPReceiptParityOpts(t *testing.T) {
 	r := &receipt.Emitter{}
 	v2 := &proxydecision.Emitter{}

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -128,6 +128,21 @@ func TestMcpProxyCmd_FileSentryKeepsRunningWhenOnePathArms(t *testing.T) {
 	}
 }
 
+func TestMcpProxyCmd_FileSentryReportsCompleteCoverage(t *testing.T) {
+	configPath := writeMCPFileSentryConfig(t, false, t.TempDir())
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err != nil {
+		t.Fatalf("mcp proxy failed with complete file-sentry coverage: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "file sentry watching 1 configured path(s) (action=warn)") {
+		t.Fatalf("stderr missing complete file-sentry coverage report:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "skipped/unarmed subtree") {
+		t.Fatalf("stderr reported degraded coverage for an armable watch path:\n%s", stderr)
+	}
+}
+
 func TestMcpProxyCmd_FileSentryBestEffortRejectsRequiredPathFailure(t *testing.T) {
 	watchDir := t.TempDir()
 	missing := filepath.Join(t.TempDir(), "nonexistent-required")

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -68,6 +68,81 @@ func TestSafeWriter(t *testing.T) {
 	}
 }
 
+func writeMCPFileSentryConfig(t *testing.T, bestEffort bool, paths ...string) string {
+	t.Helper()
+	var body strings.Builder
+	body.WriteString("mode: balanced\nfile_sentry:\n  enabled: true\n")
+	if bestEffort {
+		body.WriteString("  best_effort: true\n")
+	}
+	body.WriteString("  watch_paths:\n")
+	for _, path := range paths {
+		_, _ = fmt.Fprintf(&body, "    - %q\n", path)
+	}
+	body.WriteString("  scan_content: true\n")
+
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(configPath, []byte(body.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func TestMcpProxyCmd_FileSentryFailsWhenNoPathsArm(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent-zero-armed")
+	configPath := writeMCPFileSentryConfig(t, false, missing)
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err == nil {
+		t.Fatal("mcp proxy succeeded even though file sentry armed no paths")
+	}
+	if !strings.Contains(err.Error(), "no watch paths armed") {
+		t.Fatalf("mcp proxy error = %v, want zero-armed file-sentry failure; stderr:\n%s", err, stderr)
+	}
+}
+
+func TestMcpProxyCmd_FileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent-best-effort")
+	configPath := writeMCPFileSentryConfig(t, true, missing)
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err == nil {
+		t.Fatal("mcp proxy succeeded in best-effort mode with zero armed paths")
+	}
+	if !strings.Contains(err.Error(), "no watch paths armed") {
+		t.Fatalf("mcp proxy error = %v, want zero-armed file-sentry failure; stderr:\n%s", err, stderr)
+	}
+}
+
+func TestMcpProxyCmd_FileSentryKeepsRunningWhenOnePathArms(t *testing.T) {
+	watchDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "nonexistent-mixed-coverage")
+	configPath := writeMCPFileSentryConfig(t, true, watchDir, missing)
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err != nil {
+		t.Fatalf("mcp proxy failed even though one file-sentry path armed: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "file sentry watching 2 configured path(s)") || !strings.Contains(stderr, "1 skipped/unarmed subtree(s)") {
+		t.Fatalf("stderr missing mixed file-sentry coverage report:\n%s", stderr)
+	}
+}
+
+func TestMcpProxyCmd_FileSentryBestEffortRejectsRequiredPathFailure(t *testing.T) {
+	watchDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "nonexistent-required")
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	configBody := fmt.Sprintf("mode: balanced\nfile_sentry:\n  enabled: true\n  best_effort: true\n  watch_paths:\n    - %q\n    - path: %q\n      required: true\n  scan_content: true\n", watchDir, missing)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err == nil || !strings.Contains(err.Error(), "required watch coverage unavailable") {
+		t.Fatalf("mcp proxy error = %v, want required file-sentry failure; stderr:\n%s", err, stderr)
+	}
+}
+
 func TestMCPReceiptParityOpts(t *testing.T) {
 	r := &receipt.Emitter{}
 	v2 := &proxydecision.Emitter{}

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -32,6 +32,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+var newFileSentryWatcher = filesentry.NewWatcher
+
 func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel context.CancelFunc) (func(), error) {
 	if cfg == nil || !cfg.FileSentry.Enabled {
 		return func() {}, nil
@@ -40,7 +42,7 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 	onErr := func(err error) {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: [file_sentry] %v\n", err)
 	}
-	watcher, err := filesentry.NewWatcher(&cfg.FileSentry, liveFileSentryScanner{
+	watcher, err := newFileSentryWatcher(&cfg.FileSentry, liveFileSentryScanner{
 		load: func() *scanner.Scanner {
 			if s.proxy == nil {
 				return nil
@@ -49,10 +51,6 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		},
 	}, nil, onErr)
 	if err != nil {
-		if cfg.FileSentry.BestEffort {
-			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry init failed (best_effort: continuing without file monitoring): %v\n", err)
-			return func() {}, nil
-		}
 		return nil, fmt.Errorf("file sentry init failed (feature is enabled): %w", err)
 	}
 

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -86,20 +87,21 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 	// Report skipped subtrees explicitly. A recursive root can have multiple
 	// inaccessible descendants, so subtracting DegradedPaths from configured
 	// roots would invent an inaccurate count.
-	configuredPaths := len(cfg.FileSentry.WatchPaths)
-	degradedPaths := len(watcher.DegradedPaths())
-	if degradedPaths > 0 {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d configured path(s) (action=%s; %d skipped/unarmed subtree(s))\n",
-			configuredPaths, cfg.FileSentry.Action, degradedPaths)
-	} else {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d configured path(s) (action=%s)\n",
-			configuredPaths, cfg.FileSentry.Action)
-	}
+	reportFileSentryCoverage(s.opts.Stderr, len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action, watcher.DegradedPathCount())
 
 	return func() {
 		_ = watcher.Close()
 		waitConsumer()
 	}, nil
+}
+
+func reportFileSentryCoverage(w io.Writer, configuredPaths int, action string, degradedPaths int) {
+	if degradedPaths > 0 {
+		_, _ = fmt.Fprintf(w, "pipelock: file sentry watching %d configured path(s) (action=%s; %d skipped/unarmed subtree(s))\n",
+			configuredPaths, action, degradedPaths)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "pipelock: file sentry watching %d configured path(s) (action=%s)\n", configuredPaths, action)
 }
 
 func fileSentryArmErrorMustFailClosed(err error) bool {

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -57,7 +57,7 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 
 	if err := watcher.Arm(); err != nil {
 		_ = watcher.Close()
-		if cfg.FileSentry.BestEffort {
+		if cfg.FileSentry.BestEffort && !fileSentryArmErrorMustFailClosed(err) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry failed to arm watches (best_effort: continuing without file monitoring): %v\n", err)
 			return func() {}, nil
 		}
@@ -83,25 +83,27 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		}
 	}()
 
-	// Report the count of paths that actually ARMED, not the configured count.
-	// A non-required watch_path that failed to install is recorded in
-	// DegradedPaths() and is NOT being watched; printing the configured count
-	// would falsely assure the operator that every path is covered.
+	// Report skipped subtrees explicitly. A recursive root can have multiple
+	// inaccessible descendants, so subtracting DegradedPaths from configured
+	// roots would invent an inaccurate count.
 	configuredPaths := len(cfg.FileSentry.WatchPaths)
 	degradedPaths := len(watcher.DegradedPaths())
-	armedPaths := configuredPaths - degradedPaths
 	if degradedPaths > 0 {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d of %d path(s) (action=%s; %d degraded/unarmed)\n",
-			armedPaths, configuredPaths, cfg.FileSentry.Action, degradedPaths)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d configured path(s) (action=%s; %d skipped/unarmed subtree(s))\n",
+			configuredPaths, cfg.FileSentry.Action, degradedPaths)
 	} else {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d path(s) (action=%s)\n",
-			armedPaths, cfg.FileSentry.Action)
+		_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry watching %d configured path(s) (action=%s)\n",
+			configuredPaths, cfg.FileSentry.Action)
 	}
 
 	return func() {
 		_ = watcher.Close()
 		waitConsumer()
 	}, nil
+}
+
+func fileSentryArmErrorMustFailClosed(err error) bool {
+	return errors.Is(err, filesentry.ErrNoWatchPaths) || errors.Is(err, filesentry.ErrRequiredWatchPath)
 }
 
 // startupSummaryLine renders the one-line startup diagnostic. fetchAddr is the

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1281,7 +1281,7 @@ func TestServer_StartArmsFileSentry(t *testing.T) {
 	}()
 
 	waitForServerCancel(t, s)
-	waitForServerOutput(t, buf, "file sentry watching 1 path(s)")
+	waitForServerOutput(t, buf, "file sentry watching 1 configured path(s)")
 
 	proof := filepath.Join(watchDir, "file-sentry-run-proof.txt")
 	content := strings.Join([]string{"AKIA", "IOSFODNN7", "EXAMPLE"}, "")
@@ -1315,6 +1315,7 @@ func TestServer_StartReportsArmedWatchCount(t *testing.T) {
 		"mode: balanced",
 		"file_sentry:",
 		"  enabled: true",
+		"  best_effort: true",
 		"  watch_paths:",
 		"    - " + strconv.Quote(watchDir),
 		"    - " + strconv.Quote(missing),
@@ -1336,10 +1337,10 @@ func TestServer_StartReportsArmedWatchCount(t *testing.T) {
 	}()
 
 	waitForServerCancel(t, s)
-	// One of the two configured paths is non-required and cannot arm, so the
-	// startup line must report 1 of 2 armed with the degraded count.
-	waitForServerOutput(t, buf, "file sentry watching 1 of 2 path(s)")
-	if out := buf.String(); !strings.Contains(out, "1 degraded/unarmed") {
+	// One configured root remains armed while the missing root is reported as
+	// a skipped subtree. Do not claim an invented root count from that data.
+	waitForServerOutput(t, buf, "file sentry watching 2 configured path(s)")
+	if out := buf.String(); !strings.Contains(out, "1 skipped/unarmed subtree(s)") {
 		t.Fatalf("startup missing degraded/unarmed count:\n%s", out)
 	}
 
@@ -1353,6 +1354,118 @@ func TestServer_StartReportsArmedWatchCount(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Start did not return within 5s of Shutdown")
+	}
+}
+
+func TestServer_StartFailsWhenFileSentryArmsNoPaths(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent-zero-armed")
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(missing),
+		"  scan_content: true",
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start(context.Background())
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "no watch paths armed") {
+			t.Fatalf("Start error = %v, want zero-armed file-sentry failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		if err := s.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown after unexpected startup: %v", err)
+		}
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Start did not return after Shutdown")
+		}
+		t.Fatal("Start continued even though file sentry armed no paths")
+	}
+}
+
+func TestServer_StartFileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent-best-effort")
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  best_effort: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(missing),
+		"  scan_content: true",
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start(context.Background())
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "no watch paths armed") {
+			t.Fatalf("Start error = %v, want zero-armed file-sentry failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start continued despite zero file-sentry coverage")
+	}
+}
+
+func TestServer_StartFileSentryBestEffortRejectsRequiredPathFailure(t *testing.T) {
+	watchDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "nonexistent-required")
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  best_effort: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(watchDir),
+		"    - path: " + strconv.Quote(missing),
+		"      required: true",
+		"  scan_content: true",
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.Start(context.Background())
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "required watch coverage unavailable") {
+			t.Fatalf("Start error = %v, want required file-sentry failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start continued despite required file-sentry coverage failure")
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1429,6 +1429,14 @@ func TestServer_StartFileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
 			t.Fatalf("Start error = %v, want zero-armed file-sentry failure", err)
 		}
 	case <-time.After(5 * time.Second):
+		if err := s.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown after unexpected startup: %v", err)
+		}
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Start did not return after Shutdown")
+		}
 		t.Fatal("Start continued despite zero file-sentry coverage")
 	}
 }
@@ -1479,6 +1487,14 @@ func TestServer_StartFileSentryBestEffortRejectsRequiredPathFailure(t *testing.T
 			t.Fatalf("Start error = %v, want required file-sentry failure", err)
 		}
 	case <-time.After(5 * time.Second):
+		if err := s.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown after unexpected startup: %v", err)
+		}
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Start did not return after Shutdown")
+		}
 		t.Fatal("Start continued despite required file-sentry coverage failure")
 	}
 }
@@ -1513,6 +1529,14 @@ func TestServer_StartFileSentryBestEffortRejectsNormalizedRequiredDuplicate(t *t
 			t.Fatalf("Start error = %v, want required duplicate file-sentry failure", err)
 		}
 	case <-time.After(5 * time.Second):
+		if err := s.Shutdown(context.Background()); err != nil {
+			t.Fatalf("Shutdown after unexpected startup: %v", err)
+		}
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Start did not return after Shutdown")
+		}
 		t.Fatal("Start continued despite normalized required duplicate coverage failure")
 	}
 }

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1469,6 +1469,40 @@ func TestServer_StartFileSentryBestEffortRejectsRequiredPathFailure(t *testing.T
 	}
 }
 
+func TestServer_StartFileSentryBestEffortRejectsNormalizedRequiredDuplicate(t *testing.T) {
+	watchDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "nonexistent-required-duplicate")
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  best_effort: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(watchDir),
+		"    - " + strconv.Quote(missing),
+		"    - path: " + strconv.Quote(missing+string(filepath.Separator)),
+		"      required: true",
+		"  scan_content: true",
+		"",
+	}, "\n"))
+
+	s, _ := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Start(context.Background()) }()
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "required watch coverage unavailable") {
+			t.Fatalf("Start error = %v, want required duplicate file-sentry failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start continued despite normalized required duplicate coverage failure")
+	}
+}
+
 func TestServer_StateHelpers(t *testing.T) {
 	s, _ := newTestServer(t, nil)
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1429,6 +1430,19 @@ func TestServer_StartFileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Start continued despite zero file-sentry coverage")
+	}
+}
+
+func TestServer_StartFileSentryBestEffortRejectsInitializationFailure(t *testing.T) {
+	failFileSentryWatcher(t, errors.New("watcher setup failed"))
+	cfg := config.Defaults()
+	cfg.FileSentry.Enabled = true
+	cfg.FileSentry.BestEffort = true
+	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: t.TempDir()}}
+	s, _ := newTestServer(t, nil)
+
+	if _, err := s.startFileSentry(context.Background(), cfg, func() {}); err == nil || !strings.Contains(err.Error(), "file sentry init failed") {
+		t.Fatalf("startFileSentry error = %v, want initialization failure", err)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -223,18 +223,12 @@ type TrustedKey struct {
 }
 
 // WatchPath is a single file_sentry watch entry. YAML accepts either a bare
-// string ("/foo") for legacy/default behavior, or a mapping
-// ({path: "/foo", required: true}) when the operator wants to opt that path
-// into hard-fail-on-arm semantics.
+// string ("/foo") for the default behavior, or a mapping
+// ({path: "/foo", required: true}) when the operator wants Arm() to return
+// an error for a skipped subtree beneath that root in best-effort mode.
 //
-// Required=false (the default) means a failure to install the watch (missing
-// path, permission denied, inotify exhaustion on that specific subtree) is
-// recorded as degraded health but does not abort startup. Other paths still
-// arm. This is the soft-fail path operators get for free.
-//
-// Required=true means the watch MUST install. If Arm() cannot install it,
-// startup fails closed. Use this for paths whose monitoring is part of the
-// security boundary (e.g. credential stores under your control).
+// Required=true makes Arm() return an error when it cannot watch the root or
+// any of its descendants, even when best_effort is set.
 type WatchPath struct {
 	Path     string `yaml:"path"`
 	Required bool   `yaml:"required"`
@@ -245,7 +239,7 @@ type WatchPath struct {
 // the MCP tool call path. Applies to subprocess MCP mode only.
 type FileSentry struct {
 	Enabled        bool        `yaml:"enabled"`
-	BestEffort     bool        `yaml:"best_effort"` // degrade gracefully when watch setup fails (e.g. inotify exhaustion)
+	BestEffort     bool        `yaml:"best_effort"` // keep accessible paths armed when a root or subtree cannot be watched
 	WatchPaths     []WatchPath `yaml:"watch_paths"`
 	ScanContent    *bool       `yaml:"scan_content"`    // nil = default true
 	IgnorePatterns []string    `yaml:"ignore_patterns"` // glob patterns to skip

--- a/internal/filesentry/consumer_test.go
+++ b/internal/filesentry/consumer_test.go
@@ -29,7 +29,9 @@ func (s *stubWatcher) OverflowFindings() <-chan Finding {
 	return s.overflow
 }
 func (s *stubWatcher) DegradedPaths() []DegradedPath { return nil }
-func (s *stubWatcher) Close() error                  { return nil }
+
+func (s *stubWatcher) DegradedPathCount() int { return 0 }
+func (s *stubWatcher) Close() error           { return nil }
 
 // makeWatcher seeds a buffered channel with the given findings and closes
 // it. The returned Watcher emits each finding once and then terminates,

--- a/internal/filesentry/watcher.go
+++ b/internal/filesentry/watcher.go
@@ -44,6 +44,9 @@ type Watcher interface {
 	// DegradedPaths returns the root or descendant subtrees Arm() could not
 	// monitor. Empty when the watcher is fully armed. Safe to call concurrently.
 	DegradedPaths() []DegradedPath
+	// DegradedPathCount returns all failed roots/subtrees from the latest Arm,
+	// including samples omitted from DegradedPaths to bound diagnostics.
+	DegradedPathCount() int
 	// Close stops the watcher and releases resources.
 	Close() error
 }

--- a/internal/filesentry/watcher.go
+++ b/internal/filesentry/watcher.go
@@ -27,9 +27,9 @@ type DLPScanner interface {
 // Watcher monitors directories for file writes and scans content for secrets.
 type Watcher interface {
 	// Arm installs watches on all configured directories synchronously.
-	// Must be called before launching the child process. Returns an error
-	// only if a required:true entry cannot be installed; non-required
-	// failures are recorded via DegradedPaths and the onError callback.
+	// Must be called before launching the child process. Best-effort mode
+	// continues with accessible paths but reports every skipped subtree;
+	// strict mode, required paths, and zero armed paths return an error.
 	Arm() error
 	// Start processes filesystem events. Blocks until ctx is cancelled.
 	// Call Arm() first to install watches.
@@ -41,9 +41,8 @@ type Watcher interface {
 	// channels; agent findings on this lane remain enforcement-relevant in
 	// block mode. Single-probe diagnostics cannot saturate the normal buffer.
 	OverflowFindings() <-chan Finding
-	// DegradedPaths returns the configured watch_paths entries whose Arm()
-	// install failed and whose entry was not marked required:true. Empty
-	// when the watcher is fully armed. Safe to call concurrently.
+	// DegradedPaths returns the root or descendant subtrees Arm() could not
+	// monitor. Empty when the watcher is fully armed. Safe to call concurrently.
 	DegradedPaths() []DegradedPath
 	// Close stops the watcher and releases resources.
 	Close() error

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -33,6 +33,16 @@ const findingsChanSize = 64
 // surfaced via the watcher's error callback so it is visible, not silent.
 const maxFileSize = 10 * 1024 * 1024 // 10MB
 
+// ErrNoWatchPaths marks an Arm failure where no directory remains watched.
+// Runtimes must not interpret best-effort as permission to start with this
+// condition, because file sentry would provide no coverage at all.
+var ErrNoWatchPaths = errors.New("filesentry: no watch paths armed")
+
+// ErrRequiredWatchPath marks an Arm failure for a required watch root or one
+// of its descendants. Runtimes can use errors.Is to keep required coverage
+// fail-closed even when other file sentry paths use best-effort behavior.
+var ErrRequiredWatchPath = errors.New("filesentry: required watch coverage unavailable")
+
 // fsWatcher implements Watcher using fsnotify for cross-platform file watching.
 type fsWatcher struct {
 	cfg      *config.FileSentry
@@ -50,11 +60,17 @@ type fsWatcher struct {
 	timers   map[string]*time.Timer // per-path debounce timers
 	pidSnap  map[string]bool        // per-path agent attribution snapshot at event time
 	closed   bool
-	// degradedPaths records configured watch_paths whose Arm() install failed
-	// when the path was not marked required:true. Populated by Arm() and
-	// exposed via DegradedPaths() so health endpoints can surface "armed but
-	// degraded" without lying about coverage.
+	// watchedPaths prevents duplicate fsnotify registrations when configured
+	// roots overlap or Arm is called more than once.
+	watchedPaths map[string]struct{}
+	// degradedPaths records every configured root or descendant subtree that
+	// Arm could not monitor. Populated by Arm() and exposed via DegradedPaths()
+	// so health endpoints can surface "armed but degraded" without lying about
+	// coverage.
 	degradedPaths []DegradedPath
+	// addWatch is the fsnotify registration seam. It is only replaced by tests
+	// to deterministically exercise per-subtree watch-install failures.
+	addWatch func(string) error
 }
 
 // DegradedPath records a configured watch_paths entry whose install failed
@@ -64,6 +80,31 @@ type fsWatcher struct {
 type DegradedPath struct {
 	Path  string
 	Error string
+}
+
+type skippedSubtree struct {
+	path  string
+	cause error
+}
+
+func (s skippedSubtree) err() error {
+	return fmt.Errorf("cannot monitor subtree %q: %w", s.path, s.cause)
+}
+
+type recursiveAddResult struct {
+	added   int
+	skipped []skippedSubtree
+}
+
+func (r recursiveAddResult) err() error {
+	if len(r.skipped) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(r.skipped))
+	for _, skipped := range r.skipped {
+		errs = append(errs, skipped.err())
+	}
+	return errors.Join(errs...)
 }
 
 // NewWatcher creates a file watcher that monitors configured directories for
@@ -77,15 +118,17 @@ func NewWatcher(cfg *config.FileSentry, sc DLPScanner, lin Lineage, onError func
 		return nil, fmt.Errorf("filesentry: create watcher: %w", err)
 	}
 	return &fsWatcher{
-		cfg:      cfg,
-		scanner:  sc,
-		lineage:  lin,
-		watcher:  w,
-		findings: make(chan Finding, findingsChanSize),
-		overflow: make(chan Finding, 1),
-		timers:   make(map[string]*time.Timer),
-		pidSnap:  make(map[string]bool),
-		onError:  onError,
+		cfg:          cfg,
+		scanner:      sc,
+		lineage:      lin,
+		watcher:      w,
+		findings:     make(chan Finding, findingsChanSize),
+		overflow:     make(chan Finding, 1),
+		timers:       make(map[string]*time.Timer),
+		pidSnap:      make(map[string]bool),
+		watchedPaths: make(map[string]struct{}),
+		onError:      onError,
+		addWatch:     w.Add,
 	}, nil
 }
 
@@ -110,55 +153,77 @@ func (w *fsWatcher) effectiveMaxFileSize() int64 {
 // Call this before launching the child process to ensure no writes
 // are missed during the startup window.
 //
-// Per-path failure semantics:
-//   - WatchPath.Required=true: install failure aborts Arm with a wrapped error.
-//     Use for paths whose monitoring is part of the security boundary.
-//   - WatchPath.Required=false (default): install failure is recorded as a
-//     degraded path (visible via DegradedPaths) and reported through the
-//     optional onError callback, but Arm continues installing the remaining
-//     paths. This lets a missing or transiently-inaccessible aux path stop
-//     crash-looping the proxy when the primary watch is still healthy.
-//
-// Required:false matches the operator expectation that an optional watch
-// path that "happens to be unreadable today" should not crash-loop the
-// proxy. Operators who want hard-fail behavior for a specific path opt in
-// with required:true on that entry.
+// Any skipped root or descendant is reported individually through
+// DegradedPaths and the optional error callback. In best_effort mode, Arm
+// keeps every accessible sibling armed. Strict mode (the default) returns an
+// error after completing the walk, so a partial watch set cannot be mistaken
+// for complete coverage. required:true remains a per-root override that
+// rejects degradation even when best_effort is selected.
 func (w *fsWatcher) Arm() error {
 	w.mu.Lock()
 	w.degradedPaths = w.degradedPaths[:0]
 	w.mu.Unlock()
+	var armErrs []error
+	requiredFailed := false
+	seenRoots := make(map[string]struct{}, len(w.cfg.WatchPaths))
 	for _, wp := range w.cfg.WatchPaths {
 		abs, err := filepath.Abs(wp.Path)
 		if err != nil {
-			if wp.Required {
-				return fmt.Errorf("filesentry: resolve path %q: %w", wp.Path, err)
-			}
 			w.recordDegraded(wp.Path, err)
+			armErr := fmt.Errorf("resolve watch root %q: %w", wp.Path, err)
+			if wp.Required {
+				requiredFailed = true
+				armErr = fmt.Errorf("%w: %w", ErrRequiredWatchPath, armErr)
+			}
+			armErrs = append(armErrs, armErr)
 			continue
 		}
-		if err := w.addRecursive(abs); err != nil {
-			if wp.Required {
-				return fmt.Errorf("filesentry: watch %q: %w", abs, err)
-			}
-			w.recordDegraded(wp.Path, err)
+		if _, duplicate := seenRoots[abs]; duplicate {
 			continue
 		}
+		seenRoots[abs] = struct{}{}
+
+		result := w.addRecursiveDetailed(abs)
+		for _, skipped := range result.skipped {
+			w.recordDegraded(skipped.path, skipped.cause)
+			armErr := skipped.err()
+			if wp.Required {
+				armErr = fmt.Errorf("%w: %w", ErrRequiredWatchPath, armErr)
+			}
+			armErrs = append(armErrs, armErr)
+		}
+		if wp.Required && len(result.skipped) > 0 {
+			// required:true overrides the global best-effort setting.
+			requiredFailed = true
+		}
+	}
+
+	w.mu.Lock()
+	armed := len(w.watchedPaths)
+	w.mu.Unlock()
+	if armed == 0 {
+		if len(armErrs) == 0 {
+			return ErrNoWatchPaths
+		}
+		return fmt.Errorf("%w: %w", ErrNoWatchPaths, errors.Join(armErrs...))
+	}
+	if len(armErrs) > 0 && (!w.cfg.BestEffort || requiredFailed) {
+		return fmt.Errorf("filesentry: incomplete watch coverage: %w", errors.Join(armErrs...))
 	}
 	return nil
 }
 
-// recordDegraded captures a non-required Arm-time install failure for later
-// visibility through DegradedPaths() and the optional onError callback.
+// recordDegraded captures an Arm-time subtree failure for later visibility
+// through DegradedPaths() and the optional onError callback.
 func (w *fsWatcher) recordDegraded(path string, cause error) {
 	w.mu.Lock()
 	w.degradedPaths = append(w.degradedPaths, DegradedPath{Path: path, Error: cause.Error()})
 	w.mu.Unlock()
-	w.logError(fmt.Errorf("filesentry: watch %q failed (degraded, required:false): %w", path, cause))
+	w.logError(fmt.Errorf("filesentry: watch subtree %q failed (coverage degraded): %w", path, cause))
 }
 
-// DegradedPaths returns watch_paths entries whose Arm() install failed and
-// whose entry was not marked required:true. Returned slice is a copy safe
-// for concurrent inspection from a health endpoint.
+// DegradedPaths returns root or descendant subtrees that Arm() could not
+// monitor. Returned slice is a copy safe for concurrent health inspection.
 func (w *fsWatcher) DegradedPaths() []DegradedPath {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -255,21 +320,36 @@ func (w *fsWatcher) Close() error {
 // subdirectory. Files themselves don't need watches - directory watches
 // catch all file events within them.
 func (w *fsWatcher) addRecursive(root string) error {
-	// Verify root exists and is a directory. WalkDir silently returns nil
-	// for nonexistent paths, which would leave us watching nothing.
-	// Files are rejected - inotify watches directories, not individual files.
-	info, err := os.Stat(root)
+	return w.addRecursiveDetailed(root).err()
+}
+
+// addRecursiveDetailed adds every accessible directory beneath root and
+// records every inaccessible subtree instead of abandoning the first sibling
+// failure. Symlinks are never followed: a child symlink could leave the
+// configured tree, while a root symlink has no trustworthy direct watch root.
+func (w *fsWatcher) addRecursiveDetailed(root string) recursiveAddResult {
+	result := recursiveAddResult{}
+	info, err := os.Lstat(root)
 	if err != nil {
-		return fmt.Errorf("watch root: %w", err)
+		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("watch root: %w", err)})
+		return result
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: errors.New("watch root must not be a symlink")})
+		return result
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("watch root %q is a file, not a directory", root)
+		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("watch root %q is a file, not a directory", root)})
+		return result
 	}
-	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// Fail closed: permission errors on watched subdirectories mean
-			// we can't monitor them. Return the error so Arm() fails.
-			return fmt.Errorf("inaccessible path %q: %w", path, err)
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			result.skipped = append(result.skipped, skippedSubtree{path: path, cause: fmt.Errorf("inaccessible path: %w", walkErr)})
+			return filepath.SkipDir
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
 		}
 		if !d.IsDir() {
 			return nil
@@ -277,8 +357,33 @@ func (w *fsWatcher) addRecursive(root string) error {
 		if w.isIgnored(path) {
 			return filepath.SkipDir
 		}
-		return w.watcher.Add(path)
+		if added, addErr := w.addDirectory(path); addErr != nil {
+			result.skipped = append(result.skipped, skippedSubtree{path: path, cause: addErr})
+			return filepath.SkipDir
+		} else if added {
+			result.added++
+		}
+		return nil
 	})
+	if walkErr != nil {
+		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("walk root: %w", walkErr)})
+	}
+	return result
+}
+
+// addDirectory installs one watch once. The mutex protects the duplicate set
+// against Arm and runtime directory-creation handling overlapping.
+func (w *fsWatcher) addDirectory(path string) (bool, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.watchedPaths[path]; ok {
+		return false, nil
+	}
+	if err := w.addWatch(path); err != nil {
+		return false, err
+	}
+	w.watchedPaths[path] = struct{}{}
+	return true, nil
 }
 
 // handleEvent processes a single fsnotify event.

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,11 @@ const debounceDelay = 50 * time.Millisecond
 // findingsChanSize is the buffer size for the findings channel.
 // Large enough to avoid blocking the watcher goroutine under burst writes.
 const findingsChanSize = 64
+
+// maxArmDiagnosticSamples bounds the error paths retained and logged during a
+// single Arm call. A kernel watch limit can otherwise make a broad tree retain
+// and emit one error for every remaining directory after the limit is reached.
+const maxArmDiagnosticSamples = 64
 
 // maxFileSize is the default maximum file size to scan when file_sentry
 // max_file_bytes is unset. Files larger than the effective cap are skipped to
@@ -68,6 +74,10 @@ type fsWatcher struct {
 	// so health endpoints can surface "armed but degraded" without lying about
 	// coverage.
 	degradedPaths []DegradedPath
+	// degradedPathCount includes omitted diagnostic samples. It is kept
+	// separately so health output can say how much coverage is missing without
+	// retaining every failed path in memory.
+	degradedPathCount int
 	// addWatch is the fsnotify registration seam. It is only replaced by tests
 	// to deterministically exercise per-subtree watch-install failures.
 	addWatch func(string) error
@@ -92,8 +102,9 @@ func (s skippedSubtree) err() error {
 }
 
 type recursiveAddResult struct {
-	added   int
-	skipped []skippedSubtree
+	added        int
+	skipped      []skippedSubtree
+	skippedCount int
 }
 
 func (r recursiveAddResult) err() error {
@@ -162,10 +173,14 @@ func (w *fsWatcher) effectiveMaxFileSize() int64 {
 func (w *fsWatcher) Arm() error {
 	w.mu.Lock()
 	w.degradedPaths = w.degradedPaths[:0]
+	w.degradedPathCount = 0
 	w.mu.Unlock()
 	var armErrs []error
 	requiredFailed := false
-	seenRoots := make(map[string]struct{}, len(w.cfg.WatchPaths))
+	// Normalize before walking so a later required declaration cannot be
+	// suppressed by an equivalent optional root (for example /a and /a/).
+	roots := make(map[string]config.WatchPath, len(w.cfg.WatchPaths))
+	rootOrder := make([]string, 0, len(w.cfg.WatchPaths))
 	for _, wp := range w.cfg.WatchPaths {
 		abs, err := filepath.Abs(wp.Path)
 		if err != nil {
@@ -173,53 +188,93 @@ func (w *fsWatcher) Arm() error {
 			armErr := fmt.Errorf("resolve watch root %q: %w", wp.Path, err)
 			if wp.Required {
 				requiredFailed = true
-				armErr = fmt.Errorf("%w: %w", ErrRequiredWatchPath, armErr)
 			}
-			armErrs = append(armErrs, armErr)
+			armErrs = appendDiagnosticError(armErrs, armErr)
 			continue
 		}
-		if _, duplicate := seenRoots[abs]; duplicate {
-			continue
+		if prior, duplicate := roots[abs]; duplicate {
+			prior.Required = prior.Required || wp.Required
+			roots[abs] = prior
+		} else {
+			roots[abs] = config.WatchPath{Path: abs, Required: wp.Required}
+			rootOrder = append(rootOrder, abs)
 		}
-		seenRoots[abs] = struct{}{}
+	}
 
+	for _, abs := range rootOrder {
+		wp := roots[abs]
 		result := w.addRecursiveDetailed(abs)
 		for _, skipped := range result.skipped {
 			w.recordDegraded(skipped.path, skipped.cause)
 			armErr := skipped.err()
-			if wp.Required {
-				armErr = fmt.Errorf("%w: %w", ErrRequiredWatchPath, armErr)
-			}
-			armErrs = append(armErrs, armErr)
+			armErrs = appendDiagnosticError(armErrs, armErr)
 		}
-		if wp.Required && len(result.skipped) > 0 {
+		w.recordOmittedDegraded(result.skippedCount - len(result.skipped))
+		if wp.Required && result.skippedCount > 0 {
 			// required:true overrides the global best-effort setting.
 			requiredFailed = true
 		}
 	}
+	w.appendTruncatedDiagnostic(&armErrs)
 
 	w.mu.Lock()
 	armed := len(w.watchedPaths)
 	w.mu.Unlock()
+	cause := errors.Join(armErrs...)
+	if requiredFailed {
+		cause = errors.Join(ErrRequiredWatchPath, cause)
+	}
 	if armed == 0 {
 		if len(armErrs) == 0 {
 			return ErrNoWatchPaths
 		}
-		return fmt.Errorf("%w: %w", ErrNoWatchPaths, errors.Join(armErrs...))
+		return fmt.Errorf("%w: %w", ErrNoWatchPaths, cause)
 	}
 	if len(armErrs) > 0 && (!w.cfg.BestEffort || requiredFailed) {
-		return fmt.Errorf("filesentry: incomplete watch coverage: %w", errors.Join(armErrs...))
+		return fmt.Errorf("filesentry: incomplete watch coverage: %w", cause)
 	}
 	return nil
+}
+
+func appendDiagnosticError(errs []error, err error) []error {
+	if len(errs) < maxArmDiagnosticSamples {
+		return append(errs, err)
+	}
+	return errs
+}
+
+func (w *fsWatcher) appendTruncatedDiagnostic(errs *[]error) {
+	w.mu.Lock()
+	truncated := w.degradedPathCount - len(w.degradedPaths)
+	w.mu.Unlock()
+	if truncated == 0 {
+		return
+	}
+	*errs = append(*errs, fmt.Errorf("%d additional watch subtree failure(s) omitted from diagnostics", truncated))
+	w.logError(fmt.Errorf("filesentry: %d additional watch subtree failure(s) omitted from diagnostics", truncated))
 }
 
 // recordDegraded captures an Arm-time subtree failure for later visibility
 // through DegradedPaths() and the optional onError callback.
 func (w *fsWatcher) recordDegraded(path string, cause error) {
 	w.mu.Lock()
+	w.degradedPathCount++
+	if len(w.degradedPaths) >= maxArmDiagnosticSamples {
+		w.mu.Unlock()
+		return
+	}
 	w.degradedPaths = append(w.degradedPaths, DegradedPath{Path: path, Error: cause.Error()})
 	w.mu.Unlock()
 	w.logError(fmt.Errorf("filesentry: watch subtree %q failed (coverage degraded): %w", path, cause))
+}
+
+func (w *fsWatcher) recordOmittedDegraded(count int) {
+	if count <= 0 {
+		return
+	}
+	w.mu.Lock()
+	w.degradedPathCount += count
+	w.mu.Unlock()
 }
 
 // DegradedPaths returns root or descendant subtrees that Arm() could not
@@ -230,6 +285,15 @@ func (w *fsWatcher) DegradedPaths() []DegradedPath {
 	out := make([]DegradedPath, len(w.degradedPaths))
 	copy(out, w.degradedPaths)
 	return out
+}
+
+// DegradedPathCount returns the total number of failed root or subtree watch
+// registrations from the most recent Arm call, including diagnostic samples
+// omitted to keep startup memory and log volume bounded.
+func (w *fsWatcher) DegradedPathCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.degradedPathCount
 }
 
 // Start processes filesystem events until ctx is cancelled. Blocks until done.
@@ -331,21 +395,21 @@ func (w *fsWatcher) addRecursiveDetailed(root string) recursiveAddResult {
 	result := recursiveAddResult{}
 	info, err := os.Lstat(root)
 	if err != nil {
-		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("watch root: %w", err)})
+		result.addSkipped(root, fmt.Errorf("watch root: %w", err))
 		return result
 	}
 	if info.Mode()&fs.ModeSymlink != 0 {
-		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: errors.New("watch root must not be a symlink")})
+		result.addSkipped(root, errors.New("watch root must not be a symlink"))
 		return result
 	}
 	if !info.IsDir() {
-		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("watch root %q is a file, not a directory", root)})
+		result.addSkipped(root, fmt.Errorf("watch root %q is a file, not a directory", root))
 		return result
 	}
 
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			result.skipped = append(result.skipped, skippedSubtree{path: path, cause: fmt.Errorf("inaccessible path: %w", walkErr)})
+			result.addSkipped(path, fmt.Errorf("inaccessible path: %w", walkErr))
 			return filepath.SkipDir
 		}
 		if d.Type()&fs.ModeSymlink != 0 {
@@ -358,7 +422,7 @@ func (w *fsWatcher) addRecursiveDetailed(root string) recursiveAddResult {
 			return filepath.SkipDir
 		}
 		if added, addErr := w.addDirectory(path); addErr != nil {
-			result.skipped = append(result.skipped, skippedSubtree{path: path, cause: addErr})
+			result.addSkipped(path, addErr)
 			return filepath.SkipDir
 		} else if added {
 			result.added++
@@ -366,9 +430,16 @@ func (w *fsWatcher) addRecursiveDetailed(root string) recursiveAddResult {
 		return nil
 	})
 	if walkErr != nil {
-		result.skipped = append(result.skipped, skippedSubtree{path: root, cause: fmt.Errorf("walk root: %w", walkErr)})
+		result.addSkipped(root, fmt.Errorf("walk root: %w", walkErr))
 	}
 	return result
+}
+
+func (r *recursiveAddResult) addSkipped(path string, cause error) {
+	r.skippedCount++
+	if len(r.skipped) < maxArmDiagnosticSamples {
+		r.skipped = append(r.skipped, skippedSubtree{path: path, cause: cause})
+	}
 }
 
 // addDirectory installs one watch once. The mutex protects the duplicate set
@@ -388,6 +459,9 @@ func (w *fsWatcher) addDirectory(path string) (bool, error) {
 
 // handleEvent processes a single fsnotify event.
 func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
+	if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
+		w.forgetWatchPath(ev.Name)
+	}
 	// New directory created - add a recursive watch so we catch writes inside it.
 	// Errors here are non-fatal: the initial Arm() call fail-closes on watch
 	// failures, but runtime directory creation is best-effort. We log failures
@@ -475,6 +549,21 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	})
 	w.timers[path] = timer
 	w.mu.Unlock()
+}
+
+// forgetWatchPath drops cached registrations which fsnotify has removed after
+// a directory is deleted or renamed. A later Arm must attempt a fresh backend
+// registration rather than treating this cache as proof coverage still exists.
+func (w *fsWatcher) forgetWatchPath(path string) {
+	cleanPath := filepath.Clean(path)
+	prefix := cleanPath + string(filepath.Separator)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for watched := range w.watchedPaths {
+		if watched == cleanPath || strings.HasPrefix(watched, prefix) {
+			delete(w.watchedPaths, watched)
+		}
+	}
 }
 
 // flushScan runs a DLP scan synchronously during Close. Close keeps both

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1962,6 +1962,125 @@ func TestWatcher_ArmDeduplicatesConfiguredRoots(t *testing.T) {
 	}
 }
 
+func TestWatcher_ArmDuplicateRootMergesRequiredCoverage(t *testing.T) {
+	healthy := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	cfg := &config.FileSentry{
+		Enabled:    true,
+		BestEffort: true,
+		WatchPaths: []config.WatchPath{
+			{Path: healthy},
+			{Path: missing},
+			{Path: missing + string(filepath.Separator), Required: true},
+		},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	armErr := w.Arm()
+	if !errors.Is(armErr, ErrRequiredWatchPath) {
+		t.Fatalf("Arm error = %v, want ErrRequiredWatchPath for normalized required duplicate", armErr)
+	}
+	if errors.Is(armErr, ErrNoWatchPaths) {
+		t.Fatalf("Arm error = %v, healthy sibling should remain armed", armErr)
+	}
+}
+
+func TestWatcher_ArmBoundsFailureDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	for i := range maxArmDiagnosticSamples + 1 {
+		if err := os.Mkdir(filepath.Join(root, fmt.Sprintf("failed-%d", i)), 0o750); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+	}
+	var callbacks atomic.Int32
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		BestEffort:  true,
+		WatchPaths:  []config.WatchPath{{Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, func(error) { callbacks.Add(1) })
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fw := w.(*fsWatcher)
+	addWatch := fw.addWatch
+	fw.addWatch = func(path string) error {
+		if path != root {
+			return fs.ErrPermission
+		}
+		return addWatch(path)
+	}
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm best_effort: %v", err)
+	}
+	if got := len(w.DegradedPaths()); got != maxArmDiagnosticSamples {
+		t.Fatalf("DegradedPaths length = %d, want bounded %d", got, maxArmDiagnosticSamples)
+	}
+	if got, want := w.DegradedPathCount(), maxArmDiagnosticSamples+1; got != want {
+		t.Fatalf("DegradedPathCount = %d, want %d", got, want)
+	}
+	if got, want := callbacks.Load(), int32(maxArmDiagnosticSamples+1); got != want {
+		t.Fatalf("onError calls = %d, want %d sampled plus aggregate", got, want)
+	}
+}
+
+func TestWatcher_RearmAfterRemovedRootRegistersNewBackendWatch(t *testing.T) {
+	rootParent := t.TempDir()
+	root := filepath.Join(rootParent, "watch-root")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	cfg := &config.FileSentry{Enabled: true, WatchPaths: []config.WatchPath{{Path: root}}, ScanContent: ptrBool(true)}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	if err := w.Arm(); err != nil {
+		t.Fatalf("initial Arm: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startErr := make(chan error, 1)
+	go func() { startErr <- w.Start(ctx) }()
+
+	if err := os.Remove(root); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	fw := w.(*fsWatcher)
+	testwait.For(t, filesentryPositiveBackstop, func() bool {
+		fw.mu.Lock()
+		defer fw.mu.Unlock()
+		_, watched := fw.watchedPaths[root]
+		return !watched
+	}, "removed root cleared from cached watch registrations")
+	if err := os.Mkdir(root, 0o750); err != nil {
+		t.Fatalf("recreate root: %v", err)
+	}
+	if err := w.Arm(); err != nil {
+		t.Fatalf("re-arm recreated root: %v", err)
+	}
+	watchList := make(map[string]struct{})
+	for _, path := range fw.watcher.WatchList() {
+		watchList[path] = struct{}{}
+	}
+	if _, ok := watchList[root]; !ok {
+		t.Fatalf("recreated root missing backend watch: %#v", watchList)
+	}
+	cancel()
+	if err := <-startErr; err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+}
+
 func TestWatcher_AddDirectoryDoesNotDuplicateAnArmedWatch(t *testing.T) {
 	root := t.TempDir()
 	cfg := &config.FileSentry{

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1677,6 +1677,35 @@ func TestWatcher_ArmBestEffortStillRejectsZeroCoverage(t *testing.T) {
 	}
 }
 
+func TestWatcher_ArmRejectsEmptyCoverage(t *testing.T) {
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if armErr := w.Arm(); !errors.Is(armErr, ErrNoWatchPaths) {
+		t.Fatalf("Arm error = %v, want errors.Is(ErrNoWatchPaths)", armErr)
+	}
+}
+
+func TestRecursiveAddResultErrorJoinsSkippedSubtrees(t *testing.T) {
+	result := recursiveAddResult{skipped: []skippedSubtree{
+		{path: "first", cause: fs.ErrPermission},
+		{path: "second", cause: fs.ErrNotExist},
+	}}
+	if err := result.err(); !errors.Is(err, fs.ErrPermission) || !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("recursive result error = %v, want both skipped causes", err)
+	}
+	if err := (recursiveAddResult{}).err(); err != nil {
+		t.Fatalf("empty recursive result error = %v, want nil", err)
+	}
+}
+
 // TestWatcher_ArmMixedPathsArmsTheArmable verifies that best-effort Arm()
 // keeps a healthy path armed while reporting a missing auxiliary path.
 func TestWatcher_ArmMixedPathsArmsTheArmable(t *testing.T) {
@@ -1930,6 +1959,31 @@ func TestWatcher_ArmDeduplicatesConfiguredRoots(t *testing.T) {
 		if addCalls[path] != 1 {
 			t.Errorf("watch add calls for %q = %d, want 1", path, addCalls[path])
 		}
+	}
+}
+
+func TestWatcher_AddDirectoryDoesNotDuplicateAnArmedWatch(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+
+	added, err := w.(*fsWatcher).addDirectory(root)
+	if err != nil {
+		t.Fatalf("addDirectory: %v", err)
+	}
+	if added {
+		t.Fatal("addDirectory added an already armed watch")
 	}
 }
 

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -5,7 +5,9 @@ package filesentry
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1527,10 +1529,9 @@ done:
 }
 
 func TestWatcher_PermissionDeniedSubdir(t *testing.T) {
-	// Arm should fail closed when a subdirectory under a required:true
-	// watch path is unreadable. Required:true preserves the historical
-	// hard-fail; the non-required variant is covered separately and is
-	// expected to soft-fail (degraded) on the same input.
+	// Arm should fail closed when a subdirectory under a strict watch path is
+	// unreadable. This physical-permission variant complements the deterministic
+	// best-effort and strict sibling tests below.
 	dir := t.TempDir()
 	if os.Geteuid() == 0 {
 		t.Skip("chmod 000 does not restrict root")
@@ -1604,9 +1605,8 @@ func TestWatcher_StartReturnsOnClose(t *testing.T) {
 }
 
 func TestWatcher_ArmNonexistentPath(t *testing.T) {
-	// Required:true preserves the historical "Arm errors on missing path"
-	// semantic that operators got automatically before per-path opt-in.
-	// The soft-fail behavior for required:false is covered separately.
+	// Strict mode rejects a missing root. The best-effort zero-coverage case is
+	// covered separately.
 	cfg := &config.FileSentry{
 		Enabled:     true,
 		WatchPaths:  []config.WatchPath{{Path: "/nonexistent/path/that/does/not/exist", Required: true}},
@@ -1630,14 +1630,13 @@ func TestWatcher_ArmNonexistentPath(t *testing.T) {
 	}
 }
 
-// TestWatcher_ArmNonexistentPathSoftFail verifies that a non-required
-// watch path that cannot install is recorded as degraded rather than
-// aborting Arm(). This is the per-path soft-fail semantic that prevents
-// one missing or transiently-unreadable aux path from crash-looping the
-// proxy. The required:true variant is covered by TestWatcher_ArmNonexistentPath.
-func TestWatcher_ArmNonexistentPathSoftFail(t *testing.T) {
+// TestWatcher_ArmBestEffortStillRejectsZeroCoverage verifies that
+// best-effort means partial coverage is allowed, not that the runtime is
+// allowed to proceed while monitoring nothing.
+func TestWatcher_ArmBestEffortStillRejectsZeroCoverage(t *testing.T) {
 	cfg := &config.FileSentry{
 		Enabled:     true,
+		BestEffort:  true,
 		WatchPaths:  []config.WatchPath{{Path: "/nonexistent/path/that/does/not/exist"}},
 		ScanContent: ptrBool(true),
 	}
@@ -1656,8 +1655,12 @@ func TestWatcher_ArmNonexistentPathSoftFail(t *testing.T) {
 	}
 	defer func() { _ = w.Close() }()
 
-	if err := w.Arm(); err != nil {
-		t.Fatalf("Arm: non-required path should soft-fail, got error: %v", err)
+	armErr := w.Arm()
+	if armErr == nil {
+		t.Fatal("Arm: zero successfully armed paths must fail even in best_effort mode")
+	}
+	if !errors.Is(armErr, ErrNoWatchPaths) {
+		t.Fatalf("Arm error = %v, want errors.Is(ErrNoWatchPaths)", armErr)
 	}
 	degraded := w.DegradedPaths()
 	if len(degraded) != 1 {
@@ -1674,14 +1677,13 @@ func TestWatcher_ArmNonexistentPathSoftFail(t *testing.T) {
 	}
 }
 
-// TestWatcher_ArmMixedPathsArmsTheArmable verifies that an Arm() with a
-// healthy path AND a non-required missing path arms the healthy one and
-// records the missing one as degraded - neither failing the whole proxy
-// nor silently swallowing the missing path.
+// TestWatcher_ArmMixedPathsArmsTheArmable verifies that best-effort Arm()
+// keeps a healthy path armed while reporting a missing auxiliary path.
 func TestWatcher_ArmMixedPathsArmsTheArmable(t *testing.T) {
 	healthy := t.TempDir()
 	cfg := &config.FileSentry{
-		Enabled: true,
+		Enabled:    true,
+		BestEffort: true,
 		WatchPaths: []config.WatchPath{
 			{Path: healthy},
 			{Path: "/nonexistent/aux"},
@@ -1732,6 +1734,229 @@ func TestWatcher_ArmMixedPathsArmsTheArmable(t *testing.T) {
 		}
 	case <-time.After(filesentryPositiveBackstop):
 		t.Fatal("timeout waiting for finding from healthy path (was it actually armed?)")
+	}
+}
+
+func TestWatcher_ArmBestEffortSkipsUnreadableSiblingsAndKeepsAccessiblePaths(t *testing.T) {
+	root := t.TempDir()
+	accessible := filepath.Join(root, "accessible")
+	skippedA := filepath.Join(root, "skipped-a")
+	skippedB := filepath.Join(root, "skipped-b")
+	for _, path := range []string{accessible, skippedA, skippedB} {
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatalf("Mkdir %q: %v", path, err)
+		}
+	}
+	symlink := filepath.Join(root, "outside-link")
+	if err := os.Symlink(t.TempDir(), symlink); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		BestEffort:  true,
+		WatchPaths:  []config.WatchPath{{Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	var reported []string
+	w, err := NewWatcher(cfg, nil, nil, func(err error) { reported = append(reported, err.Error()) })
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fw := w.(*fsWatcher)
+	addWatch := fw.addWatch
+	addCalls := make(map[string]int)
+	fw.addWatch = func(path string) error {
+		addCalls[path]++
+		if path == skippedA || path == skippedB {
+			return fs.ErrPermission
+		}
+		return addWatch(path)
+	}
+
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm best_effort: %v", err)
+	}
+	degraded := w.DegradedPaths()
+	if len(degraded) != 2 {
+		t.Fatalf("degraded paths = %#v, want both skipped siblings", degraded)
+	}
+	for _, path := range []string{skippedA, skippedB} {
+		found := false
+		for _, degradedPath := range degraded {
+			if degradedPath.Path == path && strings.Contains(degradedPath.Error, "permission denied") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing reported skipped subtree %q in %#v", path, degraded)
+		}
+	}
+	if len(reported) != 2 {
+		t.Errorf("onError reports = %d, want every skipped subtree", len(reported))
+	}
+
+	watchList := make(map[string]struct{})
+	for _, path := range fw.watcher.WatchList() {
+		watchList[path] = struct{}{}
+	}
+	for _, path := range []string{root, accessible} {
+		if _, ok := watchList[path]; !ok {
+			t.Errorf("accessible path %q was not armed; watch list = %#v", path, watchList)
+		}
+	}
+	for _, path := range []string{skippedA, skippedB, symlink} {
+		if _, ok := watchList[path]; ok {
+			t.Errorf("untrusted or failed path %q must not be watched", path)
+		}
+	}
+}
+
+func TestWatcher_ArmStrictFailsAfterArmingAccessibleSiblings(t *testing.T) {
+	root := t.TempDir()
+	accessible := filepath.Join(root, "accessible")
+	skipped := filepath.Join(root, "skipped")
+	for _, path := range []string{accessible, skipped} {
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatalf("Mkdir %q: %v", path, err)
+		}
+	}
+
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fw := w.(*fsWatcher)
+	addWatch := fw.addWatch
+	fw.addWatch = func(path string) error {
+		if path == skipped {
+			return fs.ErrPermission
+		}
+		return addWatch(path)
+	}
+
+	if err := w.Arm(); err == nil {
+		t.Fatal("Arm strict: expected incomplete coverage to fail closed")
+	}
+	watchList := make(map[string]struct{})
+	for _, path := range fw.watcher.WatchList() {
+		watchList[path] = struct{}{}
+	}
+	if _, ok := watchList[accessible]; !ok {
+		t.Errorf("strict Arm stopped before accessible sibling was armed; watch list = %#v", watchList)
+	}
+	if degraded := w.DegradedPaths(); len(degraded) != 1 || degraded[0].Path != skipped {
+		t.Errorf("strict Arm degradation = %#v, want skipped subtree %q", degraded, skipped)
+	}
+}
+
+func TestWatcher_ArmRequiredWatchPathHasTypedErrorSignal(t *testing.T) {
+	root := t.TempDir()
+	accessible := filepath.Join(root, "accessible")
+	skipped := filepath.Join(root, "skipped")
+	for _, path := range []string{accessible, skipped} {
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatalf("Mkdir %q: %v", path, err)
+		}
+	}
+
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		BestEffort:  true,
+		WatchPaths:  []config.WatchPath{{Path: root, Required: true}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fw := w.(*fsWatcher)
+	addWatch := fw.addWatch
+	fw.addWatch = func(path string) error {
+		if path == skipped {
+			return fs.ErrPermission
+		}
+		return addWatch(path)
+	}
+
+	armErr := w.Arm()
+	if !errors.Is(armErr, ErrRequiredWatchPath) {
+		t.Fatalf("Arm error = %v, want errors.Is(ErrRequiredWatchPath)", armErr)
+	}
+	if errors.Is(armErr, ErrNoWatchPaths) {
+		t.Fatalf("Arm error = %v, accessible sibling means ErrNoWatchPaths must be false", armErr)
+	}
+}
+
+func TestWatcher_ArmDeduplicatesConfiguredRoots(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	if err := os.Mkdir(child, 0o750); err != nil {
+		t.Fatalf("Mkdir child: %v", err)
+	}
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: root}, {Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	fw := w.(*fsWatcher)
+	addWatch := fw.addWatch
+	addCalls := make(map[string]int)
+	fw.addWatch = func(path string) error {
+		addCalls[path]++
+		return addWatch(path)
+	}
+	if err := w.Arm(); err != nil {
+		t.Fatalf("Arm: %v", err)
+	}
+	for _, path := range []string{root, child} {
+		if addCalls[path] != 1 {
+			t.Errorf("watch add calls for %q = %d, want 1", path, addCalls[path])
+		}
+	}
+}
+
+func TestWatcher_ArmRejectsSymlinkRoot(t *testing.T) {
+	target := t.TempDir()
+	root := filepath.Join(t.TempDir(), "watch-root-link")
+	if err := os.Symlink(target, root); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		BestEffort:  true,
+		WatchPaths:  []config.WatchPath{{Path: root}},
+		ScanContent: ptrBool(true),
+	}
+	w, err := NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	if err := w.Arm(); err == nil {
+		t.Fatal("Arm: symlink root must fail rather than silently monitoring nothing")
+	}
+	degraded := w.DegradedPaths()
+	if len(degraded) != 1 || degraded[0].Path != root || !strings.Contains(degraded[0].Error, "symlink") {
+		t.Errorf("symlink degradation = %#v", degraded)
 	}
 }
 


### PR DESCRIPTION
File sentry now stops startup whenever strict coverage is incomplete. Operators can opt into best-effort monitoring for accessible paths, while required paths and zero coverage still stop startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort file monitoring that preserves accessible paths when others cannot be watched.
  * Added strict handling for required paths and startup failure when no paths can be monitored.
  * Startup logs now report configured paths and skipped or unavailable subtrees.

* **Bug Fixes**
  * Improved handling of inaccessible, duplicate, symlink, and invalid watch paths.
  * Preserved fail-closed behavior for required monitoring failures.

* **Documentation**
  * Updated configuration and filesystem monitoring guidance for strict and best-effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->