### PR TITLE
ci: drop scan exclusions that no longer suppress anything

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,19 +39,9 @@ jobs:
             internal/scanner/text_dlp_test.go
             internal/scanner/validate_test.go
             internal/proxy/intercept_test.go
-            internal/proxy/forward_test.go
-            internal/proxy/adaptive_escalation_test.go
-            internal/proxy/adaptive_coverage_test.go
-            internal/proxy/allowlist_scoring_test.go
             internal/proxy/session_api.go
-            internal/cli/session/resolver.go
-            internal/gitprotect/diffscan_test.go
-            internal/config/config_test.go
-            internal/cli/test.go
-            internal/cli/license_test.go
             internal/cli/support/bundle_test.go
             enterprise/licenseservice/*_test.go
-            configs/*.yaml
             test/secureiqlab/
             README.md
             assets/demo.cast
@@ -64,13 +54,6 @@ jobs:
             docs/guides/tls-interception.md
             docs/guides/zed.md
             examples/demo-readme.sh
-            examples/sample-events.jsonl
-            examples/quickstart/
-            internal/contract/testdata/golden/
-            internal/contract/testdata/invalid/
-            internal/signing/testdata/golden/
-            internal/cli/hermes/testdata/hermes_e2e_driver.py
-            internal/cli/hermes/hermes_e2e_test.go
             sdk/conformance/testdata/aarp-corpus/
 
   test-oss:


### PR DESCRIPTION
## What changed

Removes 17 entries from the diff-scan exclusion list. Nothing else changes: no scanner behavior, no workflow structure, no other job.

## Why these 17

The exclusion list exists for a real reason. A security product's documentation and fixtures necessarily contain specimen credentials, so scanning them as if they were live secrets produces noise. Several entries genuinely earn their place.

These 17 do not. Each was copied into a scratch repository, committed as newly added content, and scanned with a Pipelock built from the current default branch. Across all of them, 45 files and 36038 inserted lines produced zero findings. They suppress nothing, so all they do now is guarantee that a secret introduced in one of those paths would go unscanned.

Removed:

- `configs/*.yaml`
- `examples/quickstart/`
- `examples/sample-events.jsonl`
- `internal/cli/hermes/hermes_e2e_test.go`
- `internal/cli/hermes/testdata/hermes_e2e_driver.py`
- `internal/cli/license_test.go`
- `internal/cli/session/resolver.go`
- `internal/cli/test.go`
- `internal/config/config_test.go`
- `internal/contract/testdata/golden/`
- `internal/contract/testdata/invalid/`
- `internal/gitprotect/diffscan_test.go`
- `internal/proxy/adaptive_coverage_test.go`
- `internal/proxy/adaptive_escalation_test.go`
- `internal/proxy/allowlist_scoring_test.go`
- `internal/proxy/forward_test.go`
- `internal/signing/testdata/golden/`

## What deliberately stays

The remaining entries still suppress live findings, so removing them would turn the gate red on documentation and fixtures that are doing nothing wrong. `README.md`, `docs/attacks-blocked.md`, `docs/configuration.md` and `scripts/pr-review.py` are examples: they carry documented specimen keys, connection-string pattern tables, and credential-in-URL shapes by design.

A narrower mechanism would let several of those come off the list too. `README.md` already uses the official AWS documentation example key, and the scanner already knows to forgive that value in its response-scanning path, but the diff-scanning path has no equivalent awareness. Giving the diff path a fixed allowlist of published specimen credentials, matched whole-token with no surrounding-context requirement, would let those entries be removed on evidence rather than kept by default. That is a separate change and is not attempted here.

## Verification

`make release-audit` passes. The scan of all 17 candidate paths as added content is reproducible: copy each into an empty repository, commit, and pipe `git diff` into `pipelock git scan-diff` built from the default branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded security scanning coverage by removing unnecessary path exclusions.
  * Retained exclusions for designated session, bundle test, and enterprise license-service test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->