### PR TITLE
feat(config): warn when a sub-detector action is weaker than its section

### DIFF
--- a/internal/cli/diag/config_scopes.go
+++ b/internal/cli/diag/config_scopes.go
@@ -23,4 +23,5 @@ const (
 	ConfigScopeRequestBodyIgnoreHeaders   = "request_body_scanning.ignore_headers"
 	ConfigScopeBodyEntropyExclusions      = "request_body_scanning.content_entropy_exclusions"
 	ConfigScopeWSEntropyExclusions        = "websocket_proxy.content_entropy_exclusions"
+	ConfigScopeActionDivergence           = "action_divergence"
 )

--- a/internal/cli/diag/doctor_action_divergence_test.go
+++ b/internal/cli/diag/doctor_action_divergence_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// divergentConfig returns a valid config whose cross-request entropy budget is
+// weaker than its enclosing section, which is the shape configs/strict.yaml
+// ships.
+func divergentConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.ApplyDefaults()
+	cfg.CrossRequestDetection.Enabled = true
+	cfg.CrossRequestDetection.Action = config.ActionBlock
+	cfg.CrossRequestDetection.EntropyBudget.Enabled = true
+	cfg.CrossRequestDetection.EntropyBudget.BitsPerWindow = 4096
+	cfg.CrossRequestDetection.EntropyBudget.WindowMinutes = 5
+	cfg.CrossRequestDetection.EntropyBudget.Action = config.ActionWarn
+	return cfg
+}
+
+// TestAnalyzeConfigSemantics_ReportsActionDivergence locks the WIRING, not the
+// analysis. The analyzer was once correct and simultaneously unreachable from
+// the doctor and check commands, because those surfaces build advisories from
+// checkDoctorConfigSemantics rather than from ValidateWithWarnings. Every unit
+// test of the analyzer passed while operators running `pipelock check` saw
+// nothing. This test fails if that wiring is ever removed again.
+func TestAnalyzeConfigSemantics_ReportsActionDivergence(t *testing.T) {
+	findings := AnalyzeConfigSemantics(divergentConfig())
+
+	var found *ConfigSemanticFinding
+	for i := range findings {
+		if findings[i].Scope == ConfigScopeActionDivergence {
+			found = &findings[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no action-divergence finding reached the doctor surface: %+v", findings)
+	}
+	if found.Subject != "cross_request_detection.entropy_budget.action" {
+		t.Errorf("subject should name the field to edit, got %q", found.Subject)
+	}
+	// The detail must name the enclosing section too, or the operator knows
+	// something is weak but not what it is weaker than.
+	if !strings.Contains(found.Detail, "cross_request_detection.action") {
+		t.Errorf("detail does not name the parent section: %s", found.Detail)
+	}
+	if found.Next == "" {
+		t.Error("finding must carry a remediation")
+	}
+}
+
+// TestCheckConfigAdvisories_IncludesActionDivergence covers the second
+// consumer. check builds its own advisory list, so reaching doctor does not
+// prove reaching check.
+func TestCheckConfigAdvisories_IncludesActionDivergence(t *testing.T) {
+	advisories := checkConfigAdvisories(divergentConfig())
+
+	for _, a := range advisories {
+		if strings.Contains(a, "cross_request_detection.action") && strings.Contains(a, "weaker") {
+			return
+		}
+	}
+	t.Fatalf("pipelock check did not surface the divergence advisory: %+v", advisories)
+}
+
+// TestAnalyzeConfigSemantics_ConsistentActionsAreSilent is the false-positive
+// guard. An advisory that fires on a correctly-configured deployment trains
+// operators to ignore doctor output, which on a security product costs more
+// than the silence it replaced.
+func TestAnalyzeConfigSemantics_ConsistentActionsAreSilent(t *testing.T) {
+	cfg := divergentConfig()
+	cfg.CrossRequestDetection.EntropyBudget.Action = config.ActionBlock
+
+	for _, f := range AnalyzeConfigSemantics(cfg) {
+		if f.Scope == ConfigScopeActionDivergence {
+			t.Fatalf("advisory fired on a consistent config: %+v", f)
+		}
+	}
+}

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -97,6 +97,29 @@ func AnalyzeConfigSemantics(cfg *config.Config) []ConfigSemanticFinding {
 	var findings []ConfigSemanticFinding
 	findings = append(findings, analyzeDoctorSuppressEntries(cfg)...)
 	findings = append(findings, analyzeDoctorInertExemptions(cfg)...)
+	findings = append(findings, analyzeDoctorActionDivergence(cfg)...)
+	return findings
+}
+
+// analyzeDoctorActionDivergence surfaces sub-detectors whose action is weaker
+// than the section enclosing them, so an operator who configured a section to
+// block learns which findings inside it only warn.
+//
+// The analysis itself lives in internal/config and is shared with the startup
+// and reload warning paths, so doctor cannot disagree with what the server
+// printed at boot. This is the reporting adapter only; adding a new
+// sub-detector happens in exactly one place, the config membership table.
+func analyzeDoctorActionDivergence(cfg *config.Config) []ConfigSemanticFinding {
+	var findings []ConfigSemanticFinding
+	for _, w := range cfg.ActionDivergenceWarnings() {
+		findings = append(findings, newConfigSemanticFinding(
+			ConfigSemanticKindAdvisory,
+			ConfigScopeActionDivergence,
+			w.Field,
+			w.Message,
+			"raise the sub-detector action to match its section to enforce, or leave it and treat those findings as advisory",
+		))
+	}
 	return findings
 }
 

--- a/internal/cli/diag/doctor_config_semantics_test.go
+++ b/internal/cli/diag/doctor_config_semantics_test.go
@@ -145,6 +145,12 @@ func TestDoctorConfigSemantics(t *testing.T) {
 			mutate: func(cfg *config.Config) {
 				cfg.RequestBodyScanning.Enabled = true
 				cfg.RequestBodyScanning.Action = config.ActionBlock
+				// Keep the section internally consistent so this case counts
+				// only suppress findings. Leaving content entropy at its warn
+				// default under a blocking section is a real divergence and
+				// correctly raises its own advisory, which is not what this
+				// case is about.
+				cfg.RequestBodyScanning.ContentEntropyAction = config.ActionBlock
 				cfg.Suppress = []config.SuppressEntry{
 					{Rule: testDLPPatternName, Path: "*" + testExemptHost + "*", Reason: "known FP"},
 				}
@@ -266,6 +272,12 @@ func TestDoctorConfigSemantics(t *testing.T) {
 			mutate: func(cfg *config.Config) {
 				cfg.RequestBodyScanning.Enabled = true
 				cfg.RequestBodyScanning.Action = config.ActionBlock
+				// Keep the section internally consistent so this case counts
+				// only suppress findings. Leaving content entropy at its warn
+				// default under a blocking section is a real divergence and
+				// correctly raises its own advisory, which is not what this
+				// case is about.
+				cfg.RequestBodyScanning.ContentEntropyAction = config.ActionBlock
 				cfg.Suppress = []config.SuppressEntry{
 					// lowercased name must still match the active DLP pattern.
 					{Rule: strings.ToLower(testDLPPatternName), Path: "*" + testExemptHost + "*"},

--- a/internal/config/action_divergence.go
+++ b/internal/config/action_divergence.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "fmt"
+
+// Action divergence: a sub-detector whose action is weaker than the action of
+// the section that encloses it.
+//
+// An operator who sets a section to `block` reasonably believes that section
+// enforces. When an independently-enabled sub-detector inside it carries its
+// own weaker action, findings from that sub-detector are only warned about,
+// and nothing anywhere says so. The config reads as enforcement the operator
+// does not have.
+//
+// This analyzer is ADVISORY ONLY. It changes no enforcement decision. Two
+// deliberate non-goals, both of which would be worse than the silence:
+//
+//   - It does NOT make the child inherit the parent. That would silently
+//     strengthen enforcement for every existing deployment on upgrade, turning
+//     a documentation defect into an availability incident.
+//   - It does NOT reject the config. A weaker child is frequently the correct
+//     operational choice; entropy-based detectors in particular produce
+//     findings on ordinary developer traffic (a 1.3 KB base64 image exceeds a
+//     4096-bit budget on its first legitimate call), so blocking on them by
+//     default gets the whole control switched off.
+//
+// MEMBERSHIP RULE (this is the part that has to survive new code):
+//
+// A pair is reported only when the child is an unkeyed, independently enabled
+// sub-detector whose terminal action is consumed INSTEAD OF its enclosing
+// section's action for the same traffic decision.
+//
+// Membership is therefore a property of how the action is CONSUMED at runtime,
+// not of how the config struct is shaped. Struct nesting is the wrong test in
+// both directions: `request_body_scanning.content_entropy_action` is a
+// flattened sibling field and IS a member, while several genuinely nested
+// action fields are NOT. The excluded classes:
+//
+//   - Selector overrides — `mcp_tool_policy.rules[].action`,
+//     `request_body_scanning.pattern_actions`,
+//     `tool_chain_detection.custom_patterns[].action`. Making a targeted
+//     exception is the entire purpose of these knobs, so reporting them would
+//     be noise, and an advisory an operator learns to ignore is worth nothing.
+//   - Fallback/aggregate actions — a rule action that falls back to the parent
+//     when omitted, or matching rules combined by strictest result. Nothing is
+//     lost, so there is nothing to report.
+//   - Distinct-condition actions — `address_protection.unknown_action`,
+//     `mcp_session_binding.no_baseline_action`, parse-error actions. These
+//     govern a different condition, not a weaker version of the same one.
+//   - Inert fields — `dlp.patterns[].action` is reserved and rejected by
+//     validation, so it is never silently weaker; it never applies at all.
+//
+// Not covered here, and deliberately so: `response_scanning.mcp_servers[].trust`
+// resolves to an action only at runtime, so a `block` response action coexists
+// with a `reasoning` server that warns. That is the same operator surprise
+// reached through a different mechanism and needs its own analysis rather than
+// being forced into this table.
+type actionDivergence struct {
+	// parentField and childField are the operator-facing YAML paths, so the
+	// warning names what to actually go and edit.
+	parentField string
+	childField  string
+	// trigger describes, in operator terms, which findings resolve to the
+	// weaker action. Without this the warning says something is weaker but
+	// not what it costs.
+	trigger string
+	// enabled reports whether both the enclosing section and the sub-detector
+	// are active. A disabled sub-detector decides nothing, so a weaker action
+	// on it is not a divergence and must not be reported.
+	enabled func(c *Config) bool
+	parent  func(c *Config) string
+	child   func(c *Config) string
+}
+
+// independentSubDetectors is the declared membership table. Each entry is a
+// case where the child action is consumed instead of the parent's.
+//
+// Adding an entry is a claim about runtime behavior. Verify it by finding the
+// consumer that reads the child action and confirming the parent's does not
+// also apply to that finding, then add a test that fails when the consumer is
+// switched to read the parent instead.
+var independentSubDetectors = []actionDivergence{
+	{
+		// internal/mcp/cee.go reads EntropyBudget.Action for a budget
+		// crossing; CrossRequestDetection.Action governs fragment DLP
+		// matches only.
+		parentField: "cross_request_detection.action",
+		childField:  "cross_request_detection.entropy_budget.action",
+		trigger:     "per-session entropy budget crossings",
+		enabled: func(c *Config) bool {
+			return c.CrossRequestDetection.Enabled && c.CrossRequestDetection.EntropyBudget.Enabled
+		},
+		parent: func(c *Config) string { return c.CrossRequestDetection.Action },
+		child:  func(c *Config) string { return c.CrossRequestDetection.EntropyBudget.Action },
+	},
+	{
+		// internal/proxy/intercept.go and forward.go read
+		// SSEStreaming.Action for inline event-stream findings.
+		parentField: "response_scanning.action",
+		childField:  "response_scanning.sse_streaming.action",
+		trigger:     "inline text/event-stream scanning findings",
+		enabled: func(c *Config) bool {
+			return c.ResponseScanning.Enabled && c.ResponseScanning.SSEStreaming.Enabled
+		},
+		parent: func(c *Config) string { return c.ResponseScanning.Action },
+		child:  func(c *Config) string { return c.ResponseScanning.SSEStreaming.Action },
+	},
+	{
+		// internal/proxy/bodyscan.go accumulates from an empty action and
+		// contributes ContentEntropyAction for an entropy finding, so when
+		// entropy is the only finding the parent action never applies.
+		parentField: "request_body_scanning.action",
+		childField:  "request_body_scanning.content_entropy_action",
+		trigger:     "opaque high-entropy request body and frame findings",
+		enabled: func(c *Config) bool {
+			return c.RequestBodyScanning.Enabled && c.RequestBodyScanning.ContentEntropyEnabled
+		},
+		parent: func(c *Config) string { return c.RequestBodyScanning.Action },
+		child:  func(c *Config) string { return c.RequestBodyScanning.ContentEntropyAction },
+	},
+}
+
+// ActionDivergenceWarnings returns one advisory warning per enabled
+// sub-detector whose action is weaker than its enclosing section's.
+//
+// This is the single analyzer behind every surface that reports divergence:
+// startup and reload reach it through ValidateWithWarnings, and the doctor and
+// check commands consume it directly. Keeping one implementation is the point
+// — an operator who fixes what startup reported must not still see it in
+// doctor, and a second copy of this logic would drift the moment a new
+// sub-detector is added to only one of them.
+//
+// It never returns an error and never mutates the config.
+func (c *Config) ActionDivergenceWarnings() []Warning {
+	var warnings []Warning
+	for _, d := range independentSubDetectors {
+		if !d.enabled(c) {
+			continue
+		}
+		parent, child := d.parent(c), d.child(c)
+		if !actionWeakerThan(child, parent) {
+			continue
+		}
+		warnings = append(warnings, Warning{
+			Field: d.childField,
+			Message: fmt.Sprintf(
+				"action %q is weaker than %s %q, so %s resolve to %q; "+
+					"set it to %q to enforce, or leave it and treat %s as advisory",
+				child, d.parentField, parent, d.trigger, child, parent, d.trigger),
+		})
+	}
+	return warnings
+}
+
+// validateActionDivergence accumulates the advisory into the validation
+// warning path consumed by startup and accepted reloads.
+func (c *Config) validateActionDivergence(warnings *[]Warning) {
+	*warnings = append(*warnings, c.ActionDivergenceWarnings()...)
+}
+
+// actionWeakerThan reports whether a is strictly weaker than b.
+//
+// It reuses reloadActionStrength, the same total ordering the reload-downgrade
+// warnings use, so a parent/child comparison and an old/new comparison can
+// never disagree about which of two actions is stronger. Unrecognized or empty
+// actions return not-ok there, and this reports false for them: an action this
+// package cannot rank is not evidence of weakening, and a false alarm on a
+// value we simply do not understand is the failure that gets the advisory
+// ignored. Note that actionRank in action.go is a DIFFERENT, coarser ordering
+// that ranks only block and warn; it is not usable here.
+func actionWeakerThan(a, b string) bool {
+	aStrength, aOK := reloadActionStrength(a)
+	bStrength, bOK := reloadActionStrength(b)
+	return aOK && bOK && aStrength < bStrength
+}

--- a/internal/config/action_divergence_test.go
+++ b/internal/config/action_divergence_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// enableAllSubDetectors turns on every section and sub-detector in the
+// membership table so each case below controls only the actions it is testing.
+// The tuning values are set alongside the enable flags so the result is a
+// config that passes full validation, not just one that reaches the analyzer.
+func enableAllSubDetectors(c *Config) {
+	c.CrossRequestDetection.Enabled = true
+	c.CrossRequestDetection.EntropyBudget.Enabled = true
+	c.CrossRequestDetection.EntropyBudget.BitsPerWindow = 4096
+	c.CrossRequestDetection.EntropyBudget.WindowMinutes = 5
+	c.ResponseScanning.Enabled = true
+	c.ResponseScanning.SSEStreaming.Enabled = true
+	c.ResponseScanning.SSEStreaming.MaxEventBytes = 64 * 1024
+	c.RequestBodyScanning.Enabled = true
+	c.RequestBodyScanning.ContentEntropyEnabled = true
+	c.RequestBodyScanning.ContentEntropyThreshold = 4.5
+	c.RequestBodyScanning.ContentEntropyMinLength = 64
+}
+
+// setAllActions sets every parent/child pair in the table to the same values,
+// so a case that expects "no findings" is asserting it across all three
+// members rather than accidentally passing because only one was configured.
+func setAllActions(c *Config, parent, child string) {
+	c.CrossRequestDetection.Action = parent
+	c.CrossRequestDetection.EntropyBudget.Action = child
+	c.ResponseScanning.Action = parent
+	c.ResponseScanning.SSEStreaming.Action = child
+	c.RequestBodyScanning.Action = parent
+	c.RequestBodyScanning.ContentEntropyAction = child
+}
+
+func TestValidateActionDivergence(t *testing.T) {
+	tests := []struct {
+		name         string
+		parent       string
+		child        string
+		wantFindings int
+	}{
+		{name: "weaker child warns", parent: ActionBlock, child: ActionWarn, wantFindings: len(independentSubDetectors)},
+		{name: "equal actions are silent", parent: ActionBlock, child: ActionBlock, wantFindings: 0},
+		{name: "stronger child is silent", parent: ActionWarn, child: ActionBlock, wantFindings: 0},
+		{name: "both warn is silent", parent: ActionWarn, child: ActionWarn, wantFindings: 0},
+		// A weaker child under an already-weak parent still diverges: an
+		// operator reading `warn` does not expect `allow`.
+		{name: "allow under warn diverges", parent: ActionWarn, child: ActionAllow, wantFindings: len(independentSubDetectors)},
+		// Fail-safe: an action this package cannot rank is not evidence of
+		// weakening. Reporting it would be a false alarm on a value we do
+		// not understand.
+		{name: "unrecognized child is silent", parent: ActionBlock, child: "definitely-not-an-action", wantFindings: 0},
+		{name: "unrecognized parent is silent", parent: "definitely-not-an-action", child: ActionWarn, wantFindings: 0},
+		{name: "empty child is silent", parent: ActionBlock, child: "", wantFindings: 0},
+		{name: "empty parent is silent", parent: "", child: ActionWarn, wantFindings: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			enableAllSubDetectors(cfg)
+			setAllActions(cfg, tt.parent, tt.child)
+
+			var warnings []Warning
+			cfg.validateActionDivergence(&warnings)
+
+			if len(warnings) != tt.wantFindings {
+				t.Fatalf("got %d findings, want %d: %+v", len(warnings), tt.wantFindings, warnings)
+			}
+		})
+	}
+}
+
+// TestValidateActionDivergence_DisabledSubDetectorIsSilent proves the enabled
+// predicate is load-bearing. A disabled sub-detector decides nothing, so a
+// weaker action on it is not a divergence and reporting it would be noise on
+// a config that is behaving exactly as written.
+func TestValidateActionDivergence_DisabledSubDetectorIsSilent(t *testing.T) {
+	tests := []struct {
+		name    string
+		disable func(c *Config)
+	}{
+		{"entropy budget disabled", func(c *Config) { c.CrossRequestDetection.EntropyBudget.Enabled = false }},
+		{"cross request section disabled", func(c *Config) { c.CrossRequestDetection.Enabled = false }},
+		{"sse streaming disabled", func(c *Config) { c.ResponseScanning.SSEStreaming.Enabled = false }},
+		{"response scanning section disabled", func(c *Config) { c.ResponseScanning.Enabled = false }},
+		{"content entropy disabled", func(c *Config) { c.RequestBodyScanning.ContentEntropyEnabled = false }},
+		{"request body section disabled", func(c *Config) { c.RequestBodyScanning.Enabled = false }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			enableAllSubDetectors(cfg)
+			setAllActions(cfg, ActionBlock, ActionWarn)
+			tt.disable(cfg)
+
+			var warnings []Warning
+			cfg.validateActionDivergence(&warnings)
+
+			// One of the three members is now disabled, so exactly one
+			// finding must disappear.
+			if want := len(independentSubDetectors) - 1; len(warnings) != want {
+				t.Fatalf("got %d findings, want %d: %+v", len(warnings), want, warnings)
+			}
+		})
+	}
+}
+
+// TestValidateActionDivergence_MessageNamesBothPathsAndEffect checks the
+// warning is actionable. A finding that says something is wrong without
+// naming the field to edit and the resulting behavior is the kind of output
+// operators learn to skip.
+func TestValidateActionDivergence_MessageNamesBothPathsAndEffect(t *testing.T) {
+	for _, d := range independentSubDetectors {
+		t.Run(d.childField, func(t *testing.T) {
+			cfg := Defaults()
+			enableAllSubDetectors(cfg)
+			setAllActions(cfg, ActionBlock, ActionWarn)
+
+			var warnings []Warning
+			cfg.validateActionDivergence(&warnings)
+
+			var found *Warning
+			for i := range warnings {
+				if warnings[i].Field == d.childField {
+					found = &warnings[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("no finding for %s in %+v", d.childField, warnings)
+			}
+			for _, want := range []string{d.parentField, d.trigger, ActionWarn, ActionBlock} {
+				if !strings.Contains(found.Message, want) {
+					t.Errorf("message missing %q: %s", want, found.Message)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateActionDivergence_ReachedThroughValidateWithWarnings proves the
+// analyzer is actually wired into the path that startup, reload, doctor and
+// check all consume. The analyzer being correct is worth nothing if no caller
+// reaches it.
+func TestValidateActionDivergence_ReachedThroughValidateWithWarnings(t *testing.T) {
+	cfg := Defaults()
+	cfg.ApplyDefaults()
+	enableAllSubDetectors(cfg)
+	setAllActions(cfg, ActionBlock, ActionWarn)
+
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("config must remain valid; the advisory never fails a config: %v", err)
+	}
+
+	for _, d := range independentSubDetectors {
+		var seen bool
+		for _, w := range warnings {
+			if w.Field == d.childField {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			t.Errorf("ValidateWithWarnings did not surface %s", d.childField)
+		}
+	}
+}
+
+// TestActionWeakerThan_UsesTheFullOrdering guards the helper against being
+// switched to actionRank in action.go, which ranks only block and warn and
+// would silently treat strip, redirect, ask and defer as unrankable.
+func TestActionWeakerThan_UsesTheFullOrdering(t *testing.T) {
+	ordered := []string{ActionAllow, ActionWarn, ActionStrip, ActionRedirect, ActionAsk, ActionDefer, ActionBlock}
+	for i, weaker := range ordered {
+		for j, stronger := range ordered {
+			got := actionWeakerThan(weaker, stronger)
+			if want := i < j; got != want {
+				t.Errorf("actionWeakerThan(%q, %q) = %v, want %v", weaker, stronger, got, want)
+			}
+		}
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -376,6 +376,9 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	if err := c.validateGuard(); err != nil {
 		return warnings, err
 	}
+	// Advisory only, and last: it reads across sections that the validators
+	// above have already accepted, and it can never fail a config.
+	c.validateActionDivergence(&warnings)
 	return warnings, nil
 }
 

--- a/internal/proxy/cee_test.go
+++ b/internal/proxy/cee_test.go
@@ -392,6 +392,55 @@ func TestCeeAdmit_EntropyBudgetWarn(t *testing.T) {
 	}
 }
 
+// TestCeeAdmit_EntropyBudgetActionWinsOverSectionAction is the production-
+// behavior proof behind the config action-divergence advisory in
+// internal/config/action_divergence.go. The sibling tests above set only the
+// entropy-budget action and leave the section action empty, so none of them
+// covers the case an operator actually hits: the section set to block while
+// the nested budget stays warn, which is what configs/strict.yaml ships.
+//
+// The advisory claims the child action decides. This asserts that against the
+// real admit path rather than against YAML: a crossing is detected and
+// recorded, and the request is still forwarded.
+//
+// NON-VACUITY: point the consumer at internal/proxy/cee.go:381 to the section
+// action (ceeCfg.Action instead of ceeCfg.EntropyBudget.Action) and this test
+// must fail by blocking. If it still passes, the advisory is describing
+// something that is not happening.
+func TestCeeAdmit_EntropyBudgetActionWinsOverSectionAction(t *testing.T) {
+	// 1-bit budget: any real payload exceeds immediately.
+	et := scanner.NewEntropyTracker(1.0, 300)
+	defer et.Close()
+	m := metrics.New()
+	logger, _ := audit.New("json", "stdout", "", false, false)
+
+	ceeCfg := config.CrossRequestDetection{
+		Enabled: true,
+		// The operator configured enforcement at the section level.
+		Action: config.ActionBlock,
+		EntropyBudget: config.CrossRequestEntropyBudget{
+			Enabled:       true,
+			BitsPerWindow: 1.0,
+			WindowMinutes: 5,
+			// The nested sub-detector is weaker, and it is the one consulted.
+			Action: config.ActionWarn,
+		},
+	}
+
+	payload := []byte("outbound data that exceeds budget")
+	result := ceeAdmit(context.Background(),
+		testCEESessionKey, payload, nil, "http://example.com", testCEEAgent,
+		testCEEClientIP, testCEERequestID, ceeCfg, et, nil, nil, logger, m,
+	)
+
+	if result.Blocked {
+		t.Fatal("entropy budget action warn must decide; a section action of block does not apply to budget crossings")
+	}
+	if !result.EntropyHit {
+		t.Error("expected EntropyHit = true: the crossing is detected and recorded, it is simply not enforced")
+	}
+}
+
 func TestCeeAdmit_FragmentDLPBlock(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil


### PR DESCRIPTION
A section set to `block` reads as enforcement. When a detector inside that section carries its own weaker action, findings from that detector resolve to the weaker value and nothing anywhere reports it, so the config describes enforcement that is not in effect. Three shipped presets carry that shape today.

This adds a config advisory covering the cross-request entropy budget, generic SSE scanning, and request-body content entropy. Startup, accepted reloads, `pipelock doctor` and `pipelock check` all read the same analyzer, so no surface can disagree with another about what is enforced. Running `pipelock check` against a preset now names the field, the section it sits under, and the action that actually applies.

Enforcement is unchanged. Making a nested action inherit its section would strengthen enforcement on upgrade for deployments that never asked for it, and the weaker values are often the correct operational choice: entropy detectors cross their budget on ordinary developer traffic such as base64 image payloads, UUIDs and long hashes, so blocking on them by default gets the whole control switched off.

Membership is decided by how an action is consumed at runtime rather than by how the config nests, because struct shape is wrong in both directions. A flattened sibling field is included, and several genuinely nested action fields are not. Per-pattern and per-rule overrides stay out, since making a targeted exception is the entire purpose of those knobs and reporting them would be the noise that teaches operators to skip the output.

The comparison reuses the ordering already behind the reload downgrade warnings, so a section-versus-detector comparison and an old-versus-new comparison can never disagree about which of two actions is stronger. An action the package cannot rank is reported as no divergence rather than a warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration advisories when detector actions are weaker than their enclosing section actions.
  * Added guidance identifying the affected settings and recommending aligned actions.
  * Covered entropy budgets, streaming, and content-entropy scanning.

* **Bug Fixes**
  * Ensured weaker entropy-budget actions still detect and record crossings without incorrectly blocking requests.

* **Tests**
  * Added coverage for divergent, matching, stronger, disabled, empty, and unrecognized actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->