### PR TITLE
fix(commitmentkey): refuse a keyring that fails its own content check

### DIFF
--- a/docs/cli/commitment-key.md
+++ b/docs/cli/commitment-key.md
@@ -16,9 +16,16 @@ logging:
   file: /var/log/pipelock/audit.jsonl
 ```
 
+New keyrings use `pipelock-commitment-keyring/v2`. Each file carries a required
+`content_check` in the form `sha256:<hex>`. Pipelock computes it over the
+domain-separated canonical keyring content, excluding `content_check` itself.
+It detects accidental corruption and transport damage. It cannot establish
+authenticity: a party that can rewrite the backup can recompute this check.
+
 The configured file is loaded at startup. A missing keyring, a symlink, a
-non-regular file, malformed content, the wrong key purpose, or permissions
-other than `0600` aborts startup. The path is restart-only.
+non-regular file, malformed content, a v1 or check-less format, a failed
+corruption check, the wrong key purpose, or permissions other than `0600`
+aborts startup. The path is restart-only.
 
 Initialize and inspect the keyring:
 
@@ -27,8 +34,11 @@ pipelock commitment-key initialize --config /etc/pipelock/pipelock.yaml
 pipelock commitment-key inspect --config /etc/pipelock/pipelock.yaml
 ```
 
-Initialization creates 32 random bytes, an opaque key ID, and epoch 1. Inspect
-prints metadata only; it never prints key material.
+Initialization creates 32 random bytes, an opaque random key ID, and epoch 1.
+Inspect prints metadata only; it never prints key material. Its `validation`
+object reports `structural: "valid"` and `corruption: "valid"` after those
+checks pass. It always reports `authenticity: "not_established"`: no evidence
+producer retains a commitment outside this backup's write domain yet.
 
 Rotate without breaking historical opening:
 
@@ -64,6 +74,23 @@ pipelock commitment-key restore \
   --config /etc/pipelock/pipelock.yaml \
   --from /secure-backup/commitment-keyring.json
 ```
+
+The default restore rejects v1 and check-less backups. Use the one legacy
+recovery escape hatch only when the operator accepts that the legacy source's
+corruption status cannot be checked:
+
+```bash
+pipelock commitment-key restore \
+  --config /etc/pipelock/pipelock.yaml \
+  --from /secure-backup/legacy-commitment-keyring.json \
+  --allow-unverified-legacy-recovery
+```
+
+This command requires the same file-backed lifecycle audit sink as every
+mutation. It records `operator_unverified_legacy_recovery` in the durable
+intent and outcome records, writes a v2 content check for later corruption
+checks, and reports `corruption: "unverified_legacy_recovery"`. The new check
+does not establish whether the legacy backup was already corrupted.
 
 `pipelock commitment-key test` recomputes the PR 3 `CommitView` contract for a
 named key ID and epoch. The private transformed view is read from stdin by

--- a/internal/cli/commitmentkey/cmd.go
+++ b/internal/cli/commitmentkey/cmd.go
@@ -257,33 +257,43 @@ func backupCmd() *cobra.Command {
 func restoreCmd() *cobra.Command {
 	var flags pathFlags
 	var from string
+	var allowUnverifiedLegacyRecovery bool
 	cmd := &cobra.Command{
 		Use:   "restore",
-		Short: "Restore a validated backup into an absent keyring path",
+		Short: "Restore a corruption-checked backup into an absent keyring path",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			emitCapabilityNotice(cmd)
+			authorization := ""
+			if allowUnverifiedLegacyRecovery {
+				authorization = "operator_unverified_legacy_recovery"
+			}
 			if err := flags.prepareLifecycleAudit(cmd, true, from); err != nil {
 				err = fmt.Errorf("restore: file-backed lifecycle audit sink: %w", err)
-				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err})
+				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err, Authorization: authorization})
 			}
 			defer closeLifecycleAudit(cmd)
 			if err := requireFlags(cmd, "from"); err != nil {
-				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err})
+				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err, Authorization: authorization})
 			}
 			path, err := flags.resolve()
 			if err != nil {
-				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err})
+				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err, Authorization: authorization})
 			}
-			if err := beginMutationAudit(cmd, "restore", "", 0, ""); err != nil {
+			if err := beginMutationAudit(cmd, "restore", "", 0, authorization); err != nil {
 				err = fmt.Errorf("restore: durable lifecycle audit intent: %w", err)
-				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err})
+				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err, Authorization: authorization})
 			}
-			keyring, err := domkey.Restore(filepath.Clean(from), path)
+			var keyring *domkey.Keyring
+			if allowUnverifiedLegacyRecovery {
+				keyring, err = domkey.RestoreLegacyUnverified(filepath.Clean(from), path)
+			} else {
+				keyring, err = domkey.Restore(filepath.Clean(from), path)
+			}
 			if err != nil {
-				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err})
+				return finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "denied", Err: err, Authorization: authorization})
 			}
-			if err := finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "succeeded", KeyID: keyring.ActiveID, Epoch: keyring.Epoch}); err != nil {
+			if err := finishLifecycleAudit(cmd, lifecycleAuditOptions{Operation: "restore", Outcome: "succeeded", KeyID: keyring.ActiveID, Epoch: keyring.Epoch, Authorization: authorization}); err != nil {
 				return err
 			}
 			return writeJSON(cmd, keyring.Metadata())
@@ -291,6 +301,7 @@ func restoreCmd() *cobra.Command {
 	}
 	flags.bind(cmd)
 	cmd.Flags().StringVar(&from, "from", "", "backup file path")
+	cmd.Flags().BoolVar(&allowUnverifiedLegacyRecovery, "allow-unverified-legacy-recovery", false, "recover a v1 or check-less backup as unverified and record that exceptional recovery")
 	return cmd
 }
 

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -51,6 +51,8 @@ func TestCommandLifecycleAndAudit(t *testing.T) {
 	}
 	if got := decodeMetadata(t, stdout); got.ActiveID != first.ActiveID || got.Epoch != 1 {
 		t.Fatalf("inspect metadata = %+v, want active %q epoch 1", got, first.ActiveID)
+	} else if got.Validation.Structural != "valid" || got.Validation.Corruption != "valid" || got.Validation.Authenticity != "not_established" {
+		t.Fatalf("inspect validation = %+v, want structural and corruption validity without authenticity", got.Validation)
 	}
 	assertAudit(t, stderr, "inspect", "succeeded")
 	assertNoKeyMaterial(t, stdout, stderr)
@@ -329,6 +331,52 @@ func TestLifecycleDurableAuditCoversMutationsAndDenial(t *testing.T) {
 		assertDurableMutationAuditPair(t, auditPath, operation, outcome)
 	}
 	assertNoKeyMaterial(t, string(mustReadFile(t, auditPath)))
+}
+
+func TestRestoreUnverifiedLegacyRecoveryIsAudited(t *testing.T) {
+	dir := t.TempDir()
+	keyringPath := filepath.Join(dir, "keyring.json")
+	backupPath := filepath.Join(dir, "legacy-backup.json")
+	auditPath := filepath.Join(dir, "audit.jsonl")
+	configPath := writeLifecycleAuditConfig(t, dir, keyringPath, auditPath, "file", "")
+	if _, _, err := execute(t, "initialize", "--config", configPath); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, _, err := execute(t, "backup", "--config", configPath, "--out", backupPath); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	makeBackupLegacyAndCheckless(t, backupPath)
+	if err := os.Remove(keyringPath); err != nil {
+		t.Fatalf("remove live keyring: %v", err)
+	}
+
+	if _, stderr, err := execute(t, "restore", "--config", configPath, "--from", backupPath); !errors.Is(err, domkey.ErrInvalidKeyring) {
+		t.Fatalf("default restore error = %v, want ErrInvalidKeyring", err)
+	} else {
+		assertDurableAudit(t, auditPath, "restore", "denied")
+		assertAuditReason(t, stderr, "invalid_keyring")
+	}
+
+	stdout, stderr, err := execute(t, "restore", "--config", configPath, "--from", backupPath, "--allow-unverified-legacy-recovery")
+	if err != nil {
+		t.Fatalf("unverified legacy recovery: %v", err)
+	}
+	metadata := decodeMetadata(t, stdout)
+	if got := metadata.Validation; got.Structural != "valid" || got.Corruption != "unverified_legacy_recovery" || got.Authenticity != "not_established" {
+		t.Fatalf("legacy recovery metadata validation = %+v", got)
+	}
+	assertAudit(t, stderr, "restore", "succeeded")
+	assertAuditAuthorization(t, stderr, "operator_unverified_legacy_recovery")
+	assertDurableAuditAuthorization(t, auditPath, "restore", "operator_unverified_legacy_recovery")
+	assertDurableMutationAuditPair(t, auditPath, "restore", "succeeded")
+
+	stdout, _, err = execute(t, "inspect", "--config", configPath)
+	if err != nil {
+		t.Fatalf("inspect recovered keyring: %v", err)
+	}
+	if got := decodeMetadata(t, stdout).Validation.Corruption; got != "unverified_legacy_recovery" {
+		t.Fatalf("inspect legacy recovery corruption status = %q, want unverified_legacy_recovery", got)
+	}
 }
 
 func TestLifecycleAuditFileMatchesStderrRecord(t *testing.T) {
@@ -1211,6 +1259,24 @@ func lifecycleAuditConfig(keyringPath, auditPath, output, includeBlocked string)
 	return body + "evidence_provenance:\n  commitment_keyring_path: " + keyringPath + "\n"
 }
 
+func makeBackupLegacyAndCheckless(t *testing.T, path string) {
+	t.Helper()
+	data := mustReadFile(t, path)
+	var backup map[string]any
+	if err := json.Unmarshal(data, &backup); err != nil {
+		t.Fatalf("decode backup: %v", err)
+	}
+	backup["format"] = domkey.FormatV1
+	delete(backup, "content_check")
+	legacy, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		t.Fatalf("encode legacy backup: %v", err)
+	}
+	if err := os.WriteFile(path, append(legacy, '\n'), 0o600); err != nil {
+		t.Fatalf("write legacy backup: %v", err)
+	}
+}
+
 func assertDurableAudit(t *testing.T, path, operation, outcome string) {
 	t.Helper()
 	for _, line := range strings.Split(strings.TrimSpace(string(mustReadFile(t, path))), "\n") {
@@ -1223,6 +1289,20 @@ func assertDurableAudit(t *testing.T, path, operation, outcome string) {
 		}
 	}
 	t.Fatalf("durable audit %s/%s not found in %s", operation, outcome, path)
+}
+
+func assertDurableAuditAuthorization(t *testing.T, path, operation, authorization string) {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(string(mustReadFile(t, path))), "\n") {
+		var event map[string]any
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		if event["event"] == "commitment_key_lifecycle" && event["operation"] == operation && event["authorization"] == authorization {
+			return
+		}
+	}
+	t.Fatalf("durable audit %s with authorization %q not found in %s", operation, authorization, path)
 }
 
 func assertDurableMutationAuditPair(t *testing.T, path, operation, outcome string) {

--- a/internal/cli/commitmentkey/cmd_test.go
+++ b/internal/cli/commitmentkey/cmd_test.go
@@ -1291,18 +1291,39 @@ func assertDurableAudit(t *testing.T, path, operation, outcome string) {
 	t.Fatalf("durable audit %s/%s not found in %s", operation, outcome, path)
 }
 
+// assertDurableAuditAuthorization requires the authorization on BOTH the intent
+// and the outcome record.
+//
+// Accepting either one is not enough. The intent record is written before the
+// operation runs, so a version that recorded the exceptional authorization on
+// the way in and dropped it from the successful outcome would still satisfy a
+// match-any check, and the durable record of WHAT WAS ACTUALLY ALLOWED is the
+// outcome. That is the record an operator reads after an incident.
 func assertDurableAuditAuthorization(t *testing.T, path, operation, authorization string) {
 	t.Helper()
+	seen := make(map[string]bool, 2)
 	for _, line := range strings.Split(strings.TrimSpace(string(mustReadFile(t, path))), "\n") {
 		var event map[string]any
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			continue
 		}
-		if event["event"] == "commitment_key_lifecycle" && event["operation"] == operation && event["authorization"] == authorization {
-			return
+		if event["event"] != "commitment_key_lifecycle" || event["operation"] != operation {
+			continue
+		}
+		if event["authorization"] != authorization {
+			continue
+		}
+		if phase, ok := event["phase"].(string); ok {
+			seen[phase] = true
 		}
 	}
-	t.Fatalf("durable audit %s with authorization %q not found in %s", operation, authorization, path)
+	for _, phase := range []string{"intent", "outcome"} {
+		if !seen[phase] {
+			t.Fatalf("durable audit %s %s record does not carry authorization %q in %s; "+
+				"the exceptional authorization has to survive onto the record of what was allowed",
+				operation, phase, authorization, path)
+		}
+	}
 }
 
 func assertDurableMutationAuditPair(t *testing.T, path, operation, outcome string) {

--- a/internal/cli/runtime/commitment_keyring_test.go
+++ b/internal/cli/runtime/commitment_keyring_test.go
@@ -4,6 +4,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,7 +23,7 @@ func TestNewServerLoadsConfiguredCommitmentKeyring(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	cfgPath := writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json")
+	cfgPath := writeCommitmentRuntimeConfig(t, dir)
 	server, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}})
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
@@ -47,9 +48,22 @@ func TestNewServerFailsClosedOnConfiguredCommitmentKeyringErrors(t *testing.T) {
 	if err := os.Chmod(path, unsafeMode); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
-	cfgPath := writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json")
+	cfgPath := writeCommitmentRuntimeConfig(t, dir)
 	if _, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}}); err == nil || !strings.Contains(err.Error(), "unsafe permissions") {
 		t.Fatalf("NewServer error = %v, want unsafe-permission refusal", err)
+	}
+}
+
+func TestNewServerFailsClosedOnCommitmentKeyringCorruption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commitment-keyring.json")
+	if _, err := commitmentkey.Initialize(path, time.Now()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	corruptCommitmentKeyringMaterial(t, path)
+	cfgPath := writeCommitmentRuntimeConfig(t, dir)
+	if _, err := NewServer(ServerOpts{ConfigFile: cfgPath, Stdout: &syncBuffer{}, Stderr: &syncBuffer{}}); err == nil || !strings.Contains(err.Error(), "content check") {
+		t.Fatalf("NewServer corruption error = %v, want content-check refusal", err)
 	}
 }
 
@@ -89,7 +103,7 @@ func TestReloadPreservesStartupCommitmentKeyring(t *testing.T) {
 				t.Fatalf("Initialize: %v", err)
 			}
 			stderr := &syncBuffer{}
-			server, err := NewServer(ServerOpts{ConfigFile: writeCommitmentRuntimeConfig(t, dir, "commitment-keyring.json"), Stdout: &syncBuffer{}, Stderr: stderr})
+			server, err := NewServer(ServerOpts{ConfigFile: writeCommitmentRuntimeConfig(t, dir), Stdout: &syncBuffer{}, Stderr: stderr})
 			if err != nil {
 				t.Fatalf("NewServer: %v", err)
 			}
@@ -112,12 +126,48 @@ func TestReloadPreservesStartupCommitmentKeyring(t *testing.T) {
 	}
 }
 
-func writeCommitmentRuntimeConfig(t *testing.T, dir, keyringPath string) string {
+func writeCommitmentRuntimeConfig(t *testing.T, dir string) string {
 	t.Helper()
 	path := filepath.Join(dir, "pipelock.yaml")
-	body := "mode: balanced\nevidence_provenance:\n  commitment_keyring_path: " + keyringPath + "\n"
+	body := "mode: balanced\nevidence_provenance:\n  commitment_keyring_path: commitment-keyring.json\n"
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	return path
+}
+
+func corruptCommitmentKeyringMaterial(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var keyring map[string]any
+	if err := json.Unmarshal(raw, &keyring); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	keys, ok := keyring["keys"].([]any)
+	if !ok || len(keys) == 0 {
+		t.Fatalf("keys = %#v, want first key", keyring["keys"])
+	}
+	entry, ok := keys[0].(map[string]any)
+	if !ok {
+		t.Fatalf("keys[0] = %#v, want key entry", keys[0])
+	}
+	material, ok := entry["key"].(string)
+	if !ok || material == "" {
+		t.Fatalf("keys[0].key = %#v, want encoded key material", entry["key"])
+	}
+	if material[0] == 'A' {
+		entry["key"] = "B" + material[1:]
+	} else {
+		entry["key"] = "A" + material[1:]
+	}
+	data, err := json.MarshalIndent(keyring, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 }

--- a/internal/commitmentkey/keyring.go
+++ b/internal/commitmentkey/keyring.go
@@ -8,6 +8,7 @@ package commitmentkey
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -20,9 +21,12 @@ import (
 
 const (
 	FormatV1 = "pipelock-commitment-keyring/v1"
+	FormatV2 = "pipelock-commitment-keyring/v2"
 	Purpose  = "evidence-commitment"
 	keyBytes = 32
 	maxBytes = 1 << 20
+
+	contentCheckDomain = "pipelock/commitment-keyring/content-check/v2\x00"
 )
 
 var (
@@ -51,19 +55,30 @@ type Entry struct {
 }
 
 type Keyring struct {
-	Format   string  `json:"format"`
-	Purpose  string  `json:"purpose"`
-	ActiveID string  `json:"active_key_id"`
-	Epoch    uint64  `json:"epoch"`
-	Keys     []Entry `json:"keys"`
+	Format                   string  `json:"format"`
+	Purpose                  string  `json:"purpose"`
+	ActiveID                 string  `json:"active_key_id"`
+	Epoch                    uint64  `json:"epoch"`
+	Keys                     []Entry `json:"keys"`
+	ContentCheck             string  `json:"content_check"`
+	LegacyRecoveryUnverified bool    `json:"legacy_recovery_unverified,omitempty"`
 }
 
 type Metadata struct {
-	Format   string          `json:"format"`
-	Purpose  string          `json:"purpose"`
-	ActiveID string          `json:"active_key_id"`
-	Epoch    uint64          `json:"epoch"`
-	Keys     []EntryMetadata `json:"keys"`
+	Format     string             `json:"format"`
+	Purpose    string             `json:"purpose"`
+	ActiveID   string             `json:"active_key_id"`
+	Epoch      uint64             `json:"epoch"`
+	Keys       []EntryMetadata    `json:"keys"`
+	Validation ValidationMetadata `json:"validation"`
+}
+
+// ValidationMetadata distinguishes the checks this command can make from
+// authenticity, which requires evidence retained outside the keyring backup.
+type ValidationMetadata struct {
+	Structural   string `json:"structural"`
+	Corruption   string `json:"corruption"`
+	Authenticity string `json:"authenticity"`
 }
 
 type EntryMetadata struct {
@@ -88,7 +103,7 @@ func Initialize(path string, now time.Time) (*Keyring, error) {
 	if err != nil {
 		return nil, err
 	}
-	keyring := &Keyring{Format: FormatV1, Purpose: Purpose, ActiveID: entry.KeyID, Epoch: 1, Keys: []Entry{entry}}
+	keyring := &Keyring{Format: FormatV2, Purpose: Purpose, ActiveID: entry.KeyID, Epoch: 1, Keys: []Entry{entry}}
 	data, err := marshal(keyring)
 	if err != nil {
 		return nil, err
@@ -107,24 +122,35 @@ func Load(path string) (*Keyring, error) {
 	if err != nil {
 		return nil, err
 	}
-	var keyring Keyring
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&keyring); err != nil {
-		return nil, fmt.Errorf("%w: decode: %w", ErrInvalidKeyring, err)
-	}
-	var trailing any
-	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("%w: trailing JSON", ErrInvalidKeyring)
+	keyring, err := decode(raw)
+	if err != nil {
+		return nil, err
 	}
 	if err := keyring.Validate(); err != nil {
 		return nil, err
 	}
-	return &keyring, nil
+	return keyring, nil
 }
 
 func (k *Keyring) Validate() error {
-	if k.Format != FormatV1 {
+	if err := k.validateStructure(false); err != nil {
+		return err
+	}
+	if k.ContentCheck == "" {
+		return fmt.Errorf("%w: missing required content check", ErrInvalidKeyring)
+	}
+	expected, err := k.expectedContentCheck()
+	if err != nil {
+		return err
+	}
+	if k.ContentCheck != expected {
+		return fmt.Errorf("%w: content check does not match keyring content", ErrInvalidKeyring)
+	}
+	return nil
+}
+
+func (k *Keyring) validateStructure(allowLegacy bool) error {
+	if k.Format != FormatV2 && (!allowLegacy || k.Format != FormatV1) {
 		return fmt.Errorf("%w: format %q", ErrInvalidKeyring, k.Format)
 	}
 	if k.Purpose != Purpose {
@@ -289,9 +315,6 @@ func (k *Keyring) retire(path, keyID string, epoch uint64, acceptLoss bool) erro
 // saveLocked persists a validated lifecycle mutation. Callers must hold the
 // cross-process lifecycle lock for path.
 func (k *Keyring) saveLocked(path string) error {
-	if err := k.Validate(); err != nil {
-		return err
-	}
 	data, err := marshal(k)
 	if err != nil {
 		return err
@@ -303,7 +326,22 @@ func (k *Keyring) saveLocked(path string) error {
 }
 
 func (k *Keyring) Metadata() Metadata {
-	metadata := Metadata{Format: k.Format, Purpose: k.Purpose, ActiveID: k.ActiveID, Epoch: k.Epoch, Keys: make([]EntryMetadata, 0, len(k.Keys))}
+	corruption := "valid"
+	if k.LegacyRecoveryUnverified {
+		corruption = "unverified_legacy_recovery"
+	}
+	metadata := Metadata{
+		Format:   k.Format,
+		Purpose:  k.Purpose,
+		ActiveID: k.ActiveID,
+		Epoch:    k.Epoch,
+		Keys:     make([]EntryMetadata, 0, len(k.Keys)),
+		Validation: ValidationMetadata{
+			Structural:   "valid",
+			Corruption:   corruption,
+			Authenticity: "not_established",
+		},
+	}
 	for _, entry := range k.Keys {
 		metadata.Keys = append(metadata.Keys, EntryMetadata{KeyID: entry.KeyID, Epoch: entry.Epoch, State: entry.State, CreatedAt: entry.CreatedAt, RetiredAt: entry.RetiredAt})
 	}
@@ -317,6 +355,28 @@ func Backup(source, destination string) (*Keyring, error) {
 
 func Restore(source, destination string) (*Keyring, error) {
 	return copyValidated(source, destination, "load commitment keyring backup", "restore commitment keyring")
+}
+
+// RestoreLegacyUnverified recovers a v1 or check-less backup only when an
+// operator explicitly invokes the legacy recovery command. The result retains
+// that unverified status because a new check cannot establish whether the
+// legacy source was corrupted before recovery.
+func RestoreLegacyUnverified(source, destination string) (*Keyring, error) {
+	keyring, err := loadLegacyUnverified(source)
+	if err != nil {
+		return nil, fmt.Errorf("load unverified legacy commitment keyring backup: %w", err)
+	}
+	if err := ensureParent(destination); err != nil {
+		return nil, err
+	}
+	data, err := marshal(keyring)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeSecureNew(destination, data); err != nil {
+		return nil, fmt.Errorf("restore unverified legacy commitment keyring: %w", err)
+	}
+	return keyring, nil
 }
 
 func copyValidated(source, destination, loadContext, writeContext string) (*Keyring, error) {
@@ -337,6 +397,29 @@ func copyValidated(source, destination, loadContext, writeContext string) (*Keyr
 	return keyring, nil
 }
 
+func loadLegacyUnverified(path string) (*Keyring, error) {
+	raw, err := readSecure(path)
+	if err != nil {
+		return nil, err
+	}
+	keyring, err := decode(raw)
+	if err != nil {
+		return nil, err
+	}
+	if keyring.ContentCheck != "" {
+		if err := keyring.Validate(); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: legacy recovery only accepts a v1 or check-less keyring", ErrInvalidKeyring)
+	}
+	if err := keyring.validateStructure(true); err != nil {
+		return nil, err
+	}
+	keyring.Format = FormatV2
+	keyring.LegacyRecoveryUnverified = true
+	return keyring, nil
+}
+
 func newEntry(epoch uint64, now time.Time) (Entry, error) {
 	material := make([]byte, keyBytes)
 	if _, err := io.ReadFull(rand.Reader, material); err != nil {
@@ -350,9 +433,61 @@ func newEntry(epoch uint64, now time.Time) (Entry, error) {
 }
 
 func marshal(keyring *Keyring) ([]byte, error) {
+	if err := keyring.validateStructure(false); err != nil {
+		return nil, err
+	}
+	contentCheck, err := keyring.expectedContentCheck()
+	if err != nil {
+		return nil, err
+	}
+	keyring.ContentCheck = contentCheck
+	if err := keyring.Validate(); err != nil {
+		return nil, err
+	}
 	data, err := json.MarshalIndent(keyring, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal commitment keyring: %w", err)
 	}
 	return append(data, '\n'), nil
+}
+
+type canonicalKeyringContent struct {
+	Format                   string  `json:"format"`
+	Purpose                  string  `json:"purpose"`
+	ActiveID                 string  `json:"active_key_id"`
+	Epoch                    uint64  `json:"epoch"`
+	Keys                     []Entry `json:"keys"`
+	LegacyRecoveryUnverified bool    `json:"legacy_recovery_unverified,omitempty"`
+}
+
+func (k *Keyring) expectedContentCheck() (string, error) {
+	keys := append([]Entry(nil), k.Keys...)
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Epoch < keys[j].Epoch })
+	content, err := json.Marshal(canonicalKeyringContent{
+		Format:                   k.Format,
+		Purpose:                  k.Purpose,
+		ActiveID:                 k.ActiveID,
+		Epoch:                    k.Epoch,
+		Keys:                     keys,
+		LegacyRecoveryUnverified: k.LegacyRecoveryUnverified,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical commitment keyring content: %w", err)
+	}
+	sum := sha256.Sum256(append([]byte(contentCheckDomain), content...))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func decode(raw []byte) (*Keyring, error) {
+	var keyring Keyring
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&keyring); err != nil {
+		return nil, fmt.Errorf("%w: decode: %w", ErrInvalidKeyring, err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: trailing JSON", ErrInvalidKeyring)
+	}
+	return &keyring, nil
 }

--- a/internal/commitmentkey/keyring_test.go
+++ b/internal/commitmentkey/keyring_test.go
@@ -5,6 +5,7 @@ package commitmentkey
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -233,6 +234,113 @@ func TestLifecycleBackupDestroyRestoreAndOpen(t *testing.T) {
 	assertMode(t, path, 0o600)
 }
 
+func TestLoadRejectsKeyMaterialCorruption(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	corrupted := cloneKeyring(keyring)
+	corrupted.Keys[0].Key = flipBase64Character(t, corrupted.Keys[0].Key)
+	writeRawKeyring(t, path, corrupted)
+
+	if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) || !strings.Contains(err.Error(), "content check") {
+		t.Fatalf("Load corrupted keyring error = %v, want content-check refusal", err)
+	}
+}
+
+func TestContentCheckExcludesCheckField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+	keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	withDifferentStoredCheck := cloneKeyring(keyring)
+	withDifferentStoredCheck.ContentCheck = "sha256:" + strings.Repeat("0", 64)
+	got, err := withDifferentStoredCheck.expectedContentCheck()
+	if err != nil {
+		t.Fatalf("expectedContentCheck: %v", err)
+	}
+	if got != keyring.ContentCheck {
+		t.Fatalf("content check including itself: got %q, want %q", got, keyring.ContentCheck)
+	}
+}
+
+func TestLoadRejectsLegacyOrChecklessKeyring(t *testing.T) {
+	for name, mutate := range map[string]func(*Keyring){
+		"v1": func(k *Keyring) {
+			k.Format = FormatV1
+			k.ContentCheck = ""
+		},
+		"checkless v2": func(k *Keyring) {
+			k.ContentCheck = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "commitment-keyring.json")
+			keyring, err := Initialize(path, time.Unix(1_700_000_000, 0))
+			if err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			mutate(keyring)
+			writeRawKeyring(t, path, keyring)
+			if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) {
+				t.Fatalf("Load %s keyring error = %v, want ErrInvalidKeyring", name, err)
+			}
+		})
+	}
+}
+
+func TestRestoreLegacyRecoveryStaysUnverified(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "legacy.json")
+	destination := filepath.Join(dir, "restored.json")
+	keyring, err := Initialize(source, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	keyring.Format = FormatV1
+	keyring.ContentCheck = ""
+	writeRawKeyring(t, source, keyring)
+
+	restored, err := RestoreLegacyUnverified(source, destination)
+	if err != nil {
+		t.Fatalf("RestoreLegacyUnverified: %v", err)
+	}
+	if restored.Format != FormatV2 || restored.ContentCheck == "" || !restored.LegacyRecoveryUnverified {
+		t.Fatalf("legacy restoration = %+v, want v2 with a content check and unverified legacy status", restored)
+	}
+	if got := restored.Metadata().Validation; got.Structural != "valid" || got.Corruption != "unverified_legacy_recovery" || got.Authenticity != "not_established" {
+		t.Fatalf("legacy recovery validation = %+v", got)
+	}
+	loaded, err := Load(destination)
+	if err != nil {
+		t.Fatalf("Load legacy recovery: %v", err)
+	}
+	if got := loaded.Metadata().Validation.Corruption; got != "unverified_legacy_recovery" {
+		t.Fatalf("persisted legacy recovery corruption status = %q, want unverified_legacy_recovery", got)
+	}
+}
+
+func TestRestoreLegacyRecoveryRejectsCheckedCorruption(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "corrupted-v2.json")
+	destination := filepath.Join(dir, "restored.json")
+	keyring, err := Initialize(source, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	keyring.Keys[0].Key = flipBase64Character(t, keyring.Keys[0].Key)
+	writeRawKeyring(t, source, keyring)
+
+	if _, err := RestoreLegacyUnverified(source, destination); !errors.Is(err, ErrInvalidKeyring) || !strings.Contains(err.Error(), "content check") {
+		t.Fatalf("RestoreLegacyUnverified corrupted v2 error = %v, want content-check refusal", err)
+	}
+	if _, err := os.Stat(destination); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy recovery wrote destination after corruption refusal: %v", err)
+	}
+}
+
 func TestLoadFailsClosedOnPermissionsAndSymlink(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows ACL and symlink behavior differs from Unix mode semantics")
@@ -290,13 +398,7 @@ func TestPurposeValidationRejectsReceiptSigning(t *testing.T) {
 		t.Fatalf("Initialize: %v", err)
 	}
 	keyring.Purpose = "receipt-signing"
-	data, err := marshal(keyring)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write wrong-purpose keyring: %v", err)
-	}
+	writeRawKeyring(t, path, keyring)
 	if _, err := Load(path); !errors.Is(err, ErrInvalidKeyring) {
 		t.Fatalf("Load receipt-signing keyring error = %v, want ErrInvalidKeyring", err)
 	}
@@ -522,6 +624,28 @@ func cloneKeyring(keyring *Keyring) *Keyring {
 	clone := *keyring
 	clone.Keys = append([]Entry(nil), keyring.Keys...)
 	return &clone
+}
+
+func flipBase64Character(t *testing.T, value string) string {
+	t.Helper()
+	if value == "" {
+		t.Fatal("cannot corrupt an empty key")
+	}
+	if value[0] == 'A' {
+		return "B" + value[1:]
+	}
+	return "A" + value[1:]
+}
+
+func writeRawKeyring(t *testing.T, path string, keyring *Keyring) {
+	t.Helper()
+	data, err := json.MarshalIndent(keyring, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 }
 
 func commitTestReceipt(t *testing.T, keyring *Keyring, view string) committedReceipt {

--- a/internal/commitmentkey/legacy_recovery_paths_test.go
+++ b/internal/commitmentkey/legacy_recovery_paths_test.go
@@ -36,6 +36,20 @@ func TestRestoreLegacyUnverifiedRefusesEveryUnusableSource(t *testing.T) {
 			wantIs:  fs.ErrNotExist,
 		},
 		{
+			// The downgrade direction. A backup that carries a correct check has
+			// nothing to recover, so accepting it here would let a verified
+			// keyring be relabelled unverified_legacy_recovery and quietly widen
+			// the hatch from "recover an old keyring" to "skip the check".
+			name: "source is a valid checked v2 backup",
+			prepare: func(t *testing.T, source string) {
+				if _, err := Initialize(source, time.Unix(1_700_000_000, 0)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want:   "legacy recovery only accepts",
+			wantIs: ErrInvalidKeyring,
+		},
+		{
 			name: "source is not JSON",
 			prepare: func(t *testing.T, source string) {
 				if err := os.WriteFile(source, []byte("not json at all"), 0o600); err != nil {

--- a/internal/commitmentkey/legacy_recovery_paths_test.go
+++ b/internal/commitmentkey/legacy_recovery_paths_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package commitmentkey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRestoreLegacyUnverifiedRefusesEveryUnusableSource covers the refusal paths
+// of the recovery escape hatch.
+//
+// This is the one path that accepts a keyring without a verified content check,
+// so it is the path most worth pinning. Each case below is a way the hatch could
+// widen from "recover a keyring written before the check existed" into "accept
+// anything", which would return the product to the defect this change closed.
+func TestRestoreLegacyUnverifiedRefusesEveryUnusableSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T, source string)
+		want    string
+	}{
+		{
+			name:    "source does not exist",
+			prepare: func(*testing.T, string) {},
+			want:    "no such file",
+		},
+		{
+			name: "source is not JSON",
+			prepare: func(t *testing.T, source string) {
+				if err := os.WriteFile(source, []byte("not json at all"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "decode",
+		},
+		{
+			name: "source is structurally invalid",
+			prepare: func(t *testing.T, source string) {
+				keyring := &Keyring{Format: FormatV1, Purpose: Purpose}
+				writeRawKeyring(t, source, keyring)
+			},
+			want: "commitment keyring",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			source := filepath.Join(dir, "legacy.json")
+			tt.prepare(t, source)
+
+			_, err := RestoreLegacyUnverified(source, filepath.Join(dir, "restored.json"))
+			if err == nil {
+				t.Fatal("legacy recovery accepted an unusable source; the escape hatch must stay narrow")
+			}
+			if got := err.Error(); !contains(got, tt.want) {
+				t.Errorf("error = %q, want it to mention %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRestoreLegacyUnverifiedWillNotOverwrite pins that recovery creates a
+// keyring and never replaces one. An operator reaching for this flag is already
+// in an incident; silently overwriting the keyring still on disk would destroy
+// the material they might yet recover.
+func TestRestoreLegacyUnverifiedWillNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "legacy.json")
+	destination := filepath.Join(dir, "restored.json")
+
+	keyring, err := Initialize(source, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	keyring.Format = FormatV1
+	keyring.ContentCheck = ""
+	writeRawKeyring(t, source, keyring)
+
+	if _, err := Initialize(destination, time.Unix(1_700_000_001, 0)); err != nil {
+		t.Fatalf("Initialize destination: %v", err)
+	}
+	before, err := os.ReadFile(filepath.Clean(destination))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RestoreLegacyUnverified(source, destination); err == nil {
+		t.Fatal("legacy recovery overwrote an existing keyring")
+	}
+
+	after, err := os.ReadFile(filepath.Clean(destination))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Error("the existing keyring changed during a refused recovery")
+	}
+}
+
+// TestRestoreLegacyUnverifiedRefusesAnUnwritableDestination covers the parent
+// directory failure, so a recovery that cannot land reports the failure rather
+// than returning a keyring that was never written.
+func TestRestoreLegacyUnverifiedRefusesAnUnwritableDestination(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "legacy.json")
+
+	keyring, err := Initialize(source, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	keyring.Format = FormatV1
+	keyring.ContentCheck = ""
+	writeRawKeyring(t, source, keyring)
+
+	// A regular file standing where the parent directory must be.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RestoreLegacyUnverified(source, filepath.Join(blocker, "nested", "restored.json")); err == nil {
+		t.Fatal("legacy recovery reported success with nowhere to write the keyring")
+	} else if errors.Is(err, ErrInvalidKeyring) {
+		t.Errorf("error = %v, want a write failure rather than an invalid-keyring verdict", err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) &&
+		func() bool {
+			for i := 0; i+len(needle) <= len(haystack); i++ {
+				if haystack[i:i+len(needle)] == needle {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/commitmentkey/legacy_recovery_paths_test.go
+++ b/internal/commitmentkey/legacy_recovery_paths_test.go
@@ -5,8 +5,10 @@ package commitmentkey
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -23,11 +25,15 @@ func TestRestoreLegacyUnverifiedRefusesEveryUnusableSource(t *testing.T) {
 		name    string
 		prepare func(t *testing.T, source string)
 		want    string
+		wantIs  error
 	}{
 		{
+			// Matched by class, not by message: the operating system chooses the
+			// wording, so a text match fails on a platform without any product
+			// regression behind it.
 			name:    "source does not exist",
 			prepare: func(*testing.T, string) {},
-			want:    "no such file",
+			wantIs:  fs.ErrNotExist,
 		},
 		{
 			name: "source is not JSON",
@@ -58,8 +64,11 @@ func TestRestoreLegacyUnverifiedRefusesEveryUnusableSource(t *testing.T) {
 			if err == nil {
 				t.Fatal("legacy recovery accepted an unusable source; the escape hatch must stay narrow")
 			}
-			if got := err.Error(); !contains(got, tt.want) {
-				t.Errorf("error = %q, want it to mention %q", got, tt.want)
+			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
+				t.Errorf("error = %v, want it to wrap %v", err, tt.wantIs)
+			}
+			if tt.want != "" && !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tt.want)
 			}
 		})
 	}
@@ -129,16 +138,4 @@ func TestRestoreLegacyUnverifiedRefusesAnUnwritableDestination(t *testing.T) {
 	} else if errors.Is(err, ErrInvalidKeyring) {
 		t.Errorf("error = %v, want a write failure rather than an invalid-keyring verdict", err)
 	}
-}
-
-func contains(haystack, needle string) bool {
-	return len(needle) == 0 || (len(haystack) >= len(needle) &&
-		func() bool {
-			for i := 0; i+len(needle) <= len(haystack); i++ {
-				if haystack[i:i+len(needle)] == needle {
-					return true
-				}
-			}
-			return false
-		}())
 }


### PR DESCRIPTION
## What changed

A backup whose active key material had been altered by one character restored with exit 0 and every later command reported success, because nothing in the file bound the key material to anything. The keyring format now carries a required domain-separated content check that `Load` verifies, so restore, inspect, startup and every lifecycle operation refuse altered or truncated content instead of adopting it.

This is a corruption control and the code, the operator output and the docs all say so. Anyone able to rewrite the backup can recompute the check, so it defends a damaged file and not an adversary. Establishing that a restored key is the key that produced existing commitments needs evidence retained outside the backup, which is not possible while nothing commits with these keys; `inspect` now reports authenticity as not established rather than implying a verdict it cannot reach.

A keyring written in the previous format is refused by default. Recovering one requires an explicit legacy flag, which reports the result as unverified and writes a durable audit record, so an operator recovering from an incident is never silently told that an unchecked keyring was verified.

The failure direction a reviewer should distrust here is the naming rather than the arithmetic. A corruption check presented as tamper protection is worse than no check, because it retires the question while leaving the threat open. Every operator-facing string, comment and test name in this change says corruption, and the escape hatch reports unverified rather than degrading quietly to accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Commitment keyrings now use v2 format with SHA-256 corruption detection.
  - Added validation status reporting for structure, corruption, and authenticity.
  - Added an explicit option to recover legacy or unverified backups, with audit records.
- **Bug Fixes**
  - Corrupted, malformed, or unchecked keyrings are rejected during loading and startup.
  - Legacy recovery prevents overwriting existing files and rejects unusable sources.
- **Documentation**
  - Updated initialization, inspection, restoration, validation, and legacy recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->