### PR TITLE
ci(scorecard): stop filing repository grades as code-scanning alerts

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,7 +14,9 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      # No security-events: write. This job no longer uploads SARIF, so it needs
+      # no permission to write code-scanning alerts. id-token remains because
+      # publish_results signs the result for the public Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -35,7 +37,22 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
-        with:
-          sarif_file: results.sarif
+      # Scorecard results are NOT uploaded to code scanning, deliberately.
+      #
+      # Scorecard grades repository practice: pinned dependencies, branch
+      # protection, what share of pull requests carried an approving review.
+      # Code scanning is the surface for defects in this repository's code, and
+      # routing a grade into it files each check as a dismissible alert with a
+      # severity attached.
+      #
+      # Those alerts also do not stay dismissed. GitHub matches results across
+      # uploads by rule and fingerprint, and a Scorecard result whose identity
+      # shifts arrives as a NEW alert that a previous dismissal does not cover.
+      # Two alerts here reported the same finding at the same file and line on
+      # consecutive days. The outcome was a standing queue of security-labelled
+      # items that no code change could close.
+      #
+      # The results remain public and retrievable: publish_results above sends
+      # them to the OpenSSF Scorecard API that backs the badge and the public
+      # viewer, and the artifact above keeps the raw SARIF. This narrows where
+      # the grade is displayed. It does not withhold it.


### PR DESCRIPTION
## What changed

The OpenSSF Scorecard job no longer uploads its results to code scanning. It still runs, still publishes to the public Scorecard API that backs the badge and viewer, and still keeps the raw SARIF as a build artifact. The job's `security-events: write` permission is dropped because nothing in it writes alerts now.

## Why

Scorecard grades repository practice: whether actions are pinned to digests, whether branch protection is on, what share of pull requests carried an approving review. Code scanning is the surface for defects in this repository's code. Uploading the grade into that surface files each check as a dismissible alert carrying a severity, which is a different claim from the one Scorecard makes.

Those alerts also do not stay dismissed. GitHub matches results across uploads by rule and fingerprint, and a result whose identity shifts arrives as a new alert that an earlier dismissal does not cover. Two alerts in this repository reported the same finding at the same file and line on consecutive days. One rule accumulated 25 separate alert numbers over five months, and a false positive was dismissed under four different numbers. The result was a standing queue of security-labelled items that no code change could close, which trains a reader to clear the queue without reading it.

## What this does not do

It does not hide the grade. `publish_results` continues to send results to the public OpenSSF Scorecard API, so anyone can read this repository's score and its per-check detail without asking. The artifact keeps the raw SARIF for the run.

It also does not claim that code scanning now holds only genuine findings. Scorecard's own vulnerability check reports advisories that remain worth reading; they are read from the Scorecard result rather than from an alert list. Anyone auditing this repository should look at both.

CodeQL is unaffected. It uploads its own SARIF from a separate job with its own permission, and it remains a required check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scoring workflow permissions.
  * Scorecard results continue to be stored as artifacts and published through the public Scorecard API.
  * Removed uploads to GitHub code scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->