### PR TITLE
chore(ci): advance Gauntlet benchmark pin to the WebSocket attribution fix

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  AEB_REF: b7adf5770e7d4c639c68cfcf25f075b69656de60
+  AEB_REF: 53c95da15268447709914834a716516fd682bf1d
 
 jobs:
   candidate:

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -12,7 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
-EXPECTED_AEB_REF = "b7adf5770e7d4c639c68cfcf25f075b69656de60"
+EXPECTED_AEB_REF = "53c95da15268447709914834a716516fd682bf1d"
 EVIDENCE_FILES = (
     "continuous-gauntlet-pipelock.json",
     "promotion-decision.json",


### PR DESCRIPTION
## What changed

The Gauntlet candidate workflow pinned the benchmark repository at the commit that isolated benchmark targets. Two commits have landed upstream since, and the newer one repairs compressed WebSocket rejection attribution. This advances the pin to that commit in the workflow and in the structural test that guards it.

## Why

The candidate lane ran against the older pin and failed closed. One case, `ws-dlp-compressed-frame-004`, scored `error` because the adapter could not prove delivery of the exact wire input after a 1002 close. The runner therefore wrote no candidate file, and the later hashing and baseline steps failed as a consequence. No public result changed.

The upstream repair binds terminal evidence to the exact upgraded connection, counts the exact marked frame set across data and control opcodes, and refuses credit for stale markers or silence. It was proven against released Pipelock 3.3.0 over all eleven WebSocket cases with zero errors.

This is a pin advance only. It changes which benchmark code the lane executes, not any product behavior and not the expected verdict for any case.

## Verification

The workflow structural tests pass, and the diff-scoped pre-push gate passes with no Go files in the diff.

A candidate rerun from `main` after merge is the real proof. If the compressed WebSocket case still errors, that is an honest finding and will be reported as one rather than recorded as a pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Agent Egress Bench version used by the scheduled and manually triggered Gauntlet checks.
  * Updated automated validation to recognize the new benchmark version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->