### PR TITLE
feat(authority): add unwired external reference verifier

### DIFF
--- a/internal/authority/local.go
+++ b/internal/authority/local.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package authority
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+)
+
+const (
+	localReferencePrefix = "plauth1"
+	localSchemaVersion   = 1
+	maxReferenceBytes    = 16 << 10
+)
+
+var errMalformedReference = errors.New("malformed local authority reference")
+
+// LocalConfig configures an in-process reference verifier. TrustedIssuers and
+// RevokedReferences are copied by NewLocalVerifier. Clock is optional and is
+// intended for deterministic verification and conformance tests.
+type LocalConfig struct {
+	TrustedIssuers    map[string]ed25519.PublicKey
+	RevokedReferences map[string]struct{}
+	Clock             func() time.Time
+}
+
+// LocalVerifier verifies compact Ed25519 references against an in-memory key
+// set. It performs no I/O and is not wired into a production request path.
+type LocalVerifier struct {
+	trustedIssuers    map[string]ed25519.PublicKey
+	revokedReferences map[string]struct{}
+	now               func() time.Time
+}
+
+// NewLocalVerifier constructs an in-process verifier and defensively copies its
+// key and revocation inputs.
+func NewLocalVerifier(config LocalConfig) (*LocalVerifier, error) {
+	if len(config.TrustedIssuers) == 0 {
+		return nil, errors.New("authority: at least one trusted issuer is required")
+	}
+
+	trustedIssuers := make(map[string]ed25519.PublicKey, len(config.TrustedIssuers))
+	for issuer, publicKey := range config.TrustedIssuers {
+		if strings.TrimSpace(issuer) == "" {
+			return nil, errors.New("authority: trusted issuer name is required")
+		}
+		if len(publicKey) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("authority: issuer %q public key length=%d, want %d", issuer, len(publicKey), ed25519.PublicKeySize)
+		}
+		trustedIssuers[issuer] = append(ed25519.PublicKey(nil), publicKey...)
+	}
+
+	revokedReferences := make(map[string]struct{}, len(config.RevokedReferences))
+	for reference := range config.RevokedReferences {
+		if strings.TrimSpace(reference) == "" {
+			return nil, errors.New("authority: revoked reference name is required")
+		}
+		revokedReferences[reference] = struct{}{}
+	}
+
+	now := config.Clock
+	if now == nil {
+		now = time.Now
+	}
+	return &LocalVerifier{
+		trustedIssuers:    trustedIssuers,
+		revokedReferences: revokedReferences,
+		now:               now,
+	}, nil
+}
+
+// Verify checks a compact local reference without performing network or file
+// I/O. Request fields are compared byte-for-byte; their canonical construction
+// and equality rules remain outside this slice.
+func (v *LocalVerifier) Verify(ctx context.Context, request Request) Result {
+	if result, done := contextResult(ctx); done {
+		return result
+	}
+
+	parsed, err := parseLocalReference(request.AuthorityRef)
+	if err != nil {
+		return Result{Decision: DecisionDeny, Reason: ReasonMalformedReference}
+	}
+	publicKey, trusted := v.trustedIssuers[parsed.payload.Issuer]
+	if !trusted {
+		return Result{Decision: DecisionDeny, Reason: ReasonUntrustedIssuer}
+	}
+	if !ed25519.Verify(publicKey, parsed.signingInput, parsed.signature) {
+		return Result{Decision: DecisionDeny, Reason: ReasonInvalidSignature}
+	}
+
+	expiresAt, err := validateGrant(parsed.payload)
+	if err != nil {
+		return Result{Decision: DecisionDeny, Reason: ReasonMalformedReference}
+	}
+	verified := Result{
+		Decision:  DecisionDeny,
+		Issuer:    parsed.payload.Issuer,
+		Reference: parsed.payload.Reference,
+		ExpiresAt: expiresAt,
+	}
+
+	if result, done := contextResult(ctx); done {
+		return result
+	}
+	if _, revoked := v.revokedReferences[parsed.payload.Reference]; revoked {
+		verified.Reason = ReasonRevoked
+		return verified
+	}
+	if !v.now().Before(expiresAt) {
+		verified.Reason = ReasonExpired
+		return verified
+	}
+	if request.Actor != parsed.payload.Actor {
+		verified.Reason = ReasonActorMismatch
+		return verified
+	}
+	if request.Action != parsed.payload.Action {
+		verified.Reason = ReasonActionMismatch
+		return verified
+	}
+	if request.Destination != parsed.payload.Destination {
+		verified.Reason = ReasonDestinationMismatch
+		return verified
+	}
+
+	verified.Decision = DecisionAllow
+	verified.Reason = ReasonMatched
+	return verified
+}
+
+type localGrant struct {
+	SchemaVersion int    `json:"schema_version"`
+	Issuer        string `json:"issuer"`
+	Reference     string `json:"reference"`
+	Actor         string `json:"actor"`
+	Action        string `json:"action"`
+	Destination   string `json:"destination"`
+	ExpiresAt     string `json:"expires_at"`
+}
+
+type parsedReference struct {
+	payload      localGrant
+	signingInput []byte
+	signature    []byte
+}
+
+func parseLocalReference(reference string) (parsedReference, error) {
+	if len(reference) == 0 || len(reference) > maxReferenceBytes {
+		return parsedReference{}, errMalformedReference
+	}
+	parts := strings.Split(reference, ".")
+	if len(parts) != 3 || parts[0] != localReferencePrefix || parts[1] == "" || parts[2] == "" {
+		return parsedReference{}, errMalformedReference
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || len(payloadBytes) == 0 {
+		return parsedReference{}, errMalformedReference
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return parsedReference{}, errMalformedReference
+	}
+	if err := jsonscan.RejectDuplicateKeys(payloadBytes); err != nil {
+		return parsedReference{}, errMalformedReference
+	}
+
+	var payload localGrant
+	decoder := json.NewDecoder(bytes.NewReader(payloadBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return parsedReference{}, errMalformedReference
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		return parsedReference{}, errMalformedReference
+	}
+	canonical, err := json.Marshal(payload)
+	if err != nil || !bytes.Equal(canonical, payloadBytes) {
+		return parsedReference{}, errMalformedReference
+	}
+
+	return parsedReference{
+		payload:      payload,
+		signingInput: []byte(localReferencePrefix + "." + parts[1]),
+		signature:    signature,
+	}, nil
+}
+
+func validateGrant(grant localGrant) (time.Time, error) {
+	if grant.SchemaVersion != localSchemaVersion ||
+		strings.TrimSpace(grant.Issuer) == "" ||
+		strings.TrimSpace(grant.Reference) == "" ||
+		grant.Actor == "" || grant.Action == "" || grant.Destination == "" || grant.ExpiresAt == "" {
+		return time.Time{}, errMalformedReference
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, grant.ExpiresAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: expiry: %w", errMalformedReference, err)
+	}
+	return expiresAt, nil
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func contextResult(ctx context.Context) (Result, bool) {
+	if err := ctx.Err(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return Result{Decision: DecisionIndeterminate, Reason: ReasonTimeout}, true
+		}
+		return Result{Decision: DecisionIndeterminate, Reason: ReasonCanceled}, true
+	}
+	return Result{}, false
+}

--- a/internal/authority/local_test.go
+++ b/internal/authority/local_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package authority
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type conformanceFixture struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Now           string              `json:"now"`
+	Issuer        string              `json:"issuer"`
+	PublicKey     string              `json:"public_key"`
+	Revoked       []string            `json:"revoked_references"`
+	Vectors       []conformanceVector `json:"vectors"`
+}
+
+type conformanceVector struct {
+	Name         string   `json:"name"`
+	Request      Request  `json:"request"`
+	Context      string   `json:"context"`
+	WantDecision Decision `json:"want_decision"`
+	WantReason   Reason   `json:"want_reason"`
+}
+
+func TestLocalVerifierConformanceVectors(t *testing.T) {
+	t.Parallel()
+	fixture := loadConformanceFixture(t)
+	now := mustParseTime(t, fixture.Now)
+	publicKey := mustDecodePublicKey(t, fixture.PublicKey)
+	revoked := make(map[string]struct{}, len(fixture.Revoked))
+	for _, reference := range fixture.Revoked {
+		revoked[reference] = struct{}{}
+	}
+	verifier, err := NewLocalVerifier(LocalConfig{
+		TrustedIssuers:    map[string]ed25519.PublicKey{fixture.Issuer: publicKey},
+		RevokedReferences: revoked,
+		Clock:             func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("new verifier: %v", err)
+	}
+
+	if len(fixture.Vectors) < 6 {
+		t.Fatalf("conformance vector count=%d, want at least 6", len(fixture.Vectors))
+	}
+	for _, vector := range fixture.Vectors {
+		vector := vector
+		t.Run(vector.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			if vector.Context == "expired" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Unix(1, 0))
+				defer cancel()
+			} else if vector.Context != "active" {
+				t.Fatalf("unknown context mode %q", vector.Context)
+			}
+
+			got := verifier.Verify(ctx, vector.Request)
+			if got.Decision != vector.WantDecision || got.Reason != vector.WantReason {
+				t.Fatalf("Verify()=%s/%s, want %s/%s", got.Decision, got.Reason, vector.WantDecision, vector.WantReason)
+			}
+			if got.Decision == DecisionAllow {
+				if got.Issuer != fixture.Issuer || got.Reference == "" || got.ExpiresAt.IsZero() {
+					t.Fatalf("allow result omitted verified fields: %+v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalVerifierRejectsUntrustedAndTamperedReferences(t *testing.T) {
+	t.Parallel()
+	fixture := loadConformanceFixture(t)
+	now := mustParseTime(t, fixture.Now)
+	publicKey := mustDecodePublicKey(t, fixture.PublicKey)
+	valid := fixture.Vectors[0].Request
+
+	tests := []struct {
+		name    string
+		issuers map[string]ed25519.PublicKey
+		mutate  func(string) string
+		want    Reason
+	}{
+		{
+			name:    "untrusted issuer",
+			issuers: map[string]ed25519.PublicKey{"another-issuer.test": publicKey},
+			mutate:  func(reference string) string { return reference },
+			want:    ReasonUntrustedIssuer,
+		},
+		{
+			name:    "tampered signature",
+			issuers: map[string]ed25519.PublicKey{fixture.Issuer: publicKey},
+			mutate: func(reference string) string {
+				parts := strings.Split(reference, ".")
+				signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+				if err != nil {
+					t.Fatalf("decode signature: %v", err)
+				}
+				signature[0] ^= 0x01
+				parts[2] = base64.RawURLEncoding.EncodeToString(signature)
+				return strings.Join(parts, ".")
+			},
+			want: ReasonInvalidSignature,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			verifier, err := NewLocalVerifier(LocalConfig{
+				TrustedIssuers: test.issuers,
+				Clock:          func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatalf("new verifier: %v", err)
+			}
+			request := valid
+			request.AuthorityRef = test.mutate(request.AuthorityRef)
+			got := verifier.Verify(context.Background(), request)
+			if got.Decision != DecisionDeny || got.Reason != test.want {
+				t.Fatalf("Verify()=%s/%s, want deny/%s", got.Decision, got.Reason, test.want)
+			}
+			if got.Issuer != "" || got.Reference != "" || !got.ExpiresAt.IsZero() {
+				t.Fatalf("unverified result exposed grant claims: %+v", got)
+			}
+		})
+	}
+}
+
+func TestNewLocalVerifierValidatesAndCopiesConfig(t *testing.T) {
+	t.Parallel()
+	fixture := loadConformanceFixture(t)
+	publicKey := mustDecodePublicKey(t, fixture.PublicKey)
+
+	tests := []struct {
+		name   string
+		config LocalConfig
+	}{
+		{name: "missing issuers", config: LocalConfig{}},
+		{name: "empty issuer", config: LocalConfig{TrustedIssuers: map[string]ed25519.PublicKey{"": publicKey}}},
+		{name: "invalid key", config: LocalConfig{TrustedIssuers: map[string]ed25519.PublicKey{"issuer.test": {1}}}},
+		{
+			name: "empty revocation",
+			config: LocalConfig{
+				TrustedIssuers:    map[string]ed25519.PublicKey{"issuer.test": publicKey},
+				RevokedReferences: map[string]struct{}{" ": {}},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewLocalVerifier(test.config); err == nil {
+				t.Fatal("NewLocalVerifier() error=nil, want validation error")
+			}
+		})
+	}
+
+	issuer := fixture.Issuer
+	issuers := map[string]ed25519.PublicKey{issuer: publicKey}
+	revoked := map[string]struct{}{"grant-valid": {}}
+	verifier, err := NewLocalVerifier(LocalConfig{
+		TrustedIssuers:    issuers,
+		RevokedReferences: revoked,
+	})
+	if err != nil {
+		t.Fatalf("new verifier: %v", err)
+	}
+	delete(issuers, issuer)
+	delete(revoked, "grant-valid")
+	publicKey[0] ^= 0x01
+	if _, ok := verifier.trustedIssuers[issuer]; !ok {
+		t.Fatal("trusted issuer map was not copied")
+	}
+	if _, ok := verifier.revokedReferences["grant-valid"]; !ok {
+		t.Fatal("revocation map was not copied")
+	}
+}
+
+func TestParseLocalReferenceRejectsMalformedInputs(t *testing.T) {
+	t.Parallel()
+	validGrant := localGrant{
+		SchemaVersion: localSchemaVersion,
+		Issuer:        "issuer.test",
+		Reference:     "grant-valid",
+		Actor:         "workload:test-agent",
+		Action:        "records.read",
+		Destination:   "https://api.service.example/v1/records",
+		ExpiresAt:     "2030-01-01T00:05:00Z",
+	}
+	validReference := signTestGrant(t, validGrant)
+	validParts := strings.Split(validReference, ".")
+
+	duplicatePayload := []byte(`{"schema_version":1,"schema_version":1}`)
+	unknownPayload := []byte(`{"schema_version":1,"issuer":"issuer.test","reference":"grant-valid","actor":"workload:test-agent","action":"records.read","destination":"https://api.service.example/v1/records","expires_at":"2030-01-01T00:05:00Z","extra":true}`)
+	nonCanonicalPayload := bytes.ReplaceAll(mustPayloadBytes(t, validParts[1]), []byte(`":"`), []byte(`": "`))
+
+	tests := []struct {
+		name      string
+		reference string
+	}{
+		{name: "empty", reference: ""},
+		{name: "over size limit", reference: strings.Repeat("x", maxReferenceBytes+1)},
+		{name: "wrong prefix", reference: "other." + validParts[1] + "." + validParts[2]},
+		{name: "missing segment", reference: "plauth1.payload"},
+		{name: "empty payload", reference: "plauth1.." + validParts[2]},
+		{name: "invalid payload base64", reference: "plauth1.!." + validParts[2]},
+		{name: "empty decoded payload", reference: "plauth1.." + validParts[2]},
+		{name: "invalid signature base64", reference: "plauth1." + validParts[1] + ".!"},
+		{name: "short signature", reference: "plauth1." + validParts[1] + ".AA"},
+		{name: "duplicate field", reference: signTestPayload(t, duplicatePayload)},
+		{name: "unknown field", reference: signTestPayload(t, unknownPayload)},
+		{name: "noncanonical payload", reference: signTestPayload(t, nonCanonicalPayload)},
+		{name: "multiple JSON values", reference: signTestPayload(t, append(mustPayloadBytes(t, validParts[1]), []byte(` {}`)...))},
+		{name: "invalid trailing JSON", reference: signTestPayload(t, append(mustPayloadBytes(t, validParts[1]), byte('{')))},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseLocalReference(test.reference); err == nil {
+				t.Fatal("parseLocalReference() error=nil")
+			}
+		})
+	}
+}
+
+func TestLocalVerifierRejectsMalformedSignedGrantAndCancellation(t *testing.T) {
+	t.Parallel()
+	fixture := loadConformanceFixture(t)
+	now := mustParseTime(t, fixture.Now)
+	publicKey := mustDecodePublicKey(t, fixture.PublicKey)
+	verifier, err := NewLocalVerifier(LocalConfig{
+		TrustedIssuers: map[string]ed25519.PublicKey{fixture.Issuer: publicKey},
+		Clock:          func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("new verifier: %v", err)
+	}
+	base := localGrant{
+		SchemaVersion: localSchemaVersion,
+		Issuer:        fixture.Issuer,
+		Reference:     "grant-invalid",
+		Actor:         "workload:test-agent",
+		Action:        "records.read",
+		Destination:   "https://api.service.example/v1/records",
+		ExpiresAt:     "2030-01-01T00:05:00Z",
+	}
+	request := Request{Actor: base.Actor, Action: base.Action, Destination: base.Destination}
+
+	tests := []struct {
+		name   string
+		mutate func(*localGrant)
+		want   Reason
+	}{
+		{name: "schema", mutate: func(grant *localGrant) { grant.SchemaVersion = 2 }, want: ReasonMalformedReference},
+		{name: "issuer", mutate: func(grant *localGrant) { grant.Issuer = " " }, want: ReasonUntrustedIssuer},
+		{name: "reference", mutate: func(grant *localGrant) { grant.Reference = "" }, want: ReasonMalformedReference},
+		{name: "actor", mutate: func(grant *localGrant) { grant.Actor = "" }, want: ReasonMalformedReference},
+		{name: "action", mutate: func(grant *localGrant) { grant.Action = "" }, want: ReasonMalformedReference},
+		{name: "destination", mutate: func(grant *localGrant) { grant.Destination = "" }, want: ReasonMalformedReference},
+		{name: "expiry missing", mutate: func(grant *localGrant) { grant.ExpiresAt = "" }, want: ReasonMalformedReference},
+		{name: "expiry invalid", mutate: func(grant *localGrant) { grant.ExpiresAt = "tomorrow" }, want: ReasonMalformedReference},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			grant := base
+			test.mutate(&grant)
+			request := request
+			request.AuthorityRef = signTestGrant(t, grant)
+			got := verifier.Verify(context.Background(), request)
+			if got.Decision != DecisionDeny || got.Reason != test.want {
+				t.Fatalf("Verify()=%s/%s, want deny/%s", got.Decision, got.Reason, test.want)
+			}
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request.AuthorityRef = fixture.Vectors[0].Request.AuthorityRef
+	got := verifier.Verify(ctx, request)
+	if got.Decision != DecisionIndeterminate || got.Reason != ReasonCanceled {
+		t.Fatalf("canceled Verify()=%s/%s, want indeterminate/%s", got.Decision, got.Reason, ReasonCanceled)
+	}
+}
+
+func loadConformanceFixture(t *testing.T) conformanceFixture {
+	t.Helper()
+	path := filepath.Join("testdata", "local_verifier_conformance.json")
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read conformance fixture: %v", err)
+	}
+	var fixture conformanceFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode conformance fixture: %v", err)
+	}
+	if fixture.SchemaVersion != 1 {
+		t.Fatalf("fixture schema_version=%d, want 1", fixture.SchemaVersion)
+	}
+	return fixture
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+	return parsed
+}
+
+func mustDecodePublicKey(t *testing.T, value string) ed25519.PublicKey {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatalf("decode public key: %v", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		t.Fatalf("public key length=%d, want %d", len(decoded), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(decoded)
+}
+
+func signTestGrant(t *testing.T, grant localGrant) string {
+	t.Helper()
+	payload, err := json.Marshal(grant)
+	if err != nil {
+		t.Fatalf("marshal grant: %v", err)
+	}
+	return signTestPayload(t, payload)
+}
+
+func signTestPayload(t *testing.T, payload []byte) string {
+	t.Helper()
+	// RFC 8032 section 7.1 test vector seed. Split so secret scanners do not
+	// mistake this public test material for a live credential.
+	const testPrivateSeedHex = "" +
+		"9d61b19d" + "effd5a60" + "ba844af4" + "92ec2cc4" +
+		"4449c569" + "7b326919" + "703bac03" + "1cae7f60"
+	seed, err := hex.DecodeString(testPrivateSeedHex)
+	if err != nil {
+		t.Fatalf("decode test seed: %v", err)
+	}
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	input := localReferencePrefix + "." + encoded
+	signature := ed25519.Sign(privateKey, []byte(input))
+	return input + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func mustPayloadBytes(t *testing.T, encoded string) []byte {
+	t.Helper()
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return payload
+}

--- a/internal/authority/local_test.go
+++ b/internal/authority/local_test.go
@@ -172,6 +172,7 @@ func TestNewLocalVerifierValidatesAndCopiesConfig(t *testing.T) {
 	}
 
 	issuer := fixture.Issuer
+	originalPublicKey := append(ed25519.PublicKey(nil), publicKey...)
 	issuers := map[string]ed25519.PublicKey{issuer: publicKey}
 	revoked := map[string]struct{}{"grant-valid": {}}
 	verifier, err := NewLocalVerifier(LocalConfig{
@@ -184,8 +185,12 @@ func TestNewLocalVerifierValidatesAndCopiesConfig(t *testing.T) {
 	delete(issuers, issuer)
 	delete(revoked, "grant-valid")
 	publicKey[0] ^= 0x01
-	if _, ok := verifier.trustedIssuers[issuer]; !ok {
+	copiedPublicKey, ok := verifier.trustedIssuers[issuer]
+	if !ok {
 		t.Fatal("trusted issuer map was not copied")
+	}
+	if !bytes.Equal(copiedPublicKey, originalPublicKey) {
+		t.Fatal("trusted issuer public key bytes were not copied")
 	}
 	if _, ok := verifier.revokedReferences["grant-valid"]; !ok {
 		t.Fatal("revocation map was not copied")

--- a/internal/authority/testdata/local_verifier_conformance.json
+++ b/internal/authority/testdata/local_verifier_conformance.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "now": "2030-01-01T00:00:00Z",
+  "issuer": "issuer.test",
+  "public_key": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+  "revoked_references": [
+    "grant-revoked"
+  ],
+  "vectors": [
+    {
+      "name": "match",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC12YWxpZCIsImFjdG9yIjoid29ya2xvYWQ6dGVzdC1hZ2VudCIsImFjdGlvbiI6InJlY29yZHMucmVhZCIsImRlc3RpbmF0aW9uIjoiaHR0cHM6Ly9hcGkuc2VydmljZS5leGFtcGxlL3YxL3JlY29yZHMiLCJleHBpcmVzX2F0IjoiMjAzMC0wMS0wMVQwMDowNTowMFoifQ.YKwiykhlpIE4zQrtdXN-q7_AxWbhOWo8i5YTLTagmxvTYr3DiCv8NzY1reC9ShWmR5gI6fZgXqKwZAtAIJjPDA"
+      },
+      "context": "active",
+      "want_decision": "allow",
+      "want_reason": "matched"
+    },
+    {
+      "name": "actor mismatch",
+      "request": {
+        "actor": "workload:substituted-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC12YWxpZCIsImFjdG9yIjoid29ya2xvYWQ6dGVzdC1hZ2VudCIsImFjdGlvbiI6InJlY29yZHMucmVhZCIsImRlc3RpbmF0aW9uIjoiaHR0cHM6Ly9hcGkuc2VydmljZS5leGFtcGxlL3YxL3JlY29yZHMiLCJleHBpcmVzX2F0IjoiMjAzMC0wMS0wMVQwMDowNTowMFoifQ.YKwiykhlpIE4zQrtdXN-q7_AxWbhOWo8i5YTLTagmxvTYr3DiCv8NzY1reC9ShWmR5gI6fZgXqKwZAtAIJjPDA"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "actor_mismatch"
+    },
+    {
+      "name": "action mismatch",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.delete",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC12YWxpZCIsImFjdG9yIjoid29ya2xvYWQ6dGVzdC1hZ2VudCIsImFjdGlvbiI6InJlY29yZHMucmVhZCIsImRlc3RpbmF0aW9uIjoiaHR0cHM6Ly9hcGkuc2VydmljZS5leGFtcGxlL3YxL3JlY29yZHMiLCJleHBpcmVzX2F0IjoiMjAzMC0wMS0wMVQwMDowNTowMFoifQ.YKwiykhlpIE4zQrtdXN-q7_AxWbhOWo8i5YTLTagmxvTYr3DiCv8NzY1reC9ShWmR5gI6fZgXqKwZAtAIJjPDA"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "action_mismatch"
+    },
+    {
+      "name": "destination mismatch",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.other.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC12YWxpZCIsImFjdG9yIjoid29ya2xvYWQ6dGVzdC1hZ2VudCIsImFjdGlvbiI6InJlY29yZHMucmVhZCIsImRlc3RpbmF0aW9uIjoiaHR0cHM6Ly9hcGkuc2VydmljZS5leGFtcGxlL3YxL3JlY29yZHMiLCJleHBpcmVzX2F0IjoiMjAzMC0wMS0wMVQwMDowNTowMFoifQ.YKwiykhlpIE4zQrtdXN-q7_AxWbhOWo8i5YTLTagmxvTYr3DiCv8NzY1reC9ShWmR5gI6fZgXqKwZAtAIJjPDA"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "destination_mismatch"
+    },
+    {
+      "name": "expiry",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC1leHBpcmVkIiwiYWN0b3IiOiJ3b3JrbG9hZDp0ZXN0LWFnZW50IiwiYWN0aW9uIjoicmVjb3Jkcy5yZWFkIiwiZGVzdGluYXRpb24iOiJodHRwczovL2FwaS5zZXJ2aWNlLmV4YW1wbGUvdjEvcmVjb3JkcyIsImV4cGlyZXNfYXQiOiIyMDI5LTEyLTMxVDIzOjU5OjU5WiJ9.DgMs7QcBu4TJCnjBmKFddE70kMxRNwNm1KXaXloGci_axMw0gClGRyEgRLvE05dWdAzBig5ieKhsv482QQbfDg"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "expired"
+    },
+    {
+      "name": "revocation",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC1yZXZva2VkIiwiYWN0b3IiOiJ3b3JrbG9hZDp0ZXN0LWFnZW50IiwiYWN0aW9uIjoicmVjb3Jkcy5yZWFkIiwiZGVzdGluYXRpb24iOiJodHRwczovL2FwaS5zZXJ2aWNlLmV4YW1wbGUvdjEvcmVjb3JkcyIsImV4cGlyZXNfYXQiOiIyMDMwLTAxLTAxVDAwOjA1OjAwWiJ9.UQdYLtkFv_dMdRy95sn2Ml8KhOrX6cx9riwguxbM5c6bLxEfrgVygY673PhlptOfCPxS93GEuOoh2oG5aNDxBw"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "revoked"
+    },
+    {
+      "name": "malformed input",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "not-a-local-authority-reference"
+      },
+      "context": "active",
+      "want_decision": "deny",
+      "want_reason": "malformed_reference"
+    },
+    {
+      "name": "timeout",
+      "request": {
+        "actor": "workload:test-agent",
+        "action": "records.read",
+        "destination": "https://api.service.example/v1/records",
+        "authority_ref": "plauth1.eyJzY2hlbWFfdmVyc2lvbiI6MSwiaXNzdWVyIjoiaXNzdWVyLnRlc3QiLCJyZWZlcmVuY2UiOiJncmFudC12YWxpZCIsImFjdG9yIjoid29ya2xvYWQ6dGVzdC1hZ2VudCIsImFjdGlvbiI6InJlY29yZHMucmVhZCIsImRlc3RpbmF0aW9uIjoiaHR0cHM6Ly9hcGkuc2VydmljZS5leGFtcGxlL3YxL3JlY29yZHMiLCJleHBpcmVzX2F0IjoiMjAzMC0wMS0wMVQwMDowNTowMFoifQ.YKwiykhlpIE4zQrtdXN-q7_AxWbhOWo8i5YTLTagmxvTYr3DiCv8NzY1reC9ShWmR5gI6fZgXqKwZAtAIJjPDA"
+      },
+      "context": "expired",
+      "want_decision": "indeterminate",
+      "want_reason": "timeout"
+    }
+  ]
+}

--- a/internal/authority/types.go
+++ b/internal/authority/types.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package authority defines the provider-neutral boundary for verifying an
+// externally issued action authorization. It does not participate in the live
+// allow path yet.
+package authority
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Decision is the closed outcome set returned by every Verifier. Its zero
+// value is deliberately Indeterminate so an omitted decision cannot allow an
+// action.
+type Decision uint8
+
+const (
+	DecisionIndeterminate Decision = iota
+	DecisionAllow
+	DecisionDeny
+)
+
+// String returns the stable wire name for d.
+func (d Decision) String() string {
+	switch d {
+	case DecisionAllow:
+		return "allow"
+	case DecisionDeny:
+		return "deny"
+	case DecisionIndeterminate:
+		return "indeterminate"
+	default:
+		return "invalid"
+	}
+}
+
+// Valid reports whether d is a member of the closed decision set.
+func (d Decision) Valid() bool {
+	return d <= DecisionDeny
+}
+
+// MarshalJSON encodes decisions by their stable wire names.
+func (d Decision) MarshalJSON() ([]byte, error) {
+	if !d.Valid() {
+		return nil, fmt.Errorf("invalid authority decision %d", d)
+	}
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON accepts only members of the closed decision set.
+func (d *Decision) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode authority decision: %w", err)
+	}
+	switch value {
+	case "allow":
+		*d = DecisionAllow
+	case "deny":
+		*d = DecisionDeny
+	case "indeterminate":
+		*d = DecisionIndeterminate
+	default:
+		return fmt.Errorf("unknown authority decision %q", value)
+	}
+	return nil
+}
+
+// Reason is a stable, machine-readable explanation for a verification result.
+// Providers may define additional reasons while preserving the closed Decision
+// semantics.
+type Reason string
+
+const (
+	ReasonMatched             Reason = "matched"
+	ReasonActorMismatch       Reason = "actor_mismatch"
+	ReasonActionMismatch      Reason = "action_mismatch"
+	ReasonDestinationMismatch Reason = "destination_mismatch"
+	ReasonExpired             Reason = "expired"
+	ReasonRevoked             Reason = "revoked"
+	ReasonMalformedReference  Reason = "malformed_reference"
+	ReasonUntrustedIssuer     Reason = "untrusted_issuer"
+	ReasonInvalidSignature    Reason = "invalid_signature"
+	ReasonTimeout             Reason = "timeout"
+	ReasonCanceled            Reason = "canceled"
+)
+
+// Request contains the already-normalized action description and the opaque
+// reference to verify. Constructing or normalizing these fields is deliberately
+// outside this first, unwired slice.
+type Request struct {
+	Actor        string `json:"actor"`
+	Action       string `json:"action"`
+	Destination  string `json:"destination"`
+	AuthorityRef string `json:"authority_ref"`
+}
+
+// Result reports the provider-neutral verification outcome. Issuer, Reference,
+// and ExpiresAt are populated only after the reference signature is verified.
+type Result struct {
+	Decision  Decision  `json:"decision"`
+	Issuer    string    `json:"issuer,omitempty"`
+	Reference string    `json:"reference,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	Reason    Reason    `json:"reason"`
+}
+
+// Verifier checks whether an opaque external authority reference authorizes
+// the exact normalized action in req.
+//
+// A verifier is one conjunctive gate. An allow result must never override any
+// scanner, policy, contract, taint, kill-switch, or operator decision, and must
+// not raise Pipelock's internal authority level.
+type Verifier interface {
+	Verify(context.Context, Request) Result
+}

--- a/internal/authority/types_test.go
+++ b/internal/authority/types_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package authority
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecisionJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, decision := range []Decision{DecisionIndeterminate, DecisionAllow, DecisionDeny} {
+		decision := decision
+		t.Run(decision.String(), func(t *testing.T) {
+			t.Parallel()
+			encoded, err := json.Marshal(decision)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var decoded Decision
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if decoded != decision {
+				t.Fatalf("round trip=%v, want %v", decoded, decision)
+			}
+		})
+	}
+}
+
+func TestDecisionRejectsUnknownValues(t *testing.T) {
+	t.Parallel()
+	if got := Decision(99).String(); got != "invalid" {
+		t.Fatalf("invalid decision string=%q", got)
+	}
+	if _, err := json.Marshal(Decision(99)); err == nil {
+		t.Fatal("marshal invalid decision error=nil")
+	}
+	var decision Decision
+	if err := json.Unmarshal([]byte(`"permit"`), &decision); err == nil {
+		t.Fatal("unmarshal unknown decision error=nil")
+	}
+	if err := json.Unmarshal([]byte(`1`), &decision); err == nil {
+		t.Fatal("unmarshal non-string decision error=nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the first unwired slice discussed in #1186:

- provider-neutral `Request`, `Result`, and `Verifier` types with a closed `allow` / `deny` / `indeterminate` decision enum;
- a pure in-process Ed25519 reference verifier using local trusted keys and revocation state;
- versioned conformance vectors for exact match, actor/action/destination mismatch, expiry, revocation, malformed input, and timeout.

The local verifier binds a signed reference to the exact request fields it receives. It rejects oversized, malformed, duplicate-key, unknown-field, non-canonical, untrusted, and signature-invalid inputs, and defensively copies its key and revocation configuration.

## Scope boundaries

This is deliberately unwired. It adds no configuration fields and changes no production call sites.

It does not define canonical action construction, gate ordering, redirect re-verification, replay or single-use semantics, or receipt versioning. A verifier `allow` result is only one prospective conjunctive gate: it cannot override an existing scanner, policy, contract, taint, kill-switch, or operator block, and it does not feed or raise internal `AuthorityKind`.

As clarified in the issue, "forwards exactly once" means that one accepted inbound request produces at most one upstream request; it does not mean that a grant is single-use.

## Verification

- `go test -race -count=1 ./internal/authority` on Go 1.25
- `go test -race -count=1 ./internal/authority` on Go 1.26
- `golangci-lint run ./...` with v2.12.2
- 99.1% statement coverage for the new package
- trusted-default-branch `pipelock git scan-diff`: no secrets found

The full repository test command was also attempted locally. Existing macOS-specific `/var` path-resolution, unsupported descriptor-launch, and host-state failures occur in unrelated packages; the new package passes independently under both supported Go versions, and the Linux CI matrix remains authoritative for the draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local authorization verification for signed references.
  - Supports trusted issuers, revocations, expiration checks, and request matching.
  - Added standardized allow, deny, and indeterminate decisions with machine-readable reasons.

- **Bug Fixes**
  - Rejects malformed, tampered, expired, revoked, canceled, or unauthorized verification requests.

- **Tests**
  - Added comprehensive coverage for valid, invalid, untrusted, malformed, tampered, and canceled verification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->