### PR TITLE
docs(scorecard): name code scanning as the dropped destination

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -17,8 +17,8 @@ jobs:
       # No security-events: write. This job no longer uploads SARIF to code
       # scanning, so it needs no permission to write code-scanning alerts. It
       # does still upload results.sarif as a build artifact below. id-token
-      # remains because publish_results signs the result for the public
-      # Scorecard API.
+      # remains because publish_results uses GitHub's OIDC token to verify the
+      # result's authenticity when publishing it to the public Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,9 +14,11 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     permissions:
-      # No security-events: write. This job no longer uploads SARIF, so it needs
-      # no permission to write code-scanning alerts. id-token remains because
-      # publish_results signs the result for the public Scorecard API.
+      # No security-events: write. This job no longer uploads SARIF to code
+      # scanning, so it needs no permission to write code-scanning alerts. It
+      # does still upload results.sarif as a build artifact below. id-token
+      # remains because publish_results signs the result for the public
+      # Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## What changed

The comment added with the Scorecard upload removal said the job no longer uploads SARIF. The job does still upload `results.sarif` as a build artifact, so the sentence read as though that had gone too. It now says the job no longer uploads SARIF to code scanning, and states that the artifact remains.

Comment only. No workflow behavior changes.

This wording shipped in five repositories at once and is being corrected in all of them, not only where a reviewer happened to catch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow permission comments explaining that security results are retained as build artifacts and published through the public Scorecard API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->