### PR TITLE
ci: scan pull request diffs with a scanner built from the default branch

### DIFF
--- a/.github/workflows/trusted-diff-scan.yml
+++ b/.github/workflows/trusted-diff-scan.yml
@@ -1,0 +1,134 @@
+name: Trusted Diff Scan
+
+# Scans a pull request diff for secrets using a Pipelock built from the
+# repository's own default branch, never from a published release and never
+# from the pull request's source.
+#
+# Two problems this fixes:
+#
+#   1. Release lag. The previous gate downloaded the latest published Pipelock
+#      release, so a scanner fix on main did not reach the gate until the next
+#      release shipped. A whole-file-deletion parser fix sat on main for weeks
+#      while the released binary rejected every deletion-bearing pull request
+#      with "unverifiable input: content outside unified diff hunks", surfaced
+#      to the author as "Secrets detected in PR diff".
+#
+#   2. Self-judging. Building the scanner from the pull request head would let a
+#      pull request supply the tool that inspects it. The scanner is built from
+#      origin/main, which a pull request cannot influence.
+#
+# KNOWN REMAINING GAP, tracked separately: on a pull_request event GitHub runs
+# the workflow file from the pull request head, so a pull request can still edit
+# this file. That is unchanged from the previous gate rather than introduced
+# here. Closing it requires either pull_request_target, which release-audit
+# currently bans for this repository, or a check source a pull request workflow
+# cannot mint. Code-owner review on every pull request is the current
+# compensating control.
+#
+# SAFETY INVARIANT: the scanner must always be built from the fetched
+# origin/main tree and never from the checked-out pull request tree. Every step
+# below that touches pull request content treats it strictly as diff text.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: trusted-diff-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  trusted-diff-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      # Build from origin/main in a worktree of its own. Using a separate
+      # worktree keeps the pull request tree untouched and makes it obvious that
+      # no pull request file contributes to the binary under test.
+      - name: Build scanner from origin/main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+          main_sha=$(git rev-parse FETCH_HEAD)
+          echo "building scanner from origin/main ${main_sha}"
+          build_tree="${RUNNER_TEMP}/trusted-main"
+          git worktree add --detach "${build_tree}" "${main_sha}"
+          ( cd "${build_tree}" && go build -o "${RUNNER_TEMP}/pipelock" ./cmd/pipelock )
+          "${RUNNER_TEMP}/pipelock" --version
+
+      - name: Scan the diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          merge_base=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
+          diff_file="${RUNNER_TEMP}/pr.diff"
+          # Disable external diff drivers and textconv so repository-supplied
+          # configuration cannot run a program during diff generation.
+          git -c diff.external= -c core.attributesFile=/dev/null \
+            diff --no-textconv --no-ext-diff "${merge_base}" "${HEAD_SHA}" > "${diff_file}"
+
+          bytes=$(wc -c < "${diff_file}")
+          echo "diff bytes: ${bytes}"
+          # Refuse an enormous diff rather than scanning it partially. An
+          # unscannable diff is not a clean diff.
+          if [ "${bytes}" -gt 52428800 ]; then
+            echo "::error::diff is ${bytes} bytes, above the 50MB scan limit; refusing to report a partial result"
+            exit 1
+          fi
+
+          "${RUNNER_TEMP}/pipelock" git scan-diff \
+            --exclude internal/scanner/scanner_test.go \
+            --exclude internal/scanner/scan_env_test.go \
+            --exclude internal/scanner/text_dlp_test.go \
+            --exclude internal/scanner/validate_test.go \
+            --exclude internal/proxy/intercept_test.go \
+            --exclude internal/proxy/forward_test.go \
+            --exclude internal/proxy/adaptive_escalation_test.go \
+            --exclude internal/proxy/adaptive_coverage_test.go \
+            --exclude internal/proxy/allowlist_scoring_test.go \
+            --exclude internal/proxy/session_api.go \
+            --exclude internal/cli/session/resolver.go \
+            --exclude internal/gitprotect/diffscan_test.go \
+            --exclude internal/config/config_test.go \
+            --exclude internal/cli/test.go \
+            --exclude internal/cli/license_test.go \
+            --exclude internal/cli/support/bundle_test.go \
+            --exclude 'enterprise/licenseservice/*_test.go' \
+            --exclude 'configs/*.yaml' \
+            --exclude test/secureiqlab/ \
+            --exclude README.md \
+            --exclude assets/demo.cast \
+            --exclude scripts/pr-review.py \
+            --exclude docs/attacks-blocked.md \
+            --exclude docs/bypass-resistance.md \
+            --exclude docs/configuration.md \
+            --exclude docs/scan-api.md \
+            --exclude docs/guides/deployment-recipes.md \
+            --exclude docs/guides/tls-interception.md \
+            --exclude docs/guides/zed.md \
+            --exclude examples/demo-readme.sh \
+            --exclude examples/sample-events.jsonl \
+            --exclude examples/quickstart/ \
+            --exclude internal/contract/testdata/golden/ \
+            --exclude internal/contract/testdata/invalid/ \
+            --exclude internal/signing/testdata/golden/ \
+            --exclude internal/cli/hermes/testdata/hermes_e2e_driver.py \
+            --exclude internal/cli/hermes/hermes_e2e_test.go \
+            --exclude sdk/conformance/testdata/aarp-corpus/ \
+            < "${diff_file}"

--- a/.github/workflows/trusted-diff-scan.yml
+++ b/.github/workflows/trusted-diff-scan.yml
@@ -25,9 +25,10 @@ name: Trusted Diff Scan
 # cannot mint. Code-owner review on every pull request is the current
 # compensating control.
 #
-# SAFETY INVARIANT: the scanner must always be built from the fetched
-# origin/main tree and never from the checked-out pull request tree. Every step
-# below that touches pull request content treats it strictly as diff text.
+# DESIGN INTENT, subject to the PR-controlled-workflow gap above: the scanner is
+# built from fetched origin/main, never from the pull request tree. This does not
+# make the check immutable: Actions still executes this workflow and its helper
+# scripts from the pull request head.
 
 on:
   pull_request:
@@ -70,6 +71,9 @@ jobs:
           ( cd "${build_tree}" && go build -o "${RUNNER_TEMP}/pipelock" ./cmd/pipelock )
           "${RUNNER_TEMP}/pipelock" --version
 
+      - name: Verify raw blob diff generation
+        run: bash scripts/test-generate-trusted-diff.sh "${RUNNER_TEMP}/pipelock"
+
       - name: Scan the diff
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -78,19 +82,13 @@ jobs:
           set -euo pipefail
           merge_base=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
           diff_file="${RUNNER_TEMP}/pr.diff"
-          # Disable external diff drivers and textconv so repository-supplied
-          # configuration cannot run a program during diff generation.
-          git -c diff.external= -c core.attributesFile=/dev/null \
-            diff --no-textconv --no-ext-diff "${merge_base}" "${HEAD_SHA}" > "${diff_file}"
-
-          bytes=$(wc -c < "${diff_file}")
-          echo "diff bytes: ${bytes}"
-          # Refuse an enormous diff rather than scanning it partially. An
-          # unscannable diff is not a clean diff.
-          if [ "${bytes}" -gt 52428800 ]; then
-            echo "::error::diff is ${bytes} bytes, above the 50MB scan limit; refusing to report a partial result"
-            exit 1
-          fi
+          # Scan every changed new-side blob in full. Normal textual diffs can
+          # hide content behind repository .gitattributes or Git's NUL-byte
+          # binary heuristic. The generator rejects unscannable objects and
+          # bounds both its path inventory and output before scanner input is
+          # accepted.
+          bash scripts/generate-trusted-diff.sh \
+            "${merge_base}" "${HEAD_SHA}" "${diff_file}" 52428800
 
           "${RUNNER_TEMP}/pipelock" git scan-diff \
             --exclude internal/scanner/scanner_test.go \

--- a/.github/workflows/trusted-diff-scan.yml
+++ b/.github/workflows/trusted-diff-scan.yml
@@ -82,11 +82,10 @@ jobs:
           set -euo pipefail
           merge_base=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
           diff_file="${RUNNER_TEMP}/pr.diff"
-          # Scan every changed new-side blob in full. Normal textual diffs can
-          # hide content behind repository .gitattributes or Git's NUL-byte
-          # binary heuristic. The generator rejects unscannable objects and
-          # bounds both its path inventory and output before scanner input is
-          # accepted.
+          # Keep normal text findings scoped to added lines. Fall back to the
+          # full new-side blob when attributes or Git's binary heuristic hide
+          # the patch. The generator rejects unscannable objects and bounds its
+          # path inventory and output before scanner input is accepted.
           bash scripts/generate-trusted-diff.sh \
             "${merge_base}" "${HEAD_SHA}" "${diff_file}" 52428800
 

--- a/scripts/generate-trusted-diff.sh
+++ b/scripts/generate-trusted-diff.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+export LC_ALL=C
+
+usage() {
+	printf 'usage: %s BASE HEAD OUTPUT [MAX_BYTES]\n' "${0##*/}" >&2
+	exit 2
+}
+
+fail() {
+	printf 'ERROR: %s\n' "$*" >&2
+	exit 1
+}
+
+[[ $# -ge 3 && $# -le 4 ]] || usage
+
+base=$1
+head=$2
+output=$3
+max_bytes=${4:-52428800}
+
+[[ "$max_bytes" =~ ^[1-9][0-9]*$ ]] || fail "MAX_BYTES must be a positive integer"
+[[ "$max_bytes" -lt 9223372036854775807 ]] || fail "MAX_BYTES is too large"
+
+git rev-parse --verify --quiet "${base}^{commit}" >/dev/null || fail "base is not a commit: ${base}"
+git rev-parse --verify --quiet "${head}^{commit}" >/dev/null || fail "head is not a commit: ${head}"
+merge_base=$(git merge-base "$base" "$head") || fail "could not find a merge base"
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pipelock-trusted-diff.XXXXXX")
+trap 'rm -rf -- "$tmp_dir"' EXIT
+path_file="$tmp_dir/paths"
+draft="$tmp_dir/diff"
+blob_file="$tmp_dir/blob"
+header_file="$tmp_dir/header"
+
+# Bound the path inventory while preserving git's exit status. A repository
+# can classify content as binary through .gitattributes, but name-only output
+# still enumerates the changed object. Disabling rename detection makes every
+# new-side rename/copy destination appear independently.
+set +e
+git -c diff.external= -c core.attributesFile=/dev/null \
+	diff --no-textconv --no-ext-diff --no-renames \
+	--diff-filter=ACMRTUX --name-only -z "$merge_base" "$head" |
+	head -c "$((max_bytes + 1))" > "$path_file"
+statuses=("${PIPESTATUS[@]}")
+set -e
+
+path_bytes=$(wc -c < "$path_file")
+if [[ "${statuses[1]}" -ne 0 ]]; then
+	fail "could not bound changed-path inventory"
+fi
+if [[ "${statuses[0]}" -ne 0 ]]; then
+	if [[ "${statuses[0]}" -ne 141 || "$path_bytes" -le "$max_bytes" ]]; then
+		fail "git diff failed while enumerating changed paths (exit ${statuses[0]})"
+	fi
+fi
+if [[ "$path_bytes" -gt "$max_bytes" ]]; then
+	fail "changed-path inventory exceeds the ${max_bytes}-byte scan limit"
+fi
+
+: > "$draft"
+
+while IFS= read -r -d '' path; do
+	if [[ "$path" =~ [[:cntrl:]] ]]; then
+		fail "changed path contains a control character and cannot be represented safely"
+	fi
+
+	object="${head}:${path}"
+	object_type=$(git cat-file -t "$object") || fail "cannot read changed object: ${path}"
+	[[ "$object_type" == "blob" ]] || fail "changed path is not a scannable blob: ${path} (${object_type})"
+
+	blob_size=$(git cat-file -s "$object") || fail "cannot size changed blob: ${path}"
+	[[ "$blob_size" =~ ^[0-9]+$ ]] || fail "invalid blob size for changed path: ${path}"
+	[[ "$blob_size" -le "$max_bytes" ]] || fail "changed blob exceeds the ${max_bytes}-byte scan limit: ${path}"
+	git cat-file blob "$object" > "$blob_file" || fail "cannot materialize changed blob: ${path}"
+	actual_blob_size=$(wc -c < "$blob_file")
+	[[ "$actual_blob_size" -eq "$blob_size" ]] || fail "short read while materializing changed blob: ${path}"
+
+	line_count=$(wc -l < "$blob_file")
+	missing_newline=0
+	if [[ "$blob_size" -gt 0 ]]; then
+		last_byte=$(od -An -tu1 -j "$((blob_size - 1))" -N 1 "$blob_file" | tr -d '[:space:]')
+		if [[ "$last_byte" != "10" ]]; then
+			line_count=$((line_count + 1))
+			missing_newline=1
+		fi
+	fi
+
+	{
+		printf 'diff --git a/%s b/%s\n' "$path" "$path"
+		printf '%s\n' '--- /dev/null'
+		printf '+++ b/%s\n' "$path"
+		printf '@@ -0,0 +1,%s @@\n' "$line_count"
+	} > "$header_file"
+
+	current_bytes=$(wc -c < "$draft")
+	header_bytes=$(wc -c < "$header_file")
+	# Every source line receives a two-byte "+ " prefix. A final newline is
+	# inserted only when the blob did not have one, keeping subsequent diff
+	# headers structurally separate without dropping any source byte.
+	encoded_bytes=$((header_bytes + blob_size + (2 * line_count) + missing_newline))
+	if [[ "$current_bytes" -gt "$((max_bytes - encoded_bytes))" ]]; then
+		fail "raw changed blobs exceed the ${max_bytes}-byte scan limit"
+	fi
+
+	cat "$header_file" >> "$draft"
+	if [[ "$blob_size" -gt 0 ]]; then
+		sed 's/^/+ /' "$blob_file" >> "$draft"
+		if [[ "$missing_newline" -eq 1 ]]; then
+			printf '\n' >> "$draft"
+		fi
+	fi
+
+	actual_bytes=$(wc -c < "$draft")
+	[[ "$actual_bytes" -le "$max_bytes" ]] || fail "generated scan input exceeded its byte limit"
+done < "$path_file"
+
+mv -- "$draft" "$output"
+printf 'raw changed-blob diff bytes: %s\n' "$(wc -c < "$output")"

--- a/scripts/generate-trusted-diff.sh
+++ b/scripts/generate-trusted-diff.sh
@@ -74,6 +74,17 @@ while IFS= read -r -d '' path; do
 	object_type=$(git cat-file -t "$object") || fail "cannot read changed object: ${path}"
 	[[ "$object_type" == "blob" ]] || fail "changed path is not a scannable blob: ${path} (${object_type})"
 
+	# A mode-only change (chmod, symlink-to-regular) reports as changed while the
+	# content is byte-identical, so it produces no hunk and would otherwise fall
+	# through to the full-blob path and block on a pre-existing finding the
+	# author never touched. Identical blob IDs mean there is no new content to
+	# scan, so skip it. This is not a coverage hole: nothing was added.
+	base_blob=$(git rev-parse --quiet --verify "${merge_base}:${path}" 2>/dev/null || true)
+	head_blob=$(git rev-parse --quiet --verify "${object}" 2>/dev/null || true)
+	if [[ -n "$base_blob" && "$base_blob" == "$head_blob" ]]; then
+		continue
+	fi
+
 	# Preserve added-line scope whenever Git can produce a textual patch. This
 	# keeps pre-existing findings outside the pull request from blocking an
 	# unrelated edit. Bound each patch as it is generated so the temporary file

--- a/scripts/generate-trusted-diff.sh
+++ b/scripts/generate-trusted-diff.sh
@@ -35,6 +35,8 @@ path_file="$tmp_dir/paths"
 draft="$tmp_dir/diff"
 blob_file="$tmp_dir/blob"
 header_file="$tmp_dir/header"
+path_diff="$tmp_dir/path.diff"
+scan_diff="$tmp_dir/scan.diff"
 
 # Bound the path inventory while preserving git's exit status. A repository
 # can classify content as binary through .gitattributes, but name-only output
@@ -72,6 +74,69 @@ while IFS= read -r -d '' path; do
 	object_type=$(git cat-file -t "$object") || fail "cannot read changed object: ${path}"
 	[[ "$object_type" == "blob" ]] || fail "changed path is not a scannable blob: ${path} (${object_type})"
 
+	# Preserve added-line scope whenever Git can produce a textual patch. This
+	# keeps pre-existing findings outside the pull request from blocking an
+	# unrelated edit. Bound each patch as it is generated so the temporary file
+	# cannot grow past the remaining scan budget.
+	current_bytes=$(wc -c < "$draft")
+	remaining_bytes=$((max_bytes - current_bytes))
+	set +e
+	git -c diff.external= -c core.attributesFile=/dev/null \
+		diff --no-textconv --no-ext-diff --no-renames --unified=0 \
+		"$merge_base" "$head" -- "$path" |
+		head -c "$((remaining_bytes + 1))" > "$path_diff"
+	statuses=("${PIPESTATUS[@]}")
+	set -e
+
+	path_diff_bytes=$(wc -c < "$path_diff")
+	if [[ "${statuses[1]}" -ne 0 ]]; then
+		fail "could not bound textual diff for changed path: ${path}"
+	fi
+	if [[ "${statuses[0]}" -ne 0 ]]; then
+		if [[ "${statuses[0]}" -ne 141 || "$path_diff_bytes" -le "$remaining_bytes" ]]; then
+			fail "git diff failed for changed path: ${path} (exit ${statuses[0]})"
+		fi
+	fi
+	if [[ "$path_diff_bytes" -gt "$remaining_bytes" ]]; then
+		fail "generated scan input exceeds the ${max_bytes}-byte scan limit"
+	fi
+
+	if grep -a -q '^@@ ' "$path_diff"; then
+		# Separate added content from patch control lines with one space. Without
+		# this encoding, source beginning with "++ b/" becomes "+++ b/" and can
+		# impersonate a file header to the diff scanner.
+		set +e
+		awk '
+			/^diff --git / { in_hunk = 0 }
+			/^@@ / { in_hunk = 1 }
+			in_hunk && /^\+/ { print "+ " substr($0, 2); next }
+			{ print }
+		' "$path_diff" |
+			head -c "$((remaining_bytes + 1))" > "$scan_diff"
+		statuses=("${PIPESTATUS[@]}")
+		set -e
+
+		scan_diff_bytes=$(wc -c < "$scan_diff")
+		if [[ "${statuses[1]}" -ne 0 ]]; then
+			fail "could not bound encoded textual diff for changed path: ${path}"
+		fi
+		if [[ "${statuses[0]}" -ne 0 ]]; then
+			if [[ "${statuses[0]}" -ne 141 || "$scan_diff_bytes" -le "$remaining_bytes" ]]; then
+				fail "could not encode textual diff for changed path: ${path} (exit ${statuses[0]})"
+			fi
+		fi
+		if [[ "$scan_diff_bytes" -gt "$remaining_bytes" ]]; then
+			fail "generated scan input exceeds the ${max_bytes}-byte scan limit"
+		fi
+
+		cat "$scan_diff" >> "$draft"
+		continue
+	fi
+
+	# Git emits no usable hunks for binary-classified content and paths hidden
+	# by attributes such as -diff. Only those paths fall back to a synthetic
+	# full-blob patch, closing the binary bypass without broadening normal text
+	# changes to historical file content.
 	blob_size=$(git cat-file -s "$object") || fail "cannot size changed blob: ${path}"
 	[[ "$blob_size" =~ ^[0-9]+$ ]] || fail "invalid blob size for changed path: ${path}"
 	[[ "$blob_size" -le "$max_bytes" ]] || fail "changed blob exceeds the ${max_bytes}-byte scan limit: ${path}"
@@ -119,4 +184,4 @@ while IFS= read -r -d '' path; do
 done < "$path_file"
 
 mv -- "$draft" "$output"
-printf 'raw changed-blob diff bytes: %s\n' "$(wc -c < "$output")"
+printf 'trusted diff bytes: %s\n' "$(wc -c < "$output")"

--- a/scripts/test-generate-trusted-diff.sh
+++ b/scripts/test-generate-trusted-diff.sh
@@ -59,6 +59,33 @@ assert_scan_blocks() {
 
 token="AKIA$(printf 'A%.0s' {1..16})"
 
+existing_repo="$tmp_dir/existing-credential"
+init_repo "$existing_repo"
+printf 'docs example\n%s\n' "$token" > "$existing_repo/doc.md"
+commit_all "$existing_repo"
+printf 'one more line\n' >> "$existing_repo/doc.md"
+commit_all "$existing_repo"
+existing_base=$(git -C "$existing_repo" rev-parse HEAD^)
+existing_head=$(git -C "$existing_repo" rev-parse HEAD)
+(
+	cd "$existing_repo"
+	bash "$generator" "$existing_base" "$existing_head" "$tmp_dir/existing.diff"
+)
+"$pipelock_bin" git scan-diff < "$tmp_dir/existing.diff" > "$tmp_dir/existing.scan" 2>&1 ||
+	fail "untouched credential blocked an unrelated edit: $(< "$tmp_dir/existing.scan")"
+grep -q '^+ one more line$' "$tmp_dir/existing.diff" || fail "ordinary text diff omitted the added line"
+if grep -q "^+ .*${token}" "$tmp_dir/existing.diff"; then
+	fail "ordinary text diff included an untouched credential"
+fi
+
+text_repo="$tmp_dir/new-text-credential"
+init_repo "$text_repo"
+printf 'ordinary content\n' > "$text_repo/notes.txt"
+commit_all "$text_repo"
+printf 'credential=%s\n' "$token" >> "$text_repo/notes.txt"
+commit_all "$text_repo"
+assert_scan_blocks "$text_repo" new_text_credential
+
 attr_repo="$tmp_dir/attributes"
 init_repo "$attr_repo"
 printf 'secret.txt -diff\n' > "$attr_repo/.gitattributes"

--- a/scripts/test-generate-trusted-diff.sh
+++ b/scripts/test-generate-trusted-diff.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+[[ $# -eq 1 ]] || {
+	printf 'usage: %s PIPELOCK_BIN\n' "${0##*/}" >&2
+	exit 2
+}
+
+pipelock_bin=$1
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+generator="$script_dir/generate-trusted-diff.sh"
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pipelock-trusted-diff-test.XXXXXX")
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	exit 1
+}
+
+init_repo() {
+	local repo=$1
+	mkdir -p "$repo"
+	git -C "$repo" init -q
+	git -C "$repo" config user.name test
+	git -C "$repo" config user.email test@example.com
+	printf 'baseline\n' > "$repo/README.md"
+	git -C "$repo" add README.md
+	git -C "$repo" commit -qm base
+}
+
+commit_all() {
+	local repo=$1
+	git -C "$repo" add -A
+	git -C "$repo" commit -qm change
+}
+
+assert_scan_blocks() {
+	local repo=$1
+	local label=$2
+	local base head diff_file scan_output status
+	base=$(git -C "$repo" rev-parse HEAD^)
+	head=$(git -C "$repo" rev-parse HEAD)
+	diff_file="$tmp_dir/${label}.diff"
+	scan_output="$tmp_dir/${label}.scan"
+	(
+		cd "$repo"
+		bash "$generator" "$base" "$head" "$diff_file"
+	)
+	set +e
+	"$pipelock_bin" git scan-diff < "$diff_file" > "$scan_output" 2>&1
+	status=$?
+	set -e
+	[[ "$status" -eq 1 ]] || fail "$label: expected secret scan exit 1, got $status: $(< "$scan_output")"
+	grep -q 'AWS Access ID' "$scan_output" || fail "$label: scanner did not report the synthetic credential"
+}
+
+token="AKIA$(printf 'A%.0s' {1..16})"
+
+attr_repo="$tmp_dir/attributes"
+init_repo "$attr_repo"
+printf 'secret.txt -diff\n' > "$attr_repo/.gitattributes"
+printf 'credential=%s\n' "$token" > "$attr_repo/secret.txt"
+commit_all "$attr_repo"
+assert_scan_blocks "$attr_repo" attributes_binary_override
+
+nul_repo="$tmp_dir/nul"
+init_repo "$nul_repo"
+printf 'prefix\0credential=%s\nsuffix\n' "$token" > "$nul_repo/payload.bin"
+commit_all "$nul_repo"
+assert_scan_blocks "$nul_repo" nul_blob
+
+header_repo="$tmp_dir/header-shaped-content"
+init_repo "$header_repo"
+printf '++ b/credential=%s\n' "$token" > "$header_repo/header-shaped.txt"
+commit_all "$header_repo"
+assert_scan_blocks "$header_repo" header_shaped_content
+
+clean_repo="$tmp_dir/clean"
+init_repo "$clean_repo"
+printf 'ordinary content\n' > "$clean_repo/clean.txt"
+commit_all "$clean_repo"
+clean_base=$(git -C "$clean_repo" rev-parse HEAD^)
+clean_head=$(git -C "$clean_repo" rev-parse HEAD)
+(
+	cd "$clean_repo"
+	bash "$generator" "$clean_base" "$clean_head" "$tmp_dir/clean.diff"
+)
+"$pipelock_bin" git scan-diff < "$tmp_dir/clean.diff" > "$tmp_dir/clean.scan" 2>&1 ||
+	fail "clean blob did not scan cleanly: $(< "$tmp_dir/clean.scan")"
+clean_hash=$(sha256sum "$tmp_dir/clean.diff" | cut -d ' ' -f 1)
+(
+	cd "$clean_repo"
+	bash "$generator" "$clean_base" "$clean_head" "$tmp_dir/clean.diff"
+)
+rerun_hash=$(sha256sum "$tmp_dir/clean.diff" | cut -d ' ' -f 1)
+[[ "$rerun_hash" == "$clean_hash" ]] || fail "rerun did not replace output deterministically"
+
+delete_repo="$tmp_dir/delete-only"
+init_repo "$delete_repo"
+git -C "$delete_repo" rm -q README.md
+git -C "$delete_repo" commit -qm delete
+delete_base=$(git -C "$delete_repo" rev-parse HEAD^)
+delete_head=$(git -C "$delete_repo" rev-parse HEAD)
+(
+	cd "$delete_repo"
+	bash "$generator" "$delete_base" "$delete_head" "$tmp_dir/delete.diff"
+)
+"$pipelock_bin" git scan-diff < "$tmp_dir/delete.diff" > "$tmp_dir/delete.scan" 2>&1 ||
+	fail "deletion-only change did not scan cleanly: $(< "$tmp_dir/delete.scan")"
+[[ ! -s "$tmp_dir/delete.diff" ]] || fail "deletion-only change emitted new-side content"
+
+set +e
+(
+	cd "$clean_repo"
+	bash "$generator" "$clean_base" "$clean_head" "$tmp_dir/oversized.diff" 64
+) > "$tmp_dir/oversized.out" 2>&1
+oversized_status=$?
+set -e
+[[ "$oversized_status" -ne 0 ]] || fail "oversized blob was not rejected"
+grep -q 'scan limit' "$tmp_dir/oversized.out" || fail "oversized rejection did not explain the scan limit"
+
+gitlink_repo="$tmp_dir/gitlink"
+init_repo "$gitlink_repo"
+gitlink_target=$(git -C "$gitlink_repo" rev-parse HEAD)
+git -C "$gitlink_repo" update-index --add --cacheinfo "160000,$gitlink_target,vendor/submodule"
+git -C "$gitlink_repo" commit -qm gitlink
+gitlink_base=$(git -C "$gitlink_repo" rev-parse HEAD^)
+gitlink_head=$(git -C "$gitlink_repo" rev-parse HEAD)
+set +e
+(
+	cd "$gitlink_repo"
+	bash "$generator" "$gitlink_base" "$gitlink_head" "$tmp_dir/gitlink.diff"
+) > "$tmp_dir/gitlink.out" 2>&1
+gitlink_status=$?
+set -e
+[[ "$gitlink_status" -ne 0 ]] || fail "unscannable gitlink was not rejected"
+grep -q 'not a scannable blob' "$tmp_dir/gitlink.out" || fail "gitlink rejection did not identify the unscannable object"
+
+control_repo="$tmp_dir/control-path"
+init_repo "$control_repo"
+control_path=$'unsafe\nname.txt'
+printf 'ordinary content\n' > "$control_repo/$control_path"
+commit_all "$control_repo"
+control_base=$(git -C "$control_repo" rev-parse HEAD^)
+control_head=$(git -C "$control_repo" rev-parse HEAD)
+set +e
+(
+	cd "$control_repo"
+	bash "$generator" "$control_base" "$control_head" "$tmp_dir/control.diff"
+) > "$tmp_dir/control.out" 2>&1
+control_status=$?
+set -e
+[[ "$control_status" -ne 0 ]] || fail "unrepresentable control-character path was not rejected"
+grep -q 'control character' "$tmp_dir/control.out" || fail "control-character rejection was not explicit"
+
+printf 'trusted diff generator tests: PASS\n'

--- a/scripts/test-generate-trusted-diff.sh
+++ b/scripts/test-generate-trusted-diff.sh
@@ -183,4 +183,29 @@ set -e
 [[ "$control_status" -ne 0 ]] || fail "unrepresentable control-character path was not rejected"
 grep -q 'control character' "$tmp_dir/control.out" || fail "control-character rejection was not explicit"
 
+# A mode-only change reports as changed while the content is byte-identical.
+# It must scan nothing: there is no new content, and falling through to the
+# full-blob path would block the author on a pre-existing finding they never
+# touched. Pinned because that is exactly the availability regression this
+# generator was narrowed to avoid.
+mode_repo="$tmp_dir/mode-only"
+init_repo "$mode_repo"
+# Assemble the specimen at runtime so this test file does not itself carry a
+# scannable credential literal, matching the repository convention for fake
+# credentials in tests.
+mode_specimen="AKIA""IOSFODNN7EXAMPLE"
+printf '#!/bin/sh\n%s\n' "$mode_specimen" > "$mode_repo/script.sh"
+commit_all "$mode_repo"
+chmod +x "$mode_repo/script.sh"
+commit_all "$mode_repo"
+mode_base=$(git -C "$mode_repo" rev-parse HEAD^)
+mode_head=$(git -C "$mode_repo" rev-parse HEAD)
+(
+	cd "$mode_repo"
+	bash "$generator" "$mode_base" "$mode_head" "$tmp_dir/mode.diff"
+) > /dev/null 2>&1 || fail "mode-only change was rejected"
+if [[ -s "$tmp_dir/mode.diff" ]]; then
+	fail "mode-only change produced scan input; a pre-existing finding would block it"
+fi
+
 printf 'trusted diff generator tests: PASS\n'


### PR DESCRIPTION
Adds a non-blocking scan job. Nothing is removed and no required check changes, so this can land and be observed before anything depends on it.

## The problem

The existing `security-scan` job installs the latest published Pipelock release and scans the pull request diff with it. That means the scanner gating this repository is the last released build, not the current one, so a scanner fix on the default branch does not reach the gate until the next release ships.

That is live today. Whole-file-deletion hunk parsing was fixed in #1145, which is on the default branch and not in v3.3.0. The released binary therefore rejects any pull request that deletes a file, and the surfaced message is `Secrets detected in PR diff` when no secret was found. Because `lint` and `test` depend on `security-scan`, one deletion skips most of the pipeline. #1214 is blocked on exactly this and contains no secret.

The deletion parser is one instance. The general shape is that a tool which gates its own repository from a published artifact is permanently behind its own bug fixes, and the next such bug may be a missed detection rather than a visible false alarm.

## What this adds

A separate job that builds the scanner from `origin/main` in its own worktree and scans the diff between the merge base and the pull request head. Building from the default branch rather than the pull request head matters: a scanner built from the branch under review would be supplied by the code it is judging.

External diff drivers and textconv are disabled during diff generation so repository-supplied configuration cannot execute a program, an oversized diff is refused rather than partially scanned, and the exclusion list is carried over unchanged so results are directly comparable against the existing job.

## Verified

Simulated against the currently blocked pull request: merge base resolved, a 21760 byte diff generated the same way the job does, scanned with a binary built from the default branch, result `No secrets found in diff` and exit 0. The same diff scanned with the released binary fails with the parser error.

`make release-audit` passes.

## What this does not fix

On a `pull_request` event GitHub runs the workflow file from the pull request head, so a pull request can still edit this workflow. That is unchanged from the existing job rather than introduced here, and code-owner review applies to every pull request. Closing it needs either `pull_request_target`, which `release-audit` currently bans for this repository, or a check identity a pull request workflow cannot mint. That is a separate decision and is deliberately not made here.

## Suggested sequence

Land this non-blocking and watch it agree with the existing job across a few pull requests. Only then consider retiring the release-based job and moving the required status, since that step changes what can merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request security scanning that reviews only proposed changes.
  * Scans run in isolated, time-limited, and size-limited environments for improved safety and reliability.
  * Restricted permissions and controlled diff handling help reduce exposure during scanning.
  * Supports reliable detection across text, binary, renamed, deleted, and attribute-modified files.
  * Reports safely when changes exceed supported limits or contain unsupported content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->