### PR TITLE
fix(mcp): preserve request controls without listener state

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -954,7 +954,7 @@ func ForwardScannedInput(
 			// Track request ID immediately before forwarding so response-side
 			// can validate without leaving stale state when a required
 			// receipt fails before the request is written.
-			if opts.requireReceipts() && actionID != "" {
+			if isRequest(fwdLine) && opts.requireReceipts() && actionID != "" {
 				outcomeReceipt := opts.withReceiptPolicyHash(receipt.EmitOpts{
 					ActionID:            actionID,
 					Verdict:             config.ActionAllow,
@@ -975,7 +975,7 @@ func ForwardScannedInput(
 				})
 				outcomeReceipt = mcpWithContractReceipt(outcomeReceipt, contractGate)
 				tracker.TrackOutcome(verdict.ID, TrackedRequestOutcome{Receipt: outcomeReceipt})
-			} else {
+			} else if isRequest(fwdLine) {
 				tracker.Track(verdict.ID)
 			}
 			if err := forwardMessage(fwdLine); err != nil {
@@ -1310,7 +1310,9 @@ func ForwardScannedInput(
 					}
 					switch res.FinalDecision {
 					case config.ActionAllow:
-						tracker.Track(heldID)
+						if isRequest(heldLine) {
+							tracker.Track(heldID)
+						}
 						if err := forwardMessage(heldLine); err != nil {
 							_, _ = fmt.Fprintf(logW, "pipelock: input forward error: %v\n", err)
 							return
@@ -1473,7 +1475,9 @@ func ForwardScannedInput(
 			}
 			receiptEmitted = true
 			// Forward anyway (warn mode).
-			tracker.Track(verdict.ID)
+			if isRequest(fwdLine) {
+				tracker.Track(verdict.ID)
+			}
 			if err := forwardMessage(fwdLine); err != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: input forward error: %v\n", err)
 				return

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -954,7 +954,7 @@ func ForwardScannedInput(
 			// Track request ID immediately before forwarding so response-side
 			// can validate without leaving stale state when a required
 			// receipt fails before the request is written.
-			if isRequest(fwdLine) && opts.requireReceipts() && actionID != "" {
+			if isTrackableRequest(fwdLine, verdict.ID) && opts.requireReceipts() && actionID != "" {
 				outcomeReceipt := opts.withReceiptPolicyHash(receipt.EmitOpts{
 					ActionID:            actionID,
 					Verdict:             config.ActionAllow,
@@ -975,7 +975,7 @@ func ForwardScannedInput(
 				})
 				outcomeReceipt = mcpWithContractReceipt(outcomeReceipt, contractGate)
 				tracker.TrackOutcome(verdict.ID, TrackedRequestOutcome{Receipt: outcomeReceipt})
-			} else if isRequest(fwdLine) {
+			} else if isTrackableRequest(fwdLine, verdict.ID) {
 				tracker.Track(verdict.ID)
 			}
 			if err := forwardMessage(fwdLine); err != nil {
@@ -1310,7 +1310,7 @@ func ForwardScannedInput(
 					}
 					switch res.FinalDecision {
 					case config.ActionAllow:
-						if isRequest(heldLine) {
+						if isTrackableRequest(heldLine, heldID) {
 							tracker.Track(heldID)
 						}
 						if err := forwardMessage(heldLine); err != nil {
@@ -1475,7 +1475,7 @@ func ForwardScannedInput(
 			}
 			receiptEmitted = true
 			// Forward anyway (warn mode).
-			if isRequest(fwdLine) {
+			if isTrackableRequest(fwdLine, verdict.ID) {
 				tracker.Track(verdict.ID)
 			}
 			if err := forwardMessage(fwdLine); err != nil {
@@ -1595,6 +1595,10 @@ func unescapeJSONUnicode(s string) string {
 // for null is non-nil with len=4, so len(id)==0 alone is insufficient.
 func isRPCNotification(id json.RawMessage) bool {
 	return len(id) == 0 || string(id) == jsonrpc.Null
+}
+
+func isTrackableRequest(msg []byte, id json.RawMessage) bool {
+	return isRequest(msg) && !isRPCNotification(id)
 }
 
 // joinStrings joins strings with newline separator, matching jsonrpc.ExtractText pattern.

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -958,6 +958,27 @@ func TestForwardScannedInput_ClientResponseDoesNotAuthorizeServerResponse(t *tes
 	}
 }
 
+func TestIsTrackableRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		id   json.RawMessage
+		want bool
+	}{
+		{name: "request", msg: `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, id: json.RawMessage(`1`), want: true},
+		{name: "notification", msg: `{"jsonrpc":"2.0","method":"notifications/initialized"}`, id: nil, want: false},
+		{name: "null ID notification", msg: `{"jsonrpc":"2.0","id":null,"method":"notifications/progress"}`, id: json.RawMessage(`null`), want: false},
+		{name: "client response", msg: `{"jsonrpc":"2.0","id":2,"result":{}}`, id: json.RawMessage(`2`), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTrackableRequest([]byte(tt.msg), tt.id); got != tt.want {
+				t.Fatalf("isTrackableRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestForwardScannedInput_BlockedRequestSendsID(t *testing.T) {
 	sc := testInputScanner(t)
 	dirty := makeRequest(42, "tools/call", map[string]string{

--- a/internal/mcp/input_test.go
+++ b/internal/mcp/input_test.go
@@ -913,6 +913,51 @@ func TestForwardScannedInput_CleanRequestsForwarded(t *testing.T) {
 	}
 }
 
+func TestForwardScannedInput_ClientResponseDoesNotAuthorizeServerResponse(t *testing.T) {
+	sc := testInputScanner(t)
+	tracker := NewRequestTracker()
+	tracker.Track(json.RawMessage(`1`))
+	clientResponse := `{"jsonrpc":"2.0","id":89,"result":{"content":[{"type":"text","text":"client reply"}]}}` + "\n"
+
+	var serverIn bytes.Buffer
+	var inputLog bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 1)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(clientResponse)),
+		transport.NewStdioWriter(&serverIn),
+		&inputLog,
+		config.ActionBlock,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		tracker,
+		testOpts(sc),
+	)
+	if !strings.Contains(serverIn.String(), `"id":89`) {
+		t.Fatalf("client response was not forwarded: %q", serverIn.String())
+	}
+
+	unsolicited := `{"jsonrpc":"2.0","id":89,"result":{"content":[{"type":"text","text":"unsolicited"}]}}` + "\n"
+	var clientOut bytes.Buffer
+	var responseLog bytes.Buffer
+	_, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(unsolicited)),
+		transport.NewStdioWriter(&clientOut),
+		&responseLog,
+		tracker,
+		testOpts(sc),
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if !strings.Contains(responseLog.String(), "confused deputy") || !strings.Contains(clientOut.String(), "unsolicited response ID") {
+		t.Fatalf("missing confused-deputy refusal: log=%q output=%q", responseLog.String(), clientOut.String())
+	}
+	if strings.Contains(clientOut.String(), `"text":"unsolicited"`) {
+		t.Fatalf("unsolicited server response reached client: %q", clientOut.String())
+	}
+}
+
 func TestForwardScannedInput_BlockedRequestSendsID(t *testing.T) {
 	sc := testInputScanner(t)
 	dirty := makeRequest(42, "tools/call", map[string]string{

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -1827,8 +1827,10 @@ func listenerRequiresStateToken(opts MCPProxyOpts) bool {
 // listenerStatelessRequestOpts strips every control whose decision depends on
 // a retained client state partition. It is used only while a listener request
 // lacks a valid Pipelock-issued token. Stateless scanner, tool-poison, A2A,
-// policy, redaction, contract, and receipt checks remain active. Tool drift
-// uses the listener's upstream-owned baseline, never a client baseline.
+// policy, redaction, contract, receipt, and subject-keyed denial-of-wallet
+// checks remain active. Tool drift uses the listener's upstream-owned baseline,
+// never a client baseline. DoW derives identity from the authenticated principal
+// or transport peer, so it does not depend on this client state partition.
 func listenerStatelessRequestOpts(opts MCPProxyOpts) MCPProxyOpts {
 	if toolCfg := opts.toolCfg(); toolCfg != nil {
 		// Preserve response-only tool-poison matching and the explicit
@@ -1857,9 +1859,6 @@ func listenerStatelessRequestOpts(opts MCPProxyOpts) MCPProxyOpts {
 	opts.CEEFn = nil
 	opts.ToolFreezer = nil
 	opts.FrozenToolStableKey = ""
-	opts.DoWCheck = nil
-	opts.DoWEnabledFn = nil
-	opts.DoWEnforceSubjectTrust = false
 	return opts
 }
 

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -6735,6 +6735,58 @@ func TestHTTPListener_DoWBillsSessionlessRequestAtDefaultMinimumTrust(t *testing
 	}
 }
 
+func TestHTTPListener_DoWRemainsEnforcedWhenStateTokenIsOmitted(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "server-session-"+string(request.ID))
+		}
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"ok"}]}}`, request.ID)
+	}))
+	defer upstream.Close()
+
+	var budgetCalls atomic.Int32
+	baseURL, _ := startListenerProxyWithOpts(t, upstream.URL, MCPProxyOpts{
+		Scanner:                testScannerForHTTP(t),
+		ToolCfg:                &tools.ToolScanConfig{Action: config.ActionBlock},
+		DoWEnforceSubjectTrust: true,
+		DoWCheck: func(_, _, _ string) (bool, string, string, string) {
+			if budgetCalls.Add(1) > 1 {
+				return false, config.ActionBlock, "subject budget exceeded", "test_budget"
+			}
+			return true, config.ActionBlock, "", ""
+		},
+	})
+
+	// Establish two independent listener sessions, then deliberately omit both
+	// Pipelock-issued tokens. A client-controlled upstream session ID must not
+	// buy a fresh DoW subject bucket or disable the budget check.
+	_ = initializeHTTPListenerSession(t, baseURL, 101)
+	_ = initializeHTTPListenerSession(t, baseURL, 202)
+	first := postHTTPListenerToolCall(t, baseURL, "server-session-101", http.StatusOK)
+	if strings.Contains(first, "subject budget exceeded") {
+		t.Fatalf("first tokenless call unexpectedly blocked: %s", first)
+	}
+	second := postHTTPListenerToolCall(t, baseURL, "server-session-202", http.StatusOK)
+	if !strings.Contains(second, "subject budget exceeded") {
+		t.Fatalf("second tokenless call bypassed same-subject budget: %s", second)
+	}
+	if got := upstreamHits.Load(); got != 3 {
+		// Two initialize requests and only the first tools/call reach upstream.
+		t.Fatalf("upstream hits = %d, want 3", got)
+	}
+}
+
 func TestHTTPListener_DoWUsesStableSubjectAcrossServerIssuedSessions(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request struct {

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -6748,42 +6748,41 @@ func TestHTTPListener_DoWRemainsEnforcedWhenStateTokenIsOmitted(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		if request.Method == "initialize" {
-			w.Header().Set("Mcp-Session-Id", "server-session-"+string(request.ID))
-		}
 		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"ok"}]}}`, request.ID)
 	}))
 	defer upstream.Close()
 
-	var budgetCalls atomic.Int32
+	var budgetMu sync.Mutex
+	budgetBySubject := make(map[string]int)
 	baseURL, _ := startListenerProxyWithOpts(t, upstream.URL, MCPProxyOpts{
 		Scanner:                testScannerForHTTP(t),
 		ToolCfg:                &tools.ToolScanConfig{Action: config.ActionBlock},
 		DoWEnforceSubjectTrust: true,
-		DoWCheck: func(_, _, _ string) (bool, string, string, string) {
-			if budgetCalls.Add(1) > 1 {
+		DoWCheck: func(subject, _, _ string) (bool, string, string, string) {
+			budgetMu.Lock()
+			defer budgetMu.Unlock()
+			budgetBySubject[subject]++
+			if budgetBySubject[subject] > 1 {
 				return false, config.ActionBlock, "subject budget exceeded", "test_budget"
 			}
 			return true, config.ActionBlock, "", ""
 		},
 	})
 
-	// Establish two independent listener sessions, then deliberately omit both
-	// Pipelock-issued tokens. A client-controlled upstream session ID must not
-	// buy a fresh DoW subject bucket or disable the budget check.
-	_ = initializeHTTPListenerSession(t, baseURL, 101)
-	_ = initializeHTTPListenerSession(t, baseURL, 202)
-	first := postHTTPListenerToolCall(t, baseURL, "server-session-101", http.StatusOK)
+	// Current MCP clients can send tool calls without the removed initialize
+	// handshake. Omitting both listener and upstream session tokens must not
+	// disable the subject budget or buy a fresh bucket.
+	first := postHTTPListenerToolCall(t, baseURL, "")
 	if strings.Contains(first, "subject budget exceeded") {
 		t.Fatalf("first tokenless call unexpectedly blocked: %s", first)
 	}
-	second := postHTTPListenerToolCall(t, baseURL, "server-session-202", http.StatusOK)
+	second := postHTTPListenerToolCall(t, baseURL, "")
 	if !strings.Contains(second, "subject budget exceeded") {
 		t.Fatalf("second tokenless call bypassed same-subject budget: %s", second)
 	}
-	if got := upstreamHits.Load(); got != 3 {
-		// Two initialize requests and only the first tools/call reach upstream.
-		t.Fatalf("upstream hits = %d, want 3", got)
+	if got := upstreamHits.Load(); got != 1 {
+		// Only the first tools/call reaches upstream.
+		t.Fatalf("upstream hits = %d, want 1", got)
 	}
 }
 
@@ -6836,10 +6835,10 @@ func TestHTTPListener_DoWUsesStableSubjectAcrossServerIssuedSessions(t *testing.
 
 	sessionA := initializeHTTPListenerSession(t, baseURL, 101)
 	sessionB := initializeHTTPListenerSession(t, baseURL, 202)
-	if body := postHTTPListenerToolCall(t, baseURL, sessionA, http.StatusOK); strings.Contains(body, "subject budget exceeded") {
+	if body := postHTTPListenerToolCall(t, baseURL, sessionA); strings.Contains(body, "subject budget exceeded") {
 		t.Fatalf("first session-a call body = %s, want allowed", body)
 	}
-	body := postHTTPListenerToolCall(t, baseURL, sessionB, http.StatusOK)
+	body := postHTTPListenerToolCall(t, baseURL, sessionB)
 	if !strings.Contains(body, "subject budget exceeded") {
 		t.Fatalf("new server session body = %s, want same-subject budget block", body)
 	}
@@ -6894,10 +6893,10 @@ func TestHTTPListener_DoWCollapsesSelfDeclaredAgentRenameToSameSubject(t *testin
 
 	sessionA := initializeHTTPListenerSession(t, baseURL, 303)
 	sessionB := initializeHTTPListenerSession(t, baseURL, 404)
-	if body := postHTTPListenerToolCallWithAgent(t, baseURL, sessionA, "attacker-alpha", http.StatusOK); strings.Contains(body, "subject budget exceeded") {
+	if body := postHTTPListenerToolCallWithAgent(t, baseURL, sessionA, "attacker-alpha"); strings.Contains(body, "subject budget exceeded") {
 		t.Fatalf("first self-declared agent call body = %s, want allowed", body)
 	}
-	body := postHTTPListenerToolCallWithAgent(t, baseURL, sessionB, "attacker-beta", http.StatusOK)
+	body := postHTTPListenerToolCallWithAgent(t, baseURL, sessionB, "attacker-beta")
 	if !strings.Contains(body, "subject budget exceeded") {
 		t.Fatalf("renamed self-declared agent body = %s, want same-subject budget block", body)
 	}
@@ -6989,9 +6988,9 @@ func initializeHTTPListenerSession(t *testing.T, baseURL string, id int) string 
 	return sessionID
 }
 
-func postHTTPListenerToolCall(t *testing.T, baseURL, sessionID string, wantStatus int) string {
+func postHTTPListenerToolCall(t *testing.T, baseURL, sessionID string) string {
 	t.Helper()
-	return postHTTPListenerToolCallWithAgent(t, baseURL, sessionID, "", wantStatus)
+	return postHTTPListenerToolCallWithAgent(t, baseURL, sessionID, "")
 }
 
 func postHTTPListenerToolCallWithForwardedHeaders(t *testing.T, baseURL, sessionID, forwardedFor string) {
@@ -7015,7 +7014,7 @@ func postHTTPListenerToolCallWithForwardedHeaders(t *testing.T, baseURL, session
 	}
 }
 
-func postHTTPListenerToolCallWithAgent(t *testing.T, baseURL, sessionID, agent string, wantStatus int) string {
+func postHTTPListenerToolCallWithAgent(t *testing.T, baseURL, sessionID, agent string) string {
 	t.Helper()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/", strings.NewReader(jsonToolsCallEcho))
 	if err != nil {
@@ -7034,8 +7033,8 @@ func postHTTPListenerToolCallWithAgent(t *testing.T, baseURL, sessionID, agent s
 	}
 	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != wantStatus {
-		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, wantStatus, body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, http.StatusOK, body)
 	}
 	return string(body)
 }


### PR DESCRIPTION
Tokenless listener requests retain subject-based denial-of-wallet checks while controls that depend on retained client state remain disabled. Stdio response correlation now records IDs only for actual client requests across clean, deferred, and warn forwarding paths.

This keeps request budgets and response correlation tied to their proper trust boundaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request tracking so notifications are handled correctly without expecting responses.
  * Prevented unsolicited server responses from being forwarded when they are not authorized by a matching request.
  * Restored denial-of-wallet protection for stateless connections, including requests that omit state tokens.
  * Preserved subject-trust and security-policy enforcement across stateless request handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->