### PR TITLE
chore(ci): pin the patched Go toolchain that closes five stdlib advisories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -515,16 +515,17 @@ jobs:
         with:
           # Pin the exact patched release. govulncheck analyzes the active
           # toolchain's stdlib (go env GOVERSION), so the setup-go version is the
-          # lever, not the go.mod directive. go1.26.5 (2026-07-07) fixes
-          # GO-2026-5856 crypto/tls + GO-2026-4970 os after go1.26.4 fixed
-          # GO-2026-5039 net/textproto + GO-2026-5037 crypto/x509. A float to
+          # lever, not the go.mod directive. go1.26.6 fixes GO-2026-6218
+          # net/url + GO-2026-6091 html/template + GO-2026-6090 crypto/tls +
+          # GO-2026-6089 net/http + GO-2026-5972 encoding/asn1, after go1.26.5
+          # fixed GO-2026-5856 crypto/tls + GO-2026-4970 os. A float to
           # '1.26' can lag on the actions/go-versions manifest, so the scan stays
           # red until the manifest publishes the patched toolchain. An EXACT
           # version makes setup-go fall back to a direct download from the
           # official Go distribution, bypassing the manifest. Revert to '1.26'
           # + check-latest for steady-state self-healing once the manifest
-          # includes 1.26.5.
-          go-version: '1.26.5'
+          # includes 1.26.6.
+          go-version: '1.26.6'
           check-latest: true
 
       - name: Verify Go version
@@ -533,7 +534,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.26.5"
+          test "$got" = "go1.26.6"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4


### PR DESCRIPTION
## What changed

The `govulncheck` job pins an exact Go toolchain because the scan analyzes the active stdlib rather than the `go.mod` directive. This advances that pin from `1.26.5` to `1.26.6` and updates the matching version assertion and the comment that records which advisories each pin closes.

## Why

The vulnerability database published five standard-library advisories that the pinned toolchain does not carry a fix for, so the job went red with no code change. Main was green shortly before and red after, on identical source.

All five report the same fixed version.

- `GO-2026-6218` in `net/url`
- `GO-2026-6091` in `html/template`
- `GO-2026-6090` in `crypto/tls`
- `GO-2026-6089` in `net/http`
- `GO-2026-5972` in `encoding/asn1`

Only the `encoding/asn1` advisory reported a reachable trace, through Rekor public key parsing into `x509.ParsePKIXPublicKey`. The rest were flagged against the toolchain rather than through a called path.

This blocks every pull request and the default branch, so it is separated from unrelated work.

## Verification

The workflow parses, no other reference to the old patch version remains outside the historical note in the comment, and the diff-scoped pre-push gate passes with no Go files in the diff. The scan itself is the real proof and runs on this pull request.
