### PR TITLE
fix(contain): validate managed config on upgrade, constrain metrics

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -178,7 +178,7 @@ pipelock contain verify
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
 | 12 | `listed_tool_targets_resolvable` | Every entry in `tools.list` resolves to an executable absolute path in the agent user's PATH. |
-| 13 | `managed_config_metrics` | The managed config keeps `metrics_listen` on a dedicated numeric loopback port. It skips when the config cannot be read and reports unknown for other read failures. |
+| 13 | `managed_config_metrics` | The managed config keeps `metrics_listen` on a dedicated numeric loopback port. It skips only when the config file is missing or permission is denied, and reports unknown for any other read failure. |
 
 ### Managed metrics invariant
 

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -123,10 +123,11 @@ Upgrade performs a containment-aware binary update in one fail-closed command. I
 
 The sequence is:
 
-1. Download and verify the candidate release by invoking the **deployed** binary's `pipelock update --yes` (Ed25519 manifest + checksums + optional cosign), which replaces the binary only after those checks pass.
-2. Re-pin the SHA-256 integrity hash against the newly deployed binary at `/etc/pipelock/integrity/binary-pin.sha256`.
-3. Restart the `pipelock.service` systemd unit and wait for readiness.
-4. Run `contain verify` and require exit 0, which means every probe passed.
+1. Validate the managed config with the integrity-pinned deployed binary and require containment-safe metrics before any binary or service change.
+2. Download and verify the candidate release by invoking the **deployed** binary's `pipelock update --yes` (Ed25519 manifest + checksums + optional cosign), which replaces the binary only after those checks pass.
+3. Re-pin the SHA-256 integrity hash against the newly deployed binary at `/etc/pipelock/integrity/binary-pin.sha256`.
+4. Restart the `pipelock.service` systemd unit and wait for readiness.
+5. Run `contain verify` and repeat the managed-config check. Exit 0 means every probe passed.
    A failing probe exits 1 and a skipped or inconclusive probe exits 2, so
    both roll the upgrade back.
 
@@ -155,7 +156,7 @@ Exit codes:
 
 ## `pipelock contain verify`
 
-Verify is read-only. It walks 12 probes in order and prints pass / fail / skip /
+Verify is read-only. It walks 13 probes in order and prints pass / fail / skip /
 unknown per probe. It does not require root.
 
 ```bash
@@ -176,6 +177,19 @@ pipelock contain verify
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
 | 12 | `listed_tool_targets_resolvable` | Every entry in `tools.list` resolves to an executable absolute path in the agent user's PATH. |
+| 13 | `managed_config_metrics` | The managed config keeps `metrics_listen` on a dedicated numeric loopback port. It skips when the config cannot be read and reports unknown for other read failures. |
+
+### Managed metrics invariant
+
+Containment requires `metrics_listen` to remain a numeric loopback address on a port other than the agent-accessible proxy port. Keep the key present. Removing it registers `/metrics` and `/stats` on the proxy listener, where the contained agent can reach them.
+
+Repair the managed config with a dedicated loopback listener such as:
+
+```yaml
+metrics_listen: 127.0.0.1:9091
+```
+
+Choose another unused non-proxy port if `9091` is unavailable. Do not delete `metrics_listen` to disable metrics.
 
 The nftables probes fail closed when attribution is ambiguous. A regular
 lookalike chain, a table-wide listing that happens to contain matching-looking

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -126,8 +126,9 @@ The sequence is:
 1. Validate the managed config with the integrity-pinned deployed binary and require containment-safe metrics before any binary or service change.
 2. Download and verify the candidate release by invoking the **deployed** binary's `pipelock update --yes` (Ed25519 manifest + checksums + optional cosign), which replaces the binary only after those checks pass.
 3. Re-pin the SHA-256 integrity hash against the newly deployed binary at `/etc/pipelock/integrity/binary-pin.sha256`.
-4. Restart the `pipelock.service` systemd unit and wait for readiness.
-5. Run `contain verify` and repeat the managed-config check. Exit 0 means every probe passed.
+4. Add the containment marker to `/etc/systemd/system/pipelock.service` if it is absent, so a host installed before the containment runtime guard existed gains that protection on upgrade rather than only on reinstall. This edits one `Environment=` line inside `[Service]` and leaves the rest of the unit alone; it is a no-op on a unit that already carries the marker.
+5. Restart the `pipelock.service` systemd unit and wait for readiness.
+6. Run `contain verify` and repeat the managed-config check. Exit 0 means every probe passed.
    A failing probe exits 1 and a skipped or inconclusive probe exits 2, so
    both roll the upgrade back.
 

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -8,13 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 	"gopkg.in/yaml.v3"
 )
@@ -85,7 +84,7 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
 	if metricsListen == "" {
 		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
-	} else if err := validateContainMetricsListen(metricsListen, env.proxyPort); err != nil {
+	} else if err := config.ValidateContainmentMetricsListen(metricsListen, env.proxyPort); err != nil {
 		return nil, nil, err
 	}
 
@@ -161,7 +160,7 @@ func containServiceReadOnlyPaths(data []byte, proxyPort int) ([]string, error) {
 	if metricsListen == "" {
 		return nil, errors.New("metrics_listen must use a dedicated loopback port; rerun contain install with --config to migrate the managed config safely")
 	}
-	if err := validateContainMetricsListen(metricsListen, proxyPort); err != nil {
+	if err := config.ValidateContainmentMetricsListen(metricsListen, proxyPort); err != nil {
 		return nil, err
 	}
 	return containServiceReadOnlyPathsFromMapping(mapping)
@@ -225,22 +224,6 @@ func isProtectedHomePath(path string) bool {
 		}
 	}
 	return false
-}
-
-func validateContainMetricsListen(listen string, proxyPort int) error {
-	host, port, err := net.SplitHostPort(listen)
-	if err != nil {
-		return fmt.Errorf("metrics_listen %q is unsafe for containment: %w", listen, err)
-	}
-	ip := net.ParseIP(host)
-	if ip == nil || !ip.IsLoopback() {
-		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric loopback address on a dedicated port", listen)
-	}
-	parsedPort, err := strconv.ParseUint(port, 10, 16)
-	if err != nil || parsedPort == 0 || int(parsedPort) == proxyPort {
-		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a port other than the agent-accessible proxy port %d", listen, proxyPort)
-	}
-	return nil
 }
 
 func parseSingleYAMLDocument(data []byte) (*yaml.Node, error) {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -84,7 +86,7 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
 	if metricsListen == "" {
 		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
-	} else if err := config.ValidateContainmentMetricsListen(metricsListen, env.proxyPort); err != nil {
+	} else if err := config.ValidateContainmentMetricsListen(metricsListen, effectiveProxyPort(mapping, env.proxyPort)); err != nil {
 		return nil, nil, err
 	}
 
@@ -160,10 +162,42 @@ func containServiceReadOnlyPaths(data []byte, proxyPort int) ([]string, error) {
 	if metricsListen == "" {
 		return nil, errors.New("metrics_listen must use a dedicated loopback port; rerun contain install with --config to migrate the managed config safely")
 	}
-	if err := config.ValidateContainmentMetricsListen(metricsListen, proxyPort); err != nil {
+	if err := config.ValidateContainmentMetricsListen(metricsListen, effectiveProxyPort(mapping, proxyPort)); err != nil {
 		return nil, err
 	}
 	return containServiceReadOnlyPathsFromMapping(mapping)
+}
+
+// effectiveProxyPort returns the port the contained agent can actually reach.
+//
+// The caller passes the installer's port, which is the default on almost every
+// host and therefore right almost every time. On a host that configures its own
+// fetch_proxy.listen it is wrong, and wrong in the permissive direction: the
+// check would compare the metrics listener against 8888 while the agent reaches
+// the proxy somewhere else, so a metrics_listen equal to the real proxy port
+// passes here and is refused by the runtime. Reading the port out of the same
+// config being validated keeps every caller agreeing with the runtime.
+//
+// The passed port remains the fallback, because a config that omits
+// fetch_proxy.listen genuinely runs on the installer's port.
+func effectiveProxyPort(mapping *yaml.Node, fallback int) int {
+	fetchProxy := getMappingPath(mapping, []string{"fetch_proxy"})
+	if fetchProxy == nil {
+		return fallback
+	}
+	listen := strings.TrimSpace(scalarValue(mappingValue(fetchProxy, "listen")))
+	if listen == "" {
+		return fallback
+	}
+	_, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(port)
+	if err != nil || parsed < 1 || parsed > 65535 {
+		return fallback
+	}
+	return parsed
 }
 
 func containServiceReadOnlyPathsFromMapping(root *yaml.Node) ([]string, error) {

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -84,9 +84,21 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	// distinct loopback listener; the containment rules allow only the proxy
 	// port and drop agent-owned traffic to other loopback ports.
 	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
+	proxyPort := effectiveProxyPort(mapping, env.proxyPort)
 	if metricsListen == "" {
+		// The value we are about to write gets the same check as one the
+		// operator wrote. It is a fixed port, so on a host whose proxy already
+		// runs there the default collides, and inserting it unchecked would
+		// have the installer produce a config its own runtime refuses: metrics
+		// come up disabled and the reason points at a line the operator never
+		// typed.
+		if err := config.ValidateContainmentMetricsListen(containMetricsListen, proxyPort); err != nil {
+			return nil, nil, fmt.Errorf("cannot migrate %s: the default containment metrics listener %s collides with this host's proxy port %d; "+
+				"set metrics_listen to another loopback port, or move fetch_proxy.listen: %w",
+				"metrics_listen", containMetricsListen, proxyPort, err)
+		}
 		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
-	} else if err := config.ValidateContainmentMetricsListen(metricsListen, effectiveProxyPort(mapping, env.proxyPort)); err != nil {
+	} else if err := config.ValidateContainmentMetricsListen(metricsListen, proxyPort); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/cli/contain/config_migrate_proxy_port_test.go
+++ b/internal/cli/contain/config_migrate_proxy_port_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestContainServiceReadOnlyPathsUsesTheConfiguredProxyPort covers a host that
+// does not run the proxy on the installer's default port.
+//
+// The metrics listener must differ from the port the contained agent can reach.
+// Every caller here passed the installer's port, which is the default on almost
+// every host, so a host with its own fetch_proxy.listen was checked against a
+// port nothing was listening on. That is permissive in the direction that
+// matters: a metrics_listen equal to the REAL proxy port passed these checks and
+// was then refused by the runtime, so the upgrade and the probe both reported a
+// host safe that the service itself would not accept.
+func TestContainServiceReadOnlyPathsUsesTheConfiguredProxyPort(t *testing.T) {
+	const installerPort = 8888
+
+	tests := []struct {
+		name       string
+		config     string
+		wantReject bool
+		because    string
+	}{
+		{
+			name:       "metrics on the configured proxy port is rejected",
+			config:     "fetch_proxy:\n  listen: 127.0.0.1:9999\nmetrics_listen: 127.0.0.1:9999\n",
+			wantReject: true,
+			because:    "the metrics listener is the port the agent reaches",
+		},
+		{
+			name:       "metrics on the installer default is fine when the proxy moved",
+			config:     "fetch_proxy:\n  listen: 127.0.0.1:9999\nmetrics_listen: 127.0.0.1:8888\n",
+			wantReject: false,
+			because:    "nothing the agent can reach is on 8888 here",
+		},
+		{
+			name:       "metrics on the installer default is rejected when the proxy is there",
+			config:     "fetch_proxy:\n  listen: 127.0.0.1:8888\nmetrics_listen: 127.0.0.1:8888\n",
+			wantReject: true,
+			because:    "the configured port agrees with the fallback",
+		},
+		{
+			name:       "no fetch_proxy.listen falls back to the installer port",
+			config:     "metrics_listen: 127.0.0.1:8888\n",
+			wantReject: true,
+			because:    "an omitted listener really does run on the installer's port",
+		},
+		{
+			name:       "an unparsable listener falls back rather than passing everything",
+			config:     "fetch_proxy:\n  listen: \"not-a-host-port\"\nmetrics_listen: 127.0.0.1:8888\n",
+			wantReject: true,
+			because:    "a malformed listener must not silently disable the comparison",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := containServiceReadOnlyPaths([]byte(tt.config), installerPort)
+			rejected := err != nil
+			if rejected != tt.wantReject {
+				t.Fatalf("rejected = %v, want %v (%s); err = %v", rejected, tt.wantReject, tt.because, err)
+			}
+			if tt.wantReject && !strings.Contains(err.Error(), "unsafe for containment") {
+				t.Errorf("error = %q, want it to name the containment refusal", err.Error())
+			}
+		})
+	}
+}
+
+// TestEffectiveProxyPortFallsBackRatherThanGuessing covers each way the
+// configured listener can fail to yield a port.
+//
+// Every one of these has to fall back to the installer's port. Treating an
+// unreadable listener as "no comparison needed" would let a metrics listener on
+// the agent-reachable port through, which is the direction that costs something.
+func TestEffectiveProxyPortFallsBackRatherThanGuessing(t *testing.T) {
+	const fallback = 8888
+
+	tests := []struct {
+		name   string
+		config string
+		want   int
+	}{
+		{"no fetch_proxy block", "mode: balanced\n", fallback},
+		{"fetch_proxy with no listen", "fetch_proxy:\n  enabled: true\n", fallback},
+		{"listen is blank", "fetch_proxy:\n  listen: \"\"\n", fallback},
+		{"listen has no port separator", "fetch_proxy:\n  listen: \"127.0.0.1\"\n", fallback},
+		{"port is not a number", "fetch_proxy:\n  listen: \"127.0.0.1:http\"\n", fallback},
+		{"port is zero", "fetch_proxy:\n  listen: \"127.0.0.1:0\"\n", fallback},
+		{"port is above the range", "fetch_proxy:\n  listen: \"127.0.0.1:70000\"\n", fallback},
+		{"a usable port wins", "fetch_proxy:\n  listen: \"127.0.0.1:9999\"\n", 9999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := parseSingleYAMLDocument([]byte(tt.config))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := effectiveProxyPort(documentMapping(root), fallback); got != tt.want {
+				t.Errorf("effectiveProxyPort = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/contain/config_migrate_proxy_port_test.go
+++ b/internal/cli/contain/config_migrate_proxy_port_test.go
@@ -4,6 +4,9 @@
 package contain
 
 import (
+	"net"
+	"os/user"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -71,6 +74,56 @@ func TestContainServiceReadOnlyPathsUsesTheConfiguredProxyPort(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestContainMetricsDefaultIsCheckedBeforeItIsWritten covers the host where the
+// inserted default is itself unsafe.
+//
+// The default metrics listener is a fixed port. On a host whose proxy already
+// runs there, writing it unchecked has the installer produce a config its own
+// runtime refuses, so metrics come up disabled and the stated reason points at
+// a line the operator never wrote. Refusing during migration puts the problem
+// in front of them while they can still choose a port.
+func TestContainMetricsDefaultIsCheckedBeforeItIsWritten(t *testing.T) {
+	_, defaultPort, err := net.SplitHostPort(containMetricsListen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migrate := func(t *testing.T, source string) ([]byte, error) {
+		t.Helper()
+		env, _, _ := newFakeEnv(t)
+		home := t.TempDir()
+		origLookup := env.lookupUser
+		env.lookupUser = func(name string) (*user.User, error) {
+			if name == containInstallOperatorUser {
+				return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+			}
+			return origLookup(name)
+		}
+		out, _, migrateErr := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), []byte(source))
+		return out, migrateErr
+	}
+
+	t.Run("refuses when the proxy occupies the default metrics port", func(t *testing.T) {
+		out, err := migrate(t, "fetch_proxy:\n  listen: 127.0.0.1:"+defaultPort+"\n")
+		if err == nil {
+			t.Fatalf("migration wrote a config the runtime will refuse:\n%s", out)
+		}
+		if !strings.Contains(err.Error(), "collides") {
+			t.Errorf("error = %q, want it to name the collision so the operator can pick a port", err.Error())
+		}
+	})
+
+	t.Run("still inserts the default when there is no collision", func(t *testing.T) {
+		out, err := migrate(t, "fetch_proxy:\n  listen: 127.0.0.1:8888\n")
+		if err != nil {
+			t.Fatalf("migration refused an ordinary host: %v", err)
+		}
+		if !strings.Contains(string(out), containMetricsListen) {
+			t.Errorf("default metrics listener was not inserted:\n%s", out)
+		}
+	})
 }
 
 // TestEffectiveProxyPortFallsBackRatherThanGuessing covers each way the

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // installOpts collects the flag-derived state for runInstall. Mirrored as
@@ -1426,6 +1427,7 @@ func renderSystemUnit(env *installEnv) string {
 		"Type=simple",
 		"User=" + env.proxyUserName,
 		"Group=" + env.proxyUserName,
+		"Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue,
 		"ExecStart=" + env.pipelockTarget + " run --config " + configPath + " --capture-output " + capturePath,
 		"Restart=on-failure",
 		"RestartSec=5",

--- a/internal/cli/contain/install_extra_test.go
+++ b/internal/cli/contain/install_extra_test.go
@@ -383,6 +383,9 @@ func TestRenderSystemUnit_WithoutFileSentryKeepsHomeInaccessible(t *testing.T) {
 	if !strings.Contains(body, "ProtectHome=true") || strings.Contains(body, "BindReadOnlyPaths=") {
 		t.Fatalf("system unit weakens home isolation without file-sentry paths:\n%s", body)
 	}
+	if !strings.Contains(body, "Environment=PIPELOCK_CONTAINMENT_MANAGED=1") {
+		t.Fatalf("system unit does not mark its process as containment-managed:\n%s", body)
+	}
 }
 
 func TestRenderSystemUnit_FileSentryPrivateTmpPathIsVisibleReadOnly(t *testing.T) {

--- a/internal/cli/contain/upgrade.go
+++ b/internal/cli/contain/upgrade.go
@@ -16,6 +16,7 @@
 package contain
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/hex"
@@ -541,15 +542,52 @@ func upgradePostVerify(ctx context.Context, env *upgradeEnv) error {
 // A missing unit is an error rather than a skip: this command is upgrading a
 // containment-managed host, and one without a unit is not in the state the rest of
 // the upgrade assumes.
+// unitHasActiveContainmentMarker reports whether the unit already carries the
+// marker somewhere systemd will actually read it.
+//
+// A plain substring search is wrong in the unsafe direction. systemd applies
+// Environment= only inside [Service], so the same text sitting in [Unit], in
+// [Install], or in a comment means nothing at runtime. Treating it as present
+// would skip the insertion and leave the host unguarded while the upgrade
+// reported success, which is the exact failure this migration exists to fix.
+func unitHasActiveContainmentMarker(body, marker string) bool {
+	section := ""
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			continue
+		}
+		if section == "Service" && line == marker {
+			return true
+		}
+	}
+	return false
+}
+
 func ensureContainmentMarkerInUnit(env *upgradeEnv) error {
 	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+
+	// This is a root-privileged write to a path under /etc, so refuse anything
+	// that is not a plain file before touching it. A symlink here would
+	// redirect the write to a target of someone else's choosing.
+	if info, err := env.lstat(env.unitPath); err != nil {
+		return fmt.Errorf("inspect service unit %s: %w", env.unitPath, err)
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("service unit %s is a symlink; refusing privileged write", env.unitPath)
+	} else if !info.Mode().IsRegular() {
+		return fmt.Errorf("service unit %s is not a regular file; refusing privileged write", env.unitPath)
+	}
 
 	current, err := env.readFile(env.unitPath)
 	if err != nil {
 		return fmt.Errorf("read service unit %s: %w", env.unitPath, err)
 	}
 	body := string(current)
-	if strings.Contains(body, marker) {
+	if unitHasActiveContainmentMarker(body, marker) {
 		return nil
 	}
 
@@ -567,7 +605,7 @@ func ensureContainmentMarkerInUnit(env *upgradeEnv) error {
 		return fmt.Errorf("service unit %s has no [Service] section; refusing to guess where the containment marker belongs", env.unitPath)
 	}
 
-	if err := env.writeFile(env.unitPath, []byte(strings.Join(out, "\n")), 0o644); err != nil {
+	if err := env.writeFile(env.unitPath, []byte(strings.Join(out, "\n")), modeUnitFile); err != nil {
 		return fmt.Errorf("write service unit %s: %w", env.unitPath, err)
 	}
 	_, _ = fmt.Fprintf(env.out, "  containment marker added to %s\n", env.unitPath)
@@ -609,6 +647,19 @@ func preflightUpgradeManagedConfig(ctx context.Context, env *upgradeEnv) error {
 	}
 	if binaryHashAfter != binaryHashBefore {
 		return errors.New("deployed binary changed during managed config check")
+	}
+	// The config gets the same treatment as the binary above. Two separate
+	// things inspected this file, the containment validator on bytes already in
+	// memory and the deployed binary on the path, so a config that changed in
+	// between would mean neither verdict describes the file the service is
+	// about to load. Comparing the bytes does not make the sequence atomic, but
+	// it turns a silent disagreement into a refusal.
+	dataAfter, err := env.readFile(configPath)
+	if err != nil {
+		return fmt.Errorf("re-read managed config %s after config check: %w", configPath, err)
+	}
+	if !bytes.Equal(dataAfter, data) {
+		return fmt.Errorf("managed config %s changed during its own validation; refusing to upgrade against a config neither check describes", configPath)
 	}
 	return nil
 }

--- a/internal/cli/contain/upgrade.go
+++ b/internal/cli/contain/upgrade.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 )
 
 // upgradeOpts collects flag-derived state for the upgrade subcommand.
@@ -73,6 +74,7 @@ type upgradeEnv struct {
 	integrityDir   string
 	integrityPin   string
 	serviceName    string
+	unitPath       string
 	proxyPort      int
 
 	// Readiness.
@@ -100,6 +102,7 @@ func defaultUpgradeEnv(out, errOut io.Writer) *upgradeEnv {
 		integrityDir:     defaultIntegrityDir,
 		integrityPin:     defaultIntegrityPin,
 		serviceName:      defaultServiceName,
+		unitPath:         defaultSystemUnitPath,
 		proxyPort:        defaultProxyPort,
 		readinessTimeout: installReadinessTimeout,
 	}
@@ -334,6 +337,21 @@ func runUpgrade(ctx context.Context, env *upgradeEnv, opts upgradeOpts) error {
 	}
 	_, _ = fmt.Fprintln(w, "  integrity pin updated")
 
+	// ── Step 5b: carry the containment marker onto an older unit ────────
+	// A unit written before the containment runtime guard existed carries no
+	// marker, so the guard would stay inactive on exactly the hosts this command
+	// is meant to bring current. Upgrade already reloads and restarts, so this is
+	// the one moment the correction costs nothing extra.
+	if err := ensureContainmentMarkerInUnit(env); err != nil {
+		_, _ = fmt.Fprintf(env.errOut, "unit marker update failed: %v\n", err)
+		if rbErr := rollbackAll(); rbErr != nil {
+			return cliutil.ExitCodeError(cliutil.ExitGeneral, errors.Join(
+				fmt.Errorf("%w: %w", errUpgradeConfig, err),
+				fmt.Errorf("%w (backup retained at %s)", rbErr, backupPath)))
+		}
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("%w: %w", errUpgradeConfig, err))
+	}
+
 	// ── Step 6: restart the pipelock service ────────────────────────────
 	_, _ = fmt.Fprintln(w, "restarting pipelock service...")
 	if err := upgradeRestartAndWait(ctx, env); err != nil {
@@ -509,6 +527,50 @@ func upgradePostVerify(ctx context.Context, env *upgradeEnv) error {
 	if err := preflightUpgradeManagedConfig(ctx, env); err != nil {
 		return err
 	}
+	return nil
+}
+
+// ensureContainmentMarkerInUnit adds the containment marker to a service unit
+// written before the runtime guard existed.
+//
+// Without this the guard protects only hosts installed after the change, which is
+// the failure mode where a release note is true of a fresh install and false of
+// every existing one. It edits a single Environment line rather than regenerating
+// the unit, so an operator's other adjustments to that file survive.
+//
+// A missing unit is an error rather than a skip: this command is upgrading a
+// containment-managed host, and one without a unit is not in the state the rest of
+// the upgrade assumes.
+func ensureContainmentMarkerInUnit(env *upgradeEnv) error {
+	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+
+	current, err := env.readFile(env.unitPath)
+	if err != nil {
+		return fmt.Errorf("read service unit %s: %w", env.unitPath, err)
+	}
+	body := string(current)
+	if strings.Contains(body, marker) {
+		return nil
+	}
+
+	lines := strings.Split(body, "\n")
+	inserted := false
+	out := make([]string, 0, len(lines)+1)
+	for _, line := range lines {
+		out = append(out, line)
+		if !inserted && strings.TrimSpace(line) == "[Service]" {
+			out = append(out, marker)
+			inserted = true
+		}
+	}
+	if !inserted {
+		return fmt.Errorf("service unit %s has no [Service] section; refusing to guess where the containment marker belongs", env.unitPath)
+	}
+
+	if err := env.writeFile(env.unitPath, []byte(strings.Join(out, "\n")), 0o644); err != nil {
+		return fmt.Errorf("write service unit %s: %w", env.unitPath, err)
+	}
+	_, _ = fmt.Fprintf(env.out, "  containment marker added to %s\n", env.unitPath)
 	return nil
 }
 

--- a/internal/cli/contain/upgrade.go
+++ b/internal/cli/contain/upgrade.go
@@ -69,9 +69,11 @@ type upgradeEnv struct {
 	// Paths.
 	proxyUserName  string
 	pipelockTarget string
+	configPath     string
 	integrityDir   string
 	integrityPin   string
 	serviceName    string
+	proxyPort      int
 
 	// Readiness.
 	readinessTimeout time.Duration
@@ -94,9 +96,11 @@ func defaultUpgradeEnv(out, errOut io.Writer) *upgradeEnv {
 		chmod:            os.Chmod,
 		proxyUserName:    defaultProxyUser,
 		pipelockTarget:   defaultPipelockTarget,
+		configPath:       filepath.Join(defaultConfigDir, "pipelock.yaml"),
 		integrityDir:     defaultIntegrityDir,
 		integrityPin:     defaultIntegrityPin,
 		serviceName:      defaultServiceName,
+		proxyPort:        defaultProxyPort,
 		readinessTimeout: installReadinessTimeout,
 	}
 }
@@ -161,6 +165,7 @@ var (
 	errUpgradeRollback  = errors.New("rollback failed")
 	errUpgradeUpdate    = errors.New("pipelock update failed")
 	errUpgradeIntegrity = errors.New("pre-upgrade integrity check failed")
+	errUpgradeConfig    = errors.New("managed config preflight failed")
 )
 
 func runUpgrade(ctx context.Context, env *upgradeEnv, opts upgradeOpts) error {
@@ -232,6 +237,16 @@ func runUpgrade(ctx context.Context, env *upgradeEnv, opts upgradeOpts) error {
 				"an unreadable pin may indicate tampering)",
 			errUpgradeIntegrity, env.integrityPin, oldPinErr))
 	}
+
+	// The deployed binary was verified against its pin above before this check
+	// executes it. Keep this before backup, replacement, re-pinning, or service
+	// restart so a host whose managed config drifted out of containment posture
+	// stops with its running service untouched.
+	_, _ = fmt.Fprintln(w, "validating containment managed config...")
+	if err := preflightUpgradeManagedConfig(ctx, env); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("%w: %w", errUpgradeConfig, err))
+	}
+	_, _ = fmt.Fprintln(w, "  managed config accepted")
 
 	// ── Step 3: back up the current binary ──────────────────────────────
 	_, _ = fmt.Fprintln(w, "backing up current binary...")
@@ -479,7 +494,10 @@ func upgradeRestartAndWait(ctx context.Context, env *upgradeEnv) error {
 	}
 }
 
-// upgradePostVerify runs the newly deployed binary's contain verify command.
+// upgradePostVerify runs the newly deployed binary's containment probes and
+// rechecks the managed config. The latter repeats the pre-mutation condition:
+// a concurrent config edit cannot make an otherwise successful binary upgrade
+// bless a host whose metrics surface no longer satisfies containment policy.
 func upgradePostVerify(ctx context.Context, env *upgradeEnv) error {
 	out, code, err := env.runCmd(ctx, env.pipelockTarget, "contain", "verify")
 	if err != nil {
@@ -487,6 +505,48 @@ func upgradePostVerify(ctx context.Context, env *upgradeEnv) error {
 	}
 	if code != 0 {
 		return fmt.Errorf("contain verify exited %d: %s", code, truncateForErr(out))
+	}
+	if err := preflightUpgradeManagedConfig(ctx, env); err != nil {
+		return err
+	}
+	return nil
+}
+
+// preflightUpgradeManagedConfig proves that the managed config remains valid
+// for both the deployed runtime binary and the containment service sandbox.
+// It intentionally runs only after runUpgrade verified the deployed binary's
+// integrity pin, because this invokes that binary as root.
+func preflightUpgradeManagedConfig(ctx context.Context, env *upgradeEnv) error {
+	configPath := filepath.Clean(env.configPath)
+	data, err := env.readFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read managed config %s: %w", configPath, err)
+	}
+	if _, err := containServiceReadOnlyPaths(data, env.proxyPort); err != nil {
+		return fmt.Errorf("validate managed config %s for containment: %w", configPath, err)
+	}
+
+	binaryHashBefore, err := env.hashFile(env.pipelockTarget)
+	if err != nil {
+		return fmt.Errorf("hash deployed binary before config check: %w", err)
+	}
+	out, code, err := env.runCmd(ctx, env.pipelockTarget, "check", "--config", configPath)
+	if err != nil {
+		return fmt.Errorf("run deployed binary config check for %s: %w", configPath, err)
+	}
+	if code != 0 {
+		detail := strings.TrimSpace(out)
+		if detail == "" {
+			detail = fmt.Sprintf("pipelock check exited %d", code)
+		}
+		return fmt.Errorf("deployed binary rejected managed config %s: %s", configPath, oneLine(detail))
+	}
+	binaryHashAfter, err := env.hashFile(env.pipelockTarget)
+	if err != nil {
+		return fmt.Errorf("hash deployed binary after config check: %w", err)
+	}
+	if binaryHashAfter != binaryHashBefore {
+		return errors.New("deployed binary changed during managed config check")
 	}
 	return nil
 }

--- a/internal/cli/contain/upgrade_preflight_error_paths_test.go
+++ b/internal/cli/contain/upgrade_preflight_error_paths_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestPreflightUpgradeManagedConfigRefusals covers the refusal branches of the
+// upgrade preflight.
+//
+// Every branch here is a reason to stop BEFORE the binary is replaced or the
+// service restarted. They matter more than the happy path: this preflight exists
+// because `contain upgrade` previously performed the whole upgrade and then called
+// a verify that could not see the drift, so a drifted host was upgraded and
+// reported successful.
+func TestPreflightUpgradeManagedConfigRefusals(t *testing.T) {
+	const safeConfig = "metrics_listen: 127.0.0.1:9091\n"
+
+	tests := []struct {
+		name    string
+		arrange func(t *testing.T, env *upgradeEnv)
+		wantErr string
+	}{
+		{
+			name: "unreadable managed config",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				env.readFile = func(string) ([]byte, error) { return nil, errors.New("permission denied") }
+			},
+			wantErr: "read managed config",
+		},
+		{
+			name: "config violates the containment contract",
+			arrange: func(t *testing.T, env *upgradeEnv) {
+				if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 10.20.0.20:9091\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "validate managed config",
+		},
+		{
+			name: "deployed binary cannot be hashed before the check",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				env.hashFile = func(string) (string, error) { return "", errors.New("no such file") }
+			},
+			wantErr: "hash deployed binary before config check",
+		},
+		{
+			name: "the deployed binary fails to run",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+					return "", 0, errors.New("exec format error")
+				}
+			},
+			wantErr: "run deployed binary config check",
+		},
+		{
+			name: "the deployed binary rejects the config",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+					return "Config validation FAILED: something is wrong", 1, nil
+				}
+			},
+			wantErr: "deployed binary rejected managed config",
+		},
+		{
+			name: "the deployed binary rejects the config without saying why",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+					return "   ", 3, nil
+				}
+			},
+			wantErr: "exited 3",
+		},
+		{
+			name: "the binary changes underneath the check",
+			arrange: func(_ *testing.T, env *upgradeEnv) {
+				calls := 0
+				env.hashFile = func(string) (string, error) {
+					calls++
+					if calls == 1 {
+						return "hash-before", nil
+					}
+					return "hash-after", nil
+				}
+			},
+			wantErr: "deployed binary changed during managed config check",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := testUpgradeEnv(t)
+			if err := writeFileAtomic(env.configPath, []byte(safeConfig), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if env.runCmd == nil {
+				env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+			}
+			tt.arrange(t, env)
+
+			err := preflightUpgradeManagedConfig(context.Background(), env)
+			if err == nil {
+				t.Fatalf("preflight accepted a state it must refuse (%s)", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestPreflightUpgradeManagedConfigAcceptsACompliantHost is the positive control.
+// Without it the refusals above could all pass on a preflight that refuses
+// everything, which would block every upgrade rather than only drifted ones.
+func TestPreflightUpgradeManagedConfigAcceptsACompliantHost(t *testing.T) {
+	env := testUpgradeEnv(t)
+	if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 127.0.0.1:9091\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+		return "Config validation: OK", 0, nil
+	}
+	if err := preflightUpgradeManagedConfig(context.Background(), env); err != nil {
+		t.Fatalf("preflight refused a compliant host: %v", err)
+	}
+}

--- a/internal/cli/contain/upgrade_preflight_error_paths_test.go
+++ b/internal/cli/contain/upgrade_preflight_error_paths_test.go
@@ -129,3 +129,34 @@ func TestPreflightUpgradeManagedConfigAcceptsACompliantHost(t *testing.T) {
 		t.Fatalf("preflight refused a compliant host: %v", err)
 	}
 }
+
+// TestPreflightUpgradeManagedConfigRefusesAConfigThatChangedMidCheck pins the
+// re-read that makes the two inspections describe the same file.
+//
+// Preflight validates bytes it already holds, then has the deployed binary
+// check the same path. If the file changes in between, neither verdict
+// describes what the service will load, and the upgrade would proceed on a
+// config nothing actually approved. The binary is compared across the same
+// window; this is the config half of that pair.
+func TestPreflightUpgradeManagedConfigRefusesAConfigThatChangedMidCheck(t *testing.T) {
+	env := testUpgradeEnv(t)
+	if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 127.0.0.1:9091\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) {
+		// Stand in for anything that rewrites the managed config while the
+		// deployed binary is checking it.
+		if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 0.0.0.0:9091\n"), 0o600); err != nil {
+			return "", 1, err
+		}
+		return "Config validation: OK", 0, nil
+	}
+
+	err := preflightUpgradeManagedConfig(context.Background(), env)
+	if err == nil {
+		t.Fatal("preflight accepted a config that changed during its own validation")
+	}
+	if !strings.Contains(err.Error(), "changed during its own validation") {
+		t.Errorf("error = %q, want it to name the mid-check change", err.Error())
+	}
+}

--- a/internal/cli/contain/upgrade_test.go
+++ b/internal/cli/contain/upgrade_test.go
@@ -81,6 +81,16 @@ func testUpgradeEnv(t *testing.T) *upgradeEnv {
 		t.Fatal(err)
 	}
 
+	// A managed host has a service unit, and upgrade now reads it to carry the
+	// containment marker forward. Point at a temp copy rather than the real
+	// /etc/systemd/system path so tests never touch the host.
+	env.unitPath = filepath.Join(dir, "pipelock.service")
+	unit := "[Unit]\nDescription=Pipelock proxy\n\n[Service]\nType=simple\nExecStart=" +
+		env.pipelockTarget + " run --config " + env.configPath + "\n\n[Install]\nWantedBy=multi-user.target\n"
+	if err := writeFileAtomic(env.unitPath, []byte(unit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	return env
 }
 

--- a/internal/cli/contain/upgrade_test.go
+++ b/internal/cli/contain/upgrade_test.go
@@ -388,13 +388,16 @@ func TestUpgrade_RepinFails_RollsBackBinaryAndPin(t *testing.T) {
 	newBinary := []byte("new-binary-content")
 	env.runCmd = successRunCmd(env, newBinary)
 
-	// Make hashFile fail to simulate re-pin failure.
+	// Make hashFile fail to simulate re-pin failure. The initial integrity
+	// check and the managed-config preflight each hash the deployed binary
+	// before re-pinning begins.
 	origHash := env.hashFile
-	firstCall := true
+	hashCalls := 0
 	env.hashFile = func(path string) (string, error) {
-		// Allow the pre-execution hash check but fail for repin.
-		if firstCall {
-			firstCall = false
+		hashCalls++
+		// Allow the pre-execution hash check and the before/after hashes that
+		// keep the integrity-pinned config check from executing a changed binary.
+		if hashCalls <= 3 {
 			return origHash(path)
 		}
 		return "", fmt.Errorf("disk I/O error")

--- a/internal/cli/contain/upgrade_test.go
+++ b/internal/cli/contain/upgrade_test.go
@@ -70,10 +70,15 @@ func testUpgradeEnv(t *testing.T) *upgradeEnv {
 		chmod:            func(string, os.FileMode) error { return nil },
 		proxyUserName:    defaultProxyUser,
 		pipelockTarget:   target,
+		configPath:       filepath.Join(dir, "pipelock.yaml"),
 		integrityDir:     intDir,
 		integrityPin:     pinPath,
 		serviceName:      "pipelock.service",
+		proxyPort:        defaultProxyPort,
 		readinessTimeout: 2 * time.Second,
+	}
+	if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 127.0.0.1:9091\n"), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
 	return env
@@ -100,6 +105,96 @@ func successRunCmd(env *upgradeEnv, newBinary []byte) runCommand {
 			return "", 0, nil
 		}
 		return "", 0, nil
+	}
+}
+
+func TestUpgrade_UnsafeManagedConfigRefusesBeforeMutation(t *testing.T) {
+	env := testUpgradeEnv(t)
+	if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 0.0.0.0:9091\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldBinary, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPin, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return "", 0, nil
+	}
+
+	err = runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("runUpgrade succeeded with an unsafe managed metrics listener")
+	}
+	if !errors.Is(err, errUpgradeConfig) {
+		t.Fatalf("error = %v, want errUpgradeConfig", err)
+	}
+	if !strings.Contains(err.Error(), "dedicated port") {
+		t.Fatalf("error = %q, want containment metrics remediation", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("unsafe managed config reached a command mutation/check: %v", calls)
+	}
+	gotBinary, err := os.ReadFile(env.pipelockTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotBinary, oldBinary) {
+		t.Fatal("unsafe managed config changed the deployed binary")
+	}
+	gotPin, err := os.ReadFile(env.integrityPin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotPin, oldPin) {
+		t.Fatal("unsafe managed config changed the integrity pin")
+	}
+}
+
+func TestUpgrade_PostVerifyRechecksManagedConfig(t *testing.T) {
+	env := testUpgradeEnv(t)
+	newBinary := []byte("new-binary-post-verify-drift")
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == env.pipelockTarget && len(args) > 0 {
+			switch args[0] {
+			case "check":
+				return "", 0, nil
+			case "update":
+				if err := writeFileAtomic(env.pipelockTarget, newBinary, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return "Updated to v9.9.9", 0, nil
+			case "contain":
+				if err := writeFileAtomic(env.configPath, []byte("metrics_listen: 127.0.0.1:8888\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return "Result: 12 PASS / 0 FAIL / 0 SKIP", 0, nil
+			}
+		}
+		if name == "systemctl" {
+			if len(args) > 0 && args[0] == "is-active" {
+				return "active", 0, nil
+			}
+			return "", 0, nil
+		}
+		return "", 0, nil
+	}
+
+	err := runUpgrade(context.Background(), env, upgradeOpts{})
+	if err == nil {
+		t.Fatal("runUpgrade succeeded after the managed config drifted during upgrade")
+	}
+	if !errors.Is(err, errUpgradeVerify) {
+		t.Fatalf("error = %v, want errUpgradeVerify", err)
+	}
+	if !strings.Contains(err.Error(), "unsafe for containment") {
+		t.Fatalf("error = %q, want post-verify containment config failure", err)
 	}
 }
 

--- a/internal/cli/contain/upgrade_unit_marker_test.go
+++ b/internal/cli/contain/upgrade_unit_marker_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const legacyUnitWithoutMarker = `[Unit]
+Description=Pipelock proxy
+
+[Service]
+Type=simple
+User=pipelock-proxy
+ExecStart=/usr/local/bin/pipelock run --config /etc/pipelock/pipelock.yaml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+`
+
+func unitEnv(t *testing.T, body string) (*upgradeEnv, string) {
+	t.Helper()
+	dir := t.TempDir()
+	unit := filepath.Join(dir, "pipelock.service")
+	if body != "" {
+		if err := os.WriteFile(unit, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	env := testUpgradeEnv(t)
+	env.unitPath = unit
+	return env, unit
+}
+
+// TestEnsureContainmentMarkerInUnitMigratesALegacyUnit covers the case that made
+// this necessary: a host installed before the containment runtime guard existed.
+//
+// Without the migration the guard protects only fresh installs, so a release note
+// saying the runtime disables an unsafe metrics listener would be true of a new
+// host and false of every existing one.
+func TestEnsureContainmentMarkerInUnitMigratesALegacyUnit(t *testing.T) {
+	env, unit := unitEnv(t, legacyUnitWithoutMarker)
+
+	if err := ensureContainmentMarkerInUnit(env); err != nil {
+		t.Fatalf("ensureContainmentMarkerInUnit: %v", err)
+	}
+
+	updated, err := os.ReadFile(filepath.Clean(unit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(updated)
+	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+	if !strings.Contains(body, marker) {
+		t.Fatalf("marker not added:\n%s", body)
+	}
+	// The marker has to be inside [Service]; systemd ignores an Environment line
+	// placed in [Unit] or [Install], so position is the whole point.
+	serviceIdx := strings.Index(body, "[Service]")
+	markerIdx := strings.Index(body, marker)
+	installIdx := strings.Index(body, "[Install]")
+	if markerIdx < serviceIdx || markerIdx > installIdx {
+		t.Errorf("marker is outside the [Service] section; systemd would ignore it:\n%s", body)
+	}
+	// The operator's other settings survive: this edits a line, it does not
+	// regenerate the unit.
+	for _, keep := range []string{"User=pipelock-proxy", "Restart=on-failure", "WantedBy=multi-user.target"} {
+		if !strings.Contains(body, keep) {
+			t.Errorf("existing unit setting %q was lost", keep)
+		}
+	}
+}
+
+func TestEnsureContainmentMarkerInUnitIsIdempotent(t *testing.T) {
+	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+	current := strings.Replace(legacyUnitWithoutMarker, "[Service]\n", "[Service]\n"+marker+"\n", 1)
+	env, unit := unitEnv(t, current)
+
+	if err := ensureContainmentMarkerInUnit(env); err != nil {
+		t.Fatalf("ensureContainmentMarkerInUnit: %v", err)
+	}
+
+	updated, err := os.ReadFile(filepath.Clean(unit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(updated), marker); got != 1 {
+		t.Errorf("marker appears %d times, want exactly 1; a repeated upgrade must not accumulate lines", got)
+	}
+}
+
+// TestUpgradeCarriesTheContainmentMarkerOntoALegacyUnit exercises the CALL SITE,
+// not just the helper.
+//
+// The helper's own tests invoke it directly, so they keep passing if the upgrade
+// flow stops calling it. This runs the whole upgrade against a legacy unit and
+// requires the marker afterwards, which is the behavior an operator on an older
+// host actually depends on.
+func TestUpgradeCarriesTheContainmentMarkerOntoALegacyUnit(t *testing.T) {
+	env := testUpgradeEnv(t)
+	if err := writeFileAtomic(env.unitPath, []byte(legacyUnitWithoutMarker), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env.runCmd = successRunCmd(env, []byte("new-binary-marker"))
+
+	if err := runUpgrade(context.Background(), env, upgradeOpts{}); err != nil {
+		t.Fatalf("upgrade failed: %v", err)
+	}
+
+	updated, err := os.ReadFile(filepath.Clean(env.unitPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+	if !strings.Contains(string(updated), marker) {
+		t.Fatalf("upgrade left a legacy unit without the containment marker, so the runtime guard stays inactive on exactly the hosts this command brings current:\n%s", updated)
+	}
+}
+
+func TestEnsureContainmentMarkerInUnitRefusesAnUnusableUnit(t *testing.T) {
+	t.Run("missing unit", func(t *testing.T) {
+		env, _ := unitEnv(t, "")
+		err := ensureContainmentMarkerInUnit(env)
+		if err == nil {
+			t.Fatal("a missing unit was accepted; this command upgrades a containment-managed host")
+		}
+		if !strings.Contains(err.Error(), "read service unit") {
+			t.Errorf("error = %q, want it to name the unread unit", err.Error())
+		}
+	})
+
+	t.Run("no Service section", func(t *testing.T) {
+		env, _ := unitEnv(t, "[Unit]\nDescription=broken\n")
+		err := ensureContainmentMarkerInUnit(env)
+		if err == nil {
+			t.Fatal("a unit with no [Service] section was accepted; there is nowhere correct to put the marker")
+		}
+		if !strings.Contains(err.Error(), "no [Service] section") {
+			t.Errorf("error = %q, want it to say why it refused", err.Error())
+		}
+	})
+
+	t.Run("unwritable unit", func(t *testing.T) {
+		env, _ := unitEnv(t, legacyUnitWithoutMarker)
+		env.writeFile = func(string, []byte, os.FileMode) error { return errors.New("read-only file system") }
+		err := ensureContainmentMarkerInUnit(env)
+		if err == nil {
+			t.Fatal("a failed write was reported as success")
+		}
+		if !strings.Contains(err.Error(), "write service unit") {
+			t.Errorf("error = %q, want it to name the failed write", err.Error())
+		}
+	})
+}

--- a/internal/cli/contain/upgrade_unit_marker_test.go
+++ b/internal/cli/contain/upgrade_unit_marker_test.go
@@ -80,6 +80,42 @@ func TestEnsureContainmentMarkerInUnitMigratesALegacyUnit(t *testing.T) {
 	}
 }
 
+// TestEnsureContainmentMarkerInUnitIgnoresAMarkerSystemdWouldNotApply covers the
+// direction a substring search gets wrong.
+//
+// systemd applies Environment= only inside [Service]. The same text in [Unit],
+// [Install], or a comment does nothing at runtime, so treating it as present
+// skips the insertion and leaves the host unguarded while the upgrade reports
+// success.
+func TestEnsureContainmentMarkerInUnitIgnoresAMarkerSystemdWouldNotApply(t *testing.T) {
+	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"marker in [Unit]", "[Unit]\nDescription=Pipelock\n" + marker + "\n\n[Service]\nType=simple\n"},
+		{"marker in [Install]", "[Service]\nType=simple\n\n[Install]\n" + marker + "\n"},
+		{"marker only in a comment", "[Service]\nType=simple\n# migrated from " + marker + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, unit := unitEnv(t, tt.body)
+			if err := ensureContainmentMarkerInUnit(env); err != nil {
+				t.Fatalf("ensureContainmentMarkerInUnit: %v", err)
+			}
+			updated, err := os.ReadFile(filepath.Clean(unit))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !unitHasActiveContainmentMarker(string(updated), marker) {
+				t.Errorf("no active [Service] marker was added; systemd would not apply the one already present:\n%s", updated)
+			}
+		})
+	}
+}
+
 func TestEnsureContainmentMarkerInUnitIsIdempotent(t *testing.T) {
 	marker := "Environment=" + config.ContainmentManagedEnvKey + "=" + config.ContainmentManagedEnvValue
 	current := strings.Replace(legacyUnitWithoutMarker, "[Service]\n", "[Service]\n"+marker+"\n", 1)
@@ -133,8 +169,47 @@ func TestEnsureContainmentMarkerInUnitRefusesAnUnusableUnit(t *testing.T) {
 		if err == nil {
 			t.Fatal("a missing unit was accepted; this command upgrades a containment-managed host")
 		}
-		if !strings.Contains(err.Error(), "read service unit") {
-			t.Errorf("error = %q, want it to name the unread unit", err.Error())
+		if !strings.Contains(err.Error(), "inspect service unit") {
+			t.Errorf("error = %q, want it to name the unit it could not inspect", err.Error())
+		}
+	})
+
+	t.Run("symlinked unit", func(t *testing.T) {
+		env, unit := unitEnv(t, "")
+		target := filepath.Join(filepath.Dir(unit), "elsewhere.service")
+		if err := os.WriteFile(target, []byte(legacyUnitWithoutMarker), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, unit); err != nil {
+			t.Fatal(err)
+		}
+		err := ensureContainmentMarkerInUnit(env)
+		if err == nil {
+			t.Fatal("a symlinked unit was accepted; a root write would land wherever the link points")
+		}
+		if !strings.Contains(err.Error(), "symlink") {
+			t.Errorf("error = %q, want it to say it refused a symlink", err.Error())
+		}
+		after, readErr := os.ReadFile(filepath.Clean(target))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if string(after) != legacyUnitWithoutMarker {
+			t.Error("the symlink target was modified; the refusal must happen before any write")
+		}
+	})
+
+	t.Run("unit path is a directory", func(t *testing.T) {
+		env, unit := unitEnv(t, "")
+		if err := os.MkdirAll(unit, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		err := ensureContainmentMarkerInUnit(env)
+		if err == nil {
+			t.Fatal("a directory was accepted as a service unit")
+		}
+		if !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("error = %q, want it to say the path is not a regular file", err.Error())
 		}
 	})
 

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -143,6 +143,7 @@ type probeEnv struct {
 	pinPath            string
 	wrapperInvPath     string
 	toolsListPath      string
+	configPath         string
 	workspacePaths     []string
 	pipelockTarget     string
 	verifyRunningImage bool
@@ -190,6 +191,7 @@ func defaultProbeEnv() *probeEnv {
 		pinPath:            defaultIntegrityPin,
 		wrapperInvPath:     defaultWrapperInvPath,
 		toolsListPath:      defaultToolsListPath,
+		configPath:         filepath.Join(defaultConfigDir, "pipelock.yaml"),
 		pipelockTarget:     defaultPipelockTarget,
 		verifyRunningImage: true,
 		runCmd:             realRunCommand,
@@ -334,6 +336,7 @@ func allProbes() []probe {
 		{10, "binary_integrity_pin", "deployed and running pipelock binary match TOFU pin", probeBinaryIntegrity},
 		{11, "cc_launch_allow_list_enforced", "plk-launch rejects tools missing from the allow-list", probeCCLaunchAllowList},
 		{12, "listed_tool_targets_resolvable", "tools.list entries resolve for pipelock-agent", probeListedToolTargets},
+		{13, "managed_config_metrics", "managed config keeps metrics on a dedicated loopback port", probeManagedConfigMetrics},
 	}
 }
 
@@ -348,7 +351,7 @@ func probesForEnv(env *probeEnv) []probe {
 		}
 	}
 	if len(env.workspacePaths) > 0 {
-		probes = append(probes, probe{13, "workspace_access", "pipelock-agent can read configured workspace paths", probeWorkspaceAccess})
+		probes = append(probes, probe{14, "workspace_access", "pipelock-agent can read configured workspace paths", probeWorkspaceAccess})
 	}
 	return probes
 }
@@ -753,7 +756,7 @@ func verifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Run read-only probes against the containment model",
-		Long: `Run twelve read-only probes to verify the workstation containment model
+		Long: `Run thirteen read-only probes to verify the workstation containment model
 is installed correctly and the boundary is intact.
 
 Probes inspect system users, the pipelock systemd unit, nftables rules,
@@ -761,8 +764,9 @@ wrapper scripts, the CA bundle, the pipelock loopback bind, the NO_PROXY
 policy, run two egress canaries (pipelock-agent must NOT reach the internet
 directly; the operator user must still reach the internet), verify the
 deployed and running service binaries match the TOFU integrity pin written at
-install time, and exercise plk-launch end-to-end with a sentinel tool to confirm
-the allow-list enforcement path actually fires. Pass --workspace to also
+install time, exercise plk-launch end-to-end with a sentinel tool to confirm
+the allow-list enforcement path actually fires, and check that the managed
+config keeps metrics on a dedicated loopback port. Pass --workspace to also
 verify that pipelock-agent can read/traverse real project directories.
 Pass --enforcement-only when another process owns the proxy lifecycle;
 that mode verifies the kernel/user/wrapper controls and the pinned file at the
@@ -1029,6 +1033,34 @@ func parseSystemdShow(out string) map[string]string {
 		fields[k] = v
 	}
 	return fields
+}
+
+// ---------------------------------------------------------------------------
+// Probe 13: managed_config_metrics
+// ---------------------------------------------------------------------------
+
+// probeManagedConfigMetrics verifies the containment-specific metrics surface
+// from the managed config without starting or reloading Pipelock. An operator
+// may run verify without root, while the managed config is readable only by
+// root and pipelock-proxy, so an unreadable or absent file is incomplete
+// evidence and must not become a pass.
+func probeManagedConfigMetrics(_ context.Context, env *probeEnv) (string, string) {
+	configPath := filepath.Clean(env.configPath)
+	data, err := env.readFile(configPath)
+	if err != nil {
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return statusSkip, fmt.Sprintf("managed config %s is missing", configPath)
+		case errors.Is(err, os.ErrPermission):
+			return statusSkip, fmt.Sprintf("managed config %s is not readable; rerun as root", configPath)
+		default:
+			return statusUnknown, fmt.Sprintf("read managed config %s: %v", configPath, err)
+		}
+	}
+	if _, err := containServiceReadOnlyPaths(data, env.port); err != nil {
+		return statusFail, fmt.Sprintf("managed config %s violates containment metrics policy: %v", configPath, err)
+	}
+	return statusPass, fmt.Sprintf("managed config %s keeps metrics off the agent-accessible proxy port", configPath)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -207,6 +207,7 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		serviceName:        testService,
 		pinPath:            filepath.Join(t.TempDir(), "binary-pin.sha256"),
 		toolsListPath:      filepath.Join(t.TempDir(), "tools.list"),
+		configPath:         filepath.Join(t.TempDir(), "pipelock.yaml"),
 		pipelockTarget:     defaultPipelockTarget,
 		verifyRunningImage: true,
 		runCmd:             rejectAllRun,
@@ -458,6 +459,62 @@ func TestParseSystemdShow(t *testing.T) {
 		if got[k] != v {
 			t.Errorf("key %s: got %q, want %q", k, got[k], v)
 		}
+	}
+}
+
+func TestProbeManagedConfigMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		read       func(string) ([]byte, error)
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "compliant dedicated loopback listener passes",
+			read:       func(string) ([]byte, error) { return []byte("metrics_listen: 127.0.0.1:9091\n"), nil },
+			wantStatus: statusPass,
+			wantDetail: "keeps metrics off",
+		},
+		{
+			name:       "wildcard listener fails",
+			read:       func(string) ([]byte, error) { return []byte("metrics_listen: 0.0.0.0:9091\n"), nil },
+			wantStatus: statusFail,
+			wantDetail: "unsafe for containment",
+		},
+		{
+			name:       "proxy port fails",
+			read:       func(string) ([]byte, error) { return []byte("metrics_listen: 127.0.0.1:8888\n"), nil },
+			wantStatus: statusFail,
+			wantDetail: "agent-accessible proxy port",
+		},
+		{
+			name:       "missing config skips",
+			read:       func(string) ([]byte, error) { return nil, os.ErrNotExist },
+			wantStatus: statusSkip,
+			wantDetail: "is missing",
+		},
+		{
+			name:       "unreadable config skips",
+			read:       func(string) ([]byte, error) { return nil, os.ErrPermission },
+			wantStatus: statusSkip,
+			wantDetail: "rerun as root",
+		},
+		{
+			name:       "io failure is unknown",
+			read:       func(string) ([]byte, error) { return nil, errors.New("I/O fault") },
+			wantStatus: statusUnknown,
+			wantDetail: "I/O fault",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t, func(env *probeEnv) { env.readFile = tc.read })
+			status, detail := probeManagedConfigMetrics(t.Context(), env)
+			if status != tc.wantStatus || !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("probe = (%q, %q), want (%q, detail containing %q)", status, detail, tc.wantStatus, tc.wantDetail)
+			}
+		})
 	}
 }
 
@@ -2795,10 +2852,10 @@ func TestRunVerify_TextOutput_AllPass(t *testing.T) {
 	if !strings.HasPrefix(out, "pipelock contain verify") {
 		t.Errorf("missing header: %q", out)
 	}
-	if strings.Count(out, "[PASS]") != 12 {
-		t.Errorf("want 12 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
+	if strings.Count(out, "[PASS]") != 13 {
+		t.Errorf("want 13 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
 	}
-	if !strings.Contains(out, "12 PASS / 0 FAIL / 0 SKIP") {
+	if !strings.Contains(out, "13 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing aggregate: %q", out)
 	}
 }
@@ -2815,10 +2872,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	if len(lines) != 13 {
-		t.Fatalf("expected 13 JSON records (12 probes + aggregate), got %d: %q", len(lines), buf.String())
+	if len(lines) != 14 {
+		t.Fatalf("expected 14 JSON records (13 probes + aggregate), got %d: %q", len(lines), buf.String())
 	}
-	for i := 0; i < 12; i++ {
+	for i := 0; i < 13; i++ {
 		var rec probeRecord
 		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
 			t.Fatalf("line %d: parse: %v (line=%q)", i, err, lines[i])
@@ -2831,10 +2888,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 		}
 	}
 	var agg aggregateRecord
-	if err := json.Unmarshal([]byte(lines[12]), &agg); err != nil {
-		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[12])
+	if err := json.Unmarshal([]byte(lines[13]), &agg); err != nil {
+		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[13])
 	}
-	if agg.Aggregate.Pass != 12 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
+	if agg.Aggregate.Pass != 13 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
 		t.Errorf("aggregate counts: %+v", agg.Aggregate)
 	}
 	if agg.Aggregate.ExitCode != cliutil.ExitOK {
@@ -2879,7 +2936,7 @@ func TestRunVerify_EnforcementOnlySkipsProxyLiveness(t *testing.T) {
 	if strings.Contains(out, "probe 2:") || strings.Contains(out, "probe 6:") {
 		t.Errorf("liveness probes should be omitted: %q", out)
 	}
-	if !strings.Contains(out, "10 PASS / 0 FAIL / 0 SKIP") {
+	if !strings.Contains(out, "11 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing enforcement-only aggregate: %q", out)
 	}
 	if !strings.Contains(out, "probe 10: deployed pipelock binary matches TOFU pin; running-service image is not verified") ||
@@ -3095,8 +3152,8 @@ func TestRunVerify_JSONUnknownIsIncomplete(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	if len(lines) != 13 {
-		t.Fatalf("JSON record count = %d, want 13: %q", len(lines), buf.String())
+	if len(lines) != 14 {
+		t.Fatalf("JSON record count = %d, want 14: %q", len(lines), buf.String())
 	}
 	var canary probeRecord
 	if err := json.Unmarshal([]byte(lines[7]), &canary); err != nil {
@@ -3106,11 +3163,11 @@ func TestRunVerify_JSONUnknownIsIncomplete(t *testing.T) {
 		t.Fatalf("canary record = %+v, want probe 8 unknown", canary)
 	}
 	var agg aggregateRecord
-	if err := json.Unmarshal([]byte(lines[12]), &agg); err != nil {
+	if err := json.Unmarshal([]byte(lines[13]), &agg); err != nil {
 		t.Fatalf("decode aggregate: %v", err)
 	}
-	if agg.Aggregate.Unknown != 1 || agg.Aggregate.Pass != 11 || agg.Aggregate.ExitCode != cliutil.ExitConfig {
-		t.Fatalf("aggregate = %+v, want 11 pass / 1 unknown / exit 2", agg.Aggregate)
+	if agg.Aggregate.Unknown != 1 || agg.Aggregate.Pass != 12 || agg.Aggregate.ExitCode != cliutil.ExitConfig {
+		t.Fatalf("aggregate = %+v, want 12 pass / 1 unknown / exit 2", agg.Aggregate)
 	}
 }
 
@@ -3147,14 +3204,14 @@ func TestRunVerify_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
 				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &agg); err != nil {
 					t.Fatalf("decode aggregate: %v\n%s", err, out)
 				}
-				if agg.Aggregate.Pass != 8 || agg.Aggregate.Fail != 1 ||
+				if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 1 ||
 					agg.Aggregate.Skip != 2 || agg.Aggregate.Unknown != 1 ||
 					agg.Aggregate.ExitCode != cliutil.ExitGeneral {
-					t.Fatalf("mixed aggregate = %+v, want 8 pass / 1 fail / 2 skip / 1 unknown / exit 1", agg.Aggregate)
+					t.Fatalf("mixed aggregate = %+v, want 9 pass / 1 fail / 2 skip / 1 unknown / exit 1", agg.Aggregate)
 				}
 				return
 			}
-			if !strings.Contains(out, "8 PASS / 1 FAIL / 2 SKIP / 1 UNKNOWN — exit 1") {
+			if !strings.Contains(out, "9 PASS / 1 FAIL / 2 SKIP / 1 UNKNOWN — exit 1") {
 				t.Fatalf("text lost a mixed outcome or fail precedence:\n%s", out)
 			}
 		})
@@ -3178,9 +3235,9 @@ func TestRunVerify_RecordAndAggregateWriteFailuresFailClosed(t *testing.T) {
 		want             string
 	}{
 		{name: "text probe", successfulWrites: 1, want: "writing probe 1 text"},
-		{name: "text aggregate", successfulWrites: 13, want: "writing verify aggregate"},
+		{name: "text aggregate", successfulWrites: 14, want: "writing verify aggregate"},
 		{name: "JSON probe", jsonOutput: true, want: "encoding probe 1 JSON"},
-		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 12, want: "encoding aggregate JSON"},
+		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 13, want: "encoding aggregate JSON"},
 	}
 
 	for _, tc := range tests {
@@ -3404,6 +3461,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 	env := makeProbeEnv(t)
 	env.operatorUser = testOperatorUser
 	env.nftRulesPath = filepath.Join(t.TempDir(), "50-pipelock-containment.nft")
+	env.configPath = filepath.Join(t.TempDir(), "pipelock.yaml")
 
 	// Probe 1: both users present.
 	env.lookupUser = func(name string) (*user.User, error) {
@@ -3462,6 +3520,9 @@ func allPassEnv(t *testing.T) *probeEnv {
 		return defaultRunForAllPass(name, args)
 	}
 	env.readFile = func(path string) ([]byte, error) {
+		if path == env.configPath {
+			return []byte("metrics_listen: 127.0.0.1:9091\n"), nil
+		}
 		if path == env.pinPath {
 			return []byte(allPassHash + "\n"), nil
 		}

--- a/internal/cli/runtime/containment_metrics.go
+++ b/internal/cli/runtime/containment_metrics.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/emit"
+)
+
+const containmentMetricsDriftEvent = "containment_managed_config_drift"
+
+func containmentManagedRuntime() bool {
+	return os.Getenv(config.ContainmentManagedEnvKey) == config.ContainmentManagedEnvValue
+}
+
+func validateContainmentMetricsConfig(cfg *config.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("containment runtime has no active config")
+	}
+	_, port, err := net.SplitHostPort(cfg.FetchProxy.Listen)
+	if err != nil {
+		return fmt.Errorf("parse fetch_proxy.listen %q for containment metrics policy: %w", cfg.FetchProxy.Listen, err)
+	}
+	proxyPort, err := strconv.Atoi(port)
+	if err != nil || proxyPort < 1 || proxyPort > 65535 {
+		return fmt.Errorf("parse fetch_proxy.listen port %q for containment metrics policy", port)
+	}
+	return config.ValidateContainmentMetricsListen(cfg.MetricsListen, proxyPort)
+}
+
+// reportContainmentMetricsDrift makes the degraded state visible to both the
+// local audit log and configured event sinks. The explicit critical event is
+// separate from the generic audit error because telemetry must not downgrade a
+// containment metrics exposure to the normal warning severity for an error.
+func (s *Server) reportContainmentMetricsDrift(cfg *config.Config, phase string, drift error) {
+	configured := ""
+	if cfg != nil {
+		configured = cfg.MetricsListen
+	}
+	detail := fmt.Sprintf("containment managed config drift: metrics listener %q disabled: %v; set metrics_listen to a numeric loopback address on a non-proxy port and do not delete the key", configured, drift)
+	_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: CRITICAL: %s\n", detail)
+	if s.logger != nil {
+		s.logger.LogError(audit.NewResourceLogContext("CONTAINMENT_MANAGED_CONFIG", s.opts.ConfigFile), errors.New(detail))
+	}
+	if s.emitter != nil {
+		s.emitter.EmitWithSeverity(context.Background(), emit.SeverityCritical, containmentMetricsDriftEvent, map[string]any{
+			"field":             "metrics_listen",
+			"configured_listen": configured,
+			"phase":             phase,
+			"reason":            drift.Error(),
+			"outcome":           "metrics_disabled",
+		})
+	}
+}

--- a/internal/cli/runtime/containment_metrics.go
+++ b/internal/cli/runtime/containment_metrics.go
@@ -31,8 +31,11 @@ func validateContainmentMetricsConfig(cfg *config.Config) error {
 		return fmt.Errorf("parse fetch_proxy.listen %q for containment metrics policy: %w", cfg.FetchProxy.Listen, err)
 	}
 	proxyPort, err := strconv.Atoi(port)
-	if err != nil || proxyPort < 1 || proxyPort > 65535 {
-		return fmt.Errorf("parse fetch_proxy.listen port %q for containment metrics policy", port)
+	if err != nil {
+		return fmt.Errorf("parse fetch_proxy.listen port %q for containment metrics policy: %w", port, err)
+	}
+	if proxyPort < 1 || proxyPort > 65535 {
+		return fmt.Errorf("fetch_proxy.listen port %d is out of range for containment metrics policy", proxyPort)
 	}
 	return config.ValidateContainmentMetricsListen(cfg.MetricsListen, proxyPort)
 }

--- a/internal/cli/runtime/containment_metrics_error_paths_test.go
+++ b/internal/cli/runtime/containment_metrics_error_paths_test.go
@@ -54,6 +54,21 @@ func TestValidateContainmentMetricsConfigRefusals(t *testing.T) {
 			wantDetail: "parse fetch_proxy.listen port",
 		},
 		{
+			// Split out from the parse failure above: a port that parses but
+			// cannot be listened on is a different fault and says so, rather
+			// than being reported as an unparsable one.
+			name: "proxy port outside the valid range",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.ApplyDefaults()
+				c.FetchProxy.Listen = "127.0.0.1:70000"
+				c.MetricsListen = "127.0.0.1:9091"
+				return c
+			}(),
+			wantErr:    true,
+			wantDetail: "out of range",
+		},
+		{
 			name: "metrics on the proxy port",
 			cfg: func() *config.Config {
 				c := config.Defaults()

--- a/internal/cli/runtime/containment_metrics_error_paths_test.go
+++ b/internal/cli/runtime/containment_metrics_error_paths_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestValidateContainmentMetricsConfigRefusals covers the branches that decide
+// whether the containment metrics policy can be evaluated at all.
+//
+// These fail closed on purpose. If the proxy port cannot be determined there is no
+// way to know whether the metrics listener collides with the surface the agent can
+// reach, and guessing in that state is how a guard becomes decoration.
+func TestValidateContainmentMetricsConfigRefusals(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantErr    bool
+		wantDetail string
+	}{
+		{
+			name:       "nil config",
+			cfg:        nil,
+			wantErr:    true,
+			wantDetail: "no active config",
+		},
+		{
+			name: "unparseable proxy listen",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.ApplyDefaults()
+				c.FetchProxy.Listen = "not-a-host-port"
+				c.MetricsListen = "127.0.0.1:9091"
+				return c
+			}(),
+			wantErr:    true,
+			wantDetail: "parse fetch_proxy.listen",
+		},
+		{
+			name: "non-numeric proxy port",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.ApplyDefaults()
+				c.FetchProxy.Listen = "127.0.0.1:proxy"
+				c.MetricsListen = "127.0.0.1:9091"
+				return c
+			}(),
+			wantErr:    true,
+			wantDetail: "parse fetch_proxy.listen port",
+		},
+		{
+			name: "metrics on the proxy port",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.ApplyDefaults()
+				c.FetchProxy.Listen = "127.0.0.1:8888"
+				c.MetricsListen = "127.0.0.1:8888"
+				return c
+			}(),
+			wantErr:    true,
+			wantDetail: "agent-accessible proxy port",
+		},
+		{
+			name: "compliant loopback metrics",
+			cfg: func() *config.Config {
+				c := config.Defaults()
+				c.ApplyDefaults()
+				c.FetchProxy.Listen = "127.0.0.1:8888"
+				c.MetricsListen = "127.0.0.1:9091"
+				return c
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContainmentMetricsConfig(tt.cfg)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validateContainmentMetricsConfig = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("validateContainmentMetricsConfig = nil, want a refusal")
+			}
+			if !strings.Contains(err.Error(), tt.wantDetail) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantDetail)
+			}
+		})
+	}
+}
+
+// TestContainmentManagedRuntimeKeysOnTheExactMarker pins that the guard activates
+// only under the marker the installer writes.
+//
+// Generic Pipelock accepts a LAN metrics address by design, so a loose check here
+// would change behavior for deployments that never asked for containment.
+func TestContainmentManagedRuntimeKeysOnTheExactMarker(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"the installer marker", config.ContainmentManagedEnvValue, true},
+		{"unset", "", false},
+		{"a different value", "0", false},
+		{"a truthy-looking value that is not the marker", "true", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(config.ContainmentManagedEnvKey, tt.value)
+			if got := containmentManagedRuntime(); got != tt.want {
+				t.Errorf("containmentManagedRuntime() = %v with %s=%q, want %v",
+					got, config.ContainmentManagedEnvKey, tt.value, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime/containment_metrics_exposure_test.go
+++ b/internal/cli/runtime/containment_metrics_exposure_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/testport"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+// TestServer_ContainmentDeletedMetricsKeyDoesNotExposeMetricsOnTheProxyPort
+// covers the state an operator actually reaches by following the remediation
+// message: they delete metrics_listen instead of setting it.
+//
+// Deleting the key is not the same as setting an unsafe address. An unsafe
+// address leaves the value non-empty, and the proxy only publishes /metrics and
+// /stats on its own listener when the value is EMPTY. So the deleted-key case
+// is the one where disabling the dedicated listener silently hands the endpoints
+// to the agent-reachable proxy port, while startup still reports metrics
+// disabled. That combination is worse than an unguarded host, because the
+// operator has been told they are covered.
+func TestServer_ContainmentDeletedMetricsKeyDoesNotExposeMetricsOnTheProxyPort(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	fetchListen := testport.ListenAddrs(t, 1)[0]
+	// The empty address is the deleted key: config.Load leaves it "".
+	s, _ := newContainmentMetricsTestServerWithFetch(t, "", "", fetchListen)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Start(ctx) }()
+
+	client := &http.Client{Transport: &http.Transport{Proxy: nil}, Timeout: 500 * time.Millisecond}
+	get := func(path string) (int, bool) {
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+fetchListen+path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, requestErr := client.Do(request)
+		if requestErr != nil {
+			return 0, false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode, true
+	}
+
+	testwait.For(t, 3*time.Second, func() bool {
+		select {
+		case startErr := <-done:
+			t.Fatalf("Start returned before serving the proxy: %v", startErr)
+		default:
+		}
+		code, ok := get("/health")
+		return ok && code == http.StatusOK
+	}, "contained proxy to start with the metrics key deleted")
+
+	for _, path := range []string{"/metrics", "/stats"} {
+		code, ok := get(path)
+		if !ok {
+			t.Fatalf("%s: request failed against a proxy that is serving /health", path)
+		}
+		if code != http.StatusNotFound {
+			t.Errorf("%s on the agent-reachable proxy port returned %d, want 404: containment reported metrics disabled, "+
+				"so the contained agent must not be able to read them here", path, code)
+		}
+	}
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case startErr := <-done:
+		if startErr != nil {
+			t.Fatalf("Start: %v", startErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for contained proxy shutdown")
+	}
+}

--- a/internal/cli/runtime/containment_metrics_test.go
+++ b/internal/cli/runtime/containment_metrics_test.go
@@ -72,13 +72,17 @@ func TestServer_StartContainmentUnsafeMetricsSkipsBlockedListener(t *testing.T) 
 	go func() { done <- s.Start(ctx) }()
 
 	client := &http.Client{Transport: &http.Transport{Proxy: nil}, Timeout: 200 * time.Millisecond}
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+fetchListen+"/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	testwait.For(t, 2*time.Second, func() bool {
 		select {
 		case startErr := <-done:
 			t.Fatalf("Start returned before serving the proxy: %v", startErr)
 		default:
 		}
-		resp, requestErr := client.Get("http://" + fetchListen + "/health")
+		resp, requestErr := client.Do(request)
 		if requestErr != nil {
 			return false
 		}

--- a/internal/cli/runtime/containment_metrics_test.go
+++ b/internal/cli/runtime/containment_metrics_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/testport"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+func newContainmentMetricsTestServer(t *testing.T, metricsListen, webhookURL string) (*Server, *syncBuffer) {
+	return newContainmentMetricsTestServerWithFetch(t, metricsListen, webhookURL, "")
+}
+
+func newContainmentMetricsTestServerWithFetch(t *testing.T, metricsListen, webhookURL, fetchListen string) (*Server, *syncBuffer) {
+	t.Helper()
+	lines := []string{
+		"mode: balanced",
+		"metrics_listen: " + fmt.Sprintf("%q", metricsListen),
+	}
+	if webhookURL != "" {
+		lines = append(lines,
+			"emit:",
+			"  webhook:",
+			"    url: "+fmt.Sprintf("%q", webhookURL),
+			"    min_severity: warn",
+			"    timeout_seconds: 1",
+			"    queue_size: 16",
+		)
+	}
+	buf := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		ConfigFile:                        writeServerTestConfig(t, strings.Join(lines, "\n")+"\n"),
+		Listen:                            fetchListen,
+		ListenChanged:                     fetchListen != "",
+		Stdout:                            buf,
+		Stderr:                            buf,
+		allowEphemeralListenersForTesting: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { s.cleanup() })
+	return s, buf
+}
+
+func TestServer_StartContainmentUnsafeMetricsSkipsBlockedListener(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	metricsBlocker, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metricsBlocker.Close() }()
+	metricsPort := metricsBlocker.Addr().(*net.TCPAddr).Port
+	metricsListen := net.JoinHostPort("0.0.0.0", strconv.Itoa(metricsPort))
+	fetchListen := testport.ListenAddrs(t, 1)[0]
+	s, _ := newContainmentMetricsTestServerWithFetch(t, metricsListen, "", fetchListen)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Start(ctx) }()
+
+	client := &http.Client{Transport: &http.Transport{Proxy: nil}, Timeout: 200 * time.Millisecond}
+	testwait.For(t, 2*time.Second, func() bool {
+		select {
+		case startErr := <-done:
+			t.Fatalf("Start returned before serving the proxy: %v", startErr)
+		default:
+		}
+		resp, requestErr := client.Get("http://" + fetchListen + "/health")
+		if requestErr != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, "contained proxy to start while unsafe metrics port is blocked")
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case startErr := <-done:
+		if startErr != nil {
+			t.Fatalf("Start: %v", startErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for contained proxy shutdown")
+	}
+}
+
+func TestNewServer_ContainmentUnsafeMetricsDisablesListenerAndReportsCritical(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	webhookURL, events := newServerTestWebhook(t)
+	s, stderr := newContainmentMetricsTestServer(t, "0.0.0.0:19091", webhookURL)
+
+	if !s.containmentManaged {
+		t.Fatal("managed containment environment was not recognized")
+	}
+	if !s.metricsDisabled {
+		t.Fatal("unsafe containment metrics listener remained enabled")
+	}
+	if got := s.proxy.CurrentConfig().MetricsListen; got == "" {
+		t.Fatal("unsafe metrics listener was cleared, which would expose metrics on the proxy port")
+	}
+	if !stderr.contains("CRITICAL: containment managed config drift") {
+		t.Fatalf("critical containment drift was not reported:\n%s", stderr.String())
+	}
+
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case event := <-events:
+			if event.Type != containmentMetricsDriftEvent {
+				continue
+			}
+			if event.Severity != "critical" {
+				t.Fatalf("event severity = %q, want critical", event.Severity)
+			}
+			if event.Fields["outcome"] != "metrics_disabled" {
+				t.Fatalf("event outcome = %v, want metrics_disabled", event.Fields["outcome"])
+			}
+			return
+		case <-deadline.C:
+			t.Fatal("timed out waiting for critical containment metrics drift event")
+		}
+	}
+}
+
+func TestNewServer_ContainmentLoopbackMetricsRemainEnabled(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	s, stderr := newContainmentMetricsTestServer(t, "127.0.0.1:19091", "")
+
+	if !s.containmentManaged {
+		t.Fatal("managed containment environment was not recognized")
+	}
+	if s.metricsDisabled {
+		t.Fatal("compliant loopback metrics listener was disabled")
+	}
+	if stderr.contains("containment managed config drift") {
+		t.Fatalf("compliant loopback metrics listener reported drift:\n%s", stderr.String())
+	}
+}
+
+func TestServer_ReloadContainmentUnsafeMetricsPreservesLiveListenerAndReportsCritical(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	s, stderr := newContainmentMetricsTestServer(t, "127.0.0.1:19091", "")
+	oldCfg := s.proxy.CurrentConfig()
+	newCfg := oldCfg.Clone()
+	newCfg.MetricsListen = "0.0.0.0:19092"
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if got := s.proxy.CurrentConfig().MetricsListen; got != oldCfg.MetricsListen {
+		t.Fatalf("live metrics listener = %q, want preserved %q", got, oldCfg.MetricsListen)
+	}
+	if !stderr.contains("CRITICAL: containment managed config drift") {
+		t.Fatalf("unsafe reload did not report critical containment drift:\n%s", stderr.String())
+	}
+}

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -98,10 +98,12 @@ type ServerOpts struct {
 type Server struct {
 	opts ServerOpts
 
-	runtimeMode       config.RuntimeMode
-	hasMCPListen      bool
-	apiOnSeparatePort bool
-	hasApprover       bool
+	runtimeMode        config.RuntimeMode
+	hasMCPListen       bool
+	apiOnSeparatePort  bool
+	hasApprover        bool
+	containmentManaged bool
+	metricsDisabled    bool
 
 	cfg          *config.Config
 	bundleResult *rules.LoadResult
@@ -320,8 +322,9 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	}
 
 	s := &Server{
-		opts:         opts,
-		hasMCPListen: hasMCPListen,
+		opts:               opts,
+		hasMCPListen:       hasMCPListen,
+		containmentManaged: containmentManagedRuntime(),
 	}
 	s.mcpListenerBearerToken = mcpAuthToken
 	if cfg.EvidenceProvenance.CommitmentKeyringPath != "" {
@@ -377,6 +380,12 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	logger.SetEmitter(emitter)
 	s.emitter = emitter
 	s.emitSinks = append([]emit.Sink(nil), emitSinks...)
+	if s.containmentManaged {
+		if containmentErr := validateContainmentMetricsConfig(cfg); containmentErr != nil {
+			s.metricsDisabled = true
+			s.reportContainmentMetricsDrift(cfg, "startup", containmentErr)
+		}
+	}
 	emitLicenseExpiryWarning(cfg, logger, sentryClient, opts.Stderr)
 
 	runtimeMode := config.RuntimeForward

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -667,6 +667,14 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		_, _ = fmt.Fprintf(opts.Stderr, "  Envelope: enabled (mediation envelopes injected)\n")
 	}
 
+	// A containment refusal has to reach the proxy's own routes too. Skipping
+	// the dedicated listener alone leaves /metrics and /stats served on the
+	// proxy port whenever metrics_listen is empty, which is the address the
+	// contained agent can reach, while startup reports metrics disabled.
+	if s.metricsDisabled {
+		proxyOpts = append(proxyOpts, proxy.WithMetricsSuppressed())
+	}
+
 	p, pErr := proxy.New(cfg, logger, sc, m, proxyOpts...)
 	if pErr != nil {
 		s.cleanup()

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -416,7 +416,9 @@ func (s *Server) Start(ctx context.Context) error {
 	_, _ = fmt.Fprintf(s.opts.Stderr, "  Listen: %s\n", boundFetchAddr)
 	_, _ = fmt.Fprintf(s.opts.Stderr, "  Fetch:  http://%s/fetch?url=<url>\n", boundFetchAddr)
 	_, _ = fmt.Fprintf(s.opts.Stderr, "  Health: http://%s/health\n", boundFetchAddr)
-	if cfg.MetricsListen != "" {
+	if s.metricsDisabled {
+		_, _ = fmt.Fprintln(s.opts.Stderr, "  Stats:  disabled (containment managed-config drift)")
+	} else if cfg.MetricsListen != "" {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Stats:  http://%s/stats (separate port)\n", cfg.MetricsListen)
 	} else {
 		_, _ = fmt.Fprintf(s.opts.Stderr, "  Stats:  http://%s/stats\n", boundFetchAddr)
@@ -678,7 +680,7 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	var metricsErr chan error
-	if cfg.MetricsListen != "" {
+	if cfg.MetricsListen != "" && !s.metricsDisabled {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", s.metrics.PrometheusHandler())
 		metricsMux.HandleFunc("/stats", s.metrics.StatsHandler())

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -94,8 +94,17 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// Block metrics_listen changes via reload. The metrics server
 		// binds at startup and can't rebind at runtime.
 		if oldCfg.MetricsListen != newCfg.MetricsListen {
-			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
-				oldCfg.MetricsListen, newCfg.MetricsListen)
+			if s.containmentManaged {
+				if containmentErr := validateContainmentMetricsConfig(newCfg); containmentErr != nil {
+					s.reportContainmentMetricsDrift(newCfg, "reload", containmentErr)
+				} else {
+					_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
+						oldCfg.MetricsListen, newCfg.MetricsListen)
+				}
+			} else {
+				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
+					oldCfg.MetricsListen, newCfg.MetricsListen)
+			}
 			newCfg.MetricsListen = oldCfg.MetricsListen
 		}
 		// Block scan_api listener setting changes via reload. The Scan

--- a/internal/config/containment.go
+++ b/internal/config/containment.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// ContainmentManagedEnvKey and ContainmentManagedEnvValue identify a Pipelock
+// process started by the managed containment service. They are deliberately
+// separate from generic configuration validation: standalone Pipelock may
+// expose metrics on a LAN address, while containment must not.
+const (
+	ContainmentManagedEnvKey   = "PIPELOCK_CONTAINMENT_MANAGED"
+	ContainmentManagedEnvValue = "1"
+)
+
+// ValidateContainmentMetricsListen enforces the metrics listener invariant
+// used only by the containment lifecycle: a numeric loopback address on a
+// non-proxy TCP port. It does not participate in Config.Validate, because
+// ordinary Pipelock deployments may intentionally expose metrics on a LAN.
+func ValidateContainmentMetricsListen(listen string, proxyPort int) error {
+	if strings.TrimSpace(listen) == "" {
+		return fmt.Errorf("metrics_listen is unsafe for containment: set a numeric loopback address on a dedicated port and do not delete the key")
+	}
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: %w", listen, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric loopback address on a dedicated port", listen)
+	}
+	parsedPort, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || parsedPort == 0 || int(parsedPort) == proxyPort {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a port other than the agent-accessible proxy port %d", listen, proxyPort)
+	}
+	return nil
+}

--- a/internal/config/containment_error_paths_test.go
+++ b/internal/config/containment_error_paths_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateContainmentMetricsListenRefusals covers every refusal branch.
+//
+// The error paths are the point of this validator: each one is a distinct way an
+// operator edit can leave the containment contract, and each returns different
+// remediation text. The empty case matters most, because deleting the key does not
+// disable metrics, it moves them onto the agent-accessible proxy port.
+func TestValidateContainmentMetricsListenRefusals(t *testing.T) {
+	const proxyPort = 8888
+
+	tests := []struct {
+		name       string
+		listen     string
+		wantErr    bool
+		wantDetail string
+	}{
+		{
+			name:       "empty is refused and says not to delete the key",
+			listen:     "",
+			wantErr:    true,
+			wantDetail: "do not delete the key",
+		},
+		{
+			name:       "whitespace only is treated as empty",
+			listen:     "   ",
+			wantErr:    true,
+			wantDetail: "do not delete the key",
+		},
+		{
+			name:       "unparseable address",
+			listen:     "not-a-host-port",
+			wantErr:    true,
+			wantDetail: "unsafe for containment",
+		},
+		{
+			name:       "LAN address",
+			listen:     "10.20.0.20:9091",
+			wantErr:    true,
+			wantDetail: "numeric loopback address",
+		},
+		{
+			name:       "wildcard address",
+			listen:     "0.0.0.0:9091",
+			wantErr:    true,
+			wantDetail: "numeric loopback address",
+		},
+		{
+			name:       "hostname rather than a numeric address",
+			listen:     "localhost:9091",
+			wantErr:    true,
+			wantDetail: "numeric loopback address",
+		},
+		{
+			name:       "loopback on the proxy port is refused",
+			listen:     "127.0.0.1:8888",
+			wantErr:    true,
+			wantDetail: "other than the agent-accessible proxy port",
+		},
+		{
+			name:       "port zero",
+			listen:     "127.0.0.1:0",
+			wantErr:    true,
+			wantDetail: "other than the agent-accessible proxy port",
+		},
+		{
+			name:       "non-numeric port",
+			listen:     "127.0.0.1:metrics",
+			wantErr:    true,
+			wantDetail: "unsafe for containment",
+		},
+		{name: "loopback IPv4 on a dedicated port", listen: "127.0.0.1:9091"},
+		{name: "loopback IPv6 on a dedicated port", listen: "[::1]:9091"},
+		{name: "an alternate loopback address", listen: "127.0.0.2:9091"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateContainmentMetricsListen(tt.listen, proxyPort)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidateContainmentMetricsListen(%q) = nil, want a refusal", tt.listen)
+			}
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("ValidateContainmentMetricsListen(%q) = %v, want nil", tt.listen, err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantDetail) {
+				t.Errorf("error %q does not carry the remediation %q; an operator reads this to know what to change",
+					err.Error(), tt.wantDetail)
+			}
+		})
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -383,6 +383,7 @@ type Proxy struct {
 	shieldEngine         *shield.Engine                        // browser shield HTML/JS rewriter (nil = not initialized)
 	frozenTools          *FrozenToolRegistry                   // frozen tool inventories for airlock hard tier
 	wd                   *health.Watchdog                      // wedge-detection watchdog (nil = disabled)
+	metricsSuppressed    bool                                  // never publish /metrics or /stats on this listener
 	probeInflight        atomic.Bool                           // singleflight guard for scannerProbe (prevents goroutine leak when scanner wedges)
 }
 
@@ -464,6 +465,22 @@ func WithEnvelopeEmitter(e *envelope.Emitter) Option {
 // cfg.HealthWatchdog.Enabled is false.
 func WithHealthWatchdog(wd *health.Watchdog) Option {
 	return func(p *Proxy) { p.wd = wd }
+}
+
+// WithMetricsSuppressed stops the proxy publishing /metrics and /stats on its
+// own listener.
+//
+// The proxy serves those two routes itself only when metrics_listen is empty,
+// which normally means "no dedicated port, so use this one". A contained
+// runtime that refuses an unsafe metrics configuration reaches the same empty
+// value by a different route, and there the fallback is exactly wrong: the
+// proxy port is the one the contained agent can reach, so falling back hands
+// the agent the endpoints the refusal was meant to withhold.
+//
+// The caller decides, because only the caller knows which of those two
+// situations produced the empty value.
+func WithMetricsSuppressed() Option {
+	return func(p *Proxy) { p.metricsSuppressed = true }
 }
 
 // FetchResponse is the JSON response returned by the /fetch endpoint.
@@ -3658,8 +3675,11 @@ func (p *Proxy) buildMux() *http.ServeMux {
 	mux.HandleFunc("/ws", p.handleWebSocket)
 	mux.HandleFunc("/health", p.handleHealth)
 	mux.HandleFunc(envelope.WellKnownPath, p.handleEnvelopeDirectory)
-	// Register metrics/stats only when NOT running on a separate port.
-	if cfg.MetricsListen == "" {
+	// Register metrics/stats only when NOT running on a separate port, and
+	// never when the caller suppressed them. An empty metrics_listen means
+	// "serve them here" for an ordinary deployment and "refuse to serve them
+	// at all" for a contained one; see WithMetricsSuppressed.
+	if cfg.MetricsListen == "" && !p.metricsSuppressed {
 		mux.Handle("/metrics", p.metrics.PrometheusHandler())
 		mux.HandleFunc("/stats", p.metrics.StatsHandler())
 	}
@@ -3800,8 +3820,10 @@ func (p *Proxy) start(ctx context.Context, ln net.Listener) error {
 	}()
 
 	// Warn if listen address exposes metrics/stats to the network.
-	// Skip when metrics_listen is set - metrics are on a separate port.
-	if cfg.MetricsListen == "" {
+	// Skip when metrics_listen is set - metrics are on a separate port - and
+	// when they are suppressed, since then this listener serves neither route
+	// and the warning would name an exposure that does not exist.
+	if cfg.MetricsListen == "" && !p.metricsSuppressed {
 		if host, _, splitErr := net.SplitHostPort(listenAddr); splitErr == nil {
 			ip := net.ParseIP(host)
 			if host == "" || host == "0.0.0.0" || host == "::" || (ip != nil && !ip.IsLoopback()) {


### PR DESCRIPTION
## What changed

`contain upgrade` now validates the managed config before it changes anything, and again after verify. A host whose config had drifted into an unsafe state previously received the whole upgrade (backup, binary replacement, integrity re-pin, restart) and then a success report, so the command's own output was the thing hiding the problem.

A contained host no longer serves its metrics listener on a non-loopback address. The guard is scoped by an explicit marker on the service unit rather than by generic config validation, so an ordinary deployment that deliberately publishes metrics on a LAN is unaffected. `contain verify` gains a probe that reports the drift, with distinct skip and unknown outcomes when the config cannot be read.

Upgrade also adds that marker to a service unit that predates it. Without this the guard would protect only fresh installs while the release notes described it as runtime behavior, which is the failure direction to distrust here: an operator reads that their metrics listener is now constrained, upgrades, and is not covered. The edit touches one line inside `[Service]`, is a no-op when the marker is present, and refuses rather than guesses when the unit is unreadable or has no `[Service]` section, rolling the upgrade back either way.

The metrics guard sets a separate runtime flag instead of clearing the configured listen address. Clearing it would have been the obvious implementation and it is wrong: the proxy treats an empty address as a request to fall back to serving metrics on the agent-reachable proxy port, so the safe-looking change would have moved the listener somewhere worse. A reviewer should confirm that flag is what the listener actually consults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added containment-aware metrics validation requiring loopback listeners and preventing proxy-port conflicts.
  * Upgrades now validate configuration before and after changes and migrate older service units automatically.
  * Runtime monitoring reports configuration drift and disables unsafe metrics listeners while preserving safe configurations.
  * Suppressed metrics endpoints when containment configuration is unsafe.
* **Bug Fixes**
  * Prevented upgrades from applying changes when managed configuration is invalid or changes unexpectedly.
  * Added managed-configuration metrics verification, increasing the total probe count to 13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->