### PR TITLE
fix(cli): refuse outputs that name the signing key they just used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking Changes / Upgrade Notes
-
-- **ACTION REQUIRED — `airlock.triggers.on_severity` and a nonzero
-  `airlock.triggers.anomaly_count` now refuse to load.** Earlier releases
-  accepted both fields and then ignored them. Airlock still fires only from
-  `on_elevated`, `on_high`, and `on_critical`. Remove the unused keys and set
-  those three if you want a trigger. `pipelock check --config` names the
-  field. Commands that load config fail the same way until it is corrected.
-
 ### Added
 
 - Recorder readers accept the v3 outer-chain namespace fields
   `chain_kind` and `writer_instance_id`. The recorder continues to emit v2
   entries during the compatibility window.
-
-### Fixed
-
-- Signing and report CLI commands refuse an output path that names the
-  signing key, license CRL, or consumed input they just opened. The write
-  itself is a temp-file rename, so a swapped symlink at the destination
-  cannot replace the protected file.
 
 ## [3.3.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes / Upgrade Notes
+
+- **ACTION REQUIRED — `airlock.triggers.on_severity` and a nonzero
+  `airlock.triggers.anomaly_count` now refuse to load.** Earlier releases
+  accepted both fields and then ignored them. Airlock still fires only from
+  `on_elevated`, `on_high`, and `on_critical`. Remove the unused keys and set
+  those three if you want a trigger. `pipelock check --config` names the
+  field. Commands that load config fail the same way until it is corrected.
+
 ### Added
 
 - Recorder readers accept the v3 outer-chain namespace fields
   `chain_kind` and `writer_instance_id`. The recorder continues to emit v2
   entries during the compatibility window.
+
+### Fixed
+
+- Signing and report CLI commands refuse an output path that names the
+  signing key, license CRL, or consumed input they just opened. The write
+  itself is a temp-file rename, so a swapped symlink at the destination
+  cannot replace the protected file.
 
 ## [3.3.0] - 2026-07-30
 

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -67,6 +67,7 @@ into the offline verifier:
     pipelock verify-receipt /dev/stdin --fleet-report --key fleet-report.pub`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.licenseCRLFile = effectiveLicenseCRLFile(opts.licenseCRLFile)
 			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.licenseCRLFile}); err != nil {
 				return err
 			}
@@ -95,10 +96,12 @@ func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 		return err
 	}
 	if opts.out != stdoutSentinel {
+		crlFile := effectiveLicenseCRLFile(opts.licenseCRLFile)
 		if err := cliutil.RefuseOutputAliases(
 			map[string]string{
-				"the signing key":    opts.signingKey,
-				"--license-crl-file": opts.licenseCRLFile,
+				"the signing key":       opts.signingKey,
+				"--license-crl-file":    crlFile,
+				"the fleet audit store": filepath.Join(opts.storageDir, "audit.db"),
 			},
 			map[string]string{"--out": opts.out},
 		); err != nil {
@@ -177,6 +180,13 @@ func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 // stdoutSentinel is the conventional "-" value for --out meaning "write to
 // stdout" rather than a file path.
 const stdoutSentinel = "-"
+
+func effectiveLicenseCRLFile(flag string) string {
+	if v := strings.TrimSpace(flag); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(license.EnvLicenseCRLFile))
+}
 
 func openFleetReportAuditStore(cmd *cobra.Command, storageDir string) (*controlplane.SQLiteAuditStore, error) {
 	auditPath := filepath.Join(storageDir, "audit.db")

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/fleetreport"
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	clisigning "github.com/luckyPipewrench/pipelock/internal/cli/signing"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/license"
@@ -273,7 +274,7 @@ func writeFleetReportEnvelope(path string, envelope any) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Clean(path), data, 0o600); err != nil {
+	if err := atomicfile.Write(filepath.Clean(path), data, 0o600); err != nil {
 		return fmt.Errorf("write --out: %w", err)
 	}
 	return nil

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -23,6 +23,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/fleetreport"
 	clisigning "github.com/luckyPipewrench/pipelock/internal/cli/signing"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -91,6 +92,14 @@ into the offline verifier:
 func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 	if err := validateFleetReportOptions(opts); err != nil {
 		return err
+	}
+	if opts.out != stdoutSentinel {
+		if err := cliutil.RefuseOutputAliases(
+			map[string]string{"the signing key": opts.signingKey},
+			map[string]string{"--out": opts.out},
+		); err != nil {
+			return err
+		}
 	}
 	start, err := time.Parse(time.RFC3339, opts.from)
 	if err != nil {

--- a/enterprise/cli/conductor/fleet_report.go
+++ b/enterprise/cli/conductor/fleet_report.go
@@ -95,7 +95,10 @@ func runFleetReport(cmd *cobra.Command, opts fleetReportOptions) error {
 	}
 	if opts.out != stdoutSentinel {
 		if err := cliutil.RefuseOutputAliases(
-			map[string]string{"the signing key": opts.signingKey},
+			map[string]string{
+				"the signing key":    opts.signingKey,
+				"--license-crl-file": opts.licenseCRLFile,
+			},
 			map[string]string{"--out": opts.out},
 		); err != nil {
 			return err

--- a/enterprise/cli/conductor/fleet_report_test.go
+++ b/enterprise/cli/conductor/fleet_report_test.go
@@ -453,6 +453,61 @@ func TestWriteFleetReportEnvelopeRejectsUnmarshalableEnvelope(t *testing.T) {
 	}
 }
 
+func TestRunFleetReport_RefusesOutputAliasingSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	store, err := controlplane.OpenSQLiteAuditStore(context.Background(), filepath.Join(dir, "audit.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteAuditStore() error = %v", err)
+	}
+	auditPub, auditPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(audit) error = %v", err)
+	}
+	if _, err := store.IngestAuditBatch(context.Background(), cliTestAcceptedAuditBatch(t, auditPriv)); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(store) error = %v", err)
+	}
+
+	_, reportPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair(report) error = %v", err)
+	}
+	keyPath := writeFleetReportKeyFile(t, dir, "report.key", "report-key-1", signing.PurposeFleetReportSigning, reportPriv)
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("ReadFile(key) error = %v", err)
+	}
+
+	cmd := fleetReportCmd()
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	err = runFleetReport(cmd, fleetReportOptions{
+		storageDir:       dir,
+		orgID:            "org-main",
+		fleetID:          "prod",
+		from:             "2026-06-13T00:00:00Z",
+		to:               "2026-06-13T01:00:00Z",
+		signingKey:       keyPath,
+		out:              keyPath,
+		conductorID:      "conductor-1",
+		trustedAuditKeys: []string{"id=audit-key-1,inline=" + hex.EncodeToString(auditPub) + ",org=org-main,fleet=prod,instance=pl-1"},
+		limit:            10,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read signing key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("fleet report succeeded writing --out over --signing-key; key bytes changed=%v stdout=%q", !bytes.Equal(before, after), stdout.String())
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("signing key was overwritten")
+	}
+}
+
 func writeFleetReportKeyFile(t *testing.T, dir, name, keyID string, purpose signing.KeyPurpose, priv ed25519.PrivateKey) string {
 	t.Helper()
 	pub := priv.Public().(ed25519.PublicKey)

--- a/enterprise/cli/conductor/fleet_report_test.go
+++ b/enterprise/cli/conductor/fleet_report_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/internal/fleetreceipt"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -505,6 +506,122 @@ func TestRunFleetReport_RefusesOutputAliasingSigningKey(t *testing.T) {
 	}
 	if !bytes.Equal(before, after) {
 		t.Fatal("signing key was overwritten")
+	}
+}
+
+func TestRunFleetReport_RefusesOutputAliasingAuditStore(t *testing.T) {
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "audit.db")
+	store, err := controlplane.OpenSQLiteAuditStore(context.Background(), storePath)
+	if err != nil {
+		t.Fatalf("OpenSQLiteAuditStore() error = %v", err)
+	}
+	auditPub, auditPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(audit) error = %v", err)
+	}
+	if _, err := store.IngestAuditBatch(context.Background(), cliTestAcceptedAuditBatch(t, auditPriv)); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(store) error = %v", err)
+	}
+	_, reportPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair(report) error = %v", err)
+	}
+	keyPath := writeFleetReportKeyFile(t, dir, "report.key", "report-key-1", signing.PurposeFleetReportSigning, reportPriv)
+	before, err := os.ReadFile(filepath.Clean(storePath))
+	if err != nil {
+		t.Fatalf("ReadFile(store) error = %v", err)
+	}
+	cmd := fleetReportCmd()
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	err = runFleetReport(cmd, fleetReportOptions{
+		storageDir:       dir,
+		orgID:            "org-main",
+		fleetID:          "prod",
+		from:             "2026-06-13T00:00:00Z",
+		to:               "2026-06-13T01:00:00Z",
+		signingKey:       keyPath,
+		out:              storePath,
+		conductorID:      "conductor-1",
+		trustedAuditKeys: []string{"id=audit-key-1,inline=" + hex.EncodeToString(auditPub) + ",org=org-main,fleet=prod,instance=pl-1"},
+		limit:            10,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(storePath))
+	if readErr != nil {
+		t.Fatalf("re-read audit store: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("fleet report succeeded writing --out over the audit store")
+	}
+	if !strings.Contains(err.Error(), "must not name the fleet audit store") {
+		t.Fatalf("runFleetReport error = %v, want audit-store alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("fleet audit store was overwritten")
+	}
+}
+
+func TestRunFleetReport_RefusesOutputAliasingEnvLicenseCRL(t *testing.T) {
+	dir := t.TempDir()
+	store, err := controlplane.OpenSQLiteAuditStore(context.Background(), filepath.Join(dir, "audit.db"))
+	if err != nil {
+		t.Fatalf("OpenSQLiteAuditStore() error = %v", err)
+	}
+	auditPub, auditPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey(audit) error = %v", err)
+	}
+	if _, err := store.IngestAuditBatch(context.Background(), cliTestAcceptedAuditBatch(t, auditPriv)); err != nil {
+		t.Fatalf("IngestAuditBatch() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close(store) error = %v", err)
+	}
+	_, reportPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair(report) error = %v", err)
+	}
+	keyPath := writeFleetReportKeyFile(t, dir, "report.key", "report-key-1", signing.PurposeFleetReportSigning, reportPriv)
+	crlPath := filepath.Join(dir, "license.crl")
+	if err := os.WriteFile(crlPath, []byte("crl-bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile crl: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(crlPath))
+	if err != nil {
+		t.Fatalf("read crl: %v", err)
+	}
+	t.Setenv(license.EnvLicenseCRLFile, crlPath)
+	cmd := fleetReportCmd()
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	err = runFleetReport(cmd, fleetReportOptions{
+		storageDir:       dir,
+		orgID:            "org-main",
+		fleetID:          "prod",
+		from:             "2026-06-13T00:00:00Z",
+		to:               "2026-06-13T01:00:00Z",
+		signingKey:       keyPath,
+		out:              crlPath,
+		conductorID:      "conductor-1",
+		trustedAuditKeys: []string{"id=audit-key-1,inline=" + hex.EncodeToString(auditPub) + ",org=org-main,fleet=prod,instance=pl-1"},
+		limit:            10,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(crlPath))
+	if readErr != nil {
+		t.Fatalf("re-read crl: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("fleet report succeeded writing --out over PIPELOCK_LICENSE_CRL_FILE")
+	}
+	if !strings.Contains(err.Error(), "must not name --license-crl-file") {
+		t.Fatalf("runFleetReport error = %v, want env CRL alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("license CRL was overwritten")
 	}
 }
 

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,6 +68,7 @@ the Ed25519 private key specified by --signing-key.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// License gate: fail closed before any file IO.
+			opts.licenseCRLFile = effectiveCoverageLicenseCRLFile(opts.licenseCRLFile)
 			_, err := license.VerifyAgentsWithOptions(license.FleetVerifyInputs{
 				CRLFile: opts.licenseCRLFile,
 			})
@@ -119,17 +121,16 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 		return fmt.Errorf("--agent must not be empty")
 	}
 
-	if err := cliutil.RefuseOutputAliases(
-		map[string]string{
-			"the signing key":    opts.signingKeyFile,
-			"--license-crl-file": opts.licenseCRLFile,
-		},
-		map[string]string{"--out": opts.outFile},
-	); err != nil {
+	cleanDir := filepath.Clean(opts.receiptDir)
+	protected := map[string]string{
+		"the signing key":    opts.signingKeyFile,
+		"--license-crl-file": effectiveCoverageLicenseCRLFile(opts.licenseCRLFile),
+	}
+	maps.Copy(protected, cliutil.ExistingRegularFiles("receipt input", cleanDir))
+	if err := cliutil.RefuseOutputAliases(protected, map[string]string{"--out": opts.outFile}); err != nil {
 		return err
 	}
 
-	cleanDir := filepath.Clean(opts.receiptDir)
 	info, dirErr := os.Stat(cleanDir)
 	if dirErr != nil {
 		return fmt.Errorf("--receipt-dir: %w", dirErr)
@@ -251,6 +252,13 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", data)
 	return nil
+}
+
+func effectiveCoverageLicenseCRLFile(flag string) string {
+	if v := strings.TrimSpace(flag); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(license.EnvLicenseCRLFile))
 }
 
 func parseCoverageCertTrustedReceiptSigners(raw []string) ([]string, error) {

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/coveragecert"
 	"github.com/luckyPipewrench/pipelock/internal/coveragecertverify"
@@ -240,7 +241,7 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 
 	if opts.outFile != "" {
 		cleanOut := filepath.Clean(opts.outFile)
-		if writeErr := os.WriteFile(cleanOut, data, 0o600); writeErr != nil {
+		if writeErr := atomicfile.Write(cleanOut, data, 0o600); writeErr != nil {
 			return fmt.Errorf("--out: %w", writeErr)
 		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "coverage certificate written to %s\n", cleanOut)

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/coveragecert"
 	"github.com/luckyPipewrench/pipelock/internal/coveragecertverify"
 	"github.com/luckyPipewrench/pipelock/internal/evidence/completeness"
@@ -115,6 +116,13 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 	agent := strings.TrimSpace(opts.agent)
 	if agent == "" {
 		return fmt.Errorf("--agent must not be empty")
+	}
+
+	if err := cliutil.RefuseOutputAliases(
+		map[string]string{"the signing key": opts.signingKeyFile},
+		map[string]string{"--out": opts.outFile},
+	); err != nil {
+		return err
 	}
 
 	cleanDir := filepath.Clean(opts.receiptDir)

--- a/enterprise/cli/dashboard_coveragecert.go
+++ b/enterprise/cli/dashboard_coveragecert.go
@@ -119,7 +119,10 @@ func runCoverageCertGenerate(cmd *cobra.Command, opts coverageCertGenerateOption
 	}
 
 	if err := cliutil.RefuseOutputAliases(
-		map[string]string{"the signing key": opts.signingKeyFile},
+		map[string]string{
+			"the signing key":    opts.signingKeyFile,
+			"--license-crl-file": opts.licenseCRLFile,
+		},
 		map[string]string{"--out": opts.outFile},
 	); err != nil {
 		return err

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -949,3 +949,47 @@ func TestRunCoverageCertGenerate_RefusesOutputAliasingSigningKey(t *testing.T) {
 		t.Fatal("signing key was overwritten")
 	}
 }
+
+func TestRunCoverageCertGenerate_RefusesOutputAliasingLicenseCRL(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	writeCoverageCertEvidenceSession(t, dir, priv, "crl-alias", "agent-a", 3)
+	keyFile := filepath.Join(dir, "signing.key")
+	if err := signing.SavePrivateKey(priv, keyFile); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	crlFile := filepath.Join(dir, "license.crl")
+	if err := os.WriteFile(crlFile, []byte("crl-bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile crl: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(crlFile))
+	if err != nil {
+		t.Fatalf("read crl: %v", err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runCoverageCertGenerate(cmd, coverageCertGenerateOptions{
+		agent:          "agent-a",
+		receiptDir:     dir,
+		signingKeyFile: keyFile,
+		licenseCRLFile: crlFile,
+		windowStart:    start.Format(time.RFC3339),
+		windowEnd:      start.Add(24 * time.Hour).Format(time.RFC3339),
+		outFile:        crlFile,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(crlFile))
+	if readErr != nil {
+		t.Fatalf("re-read crl: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("generate succeeded writing --out over --license-crl-file")
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("license CRL was overwritten")
+	}
+}

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -993,3 +993,46 @@ func TestRunCoverageCertGenerate_RefusesOutputAliasingLicenseCRL(t *testing.T) {
 		t.Fatal("license CRL was overwritten")
 	}
 }
+
+func TestRunCoverageCertGenerate_RefusesOutputAliasingReceiptFile(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	writeCoverageCertEvidenceSession(t, dir, priv, "receipt-alias", "agent-a", 3)
+	keyFile := filepath.Join(dir, "signing.key")
+	if err := signing.SavePrivateKey(priv, keyFile); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	receiptFile := filepath.Join(dir, "evidence-receipt-alias-000000.jsonl")
+	before, err := os.ReadFile(filepath.Clean(receiptFile))
+	if err != nil {
+		t.Fatalf("read receipt: %v", err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runCoverageCertGenerate(cmd, coverageCertGenerateOptions{
+		agent:          "agent-a",
+		receiptDir:     dir,
+		signingKeyFile: keyFile,
+		windowStart:    start.Format(time.RFC3339),
+		windowEnd:      start.Add(24 * time.Hour).Format(time.RFC3339),
+		outFile:        receiptFile,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(receiptFile))
+	if readErr != nil {
+		t.Fatalf("re-read receipt: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("generate succeeded writing --out over a receipt input")
+	}
+	if !strings.Contains(err.Error(), "must not name receipt input") {
+		t.Fatalf("generate error = %v, want receipt-input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("receipt input was overwritten")
+	}
+}

--- a/enterprise/cli/dashboard_coveragecert_test.go
+++ b/enterprise/cli/dashboard_coveragecert_test.go
@@ -907,3 +907,45 @@ func TestRunCoverageCertGenerate_RejectsBlankAgent(t *testing.T) {
 		t.Fatal("expected error for blank --agent, got nil")
 	}
 }
+
+func TestRunCoverageCertGenerate_RefusesOutputAliasingSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	writeCoverageCertEvidenceSession(t, dir, priv, "alias", "agent-a", 3)
+
+	keyFile := filepath.Join(t.TempDir(), "signing.key")
+	if err := signing.SavePrivateKey(priv, keyFile); err != nil {
+		t.Fatalf("SavePrivateKey: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyFile))
+	if err != nil {
+		t.Fatalf("read signing key: %v", err)
+	}
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err = runCoverageCertGenerate(cmd, coverageCertGenerateOptions{
+		agent:          "agent-a",
+		receiptDir:     dir,
+		signingKeyFile: keyFile,
+		windowStart:    start.Format(time.RFC3339),
+		windowEnd:      start.Add(24 * time.Hour).Format(time.RFC3339),
+		outFile:        keyFile,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(keyFile))
+	if readErr != nil {
+		t.Fatalf("re-read signing key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("generate succeeded writing --out over --signing-key; key bytes changed=%v stdout=%q", !bytes.Equal(before, after), out.String())
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("signing key was overwritten")
+	}
+}

--- a/internal/atomicfile/write_test.go
+++ b/internal/atomicfile/write_test.go
@@ -92,6 +92,46 @@ func TestWrite_Success(t *testing.T) {
 	}
 }
 
+func TestWrite_ReplacingDestSymlinkLeavesTargetUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink replacement semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	protected := filepath.Join(dir, "signing.key")
+	original := []byte("protected-key-bytes")
+	if err := os.WriteFile(protected, original, 0o600); err != nil {
+		t.Fatalf("WriteFile protected: %v", err)
+	}
+	dest := filepath.Join(dir, "report.json")
+	if err := os.Symlink(protected, dest); err != nil {
+		t.Fatalf("Symlink dest: %v", err)
+	}
+	if err := Write(dest, []byte("report-body"), 0o600); err != nil {
+		t.Fatalf("Write dest symlink: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Clean(protected))
+	if err != nil {
+		t.Fatalf("read protected: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("protected file changed to %q", got)
+	}
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("Lstat dest: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("Write left dest as a symlink; rename should have replaced the directory entry")
+	}
+	written, err := os.ReadFile(filepath.Clean(dest))
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(written) != "report-body" {
+		t.Fatalf("dest content = %q, want report-body", written)
+	}
+}
+
 func TestWriteNewCreatesAndRefusesReplacement(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "ceremony.json")

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -105,6 +105,7 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	}
 	protected := cliutil.ExistingFileLabels("--key", opts.keys)
 	maps.Copy(protected, cliutil.ExistingFileLabels("the receipt input", []string{target}))
+	maps.Copy(protected, cliutil.ExistingRegularFiles("the receipt input", output.receiptDir))
 	if opts.rekorKey != "" {
 		protected["--rekor-key"] = opts.rekorKey
 	}

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	anchorpkg "github.com/luckyPipewrench/pipelock/internal/anchor"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	sigutil "github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -99,6 +100,16 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	}
 	output, err := resolveBundleOutput(target, opts)
 	if err != nil {
+		return err
+	}
+	protected := cliutil.ExistingFileLabels("--key", opts.keys)
+	if opts.rekorKey != "" {
+		protected["--rekor-key"] = opts.rekorKey
+	}
+	if err := cliutil.RefuseOutputAliases(protected, map[string]string{
+		"--out":       output.bundlePath,
+		"--local-log": opts.logPath,
+	}); err != nil {
 		return err
 	}
 	checkpoint, err := anchorpkg.BuildCheckpoint(sessionID, receipts, trustedKeys)

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,6 +104,7 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 		return err
 	}
 	protected := cliutil.ExistingFileLabels("--key", opts.keys)
+	maps.Copy(protected, cliutil.ExistingFileLabels("the receipt input", []string{target}))
 	if opts.rekorKey != "" {
 		protected["--rekor-key"] = opts.rekorKey
 	}

--- a/internal/cli/anchor/cmd.go
+++ b/internal/cli/anchor/cmd.go
@@ -109,10 +109,14 @@ func runReceipts(out io.Writer, target string, opts receiptsOptions) error {
 	if opts.rekorKey != "" {
 		protected["--rekor-key"] = opts.rekorKey
 	}
-	if err := cliutil.RefuseOutputAliases(protected, map[string]string{
+	outputs := map[string]string{
 		"--out":       output.bundlePath,
 		"--local-log": opts.logPath,
-	}); err != nil {
+	}
+	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
+		return err
+	}
+	if err := cliutil.RefuseOutputCollisions(outputs); err != nil {
 		return err
 	}
 	checkpoint, err := anchorpkg.BuildCheckpoint(sessionID, receipts, trustedKeys)

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -183,6 +183,28 @@ func TestReceiptsCmdRefusesOutputAliasingReceiptInput(t *testing.T) {
 	}
 }
 
+func TestReceiptsCmdRefusesOutAliasingLocalLog(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T13:00:00Z")
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	shared := filepath.Join(filepath.Dir(receiptsPath), "same.json")
+	cmd := receiptsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--local-log", shared,
+		"--out", shared,
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("anchor receipts succeeded writing --out over --local-log; stdout=%q", out.String())
+	}
+	if !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("anchor receipts error = %v, want --out/--local-log collision", err)
+	}
+}
+
 func TestWriteAnchorStateMarkerRejectsCheckpointWithoutSigner(t *testing.T) {
 	err := writeAnchorStateMarker(
 		bundleOutput{receiptDir: t.TempDir(), markerPath: "bundle.json"},

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -118,6 +118,39 @@ func TestReceiptsCmdWritesLocalAnchorBundle(t *testing.T) {
 	}
 }
 
+func TestReceiptsCmdRefusesOutputAliasingKeyFile(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T13:00:00Z")
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	keyFile := filepath.Join(filepath.Dir(receiptsPath), "trusted.key")
+	if err := os.WriteFile(keyFile, []byte(keyHex+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyFile))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	cmd := receiptsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyFile,
+		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+		"--out", keyFile,
+	})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(keyFile))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("anchor receipts succeeded writing --out over --key; stdout=%q", out.String())
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("trusted signer key file was overwritten")
+	}
+}
+
 func TestWriteAnchorStateMarkerRejectsCheckpointWithoutSigner(t *testing.T) {
 	err := writeAnchorStateMarker(
 		bundleOutput{receiptDir: t.TempDir(), markerPath: "bundle.json"},

--- a/internal/cli/anchor/cmd_test.go
+++ b/internal/cli/anchor/cmd_test.go
@@ -151,6 +151,38 @@ func TestReceiptsCmdRefusesOutputAliasingKeyFile(t *testing.T) {
 	}
 }
 
+func TestReceiptsCmdRefusesOutputAliasingReceiptInput(t *testing.T) {
+	t.Setenv("PIPELOCK_ANCHOR_TEST_NOW", "2026-06-28T13:00:00Z")
+	receiptsPath, keyHex := cliReceiptJSONL(t)
+	before, err := os.ReadFile(filepath.Clean(receiptsPath))
+	if err != nil {
+		t.Fatalf("read receipts: %v", err)
+	}
+	cmd := receiptsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
+		receiptsPath,
+		"--key", keyHex,
+		"--local-log", filepath.Join(t.TempDir(), "anchor.jsonl"),
+		"--out", receiptsPath,
+	})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(receiptsPath))
+	if readErr != nil {
+		t.Fatalf("re-read receipts: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("anchor receipts succeeded writing --out over the receipt input; stdout=%q", out.String())
+	}
+	if !strings.Contains(err.Error(), "--out must not name the receipt input") {
+		t.Fatalf("anchor receipts error = %v, want receipt-input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("receipt input was overwritten")
+	}
+}
+
 func TestWriteAnchorStateMarkerRejectsCheckpointWithoutSigner(t *testing.T) {
 	err := writeAnchorStateMarker(
 		bundleOutput{receiptDir: t.TempDir(), markerPath: "bundle.json"},

--- a/internal/cli/audit/report.go
+++ b/internal/cli/audit/report.go
@@ -147,6 +147,16 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("loading signing key for agent %q: %w", agentName, err)
 				}
+				keyPath, pathErr := ks.PrivateKeyPath(agentName)
+				if pathErr != nil {
+					return pathErr
+				}
+				if err := cliutil.RefuseOutputAliases(
+					map[string]string{"the signing key": keyPath},
+					map[string]string{"--output": output},
+				); err != nil {
+					return err
+				}
 			}
 
 			// Output.

--- a/internal/cli/audit/report.go
+++ b/internal/cli/audit/report.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/report"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -206,12 +207,9 @@ Examples:
 // renderToTarget renders a report to a file (if output is set) or to stdout.
 func renderToTarget(cmd *cobra.Command, output string, rpt *report.Report, renderFn func(io.Writer, *report.Report) error) error {
 	if output != "" {
-		f, err := os.OpenFile(filepath.Clean(output), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-		if err != nil {
-			return fmt.Errorf("creating output file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		return renderFn(f, rpt)
+		return atomicfile.WriteFunc(filepath.Clean(output), 0o600, func(w io.Writer) error {
+			return renderFn(w, rpt)
+		})
 	}
 	return renderFn(cmd.OutOrStdout(), rpt)
 }

--- a/internal/cli/audit/report.go
+++ b/internal/cli/audit/report.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -134,6 +135,10 @@ Examples:
 
 			// Load signing key if requested.
 			var privKey ed25519.PrivateKey
+			protected := map[string]string{}
+			if input != "" && input != "-" {
+				maps.Copy(protected, cliutil.ExistingFileLabels("--input", []string{input}))
+			}
 			if sign {
 				agentName, err := cliutil.ResolveAgentName(agent)
 				if err != nil {
@@ -152,12 +157,10 @@ Examples:
 				if pathErr != nil {
 					return pathErr
 				}
-				if err := cliutil.RefuseOutputAliases(
-					map[string]string{"the signing key": keyPath},
-					map[string]string{"--output": output},
-				); err != nil {
-					return err
-				}
+				protected["the signing key"] = keyPath
+			}
+			if err := cliutil.RefuseOutputAliases(protected, map[string]string{"--output": output}); err != nil {
+				return err
 			}
 
 			// Output.

--- a/internal/cli/audit/report_test.go
+++ b/internal/cli/audit/report_test.go
@@ -233,6 +233,74 @@ func TestReportCmd_BundleSigned(t *testing.T) {
 	}
 }
 
+func TestReportCmd_RefusesOutputAliasingInput(t *testing.T) {
+	inputPath := writeFixtureFile(t)
+	before, err := os.ReadFile(filepath.Clean(inputPath))
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+	cmd := ReportCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--input", inputPath, "--format", "json", "-o", inputPath})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(inputPath))
+	if readErr != nil {
+		t.Fatalf("re-read input: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("report succeeded writing --output over --input")
+	}
+	if !strings.Contains(err.Error(), "--output must not name --input") {
+		t.Fatalf("report error = %v, want input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("report input was overwritten")
+	}
+}
+
+func TestReportCmd_RefusesOutputAliasingSigningKey(t *testing.T) {
+	inputPath := writeFixtureFile(t)
+	ksDir := t.TempDir()
+	ks := signing.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("test-agent"); err != nil {
+		t.Fatalf("GenerateAgent: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("test-agent")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	cmd := ReportCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--input", inputPath,
+		"--format", "bundle",
+		"-o", keyPath,
+		"--sign",
+		"--agent", "test-agent",
+		"--keystore", ksDir,
+	})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("report succeeded writing --output over the signing key")
+	}
+	if !strings.Contains(err.Error(), "must not name the signing key") {
+		t.Fatalf("report error = %v, want signing-key alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("signing key was overwritten")
+	}
+}
+
 func TestReportCmd_DaysFilter(t *testing.T) {
 	// Create events spanning 2 days: one today, one 3 days ago.
 	now := time.Now().UTC()

--- a/internal/cli/learn/activate.go
+++ b/internal/cli/learn/activate.go
@@ -373,6 +373,18 @@ func resolveLifecycle(flags lifecycleFlags) (lifecycleContext, error) {
 	if err != nil {
 		return lifecycleContext{}, err
 	}
+	protected := map[string]string{
+		"the activation signing key": primary.keyID,
+		"the receipt signing key":    receiptKey.keyID,
+	}
+	if dual != nil {
+		protected["the dual-control signing key"] = dual.keyID
+	}
+	if err := refuseOutputsOverKeystoreKeys(flags.keystore, protected, map[string]string{
+		"--receipt-out": receiptOut,
+	}); err != nil {
+		return lifecycleContext{}, err
+	}
 	return lifecycleContext{
 		store:         contractstore.New(storeDir),
 		opts:          contractstore.Options{Roster: roster, MinSignatures: activation.RequiredSignatures(policy), Now: func() time.Time { return now }},
@@ -399,6 +411,29 @@ func loadLifecycleSigner(keystoreDir, keyID string) (privateKeySigner, error) {
 		return privateKeySigner{}, fmt.Errorf("load lifecycle signing key for %q: %w", keyID, err)
 	}
 	return privateKeySigner{keyID: keyID, key: priv}, nil
+}
+
+func refuseOutputsOverKeystoreKeys(keystoreDir string, protectedAgents map[string]string, outputs map[string]string) error {
+	dir, err := cliutil.ResolveKeystoreDir(keystoreDir)
+	if err != nil {
+		return err
+	}
+	ks := signing.NewKeystore(dir)
+	protected := make(map[string]string, len(protectedAgents))
+	for label, agentName := range protectedAgents {
+		if agentName == "" {
+			continue
+		}
+		keyPath, err := ks.PrivateKeyPath(agentName)
+		if err != nil {
+			return err
+		}
+		protected[label] = keyPath
+	}
+	if len(protected) == 0 {
+		return nil
+	}
+	return cliutil.RefuseOutputAliases(protected, outputs)
 }
 
 func latestAccepted(st contractstore.Store, opts contractstore.Options) (contractstore.State, bool, error) {

--- a/internal/cli/learn/activate.go
+++ b/internal/cli/learn/activate.go
@@ -380,9 +380,11 @@ func resolveLifecycle(flags lifecycleFlags) (lifecycleContext, error) {
 	if dual != nil {
 		protected["the dual-control signing key"] = dual.keyID
 	}
-	if err := refuseOutputsOverKeystoreKeys(flags.keystore, protected, map[string]string{
-		"--receipt-out": receiptOut,
-	}); err != nil {
+	outputs := map[string]string{"--receipt-out": receiptOut}
+	if err := cliutil.RefuseOutputAliases(cliutil.ExistingFileLabels("--roster", []string{flags.rosterPath}), outputs); err != nil {
+		return lifecycleContext{}, err
+	}
+	if err := refuseOutputsOverKeystoreKeys(flags.keystore, protected, outputs); err != nil {
 		return lifecycleContext{}, err
 	}
 	return lifecycleContext{

--- a/internal/cli/learn/compile.go
+++ b/internal/cli/learn/compile.go
@@ -109,14 +109,18 @@ func runCompile(cmd *cobra.Command, flags compileFlags) error {
 	if err != nil {
 		return err
 	}
+	compileOutputs := map[string]string{
+		"--output":           output,
+		"--review":           reviewPath,
+		"--compile-manifest": manifestPath,
+	}
+	if err := cliutil.RefuseOutputAliases(cliutil.ExistingFileLabels("--input", inputs), compileOutputs); err != nil {
+		return err
+	}
 	if !flags.deterministic {
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the compile signing key": signer.keyID,
-		}, map[string]string{
-			"--output":           output,
-			"--review":           reviewPath,
-			"--compile-manifest": manifestPath,
-		}); err != nil {
+		}, compileOutputs); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/compile.go
+++ b/internal/cli/learn/compile.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -114,7 +115,9 @@ func runCompile(cmd *cobra.Command, flags compileFlags) error {
 		"--review":           reviewPath,
 		"--compile-manifest": manifestPath,
 	}
-	if err := cliutil.RefuseOutputAliases(cliutil.ExistingFileLabels("--input", inputs), compileOutputs); err != nil {
+	protected := cliutil.ExistingFileLabels("--input", inputs)
+	maps.Copy(protected, cliutil.ExistingFileLabels("--config", []string{flags.configPath}))
+	if err := cliutil.RefuseOutputAliases(protected, compileOutputs); err != nil {
 		return err
 	}
 	if !flags.deterministic {

--- a/internal/cli/learn/compile.go
+++ b/internal/cli/learn/compile.go
@@ -109,6 +109,17 @@ func runCompile(cmd *cobra.Command, flags compileFlags) error {
 	if err != nil {
 		return err
 	}
+	if !flags.deterministic {
+		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
+			"the compile signing key": signer.keyID,
+		}, map[string]string{
+			"--output":           output,
+			"--review":           reviewPath,
+			"--compile-manifest": manifestPath,
+		}); err != nil {
+			return err
+		}
+	}
 
 	result, err := contractcompile.Compile(contractcompile.CompileInput{
 		Stream:           stream,

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -441,6 +441,56 @@ func TestResolveCompileSignerDeterministic(t *testing.T) {
 	}
 }
 
+func TestRunCompileRefusesOutputAliasingSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.ForceGenerateAgent("agent-a"); err != nil {
+		t.Fatalf("ForceGenerateAgent: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("agent-a")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	input := filepath.Join(dir, "capture.jsonl")
+	if err := os.WriteFile(input, []byte(compileFixtureJSONL(t)), 0o600); err != nil {
+		t.Fatalf("WriteFile input: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("learn:\n  inference:\n    floors:\n      min_sessions: 1\n      min_events: 1\n      min_windows: 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runCompile(cmd, compileFlags{
+		agent:         "agent-a",
+		inputGlob:     input,
+		output:        keyPath,
+		review:        filepath.Join(dir, "candidate.review.md"),
+		manifest:      filepath.Join(dir, "candidate.manifest.json"),
+		configPath:    cfgPath,
+		keystore:      dir,
+		deterministic: false,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runCompile succeeded writing --output over the compile signing key")
+	}
+	if !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("runCompile error = %v, want alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("compile signing key was overwritten")
+	}
+}
+
 func TestResolveCompileSignerLoadsKeystoreAgent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -526,6 +526,47 @@ func TestRunCompileRefusesOutputAliasingSigningKey(t *testing.T) {
 	}
 }
 
+func TestRunCompileRefusesOutputAliasingInput(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "capture.jsonl")
+	if err := os.WriteFile(input, []byte(compileFixtureJSONL(t)), 0o600); err != nil {
+		t.Fatalf("WriteFile input: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(input))
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("learn:\n  inference:\n    floors:\n      min_sessions: 1\n      min_events: 1\n      min_windows: 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runCompile(cmd, compileFlags{
+		agent:         "agent-a",
+		inputGlob:     input,
+		output:        input,
+		review:        filepath.Join(dir, "candidate.review.md"),
+		manifest:      filepath.Join(dir, "candidate.manifest.json"),
+		configPath:    cfgPath,
+		deterministic: true,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(input))
+	if readErr != nil {
+		t.Fatalf("re-read input: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runCompile succeeded writing --output over --input")
+	}
+	if !strings.Contains(err.Error(), "--output must not name --input") {
+		t.Fatalf("runCompile error = %v, want input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("compile input was overwritten")
+	}
+}
+
 func TestResolveCompileSignerLoadsKeystoreAgent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -567,6 +567,47 @@ func TestRunCompileRefusesOutputAliasingInput(t *testing.T) {
 	}
 }
 
+func TestRunCompileRefusesOutputAliasingConfig(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "capture.jsonl")
+	if err := os.WriteFile(input, []byte(compileFixtureJSONL(t)), 0o600); err != nil {
+		t.Fatalf("WriteFile input: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("learn:\n  inference:\n    floors:\n      min_sessions: 1\n      min_events: 1\n      min_windows: 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(cfgPath))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runCompile(cmd, compileFlags{
+		agent:         "agent-a",
+		inputGlob:     input,
+		output:        cfgPath,
+		review:        filepath.Join(dir, "candidate.review.md"),
+		manifest:      filepath.Join(dir, "candidate.manifest.json"),
+		configPath:    cfgPath,
+		deterministic: true,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(cfgPath))
+	if readErr != nil {
+		t.Fatalf("re-read config: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runCompile succeeded writing --output over --config")
+	}
+	if !strings.Contains(err.Error(), "--output must not name --config") {
+		t.Fatalf("runCompile error = %v, want config alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("compile config was overwritten")
+	}
+}
+
 func TestResolveCompileSignerLoadsKeystoreAgent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -608,6 +608,78 @@ func TestRunCompileRefusesOutputAliasingConfig(t *testing.T) {
 	}
 }
 
+func TestRunCompileRefusesEveryOutputAliasingProtectedFiles(t *testing.T) {
+	dir := t.TempDir()
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.ForceGenerateAgent("agent-a"); err != nil {
+		t.Fatalf("ForceGenerateAgent: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("agent-a")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	input := filepath.Join(dir, "capture.jsonl")
+	if err := os.WriteFile(input, []byte(compileFixtureJSONL(t)), 0o600); err != nil {
+		t.Fatalf("WriteFile input: %v", err)
+	}
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(cfgPath, []byte("learn:\n  inference:\n    floors:\n      min_sessions: 1\n      min_events: 1\n      min_windows: 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	safeOutput := filepath.Join(dir, "candidate.yaml")
+	safeReview := filepath.Join(dir, "candidate.review.md")
+	safeManifest := filepath.Join(dir, "candidate.manifest.json")
+	for _, tc := range []struct {
+		name      string
+		target    string
+		set       func(*compileFlags, string)
+		want      string
+		needStore bool
+	}{
+		{name: "review-over-input", target: input, set: func(f *compileFlags, p string) { f.review = p }, want: "--review must not name --input"},
+		{name: "manifest-over-input", target: input, set: func(f *compileFlags, p string) { f.manifest = p }, want: "--compile-manifest must not name --input"},
+		{name: "review-over-config", target: cfgPath, set: func(f *compileFlags, p string) { f.review = p }, want: "--review must not name --config"},
+		{name: "manifest-over-config", target: cfgPath, set: func(f *compileFlags, p string) { f.manifest = p }, want: "--compile-manifest must not name --config"},
+		{name: "review-over-key", target: keyPath, set: func(f *compileFlags, p string) { f.review = p }, want: "must not name", needStore: true},
+		{name: "manifest-over-key", target: keyPath, set: func(f *compileFlags, p string) { f.manifest = p }, want: "must not name", needStore: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before, err := os.ReadFile(filepath.Clean(tc.target))
+			if err != nil {
+				t.Fatalf("read protected: %v", err)
+			}
+			flags := compileFlags{
+				agent:         "agent-a",
+				inputGlob:     input,
+				output:        safeOutput,
+				review:        safeReview,
+				manifest:      safeManifest,
+				configPath:    cfgPath,
+				keystore:      dir,
+				deterministic: !tc.needStore,
+			}
+			tc.set(&flags, tc.target)
+			cmd := &cobra.Command{}
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			err = runCompile(cmd, flags)
+			after, readErr := os.ReadFile(filepath.Clean(tc.target))
+			if readErr != nil {
+				t.Fatalf("re-read protected: %v", readErr)
+			}
+			if err == nil {
+				t.Fatalf("runCompile succeeded writing over %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runCompile error = %v, want %q", err, tc.want)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatalf("protected file for %s was overwritten", tc.name)
+			}
+		})
+	}
+}
+
 func TestResolveCompileSignerLoadsKeystoreAgent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/compile_test.go
+++ b/internal/cli/learn/compile_test.go
@@ -441,6 +441,41 @@ func TestResolveCompileSignerDeterministic(t *testing.T) {
 	}
 }
 
+func TestRefuseOutputsOverKeystoreKeys(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.ForceGenerateAgent("alice"); err != nil {
+		t.Fatalf("ForceGenerateAgent: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("alice")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	err = refuseOutputsOverKeystoreKeys(dir, map[string]string{
+		"the compile signing key": "alice",
+	}, map[string]string{"--output": keyPath})
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("refuseOutputsOverKeystoreKeys error = %v, want alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("keystore key was overwritten")
+	}
+	if err := refuseOutputsOverKeystoreKeys(dir, map[string]string{
+		"the compile signing key": "alice",
+	}, map[string]string{"--output": filepath.Join(dir, "candidate.yaml")}); err != nil {
+		t.Fatalf("distinct output rejected: %v", err)
+	}
+}
+
 func TestRunCompileRefusesOutputAliasingSigningKey(t *testing.T) {
 	dir := t.TempDir()
 	ks := signing.NewKeystore(dir)

--- a/internal/cli/learn/forget.go
+++ b/internal/cli/learn/forget.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/activation"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
@@ -122,6 +123,13 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	}
 	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "redaction-receipts.jsonl")
 	if err != nil {
+		return err
+	}
+	if err := cliutil.RefuseOutputCollisions(map[string]string{
+		"--out":         dest,
+		"tombstone":     tombstonePath,
+		"--receipt-out": receiptOut,
+	}); err != nil {
 		return err
 	}
 	if !flags.deterministic {

--- a/internal/cli/learn/forget.go
+++ b/internal/cli/learn/forget.go
@@ -124,6 +124,18 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	if err != nil {
 		return err
 	}
+	if !flags.deterministic {
+		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
+			"the compile signing key":    compileSigner.keyID,
+			"the activation signing key": activationSigner.keyID,
+		}, map[string]string{
+			"--out":         dest,
+			"tombstone":     tombstonePath,
+			"--receipt-out": receiptOut,
+		}); err != nil {
+			return err
+		}
+	}
 	receipt, err := activation.SignReceipt(
 		contractreceipt.PayloadContractRedactionRequest,
 		contractreceipt.PayloadContractRedactionRequestStruct{

--- a/internal/cli/learn/forget.go
+++ b/internal/cli/learn/forget.go
@@ -125,22 +125,27 @@ func runForget(cmd *cobra.Command, flags forgetFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := cliutil.RefuseOutputCollisions(map[string]string{
+	outputs := map[string]string{
 		"--out":         dest,
 		"tombstone":     tombstonePath,
 		"--receipt-out": receiptOut,
-	}); err != nil {
+	}
+	if err := cliutil.RefuseOutputCollisions(outputs); err != nil {
+		return err
+	}
+	// dest is a new forgotten artifact by design. Refuse any of these
+	// outputs naming the loaded candidate so the original is not replaced
+	// by a receipt, a tombstone, or an in-place --out.
+	if err := cliutil.RefuseOutputAliases(map[string]string{
+		loadedCandidateLabel: clean,
+	}, outputs); err != nil {
 		return err
 	}
 	if !flags.deterministic {
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the compile signing key":    compileSigner.keyID,
 			"the activation signing key": activationSigner.keyID,
-		}, map[string]string{
-			"--out":         dest,
-			"tombstone":     tombstonePath,
-			"--receipt-out": receiptOut,
-		}); err != nil {
+		}, outputs); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/lifecycle_failure_boundaries_test.go
+++ b/internal/cli/learn/lifecycle_failure_boundaries_test.go
@@ -265,11 +265,12 @@ func TestForgetReceiptFailureDoesNotPublishReducedCandidate(t *testing.T) {
 	before := mustReadTestFile(t, candidate)
 	receiptPath := unwritableReceiptPath(t)
 
+	out := filepath.Join(dir, "forgotten.yaml")
 	err := runForget(learnTestCommand(""), forgetFlags{
 		candidatePath: candidate,
 		ruleID:        "r-enforce",
 		reason:        "ticket-42",
-		outPath:       candidate,
+		outPath:       out,
 		tombstoneDir:  filepath.Join(dir, "tombstones"),
 		receiptOut:    receiptPath,
 		deterministic: true,
@@ -278,6 +279,7 @@ func TestForgetReceiptFailureDoesNotPublishReducedCandidate(t *testing.T) {
 		t.Fatalf("runForget err = %v, want receipt open failure", err)
 	}
 	assertFileBytes(t, candidate, before)
+	assertPathAbsent(t, out)
 	assertNoStagingFiles(t, dir, filepath.Base(candidate))
 }
 

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/activation"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
@@ -134,6 +135,12 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	}
 	receiptOut, err := resolveReceiptOut(flags.receiptOut, dest, "ratification-receipts.jsonl")
 	if err != nil {
+		return err
+	}
+	if err := cliutil.RefuseOutputCollisions(map[string]string{
+		"--out":         dest,
+		"--receipt-out": receiptOut,
+	}); err != nil {
 		return err
 	}
 	if !flags.deterministic {

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -39,6 +39,8 @@ const (
 	ratifyConfidenceBrittle        = "brittle"
 	ratifyConfidenceNeverConfirmed = "never_confirmed"
 	ratifyConfidenceRefuted        = "refuted"
+
+	loadedCandidateLabel = "the loaded candidate"
 )
 
 // ErrLowConfidenceRatification is returned when ratify would promote
@@ -137,8 +139,18 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := cliutil.RefuseOutputCollisions(map[string]string{
+	outputs := map[string]string{
 		"--out":         dest,
+		"--receipt-out": receiptOut,
+	}
+	if err := cliutil.RefuseOutputCollisions(outputs); err != nil {
+		return err
+	}
+	// dest may equal the candidate when --out is omitted (in-place rewrite).
+	// The receipt must still not replace the loaded candidate.
+	if err := cliutil.RefuseOutputAliases(map[string]string{
+		loadedCandidateLabel: clean,
+	}, map[string]string{
 		"--receipt-out": receiptOut,
 	}); err != nil {
 		return err

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -159,10 +159,7 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the compile signing key": compileSigner.keyID,
 			"the receipt signing key": receiptSigner.keyID,
-		}, map[string]string{
-			"--out":         dest,
-			"--receipt-out": receiptOut,
-		}); err != nil {
+		}, outputs); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/ratify.go
+++ b/internal/cli/learn/ratify.go
@@ -136,6 +136,17 @@ func runRatify(cmd *cobra.Command, flags ratifyFlags) error {
 	if err != nil {
 		return err
 	}
+	if !flags.deterministic {
+		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
+			"the compile signing key": compileSigner.keyID,
+			"the receipt signing key": receiptSigner.keyID,
+		}, map[string]string{
+			"--out":         dest,
+			"--receipt-out": receiptOut,
+		}); err != nil {
+			return err
+		}
+	}
 	now := ratifyNow(flags.deterministic)
 	eventID := lifecycleID("", flags.deterministic, "contract-ratified")
 	receipt, err := activation.SignReceipt(

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -19,7 +19,51 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
+		t.Fatalf("ForceGenerateAgent compile: %v", err)
+	}
+	if _, err := ks.ForceGenerateAgent(defaultReceiptKeyAgent); err != nil {
+		t.Fatalf("ForceGenerateAgent receipt: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("compile-signer")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+	cmd, _ := learnTestCmd("")
+	err = runRatify(cmd, ratifyFlags{
+		candidatePath:       candidate,
+		outPath:             keyPath,
+		receiptOut:          filepath.Join(dir, "ratify.jsonl"),
+		keystore:            dir,
+		compileKeyAgent:     "compile-signer",
+		receiptKey:          defaultReceiptKeyAgent,
+		acceptLowConfidence: true,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runRatify succeeded writing --out over the compile signing key")
+	}
+	if !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("runRatify error = %v, want alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("compile signing key was overwritten")
+	}
+}
 
 func TestLearnCmdRegistersRatifyAndForget(t *testing.T) {
 	cmd := Cmd()

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -23,45 +23,56 @@ import (
 )
 
 func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
-	dir := t.TempDir()
-	ks := signing.NewKeystore(dir)
-	if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
-		t.Fatalf("ForceGenerateAgent compile: %v", err)
-	}
-	if _, err := ks.ForceGenerateAgent(defaultReceiptKeyAgent); err != nil {
-		t.Fatalf("ForceGenerateAgent receipt: %v", err)
-	}
-	keyPath, err := ks.PrivateKeyPath("compile-signer")
-	if err != nil {
-		t.Fatalf("PrivateKeyPath: %v", err)
-	}
-	before, err := os.ReadFile(filepath.Clean(keyPath))
-	if err != nil {
-		t.Fatalf("read key: %v", err)
-	}
-	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
-	cmd, _ := learnTestCmd("")
-	err = runRatify(cmd, ratifyFlags{
-		candidatePath:       candidate,
-		outPath:             keyPath,
-		receiptOut:          filepath.Join(dir, "ratify.jsonl"),
-		keystore:            dir,
-		compileKeyAgent:     "compile-signer",
-		receiptKey:          defaultReceiptKeyAgent,
-		acceptLowConfidence: true,
-	})
-	after, readErr := os.ReadFile(filepath.Clean(keyPath))
-	if readErr != nil {
-		t.Fatalf("re-read key: %v", readErr)
-	}
-	if err == nil {
-		t.Fatal("runRatify succeeded writing --out over the compile signing key")
-	}
-	if !strings.Contains(err.Error(), "must not name") {
-		t.Fatalf("runRatify error = %v, want alias refusal", err)
-	}
-	if !bytes.Equal(before, after) {
-		t.Fatal("compile signing key was overwritten")
+	for _, tc := range []struct {
+		name string
+		set  func(*ratifyFlags, string)
+	}{
+		{name: "out", set: func(f *ratifyFlags, key string) { f.outPath = key }},
+		{name: "receipt-out", set: func(f *ratifyFlags, key string) { f.receiptOut = key }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ks := signing.NewKeystore(dir)
+			if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
+				t.Fatalf("ForceGenerateAgent compile: %v", err)
+			}
+			if _, err := ks.ForceGenerateAgent(defaultReceiptKeyAgent); err != nil {
+				t.Fatalf("ForceGenerateAgent receipt: %v", err)
+			}
+			keyPath, err := ks.PrivateKeyPath("compile-signer")
+			if err != nil {
+				t.Fatalf("PrivateKeyPath: %v", err)
+			}
+			before, err := os.ReadFile(filepath.Clean(keyPath))
+			if err != nil {
+				t.Fatalf("read key: %v", err)
+			}
+			flags := ratifyFlags{
+				candidatePath:       writeCandidateEnvelope(t, dir, testRatifyContract()),
+				outPath:             filepath.Join(dir, "ratified.yaml"),
+				receiptOut:          filepath.Join(dir, "ratify.jsonl"),
+				keystore:            dir,
+				compileKeyAgent:     "compile-signer",
+				receiptKey:          defaultReceiptKeyAgent,
+				acceptLowConfidence: true,
+			}
+			tc.set(&flags, keyPath)
+			cmd, _ := learnTestCmd("")
+			err = runRatify(cmd, flags)
+			after, readErr := os.ReadFile(filepath.Clean(keyPath))
+			if readErr != nil {
+				t.Fatalf("re-read key: %v", readErr)
+			}
+			if err == nil {
+				t.Fatalf("runRatify succeeded writing %s over the compile signing key", tc.name)
+			}
+			if !strings.Contains(err.Error(), "must not name") {
+				t.Fatalf("runRatify error = %v, want alias refusal", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("compile signing key was overwritten")
+			}
+		})
 	}
 }
 
@@ -104,9 +115,13 @@ func TestRunForgetRefusesOutputsAliasingCandidate(t *testing.T) {
 	}{
 		{name: "receipt-out", set: func(f *forgetFlags, candidate string) { f.receiptOut = candidate }, want: "--receipt-out must not name the loaded candidate"},
 		{name: "out", set: func(f *forgetFlags, candidate string) { f.outPath = candidate }, want: "--out must not name the loaded candidate"},
+		{name: "tombstone", set: func(f *forgetFlags, candidate string) { f.tombstoneDir = filepath.Dir(candidate) }, want: "tombstone must not name the loaded candidate"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+			if tc.name == "tombstone" {
+				candidate = candidateAtDerivedTombstonePath(t, dir)
+			}
 			before, err := os.ReadFile(filepath.Clean(candidate))
 			if err != nil {
 				t.Fatalf("read candidate: %v", err)
@@ -141,47 +156,58 @@ func TestRunForgetRefusesOutputsAliasingCandidate(t *testing.T) {
 }
 
 func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
-	dir := t.TempDir()
-	ks := signing.NewKeystore(dir)
-	if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
-		t.Fatalf("ForceGenerateAgent compile: %v", err)
-	}
-	if _, err := ks.ForceGenerateAgent("activation-signer"); err != nil {
-		t.Fatalf("ForceGenerateAgent activation: %v", err)
-	}
-	keyPath, err := ks.PrivateKeyPath("compile-signer")
-	if err != nil {
-		t.Fatalf("PrivateKeyPath: %v", err)
-	}
-	before, err := os.ReadFile(filepath.Clean(keyPath))
-	if err != nil {
-		t.Fatalf("read key: %v", err)
-	}
-	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
-	cmd, _ := learnTestCmd("")
-	err = runForget(cmd, forgetFlags{
-		candidatePath:   candidate,
-		ruleID:          "r-enforce",
-		reason:          "legal-ticket-123",
-		outPath:         keyPath,
-		tombstoneDir:    filepath.Join(dir, "tombstones"),
-		receiptOut:      filepath.Join(dir, "redaction.jsonl"),
-		keystore:        dir,
-		compileKeyAgent: "compile-signer",
-		activationKey:   "activation-signer",
-	})
-	after, readErr := os.ReadFile(filepath.Clean(keyPath))
-	if readErr != nil {
-		t.Fatalf("re-read key: %v", readErr)
-	}
-	if err == nil {
-		t.Fatal("runForget succeeded writing --out over the compile signing key")
-	}
-	if !strings.Contains(err.Error(), "must not name") {
-		t.Fatalf("runForget error = %v, want alias refusal", err)
-	}
-	if !bytes.Equal(before, after) {
-		t.Fatal("compile signing key was overwritten")
+	for _, tc := range []struct {
+		name string
+		set  func(*forgetFlags, string)
+	}{
+		{name: "out", set: func(f *forgetFlags, key string) { f.outPath = key }},
+		{name: "receipt-out", set: func(f *forgetFlags, key string) { f.receiptOut = key }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ks := signing.NewKeystore(dir)
+			if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
+				t.Fatalf("ForceGenerateAgent compile: %v", err)
+			}
+			if _, err := ks.ForceGenerateAgent("activation-signer"); err != nil {
+				t.Fatalf("ForceGenerateAgent activation: %v", err)
+			}
+			keyPath, err := ks.PrivateKeyPath("compile-signer")
+			if err != nil {
+				t.Fatalf("PrivateKeyPath: %v", err)
+			}
+			before, err := os.ReadFile(filepath.Clean(keyPath))
+			if err != nil {
+				t.Fatalf("read key: %v", err)
+			}
+			flags := forgetFlags{
+				candidatePath:   writeCandidateEnvelope(t, dir, testRatifyContract()),
+				ruleID:          "r-enforce",
+				reason:          "legal-ticket-123",
+				outPath:         filepath.Join(dir, "forgotten.yaml"),
+				tombstoneDir:    filepath.Join(dir, "tombstones"),
+				receiptOut:      filepath.Join(dir, "redaction.jsonl"),
+				keystore:        dir,
+				compileKeyAgent: "compile-signer",
+				activationKey:   "activation-signer",
+			}
+			tc.set(&flags, keyPath)
+			cmd, _ := learnTestCmd("")
+			err = runForget(cmd, flags)
+			after, readErr := os.ReadFile(filepath.Clean(keyPath))
+			if readErr != nil {
+				t.Fatalf("re-read key: %v", readErr)
+			}
+			if err == nil {
+				t.Fatalf("runForget succeeded writing %s over the compile signing key", tc.name)
+			}
+			if !strings.Contains(err.Error(), "must not name") {
+				t.Fatalf("runForget error = %v, want alias refusal", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("compile signing key was overwritten")
+			}
+		})
 	}
 }
 
@@ -354,6 +380,25 @@ func testRule(id, host, path string) contract.Rule {
 		RecurringSupport:     map[string]any{},
 		OpportunityHealth:    map[string]any{},
 	}
+}
+
+func candidateAtDerivedTombstonePath(t *testing.T, dir string) string {
+	t.Helper()
+	src := writeCandidateEnvelope(t, dir, testRatifyContract())
+	_, env, err := loadCandidateEnvelope(src)
+	if err != nil {
+		t.Fatalf("loadCandidateEnvelope: %v", err)
+	}
+	name := strings.NewReplacer(":", "-", "/", "-").Replace(env.Body.ContractHash) + ".tombstone.yaml"
+	dest := filepath.Join(dir, name)
+	raw, err := os.ReadFile(filepath.Clean(src))
+	if err != nil {
+		t.Fatalf("read candidate: %v", err)
+	}
+	if err := os.WriteFile(dest, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile tombstone-named candidate: %v", err)
+	}
+	return dest
 }
 
 func writeCandidateEnvelope(t *testing.T, dir string, c contract.Contract) string {

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -65,6 +65,126 @@ func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
 	}
 }
 
+func TestRunRatifyRefusesReceiptOutAliasingCandidate(t *testing.T) {
+	dir := t.TempDir()
+	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+	before, err := os.ReadFile(filepath.Clean(candidate))
+	if err != nil {
+		t.Fatalf("read candidate: %v", err)
+	}
+	cmd, _ := learnTestCmd("")
+	err = runRatify(cmd, ratifyFlags{
+		candidatePath:       candidate,
+		outPath:             filepath.Join(dir, "ratified.yaml"),
+		receiptOut:          candidate,
+		deterministic:       true,
+		acceptLowConfidence: true,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(candidate))
+	if readErr != nil {
+		t.Fatalf("re-read candidate: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runRatify succeeded writing --receipt-out over the loaded candidate")
+	}
+	if !strings.Contains(err.Error(), "--receipt-out must not name the loaded candidate") {
+		t.Fatalf("runRatify error = %v, want candidate receipt alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("loaded candidate was overwritten")
+	}
+}
+
+func TestRunForgetRefusesOutputsAliasingCandidate(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name string
+		set  func(*forgetFlags, string)
+		want string
+	}{
+		{name: "receipt-out", set: func(f *forgetFlags, candidate string) { f.receiptOut = candidate }, want: "--receipt-out must not name the loaded candidate"},
+		{name: "out", set: func(f *forgetFlags, candidate string) { f.outPath = candidate }, want: "--out must not name the loaded candidate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+			before, err := os.ReadFile(filepath.Clean(candidate))
+			if err != nil {
+				t.Fatalf("read candidate: %v", err)
+			}
+			flags := forgetFlags{
+				candidatePath: candidate,
+				ruleID:        "r-enforce",
+				reason:        "legal-ticket-123",
+				outPath:       filepath.Join(dir, "forgotten-"+tc.name+".yaml"),
+				tombstoneDir:  filepath.Join(dir, "tombstones-"+tc.name),
+				receiptOut:    filepath.Join(dir, "redaction-"+tc.name+".jsonl"),
+				deterministic: true,
+			}
+			tc.set(&flags, candidate)
+			cmd, _ := learnTestCmd("")
+			err = runForget(cmd, flags)
+			after, readErr := os.ReadFile(filepath.Clean(candidate))
+			if readErr != nil {
+				t.Fatalf("re-read candidate: %v", readErr)
+			}
+			if err == nil {
+				t.Fatalf("runForget succeeded writing %s over the loaded candidate", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runForget error = %v, want %q", err, tc.want)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("loaded candidate was overwritten")
+			}
+		})
+	}
+}
+
+func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	ks := signing.NewKeystore(dir)
+	if _, err := ks.ForceGenerateAgent("compile-signer"); err != nil {
+		t.Fatalf("ForceGenerateAgent compile: %v", err)
+	}
+	if _, err := ks.ForceGenerateAgent("activation-signer"); err != nil {
+		t.Fatalf("ForceGenerateAgent activation: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("compile-signer")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
+	cmd, _ := learnTestCmd("")
+	err = runForget(cmd, forgetFlags{
+		candidatePath:   candidate,
+		ruleID:          "r-enforce",
+		reason:          "legal-ticket-123",
+		outPath:         keyPath,
+		tombstoneDir:    filepath.Join(dir, "tombstones"),
+		receiptOut:      filepath.Join(dir, "redaction.jsonl"),
+		keystore:        dir,
+		compileKeyAgent: "compile-signer",
+		activationKey:   "activation-signer",
+	})
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runForget succeeded writing --out over the compile signing key")
+	}
+	if !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("runForget error = %v, want alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("compile signing key was overwritten")
+	}
+}
+
 func TestLearnCmdRegistersRatifyAndForget(t *testing.T) {
 	cmd := Cmd()
 	for _, name := range []string{"ratify", "forget"} {

--- a/internal/cli/learn/ratify_forget_test.go
+++ b/internal/cli/learn/ratify_forget_test.go
@@ -24,11 +24,14 @@ import (
 
 func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		set  func(*ratifyFlags, string)
+		name     string
+		keyAgent string
+		set      func(*ratifyFlags, string)
 	}{
-		{name: "out", set: func(f *ratifyFlags, key string) { f.outPath = key }},
-		{name: "receipt-out", set: func(f *ratifyFlags, key string) { f.receiptOut = key }},
+		{name: "out-compile", keyAgent: "compile-signer", set: func(f *ratifyFlags, key string) { f.outPath = key }},
+		{name: "receipt-out-compile", keyAgent: "compile-signer", set: func(f *ratifyFlags, key string) { f.receiptOut = key }},
+		{name: "out-receipt", keyAgent: defaultReceiptKeyAgent, set: func(f *ratifyFlags, key string) { f.outPath = key }},
+		{name: "receipt-out-receipt", keyAgent: defaultReceiptKeyAgent, set: func(f *ratifyFlags, key string) { f.receiptOut = key }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -39,9 +42,9 @@ func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
 			if _, err := ks.ForceGenerateAgent(defaultReceiptKeyAgent); err != nil {
 				t.Fatalf("ForceGenerateAgent receipt: %v", err)
 			}
-			keyPath, err := ks.PrivateKeyPath("compile-signer")
+			keyPath, err := ks.PrivateKeyPath(tc.keyAgent)
 			if err != nil {
-				t.Fatalf("PrivateKeyPath: %v", err)
+				t.Fatalf("PrivateKeyPath %s: %v", tc.keyAgent, err)
 			}
 			before, err := os.ReadFile(filepath.Clean(keyPath))
 			if err != nil {
@@ -64,13 +67,13 @@ func TestRunRatifyRefusesOutputAliasingSigningKey(t *testing.T) {
 				t.Fatalf("re-read key: %v", readErr)
 			}
 			if err == nil {
-				t.Fatalf("runRatify succeeded writing %s over the compile signing key", tc.name)
+				t.Fatalf("runRatify succeeded writing over the %s key", tc.keyAgent)
 			}
 			if !strings.Contains(err.Error(), "must not name") {
 				t.Fatalf("runRatify error = %v, want alias refusal", err)
 			}
 			if !bytes.Equal(before, after) {
-				t.Fatal("compile signing key was overwritten")
+				t.Fatal("signing key was overwritten")
 			}
 		})
 	}
@@ -157,11 +160,16 @@ func TestRunForgetRefusesOutputsAliasingCandidate(t *testing.T) {
 
 func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		set  func(*forgetFlags, string)
+		name     string
+		keyAgent string
+		set      func(*testing.T, *forgetFlags, string, string)
 	}{
-		{name: "out", set: func(f *forgetFlags, key string) { f.outPath = key }},
-		{name: "receipt-out", set: func(f *forgetFlags, key string) { f.receiptOut = key }},
+		{name: "out-compile", keyAgent: "compile-signer", set: func(_ *testing.T, f *forgetFlags, key, _ string) { f.outPath = key }},
+		{name: "receipt-out-compile", keyAgent: "compile-signer", set: func(_ *testing.T, f *forgetFlags, key, _ string) { f.receiptOut = key }},
+		{name: "out-activation", keyAgent: "activation-signer", set: func(_ *testing.T, f *forgetFlags, key, _ string) { f.outPath = key }},
+		{name: "receipt-out-activation", keyAgent: "activation-signer", set: func(_ *testing.T, f *forgetFlags, key, _ string) { f.receiptOut = key }},
+		{name: "tombstone-activation", keyAgent: "activation-signer", set: plantForgetTombstoneOverKey},
+		{name: "tombstone-compile", keyAgent: "compile-signer", set: plantForgetTombstoneOverKey},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -172,16 +180,17 @@ func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
 			if _, err := ks.ForceGenerateAgent("activation-signer"); err != nil {
 				t.Fatalf("ForceGenerateAgent activation: %v", err)
 			}
-			keyPath, err := ks.PrivateKeyPath("compile-signer")
+			keyPath, err := ks.PrivateKeyPath(tc.keyAgent)
 			if err != nil {
-				t.Fatalf("PrivateKeyPath: %v", err)
+				t.Fatalf("PrivateKeyPath %s: %v", tc.keyAgent, err)
 			}
 			before, err := os.ReadFile(filepath.Clean(keyPath))
 			if err != nil {
 				t.Fatalf("read key: %v", err)
 			}
+			candidate := writeCandidateEnvelope(t, dir, testRatifyContract())
 			flags := forgetFlags{
-				candidatePath:   writeCandidateEnvelope(t, dir, testRatifyContract()),
+				candidatePath:   candidate,
 				ruleID:          "r-enforce",
 				reason:          "legal-ticket-123",
 				outPath:         filepath.Join(dir, "forgotten.yaml"),
@@ -191,7 +200,7 @@ func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
 				compileKeyAgent: "compile-signer",
 				activationKey:   "activation-signer",
 			}
-			tc.set(&flags, keyPath)
+			tc.set(t, &flags, keyPath, candidate)
 			cmd, _ := learnTestCmd("")
 			err = runForget(cmd, flags)
 			after, readErr := os.ReadFile(filepath.Clean(keyPath))
@@ -199,13 +208,13 @@ func TestRunForgetRefusesOutputAliasingSigningKey(t *testing.T) {
 				t.Fatalf("re-read key: %v", readErr)
 			}
 			if err == nil {
-				t.Fatalf("runForget succeeded writing %s over the compile signing key", tc.name)
+				t.Fatalf("runForget succeeded writing over the %s key", tc.keyAgent)
 			}
 			if !strings.Contains(err.Error(), "must not name") {
 				t.Fatalf("runForget error = %v, want alias refusal", err)
 			}
 			if !bytes.Equal(before, after) {
-				t.Fatal("compile signing key was overwritten")
+				t.Fatal("signing key was overwritten")
 			}
 		})
 	}
@@ -380,6 +389,24 @@ func testRule(id, host, path string) contract.Rule {
 		RecurringSupport:     map[string]any{},
 		OpportunityHealth:    map[string]any{},
 	}
+}
+
+func plantForgetTombstoneOverKey(t *testing.T, flags *forgetFlags, keyPath, candidate string) {
+	t.Helper()
+	_, env, err := loadCandidateEnvelope(candidate)
+	if err != nil {
+		t.Fatalf("loadCandidateEnvelope: %v", err)
+	}
+	name := strings.NewReplacer(":", "-", "/", "-").Replace(env.Body.ContractHash) + ".tombstone.yaml"
+	tombDir := filepath.Join(filepath.Dir(candidate), "tombstones-key-alias")
+	if err := os.MkdirAll(tombDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll tombstone dir: %v", err)
+	}
+	dest := filepath.Join(tombDir, name)
+	if err := os.Link(keyPath, dest); err != nil {
+		t.Fatalf("Link tombstone dest to key: %v", err)
+	}
+	flags.tombstoneDir = tombDir
 }
 
 func candidateAtDerivedTombstonePath(t *testing.T, dir string) string {

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -129,6 +129,20 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if err != nil {
 		return err
 	}
+	if !flags.deterministic {
+		keyAgent := flags.receiptKey
+		if keyAgent == "" {
+			keyAgent = defaultReceiptKeyAgent
+		}
+		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
+			"the receipt signing key": keyAgent,
+		}, map[string]string{
+			"--out":      flags.outPath,
+			"--out-json": flags.outJSONPath,
+		}); err != nil {
+			return err
+		}
+	}
 	if err := writeShadowReports(cmd, report, flags); err != nil {
 		return err
 	}

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -109,6 +109,9 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
 		return err
 	}
+	if err := cliutil.RefuseOutputCollisions(outputs); err != nil {
+		return err
+	}
 	sessionsDir, err := resolveShadowSessions(cfg, flags)
 	if err != nil {
 		return err

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -27,7 +27,11 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
-const defaultReceiptKeyAgent = "receipt-signing"
+const (
+	defaultReceiptKeyAgent     = "receipt-signing"
+	shadowRecorderEvidenceFile = "evidence-proxy-0.jsonl"
+	shadowReceiptsLabel        = "shadow receipts"
+)
 
 type shadowFlags struct {
 	contractPath  string
@@ -106,10 +110,27 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	}
 	protected := cliutil.ExistingFileLabels("--contract", []string{contractPath})
 	maps.Copy(protected, cliutil.ExistingFileLabels("--config", []string{flags.configPath}))
+	if flags.recorderDir != "" {
+		// emitShadowReceipts appends the first signed receipt to this shard
+		// after writeShadowReports. A report path that names it mixes the
+		// report with recorder JSONL.
+		outputs[shadowReceiptsLabel] = filepath.Join(filepath.Clean(flags.recorderDir), shadowRecorderEvidenceFile)
+	}
 	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
 		return err
 	}
-	if err := cliutil.RefuseOutputCollisions(outputs); err != nil {
+	if err := cliutil.RefuseOutputCollisions(map[string]string{
+		"--out":      flags.outPath,
+		"--out-json": flags.outJSONPath,
+	}); err != nil {
+		return err
+	}
+	if err := cliutil.RefuseOutputAliases(map[string]string{
+		shadowReceiptsLabel: outputs[shadowReceiptsLabel],
+	}, map[string]string{
+		"--out":      flags.outPath,
+		"--out-json": flags.outJSONPath,
+	}); err != nil {
 		return err
 	}
 	sessionsDir, err := resolveShadowSessions(cfg, flags)
@@ -149,10 +170,7 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 		}
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the receipt signing key": keyAgent,
-		}, map[string]string{
-			"--out":      flags.outPath,
-			"--out-json": flags.outJSONPath,
-		}); err != nil {
+		}, outputs); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -100,6 +100,15 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if !verified {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: unverified contract accepted because --allow-unsigned-contract-for-diagnostics is set; shadow replay is diagnostic only")
 	}
+	outputs := map[string]string{
+		"--out":      flags.outPath,
+		"--out-json": flags.outJSONPath,
+	}
+	protected := cliutil.ExistingFileLabels("--contract", []string{contractPath})
+	maps.Copy(protected, cliutil.ExistingFileLabels("--config", []string{flags.configPath}))
+	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
+		return err
+	}
 	sessionsDir, err := resolveShadowSessions(cfg, flags)
 	if err != nil {
 		return err
@@ -130,15 +139,6 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if err != nil {
 		return err
 	}
-	outputs := map[string]string{
-		"--out":      flags.outPath,
-		"--out-json": flags.outJSONPath,
-	}
-	protected := cliutil.ExistingFileLabels("--contract", []string{contractPath})
-	maps.Copy(protected, cliutil.ExistingFileLabels("--config", []string{flags.configPath}))
-	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
-		return err
-	}
 	if !flags.deterministic {
 		keyAgent := flags.receiptKey
 		if keyAgent == "" {
@@ -146,7 +146,10 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 		}
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the receipt signing key": keyAgent,
-		}, outputs); err != nil {
+		}, map[string]string{
+			"--out":      flags.outPath,
+			"--out-json": flags.outJSONPath,
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/shadow.go
+++ b/internal/cli/learn/shadow.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,6 +130,15 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 	if err != nil {
 		return err
 	}
+	outputs := map[string]string{
+		"--out":      flags.outPath,
+		"--out-json": flags.outJSONPath,
+	}
+	protected := cliutil.ExistingFileLabels("--contract", []string{contractPath})
+	maps.Copy(protected, cliutil.ExistingFileLabels("--config", []string{flags.configPath}))
+	if err := cliutil.RefuseOutputAliases(protected, outputs); err != nil {
+		return err
+	}
 	if !flags.deterministic {
 		keyAgent := flags.receiptKey
 		if keyAgent == "" {
@@ -136,10 +146,7 @@ func runShadow(cmd *cobra.Command, flags shadowFlags) error {
 		}
 		if err := refuseOutputsOverKeystoreKeys(flags.keystore, map[string]string{
 			"the receipt signing key": keyAgent,
-		}, map[string]string{
-			"--out":      flags.outPath,
-			"--out-json": flags.outJSONPath,
-		}); err != nil {
+		}, outputs); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -30,6 +30,39 @@ import (
 
 const testUnknownContractHash = "sha256:unknown"
 
+func TestRunShadowRefusesOutputAliasingContract(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeCandidateEnvelope(t, dir, testRatifyContract())
+	before, err := os.ReadFile(filepath.Clean(contractPath))
+	if err != nil {
+		t.Fatalf("read contract: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runShadow(cmd, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		duration:      time.Hour,
+		outPath:       contractPath,
+		deterministic: true,
+		sessionsDir:   dir,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(contractPath))
+	if readErr != nil {
+		t.Fatalf("re-read contract: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runShadow succeeded writing --out over --contract")
+	}
+	if !strings.Contains(err.Error(), "--out must not name --contract") {
+		t.Fatalf("runShadow error = %v, want contract alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("shadow contract was overwritten")
+	}
+}
+
 func TestResolveShadowSessionsUsesExplicitDirAndRejectsSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -63,6 +63,30 @@ func TestRunShadowRefusesOutputAliasingContract(t *testing.T) {
 	}
 }
 
+func TestRunShadowRefusesOutAliasingOutJSON(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeCandidateEnvelope(t, dir, testRatifyContract())
+	shared := filepath.Join(dir, "shadow-out")
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := runShadow(cmd, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		duration:      time.Hour,
+		outPath:       shared,
+		outJSONPath:   shared,
+		deterministic: true,
+		sessionsDir:   dir,
+	})
+	if err == nil {
+		t.Fatal("runShadow succeeded writing --out over --out-json")
+	}
+	if !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("runShadow error = %v, want --out/--out-json collision", err)
+	}
+}
+
 func TestResolveShadowSessionsUsesExplicitDirAndRejectsSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -88,44 +88,56 @@ func TestRunShadowRefusesOutAliasingOutJSON(t *testing.T) {
 }
 
 func TestRunShadowRefusesOutAliasingRecorderDest(t *testing.T) {
-	dir := t.TempDir()
-	contractPath := writeCandidateEnvelope(t, dir, testRatifyContract())
-	recorderDir := filepath.Join(dir, "receipts")
-	if err := os.Mkdir(recorderDir, 0o750); err != nil {
-		t.Fatalf("Mkdir recorder: %v", err)
-	}
-	receiptPath := filepath.Join(recorderDir, shadowRecorderEvidenceFile)
-	if err := os.WriteFile(receiptPath, []byte("keep-me\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile recorder dest: %v", err)
-	}
-	before, err := os.ReadFile(filepath.Clean(receiptPath))
-	if err != nil {
-		t.Fatalf("read recorder dest: %v", err)
-	}
-	cmd := &cobra.Command{}
-	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	err = runShadow(cmd, shadowFlags{
-		contractPath:  contractPath,
-		allowUnsigned: true,
-		duration:      time.Hour,
-		outPath:       receiptPath,
-		recorderDir:   recorderDir,
-		deterministic: true,
-		sessionsDir:   dir,
-	})
-	after, readErr := os.ReadFile(filepath.Clean(receiptPath))
-	if readErr != nil {
-		t.Fatalf("re-read recorder dest: %v", readErr)
-	}
-	if err == nil {
-		t.Fatal("runShadow succeeded writing --out over the shadow receipt shard")
-	}
-	if !strings.Contains(err.Error(), "--out must not name shadow receipts") {
-		t.Fatalf("runShadow error = %v, want recorder dest alias refusal", err)
-	}
-	if !bytes.Equal(before, after) {
-		t.Fatal("shadow receipt shard was overwritten")
+	for _, tc := range []struct {
+		name string
+		set  func(*shadowFlags, string)
+		want string
+	}{
+		{name: "out", set: func(f *shadowFlags, p string) { f.outPath = p }, want: "--out must not name shadow receipts"},
+		{name: "out-json", set: func(f *shadowFlags, p string) { f.outJSONPath = p }, want: "--out-json must not name shadow receipts"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			contractPath := writeCandidateEnvelope(t, dir, testRatifyContract())
+			recorderDir := filepath.Join(dir, "receipts")
+			if err := os.Mkdir(recorderDir, 0o750); err != nil {
+				t.Fatalf("Mkdir recorder: %v", err)
+			}
+			receiptPath := filepath.Join(recorderDir, shadowRecorderEvidenceFile)
+			if err := os.WriteFile(receiptPath, []byte("keep-me\n"), 0o600); err != nil {
+				t.Fatalf("WriteFile recorder dest: %v", err)
+			}
+			before, err := os.ReadFile(filepath.Clean(receiptPath))
+			if err != nil {
+				t.Fatalf("read recorder dest: %v", err)
+			}
+			flags := shadowFlags{
+				contractPath:  contractPath,
+				allowUnsigned: true,
+				duration:      time.Hour,
+				recorderDir:   recorderDir,
+				deterministic: true,
+				sessionsDir:   dir,
+			}
+			tc.set(&flags, receiptPath)
+			cmd := &cobra.Command{}
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			err = runShadow(cmd, flags)
+			after, readErr := os.ReadFile(filepath.Clean(receiptPath))
+			if readErr != nil {
+				t.Fatalf("re-read recorder dest: %v", readErr)
+			}
+			if err == nil {
+				t.Fatalf("runShadow succeeded writing %s over the shadow receipt shard", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runShadow error = %v, want %q", err, tc.want)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("shadow receipt shard was overwritten")
+			}
+		})
 	}
 }
 

--- a/internal/cli/learn/shadow_test.go
+++ b/internal/cli/learn/shadow_test.go
@@ -87,6 +87,48 @@ func TestRunShadowRefusesOutAliasingOutJSON(t *testing.T) {
 	}
 }
 
+func TestRunShadowRefusesOutAliasingRecorderDest(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeCandidateEnvelope(t, dir, testRatifyContract())
+	recorderDir := filepath.Join(dir, "receipts")
+	if err := os.Mkdir(recorderDir, 0o750); err != nil {
+		t.Fatalf("Mkdir recorder: %v", err)
+	}
+	receiptPath := filepath.Join(recorderDir, shadowRecorderEvidenceFile)
+	if err := os.WriteFile(receiptPath, []byte("keep-me\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile recorder dest: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(receiptPath))
+	if err != nil {
+		t.Fatalf("read recorder dest: %v", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err = runShadow(cmd, shadowFlags{
+		contractPath:  contractPath,
+		allowUnsigned: true,
+		duration:      time.Hour,
+		outPath:       receiptPath,
+		recorderDir:   recorderDir,
+		deterministic: true,
+		sessionsDir:   dir,
+	})
+	after, readErr := os.ReadFile(filepath.Clean(receiptPath))
+	if readErr != nil {
+		t.Fatalf("re-read recorder dest: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("runShadow succeeded writing --out over the shadow receipt shard")
+	}
+	if !strings.Contains(err.Error(), "--out must not name shadow receipts") {
+		t.Fatalf("runShadow error = %v, want recorder dest alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("shadow receipt shard was overwritten")
+	}
+}
+
 func TestResolveShadowSessionsUsesExplicitDirAndRejectsSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -286,6 +286,16 @@ func signMCPIntegrityManifest(manifestPath, sigPath, signer, keystoreDir string)
 	if sigPath == "" {
 		sigPath = manifestPath + domsigning.SigExtension
 	}
+	keyPath, err := ks.PrivateKeyPath(signerName)
+	if err != nil {
+		return mcpIntegrityReport{}, err
+	}
+	if err := cliutil.RefuseOutputAliases(
+		map[string]string{"the signer private key": keyPath},
+		map[string]string{"--sig": sigPath},
+	); err != nil {
+		return mcpIntegrityReport{}, err
+	}
 	if err := domsigning.SaveSignature(sig, sigPath); err != nil {
 		return mcpIntegrityReport{}, err
 	}

--- a/internal/cli/runtime/mcp_integrity.go
+++ b/internal/cli/runtime/mcp_integrity.go
@@ -291,7 +291,10 @@ func signMCPIntegrityManifest(manifestPath, sigPath, signer, keystoreDir string)
 		return mcpIntegrityReport{}, err
 	}
 	if err := cliutil.RefuseOutputAliases(
-		map[string]string{"the signer private key": keyPath},
+		map[string]string{
+			"the signer private key": keyPath,
+			"--manifest":             manifestPath,
+		},
 		map[string]string{"--sig": sigPath},
 	); err != nil {
 		return mcpIntegrityReport{}, err

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -251,6 +251,49 @@ func TestMCPIntegrityManifestSignAndVerifySignature(t *testing.T) {
 	}
 }
 
+func TestSignMCPIntegrityManifestRefusesOutputAliasingSignerKey(t *testing.T) {
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := domsigning.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("alice")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	beforeInfo, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{"/bin/example": strings.Repeat("a", 64)},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	_, err = signMCPIntegrityManifest(manifestPath, keyPath, "alice", ksDir)
+	after, readErr := os.ReadFile(filepath.Clean(keyPath))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	afterInfo, _ := os.Stat(keyPath)
+	if err == nil {
+		t.Fatal("sign succeeded writing --sig over the signer private key")
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("signer private key was overwritten")
+	}
+	if afterInfo.Mode().Perm() != beforeInfo.Mode().Perm() {
+		t.Fatalf("key mode changed from %v to %v", beforeInfo.Mode().Perm(), afterInfo.Mode().Perm())
+	}
+}
+
 func TestMCPIntegrityManifestVerifySignatureReportsTamper(t *testing.T) {
 	dir := t.TempDir()
 	ksDir := filepath.Join(dir, "keys")

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -294,6 +294,40 @@ func TestSignMCPIntegrityManifestRefusesOutputAliasingSignerKey(t *testing.T) {
 	}
 }
 
+func TestSignMCPIntegrityManifestRefusesOutputAliasingManifest(t *testing.T) {
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := domsigning.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := mcpintegrity.SaveManifest(manifestPath, &mcpintegrity.Manifest{
+		Version: mcpintegrity.ManifestVersion,
+		Entries: map[string]string{"/bin/example": strings.Repeat("a", 64)},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(manifestPath))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	_, err = signMCPIntegrityManifest(manifestPath, manifestPath, "alice", ksDir)
+	after, readErr := os.ReadFile(filepath.Clean(manifestPath))
+	if readErr != nil {
+		t.Fatalf("re-read manifest: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("sign succeeded writing --sig over --manifest")
+	}
+	if !strings.Contains(err.Error(), "--sig must not name --manifest") {
+		t.Fatalf("sign error = %v, want manifest alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("integrity manifest was overwritten")
+	}
+}
+
 func TestMCPIntegrityManifestVerifySignatureReportsTamper(t *testing.T) {
 	dir := t.TempDir()
 	ksDir := filepath.Join(dir, "keys")

--- a/internal/cli/runtime/mcp_integrity_test.go
+++ b/internal/cli/runtime/mcp_integrity_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	mcpintegrity "github.com/luckyPipewrench/pipelock/internal/mcp/integrity"
 	domsigning "github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -291,6 +292,46 @@ func TestSignMCPIntegrityManifestRefusesOutputAliasingSignerKey(t *testing.T) {
 	}
 	if afterInfo.Mode().Perm() != beforeInfo.Mode().Perm() {
 		t.Fatalf("key mode changed from %v to %v", beforeInfo.Mode().Perm(), afterInfo.Mode().Perm())
+	}
+}
+
+func TestSaveSignatureAfterAliasCheckDoesNotFollowSwappedDest(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("symlink replacement semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keys")
+	ks := domsigning.NewKeystore(ksDir)
+	if _, err := ks.GenerateAgent("alice"); err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	keyPath, err := ks.PrivateKeyPath("alice")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	dest := filepath.Join(dir, "manifest.sig")
+	if err := cliutil.RefuseOutputAliases(
+		map[string]string{"the signer private key": keyPath},
+		map[string]string{"--sig": dest},
+	); err != nil {
+		t.Fatalf("preflight refused a missing dest: %v", err)
+	}
+	if err := os.Symlink(keyPath, dest); err != nil {
+		t.Fatalf("Symlink dest: %v", err)
+	}
+	if err := domsigning.SaveSignature([]byte("signature-bytes-here"), dest); err != nil {
+		t.Fatalf("SaveSignature: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("re-read key: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("signer private key was overwritten through a dest swapped in after the alias check")
 	}
 }
 

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -93,6 +93,7 @@ Examples:
 			if cleanReport != "" {
 				protected := cliutil.ExistingFileLabels("--key", expectedKeys)
 				maps.Copy(protected, cliutil.ExistingFileLabels("the receipt input", args))
+				maps.Copy(protected, cliutil.ExistingRegularFiles("the receipt input", chainDir))
 				if err := cliutil.RefuseOutputAliases(
 					protected,
 					map[string]string{"--clean-report": cleanReport},

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/evidence"
 	"github.com/luckyPipewrench/pipelock/internal/evidence/display"
 	"github.com/luckyPipewrench/pipelock/internal/fleetreceipt"
@@ -86,6 +87,14 @@ Examples:
 			}
 			if len(expectedKeys) > 0 && len(trustedKeys) == 0 {
 				return fmt.Errorf("--key was provided but no valid signer keys were resolved")
+			}
+			if cleanReport != "" {
+				if err := cliutil.RefuseOutputAliases(
+					cliutil.ExistingFileLabels("--key", expectedKeys),
+					map[string]string{"--clean-report": cleanReport},
+				); err != nil {
+					return err
+				}
 			}
 			if len(endorsementPaths) > 0 {
 				switch {

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/atomicfile"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/evidence"
 	"github.com/luckyPipewrench/pipelock/internal/evidence/display"
@@ -89,8 +91,10 @@ Examples:
 				return fmt.Errorf("--key was provided but no valid signer keys were resolved")
 			}
 			if cleanReport != "" {
+				protected := cliutil.ExistingFileLabels("--key", expectedKeys)
+				maps.Copy(protected, cliutil.ExistingFileLabels("the receipt input", args))
 				if err := cliutil.RefuseOutputAliases(
-					cliutil.ExistingFileLabels("--key", expectedKeys),
+					protected,
 					map[string]string{"--clean-report": cleanReport},
 				); err != nil {
 					return err
@@ -514,7 +518,7 @@ func verifyCleanReport(out io.Writer, label string, receipts []receipt.Receipt, 
 	if err != nil {
 		return fmt.Errorf("marshal clean report: %w", err)
 	}
-	if err := os.WriteFile(filepath.Clean(reportPath), append(data, '\n'), 0o600); err != nil {
+	if err := atomicfile.Write(filepath.Clean(reportPath), append(data, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write clean report: %w", err)
 	}
 	_, _ = fmt.Fprintf(out, "CLEAN REPORT VALID: %s\n", label)

--- a/internal/cli/signing/receipt.go
+++ b/internal/cli/signing/receipt.go
@@ -90,10 +90,21 @@ Examples:
 			if len(expectedKeys) > 0 && len(trustedKeys) == 0 {
 				return fmt.Errorf("--key was provided but no valid signer keys were resolved")
 			}
+			var resolvedLocation *recorder.EvidenceLocation
+			if chainDir != "" && !fleetReport {
+				location, locationErr := recorder.ResolveEvidenceLocation(chainDir, locationID)
+				if locationErr != nil {
+					return fmt.Errorf("extracting session receipts: resolve evidence location: %w", locationErr)
+				}
+				resolvedLocation = &location
+				chainDir = location.Dir
+			}
 			if cleanReport != "" {
 				protected := cliutil.ExistingFileLabels("--key", expectedKeys)
 				maps.Copy(protected, cliutil.ExistingFileLabels("the receipt input", args))
-				maps.Copy(protected, cliutil.ExistingRegularFiles("the receipt input", chainDir))
+				if resolvedLocation != nil {
+					maps.Copy(protected, cliutil.ExistingRegularFiles("the receipt input", resolvedLocation.Dir))
+				}
 				if err := cliutil.RefuseOutputAliases(
 					protected,
 					map[string]string{"--clean-report": cleanReport},
@@ -142,20 +153,15 @@ Examples:
 				}
 				return verifyFleetReportWithOptions(out, args[0], trustedKeys, allowUnpinned)
 			}
-			if chainDir != "" {
-				location, locationErr := recorder.ResolveEvidenceLocation(chainDir, locationID)
-				if locationErr != nil {
-					return fmt.Errorf("extracting session receipts: resolve evidence location: %w", locationErr)
-				}
-				chainDir = location.Dir
+			if resolvedLocation != nil {
 				if cleanReport == "" {
-					return verifyChainFromResolvedSessionDirDetailed(out, location, sessionID, trustedKeys, verifyOpts)
+					return verifyChainFromResolvedSessionDirDetailed(out, *resolvedLocation, sessionID, trustedKeys, verifyOpts)
 				}
-				receipts, extractErr := receipt.ExtractReceiptsFromResolvedSessionDir(location, sessionID)
+				receipts, extractErr := receipt.ExtractReceiptsFromResolvedSessionDir(*resolvedLocation, sessionID)
 				if extractErr != nil {
 					return fmt.Errorf("extracting session receipts: %w", extractErr)
 				}
-				label := fmt.Sprintf("%s (session %s)", chainDir, sessionID)
+				label := fmt.Sprintf("%s (session %s)", resolvedLocation.Dir, sessionID)
 				return verifyCleanReport(out, label, receipts, trustedKeys, allowUnpinned, cleanReport)
 			}
 			if locationID != "" {

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -1157,6 +1157,33 @@ func TestVerifyReceiptCmd_CleanReportRefusesKeyFileAlias(t *testing.T) {
 	}
 }
 
+func TestVerifyReceiptCmd_CleanReportRefusesReceiptInputAlias(t *testing.T) {
+	t.Parallel()
+	path, pubKey := buildDeferredCleanChainJSONL(t)
+	before, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read receipts: %v", err)
+	}
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--key", hex.EncodeToString(pubKey), "--clean-report", path})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(path))
+	if readErr != nil {
+		t.Fatalf("re-read receipts: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("verify-receipt succeeded writing --clean-report over the receipt input; stdout=%q", buf.String())
+	}
+	if !strings.Contains(err.Error(), "--clean-report must not name the receipt input") {
+		t.Fatalf("verify-receipt error = %v, want receipt-input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("receipt input was overwritten")
+	}
+}
+
 func TestVerifyReceiptCmd_CleanReportRejectsSingleReceipt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -1802,6 +1802,58 @@ func TestReceiptCommandsRejectAmbiguousEvidenceLocations(t *testing.T) {
 	}
 }
 
+func TestVerifyReceiptCmd_CleanReportRefusesLocationReceiptAlias(t *testing.T) {
+	t.Parallel()
+	source, pub := buildRestartChainDir(t, 1)
+	otherSource, _ := buildRestartChainDir(t, 1)
+	root := t.TempDir()
+	selectedID := "recorder-a/run-a"
+	otherID := "recorder-b/run-b"
+	selectedDir := filepath.Join(root, filepath.FromSlash(selectedID))
+	copyEvidenceFiles(t, source, selectedDir)
+	copyEvidenceFiles(t, otherSource, filepath.Join(root, filepath.FromSlash(otherID)))
+	entries, err := os.ReadDir(selectedDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var receiptFile string
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			receiptFile = filepath.Join(selectedDir, entry.Name())
+			break
+		}
+	}
+	if receiptFile == "" {
+		t.Fatal("selected location has no receipt file")
+	}
+	before, err := os.ReadFile(filepath.Clean(receiptFile))
+	if err != nil {
+		t.Fatalf("read receipt: %v", err)
+	}
+	cmd := VerifyReceiptCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--chain", root,
+		"--location", selectedID,
+		"--key", hex.EncodeToString(pub),
+		"--clean-report", receiptFile,
+	})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(receiptFile))
+	if readErr != nil {
+		t.Fatalf("re-read receipt: %v", readErr)
+	}
+	if err == nil {
+		t.Fatal("verify-receipt succeeded writing --clean-report over a nested location receipt")
+	}
+	if !strings.Contains(err.Error(), "--clean-report must not name the receipt input") {
+		t.Fatalf("verify-receipt error = %v, want nested receipt-input alias refusal", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("nested receipt input was overwritten")
+	}
+}
+
 func TestReceiptCommandsSelectEvidenceLocation(t *testing.T) {
 	t.Parallel()
 	source, pub := buildRestartChainDir(t, 1)

--- a/internal/cli/signing/receipt_test.go
+++ b/internal/cli/signing/receipt_test.go
@@ -1129,6 +1129,34 @@ func TestVerifyReceiptCmd_CleanReportJSONLWithDeferPair(t *testing.T) {
 	}
 }
 
+func TestVerifyReceiptCmd_CleanReportRefusesKeyFileAlias(t *testing.T) {
+	t.Parallel()
+	path, pubKey := buildDeferredCleanChainJSONL(t)
+	keyFile := filepath.Join(t.TempDir(), "trusted.key")
+	if err := os.WriteFile(keyFile, []byte(hex.EncodeToString(pubKey)+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(keyFile))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	cmd := VerifyReceiptCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{path, "--key", keyFile, "--clean-report", keyFile})
+	err = cmd.Execute()
+	after, readErr := os.ReadFile(filepath.Clean(keyFile))
+	if readErr != nil {
+		t.Fatalf("re-read key: %v", readErr)
+	}
+	if err == nil {
+		t.Fatalf("verify-receipt succeeded writing --clean-report over --key; stdout=%q", buf.String())
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("trusted signer key file was overwritten")
+	}
+}
+
 func TestVerifyReceiptCmd_CleanReportRejectsSingleReceipt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cliutil/outputalias.go
+++ b/internal/cliutil/outputalias.go
@@ -24,6 +24,28 @@ import (
 // root key") to the path it protects. outputs maps an output flag name to the
 // path it will write. Empty paths on either side are ignored, so a caller can
 // pass optional flags without pre-filtering them.
+// ExistingFileLabels maps flag labels onto paths that currently exist as
+// regular files. Use it for --key values that may be hex or a file path so
+// a hex blob is not treated as a path to protect.
+func ExistingFileLabels(flag string, paths []string) map[string]string {
+	out := make(map[string]string, len(paths))
+	for i, path := range paths {
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		label := flag
+		if len(paths) > 1 {
+			label = fmt.Sprintf("%s[%d]", flag, i)
+		}
+		out[label] = path
+	}
+	return out
+}
+
 func RefuseOutputAliases(protectedPaths map[string]string, outputs map[string]string) error {
 	for _, outputFlag := range slices.Sorted(maps.Keys(outputs)) {
 		outputPath := outputs[outputFlag]

--- a/internal/cliutil/outputalias.go
+++ b/internal/cliutil/outputalias.go
@@ -65,6 +65,25 @@ func ExistingRegularFiles(label, dir string) map[string]string {
 	return ExistingFileLabels(label, paths)
 }
 
+// RefuseOutputCollisions rejects two output paths that name the same file.
+// RefuseOutputAliases only compares outputs to protected inputs, so two
+// outputs that collide with each other would both pass and then overwrite
+// each other.
+func RefuseOutputCollisions(outputs map[string]string) error {
+	flags := slices.Sorted(maps.Keys(outputs))
+	for i, left := range flags {
+		for _, right := range flags[i+1:] {
+			if err := RefuseOutputAliases(
+				map[string]string{left: outputs[left]},
+				map[string]string{right: outputs[right]},
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func RefuseOutputAliases(protectedPaths map[string]string, outputs map[string]string) error {
 	for _, outputFlag := range slices.Sorted(maps.Keys(outputs)) {
 		outputPath := outputs[outputFlag]

--- a/internal/cliutil/outputalias.go
+++ b/internal/cliutil/outputalias.go
@@ -46,6 +46,25 @@ func ExistingFileLabels(flag string, paths []string) map[string]string {
 	return out
 }
 
+// ExistingRegularFiles labels every regular file in dir. A missing or
+// unlistable directory yields an empty map so callers can pass optional roots.
+func ExistingRegularFiles(label, dir string) map[string]string {
+	if dir == "" {
+		return map[string]string{}
+	}
+	entries, err := os.ReadDir(filepath.Clean(dir))
+	if err != nil {
+		return map[string]string{}
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Type().IsRegular() {
+			paths = append(paths, filepath.Join(dir, entry.Name()))
+		}
+	}
+	return ExistingFileLabels(label, paths)
+}
+
 func RefuseOutputAliases(protectedPaths map[string]string, outputs map[string]string) error {
 	for _, outputFlag := range slices.Sorted(maps.Keys(outputs)) {
 		outputPath := outputs[outputFlag]

--- a/internal/cliutil/outputalias_test.go
+++ b/internal/cliutil/outputalias_test.go
@@ -321,3 +321,19 @@ func TestRefuseOpenedFileAliases(t *testing.T) {
 		}
 	})
 }
+
+func TestExistingFileLabelsIgnoresHexAndMissingPaths(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "trusted.key")
+	if err := os.WriteFile(keyPath, []byte("key-material"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ExistingFileLabels("--key", []string{
+		"4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678",
+		keyPath,
+		filepath.Join(dir, "missing.key"),
+	})
+	if len(got) != 1 || got["--key[1]"] != keyPath {
+		t.Fatalf("ExistingFileLabels = %#v, want --key[1] = %q", got, keyPath)
+	}
+}

--- a/internal/cliutil/outputalias_test.go
+++ b/internal/cliutil/outputalias_test.go
@@ -338,6 +338,26 @@ func TestExistingFileLabelsIgnoresHexAndMissingPaths(t *testing.T) {
 	}
 }
 
+func TestRefuseOutputCollisions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "same.json")
+	if err := RefuseOutputCollisions(map[string]string{
+		"--out":       path,
+		"--local-log": path,
+	}); err == nil || !strings.Contains(err.Error(), "must not name") {
+		t.Fatalf("RefuseOutputCollisions error = %v, want output collision", err)
+	}
+	if err := RefuseOutputCollisions(map[string]string{
+		"--out":       filepath.Join(dir, "bundle.json"),
+		"--local-log": filepath.Join(dir, "anchor.jsonl"),
+	}); err != nil {
+		t.Fatalf("RefuseOutputCollisions rejected distinct outputs: %v", err)
+	}
+	if err := RefuseOutputCollisions(map[string]string{"--out": path, "--local-log": ""}); err != nil {
+		t.Fatalf("RefuseOutputCollisions rejected an empty output: %v", err)
+	}
+}
+
 func TestExistingRegularFilesLabelsOnlyRegularFiles(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "evidence.jsonl")

--- a/internal/cliutil/outputalias_test.go
+++ b/internal/cliutil/outputalias_test.go
@@ -337,3 +337,21 @@ func TestExistingFileLabelsIgnoresHexAndMissingPaths(t *testing.T) {
 		t.Fatalf("ExistingFileLabels = %#v, want --key[1] = %q", got, keyPath)
 	}
 }
+
+func TestExistingRegularFilesLabelsOnlyRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "evidence.jsonl")
+	if err := os.WriteFile(filePath, []byte("receipt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	got := ExistingRegularFiles("receipt input", dir)
+	if len(got) != 1 || got["receipt input"] != filePath {
+		t.Fatalf("ExistingRegularFiles = %#v, want receipt input = %q", got, filePath)
+	}
+	if got := ExistingRegularFiles("receipt input", filepath.Join(dir, "missing")); len(got) != 0 {
+		t.Fatalf("ExistingRegularFiles missing dir = %#v, want empty", got)
+	}
+}

--- a/internal/config/airlock_shield_test.go
+++ b/internal/config/airlock_shield_test.go
@@ -99,15 +99,23 @@ func TestValidateAirlock_NegativeDrainTimeout(t *testing.T) {
 
 func TestValidateAirlock_AnomalyCountIsRejected(t *testing.T) {
 	t.Parallel()
-	for _, count := range []int{3, -3} {
-		cfg := Defaults()
-		cfg.Airlock.Enabled = true
-		cfg.SessionProfiling.Enabled = true
-		cfg.Airlock.Triggers.AnomalyCount = count
-		err := cfg.validateAirlock()
-		if err == nil || !strings.Contains(err.Error(), "anomaly_count is not enforced") {
-			t.Fatalf("validateAirlock(count=%d) error = %v, want reserved anomaly_count refusal", count, err)
-		}
+	for _, tc := range []struct {
+		name  string
+		count int
+	}{
+		{name: "positive", count: 3},
+		{name: "negative", count: -3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Airlock.Enabled = true
+			cfg.SessionProfiling.Enabled = true
+			cfg.Airlock.Triggers.AnomalyCount = tc.count
+			err := cfg.validateAirlock()
+			if err == nil || !strings.Contains(err.Error(), "anomaly_count is not enforced") {
+				t.Fatalf("validateAirlock(count=%d) error = %v, want reserved anomaly_count refusal", tc.count, err)
+			}
+		})
 	}
 }
 
@@ -148,13 +156,23 @@ func TestValidateAirlock_ReservedFieldsRejectedWhenDisabled(t *testing.T) {
 
 func TestValidateAirlock_AnomalyWindowIsRejected(t *testing.T) {
 	t.Parallel()
-	cfg := Defaults()
-	cfg.Airlock.Enabled = true
-	cfg.SessionProfiling.Enabled = true
-	cfg.Airlock.Triggers.AnomalyWindowMinutes = 5
-	err := cfg.validateAirlock()
-	if err == nil || !strings.Contains(err.Error(), "anomaly_window_minutes is not enforced") {
-		t.Fatalf("validateAirlock() error = %v, want reserved anomaly_window_minutes refusal", err)
+	for _, tc := range []struct {
+		name    string
+		minutes int
+	}{
+		{name: "positive", minutes: 5},
+		{name: "negative", minutes: -5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Airlock.Enabled = true
+			cfg.SessionProfiling.Enabled = true
+			cfg.Airlock.Triggers.AnomalyWindowMinutes = tc.minutes
+			err := cfg.validateAirlock()
+			if err == nil || !strings.Contains(err.Error(), "anomaly_window_minutes is not enforced") {
+				t.Fatalf("validateAirlock(minutes=%d) error = %v, want reserved anomaly_window_minutes refusal", tc.minutes, err)
+			}
+		})
 	}
 }
 

--- a/internal/config/airlock_shield_test.go
+++ b/internal/config/airlock_shield_test.go
@@ -57,8 +57,9 @@ func TestValidateAirlock_InvalidSeverity(t *testing.T) {
 	cfg.Airlock.Enabled = true
 	cfg.SessionProfiling.Enabled = true
 	cfg.Airlock.Triggers.OnSeverity = "low"
-	if err := cfg.validateAirlock(); err == nil {
-		t.Error("invalid severity should fail validation")
+	err := cfg.validateAirlock()
+	if err == nil || !strings.Contains(err.Error(), "on_severity is not enforced") {
+		t.Fatalf("validateAirlock() error = %v, want reserved on_severity refusal", err)
 	}
 }
 

--- a/internal/config/airlock_shield_test.go
+++ b/internal/config/airlock_shield_test.go
@@ -111,6 +111,41 @@ func TestValidateAirlock_AnomalyCountIsRejected(t *testing.T) {
 	}
 }
 
+func TestValidateAirlock_ReservedFieldsRejectedWhenDisabled(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		set  func(*Config)
+		want string
+	}{
+		{
+			name: "on_severity",
+			set:  func(c *Config) { c.Airlock.Triggers.OnSeverity = SeverityCritical },
+			want: "on_severity is not enforced",
+		},
+		{
+			name: "anomaly_count",
+			set:  func(c *Config) { c.Airlock.Triggers.AnomalyCount = 3 },
+			want: "anomaly_count is not enforced",
+		},
+		{
+			name: "anomaly_window_minutes",
+			set:  func(c *Config) { c.Airlock.Triggers.AnomalyWindowMinutes = 5 },
+			want: "anomaly_window_minutes is not enforced",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.Airlock.Enabled = false
+			tc.set(cfg)
+			err := cfg.validateAirlock()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateAirlock(disabled, %s) error = %v, want %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateAirlock_AnomalyWindowIsRejected(t *testing.T) {
 	t.Parallel()
 	cfg := Defaults()

--- a/internal/config/airlock_shield_test.go
+++ b/internal/config/airlock_shield_test.go
@@ -99,13 +99,27 @@ func TestValidateAirlock_NegativeDrainTimeout(t *testing.T) {
 
 func TestValidateAirlock_AnomalyCountIsRejected(t *testing.T) {
 	t.Parallel()
+	for _, count := range []int{3, -3} {
+		cfg := Defaults()
+		cfg.Airlock.Enabled = true
+		cfg.SessionProfiling.Enabled = true
+		cfg.Airlock.Triggers.AnomalyCount = count
+		err := cfg.validateAirlock()
+		if err == nil || !strings.Contains(err.Error(), "anomaly_count is not enforced") {
+			t.Fatalf("validateAirlock(count=%d) error = %v, want reserved anomaly_count refusal", count, err)
+		}
+	}
+}
+
+func TestValidateAirlock_AnomalyWindowIsRejected(t *testing.T) {
+	t.Parallel()
 	cfg := Defaults()
 	cfg.Airlock.Enabled = true
 	cfg.SessionProfiling.Enabled = true
-	cfg.Airlock.Triggers.AnomalyCount = 3
+	cfg.Airlock.Triggers.AnomalyWindowMinutes = 5
 	err := cfg.validateAirlock()
-	if err == nil || !strings.Contains(err.Error(), "anomaly_count is not enforced") {
-		t.Fatalf("validateAirlock() error = %v, want reserved anomaly_count refusal", err)
+	if err == nil || !strings.Contains(err.Error(), "anomaly_window_minutes is not enforced") {
+		t.Fatalf("validateAirlock() error = %v, want reserved anomaly_window_minutes refusal", err)
 	}
 }
 

--- a/internal/config/airlock_shield_test.go
+++ b/internal/config/airlock_shield_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -61,14 +62,15 @@ func TestValidateAirlock_InvalidSeverity(t *testing.T) {
 	}
 }
 
-func TestValidateAirlock_ValidSeverity(t *testing.T) {
+func TestValidateAirlock_OnSeverityIsRejected(t *testing.T) {
 	t.Parallel()
 	cfg := Defaults()
 	cfg.Airlock.Enabled = true
 	cfg.SessionProfiling.Enabled = true
 	cfg.Airlock.Triggers.OnSeverity = SeverityCritical
-	if err := cfg.validateAirlock(); err != nil {
-		t.Errorf("critical severity should validate: %v", err)
+	err := cfg.validateAirlock()
+	if err == nil || !strings.Contains(err.Error(), "on_severity is not enforced") {
+		t.Fatalf("validateAirlock() error = %v, want reserved on_severity refusal", err)
 	}
 }
 
@@ -94,14 +96,15 @@ func TestValidateAirlock_NegativeDrainTimeout(t *testing.T) {
 	}
 }
 
-func TestValidateAirlock_NegativeAnomalyCount(t *testing.T) {
+func TestValidateAirlock_AnomalyCountIsRejected(t *testing.T) {
 	t.Parallel()
 	cfg := Defaults()
 	cfg.Airlock.Enabled = true
 	cfg.SessionProfiling.Enabled = true
-	cfg.Airlock.Triggers.AnomalyCount = -1
-	if err := cfg.validateAirlock(); err == nil {
-		t.Error("negative anomaly count should fail validation")
+	cfg.Airlock.Triggers.AnomalyCount = 3
+	err := cfg.validateAirlock()
+	if err == nil || !strings.Contains(err.Error(), "anomaly_count is not enforced") {
+		t.Fatalf("validateAirlock() error = %v, want reserved anomaly_count refusal", err)
 	}
 }
 

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -313,7 +313,10 @@ const (
 	// Re-bumped for shell-boundary handling, dotted paths, and additional
 	// sensitive query-key aliases in external data-transfer directives.
 	// Re-bumped for natural-language password and private-key transfers.
-	goldenHashDefaults = "25cbe6c74358e04c76485244009be0acae9e5eec7208e540584b33cd9c2939fe"
+	// Re-bumped for airlock.triggers.anomaly_window_minutes default 0:
+	// the reserved window is now rejected when nonzero, so the default
+	// cannot stay at the previous inert 5.
+	goldenHashDefaults = "b30392fd23d378ddb33ba25884b54ad0c419cf91c3d6f5b33e8c51b8570a2990"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -586,7 +586,7 @@ func Defaults() *Config {
 				OnElevated:           AirlockTierNone,
 				OnHigh:               AirlockTierSoft,
 				OnCritical:           AirlockTierHard,
-				AnomalyWindowMinutes: 5,
+				AnomalyWindowMinutes: 0,
 			},
 			Timers: AirlockTimers{
 				SoftMinutes:         10,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1879,9 +1879,9 @@ type AirlockTriggers struct {
 	OnElevated           string `yaml:"on_elevated"`            // none|soft|hard|drain
 	OnHigh               string `yaml:"on_high"`                // none|soft|hard|drain
 	OnCritical           string `yaml:"on_critical"`            // none|soft|hard|drain
-	OnSeverity           string `yaml:"on_severity"`            // scanner severity threshold ("critical", "high", or "")
-	AnomalyCount         int    `yaml:"anomaly_count"`          // N anomalies in window triggers soft (0 = disabled)
-	AnomalyWindowMinutes int    `yaml:"anomaly_window_minutes"` // rolling window for anomaly count
+	OnSeverity           string `yaml:"on_severity"`            // rejected when set; airlock fires from on_elevated/on_high/on_critical
+	AnomalyCount         int    `yaml:"anomaly_count"`          // rejected when nonzero; no anomaly-count trigger exists
+	AnomalyWindowMinutes int    `yaml:"anomaly_window_minutes"` // reserved companion to the unused anomaly-count trigger
 }
 
 // AirlockTimers configures per-tier duration before automatic de-escalation.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1881,7 +1881,7 @@ type AirlockTriggers struct {
 	OnCritical           string `yaml:"on_critical"`            // none|soft|hard|drain
 	OnSeverity           string `yaml:"on_severity"`            // rejected when set; airlock fires from on_elevated/on_high/on_critical
 	AnomalyCount         int    `yaml:"anomaly_count"`          // rejected when nonzero; no anomaly-count trigger exists
-	AnomalyWindowMinutes int    `yaml:"anomaly_window_minutes"` // reserved companion to the unused anomaly-count trigger
+	AnomalyWindowMinutes int    `yaml:"anomaly_window_minutes"` // rejected when nonzero; no anomaly-window trigger exists
 }
 
 // AirlockTimers configures per-tier duration before automatic de-escalation.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3690,8 +3690,8 @@ func (c *Config) validateAirlock() error {
 	if c.Airlock.Triggers.AnomalyCount != 0 {
 		return fmt.Errorf("airlock.triggers.anomaly_count is not enforced; airlock fires from on_elevated, on_high, and on_critical")
 	}
-	if c.Airlock.Triggers.AnomalyWindowMinutes < 0 {
-		return fmt.Errorf("airlock.triggers.anomaly_window_minutes must be non-negative")
+	if c.Airlock.Triggers.AnomalyWindowMinutes != 0 {
+		return fmt.Errorf("airlock.triggers.anomaly_window_minutes is not enforced; airlock fires from on_elevated, on_high, and on_critical")
 	}
 
 	return nil

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3626,6 +3626,15 @@ func (c *Config) validateBehavioralBaseline() error {
 }
 
 func (c *Config) validateAirlock() error {
+	if c.Airlock.Triggers.OnSeverity != "" {
+		return fmt.Errorf("airlock.triggers.on_severity is not enforced; use on_elevated, on_high, and on_critical")
+	}
+	if c.Airlock.Triggers.AnomalyCount != 0 {
+		return fmt.Errorf("airlock.triggers.anomaly_count is not enforced; airlock fires from on_elevated, on_high, and on_critical")
+	}
+	if c.Airlock.Triggers.AnomalyWindowMinutes != 0 {
+		return fmt.Errorf("airlock.triggers.anomaly_window_minutes is not enforced; airlock fires from on_elevated, on_high, and on_critical")
+	}
 	if !c.Airlock.Enabled {
 		return nil
 	}
@@ -3673,10 +3682,6 @@ func (c *Config) validateAirlock() error {
 			c.Airlock.Triggers.OnElevated, c.Airlock.Triggers.OnHigh, c.Airlock.Triggers.OnCritical)
 	}
 
-	if c.Airlock.Triggers.OnSeverity != "" {
-		return fmt.Errorf("airlock.triggers.on_severity is not enforced; use on_elevated, on_high, and on_critical")
-	}
-
 	if c.Airlock.Timers.SoftMinutes < 0 || c.Airlock.Timers.HardMinutes < 0 || c.Airlock.Timers.DrainMinutes < 0 {
 		return fmt.Errorf("airlock timer values must be non-negative")
 	}
@@ -3685,13 +3690,6 @@ func (c *Config) validateAirlock() error {
 	// the same as 30s. Warn but don't reject.
 	if c.Airlock.Timers.DrainTimeoutSeconds < 0 {
 		return fmt.Errorf("airlock.timers.drain_timeout_seconds must be non-negative")
-	}
-
-	if c.Airlock.Triggers.AnomalyCount != 0 {
-		return fmt.Errorf("airlock.triggers.anomaly_count is not enforced; airlock fires from on_elevated, on_high, and on_critical")
-	}
-	if c.Airlock.Triggers.AnomalyWindowMinutes != 0 {
-		return fmt.Errorf("airlock.triggers.anomaly_window_minutes is not enforced; airlock fires from on_elevated, on_high, and on_critical")
 	}
 
 	return nil

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3674,12 +3674,7 @@ func (c *Config) validateAirlock() error {
 	}
 
 	if c.Airlock.Triggers.OnSeverity != "" {
-		switch c.Airlock.Triggers.OnSeverity {
-		case SeverityCritical, SeverityHigh:
-			// valid
-		default:
-			return fmt.Errorf("invalid airlock.triggers.on_severity %q: must be critical, high, or empty", c.Airlock.Triggers.OnSeverity)
-		}
+		return fmt.Errorf("airlock.triggers.on_severity is not enforced; use on_elevated, on_high, and on_critical")
 	}
 
 	if c.Airlock.Timers.SoftMinutes < 0 || c.Airlock.Timers.HardMinutes < 0 || c.Airlock.Timers.DrainMinutes < 0 {
@@ -3692,8 +3687,8 @@ func (c *Config) validateAirlock() error {
 		return fmt.Errorf("airlock.timers.drain_timeout_seconds must be non-negative")
 	}
 
-	if c.Airlock.Triggers.AnomalyCount < 0 {
-		return fmt.Errorf("airlock.triggers.anomaly_count must be non-negative")
+	if c.Airlock.Triggers.AnomalyCount != 0 {
+		return fmt.Errorf("airlock.triggers.anomaly_count is not enforced; airlock fires from on_elevated, on_high, and on_critical")
 	}
 	if c.Airlock.Triggers.AnomalyWindowMinutes < 0 {
 		return fmt.Errorf("airlock.triggers.anomaly_window_minutes must be non-negative")

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -435,6 +435,12 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			patternName = r.Name
 		}
 
+		if len(r.Pattern.ExemptDomains) > 0 {
+			ctx.Result.Warnings = append(ctx.Result.Warnings, fmt.Sprintf(
+				"bundle %q rule %q sets pattern.exempt_domains, which is ignored; exemptions belong in the local pipelock config, not in a deny-only bundle",
+				bundle.Name, r.ID))
+		}
+
 		// Convert rule to config-compatible type.
 		switch r.Type {
 		case RuleTypeDLP:

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -99,7 +99,7 @@ func TestLoadBundles_ExemptDomainsParseAndVanish(t *testing.T) {
 	bundle := testBundle(testBundleName, []Rule{rule})
 	writeUnsignedBundle(t, bundleDir, bundle)
 
-	raw, err := os.ReadFile(filepath.Join(bundleDir, bundleFilename))
+	raw, err := os.ReadFile(filepath.Clean(filepath.Join(bundleDir, bundleFilename)))
 	if err != nil {
 		t.Fatalf("read bundle.yaml: %v", err)
 	}

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -122,7 +122,9 @@ func TestLoadBundles_ExemptDomainsParseAndVanish(t *testing.T) {
 		t.Fatalf("loaded ExemptDomains = %v, want dropped", got)
 	}
 	for _, warning := range result.Warnings {
-		if strings.Contains(strings.ToLower(warning), "exempt") {
+		if strings.Contains(warning, testBundleName) &&
+			strings.Contains(warning, "dlp-exempt") &&
+			strings.Contains(warning, "pattern.exempt_domains") {
 			return
 		}
 	}

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -88,6 +88,47 @@ func TestLoadBundles_PropagatesDLPValidator(t *testing.T) {
 	}
 }
 
+func TestLoadBundles_ExemptDomainsParseAndVanish(t *testing.T) {
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, testBundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	rule := testDLPRule("dlp-exempt", confidenceHigh, StatusStable)
+	rule.Pattern.ExemptDomains = []string{"safe.vendor.example"}
+	bundle := testBundle(testBundleName, []Rule{rule})
+	writeUnsignedBundle(t, bundleDir, bundle)
+
+	raw, err := os.ReadFile(filepath.Join(bundleDir, bundleFilename))
+	if err != nil {
+		t.Fatalf("read bundle.yaml: %v", err)
+	}
+	parsed, err := ParseBundle(raw)
+	if err != nil {
+		t.Fatalf("ParseBundle rejected exempt_domains: %v", err)
+	}
+	if got := parsed.Rules[0].Pattern.ExemptDomains; len(got) != 1 || got[0] != "safe.vendor.example" {
+		t.Fatalf("parsed ExemptDomains = %v, want [safe.vendor.example]", got)
+	}
+
+	result := LoadBundles(dir, LoadOptions{MinConfidence: confidenceLow, PipelockVersion: testPipelockVersion})
+	if len(result.Errors) != 0 {
+		t.Fatalf("LoadBundles errors = %v", result.Errors)
+	}
+	if len(result.DLP) != 1 {
+		t.Fatalf("DLP patterns = %d", len(result.DLP))
+	}
+	if got := result.DLP[0].ExemptDomains; len(got) != 0 {
+		t.Fatalf("loaded ExemptDomains = %v, want dropped", got)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(strings.ToLower(warning), "exempt") {
+			return
+		}
+	}
+	t.Fatalf("LoadBundles warnings = %v, want a warning that bundle exempt_domains were ignored", result.Warnings)
+}
+
 func TestLoadResultErrorHelpers(t *testing.T) {
 	var nilResult *LoadResult
 	if got := nilResult.IntegrityErrors(); got != nil {

--- a/internal/signing/keystore.go
+++ b/internal/signing/keystore.go
@@ -284,6 +284,16 @@ func (k *Keystore) recoverAgentTransactionForRead(name string) error {
 	})
 }
 
+// PrivateKeyPath returns the on-disk path of an agent's private key
+// without opening it. Commands that sign and then write an output file
+// use this to refuse a destination that names the key they just loaded.
+func (k *Keystore) PrivateKeyPath(name string) (string, error) {
+	if err := ValidateAgentName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(k.agentDir(name), privateKeyFile), nil
+}
+
 // LoadPrivateKey loads an agent's private key from the keystore.
 func (k *Keystore) LoadPrivateKey(name string) (ed25519.PrivateKey, error) {
 	if err := ValidateAgentName(name); err != nil {

--- a/internal/signing/keystore_test.go
+++ b/internal/signing/keystore_test.go
@@ -596,6 +596,23 @@ func TestValidateAgentName(t *testing.T) {
 	}
 }
 
+func TestPrivateKeyPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ks := NewKeystore(dir)
+	got, err := ks.PrivateKeyPath("alice")
+	if err != nil {
+		t.Fatalf("PrivateKeyPath: %v", err)
+	}
+	want := filepath.Join(dir, "agents", "alice", "id_ed25519")
+	if got != want {
+		t.Fatalf("PrivateKeyPath = %q, want %q", got, want)
+	}
+	if _, err := ks.PrivateKeyPath("../escape"); err == nil {
+		t.Fatal("PrivateKeyPath accepted a traversal name")
+	}
+}
+
 func TestSanitizeAgentName(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/signing/signing_test.go
+++ b/internal/signing/signing_test.go
@@ -924,6 +924,39 @@ func TestLoadPublicKeyFile_NonexistentFile(t *testing.T) {
 	}
 }
 
+func TestSaveSignature_ReplacingDestSymlinkLeavesTargetUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink replacement semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signing.key")
+	original := []byte("protected-key-bytes")
+	if err := os.WriteFile(keyPath, original, 0o600); err != nil {
+		t.Fatalf("WriteFile key: %v", err)
+	}
+	dest := filepath.Join(dir, "manifest.sig")
+	if err := os.Symlink(keyPath, dest); err != nil {
+		t.Fatalf("Symlink dest: %v", err)
+	}
+	if err := SaveSignature([]byte("signature-bytes-here"), dest); err != nil {
+		t.Fatalf("SaveSignature: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("protected key changed to %q", got)
+	}
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("Lstat dest: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("SaveSignature left dest as a symlink; rename should have replaced the directory entry")
+	}
+}
+
 func TestSaveSignature_BadDirectory(t *testing.T) {
 	err := SaveSignature([]byte("fake-sig"), "/nonexistent/dir/test.sig")
 	if err == nil {

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -41,9 +41,9 @@ MCPDataClassLabels  # RESERVED foundation; follow-up slice wires scanner-derived
 UnknownClass  # RESERVED foundation; hard-validated fail-closed label for unknown/truncated/uncertain derivation
 
 # --- INERT-BASELINE (2026-06-10 audit; wire or remove, tracked in ops state.md) ---
-OnSeverity  # INERT airlock severity trigger; recordSessionActivityWithUserAgent wires only OnElevated/OnHigh/OnCritical
-AnomalyCount  # INERT airlock anomaly trigger; no consumer
-AnomalyWindowMinutes  # INERT airlock anomaly window; no consumer
+OnSeverity  # REJECTED at validate when set; recordSessionActivityWithUserAgent wires only OnElevated/OnHigh/OnCritical
+AnomalyCount  # REJECTED at validate when nonzero; no consumer
+AnomalyWindowMinutes  # INERT airlock anomaly window; no consumer; default 5 remains for wire shape
 ToolFreeze  # INERT struct; freeze runs via proxy FrozenTools wiring regardless of these knobs
 SnapshotOnEntry  # INERT; freeze mechanism does not consult it
 AllowCachedTools  # INERT; freeze mechanism does not consult it

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -43,7 +43,7 @@ UnknownClass  # RESERVED foundation; hard-validated fail-closed label for unknow
 # --- INERT-BASELINE (2026-06-10 audit; wire or remove, tracked in ops state.md) ---
 OnSeverity  # REJECTED at validate when set; recordSessionActivityWithUserAgent wires only OnElevated/OnHigh/OnCritical
 AnomalyCount  # REJECTED at validate when nonzero; no consumer
-AnomalyWindowMinutes  # INERT airlock anomaly window; no consumer; default 5 remains for wire shape
+AnomalyWindowMinutes  # REJECTED at validate when nonzero; no consumer; default 0
 ToolFreeze  # INERT struct; freeze runs via proxy FrozenTools wiring regardless of these knobs
 SnapshotOnEntry  # INERT; freeze mechanism does not consult it
 AllowCachedTools  # INERT; freeze mechanism does not consult it

--- a/scripts/config-consumption-allowlist.txt
+++ b/scripts/config-consumption-allowlist.txt
@@ -32,6 +32,9 @@ HeartbeatInterval  # (A) FlightRecorder.HeartbeatIntervalDuration() schema.go:14
 MatchAbsPath  # (B) enforces absolute-path constraint on RedirectProfile.Exec[0] at validate.go:816; nothing to read after validation passes
 TrustedUpstream  # (B) config-time integrity assertion that declared upstream matches Upstream URL (validate.go:2148-2188)
 Added  # (B) audit-provenance date on ReverseProxy trusted_upstream, format-validated at validate.go:2184
+OnSeverity  # (B) rejected at validate when set, including when airlock is disabled
+AnomalyCount  # (B) rejected at validate when nonzero, including when airlock is disabled
+AnomalyWindowMinutes  # (B) rejected at validate when nonzero, including when airlock is disabled; default 0
 
 # --- RESERVED (documented as reserved in docs/configuration.md Conductor section) ---
 StalePolicy  # RESERVED conductor follower knob; DecideStale exists with 0 callers (verified 2026-06-10); documented reserved
@@ -41,9 +44,6 @@ MCPDataClassLabels  # RESERVED foundation; follow-up slice wires scanner-derived
 UnknownClass  # RESERVED foundation; hard-validated fail-closed label for unknown/truncated/uncertain derivation
 
 # --- INERT-BASELINE (2026-06-10 audit; wire or remove, tracked in ops state.md) ---
-OnSeverity  # REJECTED at validate when set; recordSessionActivityWithUserAgent wires only OnElevated/OnHigh/OnCritical
-AnomalyCount  # REJECTED at validate when nonzero; no consumer
-AnomalyWindowMinutes  # REJECTED at validate when nonzero; no consumer; default 0
 ToolFreeze  # INERT struct; freeze runs via proxy FrozenTools wiring regardless of these knobs
 SnapshotOnEntry  # INERT; freeze mechanism does not consult it
 AllowCachedTools  # INERT; freeze mechanism does not consult it


### PR DESCRIPTION
## What changed

Commands that sign or verify and then write a result now refuse when the output path is the same file as a key they loaded. Coverage certificates, fleet reports, MCP integrity signatures, learn compile and lifecycle receipts, verify-receipt clean reports, and local anchor bundles are covered. Hex `--key` values are not treated as paths.

`airlock.triggers.on_severity` and `anomaly_count` no longer load. Those fields validated and never fired. Rule bundles that set `pattern.exempt_domains` still ignore the field, because bundles are deny-only, and now warn at load instead of staying silent.

Failure direction: each new refusal fails closed, so a command that would have overwritten a loaded key now stops rather than proceeding. The fields that no longer load were inert before this change, so nothing that previously enforced stops enforcing. What a reviewer should distrust most is the path comparison itself, since a key referenced by a different but equivalent path would not be caught by a naive string match.
