### PR TITLE
ci: bump the govulncheck toolchain pin to the patched Go release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -515,16 +515,24 @@ jobs:
         with:
           # Pin the exact patched release. govulncheck analyzes the active
           # toolchain's stdlib (go env GOVERSION), so the setup-go version is the
-          # lever, not the go.mod directive. go1.26.5 (2026-07-07) fixes
-          # GO-2026-5856 crypto/tls + GO-2026-4970 os after go1.26.4 fixed
-          # GO-2026-5039 net/textproto + GO-2026-5037 crypto/x509. A float to
-          # '1.26' can lag on the actions/go-versions manifest, so the scan stays
-          # red until the manifest publishes the patched toolchain. An EXACT
-          # version makes setup-go fall back to a direct download from the
-          # official Go distribution, bypassing the manifest. Revert to '1.26'
-          # + check-latest for steady-state self-healing once the manifest
-          # includes 1.26.5.
-          go-version: '1.26.5'
+          # lever, not the go.mod directive. go1.26.6 fixes six stdlib advisories
+          # that go1.26.5 carries across crypto/tls, html/template, net/http and
+          # net/url (GO-2026-5026, GO-2026-5972, GO-2026-6089, GO-2026-6090,
+          # GO-2026-6091, GO-2026-6218), reached here through the proxy and MCP
+          # transport call paths. A float to '1.26' can lag on the
+          # actions/go-versions manifest, so the scan stays red until the
+          # manifest publishes the patched toolchain. An EXACT version makes
+          # setup-go fall back to a direct download from the official Go
+          # distribution, bypassing the manifest.
+          #
+          # THIS PIN GOES STALE BY DESIGN. Every Go patch release that fixes a
+          # reachable stdlib advisory turns this job red repo-wide until the pin
+          # moves, which is what happened on 2026-08-13. Bump it here and in the
+          # assertion below, together; they are asserted equal on purpose so a
+          # half-done bump fails loudly instead of scanning the wrong toolchain.
+          # Revert to '1.26' + check-latest for steady-state self-healing once
+          # the manifest reliably carries the newest patch.
+          go-version: '1.26.6'
           check-latest: true
 
       - name: Verify Go version
@@ -533,7 +541,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.26.5"
+          test "$got" = "go1.26.6"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4


### PR DESCRIPTION
The vulnerability scan pins an exact Go patch release rather than a float, because it analyzes the active toolchain's standard library rather than the `go.mod` directive, and a float can lag behind the runner manifest. That pin was `1.26.5`.

`go1.26.6` fixes six standard-library advisories that `go1.26.5` carries, across `crypto/tls`, `html/template`, `net/http` and `net/url`. All six are reachable from this codebase through the proxy and MCP transport call paths, so the scan exits non-zero and the job is red on every branch, not just on the one that happens to be open when the release lands.

The pin therefore goes stale by design each time a patch release fixes a reachable advisory. The comment now says that outright, and says to move the pin and its assertion together. Those two are asserted equal on purpose, so a half-done bump fails loudly instead of quietly scanning a different toolchain than the one the pin claims.

No product code changes. The version was resolved from the official Go release list rather than assumed, and `go1.26.6` is the newest stable release in that line at the time of writing.
