### PR TITLE
test(guard): add hostile-input conformance gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,6 +294,9 @@ jobs:
       - name: Collect sandbox subprocess coverage
         run: bash scripts/coverage-with-subprocess.sh coverage-subprocess.out
 
+      - name: Run Guard hostile-input conformance gate
+        run: bash scripts/check-guard-conformance.sh
+
       - name: Upload subprocess coverage
         # Best-effort telemetry; see the Upload coverage step above. A Codecov
         # uploader-integrity hiccup must not red this job when coverage collection

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,9 @@ jobs:
   test-subprocess-coverage:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Includes subprocess coverage plus four race-enabled Guard conformance
+    # invocations, each with its own five-minute timeout.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     # Includes subprocess coverage plus four race-enabled Guard conformance
     # invocations, each with its own five-minute timeout.
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -201,7 +201,10 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 			if err := json.Unmarshal(encoded, &proof); err != nil {
 				return fmt.Errorf("decoding child enforcement proof: %w", err)
 			}
-			if err := proof.Verify(configPolicyHash); err != nil {
+			if err := proof.VerifyInvocation(guardfs.ExecControlOptions{
+				Profile: opts.Profile, PolicyHash: configPolicyHash,
+				Workspace: workspace, Binary: executable,
+			}, opts.Command); err != nil {
 				return err
 			}
 			if err := evidence.activate(proof); err != nil {

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -196,14 +196,14 @@ func launchGuard(opts GuardLaunchOptions, launchStandalone func(sandbox.Standalo
 		GuardDeclaration:        &declaration,
 		GuardProfile:            opts.Profile,
 		GuardPolicyHash:         configPolicyHash,
-		GuardAppliedPreExec: func(encoded []byte) error {
+		GuardAppliedPreExec: func(tempDir string, encoded []byte) error {
 			var proof guardfs.ExecutionProof
 			if err := json.Unmarshal(encoded, &proof); err != nil {
 				return fmt.Errorf("decoding child enforcement proof: %w", err)
 			}
 			if err := proof.VerifyInvocation(guardfs.ExecControlOptions{
 				Profile: opts.Profile, PolicyHash: configPolicyHash,
-				Workspace: workspace, Binary: executable,
+				Workspace: workspace, TempDir: tempDir, Binary: executable,
 			}, opts.Command); err != nil {
 				return err
 			}

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -108,6 +108,37 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	if err := got.GuardAppliedPreExec(encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
 		t.Fatalf("mismatched proof error = %v", err)
 	}
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*guardfs.ExecutionProof)
+	}{
+		{name: "profile", mutate: func(proof *guardfs.ExecutionProof) { proof.Profile = "other" }},
+		{name: "workspace", mutate: func(proof *guardfs.ExecutionProof) { proof.Workspace = "/other" }},
+		{name: "binary", mutate: func(proof *guardfs.ExecutionProof) { proof.Binary = "/usr/bin/false" }},
+		{name: "argv", mutate: func(proof *guardfs.ExecutionProof) { proof.Command = []string{"/usr/bin/false"} }},
+	} {
+		t.Run("self-consistent wrong "+testCase.name, func(t *testing.T) {
+			wrong := guardfs.NewExecutionProof(
+				guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
+				guardfs.ExecControlOptions{PolicyHash: got.GuardPolicyHash, Workspace: got.Workspace, TempDir: got.Workspace, Binary: "/usr/bin/true"},
+				[]string{"/usr/bin/true"},
+			)
+			testCase.mutate(&wrong)
+			// Rebuild after mutation so the digest is valid for the wrong
+			// invocation. The parent comparison, not hash mismatch, must deny it.
+			wrong = guardfs.NewExecutionProof(wrong.Record, guardfs.ExecControlOptions{
+				Profile: wrong.Profile, PolicyHash: wrong.ConfigPolicyHash,
+				Workspace: wrong.Workspace, TempDir: wrong.TempDir, Binary: wrong.Binary,
+			}, wrong.Command)
+			encodedWrong, marshalErr := json.Marshal(wrong)
+			if marshalErr != nil {
+				t.Fatalf("marshal wrong proof: %v", marshalErr)
+			}
+			if err := got.GuardAppliedPreExec(encodedWrong); err == nil || !strings.Contains(err.Error(), "requested invocation") {
+				t.Fatalf("wrong invocation proof error = %v", err)
+			}
+		})
+	}
 	server, client := net.Pipe()
 	defer func() { _ = client.Close() }()
 	done := make(chan struct{})

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -67,10 +67,10 @@ func TestLaunchGuardBuildsEnforcedStandaloneLaunch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal proof: %v", err)
 	}
-	if err := got.GuardAppliedPreExec(encoded); err != nil {
+	if err := got.GuardAppliedPreExec(workspace, encoded); err != nil {
 		t.Fatalf("GuardAppliedPreExec: %v", err)
 	}
-	if err := got.GuardAppliedPreExec(encoded); err != nil {
+	if err := got.GuardAppliedPreExec(workspace, encoded); err != nil {
 		t.Fatalf("repeated GuardAppliedPreExec: %v", err)
 	}
 	server, client := net.Pipe()
@@ -93,7 +93,7 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("launchGuard: %v", err)
 	}
-	if err := got.GuardAppliedPreExec([]byte("not-json")); err == nil || !strings.Contains(err.Error(), "decoding") {
+	if err := got.GuardAppliedPreExec(got.Workspace, []byte("not-json")); err == nil || !strings.Contains(err.Error(), "decoding") {
 		t.Fatalf("malformed proof error = %v", err)
 	}
 	proof := guardfs.NewExecutionProof(
@@ -105,7 +105,7 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal mismatched proof: %v", err)
 	}
-	if err := got.GuardAppliedPreExec(encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
+	if err := got.GuardAppliedPreExec(got.Workspace, encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
 		t.Fatalf("mismatched proof error = %v", err)
 	}
 	for _, testCase := range []struct {
@@ -114,6 +114,7 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	}{
 		{name: "profile", mutate: func(proof *guardfs.ExecutionProof) { proof.Profile = "other" }},
 		{name: "workspace", mutate: func(proof *guardfs.ExecutionProof) { proof.Workspace = "/other" }},
+		{name: "temporary directory", mutate: func(proof *guardfs.ExecutionProof) { proof.TempDir = "/other" }},
 		{name: "binary", mutate: func(proof *guardfs.ExecutionProof) { proof.Binary = "/usr/bin/false" }},
 		{name: "argv", mutate: func(proof *guardfs.ExecutionProof) { proof.Command = []string{"/usr/bin/false"} }},
 	} {
@@ -134,7 +135,7 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 			if marshalErr != nil {
 				t.Fatalf("marshal wrong proof: %v", marshalErr)
 			}
-			if err := got.GuardAppliedPreExec(encodedWrong); err == nil || !strings.Contains(err.Error(), "requested invocation") {
+			if err := got.GuardAppliedPreExec(got.Workspace, encodedWrong); err == nil || !strings.Contains(err.Error(), "requested invocation") {
 				t.Fatalf("wrong invocation proof error = %v", err)
 			}
 		})

--- a/internal/cli/runtime/guard_test.go
+++ b/internal/cli/runtime/guard_test.go
@@ -108,6 +108,19 @@ func TestLaunchGuardRejectsMalformedChildProof(t *testing.T) {
 	if err := got.GuardAppliedPreExec(got.Workspace, encoded); err == nil || !strings.Contains(err.Error(), "does not describe") {
 		t.Fatalf("mismatched proof error = %v", err)
 	}
+	tampered := guardfs.NewExecutionProof(
+		guardfs.EnforcementRecord{State: guardfs.EnforcementEnforced, Mechanism: "landlock", Coverage: guardfs.CoverageFull},
+		guardfs.ExecControlOptions{PolicyHash: got.GuardPolicyHash, Workspace: got.Workspace, TempDir: got.Workspace, Binary: "/usr/bin/true"},
+		[]string{"/usr/bin/true"},
+	)
+	tampered.Record.Coverage = guardfs.CoveragePartial
+	encodedTampered, err := json.Marshal(tampered)
+	if err != nil {
+		t.Fatalf("marshal tampered proof: %v", err)
+	}
+	if err := got.GuardAppliedPreExec(got.Workspace, encodedTampered); err == nil {
+		t.Fatal("parent evidence boundary accepted a tampered enforcement record")
+	}
 	for _, testCase := range []struct {
 		name   string
 		mutate func(*guardfs.ExecutionProof)

--- a/internal/guard/execution_proof.go
+++ b/internal/guard/execution_proof.go
@@ -54,12 +54,13 @@ func (p ExecutionProof) Verify(expectedConfigHash string) error {
 // VerifyInvocation checks the proof and binds it to the invocation requested
 // by the parent. Recomputing a digest over child-supplied fields proves that
 // those fields agree with each other; it does not prove they match the
-// parent's profile, workspace, executable, and argv unless they are compared.
+// parent's profile, workspace, temporary directory, executable, and argv unless
+// they are compared.
 func (p ExecutionProof) VerifyInvocation(expected ExecControlOptions, command []string) error {
 	if err := p.Verify(expected.PolicyHash); err != nil {
 		return err
 	}
-	if p.Profile != expected.Profile || p.Workspace != expected.Workspace ||
+	if p.Profile != expected.Profile || p.Workspace != expected.Workspace || p.TempDir != expected.TempDir ||
 		p.Binary != expected.Binary || !slices.Equal(p.Command, command) {
 		return errors.New("guard execution proof does not match the requested invocation")
 	}

--- a/internal/guard/execution_proof.go
+++ b/internal/guard/execution_proof.go
@@ -51,6 +51,21 @@ func (p ExecutionProof) Verify(expectedConfigHash string) error {
 	return nil
 }
 
+// VerifyInvocation checks the proof and binds it to the invocation requested
+// by the parent. Recomputing a digest over child-supplied fields proves that
+// those fields agree with each other; it does not prove they match the
+// parent's profile, workspace, executable, and argv unless they are compared.
+func (p ExecutionProof) VerifyInvocation(expected ExecControlOptions, command []string) error {
+	if err := p.Verify(expected.PolicyHash); err != nil {
+		return err
+	}
+	if p.Profile != expected.Profile || p.Workspace != expected.Workspace ||
+		p.Binary != expected.Binary || !slices.Equal(p.Command, command) {
+		return errors.New("guard execution proof does not match the requested invocation")
+	}
+	return nil
+}
+
 func (p ExecutionProof) recomputeHash() string {
 	material := struct {
 		Record           EnforcementRecord `json:"record"`

--- a/internal/guard/execution_proof_test.go
+++ b/internal/guard/execution_proof_test.go
@@ -3,7 +3,10 @@
 
 package guard
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 	newValidProof := func() ExecutionProof {
@@ -14,12 +17,32 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 		)
 	}
 	t.Run("valid proof", func(t *testing.T) {
-		if err := newValidProof().Verify("config-hash"); err != nil {
-			t.Fatalf("Verify: %v", err)
+		if err := newValidProof().VerifyInvocation(ExecControlOptions{
+			Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool",
+		}, []string{"tool", "arg"}); err != nil {
+			t.Fatalf("VerifyInvocation: %v", err)
 		}
 	})
+	for _, testCase := range []struct {
+		name     string
+		expected ExecControlOptions
+		command  []string
+	}{
+		{name: "wrong requested profile", expected: ExecControlOptions{Profile: "other", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested workspace", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/other", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested binary", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/other"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested argv", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool"}, command: []string{"tool", "other"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := newValidProof().VerifyInvocation(testCase.expected, testCase.command); err == nil {
+				t.Fatal("proof for a different requested invocation was accepted")
+			}
+		})
+	}
 	t.Run("wrong config binding", func(t *testing.T) {
-		if err := newValidProof().Verify("other-config"); err == nil {
+		if err := newValidProof().VerifyInvocation(ExecControlOptions{
+			Profile: "worker", PolicyHash: "other-config", Workspace: "/workspace", Binary: "/usr/bin/tool",
+		}, []string{"tool", "arg"}); err == nil {
 			t.Fatal("proof with the wrong config binding was accepted")
 		}
 	})
@@ -51,4 +74,30 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 			t.Fatal("proof without an effective policy hash was accepted")
 		}
 	})
+
+	// These are the remaining child-to-parent bindings. Each mutation keeps the
+	// original digest, so a mixed or malformed helper record must fail closed
+	// instead of being mistaken for proof about another invocation.
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*ExecutionProof)
+	}{
+		{name: "enforcement record", mutate: func(proof *ExecutionProof) { proof.Record.Coverage = CoveragePartial }},
+		{name: "config hash", mutate: func(proof *ExecutionProof) { proof.ConfigPolicyHash = "other-config" }},
+		{name: "profile", mutate: func(proof *ExecutionProof) { proof.Profile = "other-profile" }},
+		{name: "workspace", mutate: func(proof *ExecutionProof) { proof.Workspace = "/other-workspace" }},
+		{name: "binary", mutate: func(proof *ExecutionProof) { proof.Binary = "/usr/bin/other" }},
+	} {
+		t.Run("tampered "+testCase.name, func(t *testing.T) {
+			proof := newValidProof()
+			before := slices.Clone(proof.Command)
+			testCase.mutate(&proof)
+			if err := proof.Verify("config-hash"); err == nil {
+				t.Fatalf("proof with tampered %s was accepted", testCase.name)
+			}
+			if !slices.Equal(proof.Command, before) {
+				t.Fatal("proof verification mutated the command binding")
+			}
+		})
+	}
 }

--- a/internal/guard/execution_proof_test.go
+++ b/internal/guard/execution_proof_test.go
@@ -47,6 +47,15 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 			t.Fatal("proof with the wrong config binding was accepted")
 		}
 	})
+	t.Run("tampered record through invocation verifier", func(t *testing.T) {
+		proof := newValidProof()
+		proof.Record.Coverage = CoveragePartial
+		if err := proof.VerifyInvocation(ExecControlOptions{
+			Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool",
+		}, []string{"tool", "arg"}); err == nil {
+			t.Fatal("invocation verifier accepted a tampered enforcement record")
+		}
+	})
 	t.Run("execution failure", func(t *testing.T) {
 		proof := newValidProof()
 		proof.ExecError = "exec failed"

--- a/internal/guard/execution_proof_test.go
+++ b/internal/guard/execution_proof_test.go
@@ -18,7 +18,7 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 	}
 	t.Run("valid proof", func(t *testing.T) {
 		if err := newValidProof().VerifyInvocation(ExecControlOptions{
-			Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool",
+			Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool",
 		}, []string{"tool", "arg"}); err != nil {
 			t.Fatalf("VerifyInvocation: %v", err)
 		}
@@ -28,10 +28,11 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 		expected ExecControlOptions
 		command  []string
 	}{
-		{name: "wrong requested profile", expected: ExecControlOptions{Profile: "other", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
-		{name: "wrong requested workspace", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/other", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
-		{name: "wrong requested binary", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/other"}, command: []string{"tool", "arg"}},
-		{name: "wrong requested argv", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", Binary: "/usr/bin/tool"}, command: []string{"tool", "other"}},
+		{name: "wrong requested profile", expected: ExecControlOptions{Profile: "other", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested workspace", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/other", TempDir: "/tmp/private", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested temporary directory", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/other", Binary: "/usr/bin/tool"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested binary", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/other"}, command: []string{"tool", "arg"}},
+		{name: "wrong requested argv", expected: ExecControlOptions{Profile: "worker", PolicyHash: "config-hash", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool"}, command: []string{"tool", "other"}},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			if err := newValidProof().VerifyInvocation(testCase.expected, testCase.command); err == nil {
@@ -41,7 +42,7 @@ func TestExecutionProofBindsEffectiveInvocation(t *testing.T) {
 	}
 	t.Run("wrong config binding", func(t *testing.T) {
 		if err := newValidProof().VerifyInvocation(ExecControlOptions{
-			Profile: "worker", PolicyHash: "other-config", Workspace: "/workspace", Binary: "/usr/bin/tool",
+			Profile: "worker", PolicyHash: "other-config", Workspace: "/workspace", TempDir: "/tmp/private", Binary: "/usr/bin/tool",
 		}, []string{"tool", "arg"}); err == nil {
 			t.Fatal("proof with the wrong config binding was accepted")
 		}

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -98,7 +98,7 @@ func RunStandaloneInit() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	sandboxDir := fmt.Sprintf("/tmp/pipelock-sandbox-%d", os.Getpid())
+	sandboxDir := standaloneChildTempDir(os.Getpid())
 	var env []string
 	var binary string
 	if useDeveloperEnvironment {

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -365,6 +365,13 @@ func RunStandaloneInit() {
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+				// ExitCode reports -1 for a signaled process. Passing that to
+				// os.Exit becomes 255 and loses the command's real termination
+				// status. Preserve the shell-visible 128+signal convention across
+				// the standalone init and outer CLI process boundary.
+				exitSandboxProcess(128 + int(status.Signal()))
+			}
 			exitSandboxProcess(exitErr.ExitCode())
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] command error: %v\n", err)

--- a/internal/sandbox/guard_conformance_linux_test.go
+++ b/internal/sandbox/guard_conformance_linux_test.go
@@ -1,0 +1,455 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const guardConformanceHelperEnv = "PIPELOCK_GUARD_CONFORMANCE_HELPER"
+
+// TestGuardHostileProcessHelper runs as the final process under the real Guard
+// CLI. It is intentionally inert in the parent test process.
+func TestGuardHostileProcessHelper(t *testing.T) {
+	mode := os.Getenv(guardConformanceHelperEnv)
+	if mode == "" {
+		return
+	}
+
+	switch mode {
+	case "boundary":
+		runGuardBoundaryHelper(t)
+	case "broker":
+		if _, err := os.Stdin.Write([]byte("delegate")); err != nil {
+			t.Fatalf("same-UID broker write: %v", err)
+		}
+		response := make([]byte, len("broker-ok"))
+		_, err := io.ReadFull(os.Stdin, response)
+		if err != nil || string(response) != "broker-ok" {
+			t.Fatalf("same-UID broker response = %q, %v", response, err)
+		}
+	case "state":
+		state := os.Getenv("PIPELOCK_TEST_STATE")
+		run := os.Getenv("PIPELOCK_TEST_RUN")
+		if run == "2" {
+			if contents, err := os.ReadFile(filepath.Clean(filepath.Join(state, "first"))); err != nil || string(contents) != "one" {
+				t.Fatalf("post-success state = %q, %v", contents, err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(state, map[string]string{"1": "first", "2": "second"}[run]), []byte(map[string]string{"1": "one", "2": "two"}[run]), 0o600); err != nil {
+			t.Fatalf("write run %s state: %v", run, err)
+		}
+	case "revoked-state":
+		if _, err := os.ReadFile(filepath.Join(os.Getenv("PIPELOCK_TEST_OLD_STATE"), "first")); err == nil {
+			t.Fatal("revoked state remained readable after the policy changed")
+		}
+		if err := os.WriteFile(filepath.Join(os.Getenv("PIPELOCK_TEST_STATE"), "current"), []byte("new"), 0o600); err != nil {
+			t.Fatalf("write replacement state: %v", err)
+		}
+	default:
+		t.Fatalf("unknown Guard conformance helper mode %q", mode)
+	}
+}
+
+func runGuardBoundaryHelper(t *testing.T) {
+	t.Helper()
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil || string(stdin) != "operator stdin\n" {
+		t.Fatalf("stdin = %q, %v", stdin, err)
+	}
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(strings.ToUpper(key), "__PIPELOCK_") {
+			t.Fatalf("Pipelock control variable reached final command: %q", key)
+		}
+		if isProxyEnvKey(key) && strings.Contains(entry, "attacker.invalid") {
+			t.Fatalf("attacker proxy reached final command: %q", entry)
+		}
+	}
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		if value := os.Getenv(key); !strings.HasPrefix(value, "http://127.0.0.1:") {
+			t.Fatalf("%s = %q, want Guard loopback bridge", key, value)
+		}
+	}
+	for _, key := range []string{"NO_PROXY", "no_proxy"} {
+		if value := os.Getenv(key); value != "" {
+			t.Fatalf("%s = %q, want empty", key, value)
+		}
+	}
+
+	outside := os.Getenv("PIPELOCK_TEST_OUTSIDE")
+	if _, err := os.ReadFile(filepath.Clean(outside)); err == nil {
+		t.Fatal("read outside the Guard manifest succeeded")
+	}
+	if err := os.WriteFile(outside, []byte("overwritten"), 0o600); err == nil {
+		t.Fatal("write outside the Guard manifest succeeded")
+	}
+	link := filepath.Join(os.Getenv("PIPELOCK_TEST_WORKSPACE"), "outside-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("create workspace symlink: %v", err)
+	}
+	if _, err := os.ReadFile(filepath.Clean(link)); err == nil {
+		t.Fatal("workspace symlink escaped the Guard manifest")
+	}
+	renameSource := filepath.Join(os.Getenv("PIPELOCK_TEST_WORKSPACE"), "rename-source")
+	if err := os.WriteFile(renameSource, []byte("inside"), 0o600); err != nil {
+		t.Fatalf("write rename source: %v", err)
+	}
+	if err := os.Rename(renameSource, outside); err == nil {
+		t.Fatal("rename escaped the Guard manifest")
+	}
+
+	dialer := net.Dialer{Timeout: 300 * time.Millisecond}
+	if conn, err := dialer.DialContext(t.Context(), "tcp4", os.Getenv("PIPELOCK_TEST_TCP")); err == nil {
+		_ = conn.Close()
+		t.Fatal("direct host TCP connection succeeded")
+	}
+	if conn, err := dialer.DialContext(t.Context(), "tcp6", "[2001:db8::1]:443"); err == nil {
+		_ = conn.Close()
+		t.Fatal("direct IPv6 connection succeeded")
+	}
+	udpAddr, err := net.ResolveUDPAddr("udp4", os.Getenv("PIPELOCK_TEST_UDP"))
+	if err != nil {
+		t.Fatalf("resolve UDP witness: %v", err)
+	}
+	udp, err := net.DialUDP("udp4", nil, udpAddr)
+	if err == nil {
+		_, _ = udp.Write([]byte("guard-udp-bypass"))
+		_ = udp.Close()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if _, err := net.DefaultResolver.LookupHost(ctx, "guard-child-dns.invalid."); err == nil {
+		t.Fatal("child-side DNS unexpectedly resolved")
+	}
+}
+
+func TestIntegration_GuardHostileConformance(t *testing.T) {
+	binary := buildTestBinary(t)
+	helper, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test helper: %v", err)
+	}
+
+	t.Run("direct egress, filesystem, environment, and stdin", func(t *testing.T) {
+		root := t.TempDir()
+		workspace := filepath.Join(root, "workspace")
+		if err := os.Mkdir(workspace, 0o750); err != nil {
+			t.Fatalf("create workspace: %v", err)
+		}
+		outside := filepath.Join(root, "outside")
+		if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+			t.Fatalf("write outside fixture: %v", err)
+		}
+		tcpWitness, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen TCP witness: %v", err)
+		}
+		defer func() { _ = tcpWitness.Close() }()
+		udpWitness, err := (&net.ListenConfig{}).ListenPacket(t.Context(), "udp4", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen UDP witness: %v", err)
+		}
+		defer func() { _ = udpWitness.Close() }()
+
+		environment := guardTestEnvironment(map[string]string{
+			guardConformanceHelperEnv: "boundary",
+			"PIPELOCK_TEST_WORKSPACE": workspace,
+			"PIPELOCK_TEST_OUTSIDE":   outside,
+			"PIPELOCK_TEST_TCP":       tcpWitness.Addr().String(),
+			"PIPELOCK_TEST_UDP":       udpWitness.LocalAddr().String(),
+			"HTTP_PROXY":              "http://attacker.invalid:8080",
+			"https_proxy":             "http://attacker.invalid:8081",
+			"NO_PROXY":                "*",
+			"Http_Proxy":              "http://attacker.invalid:8082",
+			"__pipelock_attacker":     "must-be-removed",
+		})
+		_, stderr, err := runGuardBinary(t, binary, environment, strings.NewReader("operator stdin\n"),
+			"guard", "--workspace", workspace, "--", helper, "-test.run=^TestGuardHostileProcessHelper$")
+		if err != nil {
+			t.Fatalf("hostile Guard command: %v\nstderr: %s", err, stderr)
+		}
+		if contents, err := os.ReadFile(filepath.Clean(outside)); err != nil || string(contents) != "secret" {
+			t.Fatalf("outside fixture = %q, %v", contents, err)
+		}
+		assertNoTCPWitness(t, tcpWitness)
+		assertNoUDPWitness(t, udpWitness)
+	})
+
+	t.Run("argv transport preserves hostile delimiters", func(t *testing.T) {
+		workspace := t.TempDir()
+		script := filepath.Join(workspace, "argv-check")
+		body := "#!/bin/sh\n" +
+			"test \"$1\" = \"left$(printf '\\037')right\" && " +
+			"test \"$2\" = \"line one\nline two\" && " +
+			"test \"$3\" = \"--config\" && test \"$4\" = \"/proc/self/fd/0\"\n"
+		if err := os.WriteFile(script, []byte(body), 0o600); err != nil {
+			t.Fatalf("write argv helper: %v", err)
+		}
+		_, stderr, err := runGuardBinary(t, binary, nil, nil,
+			"guard", "--workspace", workspace, "--", "/bin/sh", script,
+			"left\x1fright", "line one\nline two", "--config", "/proc/self/fd/0")
+		if err != nil {
+			t.Fatalf("argv conformance: %v\nstderr: %s", err, stderr)
+		}
+	})
+
+	t.Run("rerun, post-success state, and policy replacement", func(t *testing.T) {
+		root := t.TempDir()
+		workspace := filepath.Join(root, "workspace")
+		if err := os.Mkdir(workspace, 0o750); err != nil {
+			t.Fatalf("create workspace: %v", err)
+		}
+		oldState := filepath.Join(root, "old-state")
+		newState := filepath.Join(root, "new-state")
+		oldConfig := writeGuardStateConfig(t, oldState)
+		for _, run := range []string{"1", "2"} {
+			environment := guardTestEnvironment(map[string]string{
+				guardConformanceHelperEnv: "state",
+				"PIPELOCK_TEST_STATE":     oldState,
+				"PIPELOCK_TEST_RUN":       run,
+			})
+			_, stderr, err := runGuardBinary(t, binary, environment, nil,
+				"guard", "--config", oldConfig, "--profile", "worker", "--workspace", workspace,
+				"--", helper, "-test.run=^TestGuardHostileProcessHelper$")
+			if err != nil {
+				t.Fatalf("Guard state run %s: %v\nstderr: %s", run, err, stderr)
+			}
+		}
+		newConfig := writeGuardStateConfig(t, newState)
+		environment := guardTestEnvironment(map[string]string{
+			guardConformanceHelperEnv: "revoked-state",
+			"PIPELOCK_TEST_OLD_STATE": oldState,
+			"PIPELOCK_TEST_STATE":     newState,
+		})
+		_, stderr, err := runGuardBinary(t, binary, environment, nil,
+			"guard", "--config", newConfig, "--profile", "worker", "--workspace", workspace,
+			"--", helper, "-test.run=^TestGuardHostileProcessHelper$")
+		if err != nil {
+			t.Fatalf("Guard replacement policy: %v\nstderr: %s", err, stderr)
+		}
+	})
+
+	t.Run("same-UID broker limitation remains explicit", func(t *testing.T) {
+		workspace := t.TempDir()
+		descriptors, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+		if err != nil {
+			t.Fatalf("create inherited broker socket: %v", err)
+		}
+		childBroker := os.NewFile(uintptr(descriptors[0]), "guard-broker-child")
+		parentBroker := os.NewFile(uintptr(descriptors[1]), "guard-broker-parent")
+		if childBroker == nil || parentBroker == nil {
+			t.Fatal("wrap inherited broker descriptors")
+		}
+		defer func() { _ = childBroker.Close() }()
+		defer func() { _ = parentBroker.Close() }()
+		served := make(chan error, 1)
+		go func() {
+			request := make([]byte, len("delegate"))
+			if _, readErr := io.ReadFull(parentBroker, request); readErr != nil {
+				served <- readErr
+				return
+			}
+			if string(request) != "delegate" {
+				served <- fmt.Errorf("broker request = %q", request)
+				return
+			}
+			_, writeErr := parentBroker.Write([]byte("broker-ok"))
+			served <- writeErr
+		}()
+		environment := guardTestEnvironment(map[string]string{
+			guardConformanceHelperEnv: "broker",
+		})
+		stdout, stderr, err := runGuardBinary(t, binary, environment, childBroker,
+			"guard", "--workspace", workspace, "--", helper, "-test.run=^TestGuardHostileProcessHelper$")
+		if err != nil {
+			t.Fatalf("same-UID broker proof: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+		}
+		select {
+		case err := <-served:
+			if err != nil {
+				t.Fatalf("broker: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("same-UID broker was not reached")
+		}
+		assertGuardClaimBoundary(t)
+	})
+
+	t.Run("malformed control aliases fail before command", func(t *testing.T) {
+		marker := filepath.Join(t.TempDir(), "started")
+		for _, testCase := range []struct {
+			name string
+			env  map[string]string
+			want string
+		}{
+			{name: "guard helper", env: map[string]string{"__PIPELOCK_GUARD_EXEC": "1"}, want: "invalid guard environment descriptor"},
+			{name: "standalone init", env: map[string]string{standaloneInitEnv: "1"}, want: "missing workspace, command, or socket path"},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				_, stderr, err := runGuardBinary(t, binary, guardTestEnvironment(testCase.env), nil,
+					"guard", "--workspace", t.TempDir(), "--", "sh", "-c", "touch "+marker)
+				if err == nil || !strings.Contains(stderr, testCase.want) {
+					t.Fatalf("malformed control error = %v, stderr=%q", err, stderr)
+				}
+				if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("operator command ran through malformed controls: %v", statErr)
+				}
+			})
+		}
+	})
+
+	t.Run("config stdin aliases fail before command", func(t *testing.T) {
+		workspace := t.TempDir()
+		marker := filepath.Join(workspace, "started")
+		alias := filepath.Join(t.TempDir(), "stdin-config")
+		if err := os.Symlink("/proc/self/fd/0", alias); err != nil {
+			t.Fatalf("create stdin alias: %v", err)
+		}
+		for _, configPath := range []string{"/dev/stdin", "/dev/fd/0", "/proc/self/fd/0", alias} {
+			_, stderr, err := runGuardBinary(t, binary, nil, strings.NewReader("enforce: true\n"),
+				"guard", "--config", configPath, "--workspace", workspace, "--", "sh", "-c", "touch "+marker)
+			if err == nil || !strings.Contains(stderr, "stdin") {
+				t.Fatalf("config alias %q error = %v, stderr=%q", configPath, err, stderr)
+			}
+			if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("operator command ran with config alias %q: %v", configPath, statErr)
+			}
+		}
+	})
+
+	t.Run("signaled command status and pre-exec claim", func(t *testing.T) {
+		_, stderr, err := runGuardBinary(t, binary, nil, nil,
+			"guard", "--workspace", t.TempDir(), "--", "sh", "-c", "kill -TERM $$")
+		if err == nil {
+			t.Fatal("signaled Guard command unexpectedly succeeded")
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("Guard signal error = %T %v", err, err)
+		}
+		if got := exitErr.ExitCode(); got != 128+int(syscall.SIGTERM) {
+			t.Fatalf("Guard signal exit code = %d, want %d\nstderr: %s", got, 128+int(syscall.SIGTERM), stderr)
+		}
+		if !strings.Contains(stderr, "[guard] ENFORCED") || strings.Contains(strings.ToLower(stderr), "command started") {
+			t.Fatalf("Guard signal output overclaims command start:\n%s", stderr)
+		}
+		assertGuardClaimBoundary(t)
+	})
+}
+
+func runGuardBinary(t *testing.T, binary string, environment []string, stdin io.Reader, args ...string) (string, string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, binary, args...) // #nosec G204 -- controlled conformance command.
+	cmd.Env = environment
+	cmd.Stdin = stdin
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("Guard conformance command timed out: %v\nstderr: %s", ctx.Err(), stderr.String())
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func guardTestEnvironment(overrides map[string]string) []string {
+	keys := make(map[string]struct{}, len(overrides))
+	for key := range overrides {
+		keys[key] = struct{}{}
+	}
+	environment := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, replaced := keys[key]; !replaced {
+			environment = append(environment, entry)
+		}
+	}
+	for key, value := range overrides {
+		environment = append(environment, key+"="+value)
+	}
+	return environment
+}
+
+func writeGuardStateConfig(t *testing.T, state string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	body := fmt.Sprintf("guard:\n  profiles:\n    - name: worker\n      manifests: [state]\n  manifests:\n    - name: state\n      read_write_directories:\n        - %q\n", state)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write Guard state config: %v", err)
+	}
+	return path
+}
+
+func assertNoTCPWitness(t *testing.T, listener net.Listener) {
+	t.Helper()
+	deadlineListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		t.Fatalf("TCP witness type = %T", listener)
+	}
+	if err := deadlineListener.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatalf("set TCP witness deadline: %v", err)
+	}
+	conn, err := listener.Accept()
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("guarded process reached the host TCP witness")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("TCP witness accept: %v", err)
+	}
+}
+
+func assertNoUDPWitness(t *testing.T, listener net.PacketConn) {
+	t.Helper()
+	if err := listener.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatalf("set UDP witness deadline: %v", err)
+	}
+	buffer := make([]byte, 64)
+	if n, address, err := listener.ReadFrom(buffer); err == nil {
+		t.Fatalf("guarded process reached host UDP witness from %s: %q", address, buffer[:n])
+	} else {
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("UDP witness read: %v", err)
+		}
+	}
+}
+
+func assertGuardClaimBoundary(t *testing.T) {
+	t.Helper()
+	docs, err := os.ReadFile(filepath.Join("..", "..", "docs", "cli", "guard.md"))
+	if err != nil {
+		t.Fatalf("read Guard docs: %v", err)
+	}
+	text := strings.Join(strings.Fields(string(docs)), " ")
+	for _, required := range []string{
+		"same-UID host process over an accessible broker or IPC channel",
+		"does not claim that the operator command started",
+		"direct TCP, UDP, QUIC, and child DNS",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("Guard docs lost required claim boundary %q", required)
+		}
+	}
+}

--- a/internal/sandbox/guard_conformance_linux_test.go
+++ b/internal/sandbox/guard_conformance_linux_test.go
@@ -8,6 +8,7 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -121,7 +122,7 @@ func runGuardBoundaryHelper(t *testing.T) {
 		_ = conn.Close()
 		t.Fatal("direct host TCP connection succeeded")
 	}
-	if conn, err := dialer.DialContext(t.Context(), "tcp6", "[2001:db8::1]:443"); err == nil {
+	if conn, err := dialer.DialContext(t.Context(), "tcp6", os.Getenv("PIPELOCK_TEST_TCP6")); err == nil {
 		_ = conn.Close()
 		t.Fatal("direct IPv6 connection succeeded")
 	}
@@ -136,7 +137,13 @@ func runGuardBoundaryHelper(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
-	if _, err := net.DefaultResolver.LookupHost(ctx, "guard-child-dns.invalid."); err == nil {
+	resolver := net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "udp4", os.Getenv("PIPELOCK_TEST_DNS"))
+		},
+	}
+	if _, err := resolver.LookupHost(ctx, "guard-child-dns.example."); err == nil {
 		t.Fatal("child-side DNS unexpectedly resolved")
 	}
 }
@@ -163,18 +170,28 @@ func TestIntegration_GuardHostileConformance(t *testing.T) {
 			t.Fatalf("listen TCP witness: %v", err)
 		}
 		defer func() { _ = tcpWitness.Close() }()
+		tcp6Witness, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp6", "[::1]:0")
+		if err != nil {
+			t.Fatalf("listen IPv6 witness: %v", err)
+		}
+		defer func() { _ = tcp6Witness.Close() }()
+		assertTCPWitnessReachable(t, tcp6Witness)
 		udpWitness, err := (&net.ListenConfig{}).ListenPacket(t.Context(), "udp4", "127.0.0.1:0")
 		if err != nil {
 			t.Fatalf("listen UDP witness: %v", err)
 		}
 		defer func() { _ = udpWitness.Close() }()
+		dnsWitness := startDNSWitness(t)
+		assertDNSWitnessReachable(t, dnsWitness)
 
 		environment := guardTestEnvironment(map[string]string{
 			guardConformanceHelperEnv: "boundary",
 			"PIPELOCK_TEST_WORKSPACE": workspace,
 			"PIPELOCK_TEST_OUTSIDE":   outside,
 			"PIPELOCK_TEST_TCP":       tcpWitness.Addr().String(),
+			"PIPELOCK_TEST_TCP6":      tcp6Witness.Addr().String(),
 			"PIPELOCK_TEST_UDP":       udpWitness.LocalAddr().String(),
+			"PIPELOCK_TEST_DNS":       dnsWitness.conn.LocalAddr().String(),
 			"HTTP_PROXY":              "http://attacker.invalid:8080",
 			"https_proxy":             "http://attacker.invalid:8081",
 			"NO_PROXY":                "*",
@@ -190,7 +207,9 @@ func TestIntegration_GuardHostileConformance(t *testing.T) {
 			t.Fatalf("outside fixture = %q, %v", contents, err)
 		}
 		assertNoTCPWitness(t, tcpWitness)
+		assertNoTCPWitness(t, tcp6Witness)
 		assertNoUDPWitness(t, udpWitness)
+		assertNoDNSWitness(t, dnsWitness)
 	})
 
 	t.Run("argv transport preserves hostile delimiters", func(t *testing.T) {
@@ -398,6 +417,120 @@ func writeGuardStateConfig(t *testing.T, state string) string {
 		t.Fatalf("write Guard state config: %v", err)
 	}
 	return path
+}
+
+type dnsWitness struct {
+	conn    net.PacketConn
+	queries chan struct{}
+}
+
+func startDNSWitness(t *testing.T) *dnsWitness {
+	t.Helper()
+	conn, err := (&net.ListenConfig{}).ListenPacket(t.Context(), "udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen DNS witness: %v", err)
+	}
+	witness := &dnsWitness{conn: conn, queries: make(chan struct{}, 8)}
+	t.Cleanup(func() { _ = conn.Close() })
+	go func() {
+		buffer := make([]byte, 512)
+		for {
+			n, address, readErr := conn.ReadFrom(buffer)
+			if readErr != nil {
+				return
+			}
+			select {
+			case witness.queries <- struct{}{}:
+			default:
+			}
+			if response := dnsWitnessResponse(buffer[:n]); response != nil {
+				_, _ = conn.WriteTo(response, address)
+			}
+		}
+	}()
+	return witness
+}
+
+func dnsWitnessResponse(query []byte) []byte {
+	if len(query) < 17 || binary.BigEndian.Uint16(query[4:6]) != 1 {
+		return nil
+	}
+	offset := 12
+	for offset < len(query) && query[offset] != 0 {
+		labelLength := int(query[offset])
+		offset++
+		if labelLength == 0 || offset+labelLength > len(query) {
+			return nil
+		}
+		offset += labelLength
+	}
+	if offset+5 > len(query) {
+		return nil
+	}
+	offset++
+	queryType := binary.BigEndian.Uint16(query[offset : offset+2])
+	questionEnd := offset + 4
+	response := append([]byte(nil), query[:questionEnd]...)
+	response[2], response[3] = 0x81, 0x80
+	response[6], response[7] = 0, 1
+	answer := []byte{0xc0, 0x0c, 0, 0, 0, 1, 0, 0, 0, 0}
+	binary.BigEndian.PutUint16(answer[2:4], queryType)
+	switch queryType {
+	case 1:
+		answer = append(answer, 0, 4, 192, 0, 2, 1)
+	case 28:
+		answer = append(answer, 0, 16, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+	default:
+		return nil
+	}
+	return append(response, answer...)
+}
+
+func assertTCPWitnessReachable(t *testing.T, listener net.Listener) {
+	t.Helper()
+	dialer := net.Dialer{Timeout: time.Second}
+	client, err := dialer.DialContext(t.Context(), listener.Addr().Network(), listener.Addr().String())
+	if err != nil {
+		t.Fatalf("reach TCP witness before Guard: %v", err)
+	}
+	server, err := listener.Accept()
+	if err != nil {
+		_ = client.Close()
+		t.Fatalf("accept TCP witness preflight: %v", err)
+	}
+	_ = client.Close()
+	_ = server.Close()
+}
+
+func assertDNSWitnessReachable(t *testing.T, witness *dnsWitness) {
+	t.Helper()
+	dialer := net.Dialer{Timeout: time.Second}
+	resolver := net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "udp4", witness.conn.LocalAddr().String())
+		},
+	}
+	addresses, err := resolver.LookupHost(t.Context(), "guard-child-dns.example.")
+	if err != nil || len(addresses) == 0 {
+		t.Fatalf("reach DNS witness before Guard: addresses=%v err=%v", addresses, err)
+	}
+	for {
+		select {
+		case <-witness.queries:
+		default:
+			return
+		}
+	}
+}
+
+func assertNoDNSWitness(t *testing.T, witness *dnsWitness) {
+	t.Helper()
+	select {
+	case <-witness.queries:
+		t.Fatal("guarded process emitted a query to the controlled DNS witness")
+	case <-time.After(200 * time.Millisecond):
+	}
 }
 
 func assertNoTCPWitness(t *testing.T, listener net.Listener) {

--- a/internal/sandbox/standalone_config.go
+++ b/internal/sandbox/standalone_config.go
@@ -6,9 +6,14 @@ package sandbox
 import (
 	"context"
 	"net"
+	"strconv"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
+
+func standaloneChildTempDir(pid int) string {
+	return "/tmp/pipelock-sandbox-" + strconv.Itoa(pid)
+}
 
 // StandaloneLaunchConfig configures the standalone sandbox launcher.
 type StandaloneLaunchConfig struct {
@@ -42,8 +47,9 @@ type StandaloneLaunchConfig struct {
 	GuardProfile string
 	// GuardPolicyHash binds the canonical runtime configuration.
 	GuardPolicyHash string
-	// GuardAppliedPreExec receives proof that the helper applied the filesystem
-	// ruleset before attempting exec. Pipe completion cannot prove that the
-	// operator command started; returning an error terminates the launch.
-	GuardAppliedPreExec func(proof []byte) error
+	// GuardAppliedPreExec receives the parent-created temporary directory and
+	// proof that the helper applied the filesystem ruleset before attempting
+	// exec. Pipe completion cannot prove that the operator command started;
+	// returning an error terminates the launch.
+	GuardAppliedPreExec func(tempDir string, proof []byte) error
 }

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -6,6 +6,7 @@
 package sandbox
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -133,6 +134,32 @@ func TestLaunchStandaloneGuardAppliesOnlyToFinalCommand(t *testing.T) {
 	}
 	if string(result) != "guarded" {
 		t.Fatalf("result = %q, want guarded", result)
+	}
+}
+
+func TestLaunchStandaloneGuardProofFailureCleansChildTempDir(t *testing.T) {
+	skipIfStandaloneUnavailable(t)
+	workspace := t.TempDir()
+	declaration := config.Guard{}
+	var childTempDir string
+	err := LaunchStandalone(StandaloneLaunchConfig{
+		Command:          []string{"sh", "-c", "true"},
+		Workspace:        workspace,
+		GuardDeclaration: &declaration,
+		GuardPolicyHash:  "test-policy-hash",
+		GuardAppliedPreExec: func(tempDir string, _ []byte) error {
+			childTempDir = tempDir
+			return errors.New("reject proof for cleanup test")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "reject proof for cleanup test") {
+		t.Fatalf("LaunchStandalone proof error = %v", err)
+	}
+	if childTempDir == "" {
+		t.Fatal("proof callback did not receive the child temporary directory")
+	}
+	if _, statErr := os.Stat(childTempDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("child temporary directory remained after proof failure: %v", statErr)
 	}
 }
 

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -171,6 +171,23 @@ func TestLaunchStandaloneGuardProofFailureCleansChildTempDir(t *testing.T) {
 	}
 }
 
+func TestStandaloneChildCleanupReapsOnlyInStrictMode(t *testing.T) {
+	for _, strict := range []bool{false, true} {
+		t.Run(strconv.FormatBool(strict), func(t *testing.T) {
+			reaped := false
+			stopped := false
+			cleanup := standaloneChildCleanup(0, strict, func() { stopped = true }, func() { reaped = true })
+			cleanup()
+			if reaped != strict {
+				t.Fatalf("reaped = %t, want %t", reaped, strict)
+			}
+			if !stopped {
+				t.Fatal("cleanup did not stop the proxy")
+			}
+		})
+	}
+}
+
 func TestLaunchStandaloneDeveloperEnvironmentSupportsLargeEnvironment(t *testing.T) {
 	skipIfStandaloneUnavailable(t)
 

--- a/internal/sandbox/standalone_developer_env_linux_test.go
+++ b/internal/sandbox/standalone_developer_env_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -160,6 +161,13 @@ func TestLaunchStandaloneGuardProofFailureCleansChildTempDir(t *testing.T) {
 	}
 	if _, statErr := os.Stat(childTempDir); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("child temporary directory remained after proof failure: %v", statErr)
+	}
+	childPID, parseErr := strconv.Atoi(strings.TrimPrefix(filepath.Base(childTempDir), "pipelock-sandbox-"))
+	if parseErr != nil {
+		t.Fatalf("parse child PID from %q: %v", childTempDir, parseErr)
+	}
+	if signalErr := syscall.Kill(childPID, 0); !errors.Is(signalErr, syscall.ESRCH) {
+		t.Fatalf("child process %d was not reaped after proof failure: %v", childPID, signalErr)
 	}
 }
 

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -279,7 +279,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if guardStatusReader != nil {
 		proof, proofErr := readGuardExecutionProof(guardStatusReader)
 		if proofErr == nil && cfg.GuardAppliedPreExec != nil {
-			proofErr = cfg.GuardAppliedPreExec(proof)
+			proofErr = cfg.GuardAppliedPreExec(standaloneChildTempDir(cmd.Process.Pid), proof)
 		}
 		if proofErr != nil {
 			_ = cmd.Process.Kill()

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -255,18 +255,7 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting sandbox child: %w", err)
 	}
-	cleanupChildState := func() {
-		if cmd.Process != nil {
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		}
-		if cfg.Strict {
-			ReapOrphans()
-		}
-		proxyServer.stop()
-		if cmd.Process != nil {
-			CleanupChildSandboxDir(cmd.Process.Pid)
-		}
-	}
+	cleanupChildState := standaloneChildCleanup(cmd.Process.Pid, cfg.Strict, proxyServer.stop, ReapOrphans)
 	defer cleanupChildState()
 	if guardStatusWriter != nil {
 		if err := guardStatusWriter.Close(); err != nil {
@@ -305,6 +294,21 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	waitErr := cmd.Wait()
 
 	return waitErr
+}
+
+func standaloneChildCleanup(pid int, strict bool, stopProxy, reapOrphans func()) func() {
+	return func() {
+		if pid > 0 {
+			_ = syscall.Kill(-pid, syscall.SIGTERM)
+		}
+		if strict {
+			reapOrphans()
+		}
+		stopProxy()
+		if pid > 0 {
+			CleanupChildSandboxDir(pid)
+		}
+	}
 }
 
 func guardLookupEnvironment(useDeveloperEnvironment bool, developerEnvironment []string) []string {

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -255,6 +255,19 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting sandbox child: %w", err)
 	}
+	cleanupChildState := func() {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		}
+		if cfg.Strict {
+			ReapOrphans()
+		}
+		proxyServer.stop()
+		if cmd.Process != nil {
+			CleanupChildSandboxDir(cmd.Process.Pid)
+		}
+	}
+	defer cleanupChildState()
 	if guardStatusWriter != nil {
 		if err := guardStatusWriter.Close(); err != nil {
 			_ = cmd.Process.Kill()
@@ -290,27 +303,6 @@ func LaunchStandalone(cfg StandaloneLaunchConfig) error {
 
 	// Wait for child to exit.
 	waitErr := cmd.Wait()
-
-	// Kill process group - terminate descendants that may still hold bridge
-	// proxy connections open.
-	if cmd.Process != nil {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-	}
-
-	// Strict mode: reap orphaned descendants adopted by subreaper.
-	// Best-effort relies on process-group termination plus proxy server stop.
-	if cfg.Strict {
-		ReapOrphans()
-	}
-
-	// Stop accepting, close active bridge connections, and join the accept
-	// loop plus all proxy handlers before sandbox directory cleanup.
-	proxyServer.stop()
-
-	// Clean up child's sandbox temp dir.
-	if cmd.Process != nil {
-		CleanupChildSandboxDir(cmd.Process.Pid)
-	}
 
 	return waitErr
 }

--- a/scripts/check-guard-conformance.sh
+++ b/scripts/check-guard-conformance.sh
@@ -11,6 +11,71 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+if [[ "$(go env GOOS)" != "linux" ]]; then
+  echo "FAIL: Guard hostile-input conformance requires Linux" >&2
+  exit 1
+fi
+
+# `go test -run` exits successfully when its pattern matches no test. Pin every
+# exact-name contract and require each prefix-based package group to be nonempty
+# before running the race-enabled gate.
+require_tests() {
+  local package="$1"
+  shift
+  local listed
+  listed="$(go test -list '.*' "$package")"
+  local name
+  for name in "$@"; do
+    if ! grep -Fqx -- "$name" <<<"$listed"; then
+      echo "FAIL: $package no longer defines $name" >&2
+      exit 1
+    fi
+  done
+}
+
+require_pattern() {
+  local package="$1"
+  local pattern="$2"
+  local listed
+  listed="$(go test -list "$pattern" "$package")"
+  if ! grep -Eq -- "$pattern" <<<"$listed"; then
+    echo "FAIL: $package has no tests matching $pattern" >&2
+    exit 1
+  fi
+}
+
+require_tests ./internal/guard \
+  TestExecutionProofBindsEffectiveInvocation \
+  TestReadExecEnvironmentOwnsInheritedDescriptor \
+  TestOpenExecStatusWriterValidatesAndOwnsDescriptor \
+  TestReadExecEnvironmentRoundTripAndClose \
+  TestReadExecEnvironmentRejectsDuplicateKeys \
+  TestDecodeExecEnvironmentRejectsMalformedAndOversizedPayloads \
+  TestExecEntryPointsRejectInvalidControls \
+  TestRunExecWithAppliesPolicyAndReplacesProcess \
+  TestRunExecWithRefusesIncompleteControlsAndEnforcement \
+  TestRunExecWithReportsExecFailureAfterEnforcement
+
+require_tests ./internal/sandbox \
+  TestIntegration_GuardHostileConformance \
+  TestIntegration_InitChildrenRejectMalformedLaunchState \
+  TestReadGuardExecutionProofRejectsExecFailureAndTrailingSuccess \
+  TestDeveloperEnvironmentCodecFailsClosed \
+  TestDeveloperEnvironmentControlDescriptorFailsClosed \
+  TestLaunchStandaloneRejectsInvalidGuardLaunchBeforeChildStart
+
+require_tests ./internal/cli/runtime \
+  TestLaunchGuardRejectsMalformedChildProof \
+  TestLaunchGuardFailureDoesNotEmitEnforcementEvidence \
+  TestValidateGuardRuntimeFailsClosed \
+  TestGuardEvidenceRecordsPreExecApplicationWithoutClaimingCommandStart \
+  TestGuardEvidenceActivationHandlesUnhealthyEmitter
+
+group_pattern='^(TestNewGrant_|TestGrantSet_|TestGuard)'
+require_pattern ./internal/destination "$group_pattern"
+require_pattern ./internal/scanner "$group_pattern"
+require_pattern ./internal/proxy "$group_pattern"
+
 go test -race -count=1 -timeout=5m ./internal/guard \
   -run '^(TestExecutionProofBindsEffectiveInvocation|TestReadExecEnvironmentOwnsInheritedDescriptor|TestOpenExecStatusWriterValidatesAndOwnsDescriptor|TestReadExecEnvironmentRoundTripAndClose|TestReadExecEnvironmentRejectsDuplicateKeys|TestDecodeExecEnvironmentRejectsMalformedAndOversizedPayloads|TestExecEntryPointsRejectInvalidControls|TestRunExecWithAppliesPolicyAndReplacesProcess|TestRunExecWithRefusesIncompleteControlsAndEnforcement|TestRunExecWithReportsExecFailureAfterEnforcement)$'
 

--- a/scripts/check-guard-conformance.sh
+++ b/scripts/check-guard-conformance.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2026 Josh Waldrep
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs the Linux HTTP/HTTPS Guard preview's hostile-input release gate. The
+# package tests drive the built `pipelock guard -- COMMAND` path and keep the
+# direct-egress, filesystem, control-transport, proof, and claim boundaries in
+# one CI entry point.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+go test -race -count=1 -timeout=5m ./internal/guard \
+  -run '^(TestExecutionProofBindsEffectiveInvocation|TestReadExecEnvironmentOwnsInheritedDescriptor|TestOpenExecStatusWriterValidatesAndOwnsDescriptor|TestReadExecEnvironmentRoundTripAndClose|TestReadExecEnvironmentRejectsDuplicateKeys|TestDecodeExecEnvironmentRejectsMalformedAndOversizedPayloads|TestExecEntryPointsRejectInvalidControls|TestRunExecWithAppliesPolicyAndReplacesProcess|TestRunExecWithRefusesIncompleteControlsAndEnforcement|TestRunExecWithReportsExecFailureAfterEnforcement)$'
+
+go test -race -count=1 -timeout=5m ./internal/sandbox \
+  -run '^(TestIntegration_GuardHostileConformance|TestIntegration_InitChildrenRejectMalformedLaunchState|TestReadGuardExecutionProofRejectsExecFailureAndTrailingSuccess|TestDeveloperEnvironmentCodecFailsClosed|TestDeveloperEnvironmentControlDescriptorFailsClosed|TestLaunchStandaloneRejectsInvalidGuardLaunchBeforeChildStart)$'
+
+go test -race -count=1 -timeout=5m ./internal/cli/runtime \
+  -run '^(TestLaunchGuardRejectsMalformedChildProof|TestLaunchGuardFailureDoesNotEmitEnforcementEvidence|TestValidateGuardRuntimeFailsClosed|TestGuardEvidenceRecordsPreExecApplicationWithoutClaimingCommandStart|TestGuardEvidenceActivationHandlesUnhealthyEmitter)$'
+
+go test -race -count=1 -timeout=5m ./internal/destination ./internal/scanner ./internal/proxy \
+  -run '^(TestNewGrant_|TestGrantSet_|TestGuard)'
+
+echo "PASS: Guard hostile-input conformance gate held"


### PR DESCRIPTION
## Summary

- Add real CLI coverage for direct egress, filesystem boundaries, malformed controls, state reruns, and the documented same-UID limitation.
- Bind child enforcement proofs to the profile, workspace, executable, and argv requested by the parent.
- Preserve shell-visible exit status when a guarded command terminates by signal.
- Run the Guard conformance gate in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened execution verification to ensure the requested profile, workspace, temporary directory, executable, command, and policy are honored.
  * Ensured sandbox cleanup removes temporary files and reaps child processes when startup verification fails.
  * Preserved standard signal-based exit codes for sandboxed commands.

* **Tests**
  * Added extensive Linux conformance coverage for isolation, environment handling, input transport, reruns, malformed configurations, networking, and signal behavior.
  * Added automated validation to prevent regressions in hostile-input handling.
  * Added a CI conformance gate with race-enabled checks and improved coverage-job reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->