### PR TITLE
fix(ci): handle trusted scan push events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,10 +66,23 @@ jobs:
 
       - name: Scan the diff
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          zero_sha=0000000000000000000000000000000000000000
+          if [[ -z "${BASE_SHA}" || -z "${HEAD_SHA}" || "${BASE_SHA}" == "${zero_sha}" || "${HEAD_SHA}" == "${zero_sha}" ]]; then
+            echo "refusing to scan an empty or all-zero diff endpoint" >&2
+            exit 1
+          fi
+          git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null || {
+            echo "refusing to scan: base is not an available commit: ${BASE_SHA}" >&2
+            exit 1
+          }
+          git rev-parse --verify --quiet "${HEAD_SHA}^{commit}" >/dev/null || {
+            echo "refusing to scan: head is not an available commit: ${HEAD_SHA}" >&2
+            exit 1
+          }
           merge_base=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
           diff_file="${RUNNER_TEMP}/pr.diff"
           # Added-line scope for normal text, full new-side blob only where

--- a/internal/gitprotect/trusted_scan_contract_test.go
+++ b/internal/gitprotect/trusted_scan_contract_test.go
@@ -6,6 +6,7 @@ package gitprotect
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -52,55 +53,125 @@ func TestTrustedScanSelectsDiffEndpointsForEveryTrigger(t *testing.T) {
 	}
 
 	step := steps[0]
+	if strings.TrimSpace(step.If) != "" {
+		t.Fatalf("scan step is conditional (if: %q); the endpoint gate must run for every job invocation", step.If)
+	}
+	if got, want := step.Env["BASE_SHA"], "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}"; got != want {
+		t.Fatalf("BASE_SHA expression = %q, want %q", got, want)
+	}
+	if got, want := step.Env["HEAD_SHA"], "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"; got != want {
+		t.Fatalf("HEAD_SHA expression = %q, want %q", got, want)
+	}
+	for _, exactGuard := range []string{
+		`if [[ -z "${BASE_SHA}" || -z "${HEAD_SHA}" || "${BASE_SHA}" == "${zero_sha}" || "${HEAD_SHA}" == "${zero_sha}" ]]; then`,
+		`git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null || {`,
+		`git rev-parse --verify --quiet "${HEAD_SHA}^{commit}" >/dev/null || {`,
+	} {
+		if !strings.Contains(step.Run, exactGuard) {
+			t.Fatalf("scan step lacks exact fail-closed endpoint guard %q", exactGuard)
+		}
+	}
+
+	repo, runnerTemp, baseSHA, headSHA := trustedScanTestRepo(t)
+	scanScriptPath := filepath.Join(runnerTemp, "scan-step.sh")
+	if err := os.WriteFile(scanScriptPath, []byte(step.Run), 0o600); err != nil {
+		t.Fatalf("write scan-step fixture: %v", err)
+	}
+	zeroSHA := strings.Repeat("0", 40)
 	for _, tc := range []struct {
-		name     string
-		value    string
-		required []string
+		name             string
+		baseSHA          string
+		headSHA          string
+		wantPass         bool
+		wantRanGenerator bool
+		wantRanScan      bool
 	}{
-		{
-			name:  "base",
-			value: step.Env["BASE_SHA"],
-			required: []string{
-				"github.event_name == 'pull_request'",
-				"github.event.pull_request.base.sha",
-				"github.event.before",
-			},
-		},
-		{
-			name:  "head",
-			value: step.Env["HEAD_SHA"],
-			required: []string{
-				"github.event_name == 'pull_request'",
-				"github.event.pull_request.head.sha",
-				"github.sha",
-			},
-		},
+		{name: "valid endpoints", baseSHA: baseSHA, headSHA: headSHA, wantPass: true, wantRanGenerator: true, wantRanScan: true},
+		{name: "empty base", baseSHA: "", headSHA: headSHA},
+		{name: "empty head", baseSHA: baseSHA, headSHA: ""},
+		{name: "zero base", baseSHA: zeroSHA, headSHA: headSHA},
+		{name: "zero head", baseSHA: baseSHA, headSHA: zeroSHA},
+		{name: "unavailable base", baseSHA: strings.Repeat("a", 40), headSHA: headSHA},
+		{name: "unavailable head", baseSHA: baseSHA, headSHA: strings.Repeat("b", 40)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if strings.TrimSpace(tc.value) == "" {
-				t.Fatalf("%s SHA expression is empty", tc.name)
+			for _, marker := range []string{"generator-ran", "scanner-ran", "pr.diff"} {
+				_ = os.Remove(filepath.Join(runnerTemp, marker))
 			}
-			for _, required := range tc.required {
-				if !strings.Contains(tc.value, required) {
-					t.Errorf("%s SHA expression %q does not select %q", tc.name, tc.value, required)
-				}
+			// #nosec G204 -- the script path names this test's temporary copy of the checked-in workflow step.
+			cmd := exec.CommandContext(t.Context(), "bash", scanScriptPath)
+			cmd.Dir = repo
+			cmd.Env = append(os.Environ(), "RUNNER_TEMP="+runnerTemp, "BASE_SHA="+tc.baseSHA, "HEAD_SHA="+tc.headSHA)
+			output, err := cmd.CombinedOutput()
+			if tc.wantPass && err != nil {
+				t.Fatalf("scan step rejected valid endpoints: %v\n%s", err, output)
+			}
+			if !tc.wantPass && err == nil {
+				t.Fatalf("scan step accepted invalid endpoints; output:\n%s", output)
+			}
+			_, generatorErr := os.Stat(filepath.Join(runnerTemp, "generator-ran"))
+			if got := generatorErr == nil; got != tc.wantRanGenerator {
+				t.Fatalf("generator execution = %t, want %t; output:\n%s", got, tc.wantRanGenerator, output)
+			}
+			_, scanErr := os.Stat(filepath.Join(runnerTemp, "scanner-ran"))
+			if got := scanErr == nil; got != tc.wantRanScan {
+				t.Fatalf("scanner execution = %t, want %t; output:\n%s", got, tc.wantRanScan, output)
 			}
 		})
 	}
+}
 
-	for _, required := range []string{
-		`-z "${BASE_SHA}"`,
-		`-z "${HEAD_SHA}"`,
-		`"${BASE_SHA}" == "${zero_sha}"`,
-		`"${HEAD_SHA}" == "${zero_sha}"`,
-		`git rev-parse --verify --quiet "${BASE_SHA}^{commit}"`,
-		`git rev-parse --verify --quiet "${HEAD_SHA}^{commit}"`,
-	} {
-		if !strings.Contains(step.Run, required) {
-			t.Errorf("scan step lacks fail-closed endpoint guard %q", required)
-		}
+func trustedScanTestRepo(t *testing.T) (repo, runnerTemp, baseSHA, headSHA string) {
+	t.Helper()
+	repo = t.TempDir()
+	runnerTemp = t.TempDir()
+	runTrustedScanGitCommand(t, repo, "init", "--quiet")
+	runTrustedScanGitCommand(t, repo, "config", "user.email", "test@example.invalid")
+	runTrustedScanGitCommand(t, repo, "config", "user.name", "Pipelock Test")
+	tracked := filepath.Join(repo, "tracked.txt")
+	if err := os.WriteFile(tracked, []byte("base\n"), 0o600); err != nil {
+		t.Fatalf("write base fixture: %v", err)
 	}
+	runTrustedScanGitCommand(t, repo, "add", "tracked.txt")
+	runTrustedScanGitCommand(t, repo, "commit", "--quiet", "-m", "base")
+	baseSHA = strings.TrimSpace(runTrustedScanGitCommand(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(tracked, []byte("head\n"), 0o600); err != nil {
+		t.Fatalf("write head fixture: %v", err)
+	}
+	runTrustedScanGitCommand(t, repo, "add", "tracked.txt")
+	runTrustedScanGitCommand(t, repo, "commit", "--quiet", "-m", "head")
+	headSHA = strings.TrimSpace(runTrustedScanGitCommand(t, repo, "rev-parse", "HEAD"))
+
+	scriptDir := filepath.Join(runnerTemp, "trusted-main", "scripts")
+	if err := os.MkdirAll(scriptDir, 0o750); err != nil {
+		t.Fatalf("create trusted script directory: %v", err)
+	}
+	generator := "#!/usr/bin/env bash\nset -euo pipefail\ntouch \"${RUNNER_TEMP}/generator-ran\"\ngit diff --binary \"$1\" \"$2\" > \"$3\"\n"
+	if err := os.WriteFile(filepath.Join(scriptDir, "generate-trusted-diff.sh"), []byte(generator), 0o600); err != nil {
+		t.Fatalf("write fake diff generator: %v", err)
+	}
+	scanner := "#!/usr/bin/env bash\nset -euo pipefail\ncat >/dev/null\ntouch \"${RUNNER_TEMP}/scanner-ran\"\n"
+	scannerPath := filepath.Join(runnerTemp, "pipelock")
+	if err := os.WriteFile(scannerPath, []byte(scanner), 0o600); err != nil {
+		t.Fatalf("write fake scanner: %v", err)
+	}
+	// #nosec G302 -- this temporary test fixture must be executable as the workflow scanner binary.
+	if err := os.Chmod(scannerPath, 0o700); err != nil {
+		t.Fatalf("make fake scanner executable: %v", err)
+	}
+	return repo, runnerTemp, baseSHA, headSHA
+}
+
+func runTrustedScanGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	// #nosec G204 -- arguments are fixed Git fixture commands supplied by this test.
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
 }
 
 type workflowJob struct {

--- a/internal/gitprotect/trusted_scan_contract_test.go
+++ b/internal/gitprotect/trusted_scan_contract_test.go
@@ -23,13 +23,84 @@ import (
 // nothing. Match on what runs, reached through the parsed job.
 
 type workflowStep struct {
-	Name string `yaml:"name"`
-	Uses string `yaml:"uses"`
-	If   string `yaml:"if"`
-	Run  string `yaml:"run"`
+	Name string            `yaml:"name"`
+	Uses string            `yaml:"uses"`
+	If   string            `yaml:"if"`
+	Run  string            `yaml:"run"`
+	Env  map[string]string `yaml:"env"`
 	// ContinueOnError is any-typed because YAML admits several shapes here:
 	// omitted, null, blank, a bool, or a `${{ }}` expression string.
 	ContinueOnError any `yaml:"continue-on-error"`
+}
+
+// TestTrustedScanSelectsDiffEndpointsForEveryTrigger pins both event shapes
+// accepted by the workflow. Pull-request-only fields are empty on a push, so
+// using them unconditionally makes the main-branch gate fail before scanning.
+// The explicit endpoint guards also keep an absent, zero, or unavailable ref
+// from degrading into an empty or ambiguous scan.
+func TestTrustedScanSelectsDiffEndpointsForEveryTrigger(t *testing.T) {
+	t.Parallel()
+
+	var steps []workflowStep
+	for _, step := range runStepsContaining(securityScanSteps(t), "generate-trusted-diff.sh") {
+		if step.Name == "Scan the diff" {
+			steps = append(steps, step)
+		}
+	}
+	if len(steps) != 1 {
+		t.Fatalf("got %d unconditional diff-generation steps, want exactly 1", len(steps))
+	}
+
+	step := steps[0]
+	for _, tc := range []struct {
+		name     string
+		value    string
+		required []string
+	}{
+		{
+			name:  "base",
+			value: step.Env["BASE_SHA"],
+			required: []string{
+				"github.event_name == 'pull_request'",
+				"github.event.pull_request.base.sha",
+				"github.event.before",
+			},
+		},
+		{
+			name:  "head",
+			value: step.Env["HEAD_SHA"],
+			required: []string{
+				"github.event_name == 'pull_request'",
+				"github.event.pull_request.head.sha",
+				"github.sha",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if strings.TrimSpace(tc.value) == "" {
+				t.Fatalf("%s SHA expression is empty", tc.name)
+			}
+			for _, required := range tc.required {
+				if !strings.Contains(tc.value, required) {
+					t.Errorf("%s SHA expression %q does not select %q", tc.name, tc.value, required)
+				}
+			}
+		})
+	}
+
+	for _, required := range []string{
+		`-z "${BASE_SHA}"`,
+		`-z "${HEAD_SHA}"`,
+		`"${BASE_SHA}" == "${zero_sha}"`,
+		`"${HEAD_SHA}" == "${zero_sha}"`,
+		`git rev-parse --verify --quiet "${BASE_SHA}^{commit}"`,
+		`git rev-parse --verify --quiet "${HEAD_SHA}^{commit}"`,
+	} {
+		if !strings.Contains(step.Run, required) {
+			t.Errorf("scan step lacks fail-closed endpoint guard %q", required)
+		}
+	}
 }
 
 type workflowJob struct {


### PR DESCRIPTION
The trusted scan now selects diff endpoints for both `pull_request` and `push` workflows. It uses PR base/head SHAs for pull requests and `event.before`/`github.sha` for main pushes.

It also fails closed when either endpoint is empty, all zeros, or cannot be resolved as a commit. Contract coverage pins both trigger shapes and the endpoint guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Security scans now run consistently for both pull requests and pushes.
  * Scans fail safely when commit references are missing, invalid, empty, or unavailable.
  * Diff generation now uses the appropriate source and target commits for each event type.
  * Improved scan reliability by validating commit availability before scanning changes.

* **Tests**
  * Added coverage to verify trusted diff selection and fail-closed behavior across supported triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->