### PR TITLE
fix(dashboard): show only populated budget fields

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -37,7 +37,7 @@ audit, and metadata-versus-raw redaction model.
 | Evidence | `/` and `/session/...` | `agents` | `dashboard:evidence:read` | Per-session receipt scorecard, timeline, and decision explanation from the configured recorder directory. |
 | Exemptions | `/exemptions` | `agents` | `dashboard:exemptions:read` | Read-only exemption inventory from `--config`, with lifecycle metadata overlaid from `--exemption-store` when configured. |
 | Agents | `/agents` and `/agent/...` | `agents` | `dashboard:agents:read` | Cross-session agent grouping and bounded scorecard rollups; absence means no loaded receipts, not proof the agent was idle. |
-| Budgets | `/budgets` | `agents` | `dashboard:budgets:read` | Counts-only per-agent budget pressure from `--runtime-snapshot-file` or the default runtime snapshot. |
+| Budgets | `/budgets` | `agents` | `dashboard:budgets:read` | Counts-only per-agent forward-proxy budget pressure from `--runtime-snapshot-file` or the default runtime snapshot. MCP denial-of-wallet counters are not included. |
 | Trust & Keys | `/trust-keys` | `agents` | `dashboard:trust_keys:read` | Trusted-key provenance, receipt blast radius, revocation status where verifiable, and local/Rekor anchor consistency. |
 | Fleet | `/fleet` | `fleet` | `dashboard:fleet:read` | Enrolled follower runtime and signed applied-state status from the configured Conductor read source. |
 | Workbench | `/workbench` | `fleet` | `dashboard:signed_action:read` | Prepare, dry-run, and replay guidance for signed Conductor actions; no write path. |

--- a/enterprise/dashboard/budgets.go
+++ b/enterprise/dashboard/budgets.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -18,17 +17,13 @@ const (
 	budgetCompletenessNonClaim = "does not prove consumption outside this process, before the current window, or on transports without budget enforcement"
 	budgetUnlimited            = "unlimited"
 	budgetEmptyDash            = "-"
-	budgetRedacted             = "redacted"
 	budgetAgentLimit           = 500
-	budgetSessionLimit         = 100
 )
 
 // BudgetDataSource is the dashboard-local read seam for per-agent budget
 // consumption. Implementations MUST be read-only: the budgets route has no
-// write or control authority. It surfaces two independent budget systems per
-// agent: the forward-proxy request/byte/domain budget and the MCP
-// denial-of-wallet (tool-call/concurrency) budget aggregated across the
-// agent's live sessions.
+// write or control authority. It surfaces the forward-proxy
+// request/byte/domain budget supplied by the runtime snapshot.
 type BudgetDataSource interface {
 	// AllAgentBudgets returns budget views for configured agents. Limit is a
 	// hard maximum requested by the dashboard; implementations should apply it
@@ -53,28 +48,6 @@ type AgentBudgetView struct {
 	MaxBytes          int64
 	MaxUniqueDomains  int
 	WindowMinutes     int
-
-	// MCP denial-of-wallet budget, aggregated across the agent's live sessions.
-	// MCP DoW limits are per subject/window; request budgets retain their
-	// existing per-session display semantics.
-	// consumption counters are summed across active sessions.
-	DoWConfigured          bool
-	ActiveSessions         int
-	TotalToolCalls         int
-	Inflight               int
-	MaxToolCallsPerSession int
-	MaxConcurrentToolCalls int
-	MaxWallClockMinutes    int
-	Sessions               []AgentBudgetSessionView
-	SessionsTruncated      bool
-}
-
-// AgentBudgetSessionView is one live MCP session's DoW consumption.
-type AgentBudgetSessionView struct {
-	SessionID      string
-	TotalToolCalls int
-	Inflight       int
-	StartedAt      time.Time
 }
 
 // BudgetsOverview is the rendered budgets page.
@@ -119,10 +92,6 @@ func (m *ReadModel) Budgets(ctx context.Context, rawAllowed bool) (BudgetsOvervi
 		agents = agents[:budgetAgentLimit]
 		overview.Truncated = true
 	}
-	agents = limitBudgetSessions(agents)
-	if !rawAllowed {
-		agents = redactAgentBudgets(agents)
-	}
 	overview.Agents = agents
 	return overview, nil
 }
@@ -133,40 +102,6 @@ func budgetFreshness(source BudgetDataSource) (BudgetSnapshotFreshness, bool) {
 		return BudgetSnapshotFreshness{}, false
 	}
 	return freshSource.BudgetFreshness()
-}
-
-func limitBudgetSessions(in []AgentBudgetView) []AgentBudgetView {
-	out := make([]AgentBudgetView, len(in))
-	for i, a := range in {
-		if len(a.Sessions) > budgetSessionLimit {
-			a.Sessions = a.Sessions[:budgetSessionLimit]
-			a.SessionsTruncated = true
-		}
-		out[i] = a
-	}
-	return out
-}
-
-// redactAgentBudgets strips the sensitive per-session identifier from the DoW
-// breakdown for the metadata (non-raw) view. Consumption counters and
-// configured limits are policy/operational and stay visible; only the session
-// id, which correlates a row to a specific live MCP session, is redacted. The
-// agent name is the grouping key and is kept (it is the same identifier the
-// agents panel shows).
-func redactAgentBudgets(in []AgentBudgetView) []AgentBudgetView {
-	out := make([]AgentBudgetView, len(in))
-	for i, a := range in {
-		if len(a.Sessions) > 0 {
-			sessions := make([]AgentBudgetSessionView, len(a.Sessions))
-			for j, s := range a.Sessions {
-				s.SessionID = budgetRedacted
-				sessions[j] = s
-			}
-			a.Sessions = sessions
-		}
-		out[i] = a
-	}
-	return out
 }
 
 // --- display helpers (used by budgets.tmpl.html) ---
@@ -203,44 +138,6 @@ func (a AgentBudgetView) WindowDisplay() string {
 
 func (a AgentBudgetView) WindowStartDisplay() string {
 	return displayBudgetTime(a.WindowStart)
-}
-
-func (a AgentBudgetView) ToolCallsDisplay() string {
-	// TotalToolCalls is summed ACROSS subjects while the limit is now PER
-	// subject, so the two must not be shown as a ratio: two subjects at 40 each
-	// against a 50 limit would read "80 / 50" with neither over budget. Show the
-	// total as a total and state the limit separately.
-	//
-	// Note this value is not yet populated: no snapshot path supplies DoW
-	// figures, so it currently renders as zero. Whatever wires it must supply a
-	// per-subject figure before any ratio is reintroduced here.
-	if a.MaxToolCallsPerSession <= 0 {
-		return fmt.Sprintf("%d / %s", a.TotalToolCalls, budgetUnlimited)
-	}
-	return fmt.Sprintf("%d across subjects (limit %d per subject)", a.TotalToolCalls, a.MaxToolCallsPerSession)
-}
-
-func (a AgentBudgetView) InflightDisplay() string {
-	if a.MaxConcurrentToolCalls <= 0 {
-		return fmt.Sprintf("%d / %s", a.Inflight, budgetUnlimited)
-	}
-	return fmt.Sprintf("%d / %d per session", a.Inflight, a.MaxConcurrentToolCalls)
-}
-
-func (s AgentBudgetSessionView) SessionIDDisplay() string {
-	return displayBudgetString(s.SessionID)
-}
-
-func (s AgentBudgetSessionView) StartedAtDisplay() string {
-	return displayBudgetTime(s.StartedAt)
-}
-
-func displayBudgetString(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return budgetEmptyDash
-	}
-	return value
 }
 
 func displayBudgetTime(value time.Time) string {

--- a/enterprise/dashboard/budgets.tmpl.html
+++ b/enterprise/dashboard/budgets.tmpl.html
@@ -90,14 +90,13 @@
       {{ else if .SourceUnavailable }}
         <div class="empty">Budget pressure proves only mediated per-agent budget consumption from the configured budget snapshot source. A budget source is configured, but its snapshot is missing, invalid, oversized, future-dated, or stale. Fix the configured <code>--runtime-snapshot-file</code> or refresh the default <code>--receipt-dir/dashboard/runtime-snapshot.json</code> snapshot.</div>
       {{ else if not .Agents }}
-        <div class="empty">Budget pressure proves only mediated per-agent budget consumption from the configured budget snapshot source. The source is connected, but the loaded snapshot has no agents with configured forward-proxy budgets or live MCP sessions. Configure agent budgets or create live MCP sessions in the runtime that writes <code>--runtime-snapshot-file</code>.</div>
+        <div class="empty">Budget pressure proves only mediated per-agent budget consumption from the configured budget snapshot source. The source is connected, but the loaded snapshot has no agents with configured forward-proxy budgets. Configure agent budgets in the runtime that writes <code>--runtime-snapshot-file</code>.</div>
       {{ else }}
         {{ range .Agents }}
           <div class="agent">
             <div class="agent-head">
               <span class="agent-name">{{ .Agent }}</span>
               {{ if .ForwardConfigured }}<span class="tag">forward budget</span>{{ end }}
-              {{ if .DoWConfigured }}<span class="tag">MCP denial-of-wallet</span>{{ end }}
             </div>
             <div class="cols">
               <div class="col">
@@ -112,39 +111,6 @@
                   </table>
                 {{ else }}
                   <p class="none">No forward-proxy budget configured.</p>
-                {{ end }}
-              </div>
-              <div class="col">
-                <h3>MCP denial-of-wallet</h3>
-                {{ if .DoWConfigured }}
-                  <table class="metric">
-                    <tr><td>Active sessions</td><td>{{ .ActiveSessions }}</td></tr>
-                    <tr><td>Tool calls (sum / per-session limit)</td><td>{{ .ToolCallsDisplay }}</td></tr>
-                    <tr><td>In flight (sum / per-session limit)</td><td>{{ .InflightDisplay }}</td></tr>
-                    <tr><td>Wall-clock limit (min/session)</td><td>{{ if gt .MaxWallClockMinutes 0 }}{{ .MaxWallClockMinutes }}{{ else }}unlimited{{ end }}</td></tr>
-                  </table>
-                  {{ if .Sessions }}
-                    <div class="sessions">
-                      <table>
-                        <thead><tr><th>Session</th><th>Tool calls</th><th>In flight</th><th>Started</th></tr></thead>
-                        <tbody>
-                          {{ range .Sessions }}
-                            <tr>
-                              <td><code>{{ .SessionIDDisplay }}</code></td>
-                              <td>{{ .TotalToolCalls }}</td>
-                              <td>{{ .Inflight }}</td>
-                              <td>{{ .StartedAtDisplay }}</td>
-                            </tr>
-                          {{ end }}
-                        </tbody>
-                      </table>
-                    </div>
-                    {{ if .SessionsTruncated }}
-                      <p class="note">Session rows truncated to the first {{ len .Sessions }} sessions for this agent.</p>
-                    {{ end }}
-                  {{ end }}
-                {{ else }}
-                  <p class="none">No live MCP sessions.</p>
                 {{ end }}
               </div>
             </div>

--- a/enterprise/dashboard/budgets_test.go
+++ b/enterprise/dashboard/budgets_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
-const budgetTestSensitiveSession = "mcp-session-sensitive-alpha"
-
 type fakeBudgetSource struct {
 	agents []AgentBudgetView
 	err    error
@@ -34,39 +32,22 @@ func (f *fakeBudgetSource) AllAgentBudgets(_ context.Context, limit int) ([]Agen
 		return nil, f.err
 	}
 	out := make([]AgentBudgetView, len(f.agents))
-	for i, a := range f.agents {
-		if len(a.Sessions) > 0 {
-			sessions := make([]AgentBudgetSessionView, len(a.Sessions))
-			copy(sessions, a.Sessions)
-			a.Sessions = sessions
-		}
-		out[i] = a
-	}
+	copy(out, f.agents)
 	return out, nil
 }
 
-func budgetAgentWithSession() AgentBudgetView {
+func budgetAgent() AgentBudgetView {
 	return AgentBudgetView{
-		Agent:                  "agent-alpha",
-		ForwardConfigured:      true,
-		RequestCount:           7,
-		ByteCount:              4096,
-		UniqueDomainCount:      2,
-		WindowStart:            time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
-		MaxRequests:            100,
-		MaxBytes:               1048576,
-		MaxUniqueDomains:       10,
-		WindowMinutes:          60,
-		DoWConfigured:          true,
-		ActiveSessions:         1,
-		TotalToolCalls:         3,
-		Inflight:               1,
-		MaxToolCallsPerSession: 50,
-		MaxConcurrentToolCalls: 5,
-		MaxWallClockMinutes:    30,
-		Sessions: []AgentBudgetSessionView{
-			{SessionID: budgetTestSensitiveSession, TotalToolCalls: 3, Inflight: 1, StartedAt: time.Date(2026, 7, 10, 12, 5, 0, 0, time.UTC)},
-		},
+		Agent:             "agent-alpha",
+		ForwardConfigured: true,
+		RequestCount:      7,
+		ByteCount:         4096,
+		UniqueDomainCount: 2,
+		WindowStart:       time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+		MaxRequests:       100,
+		MaxBytes:          1048576,
+		MaxUniqueDomains:  10,
+		WindowMinutes:     60,
 	}
 }
 
@@ -105,7 +86,7 @@ func TestBudgets_Gating(t *testing.T) {
 				TrustedOuterAuth: true,
 				ReceiptDir:       t.TempDir(),
 				HasFeature:       tt.hasFeature,
-				BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
+				BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgent()}},
 				AuthorizeRaw:     allowRawAccess,
 			})
 			rec := httptest.NewRecorder()
@@ -174,7 +155,7 @@ func TestBudgets_ConnectedEmptySourceExplainsSnapshotRows(t *testing.T) {
 		"agents with loaded budget rows",
 		"Budget pressure proves only mediated per-agent budget consumption",
 		"The source is connected",
-		"no agents with configured forward-proxy budgets or live MCP sessions",
+		"no agents with configured forward-proxy budgets",
 		"--runtime-snapshot-file",
 	} {
 		if !strings.Contains(body, want) {
@@ -183,12 +164,38 @@ func TestBudgets_ConnectedEmptySourceExplainsSnapshotRows(t *testing.T) {
 	}
 }
 
+func TestBudgets_RendersOnlyPopulatedForwardBudgetFields(t *testing.T) {
+	t.Parallel()
+
+	handler := New(Options{
+		TrustedOuterAuth: true,
+		ReceiptDir:       t.TempDir(),
+		HasFeature:       func(f string) bool { return f == license.FeatureAgents },
+		BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgent()}},
+		AuthorizeRaw:     allowRawAccess,
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Forward proxy", "Requests (used / limit)", "7 / 100"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("budget body missing populated forward field %q", want)
+		}
+	}
+	if strings.Contains(body, "MCP denial-of-wallet") {
+		t.Fatal("budget body advertised unpopulated MCP denial-of-wallet fields")
+	}
+}
+
 func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("trailing_slash_not_budget_panel", func(t *testing.T) {
 		t.Parallel()
-		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}}
+		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgent()}}
 		handler := New(Options{
 			TrustedOuterAuth: true,
 			ReceiptDir:       t.TempDir(),
@@ -208,7 +215,7 @@ func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 
 	t.Run("post_rejected_before_source", func(t *testing.T) {
 		t.Parallel()
-		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}}
+		source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgent()}}
 		handler := New(Options{
 			TrustedOuterAuth: true,
 			ReceiptDir:       t.TempDir(),
@@ -250,43 +257,6 @@ func TestBudgets_RouteExactMethodAndSourceError(t *testing.T) {
 	})
 }
 
-// TestBudgets_SessionIDRedaction: the sensitive per-session identifier is
-// redacted in the metadata view and shown only in the raw view.
-func TestBudgets_SessionIDRedaction(t *testing.T) {
-	t.Parallel()
-
-	newHandler := func(raw func(*http.Request) error) http.Handler {
-		return New(Options{
-			TrustedOuterAuth: true,
-			ReceiptDir:       t.TempDir(),
-			HasFeature:       func(f string) bool { return f == license.FeatureAgents },
-			BudgetSource:     &fakeBudgetSource{agents: []AgentBudgetView{budgetAgentWithSession()}},
-			AuthorizeRaw:     raw,
-		})
-	}
-
-	// Metadata view (no raw authorizer): session id must be redacted.
-	recMeta := httptest.NewRecorder()
-	newHandler(nil).ServeHTTP(recMeta, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
-	metaBody := recMeta.Body.String()
-	if recMeta.Code != http.StatusOK {
-		t.Fatalf("metadata status = %d, want 200", recMeta.Code)
-	}
-	if strings.Contains(metaBody, budgetTestSensitiveSession) {
-		t.Fatal("metadata view leaked the sensitive session id")
-	}
-	if !strings.Contains(metaBody, budgetRedacted) {
-		t.Fatal("metadata view did not mark the session id redacted")
-	}
-
-	// Raw view: session id must be visible.
-	recRaw := httptest.NewRecorder()
-	newHandler(allowRawAccess).ServeHTTP(recRaw, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/budgets", nil))
-	if !strings.Contains(recRaw.Body.String(), budgetTestSensitiveSession) {
-		t.Fatal("raw view did not show the session id")
-	}
-}
-
 func TestReadModel_Budgets_NilSource(t *testing.T) {
 	t.Parallel()
 	m := NewReadModel(Options{})
@@ -302,22 +272,18 @@ func TestReadModel_Budgets_NilSource(t *testing.T) {
 	}
 }
 
-func TestReadModel_Budgets_SortTruncateRedact(t *testing.T) {
+func TestReadModel_Budgets_SortAndTruncate(t *testing.T) {
 	t.Parallel()
 
 	// Unsorted input, one over the display cap.
 	agents := make([]AgentBudgetView, 0, budgetAgentLimit+1)
-	agents = append(agents, AgentBudgetView{
-		Agent: "zzz-last", DoWConfigured: true, ActiveSessions: 1,
-		Sessions: []AgentBudgetSessionView{{SessionID: "sensitive-zzz"}},
-	})
+	agents = append(agents, AgentBudgetView{Agent: "zzz-last", ForwardConfigured: true})
 	for i := 0; i < budgetAgentLimit; i++ {
 		agents = append(agents, AgentBudgetView{Agent: fmt.Sprintf("agent-%04d", i), ForwardConfigured: true})
 	}
 
 	m := NewReadModel(Options{BudgetSource: &fakeBudgetSource{agents: agents}})
 
-	// Redacted (metadata) view.
 	ov, err := m.Budgets(context.Background(), false)
 	if err != nil {
 		t.Fatalf("Budgets: %v", err)
@@ -334,65 +300,26 @@ func TestReadModel_Budgets_SortTruncateRedact(t *testing.T) {
 	if ov.Agents[0].Agent != "agent-0000" {
 		t.Fatalf("expected sorted-first agent-0000, got %q", ov.Agents[0].Agent)
 	}
-	// "zzz-last" (with the sensitive session) sorts last and is dropped by the
-	// cap, so build a small deterministic case for the redaction assertion.
-	small := NewReadModel(Options{BudgetSource: &fakeBudgetSource{agents: []AgentBudgetView{
-		{Agent: "a", DoWConfigured: true, ActiveSessions: 1, Sessions: []AgentBudgetSessionView{{SessionID: "sensitive-abc"}}},
-	}}})
-	red, err := small.Budgets(context.Background(), false)
-	if err != nil {
-		t.Fatalf("Budgets: %v", err)
-	}
-	if red.Agents[0].Sessions[0].SessionID != budgetRedacted {
-		t.Fatalf("session id not redacted in metadata view: %q", red.Agents[0].Sessions[0].SessionID)
-	}
-	rawov, err := small.Budgets(context.Background(), true)
-	if err != nil {
-		t.Fatalf("Budgets: %v", err)
-	}
-	if rawov.Agents[0].Sessions[0].SessionID != "sensitive-abc" {
-		t.Fatalf("session id should be visible in raw view, got %q", rawov.Agents[0].Sessions[0].SessionID)
-	}
 }
 
-func TestReadModel_Budgets_RequestsBoundedSourceAndCapsSessions(t *testing.T) {
+func TestReadModel_Budgets_RequestsBoundedSource(t *testing.T) {
 	t.Parallel()
 
-	sessions := make([]AgentBudgetSessionView, 0, budgetSessionLimit+1)
-	for i := 0; i <= budgetSessionLimit; i++ {
-		sessions = append(sessions, AgentBudgetSessionView{SessionID: fmt.Sprintf("session-%03d", i)})
-	}
-	source := &fakeBudgetSource{agents: []AgentBudgetView{{
-		Agent:          "agent-session-heavy",
-		DoWConfigured:  true,
-		ActiveSessions: len(sessions),
-		Sessions:       sessions,
-	}}}
+	source := &fakeBudgetSource{agents: []AgentBudgetView{budgetAgent()}}
 	m := NewReadModel(Options{BudgetSource: source})
 
-	ov, err := m.Budgets(context.Background(), false)
+	_, err := m.Budgets(context.Background(), false)
 	if err != nil {
 		t.Fatalf("Budgets: %v", err)
 	}
 	if source.limit != budgetAgentLimit+1 {
 		t.Fatalf("BudgetSource limit = %d, want %d", source.limit, budgetAgentLimit+1)
 	}
-	if got := len(ov.Agents[0].Sessions); got != budgetSessionLimit {
-		t.Fatalf("session rows = %d, want cap %d", got, budgetSessionLimit)
-	}
-	if !ov.Agents[0].SessionsTruncated {
-		t.Fatal("expected SessionsTruncated when source returns more than the display cap")
-	}
-	for _, session := range ov.Agents[0].Sessions {
-		if session.SessionID != budgetRedacted {
-			t.Fatalf("metadata session id after cap/redaction = %q, want %q", session.SessionID, budgetRedacted)
-		}
-	}
 }
 
 func TestAgentBudgetView_Displays(t *testing.T) {
 	t.Parallel()
-	limited := AgentBudgetView{RequestCount: 3, MaxRequests: 10, TotalToolCalls: 4, MaxToolCallsPerSession: 50}
+	limited := AgentBudgetView{RequestCount: 3, MaxRequests: 10}
 	if got := limited.RequestsDisplay(); got != "3 / 10" {
 		t.Fatalf("RequestsDisplay = %q, want %q", got, "3 / 10")
 	}
@@ -401,22 +328,8 @@ func TestAgentBudgetView_Displays(t *testing.T) {
 	if got := limited.BytesDisplay(); got != "2147483648 / 2147483649" {
 		t.Fatalf("BytesDisplay = %q, want %q", got, "2147483648 / 2147483649")
 	}
-	// The total is summed across subjects while the limit is per subject, so
-	// the two must not be rendered as a ratio: an operator reading "80 / 50"
-	// would think the budget was blown when no subject had exceeded it.
-	const wantToolCalls = "4 across subjects (limit 50 per subject)"
-	if got := limited.ToolCallsDisplay(); got != wantToolCalls {
-		t.Fatalf("ToolCallsDisplay = %q, want %q", got, wantToolCalls)
-	}
-	overCap := AgentBudgetView{TotalToolCalls: 80, MaxToolCallsPerSession: 50}
-	if got := overCap.ToolCallsDisplay(); strings.Contains(got, "80 / 50") {
-		t.Fatalf("aggregate rendered as a per-subject ratio: %q", got)
-	}
-	unlimited := AgentBudgetView{RequestCount: 3, MaxRequests: 0, TotalToolCalls: 4, MaxToolCallsPerSession: 0}
+	unlimited := AgentBudgetView{RequestCount: 3, MaxRequests: 0}
 	if got := unlimited.RequestsDisplay(); got != "3 / "+budgetUnlimited {
 		t.Fatalf("RequestsDisplay unlimited = %q", got)
-	}
-	if got := unlimited.ToolCallsDisplay(); got != "4 / "+budgetUnlimited {
-		t.Fatalf("ToolCallsDisplay unlimited = %q", got)
 	}
 }

--- a/enterprise/dashboard/budgets_test.go
+++ b/enterprise/dashboard/budgets_test.go
@@ -180,7 +180,17 @@ func TestBudgets_RendersOnlyPopulatedForwardBudgetFields(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Forward proxy", "Requests (used / limit)", "7 / 100"} {
+	// Every populated forward field is asserted by label AND rendered value.
+	// Checking only the request count would let a regression that drops the
+	// byte, unique-domain or window output pass unnoticed.
+	for _, want := range []string{
+		"Forward proxy",
+		"Requests (used / limit)", "7 / 100",
+		"Bytes (used / limit)", "4096 / 1048576",
+		"Unique domains (used / limit)", "2 / 10",
+		"Window", "60 min rolling",
+		"Window started", "2026-07-10T12:00:00Z",
+	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("budget body missing populated forward field %q", want)
 		}

--- a/enterprise/dashboard/overview.go
+++ b/enterprise/dashboard/overview.go
@@ -699,8 +699,6 @@ func budgetPressure(agent AgentBudgetView) (int, string) {
 	considerInt(agent.RequestCount, agent.MaxRequests, "request budget")
 	considerInt64(agent.ByteCount, agent.MaxBytes, "byte budget")
 	considerInt(agent.UniqueDomainCount, agent.MaxUniqueDomains, "unique-domain budget")
-	considerInt(agent.TotalToolCalls, agent.MaxToolCallsPerSession, "MCP tool-call budget")
-	considerInt(agent.Inflight, agent.MaxConcurrentToolCalls, "MCP concurrency budget")
 	return best, basis
 }
 

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -56,14 +56,7 @@ func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
 	if row.Agent != "agent-alpha" || !row.ForwardConfigured || row.RequestCount != 7 || row.UniqueDomainCount != 2 {
 		t.Fatalf("unexpected mapped row: %+v", row)
 	}
-	// Completeness: every field declared on AgentBudgetView must be mapped by
-	// the snapshot source. A zero value cannot stand in for "unmapped" here: a
-	// zero usage count is valid in a fresh window and a zero maximum is valid
-	// for an unlimited budget, so a zero-value heuristic would report correctly
-	// mapped rows as incomplete. Instead each declared field is compared to an
-	// explicit expectation, and a field with no expectation fails the test so
-	// that adding a field to the view forces a decision about populating it.
-	wantFields := map[string]any{
+	assertBudgetFieldsMapped(t, row, map[string]any{
 		"Agent":             "agent-alpha",
 		"ForwardConfigured": true,
 		"RequestCount":      7,
@@ -74,7 +67,79 @@ func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
 		"MaxBytes":          int64(1 << 20),
 		"MaxUniqueDomains":  10,
 		"WindowMinutes":     60,
+	})
+	fresh, ok := source.BudgetFreshness()
+	if !ok || fresh.ProducedAt != now || fresh.Stale {
+		t.Fatalf("freshness = %+v ok=%v, want produced_at and stale=false", fresh, ok)
 	}
+}
+
+// TestSnapshotBudgetSourceMapsLegitimateZeroValues pins the reason the
+// completeness check compares explicit expectations instead of asking whether a
+// field is zero. A fresh window has no requests yet and a zero maximum means
+// unlimited, so both are correctly mapped values that a zero-value heuristic
+// would report as unpopulated. Without this case every numeric expectation is
+// non-zero, and reintroducing that heuristic would still pass the suite.
+func TestSnapshotBudgetSourceMapsLegitimateZeroValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "dashboard", "runtime-snapshot.json")
+	if err := runtimesnapshot.Write(path, runtimesnapshot.Envelope{
+		Version:    runtimesnapshot.Version,
+		ProducedAt: now,
+		ProducerID: "producer-1",
+		Budgets: []runtimesnapshot.AgentBudgetRow{{
+			Agent: "agent-zero",
+			// Fresh window: nothing consumed yet.
+			RequestCount:      0,
+			ByteCount:         0,
+			UniqueDomainCount: 0,
+			WindowStart:       now.Add(-time.Minute),
+			// MaxBytes 0 means unlimited; other limits stay positive so the
+			// agent still has a configured forward budget.
+			MaxRequests:      100,
+			MaxBytes:         0,
+			MaxUniqueDomains: 10,
+			WindowMinutes:    60,
+		}},
+	}); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	source := &snapshotBudgetSource{path: path, maxAge: time.Minute, now: func() time.Time { return now.Add(5 * time.Second) }}
+	rows, err := source.AllAgentBudgets(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("AllAgentBudgets: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	assertBudgetFieldsMapped(t, rows[0], map[string]any{
+		"Agent":             "agent-zero",
+		"ForwardConfigured": true,
+		"RequestCount":      0,
+		"ByteCount":         int64(0),
+		"UniqueDomainCount": 0,
+		"WindowStart":       now.Add(-time.Minute),
+		"MaxRequests":       100,
+		"MaxBytes":          int64(0),
+		"MaxUniqueDomains":  10,
+		"WindowMinutes":     60,
+	})
+	// The unlimited maximum must render as unlimited rather than as a zero cap.
+	if got := rows[0].BytesDisplay(); got != "0 / "+budgetUnlimited {
+		t.Errorf("BytesDisplay() = %q, want unlimited rendering", got)
+	}
+}
+
+// assertBudgetFieldsMapped checks that every field declared on AgentBudgetView
+// is mapped by the snapshot source and matches its expectation. A field with no
+// expectation fails, so adding a field to the view forces a decision about
+// populating it rather than letting it render blank.
+func assertBudgetFieldsMapped(t *testing.T, row AgentBudgetView, wantFields map[string]any) {
+	t.Helper()
+
 	value := reflect.ValueOf(row)
 	typeOfRow := value.Type()
 	for i := range value.NumField() {
@@ -90,10 +155,6 @@ func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
 	}
 	if len(wantFields) != value.NumField() {
 		t.Errorf("expectation count %d != declared field count %d", len(wantFields), value.NumField())
-	}
-	fresh, ok := source.BudgetFreshness()
-	if !ok || fresh.ProducedAt != now || fresh.Stale {
-		t.Fatalf("freshness = %+v ok=%v, want produced_at and stale=false", fresh, ok)
 	}
 }
 

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -56,12 +56,40 @@ func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
 	if row.Agent != "agent-alpha" || !row.ForwardConfigured || row.RequestCount != 7 || row.UniqueDomainCount != 2 {
 		t.Fatalf("unexpected mapped row: %+v", row)
 	}
+	// Completeness: every field declared on AgentBudgetView must be mapped by
+	// the snapshot source. A zero value cannot stand in for "unmapped" here: a
+	// zero usage count is valid in a fresh window and a zero maximum is valid
+	// for an unlimited budget, so a zero-value heuristic would report correctly
+	// mapped rows as incomplete. Instead each declared field is compared to an
+	// explicit expectation, and a field with no expectation fails the test so
+	// that adding a field to the view forces a decision about populating it.
+	wantFields := map[string]any{
+		"Agent":             "agent-alpha",
+		"ForwardConfigured": true,
+		"RequestCount":      7,
+		"ByteCount":         int64(4096),
+		"UniqueDomainCount": 2,
+		"WindowStart":       now.Add(-time.Hour),
+		"MaxRequests":       100,
+		"MaxBytes":          int64(1 << 20),
+		"MaxUniqueDomains":  10,
+		"WindowMinutes":     60,
+	}
 	value := reflect.ValueOf(row)
 	typeOfRow := value.Type()
 	for i := range value.NumField() {
-		if value.Field(i).IsZero() {
-			t.Errorf("declared budget field %s was not populated", typeOfRow.Field(i).Name)
+		name := typeOfRow.Field(i).Name
+		want, ok := wantFields[name]
+		if !ok {
+			t.Errorf("declared budget field %s has no expectation: map it in the snapshot source and assert it here, or remove it from the view", name)
+			continue
 		}
+		if got := value.Field(i).Interface(); !reflect.DeepEqual(got, want) {
+			t.Errorf("declared budget field %s = %v, want %v", name, got, want)
+		}
+	}
+	if len(wantFields) != value.NumField() {
+		t.Errorf("expectation count %d != declared field count %d", len(wantFields), value.NumField())
 	}
 	fresh, ok := source.BudgetFreshness()
 	if !ok || fresh.ProducedAt != now || fresh.Stale {

--- a/enterprise/dashboard/snapshot_budget_source_test.go
+++ b/enterprise/dashboard/snapshot_budget_source_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -55,8 +56,12 @@ func TestSnapshotBudgetSourceMapsForwardRows(t *testing.T) {
 	if row.Agent != "agent-alpha" || !row.ForwardConfigured || row.RequestCount != 7 || row.UniqueDomainCount != 2 {
 		t.Fatalf("unexpected mapped row: %+v", row)
 	}
-	if row.DoWConfigured || row.ActiveSessions != 0 || len(row.Sessions) != 0 {
-		t.Fatalf("DoW fields should stay empty in this PR: %+v", row)
+	value := reflect.ValueOf(row)
+	typeOfRow := value.Type()
+	for i := range value.NumField() {
+		if value.Field(i).IsZero() {
+			t.Errorf("declared budget field %s was not populated", typeOfRow.Field(i).Name)
+		}
 	}
 	fresh, ok := source.BudgetFreshness()
 	if !ok || fresh.ProducedAt != now || fresh.Stale {


### PR DESCRIPTION
## What changed

The budgets view declared nine denial-of-wallet and per-session fields that no snapshot source ever populated. The interface covered forward-proxy budgets plus MCP denial-of-wallet, but the snapshot source left the DoW half empty and the snapshot rows carried only forward-budget fields, so every DoW cell rendered blank.

A blank cell is ambiguous in the worst possible direction. An operator reading it cannot tell whether the agent spent nothing or whether the number was never wired up, and those two readings call for opposite responses. This removes the unpopulated declaration so the surface matches what the runtime actually reports: the forward-proxy request, byte, domain and window budgets.

Removed the unwired fields from the interface, the template, and the pressure and redaction logic, and updated the dashboard doc to say the budget view covers forward-proxy budgets. Net 281 deletions against 60 additions, with no new executable production lines.

## Why not populate them instead

Reporting live denial-of-wallet consumption needs a new runtime provider for per-subject budget state plus matching snapshot schema fields; the current producer requests forward-budget snapshots only. That is a real feature with a cross-version fleet question attached, not a gap to paper over here. Half-building it would leave the same ambiguity in place for longer. Whether it is worth building at all is being scoped separately.

## Guarding the class

The underlying defect is not the nine fields, it is that nothing stopped a declared budget field from going unmapped. A reflection-based test now walks the declared fields and fails when one is not populated by the snapshot source, naming the offending field. A second test asserts the rendered page does not advertise denial-of-wallet.

The guard was checked against the failure it exists to catch: adding an unwired field to the view fails the test by name, and it passes once the field is either mapped or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated the Budgets view to show forward-proxy budget information only.
  - Removed MCP-related budget indicators, session details, and denial-of-wallet metrics.
  - Budget-pressure reporting now reflects request, data-transfer, and unique-domain limits.
  - Improved empty-state messaging when no agents have configured forward-proxy budgets.
  - Preserved sorting, truncation, freshness reporting, and unlimited-limit display behavior.

- **Documentation**
  - Clarified that per-agent budget-pressure counts cover forward-proxy traffic and exclude MCP counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->