### PR TITLE
docs(configs): record why three presets warn inside a blocking section

### DIFF
--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -72,6 +72,15 @@ request_body_scanning:
   enabled: true
   action: block
   content_entropy_enabled: true
+  # DELIBERATE, and weaker than the block above. `pipelock doctor` reports the
+  # difference so an operator reading `action: block` learns that opaque
+  # high-entropy bodies only warn.
+  #
+  # A named credential pattern is high-confidence and blocks. Raw entropy is
+  # not: a coding agent legitimately posts base64 images, minified bundles and
+  # long hashes, all of which cross this threshold. Blocking on entropy alone
+  # breaks normal use, and an operator who hits that turns request body scanning
+  # off entirely, which loses the credential detection too.
   content_entropy_action: warn
   content_entropy_threshold: 5.0
   content_entropy_min_length: 32

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -73,6 +73,15 @@ request_body_scanning:
   enabled: true
   action: block
   content_entropy_enabled: true
+  # DELIBERATE, and weaker than the block above. `pipelock doctor` reports the
+  # difference so an operator reading `action: block` learns that opaque
+  # high-entropy bodies only warn.
+  #
+  # A named credential pattern is high-confidence and blocks. Raw entropy is
+  # not: an editor legitimately posts base64 images, minified bundles and long
+  # hashes, all of which cross this threshold. Blocking on entropy alone breaks
+  # normal use, and an operator who hits that turns request body scanning off
+  # entirely, which loses the credential detection too.
   content_entropy_action: warn
   content_entropy_threshold: 5.0
   content_entropy_min_length: 32

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -611,6 +611,19 @@ cross_request_detection:
     enabled: true
     bits_per_window: 4096
     window_minutes: 5
+    # DELIBERATE, and weaker than the block above. `pipelock doctor` reports
+    # this difference, which is the point: an operator reading `action: block`
+    # should be told that budget crossings only warn.
+    #
+    # Entropy alone is medium-confidence and crosses on ordinary developer
+    # traffic. A 1.3 KB base64 image exceeds this budget on its first
+    # legitimate call, and UUIDs, git SHAs and minified JavaScript reach tens of
+    # thousands of bits in a handful of normal requests. Blocking on that denies
+    # real work, and the operator switches the whole control off, which costs
+    # more than the warning does.
+    #
+    # Raise it to block only alongside `exempt_domains` for the endpoints your
+    # agents legitimately push high-entropy payloads to.
     action: warn
   fragment_reassembly:
     enabled: true


### PR DESCRIPTION
Three shipped presets set a section to `block` while an entropy-based detector inside it stays at `warn`, and `pipelock doctor` now reports that difference. An operator who meets the advisory should find the reason next to the setting instead of having to work out whether the preset is a mistake.

The values are unchanged and correct. Entropy alone is medium-confidence and crosses on ordinary developer traffic: a small base64 image exceeds a 4096-bit budget on its first legitimate call, and UUIDs, git SHAs and minified bundles reach tens of thousands of bits across a handful of normal requests. Blocking on that denies real work, and an operator who hits it switches the whole control off, which loses the high-confidence credential detection alongside it.

Each comment states that the difference is deliberate, why the weaker value suits that particular detector, and what to pair with it before raising the action. `strict.yaml` covers the cross-request entropy budget; `cursor.yaml` and `claude-code.yaml` cover request-body content entropy.

Comments only, so no behavior changes. All three presets were loaded and validated after the edit, and the advisory still fires on each of them, which is the intended outcome rather than something to silence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance explaining how entropy-based request detection generates warnings, while high-confidence credential matches can block requests.
  * Documented why ordinary high-entropy traffic is not blocked automatically.
  * Added guidance on combining blocking rules with domain exemptions in strict configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->