### PR TITLE
feat(guard): enforce command execution

### DIFF
--- a/cmd/pipelock/main.go
+++ b/cmd/pipelock/main.go
@@ -10,10 +10,15 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cli"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	guardruntime "github.com/luckyPipewrench/pipelock/internal/guard"
 	"github.com/luckyPipewrench/pipelock/internal/sandbox"
 )
 
 func main() {
+	if guardruntime.IsExecMode() {
+		guardruntime.RunExec()
+		return
+	}
 	// Sandbox re-exec entry points. These run before any CLI initialization.
 	// MCP mode: applies containment then execs the command (does not return).
 	// Standalone mode: applies containment, runs bridge proxy + agent subprocess.

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,19 +37,9 @@ coverage:
         # retain kernel-dependent failure branches. They remain in project
         # coverage and have a dedicated merged subprocess-coverage CI job.
         #
-        # Guard's enforcement path is excluded for the same reason, with one
-        # difference worth stating plainly: it IS covered, on a kernel new
-        # enough to run it. Applying the restriction to a running process needs
-        # Landlock ABI 8, the hosted runners provide 7, so every enforcement
-        # test skips there and the subprocess job collects nothing to upload.
-        # Measured on a host at ABI 9 the same file reaches ~91%. Excluding it
-        # here reflects what CI can execute, not what is tested; it stays in
-        # project coverage and in the dedicated subprocess job, which asserts
-        # the file appears in the merged profile whenever the tests do run.
         paths:
           - "!internal/sandbox/child_init.go"
           - "!internal/sandbox/child_standalone_init.go"
-          - "!internal/guard/apply_linux.go"
 ignore:
   # The OpenSSF Best Practices entry certifies the Apache-2.0 FLOSS core.
   # ELv2 production sources remain fully tested in CI but are outside that

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -5,7 +5,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 
 | Command | Purpose |
 |---|---|
-| [`pipelock guard`](guard.md) | Explain unenforced guard path declarations and immutable compiled-floor refusals. |
+| [`pipelock guard`](guard.md) | Run one Linux command with filesystem and HTTP/HTTPS egress enforcement, or inspect its declarations. |
 | [`pipelock baseline`](baseline.md) | Inspect, ratify, and relearn behavioral-baseline profiles through the admin API. |
 | [`pipelock demo`](demo.md) | Run self-contained attack scenarios that show what Pipelock catches. |
 | [`pipelock status`](operator.md) | Read-only operator setup and local inspection commands. |

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -22,6 +22,10 @@ inspects an encrypted request or response body.
 Audit, receipt, and evidence work stays in the parent Pipelock process, outside
 the workload filesystem restriction. Signed Guard receipts bind the canonical
 policy hash when `flight_recorder.dir` and `signing_key_path` are configured.
+The `landlock_applied_pre_exec` receipt proves that the helper applied the
+filesystem ruleset before attempting `exec`; it does not claim that the operator
+command started, because abrupt helper termination and successful `exec` both
+close the inherited status pipe.
 
 ## Run a command
 
@@ -35,8 +39,9 @@ returns the command's exit code. `--dry-run` validates the declaration and
 checks the required kernel features without launching the command.
 
 The `show` and `explain` subcommands remain read-only. Their human and JSON
-output says that the inspection itself did not enforce anything; run output and
-the Guard receipt are the enforcement record.
+output says that the inspection itself did not enforce anything. Run output
+reports the command result; the Guard receipt records pre-exec ruleset
+application separately and does not certify command start.
 
 The commands deliberately separate two policy layers:
 

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -1,11 +1,42 @@
 # `pipelock guard`
 
-`pipelock guard` provides read-only inspection of filesystem guard declarations
-and the compiled validation floor.
+`pipelock guard -- COMMAND` runs one command inside the Linux HTTP/HTTPS Guard
+preview. It preserves the caller's environment, restricts filesystem access to
+the selected manifest and fixed runtime paths, routes HTTP and HTTPS through
+Pipelock, and denies direct TCP, UDP, QUIC, and child DNS with a required
+network namespace.
 
-> **Guard is not enforced in this build.** These commands describe what the
-> configuration declares and what the compiled floor refuses, but no workload
-> is constrained. Both human and JSON output carry this warning.
+The preview requires Linux, user and network namespaces, and Landlock ABI 5 or
+newer. Host file ownership maps to the caller's UID and GID, but the namespace
+UID can appear as 0. Writable manifest paths must belong to the caller and
+cannot be group- or world-writable. Exact service grants cover one TCP host and
+port; they never override the immutable metadata, link-local, multicast, or
+unspecified-address floor.
+
+Guard cannot stop the contained command from delegating a request to an
+already-running same-UID host process over an accessible broker or IPC channel.
+HTTPS CONNECT traffic remains opaque unless TLS interception is enabled, so the
+preview enforces the destination and visible headers but does not claim that it
+inspects an encrypted request or response body.
+
+Audit, receipt, and evidence work stays in the parent Pipelock process, outside
+the workload filesystem restriction. Signed Guard receipts bind the canonical
+policy hash when `flight_recorder.dir` and `signing_key_path` are configured.
+
+## Run a command
+
+```sh
+pipelock guard --config pipelock.yaml --profile worker --workspace /opt/app -- npm test
+pipelock guard --config pipelock.yaml --profile worker --workspace /opt/app --dry-run -- npm test
+```
+
+The separator is required. Arguments after `--` belong to the command. Guard
+returns the command's exit code. `--dry-run` validates the declaration and
+checks the required kernel features without launching the command.
+
+The `show` and `explain` subcommands remain read-only. Their human and JSON
+output says that the inspection itself did not enforce anything; run output and
+the Guard receipt are the enforcement record.
 
 The commands deliberately separate two policy layers:
 
@@ -71,9 +102,8 @@ scope (`file` or `directory`), original path, resolved path, and every
 compiled-floor refusal that applies. Read-write grants are checked for both
 read and write; read-only grants are checked for read.
 
-Unlike normal config loading—which correctly refuses all non-empty guard
-sections while enforcement is absent—these inspection commands retain a
-floor-refused path long enough to explain the refusal. All other structural
+The inspection commands retain a floor-refused path long enough to explain the
+refusal. Runtime config loading rejects that declaration. All other structural
 validation still applies, including strict YAML fields, required and unique
 names, absolute paths, valid manifest references, file-versus-directory
 declarations, and case-folded conflicts across all four path lists.
@@ -82,11 +112,14 @@ declarations, and case-folded conflicts across all four path lists.
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--config`, `-c` | built-in defaults | Config file to inspect. The file is parsed strictly without resolving unrelated runtime credential files. |
-| `--json` | `false` | Emit the stable JSON shape described below. Available on both subcommands. |
+| `--config`, `-c` | built-in defaults | Config file to load. Runtime execution does not accept standard input as the config path. |
+| `--profile` | empty | Select the workload profile. Required when profiles are declared. |
+| `--workspace` | config value or current directory | Set the writable workspace and command working directory. |
+| `--dry-run` | `false` | Validate and probe required kernel features without launching. |
+| `--json` | `false` | Emit JSON for dry-run, `show`, or `explain`. |
 
-Both commands are read-only. They do not write config or state, contact the
-proxy, create filesystem entries, or alter enforcement.
+The `show` and `explain` subcommands are read-only. They do not write config or
+state, contact the proxy, create filesystem entries, or alter enforcement.
 
 ## JSON shape
 
@@ -97,7 +130,7 @@ Both reports start with these stable fields:
   "schema_version": "1",
   "command": "explain",
   "enforced": false,
-  "enforcement_notice": "Guard is not enforced in this build. These results describe declarations and the compiled validation floor only; no workload is constrained.",
+  "enforcement_notice": "This inspection command does not enforce Guard. These results describe declarations and the compiled validation floor only; no workload is constrained.",
   "config_file": "pipelock.yaml"
 }
 ```
@@ -124,8 +157,8 @@ key compatibility on `schema_version`.
 
 ## Exit behavior
 
-A reported floor refusal or missing declaration is an explanation, so the
-command exits 0 after producing the report. Invalid arguments, an unreadable or
-malformed config, an invalid guard structure, or an unknown profile return a
-configuration/usage error. Do not interpret exit 0 as evidence of enforcement;
-check the mandatory `enforced` field, which is `false` in this build.
+A reported floor refusal or missing declaration is an explanation, so `show`
+and `explain` exit 0 after producing the report. Their `enforced` field is
+always false because inspection does not launch a workload. Runtime validation
+or containment failure returns an error without running the command. Once the
+command starts, Guard preserves its exit code.

--- a/docs/cli/guard.md
+++ b/docs/cli/guard.md
@@ -121,7 +121,7 @@ declarations, and case-folded conflicts across all four path lists.
 | `--profile` | empty | Select the workload profile. Required when profiles are declared. |
 | `--workspace` | config value or current directory | Set the writable workspace and command working directory. |
 | `--dry-run` | `false` | Validate and probe required kernel features without launching. |
-| `--json` | `false` | Emit JSON for dry-run, `show`, or `explain`. |
+| `--json` | `false` | Emit JSON for dry-run, `show`, or `explain`; runtime command execution rejects this flag. |
 
 The `show` and `explain` subcommands are read-only. They do not write config or
 state, contact the proxy, create filesystem entries, or alter enforcement.

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -283,7 +283,7 @@ func renderGuardPreflight(w io.Writer, result sandbox.PreflightResult) error {
 	if _, err := fmt.Fprintf(w, "  Workspace: %s\n", result.Workspace); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(w, "  Boundary: non-proxy TCP, UDP, QUIC, and child DNS are denied"); err != nil {
+	if _, err := fmt.Fprintln(w, "  Boundary: "+guardBoundaryNotice); err != nil {
 		return err
 	}
 	for _, layer := range result.Layers {
@@ -291,7 +291,15 @@ func renderGuardPreflight(w io.Writer, result sandbox.PreflightResult) error {
 		if !layer.Available {
 			state = "unavailable"
 		}
+		if layer.Reason != "" {
+			state += ": " + layer.Reason
+		}
 		if _, err := fmt.Fprintf(w, "  %s: %s (required=%t)\n", layer.Name, state, layer.Required); err != nil {
+			return err
+		}
+	}
+	for _, item := range result.Warnings {
+		if _, err := fmt.Fprintf(w, "  WARNING: %s\n", item); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -138,7 +138,9 @@ func Cmd() *cobra.Command {
 						return err
 					}
 				} else {
-					renderGuardPreflight(cmd.OutOrStdout(), result)
+					if err := renderGuardPreflight(cmd.OutOrStdout(), result); err != nil {
+						return err
+					}
 				}
 				if result.Status != sandbox.StatusReady {
 					return cliutil.ExitCodeError(2, errors.New("guard preflight failed"))
@@ -271,21 +273,34 @@ func resolveWorkspace(flagValue, configured string) (string, error) {
 	return resolved, nil
 }
 
-func renderGuardPreflight(w io.Writer, result sandbox.PreflightResult) {
-	_, _ = fmt.Fprintf(w, "Guard Preflight: %s\n", strings.ToUpper(result.Status))
-	_, _ = fmt.Fprintln(w, "  Surface: Linux HTTP/HTTPS preview")
-	_, _ = fmt.Fprintf(w, "  Workspace: %s\n", result.Workspace)
-	_, _ = fmt.Fprintln(w, "  Boundary: non-proxy TCP, UDP, QUIC, and child DNS are denied")
+func renderGuardPreflight(w io.Writer, result sandbox.PreflightResult) error {
+	if _, err := fmt.Fprintf(w, "Guard Preflight: %s\n", strings.ToUpper(result.Status)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "  Surface: Linux HTTP/HTTPS preview"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Workspace: %s\n", result.Workspace); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "  Boundary: non-proxy TCP, UDP, QUIC, and child DNS are denied"); err != nil {
+		return err
+	}
 	for _, layer := range result.Layers {
 		state := "available"
 		if !layer.Available {
 			state = "unavailable"
 		}
-		_, _ = fmt.Fprintf(w, "  %s: %s (required=%t)\n", layer.Name, state, layer.Required)
+		if _, err := fmt.Fprintf(w, "  %s: %s (required=%t)\n", layer.Name, state, layer.Required); err != nil {
+			return err
+		}
 	}
 	for _, item := range result.Errors {
-		_, _ = fmt.Fprintf(w, "  ERROR: %s\n", item)
+		if _, err := fmt.Fprintf(w, "  ERROR: %s\n", item); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func newHeader(command, configFile string) reportHeader {

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -1,32 +1,42 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-// Package guard implements read-only inspection of guard declarations and the
-// compiled filesystem floor. Guard is not enforced in this build.
+// Package guard implements the Guard command plus read-only declaration and
+// compiled-floor inspection.
 package guard
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	cliruntime "github.com/luckyPipewrench/pipelock/internal/cli/runtime"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
 )
 
 const (
 	reportSchemaVersion = "1"
 	defaultConfigLabel  = "(built-in defaults)"
-	enforcementNotice   = "Guard is not enforced in this build. These results describe declarations and the compiled validation floor only; no workload is constrained."
+	enforcementNotice   = "This inspection command does not enforce Guard. These results describe declarations and the compiled validation floor only; no workload is constrained."
+	guardBoundaryNotice = "Linux HTTP/HTTPS preview: non-proxy TCP, UDP, QUIC, and child DNS are denied. Host ownership maps to the caller UID while the namespace UID may be 0. Same-UID host brokers remain outside this boundary."
 )
 
 type commandOptions struct {
 	configFile string
+	profile    string
+	workspace  string
+	dryRun     bool
+	jsonOutput bool
 }
 
 type reportHeader struct {
@@ -96,21 +106,71 @@ type showReport struct {
 func Cmd() *cobra.Command {
 	opts := &commandOptions{}
 	cmd := &cobra.Command{
-		Use:          "guard",
-		Short:        "Inspect unenforced guard declarations and the compiled floor",
+		Use:          "guard [flags] -- COMMAND [ARGS...]",
+		Short:        "Run a command in the Linux HTTP/HTTPS egress-guard preview",
+		Long:         "Run a command in the Linux HTTP/HTTPS egress-guard preview.\n\n" + guardBoundaryNotice,
 		SilenceUsage: true,
-		Args:         cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
+		Args:         cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			dashIdx := cmd.ArgsLenAtDash()
+			if dashIdx < 0 || dashIdx >= len(args) {
+				return errors.New("usage: pipelock guard [flags] -- COMMAND [ARGS...]")
+			}
+			command := args[dashIdx:]
+			cfg, err := loadRuntimeConfig(opts.configFile)
+			if err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			workspace, err := resolveWorkspace(opts.workspace, cfg.Sandbox.Workspace)
+			if err != nil {
+				return err
+			}
+			if opts.dryRun {
+				result, preflightErr := cliruntime.GuardPreflight(cfg, opts.profile, workspace, command)
+				if preflightErr != nil {
+					return cliutil.ExitCodeError(cliutil.ExitConfig, preflightErr)
+				}
+				if opts.jsonOutput {
+					if err := writeJSON(cmd.OutOrStdout(), "guard", result); err != nil {
+						return err
+					}
+				} else {
+					renderGuardPreflight(cmd.OutOrStdout(), result)
+				}
+				if result.Status != sandbox.StatusReady {
+					return cliutil.ExitCodeError(2, errors.New("guard preflight failed"))
+				}
+				return nil
+			}
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "pipelock guard: "+guardBoundaryNotice)
+			launchErr := cliruntime.LaunchGuard(cliruntime.GuardLaunchOptions{
+				Context: cmd.Context(), Config: cfg, Profile: opts.profile,
+				Workspace: workspace, Command: command, Stderr: cmd.ErrOrStderr(),
+			})
+			return preserveCommandExitCode(launchErr)
 		},
 	}
 	cmd.PersistentFlags().StringVarP(&opts.configFile, "config", "c", "", "config file path (default: built-in defaults)")
+	cmd.PersistentFlags().StringVar(&opts.profile, "profile", "", "guard profile selecting state manifests")
+	cmd.PersistentFlags().StringVar(&opts.workspace, "workspace", "", "workspace directory (default: sandbox.workspace or current directory)")
+	cmd.PersistentFlags().BoolVar(&opts.dryRun, "dry-run", false, "validate and probe the Linux HTTP/HTTPS preview without launching")
+	cmd.PersistentFlags().BoolVar(&opts.jsonOutput, "json", false, "output reports as JSON")
 	cmd.AddCommand(explainCmd(opts), showCmd(opts))
 	return cmd
 }
 
+func preserveCommandExitCode(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return cliutil.ExitCodeError(exitErr.ExitCode(), err)
+	}
+	return err
+}
+
 func explainCmd(opts *commandOptions) *cobra.Command {
-	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "explain <absolute-path>",
 		Short: "Explain read and write declarations and compiled-floor refusals",
@@ -124,18 +184,16 @@ func explainCmd(opts *commandOptions) *cobra.Command {
 			if err != nil {
 				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 			}
-			if jsonOutput {
+			if opts.jsonOutput {
 				return writeJSON(cmd.OutOrStdout(), "guard explain", report)
 			}
 			return writeHuman(cmd.OutOrStdout(), renderExplain(report))
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
 	return cmd
 }
 
 func showCmd(opts *commandOptions) *cobra.Command {
-	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "show <profile>",
 		Short: "Show a profile's resolved manifests, grants, and floor refusals",
@@ -149,13 +207,12 @@ func showCmd(opts *commandOptions) *cobra.Command {
 			if err != nil {
 				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 			}
-			if jsonOutput {
+			if opts.jsonOutput {
 				return writeJSON(cmd.OutOrStdout(), "guard show", report)
 			}
 			return writeHuman(cmd.OutOrStdout(), renderShow(report))
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output report as JSON")
 	return cmd
 }
 
@@ -175,6 +232,60 @@ func loadConfig(path string) (*config.Config, string, error) {
 		return nil, "", fmt.Errorf("invalid guard declaration: %w", err)
 	}
 	return cfg, path, nil
+}
+
+func loadRuntimeConfig(path string) (*config.Config, error) {
+	if path == "" {
+		cfg := config.Defaults()
+		if err := cfg.Validate(); err != nil {
+			return nil, fmt.Errorf("validating built-in config: %w", err)
+		}
+		return cfg, nil
+	}
+	if path == "-" {
+		return nil, errors.New("guard runtime config cannot be read from stdin because stdin belongs to the operator command")
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading guard config %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+func resolveWorkspace(flagValue, configured string) (string, error) {
+	workspace := flagValue
+	if workspace == "" {
+		workspace = configured
+	}
+	if workspace == "" {
+		var err error
+		workspace, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolving workspace: %w", err)
+		}
+	}
+	resolved, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("resolving workspace: %w", err)
+	}
+	return resolved, nil
+}
+
+func renderGuardPreflight(w io.Writer, result sandbox.PreflightResult) {
+	_, _ = fmt.Fprintf(w, "Guard Preflight: %s\n", strings.ToUpper(result.Status))
+	_, _ = fmt.Fprintln(w, "  Surface: Linux HTTP/HTTPS preview")
+	_, _ = fmt.Fprintf(w, "  Workspace: %s\n", result.Workspace)
+	_, _ = fmt.Fprintln(w, "  Boundary: non-proxy TCP, UDP, QUIC, and child DNS are denied")
+	for _, layer := range result.Layers {
+		state := "available"
+		if !layer.Available {
+			state = "unavailable"
+		}
+		_, _ = fmt.Fprintf(w, "  %s: %s (required=%t)\n", layer.Name, state, layer.Required)
+	}
+	for _, item := range result.Errors {
+		_, _ = fmt.Fprintf(w, "  ERROR: %s\n", item)
+	}
 }
 
 func newHeader(command, configFile string) reportHeader {

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -116,7 +116,7 @@ func Cmd() *cobra.Command {
 				return cmd.Help()
 			}
 			dashIdx := cmd.ArgsLenAtDash()
-			if dashIdx < 0 || dashIdx >= len(args) {
+			if dashIdx != 0 || dashIdx >= len(args) {
 				return errors.New("usage: pipelock guard [flags] -- COMMAND [ARGS...]")
 			}
 			command := args[dashIdx:]
@@ -246,6 +246,20 @@ func loadRuntimeConfig(path string) (*config.Config, error) {
 	}
 	if path == "-" {
 		return nil, errors.New("guard runtime config cannot be read from stdin because stdin belongs to the operator command")
+	}
+	configInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading guard config %q: %w", path, err)
+	}
+	stdinInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspecting operator-command stdin: %w", err)
+	}
+	if os.SameFile(configInfo, stdinInfo) {
+		return nil, errors.New("guard runtime config cannot alias stdin because stdin belongs to the operator command")
+	}
+	if !configInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("loading guard config %q: not a regular file", path)
 	}
 	cfg, err := config.Load(path)
 	if err != nil {

--- a/internal/cli/guard/guard.go
+++ b/internal/cli/guard/guard.go
@@ -119,6 +119,9 @@ func Cmd() *cobra.Command {
 			if dashIdx != 0 || dashIdx >= len(args) {
 				return errors.New("usage: pipelock guard [flags] -- COMMAND [ARGS...]")
 			}
+			if opts.jsonOutput && !opts.dryRun {
+				return errors.New("--json requires --dry-run, guard show, or guard explain")
+			}
 			command := args[dashIdx:]
 			cfg, err := loadRuntimeConfig(opts.configFile)
 			if err != nil {

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -5,7 +5,6 @@ package guard
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -339,7 +338,12 @@ func TestDefaultConfigAndArgumentValidation(t *testing.T) {
 }
 
 func TestPreserveCommandExitCode(t *testing.T) {
-	err := exec.CommandContext(context.Background(), "sh", "-c", "exit 37").Run()
+	if os.Getenv("PIPELOCK_TEST_EXIT_37") == "1" {
+		os.Exit(37)
+	}
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestPreserveCommandExitCode$") // #nosec G204,G702 -- controlled re-exec of this test binary.
+	cmd.Env = append(os.Environ(), "PIPELOCK_TEST_EXIT_37=1")
+	err := cmd.Run()
 	if err == nil {
 		t.Fatal("helper command unexpectedly succeeded")
 	}

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -492,6 +492,9 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 	if _, err := runCommand(t, "--config", "-", "--", "/usr/bin/true"); err == nil || !strings.Contains(err.Error(), "stdin") {
 		t.Fatalf("runtime command config error = %v", err)
 	}
+	if _, err := runCommand(t, "--json", "--", "/usr/bin/true"); err == nil || !strings.Contains(err.Error(), "--json requires --dry-run") {
+		t.Fatalf("runtime command JSON error = %v", err)
+	}
 	if _, err := runCommand(t, "--dry-run", "--workspace", "/usr/local/bin", "--", "/usr/bin/true"); err == nil || !strings.Contains(err.Error(), "compiled floor") {
 		t.Fatalf("dry-run floor error = %v", err)
 	}

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -425,6 +425,23 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 	if _, err := loadRuntimeConfig("-"); err == nil || !strings.Contains(err.Error(), "stdin") {
 		t.Fatalf("stdin runtime config error = %v", err)
 	}
+	for _, stdinAlias := range []string{"/dev/stdin", "/dev/fd/0", "/proc/self/fd/0"} {
+		if _, err := os.Stat(stdinAlias); err != nil {
+			continue
+		}
+		if _, err := loadRuntimeConfig(stdinAlias); err == nil || !strings.Contains(err.Error(), "stdin") {
+			t.Fatalf("stdin alias %q error = %v", stdinAlias, err)
+		}
+	}
+	if _, err := os.Stat("/proc/self/fd/0"); err == nil {
+		alias := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.Symlink("/proc/self/fd/0", alias); err != nil {
+			t.Fatalf("create stdin config symlink: %v", err)
+		}
+		if _, err := loadRuntimeConfig(alias); err == nil || !strings.Contains(err.Error(), "stdin") {
+			t.Fatalf("symlinked stdin config error = %v", err)
+		}
+	}
 	if _, err := loadRuntimeConfig(filepath.Join(t.TempDir(), "missing.yaml")); err == nil || !strings.Contains(err.Error(), "loading guard config") {
 		t.Fatalf("missing runtime config error = %v", err)
 	}
@@ -480,16 +497,20 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 	}
 
 	cmd = Cmd()
+	testExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
 	cmd.SetOut(failingWriter{})
 	cmd.SetErr(io.Discard)
-	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", "/usr/bin/true"})
+	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", testExecutable})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
 		t.Fatalf("dry-run output error = %v", err)
 	}
 	cmd = Cmd()
 	cmd.SetOut(failingWriter{})
 	cmd.SetErr(io.Discard)
-	cmd.SetArgs([]string{"--dry-run", "--workspace", t.TempDir(), "--", "/usr/bin/true"})
+	cmd.SetArgs([]string{"--dry-run", "--workspace", t.TempDir(), "--", testExecutable})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
 		t.Fatalf("human dry-run output error = %v", err)
 	}
@@ -512,6 +533,16 @@ func TestRenderGuardPreflightIncludesUnavailableReasons(t *testing.T) {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("preflight output missing %q: %s", want, out.String())
 		}
+	}
+}
+
+func TestGuardCommandRejectsArgumentsBeforeSeparator(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"stray", "--", "tool"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "usage: pipelock guard") {
+		t.Fatalf("pre-separator argument error = %v", err)
 	}
 }
 

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -458,6 +458,16 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 	if _, err := resolveWorkspace("", ""); err == nil || !strings.Contains(err.Error(), "resolving workspace") {
 		t.Fatalf("removed current directory error = %v", err)
 	}
+	if _, err := resolveWorkspace("relative", ""); err == nil || !strings.Contains(err.Error(), "resolving workspace") {
+		t.Fatalf("relative workspace in removed directory error = %v", err)
+	}
+	cmd := Cmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--workspace", "relative", "--", "/usr/bin/true"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "resolving workspace") {
+		t.Fatalf("runtime command relative workspace error = %v", err)
+	}
 	if err := os.Chdir(originalDirectory); err != nil {
 		t.Fatalf("restore original directory before command tests: %v", err)
 	}
@@ -469,12 +479,19 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 		t.Fatalf("dry-run floor error = %v", err)
 	}
 
-	cmd := Cmd()
+	cmd = Cmd()
 	cmd.SetOut(failingWriter{})
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", "/usr/bin/true"})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
 		t.Fatalf("dry-run output error = %v", err)
+	}
+	cmd = Cmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--dry-run", "--workspace", t.TempDir(), "--", "/usr/bin/true"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
+		t.Fatalf("human dry-run output error = %v", err)
 	}
 }
 
@@ -484,13 +501,14 @@ func TestRenderGuardPreflightIncludesUnavailableReasons(t *testing.T) {
 		Status:    sandbox.StatusError,
 		Workspace: "/workspace",
 		Layers: []sandbox.LayerProbe{{
-			Name: sandbox.LayerLandlock, Available: false, Required: true,
+			Name: sandbox.LayerLandlock, Available: false, Required: true, Reason: "kernel rejected the ruleset",
 		}},
-		Errors: []string{"required layer unavailable"},
+		Warnings: []string{"degraded isolation"},
+		Errors:   []string{"required layer unavailable"},
 	}); err != nil {
 		t.Fatalf("renderGuardPreflight: %v", err)
 	}
-	for _, want := range []string{"unavailable", "ERROR: required layer unavailable"} {
+	for _, want := range []string{guardBoundaryNotice, "unavailable: kernel rejected the ruleset", "WARNING: degraded isolation", "ERROR: required layer unavailable"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("preflight output missing %q: %s", want, out.String())
 		}
@@ -501,10 +519,11 @@ func TestRenderGuardPreflightPropagatesEveryWriteFailure(t *testing.T) {
 	result := sandbox.PreflightResult{
 		Status:    sandbox.StatusError,
 		Workspace: "/workspace",
-		Layers:    []sandbox.LayerProbe{{Name: sandbox.LayerLandlock, Required: true}},
+		Layers:    []sandbox.LayerProbe{{Name: sandbox.LayerLandlock, Required: true, Reason: "not available"}},
+		Warnings:  []string{"degraded isolation"},
 		Errors:    []string{"required layer unavailable"},
 	}
-	for failAt := 1; failAt <= 6; failAt++ {
+	for failAt := 1; failAt <= 7; failAt++ {
 		writer := &failAfterWriter{failAt: failAt}
 		if err := renderGuardPreflight(writer, result); err == nil || !strings.Contains(err.Error(), "writer failed") {
 			t.Fatalf("write %d error = %v", failAt, err)

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -56,6 +56,19 @@ func (failingWriter) Write([]byte) (int, error) {
 	return 0, errors.New("writer failed")
 }
 
+type failAfterWriter struct {
+	writes int
+	failAt int
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failAt {
+		return 0, errors.New("writer failed")
+	}
+	return len(p), nil
+}
+
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "pipelock.yaml")
@@ -467,17 +480,34 @@ func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
 
 func TestRenderGuardPreflightIncludesUnavailableReasons(t *testing.T) {
 	var out bytes.Buffer
-	renderGuardPreflight(&out, sandbox.PreflightResult{
+	if err := renderGuardPreflight(&out, sandbox.PreflightResult{
 		Status:    sandbox.StatusError,
 		Workspace: "/workspace",
 		Layers: []sandbox.LayerProbe{{
 			Name: sandbox.LayerLandlock, Available: false, Required: true,
 		}},
 		Errors: []string{"required layer unavailable"},
-	})
+	}); err != nil {
+		t.Fatalf("renderGuardPreflight: %v", err)
+	}
 	for _, want := range []string{"unavailable", "ERROR: required layer unavailable"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("preflight output missing %q: %s", want, out.String())
+		}
+	}
+}
+
+func TestRenderGuardPreflightPropagatesEveryWriteFailure(t *testing.T) {
+	result := sandbox.PreflightResult{
+		Status:    sandbox.StatusError,
+		Workspace: "/workspace",
+		Layers:    []sandbox.LayerProbe{{Name: sandbox.LayerLandlock, Required: true}},
+		Errors:    []string{"required layer unavailable"},
+	}
+	for failAt := 1; failAt <= 6; failAt++ {
+		writer := &failAfterWriter{failAt: failAt}
+		if err := renderGuardPreflight(writer, result); err == nil || !strings.Contains(err.Error(), "writer failed") {
+			t.Fatalf("write %d error = %v", failAt, err)
 		}
 	}
 }

--- a/internal/cli/guard/guard_test.go
+++ b/internal/cli/guard/guard_test.go
@@ -5,15 +5,19 @@ package guard
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
 )
 
 const testGuardConfig = `guard:
@@ -80,7 +84,7 @@ func TestExplainHumanCompiledFloorHonesty(t *testing.T) {
 		t.Fatalf("guard explain: %v", err)
 	}
 	for _, want := range []string{
-		"WARNING: Guard is not enforced in this build",
+		"WARNING: This inspection command does not enforce Guard",
 		"READ: WOULD BE REFUSED BY COMPILED FLOOR",
 		"WRITE: WOULD BE REFUSED BY COMPILED FLOOR",
 		"Rule: forbidden_component",
@@ -237,7 +241,7 @@ func TestShowHumanEmptyAndRefusedGrants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("guard show worker: %v", err)
 	}
-	for _, want := range []string{"WARNING: Guard is not enforced", "Manifest: \"workspace\"", "compiled floor: no refusal", "COMPILED FLOOR REFUSAL", "cannot be configured away"} {
+	for _, want := range []string{"WARNING: This inspection command does not enforce Guard", "Manifest: \"workspace\"", "compiled floor: no refusal", "COMPILED FLOOR REFUSAL", "cannot be configured away"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("worker output missing %q:\n%s", want, out)
 		}
@@ -299,8 +303,13 @@ func TestCommandErrors(t *testing.T) {
 func TestDefaultConfigAndArgumentValidation(t *testing.T) {
 	t.Parallel()
 	help, err := runCommand(t)
-	if err != nil || !strings.Contains(help, "Inspect unenforced guard declarations") {
+	if err != nil || !strings.Contains(help, "Run a command in the Linux HTTP/HTTPS egress-guard preview") {
 		t.Fatalf("guard parent help: err=%v output=%q", err, help)
+	}
+	for _, claimBoundary := range []string{"non-proxy TCP, UDP, QUIC", "Same-UID host brokers remain outside this boundary"} {
+		if !strings.Contains(help, claimBoundary) {
+			t.Fatalf("guard help omitted claim boundary %q:\n%s", claimBoundary, help)
+		}
 	}
 	out, err := runCommand(t, "explain", "/opt/app", "--json")
 	if err != nil {
@@ -313,6 +322,17 @@ func TestDefaultConfigAndArgumentValidation(t *testing.T) {
 		if _, err := runCommand(t, args...); err == nil {
 			t.Fatalf("args %v should fail", args)
 		}
+	}
+}
+
+func TestPreserveCommandExitCode(t *testing.T) {
+	err := exec.CommandContext(context.Background(), "sh", "-c", "exit 37").Run()
+	if err == nil {
+		t.Fatal("helper command unexpectedly succeeded")
+	}
+	wrapped := preserveCommandExitCode(err)
+	if got := cliutil.ExitCodeOf(wrapped); got != 37 {
+		t.Fatalf("exit code = %d, want 37", got)
 	}
 }
 
@@ -384,6 +404,80 @@ func TestOutputErrors(t *testing.T) {
 		cmd.SetArgs(args)
 		if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
 			t.Fatalf("args %v error = %v", args, err)
+		}
+	}
+}
+
+func TestRuntimeCommandValidationAndDryRunErrors(t *testing.T) {
+	if _, err := loadRuntimeConfig("-"); err == nil || !strings.Contains(err.Error(), "stdin") {
+		t.Fatalf("stdin runtime config error = %v", err)
+	}
+	if _, err := loadRuntimeConfig(filepath.Join(t.TempDir(), "missing.yaml")); err == nil || !strings.Contains(err.Error(), "loading guard config") {
+		t.Fatalf("missing runtime config error = %v", err)
+	}
+	validConfig := writeConfig(t, "enforce: true\n")
+	if _, err := loadRuntimeConfig(validConfig); err != nil {
+		t.Fatalf("valid runtime config: %v", err)
+	}
+	configured := t.TempDir()
+	if got, err := resolveWorkspace("", configured); err != nil || got != configured {
+		t.Fatalf("configured workspace = %q, err=%v", got, err)
+	}
+	if got, err := resolveWorkspace("", ""); err != nil || !filepath.IsAbs(got) {
+		t.Fatalf("current workspace = %q, err=%v", got, err)
+	}
+	originalDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get original directory: %v", err)
+	}
+	removedDirectory := t.TempDir()
+	if err := os.Chdir(removedDirectory); err != nil {
+		t.Fatalf("enter removable directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDirectory); err != nil {
+			t.Fatalf("restore original directory: %v", err)
+		}
+	}()
+	if err := os.Remove(removedDirectory); err != nil {
+		t.Fatalf("remove current directory fixture: %v", err)
+	}
+	if _, err := resolveWorkspace("", ""); err == nil || !strings.Contains(err.Error(), "resolving workspace") {
+		t.Fatalf("removed current directory error = %v", err)
+	}
+	if err := os.Chdir(originalDirectory); err != nil {
+		t.Fatalf("restore original directory before command tests: %v", err)
+	}
+
+	if _, err := runCommand(t, "--config", "-", "--", "/usr/bin/true"); err == nil || !strings.Contains(err.Error(), "stdin") {
+		t.Fatalf("runtime command config error = %v", err)
+	}
+	if _, err := runCommand(t, "--dry-run", "--workspace", "/usr/local/bin", "--", "/usr/bin/true"); err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("dry-run floor error = %v", err)
+	}
+
+	cmd := Cmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--dry-run", "--json", "--workspace", t.TempDir(), "--", "/usr/bin/true"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "writer failed") {
+		t.Fatalf("dry-run output error = %v", err)
+	}
+}
+
+func TestRenderGuardPreflightIncludesUnavailableReasons(t *testing.T) {
+	var out bytes.Buffer
+	renderGuardPreflight(&out, sandbox.PreflightResult{
+		Status:    sandbox.StatusError,
+		Workspace: "/workspace",
+		Layers: []sandbox.LayerProbe{{
+			Name: sandbox.LayerLandlock, Available: false, Required: true,
+		}},
+		Errors: []string{"required layer unavailable"},
+	})
+	for _, want := range []string{"unavailable", "ERROR: required layer unavailable"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("preflight output missing %q: %s", want, out.String())
 		}
 	}
 }

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -144,18 +145,16 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 	defer logger.Close()
 
 	guardMetrics := metrics.New()
-	evidence, err := newGuardEvidence(ctxOrBackground(opts.Context), runtimeCfg, sc, guardMetrics, opts.Stderr)
+	baseCtx := ctxOrBackground(opts.Context)
+	evidence, err := newGuardEvidence(baseCtx, runtimeCfg, sc, guardMetrics, opts.Stderr)
 	if err != nil {
 		return err
 	}
 	defer evidence.close()
-	ctx := opts.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(baseCtx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 	guardReady := make(chan struct{})
+	var guardReadyOnce sync.Once
 
 	p, err := proxy.New(runtimeCfg, logger, sc, guardMetrics, evidence.proxyOptions...)
 	if err != nil {
@@ -197,7 +196,7 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 		GuardDeclaration:        &declaration,
 		GuardProfile:            opts.Profile,
 		GuardPolicyHash:         configPolicyHash,
-		GuardEnforced: func(encoded []byte) error {
+		GuardAppliedPreExec: func(encoded []byte) error {
 			var proof guardfs.ExecutionProof
 			if err := json.Unmarshal(encoded, &proof); err != nil {
 				return fmt.Errorf("decoding child enforcement proof: %w", err)
@@ -208,7 +207,7 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 			if err := evidence.activate(proof); err != nil {
 				return err
 			}
-			close(guardReady)
+			guardReadyOnce.Do(func() { close(guardReady) })
 			return nil
 		},
 	})
@@ -234,7 +233,8 @@ type guardEvidence struct {
 	heartbeat    time.Duration
 	stderr       io.Writer
 	require      bool
-	activated    bool
+	activateOnce sync.Once
+	activateErr  error
 }
 
 func (e *guardEvidence) close() {
@@ -250,10 +250,17 @@ func (e *guardEvidence) close() {
 }
 
 func (e *guardEvidence) activate(proof guardfs.ExecutionProof) error {
-	if e == nil || e.emitter == nil || e.activated {
+	if e == nil || e.emitter == nil {
 		return nil
 	}
-	e.emitter.UpdateConfigHash(proof.EffectivePolicyHash)
+	e.activateOnce.Do(func() {
+		e.activateErr = e.activateReceipts(proof)
+	})
+	return e.activateErr
+}
+
+func (e *guardEvidence) activateReceipts(proof guardfs.ExecutionProof) error {
+	e.emitter.UpdateConfigHash(proof.ConfigPolicyHash)
 	if err := emitStartupSessionOpen(e.emitter); err != nil {
 		if e.require {
 			return fmt.Errorf("emitting Guard session_open receipt: %w", err)
@@ -264,16 +271,19 @@ func (e *guardEvidence) activate(proof guardfs.ExecutionProof) error {
 	}
 	if err := e.emitter.EmitDurable(receipt.EmitOpts{
 		ActionID: receipt.NewActionID(), Verdict: config.ActionAllow,
-		Layer: "guard", Pattern: "enforcement_success", Transport: "guard_exec",
-		Method: "EXEC", Target: proof.Binary, PolicyHash: proof.EffectivePolicyHash,
+		Layer: "guard", Pattern: "landlock_applied_pre_exec", Transport: "guard_exec",
+		Method: "EXEC", Target: proof.Binary, PolicyHash: proof.ConfigPolicyHash,
+		// RequestID is the signed per-action correlation field. Guard uses it to
+		// carry the effective invocation digest without mislabeling that digest
+		// as the canonical configuration policy hash.
+		RequestID: "guard-exec:" + proof.EffectivePolicyHash,
 	}); err != nil {
 		if e.require {
-			return fmt.Errorf("emitting Guard enforcement-success receipt: %w", err)
+			return fmt.Errorf("emitting Guard pre-exec enforcement receipt: %w", err)
 		}
-		_, _ = fmt.Fprintf(e.stderr, "  Receipts: ERROR - Guard enforcement-success could not be emitted: %v\n", err)
+		_, _ = fmt.Fprintf(e.stderr, "  Receipts: ERROR - Guard pre-exec enforcement could not be emitted: %v\n", err)
 	}
 	e.stop = startStandaloneReceiptLifecycle(e.ctx, e.heartbeat, e.emitter, e.stderr, e.require, nil)
-	e.activated = true
 	return nil
 }
 

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -1,0 +1,461 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/contract/proxydecision"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
+	guardfs "github.com/luckyPipewrench/pipelock/internal/guard"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+	"github.com/luckyPipewrench/pipelock/internal/proxy"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// GuardLaunchOptions is the fully resolved operator request.
+type GuardLaunchOptions struct {
+	Context   context.Context
+	Config    *config.Config
+	Profile   string
+	Workspace string
+	Command   []string
+	Stderr    io.Writer
+}
+
+// GuardPreflight validates the runtime contract and probes every required
+// phase-0 capability without launching the command.
+func GuardPreflight(cfg *config.Config, profile, workspace string, command []string) (sandbox.PreflightResult, error) {
+	if err := validateGuardRuntime(cfg); err != nil {
+		return sandbox.PreflightResult{}, err
+	}
+	resolved, err := filepath.Abs(workspace)
+	if err != nil {
+		return sandbox.PreflightResult{}, fmt.Errorf("resolving guard workspace: %w", err)
+	}
+	if err := validateGuardRuntimeObjects(cfg, profile); err != nil {
+		return sandbox.PreflightResult{}, err
+	}
+	executable, err := resolveGuardExecutable(command, resolved)
+	if err != nil {
+		return sandbox.PreflightResult{}, err
+	}
+	if err := guardfs.ValidateExecutionPaths(resolved, executable); err != nil {
+		return sandbox.PreflightResult{}, err
+	}
+	policy, err := guardSandboxPolicy(cfg, profile, resolved)
+	if err != nil {
+		return sandbox.PreflightResult{}, err
+	}
+	policy.AllowRWDirs = existingGuardPreflightDirs(policy.AllowRWDirs)
+	return sandbox.PreflightWithRequirements(resolved, command, &policy, sandbox.PreflightRequirements{
+		RequireNetNS:        true,
+		RequireProxyHandler: true,
+		RequireLandlock:     true,
+		MinimumLandlockABI:  guardfs.MinimumABI,
+	}), nil
+}
+
+// LaunchGuard runs an operator command under the Linux HTTP/HTTPS preview.
+func LaunchGuard(opts GuardLaunchOptions) error {
+	return launchGuard(opts, sandbox.LaunchStandalone)
+}
+
+func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.StandaloneLaunchConfig) error) error {
+	if opts.Config == nil {
+		return errors.New("guard config is nil")
+	}
+	if len(opts.Command) == 0 {
+		return errors.New("guard command is empty")
+	}
+	if err := validateGuardRuntime(opts.Config); err != nil {
+		return err
+	}
+	workspace, err := filepath.Abs(opts.Workspace)
+	if err != nil {
+		return fmt.Errorf("resolving guard workspace: %w", err)
+	}
+	if err := sandbox.ValidateWorkspace(workspace); err != nil {
+		return fmt.Errorf("guard workspace: %w", err)
+	}
+	if err := validateGuardRuntimeObjects(opts.Config, opts.Profile); err != nil {
+		return err
+	}
+	executable, err := resolveGuardExecutable(opts.Command, workspace)
+	if err != nil {
+		return err
+	}
+	prepared, err := guardfs.PrepareExecution(opts.Config, opts.Profile, workspace, workspace, executable, os.Getuid())
+	if err != nil {
+		return fmt.Errorf("prepare Guard manifest before sandbox launch: %w", err)
+	}
+	if !prepared.Complete() {
+		outcomes := prepared.Outcomes()
+		_ = prepared.Close()
+		return fmt.Errorf("prepare Guard manifest before sandbox launch: incomplete grants: %+v", outcomes)
+	}
+	if err := prepared.Close(); err != nil {
+		return fmt.Errorf("close prepared Guard manifest: %w", err)
+	}
+
+	runtimeCfg := opts.Config.Clone()
+	runtimeCfg.ForwardProxy.Enabled = true
+	grants, err := guardDestinationGrants(runtimeCfg.Guard.Services)
+	if err != nil {
+		return err
+	}
+	sc, err := scanner.NewWithOptions(runtimeCfg, scanner.Options{DestinationGrants: grants})
+	if err != nil {
+		return fmt.Errorf("create guard scanner: %w", err)
+	}
+	defer sc.Close()
+
+	logger, err := audit.NewWithStream(
+		runtimeCfg.Logging.Format,
+		runtimeCfg.Logging.Output,
+		runtimeCfg.Logging.File,
+		runtimeCfg.Logging.IncludeAllowed,
+		runtimeCfg.Logging.IncludeBlocked,
+		opts.Stderr,
+	)
+	if err != nil {
+		return fmt.Errorf("create guard audit logger: %w", err)
+	}
+	defer logger.Close()
+
+	guardMetrics := metrics.New()
+	evidence, err := newGuardEvidence(ctxOrBackground(opts.Context), runtimeCfg, sc, guardMetrics, opts.Stderr)
+	if err != nil {
+		return err
+	}
+	defer evidence.close()
+
+	p, err := proxy.New(runtimeCfg, logger, sc, guardMetrics, evidence.proxyOptions...)
+	if err != nil {
+		return fmt.Errorf("create guard proxy: %w", err)
+	}
+	defer p.Close()
+	handler := p.Handler()
+	proxyHandler := func(conn net.Conn) {
+		srv := &http.Server{
+			Handler:           handler,
+			ReadHeaderTimeout: 30 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		}
+		_ = srv.Serve(&singleConnListener{conn: conn})
+	}
+
+	policy, err := guardSandboxPolicy(runtimeCfg, opts.Profile, workspace)
+	if err != nil {
+		return err
+	}
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	declaration := runtimeCfg.Guard
+	return launchStandalone(sandbox.StandaloneLaunchConfig{
+		Ctx:                     ctx,
+		Command:                 opts.Command,
+		Workspace:               workspace,
+		Policy:                  &policy,
+		RequireNetNS:            true,
+		DeveloperEnvironment:    os.Environ(),
+		UseDeveloperEnvironment: true,
+		ProxyHandler:            proxyHandler,
+		RequireProxyHandler:     true,
+		GuardDeclaration:        &declaration,
+		GuardProfile:            opts.Profile,
+		GuardPolicyHash:         runtimeCfg.CanonicalPolicyHash(),
+	})
+}
+
+func resolveGuardExecutable(command []string, workspace string) (string, error) {
+	if len(command) == 0 || command[0] == "" {
+		return "", errors.New("guard command is empty")
+	}
+	resolved, err := sandbox.ResolveCommandInDir(command[0], os.Environ(), workspace)
+	if err != nil {
+		return "", fmt.Errorf("resolving guard command %q: %w", command[0], err)
+	}
+	return resolved, nil
+}
+
+type guardEvidence struct {
+	proxyOptions []proxy.Option
+	recorder     *recorder.Recorder
+	stop         func()
+}
+
+func (e *guardEvidence) close() {
+	if e == nil {
+		return
+	}
+	if e.stop != nil {
+		e.stop()
+	}
+	if e.recorder != nil {
+		_ = e.recorder.Close()
+	}
+}
+
+func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scanner, m *metrics.Metrics, stderr io.Writer) (*guardEvidence, error) {
+	evidence := &guardEvidence{stop: func() {}}
+	if !cfg.FlightRecorder.Enabled || cfg.FlightRecorder.Dir == "" {
+		if cfg.FlightRecorder.RequireReceipts {
+			return nil, errors.New("flight_recorder.require_receipts is enabled but Guard has no configured recorder directory")
+		}
+		if cfg.FlightRecorder.Enabled {
+			_, _ = fmt.Fprintln(stderr, "  Recorder: enabled but inert; set flight_recorder.dir and signing_key_path for signed Guard receipts")
+		}
+		return evidence, nil
+	}
+
+	recorderConfig := recorder.Config{
+		Enabled:            true,
+		Dir:                cfg.FlightRecorder.Dir,
+		CheckpointInterval: cfg.FlightRecorder.CheckpointInterval,
+		RetentionDays:      cfg.FlightRecorder.RetentionDays,
+		Redact:             cfg.FlightRecorder.Redact,
+		SignCheckpoints:    cfg.FlightRecorder.SignCheckpoints,
+		MaxEntriesPerFile:  cfg.FlightRecorder.MaxEntriesPerFile,
+		FileMode:           cfg.FlightRecorder.FileMode,
+		RawEscrow:          cfg.FlightRecorder.RawEscrow,
+		EscrowPublicKey:    cfg.FlightRecorder.EscrowPublicKey,
+		Metrics:            m,
+	}
+	var redactFn recorder.RedactFunc
+	if cfg.FlightRecorder.Redact {
+		redactFn = sc.ScanTextForDLP
+	}
+	var privateKey ed25519.PrivateKey
+	if cfg.FlightRecorder.SigningKeyPath != "" {
+		key, err := signing.LoadPrivateKeyFile(cfg.FlightRecorder.SigningKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("loading Guard receipt signing key: %w", err)
+		}
+		privateKey = key
+	}
+	rec, err := recorder.New(recorderConfig, redactFn, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating Guard flight recorder: %w", err)
+	}
+	evidence.recorder = rec
+	evidence.proxyOptions = append(evidence.proxyOptions, proxy.WithRecorder(rec))
+
+	binding, err := posturebinding.LoadRuntime()
+	if err != nil {
+		evidence.close()
+		return nil, fmt.Errorf("loading Guard posture binding: %w", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec, PrivKey: privateKey, ConfigHash: cfg.CanonicalPolicyHash(),
+		Principal: "local", Actor: "pipelock", Metrics: m, PostureBinding: binding,
+		HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
+	})
+	if !receiptEmitterReady(emitter) {
+		if cfg.FlightRecorder.RequireReceipts {
+			evidence.close()
+			return nil, errors.New("flight_recorder.require_receipts is enabled but no healthy signed Guard receipt emitter is active")
+		}
+		_, _ = fmt.Fprintln(stderr, "  Receipts: disabled; set a healthy flight_recorder.signing_key_path to enable signed Guard receipts")
+		return evidence, nil
+	}
+	if err := emitStartupSessionOpen(emitter); err != nil {
+		if cfg.FlightRecorder.RequireReceipts {
+			evidence.close()
+			return nil, fmt.Errorf("emitting Guard session_open receipt: %w", err)
+		}
+		_, _ = fmt.Fprintf(stderr,
+			"  Receipts: ERROR - Guard session_open could not be emitted: %v\n"+
+				"            Receipt emission for this run is UNVERIFIED until resolved.\n",
+			err)
+	}
+	evidence.proxyOptions = append(evidence.proxyOptions,
+		proxy.WithReceiptEmitter(emitter),
+		proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath),
+	)
+	if v2 := proxydecision.NewEmitter(proxydecision.EmitterConfig{
+		Recorder: rec, Signer: proxydecision.NewKeyedSigner(privateKey),
+		Sanitize:  proxydecision.SanitizeFromRedactor(rec.ReceiptRedactor()),
+		Principal: "local", Actor: "pipelock",
+	}); v2 != nil {
+		evidence.proxyOptions = append(evidence.proxyOptions, proxy.WithV2ReceiptEmitter(v2))
+	}
+	evidence.stop = startStandaloneReceiptLifecycle(ctx, cfg.FlightRecorder.HeartbeatIntervalDuration(), emitter, stderr, cfg.FlightRecorder.RequireReceipts, nil)
+	_, _ = fmt.Fprintf(stderr, "  Recorder: %s (Guard receipts enabled)\n", cfg.FlightRecorder.Dir)
+	return evidence, nil
+}
+
+func ctxOrBackground(ctx context.Context) context.Context {
+	if ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+func validateGuardRuntime(cfg *config.Config) error {
+	if cfg == nil {
+		return errors.New("guard config is nil")
+	}
+	if cfg.Sandbox.BestEffort {
+		return errors.New("guard refuses sandbox.best_effort:true; network namespace isolation is required")
+	}
+	if !cfg.EnforceEnabled() {
+		return errors.New("guard refuses enforce:false; an egress guard cannot run audit-only")
+	}
+	if !cfg.DLP.ScanEnv {
+		return errors.New("guard refuses dlp.scan_env:false because the preserved developer environment contains secret-bearing values")
+	}
+	return cfg.ValidateGuardDeclaration()
+}
+
+func guardDestinationGrants(services []config.GuardService) (destination.GrantSet, error) {
+	grants := make([]destination.Grant, 0, len(services))
+	for _, service := range services {
+		grant, err := destination.NewGrant(destination.Network(service.Protocol), service.Host, service.Port)
+		if err != nil {
+			return destination.GrantSet{}, fmt.Errorf("guard service %q: %w", service.Name, err)
+		}
+		grants = append(grants, grant)
+	}
+	return destination.NewGrantSet(grants...)
+}
+
+func guardSandboxPolicy(cfg *config.Config, profileName, workspace string) (sandbox.Policy, error) {
+	policy := sandbox.DefaultPolicy(workspace)
+	if profileName == "" {
+		if len(cfg.Guard.Profiles) != 0 {
+			return sandbox.Policy{}, errors.New("guard profile is required when profiles are declared")
+		}
+		return policy, nil
+	}
+	var selected *config.GuardProfile
+	for i := range cfg.Guard.Profiles {
+		if cfg.Guard.Profiles[i].Name == profileName {
+			selected = &cfg.Guard.Profiles[i]
+			break
+		}
+	}
+	if selected == nil {
+		return sandbox.Policy{}, fmt.Errorf("guard profile %q not found", profileName)
+	}
+	byName := make(map[string]config.GuardManifest, len(cfg.Guard.Manifests))
+	for _, manifest := range cfg.Guard.Manifests {
+		byName[manifest.Name] = manifest
+	}
+	for _, name := range selected.Manifests {
+		manifest := byName[name]
+		policy.AllowReadFiles = append(policy.AllowReadFiles, manifest.ReadOnly...)
+		policy.AllowReadDirs = append(policy.AllowReadDirs, manifest.ReadOnlyDirectories...)
+		policy.AllowRWFiles = append(policy.AllowRWFiles, manifest.ReadWrite...)
+		policy.AllowRWDirs = append(policy.AllowRWDirs, manifest.ReadWriteDirectories...)
+	}
+	return policy, nil
+}
+
+func validateGuardRuntimeObjects(cfg *config.Config, profileName string) error {
+	selected := make(map[string]struct{})
+	profileFound := false
+	if profileName == "" {
+		if len(cfg.Guard.Profiles) != 0 {
+			return errors.New("guard profile is required when profiles are declared")
+		}
+		return nil
+	}
+	for _, profile := range cfg.Guard.Profiles {
+		if profile.Name == profileName {
+			profileFound = true
+			for _, name := range profile.Manifests {
+				selected[name] = struct{}{}
+			}
+			break
+		}
+	}
+	if !profileFound {
+		return fmt.Errorf("guard profile %q not found", profileName)
+	}
+	check := func(path string, wantDirectory, allowMissingLeaf bool) error {
+		resolved, err := filepath.EvalSymlinks(path)
+		if errors.Is(err, os.ErrNotExist) {
+			if !allowMissingLeaf {
+				return fmt.Errorf("guard path %q does not exist", path)
+			}
+			parent, parentErr := filepath.EvalSymlinks(filepath.Dir(filepath.Clean(path)))
+			if parentErr != nil {
+				return fmt.Errorf("guard writable directory parent for %q does not exist: %w", path, parentErr)
+			}
+			info, statErr := os.Stat(parent)
+			if statErr != nil || !info.IsDir() {
+				return fmt.Errorf("guard writable directory parent for %q is not a directory", path)
+			}
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("resolve Guard path %q: %w", path, err)
+		}
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return fmt.Errorf("stat Guard path %q: %w", path, err)
+		}
+		if wantDirectory && !info.IsDir() {
+			return fmt.Errorf("guard path %q is not a directory", path)
+		}
+		if !wantDirectory && !info.Mode().IsRegular() {
+			return fmt.Errorf("guard path %q is not a regular file; sockets, FIFOs, and devices cannot be granted", path)
+		}
+		return nil
+	}
+	for _, manifest := range cfg.Guard.Manifests {
+		if _, ok := selected[manifest.Name]; !ok {
+			continue
+		}
+		for _, path := range append(append([]string{}, manifest.ReadOnly...), manifest.ReadWrite...) {
+			if err := check(path, false, false); err != nil {
+				return err
+			}
+		}
+		for _, path := range manifest.ReadOnlyDirectories {
+			if err := check(path, true, false); err != nil {
+				return err
+			}
+		}
+		for _, path := range manifest.ReadWriteDirectories {
+			if err := check(path, true, true); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func existingGuardPreflightDirs(paths []string) []string {
+	existing := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			existing = append(existing, path)
+		}
+	}
+	return existing
+}

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -6,6 +6,7 @@ package runtime
 import (
 	"context"
 	"crypto/ed25519"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -59,7 +60,7 @@ func GuardPreflight(cfg *config.Config, profile, workspace string, command []str
 	if err != nil {
 		return sandbox.PreflightResult{}, err
 	}
-	if err := guardfs.ValidateExecutionPaths(resolved, executable); err != nil {
+	if err := guardfs.ValidateExecutionPaths(resolved, resolved, executable); err != nil {
 		return sandbox.PreflightResult{}, err
 	}
 	policy, err := guardSandboxPolicy(cfg, profile, resolved)
@@ -148,6 +149,13 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 		return err
 	}
 	defer evidence.close()
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	guardReady := make(chan struct{})
 
 	p, err := proxy.New(runtimeCfg, logger, sc, guardMetrics, evidence.proxyOptions...)
 	if err != nil {
@@ -156,6 +164,12 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 	defer p.Close()
 	handler := p.Handler()
 	proxyHandler := func(conn net.Conn) {
+		select {
+		case <-guardReady:
+		case <-ctx.Done():
+			_ = conn.Close()
+			return
+		}
 		srv := &http.Server{
 			Handler:           handler,
 			ReadHeaderTimeout: 30 * time.Second,
@@ -168,13 +182,8 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 	if err != nil {
 		return err
 	}
-	ctx := opts.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
 	declaration := runtimeCfg.Guard
+	configPolicyHash := runtimeCfg.CanonicalPolicyHash()
 	return launchStandalone(sandbox.StandaloneLaunchConfig{
 		Ctx:                     ctx,
 		Command:                 opts.Command,
@@ -187,7 +196,21 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 		RequireProxyHandler:     true,
 		GuardDeclaration:        &declaration,
 		GuardProfile:            opts.Profile,
-		GuardPolicyHash:         runtimeCfg.CanonicalPolicyHash(),
+		GuardPolicyHash:         configPolicyHash,
+		GuardEnforced: func(encoded []byte) error {
+			var proof guardfs.ExecutionProof
+			if err := json.Unmarshal(encoded, &proof); err != nil {
+				return fmt.Errorf("decoding child enforcement proof: %w", err)
+			}
+			if err := proof.Verify(configPolicyHash); err != nil {
+				return err
+			}
+			if err := evidence.activate(proof); err != nil {
+				return err
+			}
+			close(guardReady)
+			return nil
+		},
 	})
 }
 
@@ -206,6 +229,12 @@ type guardEvidence struct {
 	proxyOptions []proxy.Option
 	recorder     *recorder.Recorder
 	stop         func()
+	emitter      *receipt.Emitter
+	ctx          context.Context
+	heartbeat    time.Duration
+	stderr       io.Writer
+	require      bool
+	activated    bool
 }
 
 func (e *guardEvidence) close() {
@@ -220,8 +249,39 @@ func (e *guardEvidence) close() {
 	}
 }
 
+func (e *guardEvidence) activate(proof guardfs.ExecutionProof) error {
+	if e == nil || e.emitter == nil || e.activated {
+		return nil
+	}
+	e.emitter.UpdateConfigHash(proof.EffectivePolicyHash)
+	if err := emitStartupSessionOpen(e.emitter); err != nil {
+		if e.require {
+			return fmt.Errorf("emitting Guard session_open receipt: %w", err)
+		}
+		_, _ = fmt.Fprintf(e.stderr,
+			"  Receipts: ERROR - Guard session_open could not be emitted: %v\n"+
+				"            Receipt emission for this run is UNVERIFIED until resolved.\n", err)
+	}
+	if err := e.emitter.EmitDurable(receipt.EmitOpts{
+		ActionID: receipt.NewActionID(), Verdict: config.ActionAllow,
+		Layer: "guard", Pattern: "enforcement_success", Transport: "guard_exec",
+		Method: "EXEC", Target: proof.Binary, PolicyHash: proof.EffectivePolicyHash,
+	}); err != nil {
+		if e.require {
+			return fmt.Errorf("emitting Guard enforcement-success receipt: %w", err)
+		}
+		_, _ = fmt.Fprintf(e.stderr, "  Receipts: ERROR - Guard enforcement-success could not be emitted: %v\n", err)
+	}
+	e.stop = startStandaloneReceiptLifecycle(e.ctx, e.heartbeat, e.emitter, e.stderr, e.require, nil)
+	e.activated = true
+	return nil
+}
+
 func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scanner, m *metrics.Metrics, stderr io.Writer) (*guardEvidence, error) {
-	evidence := &guardEvidence{stop: func() {}}
+	evidence := &guardEvidence{
+		stop: func() {}, ctx: ctx, heartbeat: cfg.FlightRecorder.HeartbeatIntervalDuration(),
+		stderr: stderr, require: cfg.FlightRecorder.RequireReceipts,
+	}
 	if !cfg.FlightRecorder.Enabled || cfg.FlightRecorder.Dir == "" {
 		if cfg.FlightRecorder.RequireReceipts {
 			return nil, errors.New("flight_recorder.require_receipts is enabled but Guard has no configured recorder directory")
@@ -282,16 +342,7 @@ func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scann
 		_, _ = fmt.Fprintln(stderr, "  Receipts: disabled; set a healthy flight_recorder.signing_key_path to enable signed Guard receipts")
 		return evidence, nil
 	}
-	if err := emitStartupSessionOpen(emitter); err != nil {
-		if cfg.FlightRecorder.RequireReceipts {
-			evidence.close()
-			return nil, fmt.Errorf("emitting Guard session_open receipt: %w", err)
-		}
-		_, _ = fmt.Fprintf(stderr,
-			"  Receipts: ERROR - Guard session_open could not be emitted: %v\n"+
-				"            Receipt emission for this run is UNVERIFIED until resolved.\n",
-			err)
-	}
+	evidence.emitter = emitter
 	evidence.proxyOptions = append(evidence.proxyOptions,
 		proxy.WithReceiptEmitter(emitter),
 		proxy.WithReceiptKeyPath(cfg.FlightRecorder.SigningKeyPath),
@@ -303,8 +354,7 @@ func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scann
 	}); v2 != nil {
 		evidence.proxyOptions = append(evidence.proxyOptions, proxy.WithV2ReceiptEmitter(v2))
 	}
-	evidence.stop = startStandaloneReceiptLifecycle(ctx, cfg.FlightRecorder.HeartbeatIntervalDuration(), emitter, stderr, cfg.FlightRecorder.RequireReceipts, nil)
-	_, _ = fmt.Fprintf(stderr, "  Recorder: %s (Guard receipts enabled)\n", cfg.FlightRecorder.Dir)
+	_, _ = fmt.Fprintf(stderr, "  Recorder: %s (Guard receipts armed; awaiting child enforcement proof)\n", cfg.FlightRecorder.Dir)
 	return evidence, nil
 }
 
@@ -406,6 +456,9 @@ func validateGuardRuntimeObjects(cfg *config.Config, profileName string) error {
 			if parentErr != nil {
 				return fmt.Errorf("guard writable directory parent for %q does not exist: %w", path, parentErr)
 			}
+			// EvalSymlinks proved this was a directory, but the path may be
+			// replaced before the grant is prepared. Re-stat it so that race
+			// fails closed instead of creating state beneath a non-directory.
 			info, statErr := os.Stat(parent)
 			if statErr != nil || !info.IsDir() {
 				return fmt.Errorf("guard writable directory parent for %q is not a directory", path)

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/destination"
@@ -54,19 +55,23 @@ func TestLaunchGuardBuildsEnforcedStandaloneLaunch(t *testing.T) {
 	if got.ProxyHandler == nil || got.Policy == nil {
 		t.Fatalf("launch omitted proxy or policy: %+v", got)
 	}
-	if got.GuardEnforced == nil {
+	if got.GuardAppliedPreExec == nil {
 		t.Fatal("launch omitted child enforcement callback")
 	}
 	proof := guardfs.NewExecutionProof(
 		guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
-		got.GuardPolicyHash, "", workspace, workspace, "/usr/bin/true", []string{"/usr/bin/true"},
+		guardfs.ExecControlOptions{PolicyHash: got.GuardPolicyHash, Workspace: workspace, TempDir: workspace, Binary: "/usr/bin/true"},
+		[]string{"/usr/bin/true"},
 	)
 	encoded, err := json.Marshal(proof)
 	if err != nil {
 		t.Fatalf("marshal proof: %v", err)
 	}
-	if err := got.GuardEnforced(encoded); err != nil {
-		t.Fatalf("GuardEnforced: %v", err)
+	if err := got.GuardAppliedPreExec(encoded); err != nil {
+		t.Fatalf("GuardAppliedPreExec: %v", err)
+	}
+	if err := got.GuardAppliedPreExec(encoded); err != nil {
+		t.Fatalf("repeated GuardAppliedPreExec: %v", err)
 	}
 	server, client := net.Pipe()
 	if err := client.Close(); err != nil {
@@ -76,9 +81,10 @@ func TestLaunchGuardBuildsEnforcedStandaloneLaunch(t *testing.T) {
 }
 
 func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
 	var got sandbox.StandaloneLaunchConfig
 	err := launchGuard(GuardLaunchOptions{
-		Context: t.Context(), Config: config.Defaults(), Workspace: t.TempDir(),
+		Context: ctx, Config: config.Defaults(), Workspace: t.TempDir(),
 		Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
 	}, func(launch sandbox.StandaloneLaunchConfig) error {
 		got = launch
@@ -87,23 +93,34 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("launchGuard: %v", err)
 	}
-	if err := got.GuardEnforced([]byte("not-json")); err == nil || !strings.Contains(err.Error(), "decoding") {
+	if err := got.GuardAppliedPreExec([]byte("not-json")); err == nil || !strings.Contains(err.Error(), "decoding") {
 		t.Fatalf("malformed proof error = %v", err)
 	}
 	proof := guardfs.NewExecutionProof(
 		guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
-		"wrong-config", "", "/workspace", "/tmp/private", "/usr/bin/true", []string{"/usr/bin/true"},
+		guardfs.ExecControlOptions{PolicyHash: "wrong-config", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/true"},
+		[]string{"/usr/bin/true"},
 	)
 	encoded, err := json.Marshal(proof)
 	if err != nil {
 		t.Fatalf("marshal mismatched proof: %v", err)
 	}
-	if err := got.GuardEnforced(encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
+	if err := got.GuardAppliedPreExec(encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
 		t.Fatalf("mismatched proof error = %v", err)
 	}
 	server, client := net.Pipe()
 	defer func() { _ = client.Close() }()
-	got.ProxyHandler(server)
+	done := make(chan struct{})
+	go func() {
+		got.ProxyHandler(server)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxy handler did not return after cancellation")
+	}
 }
 
 func TestGuardWorkspaceResolutionFailsFromRemovedDirectory(t *testing.T) {
@@ -115,7 +132,11 @@ func TestGuardWorkspaceResolutionFailsFromRemovedDirectory(t *testing.T) {
 	if err := os.Chdir(removed); err != nil {
 		t.Fatalf("enter removable directory: %v", err)
 	}
-	defer func() { _ = os.Chdir(original) }()
+	defer func() {
+		if err := os.Chdir(original); err != nil {
+			t.Fatalf("restore original directory: %v", err)
+		}
+	}()
 	if err := os.Remove(removed); err != nil {
 		t.Fatalf("remove current directory: %v", err)
 	}
@@ -212,7 +233,7 @@ func TestLaunchGuardFailureDoesNotEmitEnforcementEvidence(t *testing.T) {
 		if readErr != nil {
 			return readErr
 		}
-		if strings.Contains(string(contents), "session_open") || strings.Contains(string(contents), "enforcement_success") {
+		if strings.Contains(string(contents), "session_open") || strings.Contains(string(contents), "landlock_applied_pre_exec") {
 			t.Fatalf("failed launch emitted enforcement evidence in %s", path)
 		}
 		return nil
@@ -615,7 +636,7 @@ func TestLaunchGuardPropagatesRuntimeAndEvidenceFailures(t *testing.T) {
 	}
 }
 
-func TestGuardEvidenceBindsEffectiveInvocationHashAfterActivation(t *testing.T) {
+func TestGuardEvidenceRecordsPreExecApplicationWithoutClaimingCommandStart(t *testing.T) {
 	cfg := config.Defaults()
 	recorderDir := filepath.Join(t.TempDir(), "recorder")
 	keyPath := filepath.Join(t.TempDir(), "receipt.key")
@@ -637,18 +658,20 @@ func TestGuardEvidenceBindsEffectiveInvocationHashAfterActivation(t *testing.T) 
 		t.Fatalf("scanner.New: %v", err)
 	}
 	defer sc.Close()
-	evidence, err := newGuardEvidence(context.Background(), cfg, sc, metrics.New(), io.Discard)
+	evidence, err := newGuardEvidence(t.Context(), cfg, sc, metrics.New(), io.Discard)
 	if err != nil {
 		t.Fatalf("newGuardEvidence: %v", err)
 	}
 	wantHash := strings.Repeat("a", 64)
-	if err := evidence.activate(guardfs.ExecutionProof{EffectivePolicyHash: wantHash, Binary: "/usr/bin/true"}); err != nil {
+	wantExecutionHash := strings.Repeat("b", 64)
+	if err := evidence.activate(guardfs.ExecutionProof{ConfigPolicyHash: wantHash, EffectivePolicyHash: wantExecutionHash, Binary: "/usr/bin/true"}); err != nil {
 		t.Fatalf("activate Guard evidence: %v", err)
 	}
 	evidence.close()
 
 	found := false
-	foundEnforcement := false
+	foundExecution := false
+	foundPreExec := false
 	recorderRoot, err := os.OpenRoot(recorderDir)
 	if err != nil {
 		t.Fatalf("open recorder root: %v", err)
@@ -669,8 +692,14 @@ func TestGuardEvidenceBindsEffectiveInvocationHashAfterActivation(t *testing.T) 
 		if strings.Contains(string(contents), wantHash) {
 			found = true
 		}
+		if strings.Contains(string(contents), "guard-exec:"+wantExecutionHash) {
+			foundExecution = true
+		}
+		if strings.Contains(string(contents), "landlock_applied_pre_exec") {
+			foundPreExec = true
+		}
 		if strings.Contains(string(contents), "enforcement_success") {
-			foundEnforcement = true
+			t.Fatalf("recorder overclaims successful command execution in %s", path)
 		}
 		return nil
 	})
@@ -678,10 +707,13 @@ func TestGuardEvidenceBindsEffectiveInvocationHashAfterActivation(t *testing.T) 
 		t.Fatalf("walk recorder: %v", err)
 	}
 	if !found {
-		t.Fatalf("recorder does not contain effective Guard policy hash %s", wantHash)
+		t.Fatalf("recorder does not contain canonical Guard policy hash %s", wantHash)
 	}
-	if !foundEnforcement {
-		t.Fatal("recorder does not contain signed enforcement-success evidence")
+	if !foundExecution {
+		t.Fatalf("recorder does not contain effective Guard execution digest %s", wantExecutionHash)
+	}
+	if !foundPreExec {
+		t.Fatal("recorder does not contain signed pre-exec enforcement evidence")
 	}
 }
 
@@ -713,7 +745,7 @@ func TestGuardEvidenceActivationHandlesUnhealthyEmitter(t *testing.T) {
 			}
 			defer evidence.close()
 			evidence.emitter.MarkUnhealthy(errors.New("test failure"))
-			proof := guardfs.ExecutionProof{EffectivePolicyHash: strings.Repeat("b", 64), Binary: "/usr/bin/true"}
+			proof := guardfs.ExecutionProof{ConfigPolicyHash: strings.Repeat("a", 64), EffectivePolicyHash: strings.Repeat("b", 64), Binary: "/usr/bin/true"}
 			activationErr := evidence.activate(proof)
 			if require && (activationErr == nil || !strings.Contains(activationErr.Error(), "session_open")) {
 				t.Fatalf("required activation error = %v", activationErr)

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -1,0 +1,512 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
+	guardfs "github.com/luckyPipewrench/pipelock/internal/guard"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/sandbox"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestLaunchGuardBuildsEnforcedStandaloneLaunch(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.Defaults()
+	var got sandbox.StandaloneLaunchConfig
+	err := launchGuard(GuardLaunchOptions{
+		Context:   t.Context(),
+		Config:    cfg,
+		Workspace: workspace,
+		Command:   []string{"/usr/bin/true"},
+		Stderr:    io.Discard,
+	}, func(launch sandbox.StandaloneLaunchConfig) error {
+		got = launch
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("launchGuard: %v", err)
+	}
+	if !got.RequireNetNS || !got.RequireProxyHandler || !got.UseDeveloperEnvironment {
+		t.Fatalf("launch requirements = %+v", got)
+	}
+	wantRuntimeConfig := cfg.Clone()
+	wantRuntimeConfig.ForwardProxy.Enabled = true
+	if got.GuardDeclaration == nil || got.GuardPolicyHash != wantRuntimeConfig.CanonicalPolicyHash() {
+		t.Fatalf("guard binding declaration=%v hash=%q", got.GuardDeclaration, got.GuardPolicyHash)
+	}
+	if got.ProxyHandler == nil || got.Policy == nil {
+		t.Fatalf("launch omitted proxy or policy: %+v", got)
+	}
+}
+
+func TestLaunchGuardRejectsInvalidRequestsBeforeLaunch(t *testing.T) {
+	workspace := t.TempDir()
+	profileCfg := config.Defaults()
+	profileCfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
+	for _, testCase := range []struct {
+		name    string
+		opts    GuardLaunchOptions
+		wantErr string
+	}{
+		{name: "nil config", opts: GuardLaunchOptions{Workspace: workspace, Command: []string{"true"}}, wantErr: "config is nil"},
+		{name: "empty command", opts: GuardLaunchOptions{Config: config.Defaults(), Workspace: workspace}, wantErr: "command is empty"},
+		{name: "invalid workspace", opts: GuardLaunchOptions{Config: config.Defaults(), Workspace: filepath.Join(workspace, "missing"), Command: []string{"true"}}, wantErr: "workspace"},
+		{name: "missing executable", opts: GuardLaunchOptions{Config: config.Defaults(), Workspace: workspace, Command: []string{"missing-guard-command"}}, wantErr: "resolving guard command"},
+		{name: "missing profile", opts: GuardLaunchOptions{Config: profileCfg, Profile: "missing", Workspace: workspace, Command: []string{"true"}}, wantErr: "profile"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			called := false
+			err := launchGuard(testCase.opts, func(sandbox.StandaloneLaunchConfig) error {
+				called = true
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error = %v, want %q", err, testCase.wantErr)
+			}
+			if called {
+				t.Fatal("invalid request reached sandbox launch")
+			}
+		})
+	}
+}
+
+func TestLaunchGuardReturnsSandboxFailure(t *testing.T) {
+	sentinel := errors.New("sandbox refused")
+	err := launchGuard(GuardLaunchOptions{
+		Config: config.Defaults(), Workspace: t.TempDir(), Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+	}, func(sandbox.StandaloneLaunchConfig) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want sandbox failure", err)
+	}
+}
+
+func TestValidateGuardRuntimeFailsClosed(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		mutate  func(*config.Config)
+		wantErr string
+	}{
+		{
+			name: "best effort",
+			mutate: func(cfg *config.Config) {
+				cfg.Sandbox.BestEffort = true
+			},
+			wantErr: "best_effort:true",
+		},
+		{
+			name: "audit only",
+			mutate: func(cfg *config.Config) {
+				enforce := false
+				cfg.Enforce = &enforce
+			},
+			wantErr: "enforce:false",
+		},
+		{
+			name: "environment scan disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.DLP.ScanEnv = false
+			},
+			wantErr: "scan_env:false",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			testCase.mutate(cfg)
+			if err := validateGuardRuntime(cfg); err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error = %v, want %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestGuardDestinationGrantsAreExact(t *testing.T) {
+	grants, err := guardDestinationGrants([]config.GuardService{{
+		Name: "vendor API", Protocol: "tcp", Host: "API.Vendor.Example.", Port: 443,
+	}})
+	if err != nil {
+		t.Fatalf("guardDestinationGrants: %v", err)
+	}
+	exact, err := destination.New(destination.NetworkTCP, "api.vendor.example", 443)
+	if err != nil {
+		t.Fatalf("exact destination: %v", err)
+	}
+	if decision := grants.Evaluate(exact); decision.Effect != destination.EffectAllow {
+		t.Fatalf("exact decision = %+v, want allow", decision)
+	}
+	siblingPort, err := destination.New(destination.NetworkTCP, "api.vendor.example", 444)
+	if err != nil {
+		t.Fatalf("sibling destination: %v", err)
+	}
+	if decision := grants.Evaluate(siblingPort); decision.Effect != destination.EffectNoMatch {
+		t.Fatalf("sibling-port decision = %+v, want no match", decision)
+	}
+}
+
+func TestGuardSandboxPolicyRequiresProfileAndMergesSelectedManifest(t *testing.T) {
+	workspace := t.TempDir()
+	state := t.TempDir()
+	cfg := config.Defaults()
+	cfg.Guard = config.Guard{
+		Profiles: []config.GuardProfile{{Name: "worker", Manifests: []string{"state"}}},
+		Manifests: []config.GuardManifest{{
+			Name: "state", ReadWriteDirectories: []string{state},
+		}},
+	}
+	if _, err := guardSandboxPolicy(cfg, "", workspace); err == nil || !strings.Contains(err.Error(), "profile is required") {
+		t.Fatalf("missing profile error = %v", err)
+	}
+	policy, err := guardSandboxPolicy(cfg, "worker", workspace)
+	if err != nil {
+		t.Fatalf("guardSandboxPolicy: %v", err)
+	}
+	if !containsString(policy.AllowRWDirs, state) {
+		t.Fatalf("RW dirs = %v, want selected state %q", policy.AllowRWDirs, state)
+	}
+}
+
+func TestValidateGuardRuntimeObjectsRejectsSocketGrant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix socket fixture is unavailable on Windows")
+	}
+	socketDir, err := os.MkdirTemp("/tmp", "plk-guard-sock-")
+	if err != nil {
+		t.Fatalf("create short socket directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "agent.sock")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	cfg := config.Defaults()
+	cfg.Guard = config.Guard{
+		Profiles:  []config.GuardProfile{{Name: "worker", Manifests: []string{"state"}}},
+		Manifests: []config.GuardManifest{{Name: "state", ReadWrite: []string{socketPath}}},
+	}
+	if err := validateGuardRuntimeObjects(cfg, "worker"); err == nil || !strings.Contains(err.Error(), "sockets") {
+		t.Fatalf("socket grant error = %v", err)
+	}
+}
+
+func TestValidateGuardRuntimeObjectsRejectsWrongAndMissingPathTypes(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	missingParent := filepath.Join(root, "missing", "state")
+	fileParent := filepath.Join(file, "state")
+	for _, testCase := range []struct {
+		name     string
+		manifest config.GuardManifest
+		wantErr  string
+	}{
+		{name: "missing read file", manifest: config.GuardManifest{Name: "m", ReadOnly: []string{filepath.Join(root, "missing")}}, wantErr: "does not exist"},
+		{name: "file used as directory", manifest: config.GuardManifest{Name: "m", ReadOnlyDirectories: []string{file}}, wantErr: "not a directory"},
+		{name: "directory used as file", manifest: config.GuardManifest{Name: "m", ReadOnly: []string{root}}, wantErr: "not a regular file"},
+		{name: "missing writable parent", manifest: config.GuardManifest{Name: "m", ReadWriteDirectories: []string{missingParent}}, wantErr: "parent"},
+		{name: "writable parent is file", manifest: config.GuardManifest{Name: "m", ReadWriteDirectories: []string{fileParent}}, wantErr: "not a directory"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.Guard = config.Guard{
+				Profiles:  []config.GuardProfile{{Name: "worker", Manifests: []string{"m"}}},
+				Manifests: []config.GuardManifest{testCase.manifest},
+			}
+			err := validateGuardRuntimeObjects(cfg, "worker")
+			if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("error = %v, want %q", err, testCase.wantErr)
+			}
+		})
+	}
+
+	cfg := config.Defaults()
+	cfg.Guard = config.Guard{
+		Profiles: []config.GuardProfile{{Name: "worker", Manifests: []string{"selected"}}},
+		Manifests: []config.GuardManifest{
+			{Name: "selected", ReadOnlyDirectories: []string{root}},
+			{Name: "unselected", ReadOnly: []string{filepath.Join(root, "missing")}},
+		},
+	}
+	if err := validateGuardRuntimeObjects(cfg, "worker"); err != nil {
+		t.Fatalf("unselected manifest affected runtime validation: %v", err)
+	}
+}
+
+func TestGuardHelpersCoverAbsentAndInvalidInputs(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
+	if _, err := guardSandboxPolicy(cfg, "missing", t.TempDir()); err == nil {
+		t.Fatal("missing profile was accepted by policy builder")
+	}
+	if err := validateGuardRuntimeObjects(cfg, "missing"); err == nil {
+		t.Fatal("missing profile was accepted by object validator")
+	}
+	if err := validateGuardRuntimeObjects(cfg, ""); err == nil {
+		t.Fatal("empty profile was accepted with declared profiles")
+	}
+	if _, err := resolveGuardExecutable(nil, t.TempDir()); err == nil {
+		t.Fatal("empty command was accepted")
+	}
+	if got := ctxOrBackground(t.Context()); got != t.Context() {
+		t.Fatal("non-nil context was replaced")
+	}
+	var absentContext context.Context
+	if ctxOrBackground(absentContext) == nil {
+		t.Fatal("nil context was not replaced")
+	}
+	var nilEvidence *guardEvidence
+	nilEvidence.close()
+
+	existing := t.TempDir()
+	missing := filepath.Join(existing, "missing")
+	got := existingGuardPreflightDirs([]string{existing, missing})
+	if len(got) != 1 || got[0] != existing {
+		t.Fatalf("existing preflight directories = %v", got)
+	}
+
+	var stderr bytes.Buffer
+	cfg = config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	evidence, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
+	if err != nil {
+		t.Fatalf("newGuardEvidence inert recorder: %v", err)
+	}
+	evidence.close()
+	if !strings.Contains(stderr.String(), "enabled but inert") {
+		t.Fatalf("inert recorder warning missing: %q", stderr.String())
+	}
+	cfg.FlightRecorder.RequireReceipts = true
+	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil {
+		t.Fatal("required receipts without recorder directory were accepted")
+	}
+
+	cfg = config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "receipts")
+	cfg.FlightRecorder.Redact = false
+	cfg.FlightRecorder.SignCheckpoints = false
+	stderr.Reset()
+	evidence, err = newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
+	if err != nil {
+		t.Fatalf("unsigned recorder: %v", err)
+	}
+	evidence.close()
+	if !strings.Contains(stderr.String(), "Receipts: disabled") {
+		t.Fatalf("unsigned receipt warning missing: %q", stderr.String())
+	}
+
+	badRecorderDir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(badRecorderDir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write recorder obstruction: %v", err)
+	}
+	cfg.FlightRecorder.Dir = badRecorderDir
+	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "creating Guard flight recorder") {
+		t.Fatalf("recorder creation error = %v", err)
+	}
+
+	cfg = config.Defaults()
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "required-receipts")
+	cfg.FlightRecorder.Redact = false
+	cfg.FlightRecorder.SignCheckpoints = false
+	cfg.FlightRecorder.RequireReceipts = true
+	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "no healthy signed Guard receipt emitter") {
+		t.Fatalf("required unsigned receipt error = %v", err)
+	}
+
+	_, privateKey, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "receipt.key")
+	if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "posture-error")
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	cfg.FlightRecorder.SignCheckpoints = true
+	t.Setenv("PIPELOCK_POSTURE_PROOF", "relative-proof.json")
+	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "loading Guard posture binding") {
+		t.Fatalf("posture binding error = %v", err)
+	}
+
+	if _, err := guardDestinationGrants([]config.GuardService{{Name: "bad", Protocol: "bad", Host: "api.vendor.example", Port: 443}}); err == nil {
+		t.Fatal("invalid Guard destination was accepted")
+	}
+}
+
+func TestGuardFirstRunDirectoryIsPreparedBeforeOuterPolicyResolution(t *testing.T) {
+	workspace := t.TempDir()
+	state := filepath.Join(t.TempDir(), "state")
+	cfg := config.Defaults()
+	cfg.Guard = config.Guard{
+		Profiles:  []config.GuardProfile{{Name: "worker", Manifests: []string{"state"}}},
+		Manifests: []config.GuardManifest{{Name: "state", ReadWriteDirectories: []string{state}}},
+	}
+	prepared, err := guardfs.PrepareExecution(cfg, "worker", workspace, workspace, "", os.Getuid())
+	if err != nil {
+		t.Fatalf("PrepareExecution: %v", err)
+	}
+	defer func() { _ = prepared.Close() }()
+	if !prepared.Complete() {
+		t.Fatalf("prepared outcomes = %+v", prepared.Outcomes())
+	}
+	policy, err := guardSandboxPolicy(cfg, "worker", workspace)
+	if err != nil {
+		t.Fatalf("guardSandboxPolicy: %v", err)
+	}
+	if _, err := sandbox.ResolvePolicyPaths(policy); err != nil {
+		t.Fatalf("outer policy could not resolve prepared state directory: %v", err)
+	}
+}
+
+func TestGuardPreflightRefusesWorkspaceThatBypassesWriteFloor(t *testing.T) {
+	_, err := GuardPreflight(config.Defaults(), "", "/usr/local/bin", []string{"/usr/bin/true"})
+	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("dangerous workspace preflight error = %v, want compiled-floor refusal", err)
+	}
+}
+
+func TestGuardPreflightValidatesAndDeclaresEveryRequirement(t *testing.T) {
+	if _, err := GuardPreflight(nil, "", t.TempDir(), []string{"/usr/bin/true"}); err == nil {
+		t.Fatal("nil preflight config was accepted")
+	}
+	workspace := t.TempDir()
+	result, err := GuardPreflight(config.Defaults(), "", workspace, []string{"/usr/bin/true"})
+	if err != nil {
+		t.Fatalf("GuardPreflight: %v", err)
+	}
+	if result.Requirements == nil || !result.Requirements.RequireNetNS || !result.Requirements.RequireProxyHandler || !result.Requirements.RequireLandlock {
+		t.Fatalf("preflight requirements = %+v", result.Requirements)
+	}
+	if _, err := GuardPreflight(config.Defaults(), "", workspace, []string{"missing-guard-command"}); err == nil {
+		t.Fatal("missing preflight executable was accepted")
+	}
+	profileCfg := config.Defaults()
+	profileCfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
+	if _, err := GuardPreflight(profileCfg, "missing", workspace, []string{"/usr/bin/true"}); err == nil {
+		t.Fatal("missing preflight profile was accepted")
+	}
+}
+
+func TestLaunchGuardPropagatesRuntimeAndEvidenceFailures(t *testing.T) {
+	workspace := t.TempDir()
+	logDirectory := t.TempDir()
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{name: "best effort", mutate: func(cfg *config.Config) { cfg.Sandbox.BestEffort = true }, want: "best_effort"},
+		{name: "receipts without directory", mutate: func(cfg *config.Config) {
+			cfg.FlightRecorder.Enabled = true
+			cfg.FlightRecorder.RequireReceipts = true
+		}, want: "no configured recorder directory"},
+		{name: "invalid signing key", mutate: func(cfg *config.Config) {
+			cfg.FlightRecorder.Enabled = true
+			cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "receipts")
+			cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "missing.key")
+		}, want: "loading Guard receipt signing key"},
+		{name: "audit file is directory", mutate: func(cfg *config.Config) {
+			cfg.Logging.Output = config.OutputFile
+			cfg.Logging.File = logDirectory
+		}, want: "create guard audit logger"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			testCase.mutate(cfg)
+			err := launchGuard(GuardLaunchOptions{
+				Config: cfg, Workspace: workspace, Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+			}, func(sandbox.StandaloneLaunchConfig) error {
+				t.Fatal("failed Guard launch reached sandbox")
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+
+	if err := launchGuard(GuardLaunchOptions{
+		Config: config.Defaults(), Workspace: "/usr/local/bin", Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+	}, func(sandbox.StandaloneLaunchConfig) error { return nil }); err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("compiled-floor launch error = %v", err)
+	}
+}
+
+func TestGuardEvidenceBindsCanonicalPolicyHash(t *testing.T) {
+	cfg := config.Defaults()
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	keyPath := filepath.Join(t.TempDir(), "receipt.key")
+	_, privateKey, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = recorderDir
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.Guard.Services = []config.GuardService{{Name: "vendor", Protocol: "tcp", Host: "api.vendor.example", Port: 443}}
+
+	sc, err := scanner.New(cfg)
+	if err != nil {
+		t.Fatalf("scanner.New: %v", err)
+	}
+	defer sc.Close()
+	evidence, err := newGuardEvidence(context.Background(), cfg, sc, metrics.New(), io.Discard)
+	if err != nil {
+		t.Fatalf("newGuardEvidence: %v", err)
+	}
+	evidence.close()
+
+	wantHash := cfg.CanonicalPolicyHash()
+	found := false
+	recorderRoot, err := os.OpenRoot(recorderDir)
+	if err != nil {
+		t.Fatalf("open recorder root: %v", err)
+	}
+	defer func() { _ = recorderRoot.Close() }()
+	err = filepath.WalkDir(recorderDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		relative, relErr := filepath.Rel(recorderDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		contents, readErr := recorderRoot.ReadFile(relative)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(contents), wantHash) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk recorder: %v", err)
+	}
+	if !found {
+		t.Fatalf("recorder does not contain canonical Guard policy hash %s", wantHash)
+	}
+}

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -384,6 +384,17 @@ func TestGuardPreflightRefusesWorkspaceThatBypassesWriteFloor(t *testing.T) {
 	}
 }
 
+func TestGuardPreflightRefusesWorkspaceSymlinkThatBypassesWriteFloor(t *testing.T) {
+	alias := filepath.Join(t.TempDir(), "workspace")
+	if err := os.Symlink("/usr/local/bin", alias); err != nil {
+		t.Fatalf("create workspace symlink: %v", err)
+	}
+	_, err := GuardPreflight(config.Defaults(), "", alias, []string{"/usr/bin/true"})
+	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("dangerous workspace symlink preflight error = %v", err)
+	}
+}
+
 func TestGuardPreflightValidatesAndDeclaresEveryRequirement(t *testing.T) {
 	if _, err := GuardPreflight(nil, "", t.TempDir(), []string{"/usr/bin/true"}); err == nil {
 		t.Fatal("nil preflight config was accepted")

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -6,7 +6,9 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -52,9 +54,85 @@ func TestLaunchGuardBuildsEnforcedStandaloneLaunch(t *testing.T) {
 	if got.ProxyHandler == nil || got.Policy == nil {
 		t.Fatalf("launch omitted proxy or policy: %+v", got)
 	}
+	if got.GuardEnforced == nil {
+		t.Fatal("launch omitted child enforcement callback")
+	}
+	proof := guardfs.NewExecutionProof(
+		guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
+		got.GuardPolicyHash, "", workspace, workspace, "/usr/bin/true", []string{"/usr/bin/true"},
+	)
+	encoded, err := json.Marshal(proof)
+	if err != nil {
+		t.Fatalf("marshal proof: %v", err)
+	}
+	if err := got.GuardEnforced(encoded); err != nil {
+		t.Fatalf("GuardEnforced: %v", err)
+	}
+	server, client := net.Pipe()
+	if err := client.Close(); err != nil {
+		t.Fatalf("close proxy client: %v", err)
+	}
+	got.ProxyHandler(server)
+}
+
+func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
+	var got sandbox.StandaloneLaunchConfig
+	err := launchGuard(GuardLaunchOptions{
+		Context: t.Context(), Config: config.Defaults(), Workspace: t.TempDir(),
+		Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+	}, func(launch sandbox.StandaloneLaunchConfig) error {
+		got = launch
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("launchGuard: %v", err)
+	}
+	if err := got.GuardEnforced([]byte("not-json")); err == nil || !strings.Contains(err.Error(), "decoding") {
+		t.Fatalf("malformed proof error = %v", err)
+	}
+	proof := guardfs.NewExecutionProof(
+		guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
+		"wrong-config", "", "/workspace", "/tmp/private", "/usr/bin/true", []string{"/usr/bin/true"},
+	)
+	encoded, err := json.Marshal(proof)
+	if err != nil {
+		t.Fatalf("marshal mismatched proof: %v", err)
+	}
+	if err := got.GuardEnforced(encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
+		t.Fatalf("mismatched proof error = %v", err)
+	}
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	got.ProxyHandler(server)
+}
+
+func TestGuardWorkspaceResolutionFailsFromRemovedDirectory(t *testing.T) {
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get original directory: %v", err)
+	}
+	removed := t.TempDir()
+	if err := os.Chdir(removed); err != nil {
+		t.Fatalf("enter removable directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(original) }()
+	if err := os.Remove(removed); err != nil {
+		t.Fatalf("remove current directory: %v", err)
+	}
+	if _, err := GuardPreflight(config.Defaults(), "", "relative", []string{"/usr/bin/true"}); err == nil || !strings.Contains(err.Error(), "resolving guard workspace") {
+		t.Fatalf("GuardPreflight error = %v", err)
+	}
+	if err := launchGuard(GuardLaunchOptions{
+		Config: config.Defaults(), Workspace: "relative", Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+	}, func(sandbox.StandaloneLaunchConfig) error { return nil }); err == nil || !strings.Contains(err.Error(), "resolving guard workspace") {
+		t.Fatalf("launchGuard error = %v", err)
+	}
 }
 
 func TestLaunchGuardRejectsInvalidRequestsBeforeLaunch(t *testing.T) {
+	if err := LaunchGuard(GuardLaunchOptions{}); err == nil || !strings.Contains(err.Error(), "config is nil") {
+		t.Fatalf("LaunchGuard nil-config error = %v", err)
+	}
 	workspace := t.TempDir()
 	profileCfg := config.Defaults()
 	profileCfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
@@ -92,6 +170,55 @@ func TestLaunchGuardReturnsSandboxFailure(t *testing.T) {
 	}, func(sandbox.StandaloneLaunchConfig) error { return sentinel })
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("error = %v, want sandbox failure", err)
+	}
+}
+
+func TestLaunchGuardFailureDoesNotEmitEnforcementEvidence(t *testing.T) {
+	cfg := config.Defaults()
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	_, privateKey, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "receipt.key")
+	if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	cfg.FlightRecorder.Enabled = true
+	cfg.FlightRecorder.Dir = recorderDir
+	cfg.FlightRecorder.SigningKeyPath = keyPath
+	cfg.FlightRecorder.RequireReceipts = true
+	sentinel := errors.New("sandbox refused")
+	err = launchGuard(GuardLaunchOptions{
+		Config: cfg, Workspace: t.TempDir(), Command: []string{"/usr/bin/true"}, Stderr: io.Discard,
+	}, func(sandbox.StandaloneLaunchConfig) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("launchGuard error = %v", err)
+	}
+	recorderRoot, err := os.OpenRoot(recorderDir)
+	if err != nil {
+		t.Fatalf("open recorder root: %v", err)
+	}
+	defer func() { _ = recorderRoot.Close() }()
+	err = filepath.WalkDir(recorderDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		relative, relErr := filepath.Rel(recorderDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		contents, readErr := recorderRoot.ReadFile(relative)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(contents), "session_open") || strings.Contains(string(contents), "enforcement_success") {
+			t.Fatalf("failed launch emitted enforcement evidence in %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk recorder: %v", err)
 	}
 }
 
@@ -211,17 +338,16 @@ func TestValidateGuardRuntimeObjectsRejectsWrongAndMissingPathTypes(t *testing.T
 		t.Fatalf("write fixture: %v", err)
 	}
 	missingParent := filepath.Join(root, "missing", "state")
-	fileParent := filepath.Join(file, "state")
 	for _, testCase := range []struct {
 		name     string
 		manifest config.GuardManifest
 		wantErr  string
 	}{
 		{name: "missing read file", manifest: config.GuardManifest{Name: "m", ReadOnly: []string{filepath.Join(root, "missing")}}, wantErr: "does not exist"},
+		{name: "missing writable file", manifest: config.GuardManifest{Name: "m", ReadWrite: []string{filepath.Join(root, "missing-writable")}}, wantErr: "does not exist"},
 		{name: "file used as directory", manifest: config.GuardManifest{Name: "m", ReadOnlyDirectories: []string{file}}, wantErr: "not a directory"},
 		{name: "directory used as file", manifest: config.GuardManifest{Name: "m", ReadOnly: []string{root}}, wantErr: "not a regular file"},
 		{name: "missing writable parent", manifest: config.GuardManifest{Name: "m", ReadWriteDirectories: []string{missingParent}}, wantErr: "parent"},
-		{name: "writable parent is file", manifest: config.GuardManifest{Name: "m", ReadWriteDirectories: []string{fileParent}}, wantErr: "not a directory"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			cfg := config.Defaults()
@@ -250,106 +376,130 @@ func TestValidateGuardRuntimeObjectsRejectsWrongAndMissingPathTypes(t *testing.T
 }
 
 func TestGuardHelpersCoverAbsentAndInvalidInputs(t *testing.T) {
-	cfg := config.Defaults()
-	cfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
-	if _, err := guardSandboxPolicy(cfg, "missing", t.TempDir()); err == nil {
-		t.Fatal("missing profile was accepted by policy builder")
-	}
-	if err := validateGuardRuntimeObjects(cfg, "missing"); err == nil {
-		t.Fatal("missing profile was accepted by object validator")
-	}
-	if err := validateGuardRuntimeObjects(cfg, ""); err == nil {
-		t.Fatal("empty profile was accepted with declared profiles")
-	}
-	if _, err := resolveGuardExecutable(nil, t.TempDir()); err == nil {
-		t.Fatal("empty command was accepted")
-	}
-	if got := ctxOrBackground(t.Context()); got != t.Context() {
-		t.Fatal("non-nil context was replaced")
-	}
-	var absentContext context.Context
-	if ctxOrBackground(absentContext) == nil {
-		t.Fatal("nil context was not replaced")
-	}
-	var nilEvidence *guardEvidence
-	nilEvidence.close()
-
-	existing := t.TempDir()
-	missing := filepath.Join(existing, "missing")
-	got := existingGuardPreflightDirs([]string{existing, missing})
-	if len(got) != 1 || got[0] != existing {
-		t.Fatalf("existing preflight directories = %v", got)
-	}
-
-	var stderr bytes.Buffer
-	cfg = config.Defaults()
-	cfg.FlightRecorder.Enabled = true
-	evidence, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
-	if err != nil {
-		t.Fatalf("newGuardEvidence inert recorder: %v", err)
-	}
-	evidence.close()
-	if !strings.Contains(stderr.String(), "enabled but inert") {
-		t.Fatalf("inert recorder warning missing: %q", stderr.String())
-	}
-	cfg.FlightRecorder.RequireReceipts = true
-	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil {
-		t.Fatal("required receipts without recorder directory were accepted")
-	}
-
-	cfg = config.Defaults()
-	cfg.FlightRecorder.Enabled = true
-	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "receipts")
-	cfg.FlightRecorder.Redact = false
-	cfg.FlightRecorder.SignCheckpoints = false
-	stderr.Reset()
-	evidence, err = newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
-	if err != nil {
-		t.Fatalf("unsigned recorder: %v", err)
-	}
-	evidence.close()
-	if !strings.Contains(stderr.String(), "Receipts: disabled") {
-		t.Fatalf("unsigned receipt warning missing: %q", stderr.String())
-	}
-
-	badRecorderDir := filepath.Join(t.TempDir(), "not-a-directory")
-	if err := os.WriteFile(badRecorderDir, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write recorder obstruction: %v", err)
-	}
-	cfg.FlightRecorder.Dir = badRecorderDir
-	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "creating Guard flight recorder") {
-		t.Fatalf("recorder creation error = %v", err)
-	}
-
-	cfg = config.Defaults()
-	cfg.FlightRecorder.Enabled = true
-	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "required-receipts")
-	cfg.FlightRecorder.Redact = false
-	cfg.FlightRecorder.SignCheckpoints = false
-	cfg.FlightRecorder.RequireReceipts = true
-	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "no healthy signed Guard receipt emitter") {
-		t.Fatalf("required unsigned receipt error = %v", err)
-	}
-
-	_, privateKey, err := signing.GenerateKeyPair()
-	if err != nil {
-		t.Fatalf("GenerateKeyPair: %v", err)
-	}
-	keyPath := filepath.Join(t.TempDir(), "receipt.key")
-	if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
-		t.Fatalf("SavePrivateKey: %v", err)
-	}
-	cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "posture-error")
-	cfg.FlightRecorder.SigningKeyPath = keyPath
-	cfg.FlightRecorder.SignCheckpoints = true
-	t.Setenv("PIPELOCK_POSTURE_PROOF", "relative-proof.json")
-	if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "loading Guard posture binding") {
-		t.Fatalf("posture binding error = %v", err)
-	}
-
-	if _, err := guardDestinationGrants([]config.GuardService{{Name: "bad", Protocol: "bad", Host: "api.vendor.example", Port: 443}}); err == nil {
-		t.Fatal("invalid Guard destination was accepted")
-	}
+	t.Run("profile validation", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
+		if _, err := guardSandboxPolicy(cfg, "missing", t.TempDir()); err == nil {
+			t.Fatal("missing profile was accepted by policy builder")
+		}
+		if err := validateGuardRuntimeObjects(cfg, "missing"); err == nil {
+			t.Fatal("missing profile was accepted by object validator")
+		}
+		if err := validateGuardRuntimeObjects(cfg, ""); err == nil {
+			t.Fatal("empty profile was accepted with declared profiles")
+		}
+	})
+	t.Run("empty command", func(t *testing.T) {
+		if _, err := resolveGuardExecutable(nil, t.TempDir()); err == nil {
+			t.Fatal("empty command was accepted")
+		}
+	})
+	t.Run("context fallback", func(t *testing.T) {
+		if got := ctxOrBackground(t.Context()); got != t.Context() {
+			t.Fatal("non-nil context was replaced")
+		}
+		var absentContext context.Context
+		if ctxOrBackground(absentContext) == nil {
+			t.Fatal("nil context was not replaced")
+		}
+	})
+	t.Run("nil evidence close", func(t *testing.T) {
+		var nilEvidence *guardEvidence
+		nilEvidence.close()
+	})
+	t.Run("existing preflight directories", func(t *testing.T) {
+		existing := t.TempDir()
+		got := existingGuardPreflightDirs([]string{existing, filepath.Join(existing, "missing")})
+		if len(got) != 1 || got[0] != existing {
+			t.Fatalf("existing preflight directories = %v", got)
+		}
+	})
+	t.Run("inert recorder", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		var stderr bytes.Buffer
+		evidence, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
+		if err != nil {
+			t.Fatalf("newGuardEvidence: %v", err)
+		}
+		evidence.close()
+		if !strings.Contains(stderr.String(), "enabled but inert") {
+			t.Fatalf("warning missing: %q", stderr.String())
+		}
+	})
+	t.Run("required receipts need directory", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		cfg.FlightRecorder.RequireReceipts = true
+		if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil {
+			t.Fatal("required receipts without recorder directory were accepted")
+		}
+	})
+	t.Run("unsigned recorder", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "receipts")
+		cfg.FlightRecorder.Redact = false
+		cfg.FlightRecorder.SignCheckpoints = false
+		var stderr bytes.Buffer
+		evidence, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), &stderr)
+		if err != nil {
+			t.Fatalf("unsigned recorder: %v", err)
+		}
+		evidence.close()
+		if !strings.Contains(stderr.String(), "Receipts: disabled") {
+			t.Fatalf("unsigned receipt warning missing: %q", stderr.String())
+		}
+	})
+	t.Run("recorder obstruction", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		cfg.FlightRecorder.Redact = false
+		badRecorderDir := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(badRecorderDir, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write recorder obstruction: %v", err)
+		}
+		cfg.FlightRecorder.Dir = badRecorderDir
+		if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "creating Guard flight recorder") {
+			t.Fatalf("recorder creation error = %v", err)
+		}
+	})
+	t.Run("required unsigned receipts", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "required-receipts")
+		cfg.FlightRecorder.Redact = false
+		cfg.FlightRecorder.SignCheckpoints = false
+		cfg.FlightRecorder.RequireReceipts = true
+		if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "no healthy signed Guard receipt emitter") {
+			t.Fatalf("required unsigned receipt error = %v", err)
+		}
+	})
+	t.Run("invalid posture binding", func(t *testing.T) {
+		_, privateKey, err := signing.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+		keyPath := filepath.Join(t.TempDir(), "receipt.key")
+		if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
+			t.Fatalf("SavePrivateKey: %v", err)
+		}
+		cfg := config.Defaults()
+		cfg.FlightRecorder.Enabled = true
+		cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "posture-error")
+		cfg.FlightRecorder.SigningKeyPath = keyPath
+		cfg.FlightRecorder.SignCheckpoints = true
+		cfg.FlightRecorder.RequireReceipts = true
+		t.Setenv("PIPELOCK_POSTURE_PROOF", "relative-proof.json")
+		if _, err := newGuardEvidence(t.Context(), cfg, nil, metrics.New(), io.Discard); err == nil || !strings.Contains(err.Error(), "loading Guard posture binding") {
+			t.Fatalf("posture binding error = %v", err)
+		}
+	})
+	t.Run("invalid destination", func(t *testing.T) {
+		if _, err := guardDestinationGrants([]config.GuardService{{Name: "bad", Protocol: "bad", Host: "api.vendor.example", Port: 443}}); err == nil {
+			t.Fatal("invalid Guard destination was accepted")
+		}
+	})
 }
 
 func TestGuardFirstRunDirectoryIsPreparedBeforeOuterPolicyResolution(t *testing.T) {
@@ -435,6 +585,9 @@ func TestLaunchGuardPropagatesRuntimeAndEvidenceFailures(t *testing.T) {
 			cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "receipts")
 			cfg.FlightRecorder.SigningKeyPath = filepath.Join(t.TempDir(), "missing.key")
 		}, want: "loading Guard receipt signing key"},
+		{name: "invalid scanner pattern", mutate: func(cfg *config.Config) {
+			cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{Name: "invalid", Regex: "[", Severity: config.SeverityHigh})
+		}, want: "create guard scanner"},
 		{name: "audit file is directory", mutate: func(cfg *config.Config) {
 			cfg.Logging.Output = config.OutputFile
 			cfg.Logging.File = logDirectory
@@ -462,7 +615,7 @@ func TestLaunchGuardPropagatesRuntimeAndEvidenceFailures(t *testing.T) {
 	}
 }
 
-func TestGuardEvidenceBindsCanonicalPolicyHash(t *testing.T) {
+func TestGuardEvidenceBindsEffectiveInvocationHashAfterActivation(t *testing.T) {
 	cfg := config.Defaults()
 	recorderDir := filepath.Join(t.TempDir(), "recorder")
 	keyPath := filepath.Join(t.TempDir(), "receipt.key")
@@ -488,10 +641,14 @@ func TestGuardEvidenceBindsCanonicalPolicyHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newGuardEvidence: %v", err)
 	}
+	wantHash := strings.Repeat("a", 64)
+	if err := evidence.activate(guardfs.ExecutionProof{EffectivePolicyHash: wantHash, Binary: "/usr/bin/true"}); err != nil {
+		t.Fatalf("activate Guard evidence: %v", err)
+	}
 	evidence.close()
 
-	wantHash := cfg.CanonicalPolicyHash()
 	found := false
+	foundEnforcement := false
 	recorderRoot, err := os.OpenRoot(recorderDir)
 	if err != nil {
 		t.Fatalf("open recorder root: %v", err)
@@ -512,12 +669,58 @@ func TestGuardEvidenceBindsCanonicalPolicyHash(t *testing.T) {
 		if strings.Contains(string(contents), wantHash) {
 			found = true
 		}
+		if strings.Contains(string(contents), "enforcement_success") {
+			foundEnforcement = true
+		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walk recorder: %v", err)
 	}
 	if !found {
-		t.Fatalf("recorder does not contain canonical Guard policy hash %s", wantHash)
+		t.Fatalf("recorder does not contain effective Guard policy hash %s", wantHash)
+	}
+	if !foundEnforcement {
+		t.Fatal("recorder does not contain signed enforcement-success evidence")
+	}
+}
+
+func TestGuardEvidenceActivationHandlesUnhealthyEmitter(t *testing.T) {
+	_, privateKey, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "receipt.key")
+	if err := signing.SavePrivateKey(privateKey, keyPath); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	for _, require := range []bool{true, false} {
+		t.Run(fmt.Sprintf("require=%t", require), func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.FlightRecorder.Enabled = true
+			cfg.FlightRecorder.Dir = filepath.Join(t.TempDir(), "recorder")
+			cfg.FlightRecorder.SigningKeyPath = keyPath
+			cfg.FlightRecorder.RequireReceipts = require
+			sc, scanErr := scanner.New(cfg)
+			if scanErr != nil {
+				t.Fatalf("scanner.New: %v", scanErr)
+			}
+			defer sc.Close()
+			var stderr bytes.Buffer
+			evidence, evidenceErr := newGuardEvidence(t.Context(), cfg, sc, metrics.New(), &stderr)
+			if evidenceErr != nil {
+				t.Fatalf("newGuardEvidence: %v", evidenceErr)
+			}
+			defer evidence.close()
+			evidence.emitter.MarkUnhealthy(errors.New("test failure"))
+			proof := guardfs.ExecutionProof{EffectivePolicyHash: strings.Repeat("b", 64), Binary: "/usr/bin/true"}
+			activationErr := evidence.activate(proof)
+			if require && (activationErr == nil || !strings.Contains(activationErr.Error(), "session_open")) {
+				t.Fatalf("required activation error = %v", activationErr)
+			}
+			if !require && (activationErr != nil || !strings.Contains(stderr.String(), "UNVERIFIED")) {
+				t.Fatalf("best-effort activation error=%v stderr=%q", activationErr, stderr.String())
+			}
+		})
 	}
 }

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -113,7 +113,12 @@ func (c *Config) computeCanonicalPolicyHash() string {
 // tool policy rules, chain detection rules, suppress entries). Only
 // set-like string slices with no semantic order (api_allowlist, internal
 // SSRF block, trusted_domains) are sorted into canonical order.
-func (c *Config) policySemanticView() Config {
+type canonicalPolicyView struct {
+	Config
+	Guard *Guard `json:"guard,omitempty"`
+}
+
+func (c *Config) policySemanticView() canonicalPolicyView {
 	view := *c
 
 	// Transport structs (FetchProxy, ForwardProxy, WebSocketProxy,
@@ -235,14 +240,11 @@ func (c *Config) policySemanticView() Config {
 	view.Redaction.AllowlistUnparseableRoutes = canonicalUnparseableRoutes(view.Redaction.Enabled, view.Redaction.AllowlistUnparseableRoutes)
 	view.Redaction.Providers = canonicalRedactionProviders(view.Redaction.Enabled, view.Redaction.Providers)
 
-	// Guard is deliberately NOT canonicalized here. It carries json:"-" and is
-	// excluded from the canonical policy hash while it has no runtime consumer:
-	// a field enters the policy hash only once a production decision path
-	// consumes it, because that hash is stamped into receipts, learn-compile
-	// output, dashboard snapshots, replay packets, and conductor bundles. An
-	// inert field entering the hash would make byte-identical effective policy
-	// emit different evidence across a mixed-version fleet mid-upgrade.
-	// Canonicalize guard here when the runtime evaluator lands.
+	// Guard declarations are set-like startup policy. The execution surface
+	// consumes them, so they belong in the policy hash; sorting copies keeps
+	// declaration order from creating false policy drift.
+	guard := canonicalGuard(view.Guard)
+	view.Guard = Guard{}
 
 	// Resolve omitted-or-zero learn-inference fields to their effective
 	// defaults so the policy hash reflects the runtime-effective policy,
@@ -254,7 +256,50 @@ func (c *Config) policySemanticView() Config {
 	view.Learn.Inference.Floors = view.Learn.Inference.Floors.Resolved()
 	view.Learn.Inference.Normalization = view.Learn.Inference.Normalization.Resolved()
 
-	return view
+	var guardView *Guard
+	if len(guard.Services) > 0 || len(guard.Profiles) > 0 || len(guard.Manifests) > 0 {
+		guardView = &guard
+	}
+	return canonicalPolicyView{Config: view, Guard: guardView}
+}
+
+func canonicalGuard(g Guard) Guard {
+	out := Guard{
+		Services:  append([]GuardService(nil), g.Services...),
+		Profiles:  make([]GuardProfile, len(g.Profiles)),
+		Manifests: make([]GuardManifest, len(g.Manifests)),
+	}
+	for i, service := range out.Services {
+		out.Services[i].Protocol = strings.ToLower(service.Protocol)
+		out.Services[i].Host = strings.TrimSuffix(strings.ToLower(service.Host), ".")
+	}
+	sort.Slice(out.Services, func(i, j int) bool {
+		a, b := out.Services[i], out.Services[j]
+		if a.Protocol != b.Protocol {
+			return a.Protocol < b.Protocol
+		}
+		if a.Host != b.Host {
+			return a.Host < b.Host
+		}
+		if a.Port != b.Port {
+			return a.Port < b.Port
+		}
+		return a.Name < b.Name
+	})
+	for i, profile := range g.Profiles {
+		out.Profiles[i] = profile
+		out.Profiles[i].Manifests = sortedCopy(profile.Manifests)
+	}
+	sort.Slice(out.Profiles, func(i, j int) bool { return out.Profiles[i].Name < out.Profiles[j].Name })
+	for i, manifest := range g.Manifests {
+		out.Manifests[i] = manifest
+		out.Manifests[i].ReadOnly = sortedCopy(manifest.ReadOnly)
+		out.Manifests[i].ReadOnlyDirectories = sortedCopy(manifest.ReadOnlyDirectories)
+		out.Manifests[i].ReadWrite = sortedCopy(manifest.ReadWrite)
+		out.Manifests[i].ReadWriteDirectories = sortedCopy(manifest.ReadWriteDirectories)
+	}
+	sort.Slice(out.Manifests, func(i, j int) bool { return out.Manifests[i].Name < out.Manifests[j].Name })
+	return out
 }
 
 func canonicalA2ATrustedCardKeys(keys []A2ATrustedCardKey) []A2ATrustedCardKey {

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -271,7 +271,7 @@ func canonicalGuard(g Guard) Guard {
 	}
 	for i, service := range out.Services {
 		out.Services[i].Protocol = strings.ToLower(service.Protocol)
-		out.Services[i].Host = strings.TrimSuffix(strings.ToLower(service.Host), ".")
+		out.Services[i].Host = strings.TrimRight(strings.ToLower(service.Host), ".")
 	}
 	sort.Slice(out.Services, func(i, j int) bool {
 		a, b := out.Services[i], out.Services[j]

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -924,6 +924,12 @@ func TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent(t *testing.T) {
 			Services: []GuardService{
 				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 8443},
 			},
+			Manifests: []GuardManifest{
+				{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}},
+			},
+			Profiles: []GuardProfile{
+				{Name: "codex", Manifests: []string{"session"}},
+			},
 		}
 	})
 
@@ -935,7 +941,7 @@ func TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent(t *testing.T) {
 		c.Guard = Guard{
 			Profiles:  []GuardProfile{{Name: "codex", Manifests: []string{"session"}}},
 			Manifests: []GuardManifest{{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}}},
-			Services:  []GuardService{{Name: "api", Protocol: "TCP", Host: "A.VENDOR.EXAMPLE.", Port: 443}},
+			Services:  []GuardService{{Name: "api", Protocol: "TCP", Host: "A.VENDOR.EXAMPLE..", Port: 443}},
 		}
 	})
 	if reordered != withGuard {

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -148,7 +147,7 @@ func TestExplainGuardPathFloorValidatorAntiDrift(t *testing.T) {
 	}
 }
 
-func TestGuardInspectionValidationSeparatesStructureFloorAndRuntimeGate(t *testing.T) {
+func TestGuardInspectionValidationSeparatesStructureAndFloor(t *testing.T) {
 	t.Parallel()
 
 	floorRefused := Defaults()
@@ -159,8 +158,8 @@ func TestGuardInspectionValidationSeparatesStructureFloorAndRuntimeGate(t *testi
 	if err := floorRefused.ValidateGuardStructure(); err != nil {
 		t.Fatalf("structure-only validation must retain a floor-refused path for explanation: %v", err)
 	}
-	if err := floorRefused.ValidateGuardDeclaration(); err == nil || errors.Is(err, errGuardNotEnforced) || !strings.Contains(err.Error(), ".netrc") {
-		t.Fatalf("declaration validation must enforce the path floor before the runtime gate: %v", err)
+	if err := floorRefused.ValidateGuardDeclaration(); err == nil || !strings.Contains(err.Error(), ".netrc") {
+		t.Fatalf("declaration validation must enforce the path floor: %v", err)
 	}
 
 	invalidStructure := Defaults()
@@ -207,17 +206,8 @@ func TestValidateGuard_ValidFull(t *testing.T) {
 			},
 		},
 	}
-	// A structurally valid declaration passes every path and naming rule and is
-	// then refused solely because nothing enforces guard yet. Asserting the
-	// exact sentinel keeps this test honest: if a real validation rule started
-	// rejecting this config, the error would no longer be the gate and this
-	// would fail rather than quietly passing for the wrong reason.
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("guard config must be refused while no runtime evaluator enforces it")
-	}
-	if !errors.Is(err, errGuardNotEnforced) {
-		t.Fatalf("valid guard config should fail only on the not-enforced gate, got: %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid enforced guard declaration rejected: %v", err)
 	}
 }
 
@@ -236,7 +226,6 @@ func TestValidateGuard_PathTypes(t *testing.T) {
 		name      string
 		manifest  GuardManifest
 		wantErr   string
-		wantGate  bool
 		noPathErr bool
 	}{
 		{
@@ -246,7 +235,6 @@ func TestValidateGuard_PathTypes(t *testing.T) {
 				ReadOnly:  []string{missingFile},
 				ReadWrite: []string{filepath.Join(t.TempDir(), "writable-state")},
 			},
-			wantGate:  true,
 			noPathErr: true,
 		},
 		{
@@ -256,7 +244,6 @@ func TestValidateGuard_PathTypes(t *testing.T) {
 				ReadOnlyDirectories:  []string{missingDirectory},
 				ReadWriteDirectories: []string{filepath.Join(t.TempDir(), "writable-state") + string(filepath.Separator)},
 			},
-			wantGate:  true,
 			noPathErr: true,
 		},
 		{
@@ -322,18 +309,12 @@ func TestValidateGuard_PathTypes(t *testing.T) {
 			cfg := Defaults()
 			cfg.Guard = Guard{Manifests: []GuardManifest{tt.manifest}}
 			err := cfg.Validate()
-			if err == nil {
-				t.Fatal("guard config must be rejected while the evaluator is absent")
-			}
-			if tt.wantGate && !errors.Is(err, errGuardNotEnforced) {
-				t.Fatalf("declared path type must pass path validation and reach the gate, got: %v", err)
-			}
-			if tt.noPathErr && !errors.Is(err, errGuardNotEnforced) {
+			if tt.noPathErr && err != nil {
 				t.Fatalf("path type validation must not depend on an absent path, got: %v", err)
 			}
 			if tt.wantErr != "" {
-				if errors.Is(err, errGuardNotEnforced) {
-					t.Fatalf("invalid declaration was refused only by the gate, not its path-type rule: %v", err)
+				if err == nil {
+					t.Fatal("invalid declaration was accepted")
 				}
 				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.wantErr)) {
 					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
@@ -574,9 +555,7 @@ func TestValidateGuard_Rejections(t *testing.T) {
 			guard: Guard{Manifests: []GuardManifest{
 				{Name: "ok", ReadWrite: []string{"/tmp/workdir"}},
 			}},
-			// The path itself is fine. The declaration is refused only by the
-			// not-enforced gate, which is the message asserted here.
-			wantErr: "not enforced",
+			// The path itself is fine and must remain available.
 		},
 		{
 			// Inverted deliberately. Read-only is NOT safe for key material
@@ -645,7 +624,6 @@ func TestValidateGuard_Rejections(t *testing.T) {
 			guard: Guard{Manifests: []GuardManifest{
 				{Name: "ok", ReadOnly: []string{filepath.Join(guardTestHome, ".config", "autostart")}},
 			}},
-			wantErr: "not enforced",
 		},
 		{
 			name: "ro_absolute_etc_pipelock_rejected",
@@ -882,18 +860,6 @@ func TestValidateGuard_ForeignHomeTrustPaths(t *testing.T) {
 				t.Errorf("read-write on %q must be rejected regardless of which user Pipelock runs as", path)
 				return
 			}
-			// Assert the rejection came from a PATH rule, not from the
-			// not-enforced gate.
-			//
-			// This test was proven non-vacuous when written, and then SILENTLY
-			// became vacuous when the errGuardNotEnforced gate was added later:
-			// the gate rejects every non-empty guard declaration, so a bare
-			// err != nil check passes even with every protected-path rule
-			// deleted. A guard proven honest at one commit is not proven honest
-			// at the next; a later change can hollow it out without touching it.
-			if errors.Is(err, errGuardNotEnforced) {
-				t.Errorf("read-write on %q was refused only by the not-enforced gate, so no path rule actually rejected it: %v", path, err)
-			}
 		})
 	}
 }
@@ -921,24 +887,14 @@ func TestValidateGuard_OrdinaryWorkspacePathsStillAllowed(t *testing.T) {
 					{Name: "ok", ReadWrite: []string{path}},
 				},
 			}
-			err := cfg.Validate()
-			if err == nil {
-				t.Fatalf("guard is refused while unenforced; %q should still reach the gate", path)
-			}
-			// The point of this test is the DIRECTION of the refusal: an
-			// ordinary workspace path must be rejected only by the
-			// not-enforced gate, never by a trust-bearing path rule. An
-			// over-strict guard that refuses legitimate work gets the whole
-			// feature switched off, which on a security product costs nearly
-			// as much as permitting too much.
-			if !errors.Is(err, errGuardNotEnforced) {
+			if err := cfg.Validate(); err != nil {
 				t.Errorf("ordinary workspace path %q must pass the path rules, got: %v", path, err)
 			}
 		})
 	}
 }
 
-func TestCanonicalPolicyHash_GuardExcludedWhileInert(t *testing.T) {
+func TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent(t *testing.T) {
 	t.Parallel()
 
 	base := canonicalHashOf(t, func(c *Config) {})
@@ -957,8 +913,8 @@ func TestCanonicalPolicyHash_GuardExcludedWhileInert(t *testing.T) {
 		}
 	})
 
-	if base != withGuard {
-		t.Errorf("inert guard config must not change the canonical policy hash:\n  without guard = %s\n  with guard    = %s", base, withGuard)
+	if base == withGuard {
+		t.Fatal("enforced guard config did not change the canonical policy hash")
 	}
 
 	// A semantically different guard must also leave the hash untouched while
@@ -971,8 +927,33 @@ func TestCanonicalPolicyHash_GuardExcludedWhileInert(t *testing.T) {
 		}
 	})
 
-	if base != differentPort {
-		t.Errorf("inert guard config must not change the canonical policy hash for any value:\n  without guard = %s\n  different port = %s", base, differentPort)
+	if withGuard == differentPort {
+		t.Fatal("changing an enforced guard destination port did not change the canonical policy hash")
+	}
+
+	reordered := canonicalHashOf(t, func(c *Config) {
+		c.Guard = Guard{
+			Profiles:  []GuardProfile{{Name: "codex", Manifests: []string{"session"}}},
+			Manifests: []GuardManifest{{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}}},
+			Services:  []GuardService{{Name: "api", Protocol: "TCP", Host: "A.VENDOR.EXAMPLE.", Port: 443}},
+		}
+	})
+	if reordered != withGuard {
+		t.Fatalf("equivalent guard declarations changed hash:\n  first = %s\n  reordered = %s", withGuard, reordered)
+	}
+
+	sorted := canonicalGuard(Guard{Services: []GuardService{
+		{Name: "z", Protocol: "udp", Host: "b.vendor.example", Port: 8443},
+		{Name: "c", Protocol: "tcp", Host: "b.vendor.example", Port: 8443},
+		{Name: "b", Protocol: "tcp", Host: "b.vendor.example", Port: 443},
+		{Name: "a", Protocol: "tcp", Host: "b.vendor.example", Port: 443},
+		{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 8443},
+	}})
+	wantNames := []string{"api", "a", "b", "c", "z"}
+	for i, want := range wantNames {
+		if sorted.Services[i].Name != want {
+			t.Fatalf("canonical service order = %+v, want names %v", sorted.Services, wantNames)
+		}
 	}
 }
 
@@ -1075,12 +1056,6 @@ func TestValidateGuard_SecretMaterialRefusedBothDirections(t *testing.T) {
 				if err == nil {
 					t.Fatalf("%s on credential path %q must be rejected", mode, path)
 				}
-				// The rejection must come from a PATH rule. A bare err != nil
-				// check passes with every rule in this file deleted, because
-				// errGuardNotEnforced refuses any non-empty guard declaration.
-				if errors.Is(err, errGuardNotEnforced) {
-					t.Errorf("%s on %q was refused only by the not-enforced gate, so no path rule rejected it: %v", mode, path, err)
-				}
 			})
 		}
 	}
@@ -1122,11 +1097,7 @@ func TestValidateGuard_NonSecretNeighboursStillAllowed(t *testing.T) {
 				cfg := Defaults()
 				cfg.Guard = Guard{Manifests: []GuardManifest{m}}
 
-				err := cfg.Validate()
-				if err == nil {
-					t.Fatalf("guard is refused while unenforced; %q should still reach the gate", path)
-				}
-				if !errors.Is(err, errGuardNotEnforced) {
+				if err := cfg.Validate(); err != nil {
 					t.Errorf("non-secret path %q must pass the %s path rules, got: %v", path, mode, err)
 				}
 			})
@@ -1162,9 +1133,6 @@ func TestValidateGuard_WholeHomeReadRefused(t *testing.T) {
 			if err == nil {
 				t.Fatalf("read access to whole home %q must be rejected", path)
 			}
-			if errors.Is(err, errGuardNotEnforced) {
-				t.Fatalf("read on %q was refused only by the not-enforced gate: %v", path, err)
-			}
 			if !strings.Contains(err.Error(), "entire home directory") {
 				t.Errorf("read on %q must be refused as a whole-home grant, not incidentally by a credential rule, got: %v", path, err)
 			}
@@ -1194,11 +1162,7 @@ func TestValidateGuard_RunSubtreesStillReadable(t *testing.T) {
 			cfg.Guard = Guard{
 				Manifests: []GuardManifest{{Name: "ok", ReadOnly: []string{path}}},
 			}
-			err := cfg.Validate()
-			if err == nil {
-				t.Fatalf("guard is refused while unenforced; %q should still reach the gate", path)
-			}
-			if !errors.Is(err, errGuardNotEnforced) {
+			if err := cfg.Validate(); err != nil {
 				t.Errorf("non-credential runtime path %q must remain readable, got: %v", path, err)
 			}
 		})
@@ -1239,9 +1203,6 @@ func TestValidateGuard_CredentialFloorIndependentOfHomeLayout(t *testing.T) {
 				err := cfg.Validate()
 				if err == nil {
 					t.Fatalf("%s on %q must be rejected regardless of home layout", mode, path)
-				}
-				if errors.Is(err, errGuardNotEnforced) {
-					t.Errorf("%s on %q was refused only by the not-enforced gate, so no path rule rejected it: %v", mode, path, err)
 				}
 			})
 		}
@@ -1291,9 +1252,6 @@ func TestValidateGuard_CredentialFloorIsCaseInsensitive(t *testing.T) {
 				err := cfg.Validate()
 				if err == nil {
 					t.Fatalf("%s on %q must be rejected on a case-insensitive volume", mode, path)
-				}
-				if errors.Is(err, errGuardNotEnforced) {
-					t.Errorf("%s on %q was refused only by the not-enforced gate: %v", mode, path, err)
 				}
 			})
 		}
@@ -1363,9 +1321,6 @@ func TestValidateGuard_CaseEquivalentGrantsConflict(t *testing.T) {
 			err := cfg.Validate()
 			if err == nil {
 				t.Fatal("case-equivalent declarations of one object must be rejected")
-			}
-			if errors.Is(err, errGuardNotEnforced) {
-				t.Fatalf("case-equivalent declarations were refused only by the not-enforced gate, so no path rule caught the conflict: %v", err)
 			}
 			if !strings.Contains(err.Error(), "conflicts") {
 				t.Errorf("expected a conflict refusal, got: %v", err)

--- a/internal/config/guard_test.go
+++ b/internal/config/guard_test.go
@@ -899,38 +899,28 @@ func TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent(t *testing.T) {
 
 	base := canonicalHashOf(t, func(c *Config) {})
 
-	withGuard := canonicalHashOf(t, func(c *Config) {
-		c.Guard = Guard{
-			Services: []GuardService{
-				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 443},
-			},
-			Manifests: []GuardManifest{
-				{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}},
-			},
-			Profiles: []GuardProfile{
-				{Name: "codex", Manifests: []string{"session"}},
-			},
-		}
-	})
+	guardDeclaration := Guard{
+		Services: []GuardService{{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 443}},
+		Manifests: []GuardManifest{
+			{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session", "/tmp/pipelock-guard-work"}},
+			{Name: "cache", ReadOnly: []string{"/tmp/pipelock-guard-cache-a", "/tmp/pipelock-guard-cache-b"}},
+		},
+		Profiles: []GuardProfile{
+			{Name: "codex", Manifests: []string{"session", "cache"}},
+			{Name: "worker", Manifests: []string{"cache", "session"}},
+		},
+	}
+	withGuard := canonicalHashOf(t, func(c *Config) { c.Guard = guardDeclaration })
 
 	if base == withGuard {
 		t.Fatal("enforced guard config did not change the canonical policy hash")
 	}
 
-	// A semantically different guard must also leave the hash untouched while
-	// the section is inert; otherwise the exclusion is only partial.
+	// Changing only an enforced Guard destination port must change the policy hash.
 	differentPort := canonicalHashOf(t, func(c *Config) {
-		c.Guard = Guard{
-			Services: []GuardService{
-				{Name: "api", Protocol: "tcp", Host: "a.vendor.example", Port: 8443},
-			},
-			Manifests: []GuardManifest{
-				{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}},
-			},
-			Profiles: []GuardProfile{
-				{Name: "codex", Manifests: []string{"session"}},
-			},
-		}
+		c.Guard = guardDeclaration
+		c.Guard.Services = append([]GuardService(nil), guardDeclaration.Services...)
+		c.Guard.Services[0].Port = 8443
 	})
 
 	if withGuard == differentPort {
@@ -939,9 +929,15 @@ func TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent(t *testing.T) {
 
 	reordered := canonicalHashOf(t, func(c *Config) {
 		c.Guard = Guard{
-			Profiles:  []GuardProfile{{Name: "codex", Manifests: []string{"session"}}},
-			Manifests: []GuardManifest{{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-session"}}},
-			Services:  []GuardService{{Name: "api", Protocol: "TCP", Host: "A.VENDOR.EXAMPLE..", Port: 443}},
+			Profiles: []GuardProfile{
+				{Name: "worker", Manifests: []string{"session", "cache"}},
+				{Name: "codex", Manifests: []string{"cache", "session"}},
+			},
+			Manifests: []GuardManifest{
+				{Name: "cache", ReadOnly: []string{"/tmp/pipelock-guard-cache-b", "/tmp/pipelock-guard-cache-a"}},
+				{Name: "session", ReadWrite: []string{"/tmp/pipelock-guard-work", "/tmp/pipelock-guard-session"}},
+			},
+			Services: []GuardService{{Name: "api", Protocol: "TCP", Host: "A.VENDOR.EXAMPLE..", Port: 443}},
 		}
 	})
 	if reordered != withGuard {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -434,7 +434,7 @@ type Config struct {
 	MediationEnvelope        MediationEnvelope       `yaml:"mediation_envelope"`
 	Redaction                redact.Config           `yaml:"redaction"`
 	Learn                    Learn                   `yaml:"learn"`
-	Guard                    Guard                   `yaml:"guard" json:"-"`      // startup-only guard declaration with no runtime consumer yet, excluded from canonical policy hash
+	Guard                    Guard                   `yaml:"guard" json:"-"`      // startup-only guard declaration, projected into the canonical hash only when non-empty
 	LearnLock                LearnLock               `yaml:"learn_lock" json:"-"` // operational lock-runtime config, excluded from canonical policy hash
 	Conductor                Conductor               `yaml:"conductor" json:"-"`  // follower control-plane config, excluded from canonical policy hash
 	Agents                   map[string]AgentProfile `yaml:"agents,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -4187,34 +4187,11 @@ var guardDangerousRWRoots = []struct {
 }
 
 func (c *Config) validateGuard() error {
-	if err := c.ValidateGuardDeclaration(); err != nil {
-		return err
-	}
-	g := &c.Guard
-	if len(g.Services) == 0 && len(g.Profiles) == 0 && len(g.Manifests) == 0 {
-		return nil
-	}
-
-	// Everything above validated the declaration. This refuses to ACCEPT it.
-	//
-	// No runtime evaluator consumes guard yet, so a config that loads cleanly
-	// would tell an operator their workload is constrained when nothing
-	// constrains it. Silent acceptance of a security-boundary declaration that
-	// has no enforcement is worse than refusing it: the operator acts on the
-	// clean load. Fail closed instead, and say exactly why.
-	//
-	// Validation still runs first so the message names a genuinely broken
-	// declaration ahead of the unsupported gate; an operator writing this
-	// config today gets accurate feedback on it for when enforcement lands.
-	//
-	// REMOVE THIS GATE in the PR that wires the guard runtime evaluator, in
-	// the same change that starts enforcing these grants.
-	return errGuardNotEnforced
+	return c.ValidateGuardDeclaration()
 }
 
 // ValidateGuardDeclaration validates guard names, references, destinations,
-// path declarations, and compiled-floor constraints without treating the
-// not-yet-enforced runtime gate as a declaration error.
+// path declarations, and compiled-floor constraints for Guard execution.
 func (c *Config) ValidateGuardDeclaration() error {
 	return c.validateGuardDeclaration(true)
 }
@@ -4380,14 +4357,6 @@ func validateGuardManifestPath(label, fieldName string, idx int, rawPath string,
 	pathFields[conflictKey] = field
 	return nil
 }
-
-// errGuardNotEnforced is returned for any non-empty guard declaration while the
-// runtime evaluator does not exist.
-var errGuardNotEnforced = errors.New(
-	"guard: configuration is not enforced in this version and is therefore refused rather than silently accepted; " +
-		"declaring guard services, profiles, or state manifests would not constrain any workload. " +
-		"Remove the guard section until a release that implements guard enforcement",
-)
 
 // validateGuardRWPath checks that a read-write path does not grant write
 // access to dangerous or trust-bearing locations.

--- a/internal/guard/apply_decisions_linux_test.go
+++ b/internal/guard/apply_decisions_linux_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	llsys "github.com/landlock-lsm/go-landlock/landlock/syscall"
 )
 
 // These cover the decisions Apply makes BEFORE it touches the kernel.
@@ -63,6 +65,78 @@ func TestApply_RefusesBelowThreadSyncABI(t *testing.T) {
 	}
 	if record.ObservedABI == nil || *record.ObservedABI != ThreadSyncABI-1 {
 		t.Errorf("ObservedABI = %v, want %d", record.ObservedABI, ThreadSyncABI-1)
+	}
+}
+
+func TestApplyForExec_AcceptsBaseABIWithoutThreadSync(t *testing.T) {
+	p := &PreparedManifest{complete: false}
+
+	record, err := p.applyMode(func() (int, error) { return MinimumABI, nil }, false)
+
+	if !errors.Is(err, ErrManifestIncomplete) {
+		t.Fatalf("err = %v, want manifest refusal after the ABI check", err)
+	}
+	if errors.Is(err, ErrABITooOld) {
+		t.Fatalf("pre-exec application incorrectly required thread sync: %v", err)
+	}
+	if record.RequiredABI != MinimumABI {
+		t.Fatalf("RequiredABI = %d, want base ABI %d", record.RequiredABI, MinimumABI)
+	}
+	if record.ObservedABI == nil || *record.ObservedABI != MinimumABI {
+		t.Fatalf("ObservedABI = %v, want %d", record.ObservedABI, MinimumABI)
+	}
+}
+
+func TestApplyForExec_CompleteSequenceUsesBaseABIAndNoThreadSync(t *testing.T) {
+	p := &PreparedManifest{complete: true}
+	var created, restricted, closed, noNewPrivs bool
+	var restrictFlags uint32
+	ops := rulesetOperations{
+		getABI: func() (int, error) { return MinimumABI, nil },
+		createRuleset: func(attr *llsys.RulesetAttr, flags int) (int, error) {
+			created = true
+			if flags != 0 || attr.HandledAccessFS == 0 {
+				t.Fatalf("create flags=%d handled=%d", flags, attr.HandledAccessFS)
+			}
+			return 42, nil
+		},
+		addPathRule: func(int, *llsys.PathBeneathAttr, int) error {
+			t.Fatal("empty manifest unexpectedly added a path rule")
+			return nil
+		},
+		restrictSelf: func(fd int, flags uint32) error {
+			restricted = true
+			restrictFlags = flags
+			if fd != 42 {
+				t.Fatalf("restrict fd=%d, want 42", fd)
+			}
+			return nil
+		},
+		setNoNewPrivs: func() error {
+			noNewPrivs = true
+			return nil
+		},
+		closeFD: func(fd int) error {
+			closed = true
+			if fd != 42 {
+				t.Fatalf("close fd=%d, want 42", fd)
+			}
+			return nil
+		},
+	}
+
+	record, err := p.applyWithOperations(ops, false)
+	if err != nil {
+		t.Fatalf("applyWithOperations: %v", err)
+	}
+	if !record.Enforced() || record.RequiredABI != MinimumABI {
+		t.Fatalf("record = %+v, want enforced at base ABI", record)
+	}
+	if !created || !noNewPrivs || !restricted || !closed {
+		t.Fatalf("sequence create=%v no_new_privs=%v restrict=%v close=%v", created, noNewPrivs, restricted, closed)
+	}
+	if restrictFlags != 0 {
+		t.Fatalf("pre-exec restrict flags=%d, want no thread-sync flag", restrictFlags)
 	}
 }
 

--- a/internal/guard/apply_linux.go
+++ b/internal/guard/apply_linux.go
@@ -94,9 +94,7 @@ func (p *PreparedManifest) Apply() (EnforcementRecord, error) {
 }
 
 func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord, error) {
-	ops := kernelRulesetOperations()
-	ops.getABI = getABI
-	return p.applyWithOperations(ops, true)
+	return p.applyMode(getABI, true)
 }
 
 // ApplyForExec enforces the manifest on the calling thread for an immediate
@@ -252,7 +250,8 @@ func (p *PreparedManifest) applyWithOperations(ops rulesetOperations, threadSync
 	// test caught it as a killed child rather than a wrong answer.
 	//
 	// LockOSThread pins this goroutine for the call so it cannot migrate to
-	// another thread between the prctl and the restrict.
+	// another thread between the prctl and the restrict. The optional TSYNC
+	// flag synchronizes existing threads only for the in-process Apply path.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/internal/guard/apply_linux.go
+++ b/internal/guard/apply_linux.go
@@ -94,6 +94,48 @@ func (p *PreparedManifest) Apply() (EnforcementRecord, error) {
 }
 
 func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord, error) {
+	ops := kernelRulesetOperations()
+	ops.getABI = getABI
+	return p.applyWithOperations(ops, true)
+}
+
+// ApplyForExec enforces the manifest on the calling thread for an immediate
+// exec. The caller must perform no concurrent application work and must replace
+// the process image after this returns. The exec'd program inherits the domain,
+// and every thread it later creates inherits it too, so base Landlock ABI 5 is
+// sufficient; kernel thread synchronization is only required by Apply's
+// already-multithreaded in-process contract.
+func (p *PreparedManifest) ApplyForExec() (EnforcementRecord, error) {
+	return p.applyWithOperations(kernelRulesetOperations(), false)
+}
+
+func (p *PreparedManifest) applyMode(getABI func() (int, error), threadSync bool) (EnforcementRecord, error) {
+	ops := kernelRulesetOperations()
+	ops.getABI = getABI
+	return p.applyWithOperations(ops, threadSync)
+}
+
+type rulesetOperations struct {
+	getABI        func() (int, error)
+	createRuleset func(*llsys.RulesetAttr, int) (int, error)
+	addPathRule   func(int, *llsys.PathBeneathAttr, int) error
+	restrictSelf  func(int, uint32) error
+	setNoNewPrivs func() error
+	closeFD       func(int) error
+}
+
+func kernelRulesetOperations() rulesetOperations {
+	return rulesetOperations{
+		getABI:        llsys.LandlockGetABIVersion,
+		createRuleset: llsys.LandlockCreateRuleset,
+		addPathRule:   llsys.LandlockAddPathBeneathRule,
+		restrictSelf:  llsys.LandlockRestrictSelf,
+		setNoNewPrivs: func() error { return unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) },
+		closeFD:       unix.Close,
+	}
+}
+
+func (p *PreparedManifest) applyWithOperations(ops rulesetOperations, threadSync bool) (EnforcementRecord, error) {
 	// Held for the whole call. Close writes -1 over each descriptor, so a
 	// concurrent Close could otherwise leave rule construction handing a stale
 	// descriptor NUMBER to the kernel, and a freed number can be reused by any
@@ -104,7 +146,7 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 	record := EnforcementRecord{
 		State:            EnforcementRefused,
 		Mechanism:        "landlock",
-		RequiredABI:      ThreadSyncABI,
+		RequiredABI:      MinimumABI,
 		ManifestComplete: p.complete,
 		Outcomes:         p.Outcomes(),
 	}
@@ -118,7 +160,7 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 		return record, ErrAlreadyApplied
 	}
 
-	abi, err := getABI()
+	abi, err := ops.getABI()
 	if err != nil {
 		record.Reason = fmt.Sprintf("landlock is unavailable: %v", err)
 		return record, fmt.Errorf("%w: %w", ErrLandlockUnavailable, err)
@@ -135,11 +177,14 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 	// of the policy: applying the same ruleset in a single-threaded child
 	// between fork and exec needs only MinimumABI, which is the route the
 	// execution surface should take.
-	if abi < ThreadSyncABI {
+	if threadSync && abi < ThreadSyncABI {
 		record.Reason = fmt.Sprintf(
 			"kernel landlock ABI %d is below %d, so this ruleset cannot be applied to every thread of this process atomically; apply it in a single-threaded child before exec instead",
 			abi, ThreadSyncABI)
 		return record, fmt.Errorf("%w: have %d, need %d for in-process application", ErrABITooOld, abi, ThreadSyncABI)
+	}
+	if threadSync {
+		record.RequiredABI = ThreadSyncABI
 	}
 
 	handledAccessFS, scoped, unmediated := capabilitiesFor(abi)
@@ -154,11 +199,18 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 	// path that could not be granted is a denied grant, and a denied grant that
 	// the workload was told it had is a failure the operator cannot diagnose.
 	if !p.complete {
-		record.Reason = "at least one declared path could not be granted; refusing to enforce a partial manifest"
+		missing := make([]string, 0)
+		for _, outcome := range p.outcomes {
+			if outcome.State.Granted() {
+				continue
+			}
+			missing = append(missing, fmt.Sprintf("%s (%s: %s)", outcome.DeclaredPath, outcome.State, outcome.Reason))
+		}
+		record.Reason = "at least one declared path could not be granted; refusing to enforce a partial manifest: " + strings.Join(missing, "; ")
 		return record, ErrManifestIncomplete
 	}
 
-	rulesetFD, err := llsys.LandlockCreateRuleset(&llsys.RulesetAttr{
+	rulesetFD, err := ops.createRuleset(&llsys.RulesetAttr{
 		HandledAccessFS: handledAccessFS,
 		Scoped:          scoped,
 	}, 0)
@@ -166,14 +218,14 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 		record.Reason = fmt.Sprintf("creating landlock ruleset: %v", err)
 		return record, fmt.Errorf("creating landlock ruleset: %w", err)
 	}
-	defer func() { _ = unix.Close(rulesetFD) }()
+	defer func() { _ = ops.closeFD(rulesetFD) }()
 
 	for _, rule := range p.rules {
 		attr := llsys.PathBeneathAttr{
 			AllowedAccess: rule.access,
 			ParentFd:      rule.fd,
 		}
-		if err := llsys.LandlockAddPathBeneathRule(rulesetFD, &attr, 0); err != nil {
+		if err := ops.addPathRule(rulesetFD, &attr, 0); err != nil {
 			record.Reason = fmt.Sprintf("adding rule for %q: %v", rule.declared, err)
 			return record, fmt.Errorf("adding landlock rule for %q: %w", rule.declared, err)
 		}
@@ -204,12 +256,16 @@ func (p *PreparedManifest) apply(getABI func() (int, error)) (EnforcementRecord,
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+	if err := ops.setNoNewPrivs(); err != nil {
 		record.Reason = fmt.Sprintf("setting no_new_privs: %v", err)
 		return record, fmt.Errorf("setting no_new_privs: %w", err)
 	}
 
-	if err := llsys.LandlockRestrictSelf(rulesetFD, llsys.FlagRestrictSelfTSync); err != nil {
+	flags := uint32(0)
+	if threadSync {
+		flags = llsys.FlagRestrictSelfTSync
+	}
+	if err := ops.restrictSelf(rulesetFD, flags); err != nil {
 		record.Reason = fmt.Sprintf("applying landlock restriction: %v", err)
 		return record, fmt.Errorf("applying landlock restriction: %w", err)
 	}

--- a/internal/guard/exec_linux.go
+++ b/internal/guard/exec_linux.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/processexec"
@@ -29,6 +30,7 @@ const (
 	execTempDirEnv     = "__PIPELOCK_GUARD_TEMP_DIR"
 	execBinaryEnv      = "__PIPELOCK_GUARD_BINARY"
 	execEnvironmentEnv = "__PIPELOCK_GUARD_ENVIRONMENT_FD"
+	execStatusEnv      = "__PIPELOCK_GUARD_STATUS_FD"
 )
 
 const execEnvironmentMaxPayload = 8 << 20
@@ -41,8 +43,8 @@ func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
 // ExecControlEnvironment returns the fixed control entries the standalone
 // init adds only to the Guard helper. The declaration contains paths and exact
 // destinations, never the developer's secret-bearing environment.
-func ExecControlEnvironment(declaration config.Guard, profile, policyHash, workspace, tempDir, binary string, environmentFD int) ([]string, error) {
-	encoded, err := json.Marshal(declaration)
+func ExecControlEnvironment(opts ExecControlOptions) ([]string, error) {
+	encoded, err := json.Marshal(opts.Declaration)
 	if err != nil {
 		return nil, fmt.Errorf("encoding guard declaration: %w", err)
 	}
@@ -52,12 +54,13 @@ func ExecControlEnvironment(declaration config.Guard, profile, policyHash, works
 	return []string{
 		execModeEnv + "=1",
 		execDeclarationEnv + "=" + string(encoded),
-		execProfileEnv + "=" + profile,
-		execPolicyHashEnv + "=" + policyHash,
-		execWorkspaceEnv + "=" + workspace,
-		execTempDirEnv + "=" + tempDir,
-		execBinaryEnv + "=" + binary,
-		execEnvironmentEnv + "=" + strconv.Itoa(environmentFD),
+		execProfileEnv + "=" + opts.Profile,
+		execPolicyHashEnv + "=" + opts.PolicyHash,
+		execWorkspaceEnv + "=" + opts.Workspace,
+		execTempDirEnv + "=" + opts.TempDir,
+		execBinaryEnv + "=" + opts.Binary,
+		execEnvironmentEnv + "=" + strconv.Itoa(opts.EnvironmentFD),
+		execStatusEnv + "=" + strconv.Itoa(opts.StatusFD),
 	}, nil
 }
 
@@ -65,13 +68,38 @@ func ExecControlEnvironment(declaration config.Guard, profile, policyHash, works
 // It exits on failure and does not return on success.
 func RunExec() {
 	environment, err := readExecEnvironment(os.Getenv(execEnvironmentEnv))
-	if err == nil {
-		err = runExec(os.Args[1:], environment)
-	}
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "[guard] REFUSED: %v\n", err)
 		os.Exit(1)
 	}
+	status, err := openExecStatusWriter(os.Getenv(execStatusEnv))
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[guard] REFUSED: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = status.Close() }()
+	err = runExecWith(os.Args[1:], environment,
+		func(prepared *PreparedManifest) (EnforcementRecord, error) { return prepared.ApplyForExec() },
+		processexec.Replace,
+		func(proof ExecutionProof) error { return json.NewEncoder(status).Encode(proof) },
+	)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[guard] REFUSED: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func openExecStatusWriter(rawFD string) (*os.File, error) {
+	fd, err := strconv.Atoi(rawFD)
+	if err != nil || fd < 3 {
+		return nil, errors.New("invalid guard status descriptor")
+	}
+	file := os.NewFile(uintptr(fd), "guard-status")
+	if file == nil {
+		return nil, errors.New("opening guard status descriptor")
+	}
+	syscall.CloseOnExec(fd)
+	return file, nil
 }
 
 func readExecEnvironment(rawFD string) ([]string, error) {
@@ -117,6 +145,7 @@ func runExec(command, environment []string) error {
 	return runExecWith(command, environment,
 		func(prepared *PreparedManifest) (EnforcementRecord, error) { return prepared.ApplyForExec() },
 		processexec.Replace,
+		func(ExecutionProof) error { return nil },
 	)
 }
 
@@ -124,6 +153,7 @@ func runExecWith(
 	command, environment []string,
 	apply func(*PreparedManifest) (EnforcementRecord, error),
 	replace func(string, []string, []string) error,
+	report func(ExecutionProof) error,
 ) error {
 	if len(command) == 0 {
 		return errors.New("missing operator command")
@@ -167,6 +197,10 @@ func runExecWith(
 	if err := prepared.Close(); err != nil {
 		return fmt.Errorf("closing prepared manifest: %w", err)
 	}
+	proof := NewExecutionProof(record, policyHash, os.Getenv(execProfileEnv), workspace, tempDir, binary, command)
+	if err := report(proof); err != nil {
+		return fmt.Errorf("reporting guard enforcement: %w", err)
+	}
 	_, _ = fmt.Fprintf(os.Stderr, "[guard] %s; policy_hash=%s\n", record.Describe(), policyHash)
 
 	clean := make([]string, 0, len(environment))
@@ -177,5 +211,12 @@ func runExecWith(
 		}
 		clean = append(clean, entry)
 	}
-	return replace(binary, command, clean)
+	if err := replace(binary, command, clean); err != nil {
+		proof.ExecError = err.Error()
+		if reportErr := report(proof); reportErr != nil {
+			return errors.Join(err, fmt.Errorf("reporting guard exec failure: %w", reportErr))
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/guard/exec_linux.go
+++ b/internal/guard/exec_linux.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/processexec"
+)
+
+const (
+	execModeEnv        = "__PIPELOCK_GUARD_EXEC"
+	execDeclarationEnv = "__PIPELOCK_GUARD_DECLARATION"
+	execProfileEnv     = "__PIPELOCK_GUARD_PROFILE"
+	execPolicyHashEnv  = "__PIPELOCK_GUARD_POLICY_HASH"
+	execWorkspaceEnv   = "__PIPELOCK_GUARD_WORKSPACE"
+	execTempDirEnv     = "__PIPELOCK_GUARD_TEMP_DIR"
+	execBinaryEnv      = "__PIPELOCK_GUARD_BINARY"
+	execEnvironmentEnv = "__PIPELOCK_GUARD_ENVIRONMENT_FD"
+)
+
+const execEnvironmentMaxPayload = 8 << 20
+
+// IsExecMode reports whether this process is the final Guard pre-exec helper.
+func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
+
+// ExecControlEnvironment returns the fixed control entries the standalone
+// init adds only to the Guard helper. The declaration contains paths and exact
+// destinations, never the developer's secret-bearing environment.
+func ExecControlEnvironment(declaration config.Guard, profile, policyHash, workspace, tempDir, binary string, environmentFD int) ([]string, error) {
+	encoded, err := json.Marshal(declaration)
+	if err != nil {
+		return nil, fmt.Errorf("encoding guard declaration: %w", err)
+	}
+	if len(encoded) > 1<<20 {
+		return nil, errors.New("guard declaration exceeds 1 MiB")
+	}
+	return []string{
+		execModeEnv + "=1",
+		execDeclarationEnv + "=" + string(encoded),
+		execProfileEnv + "=" + profile,
+		execPolicyHashEnv + "=" + policyHash,
+		execWorkspaceEnv + "=" + workspace,
+		execTempDirEnv + "=" + tempDir,
+		execBinaryEnv + "=" + binary,
+		execEnvironmentEnv + "=" + strconv.Itoa(environmentFD),
+	}, nil
+}
+
+// RunExec applies Guard and replaces this helper with the operator command.
+// It exits on failure and does not return on success.
+func RunExec() {
+	environment, err := readExecEnvironment(os.Getenv(execEnvironmentEnv))
+	if err == nil {
+		err = runExec(os.Args[1:], environment)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[guard] REFUSED: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func readExecEnvironment(rawFD string) ([]string, error) {
+	fd, err := strconv.Atoi(rawFD)
+	if err != nil || fd < 3 {
+		return nil, errors.New("invalid guard environment descriptor")
+	}
+	file := os.NewFile(uintptr(fd), "guard-environment")
+	if file == nil {
+		return nil, errors.New("opening guard environment descriptor")
+	}
+	return decodeExecEnvironment(file)
+}
+
+func decodeExecEnvironment(reader io.ReadCloser) ([]string, error) {
+	defer func() { _ = reader.Close() }()
+	payload, err := io.ReadAll(io.LimitReader(reader, execEnvironmentMaxPayload+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading guard environment: %w", err)
+	}
+	if len(payload) > execEnvironmentMaxPayload {
+		return nil, errors.New("guard environment exceeds 8 MiB")
+	}
+	var environment []string
+	if err := json.Unmarshal(payload, &environment); err != nil {
+		return nil, fmt.Errorf("decoding guard environment: %w", err)
+	}
+	seen := make(map[string]struct{}, len(environment))
+	for _, entry := range environment {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || key == "" || strings.IndexByte(entry, 0) >= 0 {
+			return nil, errors.New("guard environment contains a malformed entry")
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("guard environment contains duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+	}
+	return environment, nil
+}
+
+func runExec(command, environment []string) error {
+	return runExecWith(command, environment,
+		func(prepared *PreparedManifest) (EnforcementRecord, error) { return prepared.ApplyForExec() },
+		processexec.Replace,
+	)
+}
+
+func runExecWith(
+	command, environment []string,
+	apply func(*PreparedManifest) (EnforcementRecord, error),
+	replace func(string, []string, []string) error,
+) error {
+	if len(command) == 0 {
+		return errors.New("missing operator command")
+	}
+	workspace := os.Getenv(execWorkspaceEnv)
+	tempDir := os.Getenv(execTempDirEnv)
+	policyHash := os.Getenv(execPolicyHashEnv)
+	binary := filepath.Clean(os.Getenv(execBinaryEnv))
+	if workspace == "" || tempDir == "" || policyHash == "" || !filepath.IsAbs(binary) {
+		return errors.New("incomplete guard execution controls")
+	}
+
+	var declaration config.Guard
+	if err := json.Unmarshal([]byte(os.Getenv(execDeclarationEnv)), &declaration); err != nil {
+		return fmt.Errorf("decoding guard declaration: %w", err)
+	}
+	cfg := config.Defaults()
+	cfg.Guard = declaration
+	if err := cfg.ValidateGuardDeclaration(); err != nil {
+		return fmt.Errorf("validating guard declaration: %w", err)
+	}
+
+	prepared, err := PrepareExecution(cfg, os.Getenv(execProfileEnv), workspace, tempDir, binary, os.Getuid())
+	if err != nil {
+		return fmt.Errorf("preparing manifest: %w", err)
+	}
+	defer func() { _ = prepared.Close() }()
+
+	// Keep this goroutine on the exact thread that enters the Landlock domain
+	// until exec replaces the process image. ApplyForExec pins internally while
+	// issuing the syscalls, but unpins when it returns; without this outer pin,
+	// the Go scheduler could migrate us to an unrestricted runtime thread in the
+	// small gap before syscall.Exec and the workload would inherit no policy.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	record, err := apply(prepared)
+	if err != nil {
+		return fmt.Errorf("%s: %w", record.Describe(), err)
+	}
+	if !record.Enforced() {
+		return fmt.Errorf("%s", record.Describe())
+	}
+	if err := prepared.Close(); err != nil {
+		return fmt.Errorf("closing prepared manifest: %w", err)
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "[guard] %s; policy_hash=%s\n", record.Describe(), policyHash)
+
+	clean := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(strings.ToUpper(key), "__PIPELOCK_") {
+			continue
+		}
+		clean = append(clean, entry)
+	}
+	return replace(binary, command, clean)
+}

--- a/internal/guard/exec_linux.go
+++ b/internal/guard/exec_linux.go
@@ -180,6 +180,12 @@ func runExecWith(
 	if err != nil {
 		return fmt.Errorf("preparing manifest: %w", err)
 	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = prepared.Close()
+		}
+	}()
 	// Keep this goroutine on the exact thread that enters the Landlock domain
 	// until exec replaces the process image. ApplyForExec pins internally while
 	// issuing the syscalls, but unpins when it returns; without this outer pin,
@@ -194,10 +200,14 @@ func runExecWith(
 	if !record.Enforced() {
 		return fmt.Errorf("%s", record.Describe())
 	}
+	closed = true
 	if err := prepared.Close(); err != nil {
 		return fmt.Errorf("closing prepared manifest: %w", err)
 	}
-	proof := NewExecutionProof(record, policyHash, os.Getenv(execProfileEnv), workspace, tempDir, binary, command)
+	proof := NewExecutionProof(record, ExecControlOptions{
+		Profile: os.Getenv(execProfileEnv), PolicyHash: policyHash,
+		Workspace: workspace, TempDir: tempDir, Binary: binary,
+	}, command)
 	if err := report(proof); err != nil {
 		return fmt.Errorf("reporting guard enforcement: %w", err)
 	}

--- a/internal/guard/exec_linux.go
+++ b/internal/guard/exec_linux.go
@@ -33,6 +33,8 @@ const (
 
 const execEnvironmentMaxPayload = 8 << 20
 
+const guardDeclarationEnvironmentMaxPayload = 64 << 10
+
 // IsExecMode reports whether this process is the final Guard pre-exec helper.
 func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
 
@@ -44,8 +46,8 @@ func ExecControlEnvironment(declaration config.Guard, profile, policyHash, works
 	if err != nil {
 		return nil, fmt.Errorf("encoding guard declaration: %w", err)
 	}
-	if len(encoded) > 1<<20 {
-		return nil, errors.New("guard declaration exceeds 1 MiB")
+	if len(encoded) > guardDeclarationEnvironmentMaxPayload {
+		return nil, errors.New("guard declaration exceeds the 64 KiB environment transport limit")
 	}
 	return []string{
 		execModeEnv + "=1",
@@ -148,8 +150,6 @@ func runExecWith(
 	if err != nil {
 		return fmt.Errorf("preparing manifest: %w", err)
 	}
-	defer func() { _ = prepared.Close() }()
-
 	// Keep this goroutine on the exact thread that enters the Landlock domain
 	// until exec replaces the process image. ApplyForExec pins internally while
 	// issuing the syscalls, but unpins when it returns; without this outer pin,

--- a/internal/guard/exec_linux_test.go
+++ b/internal/guard/exec_linux_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package guard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+func TestReadExecEnvironmentOwnsInheritedDescriptor(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	if _, err := writer.Write([]byte(`["PATH=/developer/bin"]`)); err != nil {
+		t.Fatalf("write environment: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	inheritedFD, err := unix.Dup(int(reader.Fd()))
+	if err != nil {
+		t.Fatalf("dup inherited descriptor: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		_ = unix.Close(inheritedFD)
+		t.Fatalf("close original reader: %v", err)
+	}
+	got, err := readExecEnvironment(strconv.Itoa(inheritedFD))
+	if err != nil {
+		t.Fatalf("read inherited environment: %v", err)
+	}
+	if len(got) != 1 || got[0] != "PATH=/developer/bin" {
+		t.Fatalf("environment = %v", got)
+	}
+}
+
+func TestReadExecEnvironmentRoundTripAndClose(t *testing.T) {
+	want := []string{"PATH=/developer/bin", "LD_PRELOAD=/developer/hook.so", "TOKEN=preserved-value"}
+	payload, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	reader := &trackedReadCloser{Reader: bytes.NewReader(payload)}
+	got, err := decodeExecEnvironment(reader)
+	if err != nil {
+		t.Fatalf("readExecEnvironment: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("environment = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("environment[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if !reader.closed {
+		t.Fatal("environment reader remained open after decoding")
+	}
+}
+
+func TestReadExecEnvironmentRejectsDuplicateKeys(t *testing.T) {
+	reader := &trackedReadCloser{Reader: strings.NewReader(`["PATH=/usr/bin","PATH=/workspace/bin"]`)}
+	if _, err := decodeExecEnvironment(reader); err == nil {
+		t.Fatal("duplicate environment keys were accepted")
+	}
+	if !reader.closed {
+		t.Fatal("environment reader remained open after refusal")
+	}
+}
+
+func TestDecodeExecEnvironmentRejectsMalformedAndOversizedPayloads(t *testing.T) {
+	readFailure := errors.New("read failed")
+	for _, testCase := range []struct {
+		name   string
+		reader io.ReadCloser
+		want   string
+	}{
+		{name: "read failure", reader: &trackedReadCloser{Reader: errorReader{err: readFailure}}, want: "reading guard environment"},
+		{name: "oversized", reader: &trackedReadCloser{Reader: strings.NewReader(strings.Repeat("x", execEnvironmentMaxPayload+1))}, want: "exceeds 8 MiB"},
+		{name: "invalid JSON", reader: &trackedReadCloser{Reader: strings.NewReader("not-json")}, want: "decoding guard environment"},
+		{name: "missing equals", reader: &trackedReadCloser{Reader: strings.NewReader(`["PATH"]`)}, want: "malformed entry"},
+		{name: "empty key", reader: &trackedReadCloser{Reader: strings.NewReader(`["=value"]`)}, want: "malformed entry"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := decodeExecEnvironment(testCase.reader)
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+	for _, raw := range []string{"", "2", "not-a-number"} {
+		if _, err := readExecEnvironment(raw); err == nil {
+			t.Fatalf("descriptor %q was accepted", raw)
+		}
+	}
+}
+
+func TestExecEntryPointsRejectInvalidControls(t *testing.T) {
+	t.Setenv(execModeEnv, "1")
+	if !IsExecMode() {
+		t.Fatal("exec mode marker was ignored")
+	}
+	controls, err := ExecControlEnvironment(config.Guard{}, "", "policy-hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3)
+	if err != nil {
+		t.Fatalf("ExecControlEnvironment: %v", err)
+	}
+	if len(controls) == 0 || !slices.Contains(controls, execModeEnv+"=1") {
+		t.Fatalf("controls = %v", controls)
+	}
+	largeDeclaration := config.Guard{Services: []config.GuardService{{Name: strings.Repeat("x", (1<<20)+1)}}}
+	if _, err := ExecControlEnvironment(largeDeclaration, "", "hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3); err == nil || !strings.Contains(err.Error(), "exceeds 1 MiB") {
+		t.Fatalf("oversized declaration error = %v", err)
+	}
+	if err := runExec(nil, nil); err == nil || !strings.Contains(err.Error(), "missing operator command") {
+		t.Fatalf("runExec error = %v", err)
+	}
+}
+
+type errorReader struct{ err error }
+
+func (r errorReader) Read([]byte) (int, error) { return 0, r.err }
+
+type trackedReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackedReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestRunExecWithAppliesPolicyAndReplacesProcess(t *testing.T) {
+	workspace := t.TempDir()
+	tempDir := t.TempDir()
+	t.Setenv(execWorkspaceEnv, workspace)
+	t.Setenv(execTempDirEnv, tempDir)
+	t.Setenv(execPolicyHashEnv, "policy-hash")
+	t.Setenv(execBinaryEnv, "/usr/bin/true")
+	t.Setenv(execDeclarationEnv, `{}`)
+	t.Setenv(execProfileEnv, "")
+
+	var replaced bool
+	err := runExecWith(
+		[]string{"/usr/bin/true", "argument"},
+		[]string{"PATH=/usr/bin", "__PIPELOCK_ATTACKER=value", "TOKEN=preserved"},
+		func(prepared *PreparedManifest) (EnforcementRecord, error) {
+			if prepared == nil || !prepared.Complete() {
+				t.Fatal("prepared manifest is incomplete")
+			}
+			return EnforcementRecord{State: EnforcementEnforced, Mechanism: "landlock", Coverage: CoverageFull}, nil
+		},
+		func(binary string, command, environment []string) error {
+			replaced = true
+			if binary != "/usr/bin/true" || len(command) != 2 || command[1] != "argument" {
+				t.Fatalf("replacement binary=%q command=%v", binary, command)
+			}
+			if slices.Contains(environment, "__PIPELOCK_ATTACKER=value") || !slices.Contains(environment, "TOKEN=preserved") {
+				t.Fatalf("replacement environment=%v", environment)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runExecWith: %v", err)
+	}
+	if !replaced {
+		t.Fatal("process replacement was not called")
+	}
+}
+
+func TestRunExecWithRefusesIncompleteControlsAndEnforcement(t *testing.T) {
+	validControls := func(t *testing.T) {
+		t.Helper()
+		t.Setenv(execWorkspaceEnv, t.TempDir())
+		t.Setenv(execTempDirEnv, t.TempDir())
+		t.Setenv(execPolicyHashEnv, "policy-hash")
+		t.Setenv(execBinaryEnv, "/usr/bin/true")
+		t.Setenv(execDeclarationEnv, `{}`)
+		t.Setenv(execProfileEnv, "")
+	}
+	noReplace := func(string, []string, []string) error {
+		t.Fatal("refused execution reached process replacement")
+		return nil
+	}
+	for _, testCase := range []struct {
+		name    string
+		prepare func(*testing.T)
+		command []string
+		apply   func(*PreparedManifest) (EnforcementRecord, error)
+		want    string
+	}{
+		{name: "missing command", prepare: validControls, want: "missing operator command"},
+		{name: "missing controls", prepare: func(t *testing.T) {}, command: []string{"true"}, want: "incomplete guard execution controls"},
+		{name: "invalid declaration", prepare: func(t *testing.T) { validControls(t); t.Setenv(execDeclarationEnv, "{") }, command: []string{"true"}, want: "decoding guard declaration"},
+		{name: "invalid declaration structure", prepare: func(t *testing.T) {
+			validControls(t)
+			t.Setenv(execDeclarationEnv, `{"profiles":[{"name":"worker","manifests":["missing"]}]}`)
+		}, command: []string{"true"}, want: "validating guard declaration"},
+		{name: "prepare failure", prepare: func(t *testing.T) {
+			validControls(t)
+			t.Setenv(execWorkspaceEnv, "/usr/local/bin")
+		}, command: []string{"true"}, want: "preparing manifest"},
+		{name: "apply failure", prepare: validControls, command: []string{"true"}, apply: func(*PreparedManifest) (EnforcementRecord, error) {
+			return EnforcementRecord{State: EnforcementRefused, Reason: "kernel refused"}, errors.New("apply failed")
+		}, want: "apply failed"},
+		{name: "unenforced record", prepare: validControls, command: []string{"true"}, apply: func(*PreparedManifest) (EnforcementRecord, error) {
+			return EnforcementRecord{State: EnforcementRefused, Reason: "not enforced"}, nil
+		}, want: "not enforced"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.prepare(t)
+			apply := testCase.apply
+			if apply == nil {
+				apply = func(*PreparedManifest) (EnforcementRecord, error) {
+					t.Fatal("invalid controls reached enforcement")
+					return EnforcementRecord{}, nil
+				}
+			}
+			err := runExecWith(testCase.command, nil, apply, noReplace)
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+func TestPrepareExecutionGrantsExactResolvedExecutable(t *testing.T) {
+	workspace := t.TempDir()
+	executableDir := t.TempDir()
+	executable := filepath.Join(executableDir, "developer-tool")
+	if err := os.WriteFile(executable, []byte("tool"), 0o600); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	executableRoot, err := os.OpenRoot(executableDir)
+	if err != nil {
+		t.Fatalf("open executable root: %v", err)
+	}
+	defer func() { _ = executableRoot.Close() }()
+	executableFile, err := executableRoot.Open("developer-tool")
+	if err != nil {
+		t.Fatalf("open executable: %v", err)
+	}
+	if err := executableFile.Chmod(0o700); err != nil {
+		_ = executableFile.Close()
+		t.Fatalf("make executable: %v", err)
+	}
+	if err := executableFile.Close(); err != nil {
+		t.Fatalf("close executable: %v", err)
+	}
+	prepared, err := PrepareExecution(config.Defaults(), "", workspace, workspace, executable, os.Getuid())
+	if err != nil {
+		t.Fatalf("PrepareExecution: %v", err)
+	}
+	defer func() { _ = prepared.Close() }()
+	for _, outcome := range prepared.Outcomes() {
+		if outcome.DeclaredPath == executable && outcome.State.Granted() {
+			return
+		}
+	}
+	t.Fatalf("exact executable %q was not granted: %+v", executable, prepared.Outcomes())
+}
+
+func TestPrepareExecutionRefusesWorkspaceThatBypassesWriteFloor(t *testing.T) {
+	_, err := PrepareExecution(config.Defaults(), "", "/usr/local/bin", t.TempDir(), "/usr/bin/true", os.Getuid())
+	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("dangerous workspace error = %v, want compiled-floor refusal", err)
+	}
+}
+
+func TestPrepareExecutionRejectsMissingConfigAndProfile(t *testing.T) {
+	if _, err := PrepareExecution(nil, "", t.TempDir(), "", "", os.Getuid()); err == nil {
+		t.Fatal("nil execution config was accepted")
+	}
+	cfg := config.Defaults()
+	cfg.Guard.Profiles = []config.GuardProfile{{Name: "worker"}}
+	if _, err := PrepareExecution(cfg, "", t.TempDir(), "", "", os.Getuid()); err == nil || !strings.Contains(err.Error(), "profile is required") {
+		t.Fatalf("missing profile error = %v", err)
+	}
+	if _, err := PrepareExecution(cfg, "missing", t.TempDir(), "", "", os.Getuid()); err == nil {
+		t.Fatal("unknown execution profile was accepted")
+	}
+}

--- a/internal/guard/exec_linux_test.go
+++ b/internal/guard/exec_linux_test.go
@@ -119,16 +119,47 @@ func TestExecEntryPointsRejectInvalidControls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecControlEnvironment: %v", err)
 	}
-	if len(controls) == 0 || !slices.Contains(controls, execModeEnv+"=1") {
+	declarationJSON, err := json.Marshal(config.Guard{})
+	if err != nil {
+		t.Fatalf("marshal declaration: %v", err)
+	}
+	wantControls := []string{
+		execModeEnv + "=1",
+		execDeclarationEnv + "=" + string(declarationJSON),
+		execProfileEnv + "=",
+		execPolicyHashEnv + "=policy-hash",
+		execWorkspaceEnv + "=" + controlsValue(t, controls, execWorkspaceEnv),
+		execTempDirEnv + "=" + controlsValue(t, controls, execTempDirEnv),
+		execBinaryEnv + "=/usr/bin/true",
+		execEnvironmentEnv + "=3",
+	}
+	if len(controls) != len(wantControls) {
 		t.Fatalf("controls = %v", controls)
 	}
-	largeDeclaration := config.Guard{Services: []config.GuardService{{Name: strings.Repeat("x", (1<<20)+1)}}}
-	if _, err := ExecControlEnvironment(largeDeclaration, "", "hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3); err == nil || !strings.Contains(err.Error(), "exceeds 1 MiB") {
+	for _, want := range wantControls {
+		if !slices.Contains(controls, want) {
+			t.Fatalf("controls missing %q: %v", want, controls)
+		}
+	}
+	largeDeclaration := config.Guard{Services: []config.GuardService{{Name: strings.Repeat("x", guardDeclarationEnvironmentMaxPayload+1)}}}
+	if _, err := ExecControlEnvironment(largeDeclaration, "", "hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3); err == nil || !strings.Contains(err.Error(), "64 KiB") {
 		t.Fatalf("oversized declaration error = %v", err)
 	}
 	if err := runExec(nil, nil); err == nil || !strings.Contains(err.Error(), "missing operator command") {
 		t.Fatalf("runExec error = %v", err)
 	}
+}
+
+func controlsValue(t *testing.T, controls []string, key string) string {
+	t.Helper()
+	prefix := key + "="
+	for _, entry := range controls {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	t.Fatalf("control %q missing: %v", key, controls)
+	return ""
 }
 
 type errorReader struct{ err error }
@@ -280,6 +311,20 @@ func TestPrepareExecutionRefusesWorkspaceThatBypassesWriteFloor(t *testing.T) {
 	_, err := PrepareExecution(config.Defaults(), "", "/usr/local/bin", t.TempDir(), "/usr/bin/true", os.Getuid())
 	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
 		t.Fatalf("dangerous workspace error = %v, want compiled-floor refusal", err)
+	}
+}
+
+func TestPrepareExecutionRefusesWorkspaceSymlinkThatBypassesWriteFloor(t *testing.T) {
+	alias := filepath.Join(t.TempDir(), "workspace")
+	if err := os.Symlink("/usr/local/bin", alias); err != nil {
+		t.Fatalf("create workspace symlink: %v", err)
+	}
+	prepared, err := PrepareExecution(config.Defaults(), "", alias, t.TempDir(), "/usr/bin/true", os.Getuid())
+	if prepared != nil {
+		_ = prepared.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
+		t.Fatalf("workspace symlink bypass error = %v", err)
 	}
 }
 

--- a/internal/guard/exec_linux_test.go
+++ b/internal/guard/exec_linux_test.go
@@ -74,6 +74,13 @@ func TestOpenExecStatusWriterValidatesAndOwnsDescriptor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openExecStatusWriter: %v", err)
 	}
+	flags, err := unix.FcntlInt(uintptr(inheritedFD), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("read status descriptor flags: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatal("guard status descriptor is not close-on-exec")
+	}
 	if err := status.Close(); err != nil {
 		t.Fatalf("close status writer: %v", err)
 	}

--- a/internal/guard/exec_linux_test.go
+++ b/internal/guard/exec_linux_test.go
@@ -47,6 +47,36 @@ func TestReadExecEnvironmentOwnsInheritedDescriptor(t *testing.T) {
 	if len(got) != 1 || got[0] != "PATH=/developer/bin" {
 		t.Fatalf("environment = %v", got)
 	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(inheritedFD, &stat); !errors.Is(err, unix.EBADF) {
+		_ = unix.Close(inheritedFD)
+		t.Fatalf("inherited descriptor remained open: %v", err)
+	}
+}
+
+func TestOpenExecStatusWriterValidatesAndOwnsDescriptor(t *testing.T) {
+	for _, raw := range []string{"", "2", "not-a-number"} {
+		if _, err := openExecStatusWriter(raw); err == nil {
+			t.Fatalf("status descriptor %q was accepted", raw)
+		}
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	inheritedFD, err := unix.Dup(int(writer.Fd()))
+	if err != nil {
+		t.Fatalf("dup status descriptor: %v", err)
+	}
+	_ = writer.Close()
+	status, err := openExecStatusWriter(strconv.Itoa(inheritedFD))
+	if err != nil {
+		t.Fatalf("openExecStatusWriter: %v", err)
+	}
+	if err := status.Close(); err != nil {
+		t.Fatalf("close status writer: %v", err)
+	}
 }
 
 func TestReadExecEnvironmentRoundTripAndClose(t *testing.T) {
@@ -115,7 +145,12 @@ func TestExecEntryPointsRejectInvalidControls(t *testing.T) {
 	if !IsExecMode() {
 		t.Fatal("exec mode marker was ignored")
 	}
-	controls, err := ExecControlEnvironment(config.Guard{}, "", "policy-hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3)
+	workspace := t.TempDir()
+	tempDir := t.TempDir()
+	controls, err := ExecControlEnvironment(ExecControlOptions{
+		Declaration: config.Guard{}, PolicyHash: "policy-hash", Workspace: workspace,
+		TempDir: tempDir, Binary: "/usr/bin/true", EnvironmentFD: 3, StatusFD: 4,
+	})
 	if err != nil {
 		t.Fatalf("ExecControlEnvironment: %v", err)
 	}
@@ -128,10 +163,11 @@ func TestExecEntryPointsRejectInvalidControls(t *testing.T) {
 		execDeclarationEnv + "=" + string(declarationJSON),
 		execProfileEnv + "=",
 		execPolicyHashEnv + "=policy-hash",
-		execWorkspaceEnv + "=" + controlsValue(t, controls, execWorkspaceEnv),
-		execTempDirEnv + "=" + controlsValue(t, controls, execTempDirEnv),
+		execWorkspaceEnv + "=" + workspace,
+		execTempDirEnv + "=" + tempDir,
 		execBinaryEnv + "=/usr/bin/true",
 		execEnvironmentEnv + "=3",
+		execStatusEnv + "=4",
 	}
 	if len(controls) != len(wantControls) {
 		t.Fatalf("controls = %v", controls)
@@ -142,24 +178,12 @@ func TestExecEntryPointsRejectInvalidControls(t *testing.T) {
 		}
 	}
 	largeDeclaration := config.Guard{Services: []config.GuardService{{Name: strings.Repeat("x", guardDeclarationEnvironmentMaxPayload+1)}}}
-	if _, err := ExecControlEnvironment(largeDeclaration, "", "hash", t.TempDir(), t.TempDir(), "/usr/bin/true", 3); err == nil || !strings.Contains(err.Error(), "64 KiB") {
+	if _, err := ExecControlEnvironment(ExecControlOptions{Declaration: largeDeclaration, PolicyHash: "hash", Workspace: t.TempDir(), TempDir: t.TempDir(), Binary: "/usr/bin/true", EnvironmentFD: 3, StatusFD: 4}); err == nil || !strings.Contains(err.Error(), "64 KiB") {
 		t.Fatalf("oversized declaration error = %v", err)
 	}
 	if err := runExec(nil, nil); err == nil || !strings.Contains(err.Error(), "missing operator command") {
 		t.Fatalf("runExec error = %v", err)
 	}
-}
-
-func controlsValue(t *testing.T, controls []string, key string) string {
-	t.Helper()
-	prefix := key + "="
-	for _, entry := range controls {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix)
-		}
-	}
-	t.Fatalf("control %q missing: %v", key, controls)
-	return ""
 }
 
 type errorReader struct{ err error }
@@ -203,6 +227,12 @@ func TestRunExecWithAppliesPolicyAndReplacesProcess(t *testing.T) {
 			}
 			if slices.Contains(environment, "__PIPELOCK_ATTACKER=value") || !slices.Contains(environment, "TOKEN=preserved") {
 				t.Fatalf("replacement environment=%v", environment)
+			}
+			return nil
+		},
+		func(proof ExecutionProof) error {
+			if err := proof.Verify("policy-hash"); err != nil {
+				t.Fatalf("execution proof: %v", err)
 			}
 			return nil
 		},
@@ -263,11 +293,39 @@ func TestRunExecWithRefusesIncompleteControlsAndEnforcement(t *testing.T) {
 					return EnforcementRecord{}, nil
 				}
 			}
-			err := runExecWith(testCase.command, nil, apply, noReplace)
+			err := runExecWith(testCase.command, nil, apply, noReplace, func(ExecutionProof) error { return nil })
 			if err == nil || !strings.Contains(err.Error(), testCase.want) {
 				t.Fatalf("error = %v, want %q", err, testCase.want)
 			}
 		})
+	}
+}
+
+func TestRunExecWithReportsExecFailureAfterEnforcement(t *testing.T) {
+	t.Setenv(execWorkspaceEnv, t.TempDir())
+	t.Setenv(execTempDirEnv, t.TempDir())
+	t.Setenv(execPolicyHashEnv, "policy-hash")
+	t.Setenv(execBinaryEnv, "/usr/bin/true")
+	t.Setenv(execDeclarationEnv, `{}`)
+	t.Setenv(execProfileEnv, "")
+	wantErr := errors.New("exec refused")
+	var proofs []ExecutionProof
+	err := runExecWith(
+		[]string{"/usr/bin/true"}, nil,
+		func(*PreparedManifest) (EnforcementRecord, error) {
+			return EnforcementRecord{State: EnforcementEnforced, Mechanism: "landlock", Coverage: CoverageFull}, nil
+		},
+		func(string, []string, []string) error { return wantErr },
+		func(proof ExecutionProof) error {
+			proofs = append(proofs, proof)
+			return nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runExecWith error = %v", err)
+	}
+	if len(proofs) != 2 || proofs[0].ExecError != "" || proofs[1].ExecError != wantErr.Error() {
+		t.Fatalf("execution status sequence = %+v", proofs)
 	}
 }
 
@@ -299,18 +357,45 @@ func TestPrepareExecutionGrantsExactResolvedExecutable(t *testing.T) {
 		t.Fatalf("PrepareExecution: %v", err)
 	}
 	defer func() { _ = prepared.Close() }()
+	granted := false
 	for _, outcome := range prepared.Outcomes() {
+		if outcome.DeclaredPath == executableDir && outcome.State.Granted() {
+			t.Fatalf("executable directory %q was granted", executableDir)
+		}
 		if outcome.DeclaredPath == executable && outcome.State.Granted() {
-			return
+			granted = true
 		}
 	}
-	t.Fatalf("exact executable %q was not granted: %+v", executable, prepared.Outcomes())
+	if !granted {
+		t.Fatalf("exact executable %q was not granted: %+v", executable, prepared.Outcomes())
+	}
 }
 
 func TestPrepareExecutionRefusesWorkspaceThatBypassesWriteFloor(t *testing.T) {
 	_, err := PrepareExecution(config.Defaults(), "", "/usr/local/bin", t.TempDir(), "/usr/bin/true", os.Getuid())
 	if err == nil || !strings.Contains(err.Error(), "compiled floor") {
 		t.Fatalf("dangerous workspace error = %v, want compiled-floor refusal", err)
+	}
+}
+
+func TestPrepareExecutionRefusesTempDirThatBypassesWriteFloor(t *testing.T) {
+	_, err := PrepareExecution(config.Defaults(), "", t.TempDir(), "/usr/local/bin", "/usr/bin/true", os.Getuid())
+	if err == nil || !strings.Contains(err.Error(), "compiled floor") || !strings.Contains(err.Error(), "temporary directory") {
+		t.Fatalf("dangerous temporary directory error = %v, want compiled-floor refusal", err)
+	}
+}
+
+func TestPrepareExecutionDoesNotGrantPrivateCertificateTrees(t *testing.T) {
+	workspace := t.TempDir()
+	prepared, err := PrepareExecution(config.Defaults(), "", workspace, workspace, "/usr/bin/true", os.Getuid())
+	if err != nil {
+		t.Fatalf("PrepareExecution: %v", err)
+	}
+	defer func() { _ = prepared.Close() }()
+	for _, outcome := range prepared.Outcomes() {
+		if outcome.DeclaredPath == "/etc/ssl" || outcome.DeclaredPath == "/etc/pki" || strings.HasPrefix(outcome.DeclaredPath, "/etc/ssl/private") {
+			t.Fatalf("private certificate tree was granted: %+v", outcome)
+		}
 	}
 }
 

--- a/internal/guard/exec_other.go
+++ b/internal/guard/exec_other.go
@@ -10,16 +10,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
-	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 const execModeEnv = "__PIPELOCK_GUARD_EXEC"
 
 func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
 
-func ExecControlEnvironment(declaration config.Guard, profile, policyHash, workspace, tempDir, binary string, environmentFD int) ([]string, error) {
-	encoded, err := json.Marshal(declaration)
+func ExecControlEnvironment(opts ExecControlOptions) ([]string, error) {
+	encoded, err := json.Marshal(opts.Declaration)
 	if err != nil {
 		return nil, fmt.Errorf("encoding guard declaration: %w", err)
 	}

--- a/internal/guard/exec_other.go
+++ b/internal/guard/exec_other.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const execModeEnv = "__PIPELOCK_GUARD_EXEC"
+
+func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
+
+func ExecControlEnvironment(declaration config.Guard, profile, policyHash, workspace, tempDir, binary string, environmentFD int) ([]string, error) {
+	encoded, err := json.Marshal(declaration)
+	if err != nil {
+		return nil, fmt.Errorf("encoding guard declaration: %w", err)
+	}
+	if len(encoded) > 1<<20 {
+		return nil, errors.New("guard declaration exceeds 1 MiB")
+	}
+	return []string{execModeEnv + "=1"}, nil
+}
+
+func RunExec() {
+	_, _ = fmt.Fprintln(os.Stderr, "[guard] REFUSED: Guard execution requires Linux")
+	os.Exit(1)
+}

--- a/internal/guard/exec_other.go
+++ b/internal/guard/exec_other.go
@@ -6,8 +6,6 @@
 package guard
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 )
@@ -16,14 +14,7 @@ const execModeEnv = "__PIPELOCK_GUARD_EXEC"
 
 func IsExecMode() bool { return os.Getenv(execModeEnv) == "1" }
 
-func ExecControlEnvironment(opts ExecControlOptions) ([]string, error) {
-	encoded, err := json.Marshal(opts.Declaration)
-	if err != nil {
-		return nil, fmt.Errorf("encoding guard declaration: %w", err)
-	}
-	if len(encoded) > 64<<10 {
-		return nil, errors.New("guard declaration exceeds the 64 KiB environment transport limit")
-	}
+func ExecControlEnvironment(_ ExecControlOptions) ([]string, error) {
 	return []string{execModeEnv + "=1"}, nil
 }
 

--- a/internal/guard/exec_other.go
+++ b/internal/guard/exec_other.go
@@ -23,8 +23,8 @@ func ExecControlEnvironment(declaration config.Guard, profile, policyHash, works
 	if err != nil {
 		return nil, fmt.Errorf("encoding guard declaration: %w", err)
 	}
-	if len(encoded) > 1<<20 {
-		return nil, errors.New("guard declaration exceeds 1 MiB")
+	if len(encoded) > 64<<10 {
+		return nil, errors.New("guard declaration exceeds the 64 KiB environment transport limit")
 	}
 	return []string{execModeEnv + "=1"}, nil
 }

--- a/internal/guard/execution.go
+++ b/internal/guard/execution.go
@@ -54,7 +54,7 @@ func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, execu
 			return
 		}
 		seen[key] = struct{}{}
-		planned = append(planned, grant{declared: clean, access: access, runtime: floorExempt})
+		planned = append(planned, grant{declared: clean, access: access, floorExempt: floorExempt})
 	}
 	for _, path := range existingExecutionPaths([]string{
 		"/usr", "/lib", "/lib64", "/bin", "/sbin",

--- a/internal/guard/execution.go
+++ b/internal/guard/execution.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package guard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// PrepareExecution merges Guard's selected state manifest with the fixed
+// runtime paths needed to exec and run an ordinary process. Fixed system,
+// temporary, and device grants are code-owned; caller-selected workspace and
+// executable paths still pass the compiled floor before becoming grants.
+func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, executable string, uid int) (*PreparedManifest, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("guard execution config is nil")
+	}
+	planned, err := executionProfileGrants(cfg, profileName)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateExecutionPaths(workspace, executable); err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(planned)+32)
+	for _, g := range planned {
+		seen[string(g.access)+"\x00"+filepath.Clean(g.declared)] = struct{}{}
+	}
+	add := func(path string, access AccessKind) {
+		if path == "" {
+			return
+		}
+		clean := filepath.Clean(path)
+		key := string(access) + "\x00" + clean
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		planned = append(planned, grant{declared: clean, access: access, runtime: true})
+	}
+	for _, path := range existingExecutionPaths([]string{
+		"/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc/ssl", "/etc/pki",
+	}) {
+		add(path, AccessReadDirectory)
+	}
+	for _, path := range existingExecutionPaths([]string{
+		"/etc/resolv.conf", "/etc/hosts", "/etc/nsswitch.conf", "/etc/ld.so.cache", "/etc/ld.so.conf", "/etc/passwd", "/etc/group", "/usr/bin/env",
+	}) {
+		add(path, AccessReadFile)
+	}
+	add(workspace, AccessWriteDirectory)
+	add(tempDir, AccessWriteDirectory)
+	// The init process resolves PATH before enforcement and passes the exact
+	// executable here. Grant that inode, not its containing directory, so tools
+	// installed outside /usr or the workspace can start without widening the
+	// workload's filesystem view to an entire developer bin directory.
+	add(executable, AccessReadFile)
+	for _, path := range existingExecutionPaths([]string{"/dev/null", "/dev/zero", "/dev/urandom"}) {
+		add(path, accessRuntimeDevice)
+	}
+
+	return prepareGrants(planned, uid, config.ExplainGuardPathFloor)
+}
+
+// ValidateExecutionPaths applies the compiled floor to the caller-selected
+// implicit grants. Fixed Pipelock runtime paths are code-owned, but the
+// workspace and executable are operator inputs and cannot bypass the same
+// floor that applies to manifest entries.
+func ValidateExecutionPaths(workspace, executable string) error {
+	for _, required := range []struct {
+		label  string
+		path   string
+		access config.GuardAccess
+	}{
+		{label: "workspace", path: workspace, access: config.GuardAccessWrite},
+		{label: "executable", path: executable, access: config.GuardAccessRead},
+	} {
+		if required.path == "" {
+			continue
+		}
+		decision, explainErr := config.ExplainGuardPathFloor(required.path, required.access)
+		if explainErr != nil {
+			return fmt.Errorf("evaluating Guard %s %q: %w", required.label, required.path, explainErr)
+		}
+		if decision.Refused {
+			return fmt.Errorf("guard %s %q is refused by the compiled floor: %s", required.label, required.path, decision.Reason)
+		}
+	}
+	return nil
+}
+
+func existingExecutionPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+func executionProfileGrants(cfg *config.Config, profileName string) ([]grant, error) {
+	if profileName != "" {
+		return planManifests(cfg, profileName)
+	}
+	if len(cfg.Guard.Profiles) != 0 {
+		return nil, fmt.Errorf("guard profile is required when profiles are declared")
+	}
+	return []grant{}, nil
+}

--- a/internal/guard/execution.go
+++ b/internal/guard/execution.go
@@ -31,7 +31,7 @@ func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, execu
 	for _, g := range planned {
 		seen[string(g.access)+"\x00"+filepath.Clean(g.declared)] = struct{}{}
 	}
-	add := func(path string, access AccessKind) {
+	add := func(path string, access AccessKind, floorExempt bool) {
 		if path == "" {
 			return
 		}
@@ -41,31 +41,33 @@ func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, execu
 			return
 		}
 		seen[key] = struct{}{}
-		planned = append(planned, grant{declared: clean, access: access, runtime: true})
+		planned = append(planned, grant{declared: clean, access: access, runtime: floorExempt})
 	}
 	for _, path := range existingExecutionPaths([]string{
 		"/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc/ssl", "/etc/pki",
 	}) {
-		add(path, AccessReadDirectory)
+		add(path, AccessReadDirectory, true)
 	}
 	for _, path := range existingExecutionPaths([]string{
 		"/etc/resolv.conf", "/etc/hosts", "/etc/nsswitch.conf", "/etc/ld.so.cache", "/etc/ld.so.conf", "/etc/passwd", "/etc/group", "/usr/bin/env",
 	}) {
-		add(path, AccessReadFile)
+		add(path, AccessReadFile, true)
 	}
-	add(workspace, AccessWriteDirectory)
-	add(tempDir, AccessWriteDirectory)
+	add(workspace, AccessWriteDirectory, false)
+	add(tempDir, AccessWriteDirectory, true)
 	// The init process resolves PATH before enforcement and passes the exact
 	// executable here. Grant that inode, not its containing directory, so tools
 	// installed outside /usr or the workspace can start without widening the
 	// workload's filesystem view to an entire developer bin directory.
-	add(executable, AccessReadFile)
-	for _, path := range existingExecutionPaths([]string{"/dev/null", "/dev/zero", "/dev/urandom"}) {
-		add(path, accessRuntimeDevice)
+	add(executable, AccessReadFile, false)
+	for _, path := range existingExecutionPaths(runtimeDevices) {
+		add(path, accessRuntimeDevice, true)
 	}
 
 	return prepareGrants(planned, uid, config.ExplainGuardPathFloor)
 }
+
+var runtimeDevices = []string{"/dev/null", "/dev/zero", "/dev/urandom"}
 
 // ValidateExecutionPaths applies the compiled floor to the caller-selected
 // implicit grants. Fixed Pipelock runtime paths are code-owned, but the

--- a/internal/guard/execution.go
+++ b/internal/guard/execution.go
@@ -11,6 +11,19 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
+// ExecControlOptions carries the fixed controls passed to the final pre-exec
+// helper without exposing the developer environment in process metadata.
+type ExecControlOptions struct {
+	Declaration   config.Guard
+	Profile       string
+	PolicyHash    string
+	Workspace     string
+	TempDir       string
+	Binary        string
+	EnvironmentFD int
+	StatusFD      int
+}
+
 // PrepareExecution merges Guard's selected state manifest with the fixed
 // runtime paths needed to exec and run an ordinary process. Fixed system,
 // temporary, and device grants are code-owned; caller-selected workspace and
@@ -23,7 +36,7 @@ func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, execu
 	if err != nil {
 		return nil, err
 	}
-	if err := ValidateExecutionPaths(workspace, executable); err != nil {
+	if err := ValidateExecutionPaths(workspace, tempDir, executable); err != nil {
 		return nil, err
 	}
 
@@ -44,17 +57,23 @@ func PrepareExecution(cfg *config.Config, profileName, workspace, tempDir, execu
 		planned = append(planned, grant{declared: clean, access: access, runtime: floorExempt})
 	}
 	for _, path := range existingExecutionPaths([]string{
-		"/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc/ssl", "/etc/pki",
+		"/usr", "/lib", "/lib64", "/bin", "/sbin",
 	}) {
 		add(path, AccessReadDirectory, true)
 	}
 	for _, path := range existingExecutionPaths([]string{
 		"/etc/resolv.conf", "/etc/hosts", "/etc/nsswitch.conf", "/etc/ld.so.cache", "/etc/ld.so.conf", "/etc/passwd", "/etc/group", "/usr/bin/env",
+		"/etc/ssl/certs/ca-certificates.crt", "/etc/ssl/cert.pem", "/etc/pki/tls/certs/ca-bundle.crt", "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
 	}) {
 		add(path, AccessReadFile, true)
 	}
+	for _, path := range existingExecutionPaths([]string{
+		"/etc/ssl/certs", "/etc/pki/tls/certs", "/etc/pki/ca-trust/extracted",
+	}) {
+		add(path, AccessReadDirectory, true)
+	}
 	add(workspace, AccessWriteDirectory, false)
-	add(tempDir, AccessWriteDirectory, true)
+	add(tempDir, AccessWriteDirectory, false)
 	// The init process resolves PATH before enforcement and passes the exact
 	// executable here. Grant that inode, not its containing directory, so tools
 	// installed outside /usr or the workspace can start without widening the
@@ -73,13 +92,14 @@ var runtimeDevices = []string{"/dev/null", "/dev/zero", "/dev/urandom"}
 // implicit grants. Fixed Pipelock runtime paths are code-owned, but the
 // workspace and executable are operator inputs and cannot bypass the same
 // floor that applies to manifest entries.
-func ValidateExecutionPaths(workspace, executable string) error {
+func ValidateExecutionPaths(workspace, tempDir, executable string) error {
 	for _, required := range []struct {
 		label  string
 		path   string
 		access config.GuardAccess
 	}{
 		{label: "workspace", path: workspace, access: config.GuardAccessWrite},
+		{label: "temporary directory", path: tempDir, access: config.GuardAccessWrite},
 		{label: "executable", path: executable, access: config.GuardAccessRead},
 	} {
 		if required.path == "" {

--- a/internal/guard/execution_proof.go
+++ b/internal/guard/execution_proof.go
@@ -11,9 +11,11 @@ import (
 	"slices"
 )
 
-// ExecutionProof binds the kernel result to the exact invocation that entered
-// the enforced domain. It is transported over an inherited close-on-exec pipe;
-// the parent accepts it only after exec closes that pipe without a later error.
+// ExecutionProof binds the kernel result to the exact invocation whose helper
+// entered the enforced domain before attempting exec. The close-on-exec status
+// pipe can distinguish a returned exec error, but EOF cannot distinguish a
+// successful exec from abrupt helper termination. This proof never asserts
+// that the operator command started.
 type ExecutionProof struct {
 	Record              EnforcementRecord `json:"record"`
 	ConfigPolicyHash    string            `json:"config_policy_hash"`
@@ -27,10 +29,10 @@ type ExecutionProof struct {
 }
 
 // NewExecutionProof constructs and hashes the effective child-side policy.
-func NewExecutionProof(record EnforcementRecord, configHash, profile, workspace, tempDir, binary string, command []string) ExecutionProof {
+func NewExecutionProof(record EnforcementRecord, opts ExecControlOptions, command []string) ExecutionProof {
 	proof := ExecutionProof{
-		Record: record, ConfigPolicyHash: configHash, Profile: profile,
-		Workspace: workspace, TempDir: tempDir, Binary: binary,
+		Record: record, ConfigPolicyHash: opts.PolicyHash, Profile: opts.Profile,
+		Workspace: opts.Workspace, TempDir: opts.TempDir, Binary: opts.Binary,
 		Command: slices.Clone(command),
 	}
 	proof.EffectivePolicyHash = proof.recomputeHash()
@@ -40,7 +42,7 @@ func NewExecutionProof(record EnforcementRecord, configHash, profile, workspace,
 // Verify checks the child proof against the parent-side configuration binding.
 func (p ExecutionProof) Verify(expectedConfigHash string) error {
 	if !p.Record.Enforced() || p.ConfigPolicyHash == "" || p.ConfigPolicyHash != expectedConfigHash || p.ExecError != "" {
-		return errors.New("guard execution proof does not describe a successful enforced invocation")
+		return errors.New("guard execution proof does not describe valid pre-exec enforcement")
 	}
 	want := p.recomputeHash()
 	if p.EffectivePolicyHash == "" || p.EffectivePolicyHash != want {

--- a/internal/guard/execution_proof.go
+++ b/internal/guard/execution_proof.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package guard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+)
+
+// ExecutionProof binds the kernel result to the exact invocation that entered
+// the enforced domain. It is transported over an inherited close-on-exec pipe;
+// the parent accepts it only after exec closes that pipe without a later error.
+type ExecutionProof struct {
+	Record              EnforcementRecord `json:"record"`
+	ConfigPolicyHash    string            `json:"config_policy_hash"`
+	EffectivePolicyHash string            `json:"effective_policy_hash"`
+	Profile             string            `json:"profile,omitempty"`
+	Workspace           string            `json:"workspace"`
+	TempDir             string            `json:"temp_dir"`
+	Binary              string            `json:"binary"`
+	Command             []string          `json:"command"`
+	ExecError           string            `json:"exec_error,omitempty"`
+}
+
+// NewExecutionProof constructs and hashes the effective child-side policy.
+func NewExecutionProof(record EnforcementRecord, configHash, profile, workspace, tempDir, binary string, command []string) ExecutionProof {
+	proof := ExecutionProof{
+		Record: record, ConfigPolicyHash: configHash, Profile: profile,
+		Workspace: workspace, TempDir: tempDir, Binary: binary,
+		Command: slices.Clone(command),
+	}
+	proof.EffectivePolicyHash = proof.recomputeHash()
+	return proof
+}
+
+// Verify checks the child proof against the parent-side configuration binding.
+func (p ExecutionProof) Verify(expectedConfigHash string) error {
+	if !p.Record.Enforced() || p.ConfigPolicyHash == "" || p.ConfigPolicyHash != expectedConfigHash || p.ExecError != "" {
+		return errors.New("guard execution proof does not describe a successful enforced invocation")
+	}
+	want := p.recomputeHash()
+	if p.EffectivePolicyHash == "" || p.EffectivePolicyHash != want {
+		return errors.New("guard execution proof hash mismatch")
+	}
+	return nil
+}
+
+func (p ExecutionProof) recomputeHash() string {
+	material := struct {
+		Record           EnforcementRecord `json:"record"`
+		ConfigPolicyHash string            `json:"config_policy_hash"`
+		Profile          string            `json:"profile,omitempty"`
+		Workspace        string            `json:"workspace"`
+		TempDir          string            `json:"temp_dir"`
+		Binary           string            `json:"binary"`
+		Command          []string          `json:"command"`
+	}{p.Record, p.ConfigPolicyHash, p.Profile, p.Workspace, p.TempDir, p.Binary, p.Command}
+	encoded, _ := json.Marshal(material)
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/guard/execution_proof_test.go
+++ b/internal/guard/execution_proof_test.go
@@ -6,21 +6,49 @@ package guard
 import "testing"
 
 func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
-	record := EnforcementRecord{State: EnforcementEnforced, Mechanism: "landlock", Coverage: CoverageFull}
-	proof := NewExecutionProof(record, "config-hash", "worker", "/workspace", "/tmp/private", "/usr/bin/tool", []string{"tool", "arg"})
-	if err := proof.Verify("config-hash"); err != nil {
-		t.Fatalf("Verify: %v", err)
+	newValidProof := func() ExecutionProof {
+		return NewExecutionProof(
+			EnforcementRecord{State: EnforcementEnforced, Mechanism: "landlock", Coverage: CoverageFull},
+			ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool"},
+			[]string{"tool", "arg"},
+		)
 	}
-	if err := proof.Verify("other-config"); err == nil {
-		t.Fatal("proof with the wrong config binding was accepted")
-	}
-	failed := NewExecutionProof(record, "config-hash", "worker", "/workspace", "/tmp/private", "/usr/bin/tool", []string{"tool"})
-	failed.ExecError = "exec failed"
-	if err := failed.Verify("config-hash"); err == nil {
-		t.Fatal("proof carrying an exec failure was accepted")
-	}
-	proof.TempDir = "/tmp/other"
-	if err := proof.Verify("config-hash"); err == nil {
-		t.Fatal("tampered effective invocation was accepted")
-	}
+	t.Run("valid proof", func(t *testing.T) {
+		if err := newValidProof().Verify("config-hash"); err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+	})
+	t.Run("wrong config binding", func(t *testing.T) {
+		if err := newValidProof().Verify("other-config"); err == nil {
+			t.Fatal("proof with the wrong config binding was accepted")
+		}
+	})
+	t.Run("execution failure", func(t *testing.T) {
+		proof := newValidProof()
+		proof.ExecError = "exec failed"
+		if err := proof.Verify("config-hash"); err == nil {
+			t.Fatal("proof carrying an exec failure was accepted")
+		}
+	})
+	t.Run("tampered temporary directory", func(t *testing.T) {
+		proof := newValidProof()
+		proof.TempDir = "/tmp/other"
+		if err := proof.Verify("config-hash"); err == nil {
+			t.Fatal("tampered effective invocation was accepted")
+		}
+	})
+	t.Run("tampered command", func(t *testing.T) {
+		proof := newValidProof()
+		proof.Command = []string{"other"}
+		if err := proof.Verify("config-hash"); err == nil {
+			t.Fatal("tampered command was accepted")
+		}
+	})
+	t.Run("missing effective hash", func(t *testing.T) {
+		proof := newValidProof()
+		proof.EffectivePolicyHash = ""
+		if err := proof.Verify("config-hash"); err == nil {
+			t.Fatal("proof without an effective policy hash was accepted")
+		}
+	})
 }

--- a/internal/guard/execution_proof_test.go
+++ b/internal/guard/execution_proof_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package guard
+
+import "testing"
+
+func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
+	record := EnforcementRecord{State: EnforcementEnforced, Mechanism: "landlock", Coverage: CoverageFull}
+	proof := NewExecutionProof(record, "config-hash", "worker", "/workspace", "/tmp/private", "/usr/bin/tool", []string{"tool", "arg"})
+	if err := proof.Verify("config-hash"); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if err := proof.Verify("other-config"); err == nil {
+		t.Fatal("proof with the wrong config binding was accepted")
+	}
+	failed := NewExecutionProof(record, "config-hash", "worker", "/workspace", "/tmp/private", "/usr/bin/tool", []string{"tool"})
+	failed.ExecError = "exec failed"
+	if err := failed.Verify("config-hash"); err == nil {
+		t.Fatal("proof carrying an exec failure was accepted")
+	}
+	proof.TempDir = "/tmp/other"
+	if err := proof.Verify("config-hash"); err == nil {
+		t.Fatal("tampered effective invocation was accepted")
+	}
+}

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -8,9 +8,9 @@
 // enforced. Sharing an adapter would force one of those two contracts to bend,
 // and the one that would bend in practice is this one.
 //
-// Nothing here is wired to a command yet. Guard remains unenforced as a product
-// surface until the execution surface consumes this package; config validation
-// still refuses a runtime guard declaration.
+// The execution surface consumes this package only in its final pre-exec
+// helper. Parent-side proxying, audit, receipts, and evidence remain outside
+// the workload restriction.
 package guard
 
 import (
@@ -96,6 +96,7 @@ const (
 	AccessReadDirectory  AccessKind = "read_only_directories"
 	AccessWriteFile      AccessKind = "read_write"
 	AccessWriteDirectory AccessKind = "read_write_directories"
+	accessRuntimeDevice  AccessKind = "runtime_device"
 )
 
 // IsDirectory reports whether the grant covers a subtree.
@@ -105,7 +106,7 @@ func (a AccessKind) IsDirectory() bool {
 
 // IsWrite reports whether the grant confers modification rights.
 func (a AccessKind) IsWrite() bool {
-	return a == AccessWriteFile || a == AccessWriteDirectory
+	return a == AccessWriteFile || a == AccessWriteDirectory || a == accessRuntimeDevice
 }
 
 // PathState is what actually happened to one declared path.

--- a/internal/guard/plan.go
+++ b/internal/guard/plan.go
@@ -16,6 +16,7 @@ import (
 type grant struct {
 	declared string
 	access   AccessKind
+	runtime  bool
 	// refusal is non-empty when the compiled floor rejected this declaration.
 	// The grant is retained rather than dropped so the outcome list can report
 	// it; a dropped declaration is indistinguishable from one that was never

--- a/internal/guard/plan.go
+++ b/internal/guard/plan.go
@@ -16,10 +16,10 @@ import (
 type grant struct {
 	declared string
 	access   AccessKind
-	// runtime marks a code-owned execution grant. It skips the compiled-floor
+	// floorExempt marks a code-owned execution grant. It skips the compiled-floor
 	// check against the resolved target and permits the fixed character-device
 	// allowlist. Never set it for an operator-selected path.
-	runtime bool
+	floorExempt bool
 	// refusal is non-empty when the compiled floor rejected this declaration.
 	// The grant is retained rather than dropped so the outcome list can report
 	// it; a dropped declaration is indistinguishable from one that was never

--- a/internal/guard/plan.go
+++ b/internal/guard/plan.go
@@ -16,7 +16,10 @@ import (
 type grant struct {
 	declared string
 	access   AccessKind
-	runtime  bool
+	// runtime marks a code-owned execution grant. It skips the compiled-floor
+	// check against the resolved target and permits the fixed character-device
+	// allowlist. Never set it for an operator-selected path.
+	runtime bool
 	// refusal is non-empty when the compiled floor rejected this declaration.
 	// The grant is retained rather than dropped so the outcome list can report
 	// it; a dropped declaration is indistinguishable from one that was never

--- a/internal/guard/prepare_linux.go
+++ b/internal/guard/prepare_linux.go
@@ -427,6 +427,8 @@ func verifyPinned(fd int, resolved string, access AccessKind, uid int, runtimeGr
 			return fmt.Sprintf("%q is a regular file but was declared as a directory subtree", resolved)
 		}
 	case unix.S_IFCHR:
+		// Fixed runtime devices are root-owned and world-writable by design.
+		// The resolved-path check still refuses symlinks to any other device.
 		if !runtimeGrant || access != accessRuntimeDevice || !runtimeDevicePath(resolved) {
 			return fmt.Sprintf("%q is a device node and is not one of Guard's fixed runtime devices", resolved)
 		}
@@ -452,12 +454,13 @@ func verifyPinned(fd int, resolved string, access AccessKind, uid int, runtimeGr
 }
 
 func runtimeDevicePath(path string) bool {
-	switch filepath.Clean(path) {
-	case "/dev/null", "/dev/zero", "/dev/urandom":
-		return true
-	default:
-		return false
+	clean := filepath.Clean(path)
+	for _, device := range runtimeDevices {
+		if clean == device {
+			return true
+		}
 	}
+	return false
 }
 
 // verifyAncestor refuses to create state beneath a directory other users can

--- a/internal/guard/prepare_linux.go
+++ b/internal/guard/prepare_linux.go
@@ -224,7 +224,7 @@ func prepareGrants(grants []grant, uid int, explainFloor floorEvaluator) (*Prepa
 		}
 		outcome.ResolvedPath = resolved
 
-		if refusal := floorRefusal(resolved, g.access, explainFloor); refusal != "" && !g.runtime {
+		if refusal := floorRefusal(resolved, g.access, explainFloor); refusal != "" && !g.floorExempt {
 			outcome.State = StateRefused
 			outcome.Reason = "resolved target refused by compiled floor: " + refusal
 			prepared.outcomes = append(prepared.outcomes, outcome)
@@ -241,7 +241,7 @@ func prepareGrants(grants []grant, uid int, explainFloor floorEvaluator) (*Prepa
 			continue
 		}
 
-		fd, state, reason := pinTarget(resolved, g.access, uid, g.runtime)
+		fd, state, reason := pinTarget(resolved, g.access, uid, g.floorExempt)
 		outcome.State = state
 		outcome.Reason = reason
 		if !state.Granted() {

--- a/internal/guard/prepare_linux.go
+++ b/internal/guard/prepare_linux.go
@@ -167,6 +167,8 @@ func rightsFor(access AccessKind) uint64 {
 		return rightsWriteFile
 	case AccessWriteDirectory:
 		return rightsWriteDir
+	case accessRuntimeDevice:
+		return llsys.AccessFSReadFile | llsys.AccessFSWriteFile
 	default:
 		return 0
 	}
@@ -222,7 +224,7 @@ func prepareGrants(grants []grant, uid int, explainFloor floorEvaluator) (*Prepa
 		}
 		outcome.ResolvedPath = resolved
 
-		if refusal := floorRefusal(resolved, g.access, explainFloor); refusal != "" {
+		if refusal := floorRefusal(resolved, g.access, explainFloor); refusal != "" && !g.runtime {
 			outcome.State = StateRefused
 			outcome.Reason = "resolved target refused by compiled floor: " + refusal
 			prepared.outcomes = append(prepared.outcomes, outcome)
@@ -239,7 +241,7 @@ func prepareGrants(grants []grant, uid int, explainFloor floorEvaluator) (*Prepa
 			continue
 		}
 
-		fd, state, reason := pinTarget(resolved, g.access, uid)
+		fd, state, reason := pinTarget(resolved, g.access, uid, g.runtime)
 		outcome.State = state
 		outcome.Reason = reason
 		if !state.Granted() {
@@ -296,11 +298,11 @@ func resolvePhysical(path string) (string, error) {
 
 // pinTarget opens the resolved path as an O_PATH descriptor, creating an
 // absent read-write directory leaf when that is the declared access.
-func pinTarget(resolved string, access AccessKind, uid int) (int, PathState, string) {
+func pinTarget(resolved string, access AccessKind, uid int, runtimeGrant bool) (int, PathState, string) {
 	fd, err := openNoSymlinks(resolved, access.IsDirectory())
 	switch {
 	case err == nil:
-		if reason := verifyPinned(fd, resolved, access, uid); reason != "" {
+		if reason := verifyPinned(fd, resolved, access, uid, runtimeGrant); reason != "" {
 			_ = unix.Close(fd)
 			return -1, StateRefused, reason
 		}
@@ -355,7 +357,7 @@ func createLeaf(resolved string, uid int) (int, PathState, string) {
 	if err != nil {
 		return -1, StateWithheld, fmt.Sprintf("reopening created %q: %v", resolved, err)
 	}
-	if reason := verifyPinned(fd, resolved, AccessWriteDirectory, uid); reason != "" {
+	if reason := verifyPinned(fd, resolved, AccessWriteDirectory, uid, false); reason != "" {
 		_ = unix.Close(fd)
 		return -1, StateRefused, reason
 	}
@@ -409,7 +411,7 @@ func openatNoSymlinks(dirfd int, rel string, dir bool) (int, error) {
 // the object that will actually be granted. Refusing a socket, FIFO, or device
 // here is not redundant with the rights masks above: a directory grant whose
 // target turns out to be a device node would hand out access to raw storage.
-func verifyPinned(fd int, resolved string, access AccessKind, uid int) string {
+func verifyPinned(fd int, resolved string, access AccessKind, uid int, runtimeGrant bool) string {
 	var st unix.Stat_t
 	if err := unix.Fstat(fd, &st); err != nil {
 		return fmt.Sprintf("stat of pinned %q failed: %v", resolved, err)
@@ -424,6 +426,11 @@ func verifyPinned(fd int, resolved string, access AccessKind, uid int) string {
 		if access.IsDirectory() {
 			return fmt.Sprintf("%q is a regular file but was declared as a directory subtree", resolved)
 		}
+	case unix.S_IFCHR:
+		if !runtimeGrant || access != accessRuntimeDevice || !runtimeDevicePath(resolved) {
+			return fmt.Sprintf("%q is a device node and is not one of Guard's fixed runtime devices", resolved)
+		}
+		return ""
 	default:
 		return fmt.Sprintf("%q is neither a regular file nor a directory; guard refuses to grant sockets, FIFOs, and device nodes", resolved)
 	}
@@ -442,6 +449,15 @@ func verifyPinned(fd int, resolved string, access AccessKind, uid int) string {
 		return fmt.Sprintf("writable %q is group- or world-writable (mode %04o)", resolved, st.Mode&0o7777)
 	}
 	return ""
+}
+
+func runtimeDevicePath(path string) bool {
+	switch filepath.Clean(path) {
+	case "/dev/null", "/dev/zero", "/dev/urandom":
+		return true
+	default:
+		return false
+	}
 }
 
 // verifyAncestor refuses to create state beneath a directory other users can

--- a/internal/guard/prepare_other.go
+++ b/internal/guard/prepare_other.go
@@ -41,6 +41,10 @@ func Prepare(cfg *config.Config, profileName string, _ int) (*PreparedManifest, 
 	if err != nil {
 		return nil, err
 	}
+	return prepareGrants(grants, 0, config.ExplainGuardPathFloor)
+}
+
+func prepareGrants(grants []grant, _ int, _ floorEvaluator) (*PreparedManifest, error) {
 	prepared := &PreparedManifest{outcomes: make([]PathOutcome, 0, len(grants))}
 	for _, g := range grants {
 		outcome := PathOutcome{DeclaredPath: g.declared, Access: g.access, State: StateWithheld}
@@ -66,4 +70,9 @@ func (p *PreparedManifest) Apply() (EnforcementRecord, error) {
 		Outcomes:         p.Outcomes(),
 	}
 	return record, ErrUnsupportedPlatform
+}
+
+// ApplyForExec always refuses off Linux, like Apply.
+func (p *PreparedManifest) ApplyForExec() (EnforcementRecord, error) {
+	return p.Apply()
 }

--- a/internal/processexec/replace_other.go
+++ b/internal/processexec/replace_other.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !unix
+
+package processexec
+
+import "errors"
+
+// Replace fails closed on platforms without Unix process replacement.
+func Replace(string, []string, []string) error {
+	return errors.New("process replacement is unavailable on this platform")
+}

--- a/internal/processexec/replace_unix.go
+++ b/internal/processexec/replace_unix.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+// Package processexec centralizes intentional process replacement after a
+// caller has resolved and validated the executable and arguments.
+package processexec
+
+import "syscall"
+
+// Replace replaces the calling process image and returns only on failure.
+func Replace(binary string, argv, environment []string) error {
+	return syscall.Exec(binary, argv, environment) //nolint:gosec // G204: callers resolve and validate the exact executable before replacement
+}

--- a/internal/proxy/guard_grants_test.go
+++ b/internal/proxy/guard_grants_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func TestGuardDestinationGrantRequiresExactPortAndScanSnapshot(t *testing.T) {
+	t.Parallel()
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	port := listener.Addr().(*net.TCPAddr).Port
+	portText := strconv.Itoa(port)
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{"guard.internal.example": {"127.0.0.1"}}
+	grantPort, err := destination.ParsePort(portText)
+	if err != nil {
+		t.Fatalf("ParsePort: %v", err)
+	}
+	grant, err := destination.NewGrant(destination.NetworkTCP, "guard.internal.example", grantPort)
+	if err != nil {
+		t.Fatalf("NewGrant: %v", err)
+	}
+	grants, err := destination.NewGrantSet(grant)
+	if err != nil {
+		t.Fatalf("NewGrantSet: %v", err)
+	}
+	sc, err := scanner.NewWithOptions(cfg, scanner.Options{DestinationGrants: grants})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	defer sc.Close()
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	scanResult := sc.Scan(context.Background(), "http://guard.internal.example:"+portText+"/")
+	if !scanResult.Allowed {
+		t.Fatalf("guard-granted scan blocked: %+v", scanResult)
+	}
+	ctx := withAllowedSSRFDialScanSnapshot(context.Background(), sc, "guard.internal.example", portText, scanResult)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	conn, err := p.ssrfSafeDialContext(ctx, "tcp", net.JoinHostPort("guard.internal.example", portText))
+	if err != nil {
+		t.Fatalf("exact grant dial: %v", err)
+	}
+	_ = conn.Close()
+
+	wrongPort := port + 1
+	if wrongPort > 65535 {
+		wrongPort = port - 1
+	}
+	_, err = p.ssrfSafeDialContext(ctx, "tcp", net.JoinHostPort("guard.internal.example", strconv.Itoa(wrongPort)))
+	if err == nil {
+		t.Fatal("guard grant authorized a sibling port")
+	}
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) || blocked.reason != blockreason.SSRFPrivateIP {
+		t.Fatalf("wrong-port error = %T %v, want private-IP refusal", err, err)
+	}
+
+	rebindCtx := withSSRFDialScanSnapshot(context.Background(), "guard.internal.example", portText, []string{"203.0.113.10"})
+	rebindCtx, rebindCancel := context.WithTimeout(rebindCtx, 2*time.Second)
+	defer rebindCancel()
+	_, err = p.ssrfSafeDialContext(rebindCtx, "tcp", net.JoinHostPort("guard.internal.example", portText))
+	if !errors.As(err, &blocked) || blocked.reason != blockreason.SSRFDNSRebind {
+		t.Fatalf("rebind error = %T %v, want DNS-rebind refusal", err, err)
+	}
+}
+
+func TestGuardSSRFDialSnapshotContainsExactPort(t *testing.T) {
+	ip := net.ParseIP("203.0.113.10")
+	var absentContext context.Context
+	if ssrfDialSnapshotContains(absentContext, "api.vendor.example", ip) {
+		t.Fatal("nil context matched a dial snapshot")
+	}
+	ctx := withSSRFDialScanSnapshot(context.Background(), "api.vendor.example", "443", []string{ip.String()})
+	if ssrfDialSnapshotContains(ctx, "other.vendor.example", ip) {
+		t.Fatal("different host matched a dial snapshot")
+	}
+	if ssrfDialSnapshotContains(ctx, "api.vendor.example", ip) {
+		t.Fatal("snapshot without a dial port matched")
+	}
+	ctx = withSSRFDialPort(ctx, "443")
+	if !ssrfDialSnapshotContains(ctx, "API.VENDOR.EXAMPLE.", ip) {
+		t.Fatal("exact host, port, and IP did not match")
+	}
+	if ssrfDialSnapshotContains(ctx, "api.vendor.example", net.IP{}) {
+		t.Fatal("malformed IP matched a dial snapshot")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3503,6 +3503,7 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 	// Bind the rebind snapshot to this dial's port: a scan-time snapshot only
 	// vouches for the exact host:port it was taken for.
 	ctx = withSSRFDialPort(ctx, port)
+	guardGranted := scannerDestinationGranted(currentSc, host, port)
 
 	// If the host is already an IP, check it and dial directly.
 	// IsTrustedDomain rejects IP literals, so raw IPs are always
@@ -3516,7 +3517,7 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		if err := blockIfNonOverridableSSRFTarget(ctx, host, ip); err != nil {
 			return nil, err
 		}
-		if currentSc.IsInternalIP(ip) && !currentSc.IsIPAllowlisted(ip) {
+		if currentSc.IsInternalIP(ip) && !currentSc.IsIPAllowlisted(ip) && !guardGranted {
 			return nil, newSSRFDialBlockError(ctx, host, ip, ssrfDialBlockDetail(host, ip))
 		}
 		return p.dialer.DialContext(ctx, network, addr)
@@ -3552,6 +3553,9 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 				// Trusted domain or IP-allowlisted address - allow.
 				// The scanner-level checkSSRF handles the authoritative
 				// allow/deny decision and logging.
+				continue
+			}
+			if guardGranted && ssrfDialSnapshotContains(ctx, host, ip) {
 				continue
 			}
 			return nil, newSSRFDialBlockError(ctx, host, ip, ssrfDialBlockDetail(host, ip))

--- a/internal/proxy/ssrf_dial_block.go
+++ b/internal/proxy/ssrf_dial_block.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -83,13 +85,19 @@ func withAllowedSSRFDialScanSnapshot(ctx context.Context, sc *scanner.Scanner, h
 	if sc == nil || !result.Allowed || len(result.SSRFResolvedIPs) == 0 {
 		return clearSnapshot()
 	}
+	guardGranted := scannerDestinationGranted(sc, host, port)
 	for _, ipStr := range result.SSRFResolvedIPs {
 		ip := normalizeSSRFDialIP(net.ParseIP(strings.TrimSpace(stripIPv6Zone(ipStr))))
-		if ip == nil || scanner.IsNonOverridableSSRFTarget(ip) || sc.IsInternalIP(ip) {
+		if ip == nil || scanner.IsNonOverridableSSRFTarget(ip) || (sc.IsInternalIP(ip) && !guardGranted) {
 			return clearSnapshot()
 		}
 	}
 	return withSSRFDialScanSnapshot(ctx, host, port, result.SSRFResolvedIPs)
+}
+
+func scannerDestinationGranted(sc *scanner.Scanner, host, port string) bool {
+	value, err := strconv.ParseUint(normalizeSSRFDialPort(port), 10, 16)
+	return err == nil && value != 0 && sc.IsDestinationGranted(destination.NetworkTCP, host, uint16(value))
 }
 
 // withSSRFDialPort records the exact destination port of an in-progress dial so
@@ -147,6 +155,25 @@ func isSSRFDNSRebind(ctx context.Context, host string, ip net.IP) bool {
 	}
 	_, seenAtScanTime := snapshot.ips[ip.String()]
 	return !seenAtScanTime
+}
+
+func ssrfDialSnapshotContains(ctx context.Context, host string, ip net.IP) bool {
+	if ctx == nil || ip == nil {
+		return false
+	}
+	snapshot, ok := ctx.Value(ctxKeySSRFDialScanSnapshot).(ssrfDialScanSnapshot)
+	if !ok || normalizeSSRFDialHost(host) != snapshot.host {
+		return false
+	}
+	if dialPort := ssrfDialPortFromContext(ctx); dialPort == "" || snapshot.port == "" || dialPort != snapshot.port {
+		return false
+	}
+	ip = normalizeSSRFDialIP(ip)
+	if ip == nil {
+		return false
+	}
+	_, ok = snapshot.ips[ip.String()]
+	return ok
 }
 
 func normalizeSSRFDialHost(host string) string {

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/luckyPipewrench/pipelock/internal/processexec"
 )
 
 // RunInit is the entry point for the MCP sandbox-init child process.
@@ -187,7 +189,7 @@ func RunInit() {
 	}
 
 	reportSubprocessCoverageError(flushSubprocessCoverage())
-	err = syscall.Exec(binary, command, env) //nolint:gosec // G204: intentional exec of user-specified command
+	err = processexec.Replace(binary, command, env)
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] exec failed: %v\n", err)
 	exitSandboxProcess(1)
 }

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -9,14 +9,19 @@ package sandbox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	guardruntime "github.com/luckyPipewrench/pipelock/internal/guard"
 )
 
 // RunStandaloneInit is the entry point for standalone sandbox-init mode.
@@ -26,16 +31,37 @@ import (
 func RunStandaloneInit() {
 	workspace := os.Getenv("__PIPELOCK_SANDBOX_WORKSPACE")
 	commandStr := os.Getenv("__PIPELOCK_SANDBOX_COMMAND")
+	commandJSON := os.Getenv(standaloneCommandJSONEnv)
 	socketPath := os.Getenv(sandboxSocketEnv)
 	extraEnvStr := os.Getenv("__PIPELOCK_SANDBOX_EXTRA_ENV")
 	developerEnvFDStr := os.Getenv(developerEnvironmentControlEnv)
+	guardDeclarationRaw := os.Getenv(standaloneGuardDeclarationEnv)
+	guardProfile := os.Getenv(standaloneGuardProfileEnv)
+	guardPolicyHash := os.Getenv(standaloneGuardPolicyHashEnv)
 
-	if workspace == "" || commandStr == "" || socketPath == "" {
+	var guardDeclaration *config.Guard
+	if guardDeclarationRaw != "" {
+		guardDeclaration = &config.Guard{}
+		if err := json.Unmarshal([]byte(guardDeclarationRaw), guardDeclaration); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard declaration: %v\n", err)
+			exitSandboxProcess(1)
+		}
+		if guardPolicyHash == "" {
+			_, _ = fmt.Fprintln(os.Stderr, "[sandbox] guard policy hash is missing")
+			exitSandboxProcess(1)
+		}
+	}
+
+	if workspace == "" || (commandJSON == "" && commandStr == "") || socketPath == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] missing workspace, command, or socket path\n")
 		exitSandboxProcess(1)
 	}
 
-	command := strings.Split(commandStr, "\x1f")
+	command, err := decodeStandaloneCommand(commandJSON, commandStr)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command transport: %v\n", err)
+		exitSandboxProcess(1)
+	}
 	var extraEnv []string
 	if extraEnvStr != "" {
 		extraEnv = strings.Split(extraEnvStr, "\x1f")
@@ -66,7 +92,6 @@ func RunStandaloneInit() {
 	sandboxDir := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid())
 	var env []string
 	var binary string
-	var err error
 	if useDeveloperEnvironment {
 		// SyntheticEnv normally creates this directory before policy resolution.
 		// The developer path preserves the caller environment instead, but the
@@ -75,7 +100,11 @@ func RunStandaloneInit() {
 			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] developer scratch dir: %v\n", err)
 			exitSandboxProcess(1)
 		}
-		binary, err = lookPathIn(command[0], developerEnvironment)
+		if guardDeclaration != nil {
+			binary, err = ResolveCommandInDir(command[0], developerEnvironment, workspace)
+		} else {
+			binary, err = lookPathIn(command[0], developerEnvironment)
+		}
 	} else {
 		// Build synthetic environment.
 		env, err = SyntheticEnv(sandboxDir, workspace, extraEnv)
@@ -83,7 +112,11 @@ func RunStandaloneInit() {
 			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] env setup: %v\n", err)
 			exitSandboxProcess(1)
 		}
-		binary, err = lookPathIn(command[0], env)
+		if guardDeclaration != nil {
+			binary, err = ResolveCommandInDir(command[0], env, workspace)
+		} else {
+			binary, err = lookPathIn(command[0], env)
+		}
 	}
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command not found: %s (%v)\n", command[0], err)
@@ -208,6 +241,11 @@ func RunStandaloneInit() {
 			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] env setup: %v\n", err)
 			exitSandboxProcess(1)
 		}
+		// The caller's environment may point PWD or TMPDIR outside the paths
+		// granted to the final Guard process. Force both to the contained paths
+		// so ordinary tools do not fail merely by honoring inherited metadata.
+		env = forceEnvValue(env, "PWD", workspace)
+		env = forceEnvValue(env, "TMPDIR", sandboxDir)
 	} else {
 		// Add HTTP_PROXY/HTTPS_PROXY to agent's environment.
 		env = appendBridgeProxyEnv(env, bridge.Addr())
@@ -217,24 +255,86 @@ func RunStandaloneInit() {
 	for _, key := range []string{
 		standaloneInitEnv, initEnvKey,
 		"__PIPELOCK_SANDBOX_WORKSPACE", "__PIPELOCK_SANDBOX_COMMAND",
+		standaloneCommandJSONEnv,
 		sandboxSocketEnv, "__PIPELOCK_SANDBOX_EXTRA_ENV",
 		"__PIPELOCK_SANDBOX_POLICY", noNetNSEnvKey,
 		developerEnvironmentControlEnv,
+		standaloneGuardDeclarationEnv, standaloneGuardProfileEnv, standaloneGuardPolicyHashEnv,
 	} {
 		env = removeEnvKey(env, key)
 	}
 
-	// Run the agent command as a subprocess.
+	// Run the agent command as a subprocess. Guard adds one final self re-exec:
+	// that helper applies the manifest to its calling thread and immediately
+	// replaces itself with the operator command, leaving this bridge process
+	// outside the workload filesystem restriction.
+	var guardEnvironmentReader, guardEnvironmentWriter *os.File
+	var guardEnvironmentPayload []byte
+	if guardDeclaration != nil {
+		selfExe, readErr := os.Readlink("/proc/self/exe")
+		if readErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard helper path: %v\n", readErr)
+			exitSandboxProcess(1)
+		}
+		guardEnvironmentPayload, readErr = json.Marshal(env)
+		if readErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard environment: %v\n", readErr)
+			exitSandboxProcess(1)
+		}
+		guardEnvironmentReader, guardEnvironmentWriter, readErr = os.Pipe()
+		if readErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard environment pipe: %v\n", readErr)
+			exitSandboxProcess(1)
+		}
+		controls, controlErr := guardruntime.ExecControlEnvironment(*guardDeclaration, guardProfile, guardPolicyHash, workspace, sandboxDir, binary, 3)
+		if controlErr != nil {
+			_ = guardEnvironmentReader.Close()
+			_ = guardEnvironmentWriter.Close()
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard controls: %v\n", controlErr)
+			exitSandboxProcess(1)
+		}
+		// The helper receives no developer-controlled loader or runtime hooks.
+		// It reads the preserved environment as inert JSON over fd 3, applies
+		// Guard, closes the pipe, and gives those values only to the final exec.
+		env = append([]string{
+			"PATH=/usr/bin:/bin",
+			"PWD=" + workspace,
+			"TMPDIR=" + sandboxDir,
+		}, controls...)
+		binary = selfExe
+		command = append([]string{selfExe}, command...)
+	}
 	agentCmd := exec.CommandContext(ctx, binary, command[1:]...) //nolint:gosec // G204: user-specified agent command
 	agentCmd.Stdin = os.Stdin
 	agentCmd.Stdout = os.Stdout
 	agentCmd.Stderr = os.Stderr
 	agentCmd.Env = env
 	agentCmd.Dir = workspace
+	if guardEnvironmentReader != nil {
+		agentCmd.ExtraFiles = []*os.File{guardEnvironmentReader}
+	}
 
 	if err := agentCmd.Start(); err != nil {
+		if guardEnvironmentReader != nil {
+			_ = guardEnvironmentReader.Close()
+			_ = guardEnvironmentWriter.Close()
+		}
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
 		exitSandboxProcess(1)
+	}
+	if guardEnvironmentReader != nil {
+		_ = guardEnvironmentReader.Close()
+		written, writeErr := guardEnvironmentWriter.Write(guardEnvironmentPayload)
+		if writeErr == nil && written != len(guardEnvironmentPayload) {
+			writeErr = io.ErrShortWrite
+		}
+		closeErr := guardEnvironmentWriter.Close()
+		if writeErr != nil || closeErr != nil {
+			_ = agentCmd.Process.Kill()
+			_ = agentCmd.Wait()
+			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard environment transport: %v\n", errors.Join(writeErr, closeErr))
+			exitSandboxProcess(1)
+		}
 	}
 	agentDone := make(chan error, 1)
 	go func() { agentDone <- agentCmd.Wait() }()
@@ -255,6 +355,28 @@ func RunStandaloneInit() {
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
 		exitSandboxProcess(1)
 	}
+}
+
+func decodeStandaloneCommand(encoded, legacy string) ([]string, error) {
+	if encoded == "" {
+		if legacy == "" {
+			return nil, errors.New("missing command")
+		}
+		return strings.Split(legacy, "\x1f"), nil
+	}
+	var command []string
+	if err := json.Unmarshal([]byte(encoded), &command); err != nil {
+		return nil, fmt.Errorf("decoding command JSON: %w", err)
+	}
+	if len(command) == 0 || command[0] == "" {
+		return nil, errors.New("decoded command is empty")
+	}
+	for _, arg := range command {
+		if strings.IndexByte(arg, 0) >= 0 {
+			return nil, errors.New("decoded command contains NUL")
+		}
+	}
+	return command, nil
 }
 
 // waitStandaloneAgentAndBridge waits for the agent and its required bridge.

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -59,10 +59,6 @@ func RunStandaloneInit() {
 			exitSandboxProcess(1)
 		}
 		guardStatus = os.NewFile(uintptr(fd), "guard-status")
-		if guardStatus == nil {
-			_, _ = fmt.Fprintln(os.Stderr, "[sandbox] guard status descriptor is unavailable")
-			exitSandboxProcess(1)
-		}
 	}
 
 	if workspace == "" || (commandJSON == "" && commandStr == "") || socketPath == "" {

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -38,8 +39,10 @@ func RunStandaloneInit() {
 	guardDeclarationRaw := os.Getenv(standaloneGuardDeclarationEnv)
 	guardProfile := os.Getenv(standaloneGuardProfileEnv)
 	guardPolicyHash := os.Getenv(standaloneGuardPolicyHashEnv)
+	guardStatusFDStr := os.Getenv(guardStatusControlEnv)
 
 	var guardDeclaration *config.Guard
+	var guardStatus *os.File
 	if guardDeclarationRaw != "" {
 		guardDeclaration = &config.Guard{}
 		if err := json.Unmarshal([]byte(guardDeclarationRaw), guardDeclaration); err != nil {
@@ -48,6 +51,16 @@ func RunStandaloneInit() {
 		}
 		if guardPolicyHash == "" {
 			_, _ = fmt.Fprintln(os.Stderr, "[sandbox] guard policy hash is missing")
+			exitSandboxProcess(1)
+		}
+		fd, fdErr := strconv.Atoi(guardStatusFDStr)
+		if fdErr != nil || fd < 3 {
+			_, _ = fmt.Fprintln(os.Stderr, "[sandbox] guard status descriptor is invalid")
+			exitSandboxProcess(1)
+		}
+		guardStatus = os.NewFile(uintptr(fd), "guard-status")
+		if guardStatus == nil {
+			_, _ = fmt.Fprintln(os.Stderr, "[sandbox] guard status descriptor is unavailable")
 			exitSandboxProcess(1)
 		}
 	}
@@ -260,6 +273,7 @@ func RunStandaloneInit() {
 		"__PIPELOCK_SANDBOX_POLICY", noNetNSEnvKey,
 		developerEnvironmentControlEnv,
 		standaloneGuardDeclarationEnv, standaloneGuardProfileEnv, standaloneGuardPolicyHashEnv,
+		guardStatusControlEnv,
 	} {
 		env = removeEnvKey(env, key)
 	}
@@ -286,7 +300,10 @@ func RunStandaloneInit() {
 			_, _ = fmt.Fprintf(os.Stderr, "[sandbox] guard environment pipe: %v\n", readErr)
 			exitSandboxProcess(1)
 		}
-		controls, controlErr := guardruntime.ExecControlEnvironment(*guardDeclaration, guardProfile, guardPolicyHash, workspace, sandboxDir, binary, 3)
+		controls, controlErr := guardruntime.ExecControlEnvironment(guardruntime.ExecControlOptions{
+			Declaration: *guardDeclaration, Profile: guardProfile, PolicyHash: guardPolicyHash,
+			Workspace: workspace, TempDir: sandboxDir, Binary: binary, EnvironmentFD: 3, StatusFD: 4,
+		})
 		if controlErr != nil {
 			_ = guardEnvironmentReader.Close()
 			_ = guardEnvironmentWriter.Close()
@@ -311,19 +328,21 @@ func RunStandaloneInit() {
 	agentCmd.Env = env
 	agentCmd.Dir = workspace
 	if guardEnvironmentReader != nil {
-		agentCmd.ExtraFiles = []*os.File{guardEnvironmentReader}
+		agentCmd.ExtraFiles = []*os.File{guardEnvironmentReader, guardStatus}
 	}
 
 	if err := agentCmd.Start(); err != nil {
 		if guardEnvironmentReader != nil {
 			_ = guardEnvironmentReader.Close()
 			_ = guardEnvironmentWriter.Close()
+			_ = guardStatus.Close()
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)
 		exitSandboxProcess(1)
 	}
 	if guardEnvironmentReader != nil {
 		_ = guardEnvironmentReader.Close()
+		_ = guardStatus.Close()
 		written, writeErr := guardEnvironmentWriter.Write(guardEnvironmentPayload)
 		if writeErr == nil && written != len(guardEnvironmentPayload) {
 			writeErr = io.ErrShortWrite

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -358,15 +358,16 @@ func RunStandaloneInit() {
 }
 
 func decodeStandaloneCommand(encoded, legacy string) ([]string, error) {
+	var command []string
 	if encoded == "" {
 		if legacy == "" {
 			return nil, errors.New("missing command")
 		}
-		return strings.Split(legacy, "\x1f"), nil
-	}
-	var command []string
-	if err := json.Unmarshal([]byte(encoded), &command); err != nil {
-		return nil, fmt.Errorf("decoding command JSON: %w", err)
+		command = strings.Split(legacy, "\x1f")
+	} else {
+		if err := json.Unmarshal([]byte(encoded), &command); err != nil {
+			return nil, fmt.Errorf("decoding command JSON: %w", err)
+		}
 	}
 	if len(command) == 0 || command[0] == "" {
 		return nil, errors.New("decoded command is empty")

--- a/internal/sandbox/developer_env_test.go
+++ b/internal/sandbox/developer_env_test.go
@@ -23,8 +23,8 @@ func TestDeveloperEnvPreservesDeveloperVariablesAndForcesBridgeProxy(t *testing.
 		"ENV=/developer/shenv",
 		"__PIPELOCK_SANDBOX_POLICY=must-not-reach-agent",
 		"__pipelock_private=must-not-reach-agent",
-		"Http_Proxy=http://attacker.invalid",
-		"ALL_proxy=socks5://attacker.invalid",
+		"Http_Proxy=http://api.vendor.example",
+		"ALL_proxy=socks5://api.vendor.example",
 		"No_PrOxY=*",
 	}, "127.0.0.1:43210")
 	if err != nil {

--- a/internal/sandbox/env.go
+++ b/internal/sandbox/env.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 )
 
+const syntheticPath = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+
+const guardStatusControlEnv = "__PIPELOCK_SANDBOX_GUARD_STATUS_FD"
+
 // safePassthroughKeys are the ONLY parent environment variables passed to the
 // sandboxed child. This is an allowlist, not a blocklist - any variable not
 // listed here is dropped. Matches the MCP proxy's safeEnv() approach to
@@ -101,7 +105,7 @@ func SyntheticEnv(sandboxDir, workspace string, extraEnv []string) ([]string, er
 		"XDG_DATA_HOME="+filepath.Join(homeDir, "data"),
 		"TMPDIR="+filepath.Join(sandboxDir, "tmp"),
 		"SHELL=/bin/sh",
-		"PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
+		"PATH="+syntheticPath,
 		"PWD="+workspace,
 	)
 

--- a/internal/sandbox/helpers.go
+++ b/internal/sandbox/helpers.go
@@ -83,6 +83,11 @@ func removeEnvKey(env []string, key string) []string {
 	return result
 }
 
+func forceEnvValue(env []string, key, value string) []string {
+	env = removeEnvKey(env, key)
+	return append(env, key+"="+value)
+}
+
 // lookPathIn resolves a command name to an absolute path using the PATH
 // from the given environment slice (not os.Getenv).
 func lookPathIn(name string, env []string) (string, error) {
@@ -115,6 +120,44 @@ func lookPathIn(name string, env []string) (string, error) {
 		}
 	}
 
+	return "", fmt.Errorf("%w: %s not found in PATH", exec.ErrNotFound, name)
+}
+
+// ResolveCommandInDir resolves a Guard command exactly as it will execute from
+// workingDir. Unlike lookPathIn, relative slash paths and relative PATH entries
+// are anchored to the final working directory and the result is absolute, so
+// the outer and final Landlock domains grant the same file.
+func ResolveCommandInDir(name string, env []string, workingDir string) (string, error) {
+	if name == "" || !filepath.IsAbs(workingDir) {
+		return "", fmt.Errorf("%w: invalid command or working directory", exec.ErrNotFound)
+	}
+	check := func(path string) (string, bool) {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(workingDir, path)
+		}
+		path = filepath.Clean(path)
+		info, err := os.Stat(path)
+		return path, err == nil && !info.IsDir()
+	}
+	if strings.Contains(name, "/") {
+		if path, ok := check(name); ok {
+			return path, nil
+		}
+		return "", fmt.Errorf("%w: %s", exec.ErrNotFound, name)
+	}
+
+	pathValue := "/usr/local/bin:/usr/bin:/bin"
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			pathValue = entry[5:]
+			break
+		}
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		if path, ok := check(filepath.Join(dir, name)); ok {
+			return path, nil
+		}
+	}
 	return "", fmt.Errorf("%w: %s not found in PATH", exec.ErrNotFound, name)
 }
 

--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -6,6 +6,10 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,6 +93,84 @@ func TestIntegration_SandboxCLI_Echo(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "containment") {
 		t.Errorf("expected containment summary in stderr:\n%s", stderr)
+	}
+}
+
+func TestIntegration_GuardCLI_EnforcesFinalCommand(t *testing.T) {
+	binary := buildTestBinary(t)
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o750); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside fixture: %v", err)
+	}
+	t.Setenv("OUTSIDE_PATH", outside)
+
+	stdout, stderr, err := runSandboxBinary(t, binary,
+		"guard", "--workspace", workspace, "--", "sh", "-c",
+		`printf guarded > result.txt && ! cat "$OUTSIDE_PATH" >/dev/null 2>&1 && cat result.txt`,
+	)
+	if err != nil {
+		t.Fatalf("guard command failed: %v\nstderr: %s", err, stderr)
+	}
+	if stdout != "guarded" {
+		t.Fatalf("Guard result = %q", stdout)
+	}
+	if !strings.Contains(stderr, "[guard] ENFORCED") {
+		t.Fatalf("Guard enforcement record missing:\n%s", stderr)
+	}
+}
+
+func TestIntegration_GuardCLI_DryRunProbesRequiredBoundary(t *testing.T) {
+	binary := buildTestBinary(t)
+	workspace := t.TempDir()
+
+	stdout, stderr, err := runSandboxBinary(t, binary,
+		"guard", "--dry-run", "--workspace", workspace, "--", "sh", "-c", "true",
+	)
+	if err != nil {
+		t.Fatalf("guard dry-run failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	for _, want := range []string{
+		"Guard Preflight: CAPABILITIES_OK",
+		"filesystem: available (required=true)",
+		"network: available (required=true)",
+		"syscall: available (required=false)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("guard dry-run output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestIntegration_GuardCLI_ProxiesExactGrantedService(t *testing.T) {
+	curl, err := exec.LookPath("curl")
+	if err != nil {
+		t.Skip("curl is required for the Guard proxy integration test")
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("through-guard"))
+	}))
+	defer server.Close()
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	configBody := fmt.Sprintf("guard:\n  services:\n    - name: fixture\n      protocol: tcp\n      host: 127.0.0.1\n      port: %d\n", port)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write Guard config: %v", err)
+	}
+
+	binary := buildTestBinary(t)
+	stdout, stderr, err := runSandboxBinary(t, binary,
+		"guard", "--config", configPath, "--workspace", t.TempDir(), "--", curl, "--silent", server.URL,
+	)
+	if err != nil {
+		t.Fatalf("guard proxied command failed: %v\nstderr: %s", err, stderr)
+	}
+	if stdout != "through-guard" {
+		t.Fatalf("proxied response = %q", stdout)
 	}
 }
 

--- a/internal/sandbox/landlock_test.go
+++ b/internal/sandbox/landlock_test.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	guardruntime "github.com/luckyPipewrench/pipelock/internal/guard"
 )
 
 // Landlock tests use subprocess execution because Landlock restrictions are
@@ -32,7 +34,11 @@ const landlockTestEnv = "__SANDBOX_LANDLOCK_TEST"
 const landlockChildTimeout = 60 * time.Second
 
 func TestMain(m *testing.M) {
-	// Sandbox re-exec entry point. Must be checked FIRST because the
+	if guardruntime.IsExecMode() {
+		guardruntime.RunExec()
+		return
+	}
+	// Sandbox re-exec entry point. Must be checked before ordinary tests because the
 	// re-exec'd child is the test binary itself. Without this, the child
 	// would run the full test suite recursively.
 	if IsInitMode() {

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // LaunchConfig configures how the sandbox launcher wraps the child process.
@@ -53,6 +55,9 @@ type StandaloneLaunchConfig struct {
 	UseDeveloperEnvironment bool
 	ProxyHandler            func(conn net.Conn)
 	RequireProxyHandler     bool
+	GuardDeclaration        *config.Guard
+	GuardProfile            string
+	GuardPolicyHash         string
 }
 
 // PrepareSandboxCmd builds an exec.Cmd that wraps the child command with

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -9,12 +9,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // LaunchConfig configures how the sandbox launcher wraps the child process.
@@ -39,26 +36,6 @@ type LaunchConfig struct {
 	Stdin            io.Reader
 	Stdout           io.Writer
 	Stderr           io.Writer
-}
-
-// StandaloneLaunchConfig configures the standalone sandbox launcher.
-type StandaloneLaunchConfig struct {
-	Ctx                     context.Context
-	Command                 []string
-	Workspace               string
-	Policy                  *Policy
-	Strict                  bool
-	BestEffort              bool
-	RequireNetNS            bool
-	ExtraEnv                []string
-	DeveloperEnvironment    []string
-	UseDeveloperEnvironment bool
-	ProxyHandler            func(conn net.Conn)
-	RequireProxyHandler     bool
-	GuardDeclaration        *config.Guard
-	GuardProfile            string
-	GuardPolicyHash         string
-	GuardEnforced           func(proof []byte) error
 }
 
 // PrepareSandboxCmd builds an exec.Cmd that wraps the child command with
@@ -143,7 +120,10 @@ func LaunchSandboxed(cfg LaunchConfig) (*exec.Cmd, error) {
 // LaunchStandalone returns ErrUnavailable on macOS.
 // Standalone mode (veth routing) requires Linux network namespaces.
 // MCP mode (stdio) works on macOS via PrepareSandboxCmd.
-func LaunchStandalone(_ StandaloneLaunchConfig) error {
+func LaunchStandalone(cfg StandaloneLaunchConfig) error {
+	if cfg.GuardDeclaration != nil {
+		return fmt.Errorf("%w: Guard execution requires Linux", ErrUnavailable)
+	}
 	return fmt.Errorf("%w: standalone sandbox mode requires Linux (use MCP mode on macOS)", ErrUnavailable)
 }
 

--- a/internal/sandbox/launcher_darwin.go
+++ b/internal/sandbox/launcher_darwin.go
@@ -58,6 +58,7 @@ type StandaloneLaunchConfig struct {
 	GuardDeclaration        *config.Guard
 	GuardProfile            string
 	GuardPolicyHash         string
+	GuardEnforced           func(proof []byte) error
 }
 
 // PrepareSandboxCmd builds an exec.Cmd that wraps the child command with

--- a/internal/sandbox/launcher_helpers_test.go
+++ b/internal/sandbox/launcher_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -174,6 +175,51 @@ func TestLookPathIn_FallbackPATH(t *testing.T) {
 	}
 	if path == "" {
 		t.Error("expected non-empty path for sh")
+	}
+}
+
+func TestResolveCommandInDirAnchorsRelativePathsToWorkspace(t *testing.T) {
+	if _, err := ResolveCommandInDir("", nil, "/relative"); err == nil {
+		t.Fatal("empty command and relative working directory were accepted")
+	}
+	workspace := t.TempDir()
+	tool := filepath.Join(workspace, "tool")
+	if err := os.WriteFile(tool, []byte("tool"), 0o600); err != nil {
+		t.Fatalf("write tool: %v", err)
+	}
+	workspaceRoot, err := os.OpenRoot(workspace)
+	if err != nil {
+		t.Fatalf("open workspace root: %v", err)
+	}
+	defer func() { _ = workspaceRoot.Close() }()
+	toolFile, err := workspaceRoot.Open("tool")
+	if err != nil {
+		t.Fatalf("open tool: %v", err)
+	}
+	if err := toolFile.Chmod(0o700); err != nil {
+		_ = toolFile.Close()
+		t.Fatalf("make tool executable: %v", err)
+	}
+	if err := toolFile.Close(); err != nil {
+		t.Fatalf("close tool: %v", err)
+	}
+	for _, testCase := range []struct {
+		name string
+		cmd  string
+		env  []string
+	}{
+		{name: "slash path", cmd: "./tool"},
+		{name: "relative PATH", cmd: "tool", env: []string{"PATH=."}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			resolved, err := ResolveCommandInDir(testCase.cmd, testCase.env, workspace)
+			if err != nil {
+				t.Fatalf("ResolveCommandInDir: %v", err)
+			}
+			if resolved != tool {
+				t.Fatalf("resolved = %q, want %q", resolved, tool)
+			}
+		})
 	}
 }
 

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -9,10 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"os/exec"
-
-	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // LaunchConfig configures how the sandbox launcher forks the child process.
@@ -32,26 +29,6 @@ type LaunchConfig struct {
 	Stderr           io.Writer
 }
 
-// StandaloneLaunchConfig configures the standalone sandbox launcher.
-type StandaloneLaunchConfig struct {
-	Ctx                     context.Context
-	Command                 []string
-	Workspace               string
-	Policy                  *Policy
-	Strict                  bool
-	BestEffort              bool
-	RequireNetNS            bool
-	ExtraEnv                []string
-	DeveloperEnvironment    []string
-	UseDeveloperEnvironment bool
-	ProxyHandler            func(conn net.Conn)
-	RequireProxyHandler     bool
-	GuardDeclaration        *config.Guard
-	GuardProfile            string
-	GuardPolicyHash         string
-	GuardEnforced           func(proof []byte) error
-}
-
 // PrepareSandboxCmd returns ErrUnavailable on non-Linux platforms.
 func PrepareSandboxCmd(_ LaunchConfig) (*exec.Cmd, error) {
 	return nil, fmt.Errorf("%w: requires linux", ErrUnavailable)
@@ -63,7 +40,10 @@ func LaunchSandboxed(_ LaunchConfig) (*exec.Cmd, error) {
 }
 
 // LaunchStandalone returns ErrUnavailable on non-Linux platforms.
-func LaunchStandalone(_ StandaloneLaunchConfig) error {
+func LaunchStandalone(cfg StandaloneLaunchConfig) error {
+	if cfg.GuardDeclaration != nil {
+		return fmt.Errorf("%w: Guard execution requires Linux", ErrUnavailable)
+	}
 	return fmt.Errorf("%w: requires linux", ErrUnavailable)
 }
 

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -49,6 +49,7 @@ type StandaloneLaunchConfig struct {
 	GuardDeclaration        *config.Guard
 	GuardProfile            string
 	GuardPolicyHash         string
+	GuardEnforced           func(proof []byte) error
 }
 
 // PrepareSandboxCmd returns ErrUnavailable on non-Linux platforms.

--- a/internal/sandbox/launcher_other.go
+++ b/internal/sandbox/launcher_other.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"net"
 	"os/exec"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // LaunchConfig configures how the sandbox launcher forks the child process.
@@ -44,6 +46,9 @@ type StandaloneLaunchConfig struct {
 	UseDeveloperEnvironment bool
 	ProxyHandler            func(conn net.Conn)
 	RequireProxyHandler     bool
+	GuardDeclaration        *config.Guard
+	GuardProfile            string
+	GuardPolicyHash         string
 }
 
 // PrepareSandboxCmd returns ErrUnavailable on non-Linux platforms.

--- a/internal/sandbox/preflight.go
+++ b/internal/sandbox/preflight.go
@@ -35,6 +35,7 @@ type PreflightRequirements struct {
 	RequireNetNS        bool `json:"network"`
 	RequireProxyHandler bool `json:"handler"`
 	RequireLandlock     bool `json:"landlock"`
+	MinimumLandlockABI  int  `json:"minimum_landlock_abi,omitempty"`
 	RequireSeccomp      bool `json:"seccomp"`
 }
 
@@ -119,10 +120,11 @@ func preflight(workspace string, argv []string, policy *Policy, requirements Pre
 	// NOTE: These are capability probes, not launch guarantees.
 	// User namespaces may probe as available while loopback setup or
 	// /dev/shm mount fails under AppArmor/container restrictions.
+	landlockAvailable := landlockMeetsRequirement(caps.LandlockABI, requirements.MinimumLandlockABI)
 	result.Layers = []LayerProbe{
 		{
 			Name:      LayerLandlock,
-			Available: caps.LandlockABI > 0,
+			Available: landlockAvailable,
 			Required:  requirements.RequireLandlock,
 			Detail:    fmt.Sprintf("ABI v%d", caps.LandlockABI),
 		},
@@ -141,6 +143,8 @@ func preflight(workspace string, argv []string, policy *Policy, requirements Pre
 
 	if caps.LandlockABI <= 0 {
 		result.Layers[0].Reason = "Landlock not available (kernel 5.13+ required)"
+	} else if requirements.MinimumLandlockABI > 0 && caps.LandlockABI < requirements.MinimumLandlockABI {
+		result.Layers[0].Reason = fmt.Sprintf("Landlock ABI v%d is below required ABI v%d", caps.LandlockABI, requirements.MinimumLandlockABI)
 	}
 	if !caps.UserNamespaces {
 		result.Layers[1].Reason = "user namespaces unavailable"
@@ -188,4 +192,11 @@ func preflight(workspace string, argv []string, policy *Policy, requirements Pre
 	}
 
 	return result
+}
+
+func landlockMeetsRequirement(observedABI, minimumABI int) bool {
+	if minimumABI > 0 {
+		return observedABI >= minimumABI
+	}
+	return observedABI > 0
 }

--- a/internal/sandbox/seccomp_linux.go
+++ b/internal/sandbox/seccomp_linux.go
@@ -275,7 +275,7 @@ func allowedSyscalls() []uint32 {
 		unix.SYS_PKEY_ALLOC, unix.SYS_PKEY_FREE, unix.SYS_PKEY_MPROTECT,
 
 		// File I/O
-		unix.SYS_READ, unix.SYS_WRITE, unix.SYS_OPENAT, unix.SYS_CLOSE,
+		unix.SYS_READ, unix.SYS_WRITE, unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_CLOSE,
 		unix.SYS_LSEEK, unix.SYS_PREAD64, unix.SYS_PWRITE64,
 		unix.SYS_READV, unix.SYS_WRITEV, unix.SYS_PREADV, unix.SYS_PWRITEV,
 		unix.SYS_PREADV2, unix.SYS_PWRITEV2,
@@ -370,6 +370,10 @@ func allowedSyscalls() []uint32 {
 		// Misc / system info
 		unix.SYS_GETRANDOM, unix.SYS_UNAME, unix.SYS_SYSINFO, unix.SYS_GETCPU,
 		unix.SYS_SECCOMP, // allow nested seccomp (additional restrictions only)
+		// Allow the final Guard helper to add a nested Landlock ruleset before
+		// exec. Landlock is monotonic: these calls can only add restrictions to
+		// the already-contained process and its descendants.
+		unix.SYS_LANDLOCK_CREATE_RULESET, unix.SYS_LANDLOCK_ADD_RULE, unix.SYS_LANDLOCK_RESTRICT_SELF,
 	}
 }
 

--- a/internal/sandbox/standalone.go
+++ b/internal/sandbox/standalone.go
@@ -12,6 +12,13 @@ import (
 // (with bridge proxy, unlike MCP mode which uses syscall.Exec).
 const standaloneInitEnv = "__PIPELOCK_SANDBOX_STANDALONE"
 
+const (
+	standaloneGuardDeclarationEnv = "__PIPELOCK_SANDBOX_GUARD_DECLARATION"
+	standaloneGuardProfileEnv     = "__PIPELOCK_SANDBOX_GUARD_PROFILE"
+	standaloneGuardPolicyHashEnv  = "__PIPELOCK_SANDBOX_GUARD_POLICY_HASH"
+	standaloneCommandJSONEnv      = "__PIPELOCK_SANDBOX_COMMAND_JSON"
+)
+
 // sandboxSocketEnv carries the parent Unix socket path used by sandbox
 // bridge mode. The child-side loopback proxy forwards connections there.
 const sandboxSocketEnv = "__PIPELOCK_SANDBOX_SOCKET"

--- a/internal/sandbox/standalone_config.go
+++ b/internal/sandbox/standalone_config.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package sandbox
+
+import (
+	"context"
+	"net"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// StandaloneLaunchConfig configures the standalone sandbox launcher.
+type StandaloneLaunchConfig struct {
+	// Ctx controls the child's lifetime.
+	Ctx context.Context
+	// Command is the command and arguments to execute inside the sandbox.
+	Command []string
+	// Workspace is the resolved absolute workspace path.
+	Workspace string
+	// Policy overrides the default sandbox policy.
+	Policy *Policy
+	// Strict enables strict containment.
+	Strict bool
+	// BestEffort permits supported degraded containment.
+	BestEffort bool
+	// RequireNetNS rejects launches without a network namespace.
+	RequireNetNS bool
+	// ExtraEnv contains additional KEY=VALUE pairs for the child.
+	ExtraEnv []string
+	// DeveloperEnvironment is transported over an anonymous pipe.
+	DeveloperEnvironment []string
+	// UseDeveloperEnvironment selects DeveloperEnvironment.
+	UseDeveloperEnvironment bool
+	// ProxyHandler handles each connection from the sandboxed command.
+	ProxyHandler func(net.Conn)
+	// RequireProxyHandler rejects a nil ProxyHandler before child start.
+	RequireProxyHandler bool
+	// GuardDeclaration enables the Linux-only final pre-exec Guard helper.
+	GuardDeclaration *config.Guard
+	// GuardProfile selects the declaration profile.
+	GuardProfile string
+	// GuardPolicyHash binds the canonical runtime configuration.
+	GuardPolicyHash string
+	// GuardAppliedPreExec receives proof that the helper applied the filesystem
+	// ruleset before attempting exec. Pipe completion cannot prove that the
+	// operator command started; returning an error terminates the launch.
+	GuardAppliedPreExec func(proof []byte) error
+}

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -7,9 +7,12 @@ package sandbox
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T) {
@@ -43,6 +46,28 @@ func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T
 	}
 }
 
+func TestStandaloneCommandJSONPreservesLegacyDelimiterInArgument(t *testing.T) {
+	want := []string{"tool", "left\x1fright", "line one\nline two"}
+	controlEnv := standaloneInitControlEnv(StandaloneLaunchConfig{
+		Command: want, Workspace: "/workspace",
+	}, "/tmp/pipelock-sandbox-test/proxy.sock", nil, `{"workspace":"/workspace"}`, true)
+	got, err := decodeStandaloneCommand(envValue(controlEnv, standaloneCommandJSONEnv), "")
+	if err != nil {
+		t.Fatalf("decodeStandaloneCommand: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("command = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if _, err := decodeStandaloneCommand("", ""); err == nil || !strings.Contains(err.Error(), "missing command") {
+		t.Fatalf("missing legacy command error = %v", err)
+	}
+}
+
 func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.T) {
 	skipIfStandaloneUnavailable(t)
 	workspace := t.TempDir()
@@ -63,6 +88,48 @@ func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.
 	})
 	if err != nil {
 		t.Fatalf("LaunchStandalone: %v", err)
+	}
+}
+
+func TestLaunchStandaloneGuardAppliesOnlyToFinalCommand(t *testing.T) {
+	skipIfStandaloneUnavailable(t)
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o750); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("must stay unreadable"), 0o600); err != nil {
+		t.Fatalf("write outside fixture: %v", err)
+	}
+
+	developerEnvironment := forceEnvValue(os.Environ(), "PWD", root)
+	developerEnvironment = forceEnvValue(developerEnvironment, "TMPDIR", "/tmp")
+	developerEnvironment = forceEnvValue(developerEnvironment, "EXPECTED_WORKSPACE", workspace)
+	developerEnvironment = forceEnvValue(developerEnvironment, "OUTSIDE_PATH", outside)
+	declaration := config.Guard{}
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:                 []string{"sh", "-c", `test -z "$__PIPELOCK_GUARD_EXEC$__PIPELOCK_GUARD_DECLARATION$__PIPELOCK_SANDBOX_POLICY" && test "$PWD" = "$EXPECTED_WORKSPACE" && test "$TMPDIR" != /tmp && : > "$TMPDIR/temp-ok" && printf guarded > result.txt && ! cat "$OUTSIDE_PATH" >/dev/null 2>&1`},
+		Workspace:               workspace,
+		DeveloperEnvironment:    developerEnvironment,
+		UseDeveloperEnvironment: true,
+		GuardDeclaration:        &declaration,
+		GuardPolicyHash:         "test-policy-hash",
+	})
+	if err != nil {
+		t.Fatalf("LaunchStandalone with Guard: %v", err)
+	}
+	workspaceRoot, err := os.OpenRoot(workspace)
+	if err != nil {
+		t.Fatalf("open workspace root: %v", err)
+	}
+	defer func() { _ = workspaceRoot.Close() }()
+	result, err := workspaceRoot.ReadFile("result.txt")
+	if err != nil {
+		t.Fatalf("read command result: %v", err)
+	}
+	if string(result) != "guarded" {
+		t.Fatalf("result = %q, want guarded", result)
 	}
 }
 

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T) {
-	const token = "recognizable-api-token-for-control-env-test"
+	token := "test-" + strings.ReplaceAll(t.Name(), "/", "-")
 	cfg := StandaloneLaunchConfig{
 		Command:                 []string{"sh", "-c", "true"},
 		Workspace:               "/workspace",
@@ -74,7 +74,7 @@ func TestStandaloneCommandJSONPreservesLegacyDelimiterInArgument(t *testing.T) {
 func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.T) {
 	skipIfStandaloneUnavailable(t)
 	workspace := t.TempDir()
-	const token = "recognizable-api-token-for-final-command-test"
+	token := "test-" + strings.ReplaceAll(t.Name(), "/", "-")
 
 	err := LaunchStandalone(StandaloneLaunchConfig{
 		Command:   []string{"sh", "-c", "test \"$API_TOKEN\" = \"$EXPECTED_TOKEN\" && test -n \"$HTTP_PROXY\" && test -n \"$HTTPS_PROXY\" && test -z \"$NO_PROXY\" && test -z \"$no_proxy\" && test -z \"$Http_Proxy\" && test -z \"$ALL_proxy\" && test ! -e /proc/self/fd/3 && { test ! -e /proc/$PPID/fd/3 || ! readlink /proc/$PPID/fd/3 | grep -q '^pipe:'; } && ! tr '\\000' '\\n' < \"/proc/$PPID/environ\" | grep -F -q -- \"$EXPECTED_TOKEN\""},
@@ -83,8 +83,8 @@ func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.
 			"PATH=" + os.Getenv("PATH"),
 			"API_TOKEN=" + token,
 			"EXPECTED_TOKEN=" + token,
-			"Http_Proxy=http://attacker.invalid",
-			"ALL_proxy=socks5://attacker.invalid",
+			"Http_Proxy=http://api.vendor.example",
+			"ALL_proxy=socks5://api.vendor.example",
 			"NO_proxy=*",
 		},
 		UseDeveloperEnvironment: true,

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -30,7 +30,7 @@ func TestStandaloneInitControlEnvDoesNotContainDeveloperEnvironment(t *testing.T
 	controlEnv := standaloneInitControlEnv(cfg, "/tmp/pipelock-sandbox-test/proxy.sock", []string{
 		"GOCOVERDIR=/tmp/pipelock-covdata-" + token,
 		"PIPELOCK_SUBPROCESS_COVERAGE=1",
-	}, `{"workspace":"/workspace"}`, true)
+	}, `{"workspace":"/workspace"}`, true, nil, 0)
 
 	for _, entry := range controlEnv {
 		if strings.Contains(entry, token) || strings.Contains(entry, "LD_PRELOAD") || strings.Contains(entry, "NODE_OPTIONS") {
@@ -50,7 +50,7 @@ func TestStandaloneCommandJSONPreservesLegacyDelimiterInArgument(t *testing.T) {
 	want := []string{"tool", "left\x1fright", "line one\nline two"}
 	controlEnv := standaloneInitControlEnv(StandaloneLaunchConfig{
 		Command: want, Workspace: "/workspace",
-	}, "/tmp/pipelock-sandbox-test/proxy.sock", nil, `{"workspace":"/workspace"}`, true)
+	}, "/tmp/pipelock-sandbox-test/proxy.sock", nil, `{"workspace":"/workspace"}`, true, nil, 0)
 	got, err := decodeStandaloneCommand(envValue(controlEnv, standaloneCommandJSONEnv), "")
 	if err != nil {
 		t.Fatalf("decodeStandaloneCommand: %v", err)

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -66,6 +66,9 @@ func TestStandaloneCommandJSONPreservesLegacyDelimiterInArgument(t *testing.T) {
 	if _, err := decodeStandaloneCommand("", ""); err == nil || !strings.Contains(err.Error(), "missing command") {
 		t.Fatalf("missing legacy command error = %v", err)
 	}
+	if _, err := decodeStandaloneCommand("", "\x1farg"); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("legacy empty command error = %v", err)
+	}
 }
 
 func TestLaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand(t *testing.T) {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -20,73 +20,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/luckyPipewrench/pipelock/internal/config"
 )
-
-// StandaloneLaunchConfig configures the standalone sandbox launcher.
-type StandaloneLaunchConfig struct {
-	// Ctx controls the child's lifetime.
-	Ctx context.Context
-
-	// Command is the command and arguments to execute inside the sandbox.
-	Command []string
-
-	// Workspace is the resolved absolute workspace path.
-	Workspace string
-
-	// Policy overrides the default sandbox policy.
-	Policy *Policy
-
-	// Strict enables strict containment: error on missing layers,
-	// private /dev/shm mount, clone3 blocked, subreaper enabled.
-	Strict bool
-
-	// BestEffort skips namespace isolation when unavailable (e.g. inside
-	// containers where CLONE_NEWUSER is blocked by seccomp). Landlock and
-	// seccomp are still applied. Network scanning uses proxy-based routing
-	// instead of kernel-enforced isolation. Mutually exclusive with Strict.
-	BestEffort bool
-
-	// RequireNetNS rejects launches that cannot create a user and network
-	// namespace. It is independent of Strict, which additionally requires the
-	// optional filesystem and syscall containment layers.
-	RequireNetNS bool
-
-	// ExtraEnv contains additional KEY=VALUE pairs to pass to the child.
-	ExtraEnv []string
-
-	// DeveloperEnvironment is the caller's complete developer environment for
-	// the final contained command. It is transported over an anonymous pipe,
-	// never through the re-exec control environment.
-	DeveloperEnvironment []string
-
-	// UseDeveloperEnvironment selects DeveloperEnvironment instead of the
-	// ordinary minimal SyntheticEnv. It is opt-in and fails closed on a nil
-	// environment or when combined with ExtraEnv.
-	UseDeveloperEnvironment bool
-
-	// ProxyHandler is called for each connection from the sandboxed agent.
-	// It receives the connection from the bridge proxy and should handle
-	// it as an HTTP forward proxy (CONNECT tunneling, DLP scanning, etc.).
-	// If nil, connections are closed without forwarding.
-	ProxyHandler func(conn net.Conn)
-
-	// RequireProxyHandler rejects a nil ProxyHandler before the child starts.
-	// This makes the debug-only direct-forward path unreachable for callers
-	// that require scanning.
-	RequireProxyHandler bool
-
-	// GuardDeclaration enables the final pre-exec Guard helper. The parent
-	// bridge remains outside this restriction so scanning and evidence outputs
-	// are not accidentally denied by the workload filesystem policy.
-	GuardDeclaration *config.Guard
-	GuardProfile     string
-	GuardPolicyHash  string
-	// GuardEnforced receives the child-side proof only after the status pipe
-	// closes on successful exec. Returning an error terminates the launch.
-	GuardEnforced func(proof []byte) error
-}
 
 // standaloneProxyConnectionConfig controls how one accepted bridge connection
 // is dispatched. Unscanned forwarding is an internal debug-only opt-in whose
@@ -145,6 +79,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if cfg.GuardDeclaration != nil && cfg.GuardPolicyHash == "" {
 		return errors.New("sandbox: guard policy hash is required")
 	}
+	var guardDeclarationJSON []byte
 	if cfg.GuardDeclaration != nil {
 		declaration, err := json.Marshal(cfg.GuardDeclaration)
 		if err != nil {
@@ -153,6 +88,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		if len(declaration) > 64<<10 {
 			return errors.New("sandbox: guard declaration exceeds the 64 KiB environment transport limit")
 		}
+		guardDeclarationJSON = declaration
 	}
 
 	if err := ValidateWorkspace(cfg.Workspace); err != nil {
@@ -251,8 +187,6 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if jsonErr != nil {
 		return fmt.Errorf("encoding sandbox policy: %w", jsonErr)
 	}
-	cmd.Env = standaloneInitControlEnv(cfg, socketPath, coverageEnv, policyJSON, hasNamespaces)
-
 	var guardStatusReader, guardStatusWriter *os.File
 	if cfg.GuardDeclaration != nil {
 		guardStatusReader, guardStatusWriter, err = os.Pipe()
@@ -277,6 +211,11 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if guardStatusWriter != nil {
 		cmd.ExtraFiles = append(cmd.ExtraFiles, guardStatusWriter)
 	}
+	guardStatusFD := 0
+	if guardStatusWriter != nil {
+		guardStatusFD = 2 + len(cmd.ExtraFiles)
+	}
+	cmd.Env = standaloneInitControlEnv(cfg, socketPath, coverageEnv, policyJSON, hasNamespaces, guardDeclarationJSON, guardStatusFD)
 
 	if hasNamespaces {
 		cloneFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNET)
@@ -339,8 +278,8 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 	if guardStatusReader != nil {
 		proof, proofErr := readGuardExecutionProof(guardStatusReader)
-		if proofErr == nil && cfg.GuardEnforced != nil {
-			proofErr = cfg.GuardEnforced(proof)
+		if proofErr == nil && cfg.GuardAppliedPreExec != nil {
+			proofErr = cfg.GuardAppliedPreExec(proof)
 		}
 		if proofErr != nil {
 			_ = cmd.Process.Kill()
@@ -384,6 +323,9 @@ func guardLookupEnvironment(useDeveloperEnvironment bool, developerEnvironment [
 }
 
 func readGuardExecutionProof(r io.Reader) ([]byte, error) {
+	// EOF proves only that the close-on-exec writer is gone. That can follow a
+	// successful exec or abrupt helper termination, so the returned record is
+	// strictly proof of ruleset application before the exec attempt.
 	decoder := json.NewDecoder(io.LimitReader(r, 1<<20))
 	var proof json.RawMessage
 	if err := decoder.Decode(&proof); err != nil {
@@ -417,7 +359,7 @@ func readGuardExecutionProof(r io.Reader) ([]byte, error) {
 // standaloneInitControlEnv is the complete re-exec environment. In
 // developer-environment mode it carries only a fixed descriptor number, never
 // a developer-supplied value.
-func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, coverageEnv []string, policyJSON string, hasNamespaces bool) []string {
+func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, coverageEnv []string, policyJSON string, hasNamespaces bool, guardDeclarationJSON []byte, guardStatusFD int) []string {
 	commandJSON, _ := json.Marshal(cfg.Command)
 	env := []string{
 		standaloneInitEnv + "=1",
@@ -440,13 +382,8 @@ func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, cov
 		env = append(env, noNetNSEnvKey+"=1")
 	}
 	if cfg.GuardDeclaration != nil {
-		declaration, _ := json.Marshal(cfg.GuardDeclaration)
-		guardStatusFD := 3
-		if cfg.UseDeveloperEnvironment {
-			guardStatusFD++
-		}
 		env = append(env,
-			standaloneGuardDeclarationEnv+"="+string(declaration),
+			standaloneGuardDeclarationEnv+"="+string(guardDeclarationJSON),
 			standaloneGuardProfileEnv+"="+cfg.GuardProfile,
 			standaloneGuardPolicyHashEnv+"="+cfg.GuardPolicyHash,
 			guardStatusControlEnv+"="+strconv.Itoa(guardStatusFD),

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -7,6 +7,7 @@ package sandbox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
@@ -73,6 +76,13 @@ type StandaloneLaunchConfig struct {
 	// This makes the debug-only direct-forward path unreachable for callers
 	// that require scanning.
 	RequireProxyHandler bool
+
+	// GuardDeclaration enables the final pre-exec Guard helper. The parent
+	// bridge remains outside this restriction so scanning and evidence outputs
+	// are not accidentally denied by the workload filesystem policy.
+	GuardDeclaration *config.Guard
+	GuardProfile     string
+	GuardPolicyHash  string
 }
 
 // standaloneProxyConnectionConfig controls how one accepted bridge connection
@@ -103,6 +113,9 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if runtime.GOOS != osLinux {
 		return fmt.Errorf("%w: sandbox requires Linux", ErrUnavailable)
 	}
+	if len(cfg.Command) == 0 || cfg.Command[0] == "" {
+		return errors.New("sandbox: command is required")
+	}
 	if cfg.RequireProxyHandler && cfg.ProxyHandler == nil {
 		return errors.New("sandbox: proxy handler is required")
 	}
@@ -126,6 +139,18 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if cfg.UseDeveloperEnvironment && len(cfg.ExtraEnv) > 0 {
 		return errors.New("sandbox: developer environment cannot be combined with extra environment")
 	}
+	if cfg.GuardDeclaration != nil && cfg.GuardPolicyHash == "" {
+		return errors.New("sandbox: guard policy hash is required")
+	}
+	if cfg.GuardDeclaration != nil {
+		declaration, err := json.Marshal(cfg.GuardDeclaration)
+		if err != nil {
+			return fmt.Errorf("sandbox: encoding guard declaration: %w", err)
+		}
+		if len(declaration) > 1<<20 {
+			return errors.New("sandbox: guard declaration exceeds 1 MiB")
+		}
+	}
 
 	if err := ValidateWorkspace(cfg.Workspace); err != nil {
 		return fmt.Errorf("workspace validation: %w", err)
@@ -136,8 +161,32 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if cfg.Policy != nil {
 		policy = *cfg.Policy
 	}
+	// The standalone child re-execs this exact binary after applying the outer
+	// Landlock policy. Installed binaries are normally covered by /usr or /bin,
+	// but development and CI binaries commonly live in a private /tmp tree.
+	// Grant only the resolved executable file, never its containing directory.
+	selfExe, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return fmt.Errorf("reading /proc/self/exe: %w", err)
+	}
+	policy.AllowReadFiles = append(policy.AllowReadFiles, selfExe)
+	if cfg.GuardDeclaration != nil {
+		lookupEnvironment := []string(nil)
+		if cfg.UseDeveloperEnvironment {
+			lookupEnvironment = cfg.DeveloperEnvironment
+		}
+		guardExecutable, lookupErr := ResolveCommandInDir(cfg.Command[0], lookupEnvironment, cfg.Workspace)
+		if lookupErr != nil {
+			return fmt.Errorf("resolving guard command %q: %w", cfg.Command[0], lookupErr)
+		}
+		// The outer domain must admit the same exact executable that the final
+		// Guard domain admits. Otherwise the final helper correctly detects an
+		// ancestor policy narrowing and refuses developer tools outside /usr or
+		// the workspace. Grant the file only, never its bin directory.
+		policy.AllowReadFiles = append(policy.AllowReadFiles, guardExecutable)
+	}
 	policy, coverageEnv := prepareSubprocessCoverage(policy, nil)
-	policy, err := ResolvePolicyPaths(policy)
+	policy, err = ResolvePolicyPaths(policy)
 	if err != nil {
 		return fmt.Errorf("resolve policy paths: %w", err)
 	}
@@ -193,11 +242,6 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	defer proxyServer.stop()
 
 	// Fork child in sandbox with standalone init mode.
-	selfExe, err := os.Readlink("/proc/self/exe")
-	if err != nil {
-		return fmt.Errorf("reading /proc/self/exe: %w", err)
-	}
-
 	cmd := exec.CommandContext(ctx, selfExe) //nolint:gosec // G204: re-exec of self
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -303,15 +347,14 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 // developer-environment mode it carries only a fixed descriptor number, never
 // a developer-supplied value.
 func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, coverageEnv []string, policyJSON string, hasNamespaces bool) []string {
+	commandJSON, _ := json.Marshal(cfg.Command)
 	env := []string{
 		standaloneInitEnv + "=1",
 		"__PIPELOCK_SANDBOX_WORKSPACE=" + cfg.Workspace,
-		"__PIPELOCK_SANDBOX_COMMAND=" + strings.Join(cfg.Command, "\x1f"),
+		standaloneCommandJSONEnv + "=" + string(commandJSON),
 		sandboxSocketEnv + "=" + socketPath,
 	}
-	if !cfg.UseDeveloperEnvironment {
-		env = append(env, coverageEnv...)
-	}
+	env = append(env, subprocessCoverageControlEnv(coverageEnv)...)
 	if cfg.Strict {
 		env = append(env, strictEnvKey+"=1")
 	}
@@ -324,6 +367,14 @@ func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, cov
 	env = append(env, "__PIPELOCK_SANDBOX_POLICY="+policyJSON)
 	if !hasNamespaces {
 		env = append(env, noNetNSEnvKey+"=1")
+	}
+	if cfg.GuardDeclaration != nil {
+		declaration, _ := json.Marshal(cfg.GuardDeclaration)
+		env = append(env,
+			standaloneGuardDeclarationEnv+"="+string(declaration),
+			standaloneGuardProfileEnv+"="+cfg.GuardProfile,
+			standaloneGuardPolicyHashEnv+"="+cfg.GuardPolicyHash,
+		)
 	}
 	return env
 }

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -147,8 +147,8 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		if err != nil {
 			return fmt.Errorf("sandbox: encoding guard declaration: %w", err)
 		}
-		if len(declaration) > 1<<20 {
-			return errors.New("sandbox: guard declaration exceeds 1 MiB")
+		if len(declaration) > 64<<10 {
+			return errors.New("sandbox: guard declaration exceeds the 64 KiB environment transport limit")
 		}
 	}
 

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -83,6 +83,9 @@ type StandaloneLaunchConfig struct {
 	GuardDeclaration *config.Guard
 	GuardProfile     string
 	GuardPolicyHash  string
+	// GuardEnforced receives the child-side proof only after the status pipe
+	// closes on successful exec. Returning an error terminates the launch.
+	GuardEnforced func(proof []byte) error
 }
 
 // standaloneProxyConnectionConfig controls how one accepted bridge connection
@@ -171,10 +174,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 	policy.AllowReadFiles = append(policy.AllowReadFiles, selfExe)
 	if cfg.GuardDeclaration != nil {
-		lookupEnvironment := []string(nil)
-		if cfg.UseDeveloperEnvironment {
-			lookupEnvironment = cfg.DeveloperEnvironment
-		}
+		lookupEnvironment := guardLookupEnvironment(cfg.UseDeveloperEnvironment, cfg.DeveloperEnvironment)
 		guardExecutable, lookupErr := ResolveCommandInDir(cfg.Command[0], lookupEnvironment, cfg.Workspace)
 		if lookupErr != nil {
 			return fmt.Errorf("resolving guard command %q: %w", cfg.Command[0], lookupErr)
@@ -253,6 +253,18 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	}
 	cmd.Env = standaloneInitControlEnv(cfg, socketPath, coverageEnv, policyJSON, hasNamespaces)
 
+	var guardStatusReader, guardStatusWriter *os.File
+	if cfg.GuardDeclaration != nil {
+		guardStatusReader, guardStatusWriter, err = os.Pipe()
+		if err != nil {
+			return fmt.Errorf("creating guard status pipe: %w", err)
+		}
+		defer func() {
+			_ = guardStatusReader.Close()
+			_ = guardStatusWriter.Close()
+		}()
+	}
+
 	var developerPipe *developerEnvironmentPipe
 	if cfg.UseDeveloperEnvironment {
 		developerPipe, err = newDeveloperEnvironmentPipe(cfg.DeveloperEnvironment)
@@ -261,6 +273,9 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 		}
 		defer developerPipe.close()
 		cmd.ExtraFiles = []*os.File{developerPipe.reader}
+	}
+	if guardStatusWriter != nil {
+		cmd.ExtraFiles = append(cmd.ExtraFiles, guardStatusWriter)
 	}
 
 	if hasNamespaces {
@@ -301,6 +316,13 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting sandbox child: %w", err)
 	}
+	if guardStatusWriter != nil {
+		if err := guardStatusWriter.Close(); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return fmt.Errorf("closing guard status write pipe: %w", err)
+		}
+	}
 	if developerPipe != nil {
 		// ExtraFiles duplicates reader into the re-exec child. Drop the parent's
 		// copy before writing so every failure path closes both local pipe ends.
@@ -313,6 +335,17 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
 			return fmt.Errorf("transporting developer environment: %w", err)
+		}
+	}
+	if guardStatusReader != nil {
+		proof, proofErr := readGuardExecutionProof(guardStatusReader)
+		if proofErr == nil && cfg.GuardEnforced != nil {
+			proofErr = cfg.GuardEnforced(proof)
+		}
+		if proofErr != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return fmt.Errorf("guard execution proof: %w", proofErr)
 		}
 	}
 
@@ -343,6 +376,44 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	return waitErr
 }
 
+func guardLookupEnvironment(useDeveloperEnvironment bool, developerEnvironment []string) []string {
+	if useDeveloperEnvironment {
+		return developerEnvironment
+	}
+	return []string{"PATH=" + syntheticPath}
+}
+
+func readGuardExecutionProof(r io.Reader) ([]byte, error) {
+	decoder := json.NewDecoder(io.LimitReader(r, 1<<20))
+	var proof json.RawMessage
+	if err := decoder.Decode(&proof); err != nil {
+		return nil, fmt.Errorf("reading enforced record: %w", err)
+	}
+	var status struct {
+		ExecError string `json:"exec_error"`
+	}
+	if err := json.Unmarshal(proof, &status); err != nil {
+		return nil, fmt.Errorf("decoding enforced record: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err == nil {
+		var failure struct {
+			ExecError string `json:"exec_error"`
+		}
+		_ = json.Unmarshal(trailing, &failure)
+		if failure.ExecError != "" {
+			return nil, fmt.Errorf("operator command exec failed: %s", failure.ExecError)
+		}
+		return nil, errors.New("guard status pipe contained multiple success records")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("reading guard status completion: %w", err)
+	}
+	if status.ExecError != "" {
+		return nil, fmt.Errorf("operator command exec failed: %s", status.ExecError)
+	}
+	return proof, nil
+}
+
 // standaloneInitControlEnv is the complete re-exec environment. In
 // developer-environment mode it carries only a fixed descriptor number, never
 // a developer-supplied value.
@@ -370,10 +441,15 @@ func standaloneInitControlEnv(cfg StandaloneLaunchConfig, socketPath string, cov
 	}
 	if cfg.GuardDeclaration != nil {
 		declaration, _ := json.Marshal(cfg.GuardDeclaration)
+		guardStatusFD := 3
+		if cfg.UseDeveloperEnvironment {
+			guardStatusFD++
+		}
 		env = append(env,
 			standaloneGuardDeclarationEnv+"="+string(declaration),
 			standaloneGuardProfileEnv+"="+cfg.GuardProfile,
 			standaloneGuardPolicyHashEnv+"="+cfg.GuardPolicyHash,
+			guardStatusControlEnv+"="+strconv.Itoa(guardStatusFD),
 		)
 	}
 	return env

--- a/internal/sandbox/standalone_nonlinux_test.go
+++ b/internal/sandbox/standalone_nonlinux_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestLaunchStandaloneRejectsGuardOnNonLinux(t *testing.T) {
+	err := LaunchStandalone(StandaloneLaunchConfig{GuardDeclaration: &config.Guard{}})
+	if err == nil || !strings.Contains(err.Error(), "Guard execution requires Linux") {
+		t.Fatalf("guarded non-Linux launch error = %v", err)
+	}
+}

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
@@ -130,6 +131,29 @@ func TestLaunchStandalone_RequireProxyHandlerRejectsBeforeChildStart(t *testing.
 	}
 	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("child started despite required proxy handler denial: stat error = %v", statErr)
+	}
+}
+
+func TestLaunchStandaloneRejectsInvalidGuardLaunchBeforeChildStart(t *testing.T) {
+	workspace := t.TempDir()
+	largeDeclaration := &config.Guard{Services: []config.GuardService{{
+		Name: strings.Repeat("x", (1<<20)+1), Protocol: "tcp", Host: "api.vendor.example", Port: 443,
+	}}}
+	for _, testCase := range []struct {
+		name string
+		cfg  StandaloneLaunchConfig
+		want string
+	}{
+		{name: "missing command", cfg: StandaloneLaunchConfig{Workspace: workspace}, want: "command is required"},
+		{name: "missing guard hash", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"true"}, GuardDeclaration: &config.Guard{}}, want: "policy hash is required"},
+		{name: "oversized guard declaration", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"true"}, GuardDeclaration: largeDeclaration, GuardPolicyHash: "hash"}, want: "exceeds 1 MiB"},
+		{name: "missing guard command", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"missing-guard-command"}, GuardDeclaration: &config.Guard{}, GuardPolicyHash: "hash"}, want: "resolving guard command"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := LaunchStandalone(testCase.cfg); err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want %q", err, testCase.want)
+			}
+		})
 	}
 }
 
@@ -278,6 +302,26 @@ func TestPreflight_BackwardCompatibleStrictWrapper(t *testing.T) {
 	}
 	if result.Mode != "best-effort" {
 		t.Fatalf("legacy Preflight mode = %q, want best-effort", result.Mode)
+	}
+}
+
+func TestLandlockMeetsRequirementRejectsOlderABI(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		observedABI int
+		minimumABI  int
+		want        bool
+	}{
+		{name: "absent legacy probe", observedABI: 0, want: false},
+		{name: "present legacy probe", observedABI: 1, want: true},
+		{name: "below explicit floor", observedABI: 4, minimumABI: 5, want: false},
+		{name: "at explicit floor", observedABI: 5, minimumABI: 5, want: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := landlockMeetsRequirement(testCase.observedABI, testCase.minimumABI); got != testCase.want {
+				t.Fatalf("landlockMeetsRequirement(%d, %d) = %v, want %v", testCase.observedABI, testCase.minimumABI, got, testCase.want)
+			}
+		})
 	}
 }
 

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -146,7 +146,7 @@ func TestLaunchStandaloneRejectsInvalidGuardLaunchBeforeChildStart(t *testing.T)
 	}{
 		{name: "missing command", cfg: StandaloneLaunchConfig{Workspace: workspace}, want: "command is required"},
 		{name: "missing guard hash", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"true"}, GuardDeclaration: &config.Guard{}}, want: "policy hash is required"},
-		{name: "oversized guard declaration", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"true"}, GuardDeclaration: largeDeclaration, GuardPolicyHash: "hash"}, want: "exceeds 1 MiB"},
+		{name: "oversized guard declaration", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"true"}, GuardDeclaration: largeDeclaration, GuardPolicyHash: "hash"}, want: "64 KiB"},
 		{name: "missing guard command", cfg: StandaloneLaunchConfig{Workspace: workspace, Command: []string{"missing-guard-command"}, GuardDeclaration: &config.Guard{}, GuardPolicyHash: "hash"}, want: "resolving guard command"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -193,12 +193,16 @@ func TestGuardLookupEnvironmentResolvesSystemSbinCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve sbin command %q: %v", candidate, err)
 	}
-	want, err := filepath.EvalSymlinks(candidate)
+	resolvedInfo, err := os.Stat(resolved)
 	if err != nil {
-		t.Fatalf("resolve candidate %q: %v", candidate, err)
+		t.Fatalf("stat resolved command %q: %v", resolved, err)
 	}
-	if resolved != want {
-		t.Fatalf("resolved sbin command = %q, want %q", resolved, want)
+	candidateInfo, err := os.Stat(candidate)
+	if err != nil {
+		t.Fatalf("stat candidate %q: %v", candidate, err)
+	}
+	if !os.SameFile(resolvedInfo, candidateInfo) {
+		t.Fatalf("resolved sbin command = %q, want the same file as %q", resolved, candidate)
 	}
 }
 

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -157,6 +157,81 @@ func TestLaunchStandaloneRejectsInvalidGuardLaunchBeforeChildStart(t *testing.T)
 	}
 }
 
+func TestGuardLookupEnvironmentUsesCompleteSyntheticPath(t *testing.T) {
+	got := guardLookupEnvironment(false, []string{"PATH=/developer/bin"})
+	if len(got) != 1 || got[0] != "PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin" {
+		t.Fatalf("synthetic guard lookup environment = %v", got)
+	}
+	developer := []string{"PATH=/developer/bin", "TOKEN=value"}
+	if got := guardLookupEnvironment(true, developer); len(got) != len(developer) || got[0] != developer[0] || got[1] != developer[1] {
+		t.Fatalf("developer guard lookup environment = %v", got)
+	}
+}
+
+func TestGuardLookupEnvironmentResolvesSystemSbinCommand(t *testing.T) {
+	var candidate string
+	for _, path := range []string{"/usr/local/sbin", "/usr/sbin", "/sbin"} {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			info, infoErr := entry.Info()
+			if infoErr == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+				candidate = filepath.Join(path, entry.Name())
+				break
+			}
+		}
+		if candidate != "" {
+			break
+		}
+	}
+	if candidate == "" {
+		t.Skip("no executable found in a system sbin directory")
+	}
+	resolved, err := ResolveCommandInDir(filepath.Base(candidate), guardLookupEnvironment(false, nil), t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve sbin command %q: %v", candidate, err)
+	}
+	want, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		t.Fatalf("resolve candidate %q: %v", candidate, err)
+	}
+	if resolved != want {
+		t.Fatalf("resolved sbin command = %q, want %q", resolved, want)
+	}
+}
+
+func TestReadGuardExecutionProofRejectsExecFailureAndTrailingSuccess(t *testing.T) {
+	success := `{"record":{"state":"enforced"},"effective_policy_hash":"hash"}`
+	if got, err := readGuardExecutionProof(strings.NewReader(success)); err != nil || string(got) != success {
+		t.Fatalf("success proof = %q, %v", got, err)
+	}
+	failure := success + "\n" + `{"exec_error":"permission denied"}`
+	if _, err := readGuardExecutionProof(strings.NewReader(failure)); err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("exec failure proof error = %v", err)
+	}
+	if _, err := readGuardExecutionProof(strings.NewReader(success + "\n" + success)); err == nil || !strings.Contains(err.Error(), "multiple") {
+		t.Fatalf("duplicate success proof error = %v", err)
+	}
+	for _, testCase := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty", raw: "", want: "reading enforced record"},
+		{name: "wrong JSON type", raw: "1", want: "decoding enforced record"},
+		{name: "truncated trailing record", raw: success + "\n{", want: "status completion"},
+		{name: "first record is failure", raw: `{"exec_error":"refused"}`, want: "refused"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := readGuardExecutionProof(strings.NewReader(testCase.raw)); err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want %q", err, testCase.want)
+			}
+		})
+	}
+}
+
 func TestLaunchStandalone_RequireNetNSRejectsBestEffort(t *testing.T) {
 	err := LaunchStandalone(StandaloneLaunchConfig{
 		Command:      []string{"true"},

--- a/internal/sandbox/subprocess_coverage.go
+++ b/internal/sandbox/subprocess_coverage.go
@@ -11,6 +11,8 @@ func prepareSubprocessCoverage(policy Policy, env []string) (Policy, []string) {
 	return policy, env
 }
 
+func subprocessCoverageControlEnv([]string) []string { return nil }
+
 func flushSubprocessCoverage() error {
 	return nil
 }

--- a/internal/sandbox/subprocess_coverage_enabled.go
+++ b/internal/sandbox/subprocess_coverage_enabled.go
@@ -27,6 +27,8 @@ func prepareSubprocessCoverage(policy Policy, env []string) (Policy, []string) {
 	return policy, env
 }
 
+func subprocessCoverageControlEnv(env []string) []string { return env }
+
 func flushSubprocessCoverage() error {
 	dir, err := validatedSubprocessCoverageDir()
 	if err != nil {

--- a/internal/sandbox/subprocess_coverage_enabled_test.go
+++ b/internal/sandbox/subprocess_coverage_enabled_test.go
@@ -33,6 +33,12 @@ func TestPrepareSubprocessCoverageEnabled(t *testing.T) {
 	if !slices.Contains(env, "GOCOVERDIR="+cleanDir) {
 		t.Fatalf("environment = %v, want GOCOVERDIR", env)
 	}
+	controlEnv := standaloneInitControlEnv(StandaloneLaunchConfig{
+		Command: []string{"true"}, Workspace: "/workspace", UseDeveloperEnvironment: true,
+	}, "/tmp/pipelock-sandbox-test/proxy.sock", env, `{"workspace":"/workspace"}`, true)
+	if !slices.Contains(controlEnv, "GOCOVERDIR="+cleanDir) || !slices.Contains(controlEnv, subprocessCoverageMarker+"=1") {
+		t.Fatalf("developer-mode control environment omitted validated coverage state: %v", controlEnv)
+	}
 }
 
 func TestPrepareSubprocessCoverageRejectsUnsafeDirectories(t *testing.T) {

--- a/internal/sandbox/subprocess_coverage_enabled_test.go
+++ b/internal/sandbox/subprocess_coverage_enabled_test.go
@@ -35,7 +35,7 @@ func TestPrepareSubprocessCoverageEnabled(t *testing.T) {
 	}
 	controlEnv := standaloneInitControlEnv(StandaloneLaunchConfig{
 		Command: []string{"true"}, Workspace: "/workspace", UseDeveloperEnvironment: true,
-	}, "/tmp/pipelock-sandbox-test/proxy.sock", env, `{"workspace":"/workspace"}`, true)
+	}, "/tmp/pipelock-sandbox-test/proxy.sock", env, `{"workspace":"/workspace"}`, true, nil, 0)
 	if !slices.Contains(controlEnv, "GOCOVERDIR="+cleanDir) || !slices.Contains(controlEnv, subprocessCoverageMarker+"=1") {
 		t.Fatalf("developer-mode control environment omitted validated coverage state: %v", controlEnv)
 	}

--- a/internal/sandbox/subprocess_failure_integration_test.go
+++ b/internal/sandbox/subprocess_failure_integration_test.go
@@ -89,6 +89,78 @@ func TestIntegration_InitChildrenRejectMalformedLaunchState(t *testing.T) {
 			wantErr:  "FATAL: invalid policy JSON",
 		},
 		{
+			name: "standalone init rejects corrupted guard declaration",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				"__PIPELOCK_SANDBOX_COMMAND=true",
+				sandboxSocketEnv + "=" + socketPath,
+				standaloneGuardDeclarationEnv + "={",
+				standaloneGuardPolicyHashEnv + "=hash",
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "guard declaration",
+		},
+		{
+			name: "standalone init rejects missing guard policy hash",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				"__PIPELOCK_SANDBOX_COMMAND=true",
+				sandboxSocketEnv + "=" + socketPath,
+				standaloneGuardDeclarationEnv + "={}",
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "guard policy hash is missing",
+		},
+		{
+			name: "standalone init rejects malformed command transport",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				standaloneCommandJSONEnv + "={",
+				sandboxSocketEnv + "=" + socketPath,
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "command transport",
+		},
+		{
+			name: "standalone init rejects empty decoded command",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				standaloneCommandJSONEnv + "=[]",
+				sandboxSocketEnv + "=" + socketPath,
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "decoded command is empty",
+		},
+		{
+			name: "standalone init rejects decoded command NUL",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				standaloneCommandJSONEnv + `=["bad\u0000arg"]`,
+				sandboxSocketEnv + "=" + socketPath,
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "decoded command contains NUL",
+		},
+		{
+			name: "guard helper rejects invalid environment descriptor",
+			env: []string{
+				"__PIPELOCK_GUARD_EXEC=1",
+				"__PIPELOCK_GUARD_ENVIRONMENT_FD=bad",
+			},
+			wantCode: 1,
+			wantErr:  "[guard] REFUSED: invalid guard environment descriptor",
+		},
+		{
 			name: "mcp init rejects missing command",
 			env: []string{
 				initEnvKey + "=1",

--- a/internal/sandbox/subprocess_failure_integration_test.go
+++ b/internal/sandbox/subprocess_failure_integration_test.go
@@ -116,6 +116,36 @@ func TestIntegration_InitChildrenRejectMalformedLaunchState(t *testing.T) {
 			wantErr:  "guard policy hash is missing",
 		},
 		{
+			name: "standalone init rejects nonnumeric guard status descriptor",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				"__PIPELOCK_SANDBOX_COMMAND=true",
+				sandboxSocketEnv + "=" + socketPath,
+				standaloneGuardDeclarationEnv + "={}",
+				standaloneGuardPolicyHashEnv + "=hash",
+				guardStatusControlEnv + "=not-a-number",
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "[sandbox] guard status descriptor is invalid",
+		},
+		{
+			name: "standalone init rejects reserved guard status descriptor",
+			env: []string{
+				standaloneInitEnv + "=1",
+				"__PIPELOCK_SANDBOX_WORKSPACE=" + workspace,
+				"__PIPELOCK_SANDBOX_COMMAND=true",
+				sandboxSocketEnv + "=" + socketPath,
+				standaloneGuardDeclarationEnv + "={}",
+				standaloneGuardPolicyHashEnv + "=hash",
+				guardStatusControlEnv + "=2",
+				noNetNSEnvKey + "=1",
+			},
+			wantCode: 1,
+			wantErr:  "[sandbox] guard status descriptor is invalid",
+		},
+		{
 			name: "standalone init rejects malformed command transport",
 			env: []string{
 				standaloneInitEnv + "=1",

--- a/internal/scanner/core.go
+++ b/internal/scanner/core.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
 )
 
@@ -649,7 +650,8 @@ func (s *Scanner) mergedSSRFCIDRs() []*net.IPNet {
 //
 // Respects ssrf.ip_allowlist so operators can explicitly permit specific
 // internal IPs (e.g., sidecar communication, test servers).
-func (s *Scanner) checkCoreSSRFLiteral(hostname string) Result {
+func (s *Scanner) checkCoreSSRFLiteral(dest destination.Destination) Result {
+	hostname := dest.Host
 	if s.core == nil {
 		return Result{Allowed: true}
 	}
@@ -672,7 +674,7 @@ func (s *Scanner) checkCoreSSRFLiteral(hostname string) Result {
 	}
 
 	// Operator override: ip_allowlist exempts specific ranges.
-	if s.IsIPAllowlisted(ip) {
+	if s.IsIPAllowlisted(ip) || s.destinationGrants.Contains(dest) {
 		return Result{Allowed: true}
 	}
 

--- a/internal/scanner/core_test.go
+++ b/internal/scanner/core_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
 	"gopkg.in/yaml.v3"
 )
 
@@ -374,7 +375,7 @@ func TestCore_SSRFLiteral_ConfigMismatch_CanonicalIPNeverAllows(t *testing.T) {
 
 			// Classification is metadata on the denial: recognizing an equivalent
 			// api_allowlist spelling must never turn the core SSRF block into allow.
-			result := s.checkCoreSSRFLiteral(tt.hostname)
+			result := s.checkCoreSSRFLiteral(destination.Destination{Network: destination.NetworkTCP, Host: tt.hostname, Port: 80})
 			if result.Allowed {
 				t.Fatalf("api_allowlist classification allowed blocked literal %q", tt.hostname)
 			}

--- a/internal/scanner/guard_grants_test.go
+++ b/internal/scanner/guard_grants_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
+)
+
+func TestGuardDestinationGrantIsExactAndActivatesDNSFloor(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.Mode = config.ModeStrict
+	cfg.APIAllowlist = []string{"public.vendor.example"}
+	cfg.DNS.HostOverrides = map[string][]string{
+		"db.internal.example": {"127.0.0.1"},
+	}
+	grant, err := destination.NewGrant(destination.NetworkTCP, "db.internal.example", 5432)
+	if err != nil {
+		t.Fatalf("NewGrant: %v", err)
+	}
+	grants, err := destination.NewGrantSet(grant)
+	if err != nil {
+		t.Fatalf("NewGrantSet: %v", err)
+	}
+	s, err := NewWithOptions(cfg, Options{DestinationGrants: grants})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	defer s.Close()
+
+	allowed := s.Scan(context.Background(), "https://db.internal.example:5432/health")
+	if !allowed.Allowed {
+		t.Fatalf("exact guard grant blocked: %+v", allowed)
+	}
+	if len(allowed.SSRFResolvedIPs) != 1 || allowed.SSRFResolvedIPs[0] != "127.0.0.1" {
+		t.Fatalf("guard-granted DNS snapshot = %#v, want internal answer retained", allowed.SSRFResolvedIPs)
+	}
+
+	wrongPort := s.Scan(context.Background(), "https://db.internal.example:443/health")
+	if wrongPort.Allowed {
+		t.Fatal("host grant authorized the wrong port")
+	}
+	if wrongPort.Scanner != ScannerAllowlist {
+		t.Fatalf("wrong-port scanner = %q, want strict allowlist refusal", wrongPort.Scanner)
+	}
+}
+
+func TestGuardDestinationHelpersFailClosed(t *testing.T) {
+	cfg := config.Defaults()
+	s := MustNew(cfg)
+	defer s.Close()
+	if s.IsDestinationGranted(destination.NetworkTCP, "bad host", 443) {
+		t.Fatal("malformed destination was granted")
+	}
+	for _, testCase := range []struct {
+		name string
+		url  *url.URL
+		ok   bool
+		port uint16
+	}{
+		{name: "nil"},
+		{name: "http default", url: &url.URL{Scheme: "http"}, ok: true, port: 80},
+		{name: "https default", url: &url.URL{Scheme: "https"}, ok: true, port: 443},
+		{name: "unsupported scheme", url: &url.URL{Scheme: "ftp"}},
+		{name: "invalid port", url: &url.URL{Scheme: "https", Host: "vendor.example:0"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, ok := urlDestination(testCase.url, "vendor.example")
+			if ok != testCase.ok || ok && got.Port != testCase.port {
+				t.Fatalf("destination = %+v, ok=%t", got, ok)
+			}
+		})
+	}
+	result := s.Scan(context.Background(), "https://vendor.example:0/")
+	if result.Allowed || result.Scanner != ScannerParser {
+		t.Fatalf("zero-port scan result = %+v", result)
+	}
+}
+
+func TestGuardLiteralGrantDoesNotBroadenSiblingPort(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	grant, err := destination.NewGrant(destination.NetworkTCP, "127.0.0.1", 8080)
+	if err != nil {
+		t.Fatalf("NewGrant: %v", err)
+	}
+	grants, err := destination.NewGrantSet(grant)
+	if err != nil {
+		t.Fatalf("NewGrantSet: %v", err)
+	}
+	s, err := NewWithOptions(cfg, Options{DestinationGrants: grants})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	defer s.Close()
+
+	exactDest, err := destination.New(destination.NetworkTCP, "127.0.0.1", 8080)
+	if err != nil {
+		t.Fatalf("exact destination: %v", err)
+	}
+	if result := s.checkCoreSSRFLiteral(exactDest); !result.Allowed {
+		t.Fatalf("core literal floor blocked exact grant: %+v", result)
+	}
+	siblingDest, err := destination.New(destination.NetworkTCP, "127.0.0.1", 8081)
+	if err != nil {
+		t.Fatalf("sibling destination: %v", err)
+	}
+	if result := s.checkCoreSSRFLiteral(siblingDest); result.Allowed {
+		t.Fatal("core literal floor authorized a sibling port")
+	}
+
+	if result := s.Scan(context.Background(), "http://127.0.0.1:8080/"); !result.Allowed {
+		t.Fatalf("exact literal grant blocked: %+v", result)
+	}
+	if result := s.Scan(context.Background(), "http://127.0.0.1:8081/"); result.Allowed {
+		t.Fatal("literal grant authorized a sibling port")
+	}
+}
+
+func TestGuardHostnameGrantCannotOverrideMetadataResolution(t *testing.T) {
+	t.Parallel()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DNS.HostOverrides = map[string][]string{
+		"metadata.internal.example": {"169.254.169.254"},
+	}
+	grant, err := destination.NewGrant(destination.NetworkTCP, "metadata.internal.example", 80)
+	if err != nil {
+		t.Fatalf("NewGrant: %v", err)
+	}
+	grants, err := destination.NewGrantSet(grant)
+	if err != nil {
+		t.Fatalf("NewGrantSet: %v", err)
+	}
+	s, err := NewWithOptions(cfg, Options{DestinationGrants: grants})
+	if err != nil {
+		t.Fatalf("NewWithOptions: %v", err)
+	}
+	defer s.Close()
+	result := s.Scan(context.Background(), "http://metadata.internal.example/")
+	if result.Allowed || result.Scanner != ScannerSSRFMetadata {
+		t.Fatalf("metadata-resolving grant result = %+v, want metadata refusal", result)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -215,7 +216,8 @@ type Scanner struct {
 	internalCIDRs              []*net.IPNet
 	ipAllowlistCIDRs           []*net.IPNet // SSRF-exempt IP ranges (ssrf.ip_allowlist)
 	trustedDomains             []string     // SSRF-exempt domains (wildcard via MatchDomain)
-	rawAPIAllowlist            []string     // full api_allowlist for SSRF hint generation (all modes)
+	destinationGrants          destination.GrantSet
+	rawAPIAllowlist            []string // full api_allowlist for SSRF hint generation (all modes)
 	rateLimiter                *RateLimiter
 	dataBudget                 *DataBudget
 	envSecrets                 []string // filtered high-entropy env var values
@@ -357,7 +359,18 @@ func (p *compiledPattern) matches(text string) bool {
 // config.Validate(), but scanner construction is also a runtime activation
 // boundary: invalid config-derived compile inputs and unavailable runtime
 // files are returned as errors so callers can fail closed without panicking.
+type Options struct {
+	DestinationGrants destination.GrantSet
+}
+
 func New(cfg *config.Config) (*Scanner, error) {
+	return NewWithOptions(cfg, Options{})
+}
+
+// NewWithOptions creates a scanner with runtime-only policy overlays. These
+// overlays never mutate Config, so a Guard invocation cannot widen another
+// runtime built from the same configuration.
+func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 	// Only enforce the allowlist in strict mode. In balanced/audit modes,
 	// the allowlist is a config field but not enforced at the scanner level.
 	var allowlist []string
@@ -377,6 +390,7 @@ func New(cfg *config.Config) (*Scanner, error) {
 		queryExclusions:           cfg.FetchProxy.Monitoring.QueryEntropyExclusions,
 		queryParamExclusions:      buildQueryEntropyParamExclusions(cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions),
 		pathEntropyExempt:         buildPathEntropyExempt(cfg),
+		destinationGrants:         opts.DestinationGrants,
 	}
 
 	// Initialize rate limiter if enabled
@@ -589,6 +603,36 @@ func New(cfg *config.Config) (*Scanner, error) {
 	}
 
 	return s, nil
+}
+
+// IsDestinationGranted reports whether Guard authorized this exact
+// network/host/port tuple. Malformed destinations fail closed as no match.
+func (s *Scanner) IsDestinationGranted(network destination.Network, host string, port uint16) bool {
+	dest, err := destination.New(network, host, port)
+	return err == nil && s.destinationGrants.Contains(dest)
+}
+
+func urlDestination(parsed *url.URL, hostname string) (destination.Destination, bool) {
+	if parsed == nil {
+		return destination.Destination{}, false
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch strings.ToLower(parsed.Scheme) {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return destination.Destination{}, false
+		}
+	}
+	value, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || value == 0 {
+		return destination.Destination{}, false
+	}
+	dest, err := destination.New(destination.NetworkTCP, hostname, uint16(value))
+	return dest, err == nil
 }
 
 // MustNew creates a Scanner and panics if construction fails.
@@ -906,6 +950,10 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 			Score:   1.0,
 		}
 	}
+	dest, destinationOK := urlDestination(parsed, hostname)
+	if !destinationOK {
+		return Result{Allowed: false, Reason: "invalid destination port", Scanner: ScannerParser, Score: 1.0}
+	}
 
 	// CRLF injection check - %0D%0A in URLs enables header injection.
 	// Runs early because CRLF is never legitimate in a URL.
@@ -920,7 +968,7 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 
 	// Allowlist check - if configured, only allowlisted domains are permitted.
 	// Runs before DNS to reject disallowed domains without any network I/O.
-	if result := s.checkAllowlist(hostname); !result.Allowed {
+	if result := s.checkAllowlist(dest); !result.Allowed {
 		return result
 	}
 
@@ -933,7 +981,7 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	// even when cfg.Internal is nil (SSRF disabled). Blocks direct requests
 	// to private IPs (127.0.0.1, 169.254.169.254, 10.x, etc.). Respects
 	// ssrf.ip_allowlist for operator overrides.
-	if result := s.checkCoreSSRFLiteral(hostname); !result.Allowed {
+	if result := s.checkCoreSSRFLiteral(dest); !result.Allowed {
 		return result
 	}
 
@@ -1000,7 +1048,7 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	// When active, core CIDRs are always included via mergedSSRFCIDRs()
 	// so private ranges (10.x, 172.16.x, 192.168.x, loopback, link-local)
 	// cannot be removed from the check set via config alone.
-	ssrfResult := s.checkSSRF(ctx, hostname)
+	ssrfResult := s.checkSSRF(ctx, dest)
 	if !ssrfResult.Allowed {
 		return ssrfResult
 	}
@@ -1063,7 +1111,8 @@ func isCloudMetadataIP(ip net.IP) bool {
 // When no internal CIDRs are configured (nil slice), SSRF protection is disabled.
 // To block loopback, link-local, etc., include those CIDRs in config.Internal.
 // When SSRF IS active, core CIDRs are always included in the check set.
-func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
+func (s *Scanner) checkSSRF(ctx context.Context, dest destination.Destination) Result {
+	hostname := dest.Host
 	// Check context before the SSRF-disabled fast path so cancelled requests
 	// don't slip through when internalCIDRs is empty.
 	if ctx.Err() != nil {
@@ -1074,7 +1123,7 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 			Score:   1.0,
 		}
 	}
-	if len(s.internalCIDRs) == 0 {
+	if len(s.internalCIDRs) == 0 && s.destinationGrants.Len() == 0 {
 		return Result{Allowed: true}
 	}
 
@@ -1102,7 +1151,7 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 			}
 		}
 		for _, cidr := range allCIDRs {
-			if cidr.Contains(literalIP) && !s.IsIPAllowlisted(literalIP) {
+			if cidr.Contains(literalIP) && !s.IsIPAllowlisted(literalIP) && !s.destinationGrants.Contains(dest) {
 				result := Result{
 					Allowed: false,
 					Reason:  fmt.Sprintf("SSRF blocked: %s is an internal IP", hostname),
@@ -1197,6 +1246,9 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 	if s.IsTrustedDomain(hostname) {
 		return Result{Allowed: true}
 	}
+	if s.destinationGrants.Contains(dest) {
+		return Result{Allowed: true, SSRFResolvedIPs: append([]string(nil), ips...)}
+	}
 
 	// Internal CIDRs (core + config). Cloud-metadata addresses never reach here:
 	// they are non-overridable and already returned above, so this pass only
@@ -1227,7 +1279,11 @@ func (s *Scanner) checkSSRF(ctx context.Context, hostname string) Result {
 // checkAllowlist rejects requests to domains not in the allowlist.
 // When the allowlist is empty, all domains are permitted (allowlist is opt-in).
 // Uses MatchDomain for consistent wildcard matching with the blocklist.
-func (s *Scanner) checkAllowlist(hostname string) Result {
+func (s *Scanner) checkAllowlist(dest destination.Destination) Result {
+	hostname := dest.Host
+	if s.destinationGrants.Contains(dest) {
+		return Result{Allowed: true}
+	}
 	if len(s.allowlist) == 0 {
 		return Result{Allowed: true}
 	}

--- a/scripts/coverage-with-subprocess.sh
+++ b/scripts/coverage-with-subprocess.sh
@@ -40,18 +40,30 @@ go test -count=1 -covermode=set -coverprofile="$UNIT_PROFILE" \
 # create/add/restrict/close sequence at the base ABI without changing the test
 # process, so hosted runners cover the path even when their kernel is below the
 # in-process thread-sync floor.
-go test -count=1 -covermode=set -coverprofile="$GUARD_UNIT_PROFILE" \
-    ./internal/guard -run '^TestApplyForExec_CompleteSequenceUsesBaseABIAndNoThreadSync$'
+run_targeted_coverage() {
+    local profile="$1" package="$2" pattern="$3"
+    local output
+    output=$(go test -count=1 -covermode=set -coverprofile="$profile" "$package" -run "$pattern" 2>&1) || {
+        echo "$output"
+        return 1
+    }
+    echo "$output"
+    if grep -q 'no tests to run' <<<"$output"; then
+        echo "Targeted coverage pattern '$pattern' matched no test in $package."
+        return 1
+    fi
+}
+
+run_targeted_coverage "$GUARD_UNIT_PROFILE" ./internal/guard \
+    '^TestApplyForExec_CompleteSequenceUsesBaseABIAndNoThreadSync$'
 
 # The scoped PR gate defers the high-fan-in scanner and proxy race suites to CI.
 # Collect the narrow Guard tests here so their changed lines are measured
 # alongside the child paths that consume the same exact destination grants.
-go test -count=1 -covermode=set -coverprofile="$CONFIG_UNIT_PROFILE" \
-    ./internal/config -run '^TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent$'
-go test -count=1 -covermode=set -coverprofile="$SCANNER_UNIT_PROFILE" \
-    ./internal/scanner -run '^TestGuard'
-go test -count=1 -covermode=set -coverprofile="$PROXY_UNIT_PROFILE" \
-    ./internal/proxy -run '^TestGuard'
+run_targeted_coverage "$CONFIG_UNIT_PROFILE" ./internal/config \
+    '^TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent$'
+run_targeted_coverage "$SCANNER_UNIT_PROFILE" ./internal/scanner '^TestGuard'
+run_targeted_coverage "$PROXY_UNIT_PROFILE" ./internal/proxy '^TestGuard'
 
 PIPELOCK_SUBPROCESS_COVERAGE=1 GOCOVERDIR="$COVERDIR" \
     go test -count=1 -timeout=5m ./internal/sandbox \

--- a/scripts/coverage-with-subprocess.sh
+++ b/scripts/coverage-with-subprocess.sh
@@ -14,10 +14,15 @@ OUTPUT="${1:-coverage-subprocess.out}"
 COVERDIR=$(mktemp -d /tmp/pipelock-covdata-XXXXXX)
 RAW_PROFILE=$(mktemp /tmp/pipelock-subprocess-raw-XXXXXX.out)
 UNIT_PROFILE=$(mktemp /tmp/pipelock-subprocess-unit-XXXXXX.out)
+GUARD_UNIT_PROFILE=$(mktemp /tmp/pipelock-guard-unit-XXXXXX.out)
+CONFIG_UNIT_PROFILE=$(mktemp /tmp/pipelock-guard-config-unit-XXXXXX.out)
+SCANNER_UNIT_PROFILE=$(mktemp /tmp/pipelock-guard-scanner-unit-XXXXXX.out)
+PROXY_UNIT_PROFILE=$(mktemp /tmp/pipelock-guard-proxy-unit-XXXXXX.out)
 
 GUARD_LOG=""
 cleanup() {
-    rm -rf "$COVERDIR" "$RAW_PROFILE" "$UNIT_PROFILE"
+    rm -rf "$COVERDIR" "$RAW_PROFILE" "$UNIT_PROFILE" "$GUARD_UNIT_PROFILE" \
+        "$CONFIG_UNIT_PROFILE" "$SCANNER_UNIT_PROFILE" "$PROXY_UNIT_PROFILE"
     [ -n "$GUARD_LOG" ] && rm -f "$GUARD_LOG"
     return 0
 }
@@ -31,8 +36,26 @@ go test -count=1 -covermode=set -coverprofile="$UNIT_PROFILE" \
     -tags subprocess_coverage ./internal/sandbox \
     -run '^Test(Prepare|Validated)SubprocessCoverage'
 
+# The pre-exec ruleset operations are injectable. This runs the complete
+# create/add/restrict/close sequence at the base ABI without changing the test
+# process, so hosted runners cover the path even when their kernel is below the
+# in-process thread-sync floor.
+go test -count=1 -covermode=set -coverprofile="$GUARD_UNIT_PROFILE" \
+    ./internal/guard -run '^TestApplyForExec_CompleteSequenceUsesBaseABIAndNoThreadSync$'
+
+# The scoped PR gate defers the high-fan-in scanner and proxy race suites to CI.
+# Collect the narrow Guard tests here so their changed lines are measured
+# alongside the child paths that consume the same exact destination grants.
+go test -count=1 -covermode=set -coverprofile="$CONFIG_UNIT_PROFILE" \
+    ./internal/config -run '^TestCanonicalPolicyHash_GuardIncludedAndOrderIndependent$'
+go test -count=1 -covermode=set -coverprofile="$SCANNER_UNIT_PROFILE" \
+    ./internal/scanner -run '^TestGuard'
+go test -count=1 -covermode=set -coverprofile="$PROXY_UNIT_PROFILE" \
+    ./internal/proxy -run '^TestGuard'
+
 PIPELOCK_SUBPROCESS_COVERAGE=1 GOCOVERDIR="$COVERDIR" \
-    go test -count=1 -timeout=5m ./internal/sandbox -run '^TestIntegration_'
+    go test -count=1 -timeout=5m ./internal/sandbox \
+    -run '^Test(Integration_|LaunchStandaloneDeveloperEnvironmentReachesOnlyFinalCommand$|LaunchStandaloneGuardAppliesOnlyToFinalCommand$)'
 
 # Guard's enforcement can only be observed from a process that has actually been
 # restricted, and Landlock is irreversible, so those assertions run in a
@@ -100,7 +123,8 @@ awk '
             print key, count[key]
         }
     }
-' "$RAW_PROFILE" "$UNIT_PROFILE" > "$OUTPUT"
+' "$RAW_PROFILE" "$UNIT_PROFILE" "$GUARD_UNIT_PROFILE" "$CONFIG_UNIT_PROFILE" \
+    "$SCANNER_UNIT_PROFILE" "$PROXY_UNIT_PROFILE" > "$OUTPUT"
 
 covered_statements() {
     local source_file="$1"
@@ -123,20 +147,10 @@ fi
 # honest: if child collection silently stops working, the merged profile still
 # parses and the script still exits zero, so only naming the file that MUST
 # appear turns a broken collection into a failure instead of a quiet drop.
-# Guard's enforcement tests need a kernel above the in-process Landlock floor
-# and skip below it. A host that skipped them has collected nothing to assert
-# on, and failing there would red the job for a kernel version rather than for a
-# defect. The distinction is made from the test log, not from the coverage
-# number, because "skipped" and "ran but collected nothing" both produce zero
-# and only the second is a broken mechanism.
 guard_apply_covered=$(covered_statements "internal/guard/apply_linux.go")
-if grep -q -- '--- SKIP: TestEnforcement_' "$GUARD_LOG"; then
-    echo "Guard enforcement tests SKIPPED on this host (landlock ABI below the in-process floor)."
-    echo "Guard subprocess coverage was not collected; skipping the guard assertion."
-    echo "apply_linux.go covered statements: $guard_apply_covered"
-elif [ "$guard_apply_covered" -eq 0 ]; then
+if [ "$guard_apply_covered" -eq 0 ]; then
     echo "Merged profile is missing guard enforcement execution."
-    echo "The enforcement tests ran but produced no counters, so collection is broken."
+    echo "The injectable pre-exec sequence ran but produced no counters, so collection is broken."
     echo "apply_linux.go covered statements: $guard_apply_covered"
     exit 1
 fi


### PR DESCRIPTION
## Summary

Adds enforced command execution to `pipelock guard` on Linux. Guard preserves the developer environment while requiring a network namespace, routes HTTP and HTTPS through the scanner, and applies the selected filesystem policy in a single-threaded child immediately before the command starts.

Execution and receipts bind to the canonical policy hash. Exact host and port service grants are enforced at scan and dial time, unsupported runtime objects such as sockets are refused, and audit plus evidence work stays in the unrestricted parent process.

The command reports its preview boundary directly. Non-proxy TCP, UDP, QUIC, and child DNS are denied. Same-UID host brokers remain outside the boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux Guard command execution with filesystem and HTTP/HTTPS egress enforcement.
  - Added profile and workspace selection, dry-run preflight checks, JSON output, receipt handling, and exit-code preservation.
  - Added guarded standalone command execution with safer command and path handling.
  - Improved SSRF protection with exact host-and-port destination grants.

- **Documentation**
  - Expanded Guard CLI documentation with requirements, restrictions, examples, dry-run behavior, and exit details.

- **Bug Fixes**
  - Policy hashes now include Guard declarations and normalize equivalent configurations consistently.
  - Guarded execution now fails closed when required containment capabilities are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->