### PR TITLE
fix(config): rank every enforcement action when combining findings

### DIFF
--- a/internal/config/action.go
+++ b/internal/config/action.go
@@ -3,8 +3,9 @@
 
 package config
 
-// StrongestAction returns the strongest enforcement action in block > warn >
-// default order. Unknown and empty actions have default rank.
+// StrongestAction returns the strongest enforcement action among those given.
+// Unknown and empty actions have default rank and are never selected over a
+// recognized one.
 func StrongestAction(actions ...string) string {
 	strongest := ""
 	strongestRank := 0
@@ -18,13 +19,45 @@ func StrongestAction(actions ...string) string {
 	return strongest
 }
 
+// actionRank ranks an action by ENFORCEMENT strength.
+//
+// It previously ranked only block and warn, leaving strip, redirect, ask and
+// defer at default rank alongside genuinely unknown values. Every current
+// caller is fed from a field that validation constrains to warn or block, so
+// that was correct in practice, and extending the ranking is behavior-
+// preserving for every reachable input today.
+//
+// It was a trap for the next caller. Several config fields do accept strip and
+// ask, and routing one of those through StrongestAction would have discarded
+// it in favor of a weaker action, which on this codebase means enforcing less
+// than the operator configured. Ranking them closes that class instead of
+// waiting for the instance.
+//
+// This deliberately does NOT delegate to reloadActionStrength, and the
+// difference is not an oversight. That ordering ranks allow and forward above
+// nothing, because it detects downgrades across a reload and block -> allow is
+// the downgrade it exists to catch. Here, allow and forward mean NO
+// enforcement: they must never be selected over a real action, and
+// StrongestAction("allow") must stay empty rather than reporting that allow
+// was chosen. Same words, two correct orderings, because the two callers are
+// asking different questions.
 func actionRank(action string) int {
 	switch action {
 	case ActionBlock:
+		return 6
+	case ActionDefer:
+		return 5
+	case ActionAsk:
+		return 4
+	case ActionRedirect:
+		return 3
+	case ActionStrip:
 		return 2
 	case ActionWarn:
 		return 1
 	default:
+		// Includes allow, forward, empty and anything unrecognized: no
+		// enforcement to contribute.
 		return 0
 	}
 }

--- a/internal/config/action_test.go
+++ b/internal/config/action_test.go
@@ -16,6 +16,33 @@ func TestStrongestAction(t *testing.T) {
 		{name: "warn beats default", actions: []string{"", ActionWarn}, want: ActionWarn},
 		{name: "block beats warn regardless of order", actions: []string{ActionWarn, ActionBlock}, want: ActionBlock},
 		{name: "block beats warn when first", actions: []string{ActionBlock, ActionWarn}, want: ActionBlock},
+
+		// allow and forward mean no enforcement. They must never be selected
+		// over a real action, and must not be reported as a chosen action on
+		// their own, or a caller combining a permissive default with a real
+		// finding action would enforce the permissive one.
+		{name: "forward alone is no enforcement", actions: []string{ActionForward}, want: ""},
+		// Both orders, because selection walks the arguments in order: a
+		// regression that picked forward over a ranked action would survive a
+		// test that only ever passed forward second.
+		{name: "forward does not override strip", actions: []string{ActionForward, ActionStrip}, want: ActionStrip},
+		{name: "strip is not lost when forward comes after", actions: []string{ActionStrip, ActionForward}, want: ActionStrip},
+		// An unrecognized value on its own must not be returned as if it were
+		// a chosen action. Pairing it with a real action, as the strip case
+		// below does, cannot catch that regression.
+		{name: "unrecognized only", actions: []string{"not-an-action"}, want: ""},
+		{name: "warn beats allow", actions: []string{ActionAllow, ActionWarn}, want: ActionWarn},
+		{name: "block beats allow", actions: []string{ActionAllow, ActionBlock}, want: ActionBlock},
+
+		// Actions that are not block or warn were previously unranked, so a
+		// weaker action would win against them. These fix that ordering.
+		{name: "strip beats warn", actions: []string{ActionWarn, ActionStrip}, want: ActionStrip},
+		{name: "redirect beats strip", actions: []string{ActionStrip, ActionRedirect}, want: ActionRedirect},
+		{name: "ask beats redirect", actions: []string{ActionRedirect, ActionAsk}, want: ActionAsk},
+		{name: "defer beats ask", actions: []string{ActionAsk, ActionDefer}, want: ActionDefer},
+		{name: "block beats defer", actions: []string{ActionDefer, ActionBlock}, want: ActionBlock},
+		{name: "block wins against every other action", actions: []string{ActionWarn, ActionStrip, ActionRedirect, ActionAsk, ActionDefer, ActionBlock}, want: ActionBlock},
+		{name: "strip is not lost to an unknown value", actions: []string{"not-an-action", ActionStrip}, want: ActionStrip},
 	}
 
 	for _, tt := range tests {
@@ -25,4 +52,84 @@ func TestStrongestAction(t *testing.T) {
 			}
 		})
 	}
+}
+
+// rankedActionsAscending is every action that carries enforcement weight, in
+// increasing strength. nonEnforcingActions carry none: they must never be
+// selected over a ranked action and must never be returned alone.
+var (
+	rankedActionsAscending = []string{ActionWarn, ActionStrip, ActionRedirect, ActionAsk, ActionDefer, ActionBlock}
+	nonEnforcingActions    = []string{ActionAllow, ActionForward, "", "not-an-action"}
+)
+
+// TestStrongestAction_ContractHoldsForEveryCombination asserts the whole
+// contract exhaustively instead of enumerating hand-picked pairs.
+//
+// The property is that StrongestAction returns the highest-ranked argument
+// regardless of argument order, and returns empty when no argument carries
+// enforcement weight. Enumerating that by hand invites an endless series of
+// "add the reverse of this pair too" rounds and still leaves gaps, because the
+// table only ever covers the combinations somebody thought to write down.
+func TestStrongestAction_ContractHoldsForEveryCombination(t *testing.T) {
+	// Every ordered pair of ranked actions, both directions. The stronger one
+	// wins no matter which position it occupies.
+	t.Run("ranked pairs are order independent", func(t *testing.T) {
+		for i, a := range rankedActionsAscending {
+			for j, b := range rankedActionsAscending {
+				want := a
+				if j > i {
+					want = b
+				}
+				if got := StrongestAction(a, b); got != want {
+					t.Errorf("StrongestAction(%q, %q) = %q, want %q", a, b, got, want)
+				}
+			}
+		}
+	})
+
+	// A non-enforcing value never beats a ranked action, in either position.
+	t.Run("non-enforcing never overrides a ranked action", func(t *testing.T) {
+		for _, n := range nonEnforcingActions {
+			for _, r := range rankedActionsAscending {
+				if got := StrongestAction(n, r); got != r {
+					t.Errorf("StrongestAction(%q, %q) = %q, want %q", n, r, got, r)
+				}
+				if got := StrongestAction(r, n); got != r {
+					t.Errorf("StrongestAction(%q, %q) = %q, want %q", r, n, got, r)
+				}
+			}
+		}
+	})
+
+	// Nothing to enforce means nothing is returned, however many permissive or
+	// unrecognized values are combined.
+	t.Run("non-enforcing combinations select nothing", func(t *testing.T) {
+		if got := StrongestAction(nonEnforcingActions...); got != "" {
+			t.Errorf("StrongestAction(%v) = %q, want empty", nonEnforcingActions, got)
+		}
+		for _, a := range nonEnforcingActions {
+			for _, b := range nonEnforcingActions {
+				if got := StrongestAction(a, b); got != "" {
+					t.Errorf("StrongestAction(%q, %q) = %q, want empty", a, b, got)
+				}
+			}
+		}
+	})
+
+	// The full set, in both directions and with the strongest action first,
+	// still selects block.
+	t.Run("full set selects block in any order", func(t *testing.T) {
+		ascending := append([]string{}, rankedActionsAscending...)
+		descending := make([]string, 0, len(ascending))
+		for i := len(ascending) - 1; i >= 0; i-- {
+			descending = append(descending, ascending[i])
+		}
+		withNonEnforcing := append(append([]string{}, nonEnforcingActions...), ascending...)
+
+		for _, set := range [][]string{ascending, descending, withNonEnforcing} {
+			if got := StrongestAction(set...); got != ActionBlock {
+				t.Errorf("StrongestAction(%v) = %q, want %q", set, got, ActionBlock)
+			}
+		}
+	})
 }


### PR DESCRIPTION
`StrongestAction` combines the actions contributed by each finding and returns the strongest one, but it ranked only `block` and `warn`. Anything else sat at default rank alongside genuinely unrecognized values, so combining `strip`, `redirect`, `ask` or `defer` with a weaker action returned the weaker one, which means enforcing less than the operator configured.

No reachable input changes behavior today. Every caller reads a field that validation constrains to `warn` or `block`, and both the old and new ordering agree that `block` outranks `warn`. Several config fields do accept `strip` and `ask`, so this ranks the full set now rather than waiting for the caller that routes one of them through here.

`allow` and `forward` stay at default rank on purpose. They mean no enforcement in this context and must never be selected over a real action, so combining a permissive default with a real finding action still yields the finding's action. This is also why the ranking here does not delegate to the ordering behind the reload downgrade warnings, which ranks `allow` above nothing so that a change from `block` to `allow` is caught as a downgrade. The two callers ask different questions and need different answers, and the comment on each says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of conflicting actions so the most restrictive recognized action is consistently selected.
  * Ensured permissive, empty, and unrecognized actions do not override valid actions.
  * Added consistent precedence across blocking, deferring, prompting, redirecting, stripping, and warning actions.

* **Tests**
  * Expanded coverage for action precedence, unknown values, and different action orderings.
  * Verified results remain consistent regardless of action order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->