### PR TITLE
fix(mcp): reassemble fragmented tool arguments for cross-request detection

### DIFF
--- a/docs/attacks-blocked.md
+++ b/docs/attacks-blocked.md
@@ -447,6 +447,8 @@ seed_phrase_detection:
 
 **Why pipelock catches it:** The dedicated seed phrase scanner tokenizes text and runs a sliding window over BIP-39 dictionary words. SHA-256 checksum validation eliminates false positives from normal English text. Detection covers URL query params, hostname labels, path segments, MCP tool arguments, request bodies, headers, WebSocket frames, and cross-request fragment reassembly. The scanner uses `ForMatching()` normalization to preserve word boundaries while still catching zero-width character and homoglyph evasion.
 
+**Bound on cross-request fragment reassembly:** reassembly recognizes a known pattern that arrives split across requests within the configured byte and time window. It is detection, not a guarantee against arbitrary multi-request transfer: a sender that controls fragment size, argument placement, and pacing can stay under any recognizer. Treat it as raising the cost of split exfiltration and producing evidence when it occurs, and see the cross-request detection section in [configuration.md](configuration.md) for the throughput ceiling an operator can enforce and what it costs in false positives.
+
 ## Cryptocurrency Private Key Exfiltration
 
 **MITRE ATT&CK:** T1048 (Exfiltration Over Alternative Protocol)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1634,6 +1634,8 @@ Tracks cumulative Shannon entropy of all outbound payloads (URLs, request bodies
 
 **Tuning:** The default 4096 bits per 5-minute window allows roughly 500 characters of random data across URL query parameters and path segments. This is appropriate when scanning URL-level traffic only.
 
+`entropy_budget.action: warn` records a threshold crossing but forwards the request. Set it to `block` to make the budget an enforcement limit. Lower `bits_per_window` or increase `window_minutes` to reduce the amount of opaque data a session can send before a block. Both settings can block legitimate uploads, identifiers, hashes, or encoded media, so tune them against expected traffic before enforcing them.
+
 **With TLS interception enabled**, request bodies are also scanned for entropy. A single LLM API call body (conversation context) can contain 100,000+ bits of entropy. Set `bits_per_window` to `500000` or higher when using `tls_interception` with cross-request detection, and add your LLM provider to `exempt_domains`:
 
 ```yaml
@@ -1661,6 +1663,8 @@ Buffers outbound payloads (URLs, request bodies, MCP JSON-RPC payloads, WebSocke
 **Memory:** Each tracked session uses up to `max_buffer_bytes`. With 10,000 concurrent sessions (hard cap), the worst-case memory is `max_buffer_bytes * 10000` (640 MB at defaults). Reduce `max_buffer_bytes` in memory-constrained environments.
 
 **Scope note:** Cross-request detection scans all outbound content visible to the proxy: URLs, request bodies, MCP JSON-RPC payloads, and WebSocket frames. CONNECT tunnels without TLS interception only expose the target hostname (entropy tracking only). Enable `tls_interception` for full cross-request coverage on tunneled traffic.
+
+Fragment reassembly detects known DLP patterns inside the configured byte and time window. It does not guarantee prevention for arbitrary multi-request data transfer. MCP arguments are buffered independently so ordinary sibling values are not treated as one payload; a tool can therefore send data in separate populated arguments, and a stream can also age out after `fragment_reassembly.window_minutes`. Use fragment reassembly for detection and evidence, then use `entropy_budget.action: block` with a tuned `bits_per_window` and `window_minutes` when a lower sustained-throughput ceiling is worth the false-positive cost.
 
 ## Finding Suppression
 

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -154,6 +154,15 @@ func ceeSessionKeyMCP(agent, sessionOrIP string) string {
 // number or progress label) appears alongside each data chunk, so each leaf
 // argument receives its own rolling stream.
 //
+// A tools/call with exactly one non-empty argument also gets one synthetic
+// stream scoped to its tool name. This covers field-name rotation: an attacker
+// can choose a different (even fresh) argument name for every fragment, but
+// cannot make those singleton values stop being the sole payload for the same
+// tool. Multi-value calls deliberately do not join this stream, preserving the
+// sibling isolation above. The extra stream adds at most one bounded fragment
+// buffer per distinct tool name; FragmentBuffer's existing global session cap
+// still bounds the total buffered state.
+//
 // Entropy accounting continues to use the raw frame. This reduction is only
 // for fragment reassembly. Non-tool frames, malformed arguments, and argument
 // values with no scalar content fall back to the raw frame so an unexpected
@@ -171,7 +180,35 @@ func mcpCEEFragmentPayloads(frame MCPFrame) map[string][]byte {
 	if _, err := decoder.Token(); err != io.EOF {
 		return map[string][]byte{"": frame.Raw}
 	}
+	if toolStream, value, ok := mcpCEEUnambiguousToolValue(frame.ToolCallName, payloads); ok {
+		payloads[toolStream] = append(payloads[toolStream], value...)
+	}
 	return payloads
+}
+
+// mcpCEEUnambiguousToolValue returns the synthetic stream and value for a
+// tools/call with exactly one non-empty argument leaf. Empty sibling values do
+// not carry tool input, while two non-empty values are intentionally kept in
+// their independent path streams to avoid inventing a concatenation between
+// unrelated arguments.
+func mcpCEEUnambiguousToolValue(toolName string, payloads map[string][]byte) (string, []byte, bool) {
+	if toolName == "" {
+		return "", nil, false
+	}
+	var value []byte
+	for _, payload := range payloads {
+		if len(payload) == 0 {
+			continue
+		}
+		if value != nil {
+			return "", nil, false
+		}
+		value = payload
+	}
+	if len(value) == 0 {
+		return "", nil, false
+	}
+	return "@tool/" + mcpCEEPathEscape(toolName), value, true
 }
 
 // appendMCPCEEArgumentText walks a JSON value in wire order and appends each

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -144,6 +145,33 @@ func ceeSessionKeyMCP(agent, sessionOrIP string) string {
 	return sessionOrIP
 }
 
+const (
+	// mcpCEEArgumentMaxDepth bounds recursive token walking independently from
+	// encoding/json's object decoding depth limit, which Decoder.Token does not
+	// apply.
+	mcpCEEArgumentMaxDepth = 64
+
+	// mcpCEEArgumentMaxStreams limits FragmentBuffer sessions created by one
+	// tools/call frame. An overflow falls back to the complete raw frame.
+	mcpCEEArgumentMaxStreams = 128
+
+	// mcpCEEArgumentMaxPathBytes bounds one escaped JSON argument path and the
+	// cumulative allocation used by recursive descent.
+	mcpCEEArgumentMaxPathBytes = 512
+
+	// mcpCEEArgumentMaxStreamKeyBytes also bounds the complete tool-qualified
+	// stream key when an attacker supplies an unusually long tool identity.
+	mcpCEEArgumentMaxStreamKeyBytes = 640
+)
+
+const (
+	mcpCEEToolStreamPrefix      = "@tool/"
+	mcpCEEArgumentStreamSuffix  = "/args"
+	mcpCEESingletonStreamSuffix = "/singleton"
+)
+
+var mcpCEEPathEscaper = strings.NewReplacer("~", "~0", "/", "~1")
+
 // mcpCEEFragmentPayloads returns text-bearing tool argument values partitioned
 // by their argument path for fragment reassembly. CEE previously buffered the
 // entire JSON-RPC envelope, which placed protocol syntax and unrelated fields
@@ -168,22 +196,37 @@ func ceeSessionKeyMCP(agent, sessionOrIP string) string {
 // values with no scalar content fall back to the raw frame so an unexpected
 // shape cannot skip cross-request evaluation.
 func mcpCEEFragmentPayloads(frame MCPFrame) map[string][]byte {
-	if !frame.IsToolsCall() || len(frame.Args) == 0 {
+	if !frame.IsToolsCall() || len(frame.Args) == 0 || frame.ToolCallName == "" {
+		return map[string][]byte{"": frame.Raw}
+	}
+	toolPrefix, ok := mcpCEEToolStreamPrefixFor(frame.ToolCallName)
+	if !ok {
 		return map[string][]byte{"": frame.Raw}
 	}
 	decoder := json.NewDecoder(bytes.NewReader(frame.Args))
 	decoder.UseNumber()
 	payloads := make(map[string][]byte)
-	if !appendMCPCEEArgumentText(decoder, payloads, "$") || len(payloads) == 0 {
+	if !appendMCPCEEArgumentText(decoder, payloads, toolPrefix, []byte("$"), 0) || len(payloads) == 0 {
 		return map[string][]byte{"": frame.Raw}
 	}
 	if _, err := decoder.Token(); err != io.EOF {
 		return map[string][]byte{"": frame.Raw}
 	}
-	if toolStream, value, ok := mcpCEEUnambiguousToolValue(frame.ToolCallName, payloads); ok {
+	if toolStream, value, ok := mcpCEEUnambiguousToolValue(toolPrefix, payloads); ok {
+		if len(payloads) >= mcpCEEArgumentMaxStreams {
+			return map[string][]byte{"": frame.Raw}
+		}
 		payloads[toolStream] = append(payloads[toolStream], value...)
 	}
 	return payloads
+}
+
+func mcpCEEToolStreamPrefixFor(toolName string) (string, bool) {
+	if toolName == "" {
+		return "", false
+	}
+	prefix := mcpCEEToolStreamPrefix + mcpCEEPathEscape(toolName)
+	return prefix, len(prefix)+len(mcpCEEArgumentStreamSuffix)+1 <= mcpCEEArgumentMaxStreamKeyBytes
 }
 
 // mcpCEEUnambiguousToolValue returns the synthetic stream and value for a
@@ -191,8 +234,8 @@ func mcpCEEFragmentPayloads(frame MCPFrame) map[string][]byte {
 // not carry tool input, while two non-empty values are intentionally kept in
 // their independent path streams to avoid inventing a concatenation between
 // unrelated arguments.
-func mcpCEEUnambiguousToolValue(toolName string, payloads map[string][]byte) (string, []byte, bool) {
-	if toolName == "" {
+func mcpCEEUnambiguousToolValue(toolPrefix string, payloads map[string][]byte) (string, []byte, bool) {
+	if toolPrefix == "" {
 		return "", nil, false
 	}
 	var value []byte
@@ -208,7 +251,7 @@ func mcpCEEUnambiguousToolValue(toolName string, payloads map[string][]byte) (st
 	if len(value) == 0 {
 		return "", nil, false
 	}
-	return "@tool/" + mcpCEEPathEscape(toolName), value, true
+	return toolPrefix + mcpCEESingletonStreamSuffix, value, true
 }
 
 // appendMCPCEEArgumentText walks a JSON value in wire order and appends each
@@ -216,7 +259,12 @@ func mcpCEEUnambiguousToolValue(toolName string, payloads map[string][]byte) (st
 // map, preserves array and object ordering without reintroducing JSON syntax
 // between values. Object keys identify a stream but are not themselves mixed
 // into data values: a server receives alpha and progress as distinct arguments.
-func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte, path string) bool {
+// The mutable path buffer avoids allocating a new cumulative path at each
+// nested object key or array element.
+func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte, toolPrefix string, path []byte, depth int) bool {
+	if depth > mcpCEEArgumentMaxDepth {
+		return false
+	}
 	token, err := decoder.Token()
 	if err != nil {
 		return false
@@ -231,9 +279,15 @@ func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte,
 					return false
 				}
 				keyString, ok := key.(string)
-				if !ok || !appendMCPCEEArgumentText(decoder, payloads, path+"/"+mcpCEEPathEscape(keyString)) {
+				if !ok {
 					return false
 				}
+				pathLen := len(path)
+				path, ok = mcpCEEAppendPathPart(path, keyString)
+				if !ok || !appendMCPCEEArgumentText(decoder, payloads, toolPrefix, path, depth+1) {
+					return false
+				}
+				path = path[:pathLen]
 			}
 			end, err := decoder.Token()
 			return err == nil && end == json.Delim('}')
@@ -241,9 +295,13 @@ func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte,
 			// json.Decoder only yields '{' or '[' as an opening delimiter.
 			// A different delimiter reaches the same fail-closed end-token check.
 			for index := 0; decoder.More(); index++ {
-				if !appendMCPCEEArgumentText(decoder, payloads, path+"/"+strconv.Itoa(index)) {
+				pathLen := len(path)
+				var ok bool
+				path, ok = mcpCEEAppendPathPart(path, strconv.Itoa(index))
+				if !ok || !appendMCPCEEArgumentText(decoder, payloads, toolPrefix, path, depth+1) {
 					return false
 				}
+				path = path[:pathLen]
 			}
 			end, err := decoder.Token()
 			return err == nil && end == json.Delim(']')
@@ -251,21 +309,55 @@ func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte,
 	case nil:
 		return true
 	case string:
-		payloads[path] = append(payloads[path], value...)
-		return true
+		return mcpCEEAppendArgumentPayload(payloads, toolPrefix, path, value)
 	case json.Number:
-		payloads[path] = append(payloads[path], value.String()...)
-		return true
+		return mcpCEEAppendArgumentPayload(payloads, toolPrefix, path, value.String())
 	case bool:
-		payloads[path] = append(payloads[path], strconv.FormatBool(value)...)
-		return true
+		return mcpCEEAppendArgumentPayload(payloads, toolPrefix, path, strconv.FormatBool(value))
 	default:
 		return false
 	}
 }
 
+func mcpCEEAppendPathPart(path []byte, part string) ([]byte, bool) {
+	pathBytes := len(path) + 1
+	for i := 0; i < len(part); i++ {
+		pathBytes++
+		if part[i] == '~' || part[i] == '/' {
+			pathBytes++
+		}
+	}
+	if pathBytes > mcpCEEArgumentMaxPathBytes {
+		return nil, false
+	}
+	path = append(path, '/')
+	for i := 0; i < len(part); i++ {
+		switch part[i] {
+		case '~':
+			path = append(path, '~', '0')
+		case '/':
+			path = append(path, '~', '1')
+		default:
+			path = append(path, part[i])
+		}
+	}
+	return path, true
+}
+
+func mcpCEEAppendArgumentPayload(payloads map[string][]byte, toolPrefix string, path []byte, value string) bool {
+	stream := toolPrefix + mcpCEEArgumentStreamSuffix + string(path)
+	if len(stream) > mcpCEEArgumentMaxStreamKeyBytes {
+		return false
+	}
+	if _, exists := payloads[stream]; !exists && len(payloads) >= mcpCEEArgumentMaxStreams {
+		return false
+	}
+	payloads[stream] = append(payloads[stream], value...)
+	return true
+}
+
 func mcpCEEPathEscape(part string) string {
-	return strings.NewReplacer("~", "~0", "/", "~1").Replace(part)
+	return mcpCEEPathEscaper.Replace(part)
 }
 
 // mcpCEEFragmentSessionKey isolates one argument path's fragment history from
@@ -279,83 +371,149 @@ func mcpCEEFragmentSessionKey(sessionKey, path string) string {
 	return sessionKey + "|mcp-arg|" + fmt.Sprintf("%x", digest[:])
 }
 
+type ceeRecordMCPOptions struct {
+	sessionKey       string
+	entropyPayload   []byte
+	fragmentPayloads map[string][]byte
+	frame            MCPFrame
+	cee              *CEEDeps
+	sc               *scanner.Scanner
+	logW             io.Writer
+	logger           *audit.Logger
+}
+
 // ceeRecordMCP runs cross-request exfiltration checks on outbound MCP payload.
 // Returns a non-empty reason string if the request should be blocked.
 // Returns "" if clean or CEE is disabled.
-func ceeRecordMCP(
-	sessionKey string,
-	entropyPayload []byte,
-	fragmentPayloads map[string][]byte,
-	cee *CEEDeps,
-	sc *scanner.Scanner,
-	logW io.Writer,
-	logger *audit.Logger,
-) string {
-	if cee == nil || (len(entropyPayload) == 0 && len(fragmentPayloads) == 0) {
+func ceeRecordMCP(opts ceeRecordMCPOptions) string {
+	if opts.cee == nil {
 		return ""
 	}
-	if len(entropyPayload) == 0 {
-		for _, payload := range fragmentPayloads {
+	tracker, buffer, m, ceeCfg, release := opts.cee.snapshot()
+	defer release()
+	if tracker == nil && (buffer == nil || !ceeCfg.FragmentReassembly.Enabled) {
+		return ""
+	}
+
+	fragmentPayloads := opts.fragmentPayloads
+	if buffer != nil && ceeCfg.FragmentReassembly.Enabled && fragmentPayloads == nil {
+		fragmentPayloads = mcpCEEFragmentPayloads(opts.frame)
+	}
+	if len(opts.entropyPayload) == 0 && len(fragmentPayloads) == 0 {
+		return ""
+	}
+	if len(opts.entropyPayload) == 0 {
+		for _, path := range mcpCEEFragmentPayloadPaths(fragmentPayloads) {
+			payload := fragmentPayloads[path]
 			if len(payload) == 0 {
 				continue
 			}
-			entropyPayload = payload
+			opts.entropyPayload = payload
 			break
 		}
 	}
-	tracker, buffer, m, ceeCfg, release := cee.snapshot()
-	defer release()
 
 	// Entropy budget check.
 	if tracker != nil && ceeCfg.EntropyBudget.Enabled {
-		tracker.Record(sessionKey, entropyPayload)
-		if tracker.BudgetExceeded(sessionKey) {
+		tracker.Record(opts.sessionKey, opts.entropyPayload)
+		if tracker.BudgetExceeded(opts.sessionKey) {
 			if m != nil {
 				m.RecordCrossRequestEntropyExceeded()
 			}
 			reason := fmt.Sprintf("cross-request entropy budget exceeded: %.0f/%.0f bits",
-				tracker.CurrentUsage(sessionKey), tracker.Budget())
-			_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
+				tracker.CurrentUsage(opts.sessionKey), tracker.Budget())
+			_, _ = fmt.Fprintf(opts.logW, "pipelock: CEE: %s (session=%s)\n", reason, opts.sessionKey)
 			if ceeCfg.EntropyBudget.Action == config.ActionBlock {
-				if logger != nil {
-					logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_entropy", reason)
+				if opts.logger != nil {
+					opts.logger.LogBlocked(mustMCPAuditContext(opts.logger, "CEE", "mcp-input"), "cross_request_entropy", reason)
 				}
 				return reason
 			}
 			// Warn mode: emit structured anomaly event for audit trail.
-			if logger != nil {
-				logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_entropy", reason, 0)
+			if opts.logger != nil {
+				opts.logger.LogAnomaly(mustMCPAuditContext(opts.logger, "CEE", "mcp-input"), "cross_request_entropy", reason, 0)
 			}
 		}
 	}
 
 	// Fragment reassembly DLP check.
 	if buffer != nil && ceeCfg.FragmentReassembly.Enabled {
-		for path, payload := range fragmentPayloads {
+		seenSingletonFindings := make(map[string]struct{})
+		seenArgumentFindings := make(map[string]struct{})
+		for _, path := range mcpCEEFragmentPayloadPaths(fragmentPayloads) {
+			payload := fragmentPayloads[path]
 			if len(payload) == 0 {
 				continue
 			}
-			fragmentKey := mcpCEEFragmentSessionKey(sessionKey, path)
+			fragmentKey := mcpCEEFragmentSessionKey(opts.sessionKey, path)
 			buffer.Append(fragmentKey, payload)
-			if matches := buffer.ScanForSecrets(context.Background(), fragmentKey, sc); len(matches) > 0 {
+			if matches := buffer.ScanForSecrets(context.Background(), fragmentKey, opts.sc); len(matches) > 0 {
+				findingKey, kind := mcpCEEFragmentFindingKey(path, payload, matches[0].PatternName)
+				if mcpCEEFragmentFindingAlreadyRecorded(kind, findingKey, seenSingletonFindings, seenArgumentFindings) {
+					continue
+				}
 				if m != nil {
 					m.RecordCrossRequestDLPMatch()
 				}
 				reason := fmt.Sprintf("cross-request fragment DLP match: %s; remove the secret from tool arguments, or lower cross_request_detection.fragment_reassembly.max_buffer_bytes for a narrower window (reduces protection against long chunk sequences)", matches[0].PatternName)
-				_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
+				_, _ = fmt.Fprintf(opts.logW, "pipelock: CEE: %s (session=%s)\n", reason, opts.sessionKey)
 				if ceeCfg.Action == config.ActionBlock {
-					if logger != nil {
-						logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason)
+					if opts.logger != nil {
+						opts.logger.LogBlocked(mustMCPAuditContext(opts.logger, "CEE", "mcp-input"), "cross_request_fragment", reason)
 					}
 					return reason
 				}
 				// Warn mode: emit structured anomaly event for audit trail.
-				if logger != nil {
-					logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason, 0)
+				if opts.logger != nil {
+					opts.logger.LogAnomaly(mustMCPAuditContext(opts.logger, "CEE", "mcp-input"), "cross_request_fragment", reason, 0)
 				}
 			}
 		}
 	}
 
 	return ""
+}
+
+func mcpCEEFragmentPayloadPaths(payloads map[string][]byte) []string {
+	paths := make([]string, 0, len(payloads))
+	for path := range payloads {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+type mcpCEEFragmentStreamKind uint8
+
+const (
+	mcpCEEFragmentRawStream mcpCEEFragmentStreamKind = iota
+	mcpCEEFragmentArgumentStream
+	mcpCEEFragmentSingletonStream
+)
+
+func mcpCEEFragmentFindingKey(stream string, payload []byte, patternName string) (string, mcpCEEFragmentStreamKind) {
+	if strings.HasSuffix(stream, mcpCEESingletonStreamSuffix) {
+		digest := sha256.Sum256(payload)
+		return strings.TrimSuffix(stream, mcpCEESingletonStreamSuffix) + "|" + fmt.Sprintf("%x", digest[:]) + "|" + patternName, mcpCEEFragmentSingletonStream
+	}
+	if index := strings.Index(stream, mcpCEEArgumentStreamSuffix+"$"); index >= 0 {
+		digest := sha256.Sum256(payload)
+		return stream[:index] + "|" + fmt.Sprintf("%x", digest[:]) + "|" + patternName, mcpCEEFragmentArgumentStream
+	}
+	return "", mcpCEEFragmentRawStream
+}
+
+func mcpCEEFragmentFindingAlreadyRecorded(kind mcpCEEFragmentStreamKind, findingKey string, singletonFindings, argumentFindings map[string]struct{}) bool {
+	switch kind {
+	case mcpCEEFragmentSingletonStream:
+		_, duplicate := argumentFindings[findingKey]
+		singletonFindings[findingKey] = struct{}{}
+		return duplicate
+	case mcpCEEFragmentArgumentStream:
+		_, duplicate := singletonFindings[findingKey]
+		argumentFindings[findingKey] = struct{}{}
+		return duplicate
+	default:
+		return false
+	}
 }

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -200,7 +200,9 @@ func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte,
 			}
 			end, err := decoder.Token()
 			return err == nil && end == json.Delim('}')
-		case '[':
+		default:
+			// json.Decoder only yields '{' or '[' as an opening delimiter.
+			// A different delimiter reaches the same fail-closed end-token check.
 			for index := 0; decoder.More(); index++ {
 				if !appendMCPCEEArgumentText(decoder, payloads, path+"/"+strconv.Itoa(index)) {
 					return false
@@ -208,8 +210,6 @@ func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte,
 			}
 			end, err := decoder.Token()
 			return err == nil && end == json.Delim(']')
-		default:
-			return false
 		}
 	case nil:
 		return true
@@ -259,6 +259,9 @@ func ceeRecordMCP(
 	}
 	if len(entropyPayload) == 0 {
 		for _, payload := range fragmentPayloads {
+			if len(payload) == 0 {
+				continue
+			}
 			entropyPayload = payload
 			break
 		}

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -4,9 +4,13 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
+	"strconv"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -139,26 +143,104 @@ func ceeSessionKeyMCP(agent, sessionOrIP string) string {
 	return sessionOrIP
 }
 
+// mcpCEEFragmentPayload returns the text-bearing tool argument values in a
+// stable order for fragment reassembly. CEE previously buffered the entire
+// JSON-RPC envelope, which placed protocol syntax and unrelated fields between
+// chunks from consecutive tools/call requests. That makes a secret split over
+// calls non-contiguous to the fragment DLP scanner even though the tool server
+// receives contiguous argument data.
+//
+// Entropy accounting continues to use the raw frame. This reduction is only
+// for fragment reassembly. Non-tool frames, malformed arguments, and argument
+// values with no scalar content fall back to the raw frame so an unexpected
+// shape cannot skip cross-request evaluation.
+func mcpCEEFragmentPayload(frame MCPFrame) []byte {
+	if !frame.IsToolsCall() || len(frame.Args) == 0 {
+		return frame.Raw
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(frame.Args))
+	decoder.UseNumber()
+	var arguments any
+	if err := decoder.Decode(&arguments); err != nil {
+		return frame.Raw
+	}
+
+	var payload bytes.Buffer
+	if !appendMCPCEEArgumentText(&payload, arguments) || payload.Len() == 0 {
+		return frame.Raw
+	}
+	return payload.Bytes()
+}
+
+// appendMCPCEEArgumentText emits every scalar argument value without JSON
+// scaffolding. Map keys are sorted so semantically equivalent MCP argument
+// objects produce the same stream regardless of Go map iteration order. Array
+// order remains significant and is retained.
+func appendMCPCEEArgumentText(dst *bytes.Buffer, value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case string:
+		dst.WriteString(v)
+		return true
+	case json.Number:
+		dst.WriteString(v.String())
+		return true
+	case bool:
+		dst.WriteString(strconv.FormatBool(v))
+		return true
+	case []any:
+		for _, item := range v {
+			if !appendMCPCEEArgumentText(dst, item) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if !appendMCPCEEArgumentText(dst, v[key]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
 // ceeRecordMCP runs cross-request exfiltration checks on outbound MCP payload.
 // Returns a non-empty reason string if the request should be blocked.
 // Returns "" if clean or CEE is disabled.
 func ceeRecordMCP(
 	sessionKey string,
-	payload []byte,
+	entropyPayload []byte,
+	fragmentPayload []byte,
 	cee *CEEDeps,
 	sc *scanner.Scanner,
 	logW io.Writer,
 	logger *audit.Logger,
 ) string {
-	if cee == nil || len(payload) == 0 {
+	if cee == nil || (len(entropyPayload) == 0 && len(fragmentPayload) == 0) {
 		return ""
+	}
+	if len(entropyPayload) == 0 {
+		entropyPayload = fragmentPayload
+	}
+	if len(fragmentPayload) == 0 {
+		fragmentPayload = entropyPayload
 	}
 	tracker, buffer, m, ceeCfg, release := cee.snapshot()
 	defer release()
 
 	// Entropy budget check.
 	if tracker != nil && ceeCfg.EntropyBudget.Enabled {
-		tracker.Record(sessionKey, payload)
+		tracker.Record(sessionKey, entropyPayload)
 		if tracker.BudgetExceeded(sessionKey) {
 			if m != nil {
 				m.RecordCrossRequestEntropyExceeded()
@@ -181,12 +263,12 @@ func ceeRecordMCP(
 
 	// Fragment reassembly DLP check.
 	if buffer != nil && ceeCfg.FragmentReassembly.Enabled {
-		buffer.Append(sessionKey, payload)
+		buffer.Append(sessionKey, fragmentPayload)
 		if matches := buffer.ScanForSecrets(context.Background(), sessionKey, sc); len(matches) > 0 {
 			if m != nil {
 				m.RecordCrossRequestDLPMatch()
 			}
-			reason := fmt.Sprintf("cross-request fragment DLP match: %s", matches[0].PatternName)
+			reason := fmt.Sprintf("cross-request fragment DLP match: %s; remove the secret from tool arguments, or lower cross_request_detection.fragment_reassembly.max_buffer_bytes for a narrower window (reduces protection against long chunk sequences)", matches[0].PatternName)
 			_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
 			if ceeCfg.Action == config.ActionBlock {
 				if logger != nil {

--- a/internal/mcp/cee.go
+++ b/internal/mcp/cee.go
@@ -6,11 +6,12 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -143,75 +144,102 @@ func ceeSessionKeyMCP(agent, sessionOrIP string) string {
 	return sessionOrIP
 }
 
-// mcpCEEFragmentPayload returns the text-bearing tool argument values in a
-// stable order for fragment reassembly. CEE previously buffered the entire
-// JSON-RPC envelope, which placed protocol syntax and unrelated fields between
-// chunks from consecutive tools/call requests. That makes a secret split over
-// calls non-contiguous to the fragment DLP scanner even though the tool server
-// receives contiguous argument data.
+// mcpCEEFragmentPayloads returns text-bearing tool argument values partitioned
+// by their argument path for fragment reassembly. CEE previously buffered the
+// entire JSON-RPC envelope, which placed protocol syntax and unrelated fields
+// between chunks from consecutive tools/call requests. That makes a secret
+// split over calls non-contiguous to the fragment DLP scanner even though the
+// tool server receives contiguous argument data. Flattening all argument
+// values has the same defect when a benign sibling field (for example a page
+// number or progress label) appears alongside each data chunk, so each leaf
+// argument receives its own rolling stream.
 //
 // Entropy accounting continues to use the raw frame. This reduction is only
 // for fragment reassembly. Non-tool frames, malformed arguments, and argument
 // values with no scalar content fall back to the raw frame so an unexpected
 // shape cannot skip cross-request evaluation.
-func mcpCEEFragmentPayload(frame MCPFrame) []byte {
+func mcpCEEFragmentPayloads(frame MCPFrame) map[string][]byte {
 	if !frame.IsToolsCall() || len(frame.Args) == 0 {
-		return frame.Raw
+		return map[string][]byte{"": frame.Raw}
 	}
-
 	decoder := json.NewDecoder(bytes.NewReader(frame.Args))
 	decoder.UseNumber()
-	var arguments any
-	if err := decoder.Decode(&arguments); err != nil {
-		return frame.Raw
+	payloads := make(map[string][]byte)
+	if !appendMCPCEEArgumentText(decoder, payloads, "$") || len(payloads) == 0 {
+		return map[string][]byte{"": frame.Raw}
 	}
-
-	var payload bytes.Buffer
-	if !appendMCPCEEArgumentText(&payload, arguments) || payload.Len() == 0 {
-		return frame.Raw
+	if _, err := decoder.Token(); err != io.EOF {
+		return map[string][]byte{"": frame.Raw}
 	}
-	return payload.Bytes()
+	return payloads
 }
 
-// appendMCPCEEArgumentText emits every scalar argument value without JSON
-// scaffolding. Map keys are sorted so semantically equivalent MCP argument
-// objects produce the same stream regardless of Go map iteration order. Array
-// order remains significant and is retained.
-func appendMCPCEEArgumentText(dst *bytes.Buffer, value any) bool {
-	switch v := value.(type) {
+// appendMCPCEEArgumentText walks a JSON value in wire order and appends each
+// scalar to its JSON-pointer-like argument path. A decoder, instead of a Go
+// map, preserves array and object ordering without reintroducing JSON syntax
+// between values. Object keys identify a stream but are not themselves mixed
+// into data values: a server receives alpha and progress as distinct arguments.
+func appendMCPCEEArgumentText(decoder *json.Decoder, payloads map[string][]byte, path string) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	switch value := token.(type) {
+	case json.Delim:
+		switch value {
+		case '{':
+			for decoder.More() {
+				key, err := decoder.Token()
+				if err != nil {
+					return false
+				}
+				keyString, ok := key.(string)
+				if !ok || !appendMCPCEEArgumentText(decoder, payloads, path+"/"+mcpCEEPathEscape(keyString)) {
+					return false
+				}
+			}
+			end, err := decoder.Token()
+			return err == nil && end == json.Delim('}')
+		case '[':
+			for index := 0; decoder.More(); index++ {
+				if !appendMCPCEEArgumentText(decoder, payloads, path+"/"+strconv.Itoa(index)) {
+					return false
+				}
+			}
+			end, err := decoder.Token()
+			return err == nil && end == json.Delim(']')
+		default:
+			return false
+		}
 	case nil:
 		return true
 	case string:
-		dst.WriteString(v)
+		payloads[path] = append(payloads[path], value...)
 		return true
 	case json.Number:
-		dst.WriteString(v.String())
+		payloads[path] = append(payloads[path], value.String()...)
 		return true
 	case bool:
-		dst.WriteString(strconv.FormatBool(v))
-		return true
-	case []any:
-		for _, item := range v {
-			if !appendMCPCEEArgumentText(dst, item) {
-				return false
-			}
-		}
-		return true
-	case map[string]any:
-		keys := make([]string, 0, len(v))
-		for key := range v {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			if !appendMCPCEEArgumentText(dst, v[key]) {
-				return false
-			}
-		}
+		payloads[path] = append(payloads[path], strconv.FormatBool(value)...)
 		return true
 	default:
 		return false
 	}
+}
+
+func mcpCEEPathEscape(part string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(part)
+}
+
+// mcpCEEFragmentSessionKey isolates one argument path's fragment history from
+// its siblings. Hashing keeps attacker-controlled paths bounded in tracker
+// keys without preserving a plaintext tool schema in memory or logs.
+func mcpCEEFragmentSessionKey(sessionKey, path string) string {
+	if path == "" {
+		return sessionKey
+	}
+	digest := sha256.Sum256([]byte(path))
+	return sessionKey + "|mcp-arg|" + fmt.Sprintf("%x", digest[:])
 }
 
 // ceeRecordMCP runs cross-request exfiltration checks on outbound MCP payload.
@@ -220,20 +248,20 @@ func appendMCPCEEArgumentText(dst *bytes.Buffer, value any) bool {
 func ceeRecordMCP(
 	sessionKey string,
 	entropyPayload []byte,
-	fragmentPayload []byte,
+	fragmentPayloads map[string][]byte,
 	cee *CEEDeps,
 	sc *scanner.Scanner,
 	logW io.Writer,
 	logger *audit.Logger,
 ) string {
-	if cee == nil || (len(entropyPayload) == 0 && len(fragmentPayload) == 0) {
+	if cee == nil || (len(entropyPayload) == 0 && len(fragmentPayloads) == 0) {
 		return ""
 	}
 	if len(entropyPayload) == 0 {
-		entropyPayload = fragmentPayload
-	}
-	if len(fragmentPayload) == 0 {
-		fragmentPayload = entropyPayload
+		for _, payload := range fragmentPayloads {
+			entropyPayload = payload
+			break
+		}
 	}
 	tracker, buffer, m, ceeCfg, release := cee.snapshot()
 	defer release()
@@ -263,22 +291,28 @@ func ceeRecordMCP(
 
 	// Fragment reassembly DLP check.
 	if buffer != nil && ceeCfg.FragmentReassembly.Enabled {
-		buffer.Append(sessionKey, fragmentPayload)
-		if matches := buffer.ScanForSecrets(context.Background(), sessionKey, sc); len(matches) > 0 {
-			if m != nil {
-				m.RecordCrossRequestDLPMatch()
+		for path, payload := range fragmentPayloads {
+			if len(payload) == 0 {
+				continue
 			}
-			reason := fmt.Sprintf("cross-request fragment DLP match: %s; remove the secret from tool arguments, or lower cross_request_detection.fragment_reassembly.max_buffer_bytes for a narrower window (reduces protection against long chunk sequences)", matches[0].PatternName)
-			_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
-			if ceeCfg.Action == config.ActionBlock {
-				if logger != nil {
-					logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason)
+			fragmentKey := mcpCEEFragmentSessionKey(sessionKey, path)
+			buffer.Append(fragmentKey, payload)
+			if matches := buffer.ScanForSecrets(context.Background(), fragmentKey, sc); len(matches) > 0 {
+				if m != nil {
+					m.RecordCrossRequestDLPMatch()
 				}
-				return reason
-			}
-			// Warn mode: emit structured anomaly event for audit trail.
-			if logger != nil {
-				logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason, 0)
+				reason := fmt.Sprintf("cross-request fragment DLP match: %s; remove the secret from tool arguments, or lower cross_request_detection.fragment_reassembly.max_buffer_bytes for a narrower window (reduces protection against long chunk sequences)", matches[0].PatternName)
+				_, _ = fmt.Fprintf(logW, "pipelock: CEE: %s (session=%s)\n", reason, sessionKey)
+				if ceeCfg.Action == config.ActionBlock {
+					if logger != nil {
+						logger.LogBlocked(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason)
+					}
+					return reason
+				}
+				// Warn mode: emit structured anomaly event for audit trail.
+				if logger != nil {
+					logger.LogAnomaly(mustMCPAuditContext(logger, "CEE", "mcp-input"), "cross_request_fragment", reason, 0)
+				}
 			}
 		}
 	}

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -6,6 +6,8 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -190,10 +192,10 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 			name:  "tool arguments keep sibling values in separate streams",
 			frame: ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"z":["three",true],"a":{"y":"one","x":2}}}}`)),
 			want: map[string]string{
-				"$/a/x": "2",
-				"$/a/y": "one",
-				"$/z/0": "three",
-				"$/z/1": "true",
+				"@tool/integrity_checker/args$/a/x": "2",
+				"@tool/integrity_checker/args$/a/y": "one",
+				"@tool/integrity_checker/args$/z/0": "three",
+				"@tool/integrity_checker/args$/z/1": "true",
 			},
 		},
 		{
@@ -204,18 +206,20 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 		{
 			name: "malformed arguments fall back to raw frame",
 			frame: MCPFrame{
-				Raw:    []byte("raw-frame"),
-				Method: methodToolsCall,
-				Args:   []byte(`{"unterminated"`),
+				Raw:          []byte("raw-frame"),
+				Method:       methodToolsCall,
+				ToolCallName: "integrity_checker",
+				Args:         []byte(`{"unterminated"`),
 			},
 			want: map[string]string{"": "raw-frame"},
 		},
 		{
 			name: "arguments without scalar content fall back to raw frame",
 			frame: MCPFrame{
-				Raw:    []byte("raw-frame"),
-				Method: methodToolsCall,
-				Args:   []byte(`{"empty":[]}`),
+				Raw:          []byte("raw-frame"),
+				Method:       methodToolsCall,
+				ToolCallName: "integrity_checker",
+				Args:         []byte(`{"empty":[]}`),
 			},
 			want: map[string]string{"": "raw-frame"},
 		},
@@ -230,29 +234,35 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 		{
 			name: "null argument falls back to raw frame",
 			frame: MCPFrame{
-				Raw:    []byte("raw-frame"),
-				Method: methodToolsCall,
-				Args:   []byte(`null`),
+				Raw:          []byte("raw-frame"),
+				Method:       methodToolsCall,
+				ToolCallName: "integrity_checker",
+				Args:         []byte(`null`),
 			},
 			want: map[string]string{"": "raw-frame"},
 		},
 		{
 			name: "extra root value falls back to raw frame",
 			frame: MCPFrame{
-				Raw:    []byte("raw-frame"),
-				Method: methodToolsCall,
-				Args:   []byte(`"one" "two"`),
+				Raw:          []byte("raw-frame"),
+				Method:       methodToolsCall,
+				ToolCallName: "integrity_checker",
+				Args:         []byte(`"one" "two"`),
 			},
 			want: map[string]string{"": "raw-frame"},
 		},
 		{
 			name: "root scalar and escaped path are retained",
 			frame: MCPFrame{
-				Raw:    []byte("raw-frame"),
-				Method: methodToolsCall,
-				Args:   []byte(`{"a/b~c":[null,"value"]}`),
+				Raw:          []byte("raw-frame"),
+				Method:       methodToolsCall,
+				ToolCallName: "integrity_checker",
+				Args:         []byte(`{"a/b~c":[null,"value"]}`),
 			},
-			want: map[string]string{"$/a~1b~0c/1": "value"},
+			want: map[string]string{
+				"@tool/integrity_checker/args$/a~1b~0c/1": "value",
+				"@tool/integrity_checker/singleton":       "value",
+			},
 		},
 	}
 
@@ -275,10 +285,10 @@ func TestMCPCEEFragmentPayloads_AddsToolStreamForUnambiguousValue(t *testing.T) 
 	frame := ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"rotating_name":"AKIA","empty":""}}}`))
 	payloads := mcpCEEFragmentPayloads(frame)
 
-	if got := string(payloads["$/rotating_name"]); got != "AKIA" {
+	if got := string(payloads["@tool/integrity_checker/args$/rotating_name"]); got != "AKIA" {
 		t.Fatalf("path payload = %q, want %q", got, "AKIA")
 	}
-	if got := string(payloads["@tool/integrity_checker"]); got != "AKIA" {
+	if got := string(payloads["@tool/integrity_checker/singleton"]); got != "AKIA" {
 		t.Fatalf("singleton tool payload = %q, want %q", got, "AKIA")
 	}
 }
@@ -287,7 +297,7 @@ func TestMCPCEEFragmentPayloads_DoesNotJoinSiblingValues(t *testing.T) {
 	frame := ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"one","beta":"two"}}}`))
 	payloads := mcpCEEFragmentPayloads(frame)
 
-	if _, ok := payloads["@tool/integrity_checker"]; ok {
+	if _, ok := payloads["@tool/integrity_checker/singleton"]; ok {
 		t.Fatalf("multi-value tool call unexpectedly joined sibling values: %#v", payloads)
 	}
 }
@@ -303,26 +313,27 @@ func TestMCPCEEUnambiguousToolValue(t *testing.T) {
 	}{
 		{
 			name:     "empty tool name",
-			payloads: map[string][]byte{"$/alpha": []byte("value")},
+			payloads: map[string][]byte{"@tool/integrity_checker/args$/alpha": []byte("value")},
 		},
 		{
 			name:     "all values empty",
 			toolName: "integrity_checker",
-			payloads: map[string][]byte{"$/alpha": nil, "$/beta": {}},
+			payloads: map[string][]byte{"@tool/integrity_checker/args$/alpha": nil, "@tool/integrity_checker/args$/beta": {}},
 		},
 		{
 			name:      "one non-empty value",
 			toolName:  "integrity_checker",
-			payloads:  map[string][]byte{"$/alpha": []byte("value"), "$/beta": nil},
+			payloads:  map[string][]byte{"@tool/integrity_checker/args$/alpha": []byte("value"), "@tool/integrity_checker/args$/beta": nil},
 			wantOK:    true,
-			wantPath:  "@tool/integrity_checker",
+			wantPath:  "@tool/integrity_checker/singleton",
 			wantValue: "value",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path, value, ok := mcpCEEUnambiguousToolValue(tt.toolName, tt.payloads)
+			toolPrefix, _ := mcpCEEToolStreamPrefixFor(tt.toolName)
+			path, value, ok := mcpCEEUnambiguousToolValue(toolPrefix, tt.payloads)
 			if ok != tt.wantOK || path != tt.wantPath || string(value) != tt.wantValue {
 				t.Fatalf("mcpCEEUnambiguousToolValue() = (%q, %q, %t), want (%q, %q, %t)", path, value, ok, tt.wantPath, tt.wantValue, tt.wantOK)
 			}
@@ -372,11 +383,119 @@ func TestAppendMCPCEEArgumentText_RejectsMalformedNestedValues(t *testing.T) {
 			if tt.useNum {
 				decoder.UseNumber()
 			}
-			if appendMCPCEEArgumentText(decoder, make(map[string][]byte), "$") {
+			if appendMCPCEEArgumentText(decoder, make(map[string][]byte), "@tool/integrity_checker", []byte("$"), 0) {
 				t.Fatal("appendMCPCEEArgumentText() = true, want false")
 			}
 		})
 	}
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawAtDepthLimit(t *testing.T) {
+	depth := mcpCEEArgumentMaxDepth + 1
+	frame := MCPFrame{
+		Raw:          []byte("raw-depth-limit"),
+		Method:       methodToolsCall,
+		ToolCallName: "integrity_checker",
+		Args:         []byte(strings.Repeat("[", depth) + `"value"` + strings.Repeat("]", depth)),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawAtPathLimit(t *testing.T) {
+	frame := MCPFrame{
+		Raw:          []byte("raw-path-limit"),
+		Method:       methodToolsCall,
+		ToolCallName: "integrity_checker",
+		Args:         []byte(`{"` + strings.Repeat("x", mcpCEEArgumentMaxPathBytes) + `":"value"}`),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawAtStreamLimit(t *testing.T) {
+	frame := MCPFrame{
+		Raw:          []byte("raw-stream-limit"),
+		Method:       methodToolsCall,
+		ToolCallName: "integrity_checker",
+		Args:         mcpCEEArgumentsWithLeaves(mcpCEEArgumentMaxStreams + 1),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawWhenSingletonWouldExceedStreamLimit(t *testing.T) {
+	frame := MCPFrame{
+		Raw:          []byte("raw-singleton-stream-limit"),
+		Method:       methodToolsCall,
+		ToolCallName: "integrity_checker",
+		Args:         mcpCEEArgumentsWithSingleNonEmptyLeaf(mcpCEEArgumentMaxStreams),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawAtStreamKeyLimit(t *testing.T) {
+	frame := MCPFrame{
+		Raw:          []byte("raw-stream-key-limit"),
+		Method:       methodToolsCall,
+		ToolCallName: strings.Repeat("x", mcpCEEArgumentMaxStreamKeyBytes),
+		Args:         []byte(`{"alpha":"value"}`),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func TestMCPCEEFragmentPayloads_FallsBackToRawWithoutToolName(t *testing.T) {
+	frame := MCPFrame{
+		Raw:    []byte("raw-missing-tool-name"),
+		Method: methodToolsCall,
+		Args:   []byte(`{"alpha":"value"}`),
+	}
+
+	assertMCPCEERawFallback(t, frame)
+}
+
+func assertMCPCEERawFallback(t *testing.T, frame MCPFrame) {
+	t.Helper()
+	payloads := mcpCEEFragmentPayloads(frame)
+	if len(payloads) != 1 || string(payloads[""]) != string(frame.Raw) {
+		t.Fatalf("mcpCEEFragmentPayloads() = %#v, want complete raw frame %q", payloads, frame.Raw)
+	}
+}
+
+func mcpCEEArgumentsWithLeaves(leaves int) []byte {
+	var args strings.Builder
+	args.WriteByte('{')
+	for index := range leaves {
+		if index > 0 {
+			args.WriteByte(',')
+		}
+		args.WriteString(strconv.Quote("field_" + strconv.Itoa(index)))
+		args.WriteByte(':')
+		args.WriteString(strconv.Quote("value"))
+	}
+	args.WriteByte('}')
+	return []byte(args.String())
+}
+
+func mcpCEEArgumentsWithSingleNonEmptyLeaf(leaves int) []byte {
+	var args strings.Builder
+	args.WriteByte('{')
+	for index := range leaves {
+		if index > 0 {
+			args.WriteByte(',')
+		}
+		args.WriteString(strconv.Quote("field_" + strconv.Itoa(index)))
+		args.WriteByte(':')
+		if index == 0 {
+			args.WriteString(strconv.Quote("value"))
+		} else {
+			args.WriteString(strconv.Quote(""))
+		}
+	}
+	args.WriteByte('}')
+	return []byte(args.String())
 }
 
 func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
@@ -388,10 +507,10 @@ func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
 	second := ParseMCPFrame(mcpChunkedCEERequest(2, testMCPAWSKeySuffix))
 	var logBuf bytes.Buffer
 
-	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
 		t.Fatalf("first fragment blocked: %s", reason)
 	}
-	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf})
 	if !strings.Contains(reason, "cross-request fragment DLP match") {
 		t.Fatalf("second fragment reason = %q, want fragment DLP block", reason)
 	}
@@ -409,29 +528,136 @@ func TestCeeRecordMCP_ReassemblesRotatedSingletonArgumentsAcrossCalls(t *testing
 	second := ParseMCPFrame(mcpSingletonCEERequest(2, "fresh_beta", "integrity_checker", testMCPAWSKeySuffix))
 	var logBuf bytes.Buffer
 
-	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
 		t.Fatalf("first rotated fragment blocked: %s", reason)
 	}
-	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf})
 	if !strings.Contains(reason, "cross-request fragment DLP match") {
 		t.Fatalf("second rotated fragment reason = %q, want fragment DLP block", reason)
 	}
 }
 
-func TestCeeRecordMCP_DoesNotJoinSingletonValuesAcrossTools(t *testing.T) {
+func TestCeeRecordMCP_ReassemblesSamePathWithinTool(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+
+	first := ParseMCPFrame(mcpSingletonCEERequest(1, "alpha", "integrity_checker", "AKI"+"A"))
+	second := ParseMCPFrame(mcpSingletonCEERequest(2, "alpha", "integrity_checker", testMCPAWSKeySuffix))
+	var logBuf bytes.Buffer
+
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
+		t.Fatalf("first same-path fragment blocked: %s", reason)
+	}
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf}); !strings.Contains(reason, "cross-request fragment DLP match") {
+		t.Fatalf("same-path fragments within one tool = %q, want fragment DLP block", reason)
+	}
+}
+
+func TestCeeRecordMCP_DoesNotJoinSamePathValuesAcrossTools(t *testing.T) {
 	cee := testMCPCEEFragmentBlock(t)
 	sc := testMCPScanner()
 	t.Cleanup(sc.Close)
 
 	first := ParseMCPFrame(mcpSingletonCEERequest(1, "alpha", "first_tool", "AKI"+"A"))
-	second := ParseMCPFrame(mcpSingletonCEERequest(2, "beta", "second_tool", testMCPAWSKeySuffix))
+	second := ParseMCPFrame(mcpSingletonCEERequest(2, "alpha", "second_tool", testMCPAWSKeySuffix))
 	var logBuf bytes.Buffer
 
-	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
 		t.Fatalf("first tool fragment blocked: %s", reason)
 	}
-	if reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
 		t.Fatalf("different tool names unexpectedly joined: %s", reason)
+	}
+}
+
+func TestCeeRecordMCP_HighLeafFallbackPreservesExistingFragment(t *testing.T) {
+	buffer := scanner.NewFragmentBuffer(64, 3, testMCPWindowSecs)
+	t.Cleanup(buffer.Close)
+	cee := &CEEDeps{
+		Buffer: buffer,
+		Config: &config.CrossRequestDetection{
+			Action: config.ActionBlock,
+			FragmentReassembly: config.CrossRequestFragments{
+				Enabled:        true,
+				MaxBufferBytes: 64,
+				WindowMinutes:  testMCPWindowSecs / 60,
+			},
+		},
+	}
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+	var logBuf bytes.Buffer
+
+	first := ParseMCPFrame(mcpSingletonCEERequest(1, "alpha", "integrity_checker", "AKI"+"A"))
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
+		t.Fatalf("first fragment blocked: %s", reason)
+	}
+
+	highLeafArgs := mcpCEEArgumentsWithLeaves(mcpCEEArgumentMaxStreams + 1)
+	highLeaf := ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"integrity_checker","arguments":` + string(highLeafArgs) + `}}`))
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: highLeaf.Raw, frame: highLeaf, cee: cee, sc: sc, logW: &logBuf}); reason != "" {
+		t.Fatalf("high-leaf frame blocked: %s", reason)
+	}
+
+	second := ParseMCPFrame(mcpSingletonCEERequest(3, "alpha", "integrity_checker", testMCPAWSKeySuffix))
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf}); !strings.Contains(reason, "cross-request fragment DLP match") {
+		t.Fatalf("secret split around high-leaf frame = %q, want fragment DLP block", reason)
+	}
+}
+
+func TestCeeRecordMCP_DeduplicatesEquivalentSingletonFindings(t *testing.T) {
+	m := metrics.New()
+	cee := NewCEEDeps(config.CrossRequestDetection{
+		Enabled: true,
+		Action:  config.ActionWarn,
+		FragmentReassembly: config.CrossRequestFragments{
+			Enabled:        true,
+			MaxBufferBytes: 64,
+			WindowMinutes:  testMCPWindowSecs / 60,
+		},
+	}, m)
+	t.Cleanup(cee.Close)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+	auditPath := filepath.Join(t.TempDir(), "cee-audit.jsonl")
+	logger, err := audit.New("json", "file", auditPath, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(logger.Close)
+	var logBuf bytes.Buffer
+
+	first := ParseMCPFrame(mcpSingletonCEERequest(1, "alpha", "integrity_checker", "AKI"+"A"))
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: first.Raw, frame: first, cee: cee, sc: sc, logW: &logBuf, logger: logger}); reason != "" {
+		t.Fatalf("first fragment blocked in warn mode: %s", reason)
+	}
+	second := ParseMCPFrame(mcpSingletonCEERequest(2, "alpha", "integrity_checker", testMCPAWSKeySuffix))
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, entropyPayload: second.Raw, frame: second, cee: cee, sc: sc, logW: &logBuf, logger: logger}); reason != "" {
+		t.Fatalf("completed secret blocked in warn mode: %s", reason)
+	}
+	logger.Close()
+
+	families, err := m.Registry().Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var matches float64
+	for _, family := range families {
+		if family.GetName() == "pipelock_cross_request_dlp_match_total" && len(family.Metric) == 1 {
+			matches = family.Metric[0].GetCounter().GetValue()
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("cross-request DLP match metric = %v, want 1", matches)
+	}
+
+	auditData, err := os.ReadFile(filepath.Clean(auditPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if anomalies := strings.Count(string(auditData), `"scanner":"cross_request_fragment"`); anomalies != 1 {
+		t.Fatalf("cross-request fragment anomaly records = %d, want 1; audit=%s", anomalies, auditData)
 	}
 }
 
@@ -452,10 +678,15 @@ func TestCeeRecordMCP_EntropyUsesFragmentPayloadAndSkipsEmptyPath(t *testing.T) 
 	}, metrics.New())
 	t.Cleanup(cee.Close)
 
-	reason := ceeRecordMCP(testMCPSessionKey, nil, map[string][]byte{
-		"$/empty": nil,
-		"$/value": []byte("entropy"),
-	}, cee, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey,
+		fragmentPayloads: map[string][]byte{
+			"$/empty": nil,
+			"$/value": []byte("entropy"),
+		},
+		cee:  cee,
+		logW: &bytes.Buffer{},
+	})
 	if !strings.Contains(reason, "entropy budget exceeded") {
 		t.Fatalf("reason = %q, want entropy budget block", reason)
 	}
@@ -470,16 +701,26 @@ func TestCeeRecordMCP_FragmentSkipsEmptyPayloads(t *testing.T) {
 	second := []byte(testMCPAWSKeySuffix)
 	var logBuf bytes.Buffer
 
-	if reason := ceeRecordMCP(testMCPSessionKey, first, map[string][]byte{
-		"$/empty":  nil,
-		"$/active": first,
-	}, cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey:     testMCPSessionKey,
+		entropyPayload: first,
+		fragmentPayloads: map[string][]byte{
+			"$/empty":  nil,
+			"$/active": first,
+		},
+		cee: cee, sc: sc, logW: &logBuf,
+	}); reason != "" {
 		t.Fatalf("first fragment blocked: %s", reason)
 	}
-	if reason := ceeRecordMCP(testMCPSessionKey, second, map[string][]byte{
-		"$/empty":  {},
-		"$/active": second,
-	}, cee, sc, &logBuf, nil); !strings.Contains(reason, "cross-request fragment DLP match") {
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey:     testMCPSessionKey,
+		entropyPayload: second,
+		fragmentPayloads: map[string][]byte{
+			"$/empty":  {},
+			"$/active": second,
+		},
+		cee: cee, sc: sc, logW: &logBuf,
+	}); !strings.Contains(reason, "cross-request fragment DLP match") {
 		t.Fatalf("second fragment reason = %q, want fragment DLP block", reason)
 	}
 }
@@ -508,7 +749,9 @@ func mcpSingletonCEERequest(id int, argumentName, toolName, chunk string) []byte
 }
 
 func TestCeeRecordMCP_NilCEE(t *testing.T) {
-	reason := ceeRecordMCP(testMCPSessionKey, []byte("payload"), map[string][]byte{"": []byte("payload")}, nil, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: []byte("payload"), fragmentPayloads: map[string][]byte{"": []byte("payload")}, logW: &bytes.Buffer{},
+	})
 	if reason != "" {
 		t.Errorf("expected empty reason for nil CEE, got %q", reason)
 	}
@@ -516,15 +759,29 @@ func TestCeeRecordMCP_NilCEE(t *testing.T) {
 
 func TestCeeRecordMCP_EmptyPayload(t *testing.T) {
 	cee := &CEEDeps{}
-	reason := ceeRecordMCP(testMCPSessionKey, []byte{}, map[string][]byte{}, cee, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: []byte{}, fragmentPayloads: map[string][]byte{}, cee: cee, logW: &bytes.Buffer{},
+	})
 	if reason != "" {
 		t.Errorf("expected empty reason for empty payload, got %q", reason)
 	}
 
 	// Also test nil payload.
-	reason = ceeRecordMCP(testMCPSessionKey, nil, nil, cee, nil, &bytes.Buffer{}, nil)
+	reason = ceeRecordMCP(ceeRecordMCPOptions{sessionKey: testMCPSessionKey, cee: cee, logW: &bytes.Buffer{}})
 	if reason != "" {
 		t.Errorf("expected empty reason for nil payload, got %q", reason)
+	}
+}
+
+func TestCeeRecordMCP_EmptyActivePayload(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	if reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey:       testMCPSessionKey,
+		fragmentPayloads: map[string][]byte{},
+		cee:              cee,
+		logW:             &bytes.Buffer{},
+	}); reason != "" {
+		t.Fatalf("empty active CEE payload = %q, want no block", reason)
 	}
 }
 
@@ -558,7 +815,9 @@ func TestCeeRecordMCP_EntropyBudgetBlock(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: payload, fragmentPayloads: map[string][]byte{"": payload}, cee: cee, sc: sc, logW: &logBuf, logger: logger,
+	})
 
 	if reason == "" {
 		t.Fatal("expected non-empty reason for entropy budget block")
@@ -593,7 +852,9 @@ func TestCeeRecordMCP_EntropyBudgetWarn(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, nil, &logBuf, nil)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: payload, fragmentPayloads: map[string][]byte{"": payload}, cee: cee, logW: &logBuf,
+	})
 
 	// Warn mode: should NOT block (empty reason).
 	if reason != "" {
@@ -640,13 +901,17 @@ func TestCeeRecordMCP_FragmentDLPBlock(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment: not enough to trigger.
-	reason := ceeRecordMCP(testMCPSessionKey, []byte(part1), map[string][]byte{"": []byte(part1)}, cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: []byte(part1), fragmentPayloads: map[string][]byte{"": []byte(part1)}, cee: cee, sc: sc, logW: &logBuf, logger: logger,
+	})
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key, should block.
-	reason = ceeRecordMCP(testMCPSessionKey, []byte(part2), map[string][]byte{"": []byte(part2)}, cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: []byte(part2), fragmentPayloads: map[string][]byte{"": []byte(part2)}, cee: cee, sc: sc, logW: &logBuf, logger: logger,
+	})
 	if reason == "" {
 		t.Fatal("expected non-empty reason for fragment DLP block")
 	}
@@ -686,13 +951,17 @@ func TestCeeRecordMCP_FragmentDLPWarn(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment.
-	reason := ceeRecordMCP("warn-session", []byte(part1), map[string][]byte{"": []byte(part1)}, cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: "warn-session", entropyPayload: []byte(part1), fragmentPayloads: map[string][]byte{"": []byte(part1)}, cee: cee, sc: sc, logW: &logBuf, logger: logger,
+	})
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key. Warn mode should NOT block.
-	reason = ceeRecordMCP("warn-session", []byte(part2), map[string][]byte{"": []byte(part2)}, cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: "warn-session", entropyPayload: []byte(part2), fragmentPayloads: map[string][]byte{"": []byte(part2)}, cee: cee, sc: sc, logW: &logBuf, logger: logger,
+	})
 	if reason != "" {
 		t.Errorf("expected empty reason for warn mode, got %q", reason)
 	}
@@ -729,7 +998,9 @@ func TestCeeRecordMCP_EntropyBudgetWarnWithLogger(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, nil, &logBuf, logger)
+	reason := ceeRecordMCP(ceeRecordMCPOptions{
+		sessionKey: testMCPSessionKey, entropyPayload: payload, fragmentPayloads: map[string][]byte{"": payload}, cee: cee, logW: &logBuf, logger: logger,
+	})
 
 	// Warn mode: should NOT block.
 	if reason != "" {

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -461,6 +461,29 @@ func TestCeeRecordMCP_EntropyUsesFragmentPayloadAndSkipsEmptyPath(t *testing.T) 
 	}
 }
 
+func TestCeeRecordMCP_FragmentSkipsEmptyPayloads(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+
+	first := []byte("AKI" + "A")
+	second := []byte(testMCPAWSKeySuffix)
+	var logBuf bytes.Buffer
+
+	if reason := ceeRecordMCP(testMCPSessionKey, first, map[string][]byte{
+		"$/empty":  nil,
+		"$/active": first,
+	}, cee, sc, &logBuf, nil); reason != "" {
+		t.Fatalf("first fragment blocked: %s", reason)
+	}
+	if reason := ceeRecordMCP(testMCPSessionKey, second, map[string][]byte{
+		"$/empty":  {},
+		"$/active": second,
+	}, cee, sc, &logBuf, nil); !strings.Contains(reason, "cross-request fragment DLP match") {
+		t.Fatalf("second fragment reason = %q, want fragment DLP block", reason)
+	}
+}
+
 func testMCPCEEFragmentBlock(t *testing.T) *CEEDeps {
 	t.Helper()
 	cee := NewCEEDeps(config.CrossRequestDetection{

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"bytes"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -218,6 +219,41 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 			},
 			want: map[string]string{"": "raw-frame"},
 		},
+		{
+			name: "empty tool arguments fall back to raw frame",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+			},
+			want: map[string]string{"": "raw-frame"},
+		},
+		{
+			name: "null argument falls back to raw frame",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+				Args:   []byte(`null`),
+			},
+			want: map[string]string{"": "raw-frame"},
+		},
+		{
+			name: "extra root value falls back to raw frame",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+				Args:   []byte(`"one" "two"`),
+			},
+			want: map[string]string{"": "raw-frame"},
+		},
+		{
+			name: "root scalar and escaped path are retained",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+				Args:   []byte(`{"a/b~c":[null,"value"]}`),
+			},
+			want: map[string]string{"$/a~1b~0c/1": "value"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +266,55 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 				if value := string(got[path]); value != want {
 					t.Fatalf("mcpCEEFragmentPayloads()[%q] = %q, want %q", path, value, want)
 				}
+			}
+		})
+	}
+}
+
+func TestMCPCEEFragmentSessionKey(t *testing.T) {
+	if got := mcpCEEFragmentSessionKey("session", ""); got != "session" {
+		t.Fatalf("raw fragment key = %q, want session", got)
+	}
+	first := mcpCEEFragmentSessionKey("session", "$/alpha")
+	second := mcpCEEFragmentSessionKey("session", "$/beta")
+	if first == second || !strings.HasPrefix(first, "session|mcp-arg|") {
+		t.Fatalf("argument keys = %q / %q, want distinct hashed keys", first, second)
+	}
+	if strings.Contains(first, "alpha") || strings.Contains(second, "beta") {
+		t.Fatalf("argument key exposed its plaintext path: %q / %q", first, second)
+	}
+}
+
+func TestAppendMCPCEEArgumentText_RejectsMalformedNestedValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		useNum bool
+	}{
+		{
+			name:   "malformed object key",
+			input:  `{"`,
+			useNum: true,
+		},
+		{
+			name:   "malformed array item",
+			input:  `["ok",`,
+			useNum: true,
+		},
+		{
+			name:   "number without UseNumber is an unexpected token type",
+			input:  `1`,
+			useNum: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoder := json.NewDecoder(strings.NewReader(tt.input))
+			if tt.useNum {
+				decoder.UseNumber()
+			}
+			if appendMCPCEEArgumentText(decoder, make(map[string][]byte), "$") {
+				t.Fatal("appendMCPCEEArgumentText() = true, want false")
 			}
 		})
 	}
@@ -253,6 +338,32 @@ func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
 	}
 	if !strings.Contains(reason, "cross_request_detection.fragment_reassembly.max_buffer_bytes") {
 		t.Fatalf("fragment block missing live remediation knob: %q", reason)
+	}
+}
+
+func TestCeeRecordMCP_EntropyUsesFragmentPayloadAndSkipsEmptyPath(t *testing.T) {
+	cee := NewCEEDeps(config.CrossRequestDetection{
+		Enabled: true,
+		EntropyBudget: config.CrossRequestEntropyBudget{
+			Enabled:       true,
+			BitsPerWindow: 1,
+			WindowMinutes: testMCPWindowSecs / 60,
+			Action:        config.ActionBlock,
+		},
+		FragmentReassembly: config.CrossRequestFragments{
+			Enabled:        true,
+			MaxBufferBytes: 64,
+			WindowMinutes:  testMCPWindowSecs / 60,
+		},
+	}, metrics.New())
+	t.Cleanup(cee.Close)
+
+	reason := ceeRecordMCP(testMCPSessionKey, nil, map[string][]byte{
+		"$/empty": nil,
+		"$/value": []byte("entropy"),
+	}, cee, nil, &bytes.Buffer{}, nil)
+	if !strings.Contains(reason, "entropy budget exceeded") {
+		t.Fatalf("reason = %q, want entropy budget block", reason)
 	}
 }
 

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -271,6 +271,65 @@ func TestMCPCEEFragmentPayloads(t *testing.T) {
 	}
 }
 
+func TestMCPCEEFragmentPayloads_AddsToolStreamForUnambiguousValue(t *testing.T) {
+	frame := ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"rotating_name":"AKIA","empty":""}}}`))
+	payloads := mcpCEEFragmentPayloads(frame)
+
+	if got := string(payloads["$/rotating_name"]); got != "AKIA" {
+		t.Fatalf("path payload = %q, want %q", got, "AKIA")
+	}
+	if got := string(payloads["@tool/integrity_checker"]); got != "AKIA" {
+		t.Fatalf("singleton tool payload = %q, want %q", got, "AKIA")
+	}
+}
+
+func TestMCPCEEFragmentPayloads_DoesNotJoinSiblingValues(t *testing.T) {
+	frame := ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"one","beta":"two"}}}`))
+	payloads := mcpCEEFragmentPayloads(frame)
+
+	if _, ok := payloads["@tool/integrity_checker"]; ok {
+		t.Fatalf("multi-value tool call unexpectedly joined sibling values: %#v", payloads)
+	}
+}
+
+func TestMCPCEEUnambiguousToolValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		payloads  map[string][]byte
+		wantOK    bool
+		wantPath  string
+		wantValue string
+	}{
+		{
+			name:     "empty tool name",
+			payloads: map[string][]byte{"$/alpha": []byte("value")},
+		},
+		{
+			name:     "all values empty",
+			toolName: "integrity_checker",
+			payloads: map[string][]byte{"$/alpha": nil, "$/beta": {}},
+		},
+		{
+			name:      "one non-empty value",
+			toolName:  "integrity_checker",
+			payloads:  map[string][]byte{"$/alpha": []byte("value"), "$/beta": nil},
+			wantOK:    true,
+			wantPath:  "@tool/integrity_checker",
+			wantValue: "value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, value, ok := mcpCEEUnambiguousToolValue(tt.toolName, tt.payloads)
+			if ok != tt.wantOK || path != tt.wantPath || string(value) != tt.wantValue {
+				t.Fatalf("mcpCEEUnambiguousToolValue() = (%q, %q, %t), want (%q, %q, %t)", path, value, ok, tt.wantPath, tt.wantValue, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestMCPCEEFragmentSessionKey(t *testing.T) {
 	if got := mcpCEEFragmentSessionKey("session", ""); got != "session" {
 		t.Fatalf("raw fragment key = %q, want session", got)
@@ -341,6 +400,41 @@ func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
 	}
 }
 
+func TestCeeRecordMCP_ReassemblesRotatedSingletonArgumentsAcrossCalls(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+
+	first := ParseMCPFrame(mcpSingletonCEERequest(1, "fresh_alpha", "integrity_checker", "AKI"+"A"))
+	second := ParseMCPFrame(mcpSingletonCEERequest(2, "fresh_beta", "integrity_checker", testMCPAWSKeySuffix))
+	var logBuf bytes.Buffer
+
+	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
+		t.Fatalf("first rotated fragment blocked: %s", reason)
+	}
+	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil)
+	if !strings.Contains(reason, "cross-request fragment DLP match") {
+		t.Fatalf("second rotated fragment reason = %q, want fragment DLP block", reason)
+	}
+}
+
+func TestCeeRecordMCP_DoesNotJoinSingletonValuesAcrossTools(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+
+	first := ParseMCPFrame(mcpSingletonCEERequest(1, "alpha", "first_tool", "AKI"+"A"))
+	second := ParseMCPFrame(mcpSingletonCEERequest(2, "beta", "second_tool", testMCPAWSKeySuffix))
+	var logBuf bytes.Buffer
+
+	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
+		t.Fatalf("first tool fragment blocked: %s", reason)
+	}
+	if reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil); reason != "" {
+		t.Fatalf("different tool names unexpectedly joined: %s", reason)
+	}
+}
+
 func TestCeeRecordMCP_EntropyUsesFragmentPayloadAndSkipsEmptyPath(t *testing.T) {
 	cee := NewCEEDeps(config.CrossRequestDetection{
 		Enabled: true,
@@ -384,6 +478,10 @@ func testMCPCEEFragmentBlock(t *testing.T) *CEEDeps {
 
 func mcpChunkedCEERequest(id int, chunk string) []byte {
 	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"` + chunk + `","beta":"part ` + strconv.Itoa(id) + `/120"}}}`)
+}
+
+func mcpSingletonCEERequest(id int, argumentName, toolName, chunk string) []byte {
+	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"` + toolName + `","arguments":{"` + argumentName + `":"` + chunk + `"}}}`)
 }
 
 func TestCeeRecordMCP_NilCEE(t *testing.T) {

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -5,6 +5,8 @@ package mcp
 
 import (
 	"bytes"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -177,8 +179,93 @@ func TestCeeSessionKeyMCP_WithAgent(t *testing.T) {
 	}
 }
 
+func TestMCPCEEFragmentPayload(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame MCPFrame
+		want  string
+	}{
+		{
+			name:  "tool arguments emit scalar values without JSON scaffolding",
+			frame: ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"z":["three",true],"a":{"y":"one","x":2}}}}`)),
+			want:  "2onethreetrue",
+		},
+		{
+			name:  "non-tool call falls back to raw frame",
+			frame: ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)),
+			want:  `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		},
+		{
+			name: "malformed arguments fall back to raw frame",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+				Args:   []byte(`{"unterminated"`),
+			},
+			want: "raw-frame",
+		},
+		{
+			name: "arguments without scalar content fall back to raw frame",
+			frame: MCPFrame{
+				Raw:    []byte("raw-frame"),
+				Method: methodToolsCall,
+				Args:   []byte(`{"empty":[]}`),
+			},
+			want: "raw-frame",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(mcpCEEFragmentPayload(tt.frame)); got != tt.want {
+				t.Fatalf("mcpCEEFragmentPayload() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
+	cee := testMCPCEEFragmentBlock(t)
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+
+	first := ParseMCPFrame(mcpChunkedCEERequest(1, "AKI"+"A"))
+	second := ParseMCPFrame(mcpChunkedCEERequest(2, testMCPAWSKeySuffix))
+	var logBuf bytes.Buffer
+
+	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayload(first), cee, sc, &logBuf, nil); reason != "" {
+		t.Fatalf("first fragment blocked: %s", reason)
+	}
+	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayload(second), cee, sc, &logBuf, nil)
+	if !strings.Contains(reason, "cross-request fragment DLP match") {
+		t.Fatalf("second fragment reason = %q, want fragment DLP block", reason)
+	}
+	if !strings.Contains(reason, "cross_request_detection.fragment_reassembly.max_buffer_bytes") {
+		t.Fatalf("fragment block missing live remediation knob: %q", reason)
+	}
+}
+
+func testMCPCEEFragmentBlock(t *testing.T) *CEEDeps {
+	t.Helper()
+	cee := NewCEEDeps(config.CrossRequestDetection{
+		Enabled: true,
+		Action:  config.ActionBlock,
+		FragmentReassembly: config.CrossRequestFragments{
+			Enabled:        true,
+			MaxBufferBytes: 64,
+			WindowMinutes:  testMCPWindowSecs / 60,
+		},
+	}, metrics.New())
+	t.Cleanup(cee.Close)
+	return cee
+}
+
+func mcpChunkedCEERequest(id int, chunk string) []byte {
+	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"` + chunk + `"}}}`)
+}
+
 func TestCeeRecordMCP_NilCEE(t *testing.T) {
-	reason := ceeRecordMCP(testMCPSessionKey, []byte("payload"), nil, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte("payload"), []byte("payload"), nil, nil, &bytes.Buffer{}, nil)
 	if reason != "" {
 		t.Errorf("expected empty reason for nil CEE, got %q", reason)
 	}
@@ -186,13 +273,13 @@ func TestCeeRecordMCP_NilCEE(t *testing.T) {
 
 func TestCeeRecordMCP_EmptyPayload(t *testing.T) {
 	cee := &CEEDeps{}
-	reason := ceeRecordMCP(testMCPSessionKey, []byte{}, cee, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte{}, []byte{}, cee, nil, &bytes.Buffer{}, nil)
 	if reason != "" {
 		t.Errorf("expected empty reason for empty payload, got %q", reason)
 	}
 
 	// Also test nil payload.
-	reason = ceeRecordMCP(testMCPSessionKey, nil, cee, nil, &bytes.Buffer{}, nil)
+	reason = ceeRecordMCP(testMCPSessionKey, nil, nil, cee, nil, &bytes.Buffer{}, nil)
 	if reason != "" {
 		t.Errorf("expected empty reason for nil payload, got %q", reason)
 	}
@@ -228,7 +315,7 @@ func TestCeeRecordMCP_EntropyBudgetBlock(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, sc, &logBuf, logger)
 
 	if reason == "" {
 		t.Fatal("expected non-empty reason for entropy budget block")
@@ -263,7 +350,7 @@ func TestCeeRecordMCP_EntropyBudgetWarn(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, cee, nil, &logBuf, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, nil, &logBuf, nil)
 
 	// Warn mode: should NOT block (empty reason).
 	if reason != "" {
@@ -310,13 +397,13 @@ func TestCeeRecordMCP_FragmentDLPBlock(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment: not enough to trigger.
-	reason := ceeRecordMCP(testMCPSessionKey, []byte(part1), cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte(part1), []byte(part1), cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key, should block.
-	reason = ceeRecordMCP(testMCPSessionKey, []byte(part2), cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP(testMCPSessionKey, []byte(part2), []byte(part2), cee, sc, &logBuf, logger)
 	if reason == "" {
 		t.Fatal("expected non-empty reason for fragment DLP block")
 	}
@@ -356,13 +443,13 @@ func TestCeeRecordMCP_FragmentDLPWarn(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment.
-	reason := ceeRecordMCP("warn-session", []byte(part1), cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP("warn-session", []byte(part1), []byte(part1), cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key. Warn mode should NOT block.
-	reason = ceeRecordMCP("warn-session", []byte(part2), cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP("warn-session", []byte(part2), []byte(part2), cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Errorf("expected empty reason for warn mode, got %q", reason)
 	}
@@ -399,7 +486,7 @@ func TestCeeRecordMCP_EntropyBudgetWarnWithLogger(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, cee, nil, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, nil, &logBuf, logger)
 
 	// Warn mode: should NOT block.
 	if reason != "" {

--- a/internal/mcp/cee_test.go
+++ b/internal/mcp/cee_test.go
@@ -179,21 +179,26 @@ func TestCeeSessionKeyMCP_WithAgent(t *testing.T) {
 	}
 }
 
-func TestMCPCEEFragmentPayload(t *testing.T) {
+func TestMCPCEEFragmentPayloads(t *testing.T) {
 	tests := []struct {
 		name  string
 		frame MCPFrame
-		want  string
+		want  map[string]string
 	}{
 		{
-			name:  "tool arguments emit scalar values without JSON scaffolding",
+			name:  "tool arguments keep sibling values in separate streams",
 			frame: ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"z":["three",true],"a":{"y":"one","x":2}}}}`)),
-			want:  "2onethreetrue",
+			want: map[string]string{
+				"$/a/x": "2",
+				"$/a/y": "one",
+				"$/z/0": "three",
+				"$/z/1": "true",
+			},
 		},
 		{
 			name:  "non-tool call falls back to raw frame",
 			frame: ParseMCPFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)),
-			want:  `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+			want:  map[string]string{"": `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`},
 		},
 		{
 			name: "malformed arguments fall back to raw frame",
@@ -202,7 +207,7 @@ func TestMCPCEEFragmentPayload(t *testing.T) {
 				Method: methodToolsCall,
 				Args:   []byte(`{"unterminated"`),
 			},
-			want: "raw-frame",
+			want: map[string]string{"": "raw-frame"},
 		},
 		{
 			name: "arguments without scalar content fall back to raw frame",
@@ -211,14 +216,20 @@ func TestMCPCEEFragmentPayload(t *testing.T) {
 				Method: methodToolsCall,
 				Args:   []byte(`{"empty":[]}`),
 			},
-			want: "raw-frame",
+			want: map[string]string{"": "raw-frame"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := string(mcpCEEFragmentPayload(tt.frame)); got != tt.want {
-				t.Fatalf("mcpCEEFragmentPayload() = %q, want %q", got, tt.want)
+			got := mcpCEEFragmentPayloads(tt.frame)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mcpCEEFragmentPayloads() = %#v, want %#v", got, tt.want)
+			}
+			for path, want := range tt.want {
+				if value := string(got[path]); value != want {
+					t.Fatalf("mcpCEEFragmentPayloads()[%q] = %q, want %q", path, value, want)
+				}
 			}
 		})
 	}
@@ -233,10 +244,10 @@ func TestCeeRecordMCP_ReassemblesToolArgumentsAcrossCalls(t *testing.T) {
 	second := ParseMCPFrame(mcpChunkedCEERequest(2, testMCPAWSKeySuffix))
 	var logBuf bytes.Buffer
 
-	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayload(first), cee, sc, &logBuf, nil); reason != "" {
+	if reason := ceeRecordMCP(testMCPSessionKey, first.Raw, mcpCEEFragmentPayloads(first), cee, sc, &logBuf, nil); reason != "" {
 		t.Fatalf("first fragment blocked: %s", reason)
 	}
-	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayload(second), cee, sc, &logBuf, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, second.Raw, mcpCEEFragmentPayloads(second), cee, sc, &logBuf, nil)
 	if !strings.Contains(reason, "cross-request fragment DLP match") {
 		t.Fatalf("second fragment reason = %q, want fragment DLP block", reason)
 	}
@@ -261,11 +272,11 @@ func testMCPCEEFragmentBlock(t *testing.T) *CEEDeps {
 }
 
 func mcpChunkedCEERequest(id int, chunk string) []byte {
-	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"` + chunk + `"}}}`)
+	return []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"tools/call","params":{"name":"integrity_checker","arguments":{"alpha":"` + chunk + `","beta":"part ` + strconv.Itoa(id) + `/120"}}}`)
 }
 
 func TestCeeRecordMCP_NilCEE(t *testing.T) {
-	reason := ceeRecordMCP(testMCPSessionKey, []byte("payload"), []byte("payload"), nil, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte("payload"), map[string][]byte{"": []byte("payload")}, nil, nil, &bytes.Buffer{}, nil)
 	if reason != "" {
 		t.Errorf("expected empty reason for nil CEE, got %q", reason)
 	}
@@ -273,7 +284,7 @@ func TestCeeRecordMCP_NilCEE(t *testing.T) {
 
 func TestCeeRecordMCP_EmptyPayload(t *testing.T) {
 	cee := &CEEDeps{}
-	reason := ceeRecordMCP(testMCPSessionKey, []byte{}, []byte{}, cee, nil, &bytes.Buffer{}, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte{}, map[string][]byte{}, cee, nil, &bytes.Buffer{}, nil)
 	if reason != "" {
 		t.Errorf("expected empty reason for empty payload, got %q", reason)
 	}
@@ -315,7 +326,7 @@ func TestCeeRecordMCP_EntropyBudgetBlock(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, sc, &logBuf, logger)
 
 	if reason == "" {
 		t.Fatal("expected non-empty reason for entropy budget block")
@@ -350,7 +361,7 @@ func TestCeeRecordMCP_EntropyBudgetWarn(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, nil, &logBuf, nil)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, nil, &logBuf, nil)
 
 	// Warn mode: should NOT block (empty reason).
 	if reason != "" {
@@ -397,13 +408,13 @@ func TestCeeRecordMCP_FragmentDLPBlock(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment: not enough to trigger.
-	reason := ceeRecordMCP(testMCPSessionKey, []byte(part1), []byte(part1), cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, []byte(part1), map[string][]byte{"": []byte(part1)}, cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key, should block.
-	reason = ceeRecordMCP(testMCPSessionKey, []byte(part2), []byte(part2), cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP(testMCPSessionKey, []byte(part2), map[string][]byte{"": []byte(part2)}, cee, sc, &logBuf, logger)
 	if reason == "" {
 		t.Fatal("expected non-empty reason for fragment DLP block")
 	}
@@ -443,13 +454,13 @@ func TestCeeRecordMCP_FragmentDLPWarn(t *testing.T) {
 	var logBuf bytes.Buffer
 
 	// First fragment.
-	reason := ceeRecordMCP("warn-session", []byte(part1), []byte(part1), cee, sc, &logBuf, logger)
+	reason := ceeRecordMCP("warn-session", []byte(part1), map[string][]byte{"": []byte(part1)}, cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Fatalf("expected no block on first fragment, got %q", reason)
 	}
 
 	// Second fragment: completes the key. Warn mode should NOT block.
-	reason = ceeRecordMCP("warn-session", []byte(part2), []byte(part2), cee, sc, &logBuf, logger)
+	reason = ceeRecordMCP("warn-session", []byte(part2), map[string][]byte{"": []byte(part2)}, cee, sc, &logBuf, logger)
 	if reason != "" {
 		t.Errorf("expected empty reason for warn mode, got %q", reason)
 	}
@@ -486,7 +497,7 @@ func TestCeeRecordMCP_EntropyBudgetWarnWithLogger(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	payload := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz")
-	reason := ceeRecordMCP(testMCPSessionKey, payload, payload, cee, nil, &logBuf, logger)
+	reason := ceeRecordMCP(testMCPSessionKey, payload, map[string][]byte{"": payload}, cee, nil, &logBuf, logger)
 
 	// Warn mode: should NOT block.
 	if reason != "" {

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -859,7 +859,15 @@ func ForwardScannedInput(
 				continue
 			}
 			// Cross-request exfiltration check on clean outbound messages.
-			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeRecordMCPOptions{
+				sessionKey:     ceeStdioKey,
+				entropyPayload: line,
+				frame:          frame,
+				cee:            cee,
+				sc:             sc,
+				logW:           logW,
+				logger:         auditLogger,
+			}); reason != "" {
 				// Capture: record CEE verdict.
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",
@@ -1369,7 +1377,15 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: warning — %s request contains flagged content (%s)\n",
 				lineNum, method, reasonStr)
 			// Cross-request exfiltration check even in warn mode.
-			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeRecordMCPOptions{
+				sessionKey:     ceeStdioKey,
+				entropyPayload: line,
+				frame:          frame,
+				cee:            cee,
+				sc:             sc,
+				logW:           logW,
+				logger:         auditLogger,
+			}); reason != "" {
 				// Capture: record CEE verdict (warn-path).
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -859,7 +859,7 @@ func ForwardScannedInput(
 				continue
 			}
 			// Cross-request exfiltration check on clean outbound messages.
-			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict.
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",
@@ -1369,7 +1369,7 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: warning — %s request contains flagged content (%s)\n",
 				lineNum, method, reasonStr)
 			// Cross-request exfiltration check even in warn mode.
-			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict (warn-path).
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -859,7 +859,7 @@ func ForwardScannedInput(
 				continue
 			}
 			// Cross-request exfiltration check on clean outbound messages.
-			if reason := ceeRecordMCP(ceeStdioKey, line, cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict.
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",
@@ -1369,7 +1369,7 @@ func ForwardScannedInput(
 			_, _ = fmt.Fprintf(logW, "pipelock: input line %d: warning — %s request contains flagged content (%s)\n",
 				lineNum, method, reasonStr)
 			// Cross-request exfiltration check even in warn mode.
-			if reason := ceeRecordMCP(ceeStdioKey, line, cee, sc, logW, auditLogger); reason != "" {
+			if reason := ceeRecordMCP(ceeStdioKey, line, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
 				// Capture: record CEE verdict (warn-path).
 				obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 					Subsurface:        "cee_mcp_stdio",

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -3783,6 +3783,40 @@ func TestForwardScannedInput_CEEBlocksCleanMessage(t *testing.T) {
 	}
 }
 
+func TestForwardScannedInput_CEEReassemblesToolArgumentsAcrossCalls(t *testing.T) {
+	sc := testInputScanner(t)
+	cee := testMCPCEEFragmentBlock(t)
+	first := mcpChunkedCEERequest(1, "AKI"+"A")
+	second := mcpChunkedCEERequest(2, testMCPAWSKeySuffix)
+
+	var serverIn bytes.Buffer
+	var logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 2)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(string(first)+"\n"+string(second)+"\n")),
+		transport.NewStdioWriter(&serverIn),
+		&logBuf, config.ActionBlock, config.ActionBlock, blockedCh,
+		nil, nil, MCPProxyOpts{Scanner: sc, CEE: cee},
+	)
+
+	var blocked []BlockedRequest
+	for request := range blockedCh {
+		blocked = append(blocked, request)
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("blocked requests = %d, want 1; log=%s", len(blocked), logBuf.String())
+	}
+	if blocked[0].ErrorCode != -32005 || !strings.Contains(blocked[0].ErrorMessage, "cross-request fragment DLP match") {
+		t.Fatalf("blocked request = %+v, want cross-request fragment DLP block", blocked[0])
+	}
+	if !strings.Contains(serverIn.String(), `"id":1`) {
+		t.Fatalf("first fragment was not forwarded: %s", serverIn.String())
+	}
+	if strings.Contains(serverIn.String(), `"id":2`) {
+		t.Fatalf("second fragment was forwarded after CEE block: %s", serverIn.String())
+	}
+}
+
 func TestForwardScannedInput_CEEBlocksInWarnMode(t *testing.T) {
 	sc := testInputScanner(t)
 	logger, err := audit.New("json", "stdout", "", false, false)

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -634,7 +634,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check on clean outbound messages.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict.
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",
@@ -1085,7 +1085,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check even in warn mode.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict (warn-path).
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -634,7 +634,15 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check on clean outbound messages.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeRecordMCPOptions{
+			sessionKey:     ceeKey,
+			entropyPayload: msg,
+			frame:          frame,
+			cee:            cee,
+			sc:             sc,
+			logW:           logW,
+			logger:         auditLogger,
+		}); reason != "" {
 			// Capture: record CEE verdict.
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",
@@ -1085,7 +1093,15 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check even in warn mode.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeRecordMCPOptions{
+			sessionKey:     ceeKey,
+			entropyPayload: msg,
+			frame:          frame,
+			cee:            cee,
+			sc:             sc,
+			logW:           logW,
+			logger:         auditLogger,
+		}); reason != "" {
 			// Capture: record CEE verdict (warn-path).
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -634,7 +634,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check on clean outbound messages.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict.
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",
@@ -1085,7 +1085,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		}
 		// Cross-request exfiltration check even in warn mode.
 		ceeKey := ceeSessionKeyMCP("", sessionKey)
-		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayload(frame), cee, sc, logW, auditLogger); reason != "" {
+		if reason := ceeRecordMCP(ceeKey, msg, mcpCEEFragmentPayloads(frame), cee, sc, logW, auditLogger); reason != "" {
 			// Capture: record CEE verdict (warn-path).
 			obs.ObserveCEEVerdict(context.Background(), &capture.CEERecord{
 				Subsurface:        "cee_mcp_http",

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -5574,6 +5574,23 @@ func TestScanHTTPInput_CEEBlocksClean(t *testing.T) {
 	}
 }
 
+func TestScanHTTPInput_CEEReassemblesToolArgumentsAcrossCalls(t *testing.T) {
+	sc := testMCPScanner()
+	t.Cleanup(sc.Close)
+	cee := testMCPCEEFragmentBlock(t)
+
+	if blocked := scanHTTPInput(mcpChunkedCEERequest(1, "AKI"+"A"), io.Discard, "mcp-session", "mcp-session", MCPProxyOpts{Scanner: sc, CEE: cee}); blocked != nil {
+		t.Fatalf("first fragment blocked: %+v", blocked)
+	}
+	blocked := scanHTTPInput(mcpChunkedCEERequest(2, testMCPAWSKeySuffix), io.Discard, "mcp-session", "mcp-session", MCPProxyOpts{Scanner: sc, CEE: cee})
+	if blocked == nil {
+		t.Fatal("second fragment was allowed, want cross-request fragment DLP block")
+	}
+	if blocked.ErrorCode != -32005 || !strings.Contains(blocked.ErrorMessage, "cross-request fragment DLP match") {
+		t.Fatalf("blocked request = %+v, want cross-request fragment DLP block", blocked)
+	}
+}
+
 func TestScanHTTPInput_CEEBlocksWarnMode(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil


### PR DESCRIPTION
Cross-request detection now reassembles MCP tool-call arguments per argument path, so a payload split across several calls is evaluated as one stream instead of being broken up by the surrounding JSON envelope and sibling argument values. Applies to both stdio and HTTP MCP input.

Calls carrying a single populated argument also feed a tool-scoped stream, so an argument name that changes between calls no longer defeats reassembly.

The docs now state the bound on this control. Fragment reassembly recognizes a known pattern that arrives split across requests inside the configured byte and time window, and it does not guarantee prevention of arbitrary multi-request transfer. `entropy_budget.action: block` is the throughput ceiling an operator can enforce instead, and the configuration section states what that costs in false positives so the choice is deliberate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of sensitive content split across MCP tool arguments and requests.
  - Added independent monitoring of argument fragments, including nested and multi-value inputs.
  - Added clearer warnings when fragment buffering or detection limits are reached.

- **Bug Fixes**
  - Sensitive fragments are now reassembled and blocked when combined content matches detection rules, while earlier fragments continue normally.

- **Documentation**
  - Clarified detection limitations, throughput settings, buffering behavior, data aging, and false-positive tradeoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->