### PR TITLE
ci(release): gate artifacts on public verifier parity

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,8 +128,44 @@ jobs:
           packages="$(python3 scripts/ci_test_packages.py "${package_args[@]}")"
           go test "${tag_args[@]}" -race -count=1 -timeout 30m $packages
 
-  release:
+  # Source-tree conformance proves the implementations agree. This gate proves
+  # the packages customers can install accept a receipt from this candidate
+  # and reject a changed copy.
+  release-verifier-install:
     needs: [release-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25.12'
+          check-latest: true
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Set up Rust 1.95.0
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+
+      - name: Install and verify customer receipt verifiers
+        run: scripts/release-verifier-install-gate.sh --tag "$GITHUB_REF_NAME"
+
+  release:
+    needs: [release-tests, release-verifier-install]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,7 +149,8 @@ jobs:
           check-latest: true
           cache: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # zizmor 1.29.0 treats the empty cache value as enabled; setup-node treats it as disabled.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0; zizmor: ignore[cache-poisoning]
         with:
           node-version: '24'
           cache: ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,10 +147,12 @@ jobs:
         with:
           go-version: '1.25.12'
           check-latest: true
+          cache: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          cache: ''
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/release/verifier-installers.json
+++ b/release/verifier-installers.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "release_blocked": true,
   "verifiers": [
     {
       "language": "Go",

--- a/release/verifier-installers.json
+++ b/release/verifier-installers.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "verifiers": [
+    {
+      "language": "Go",
+      "package": "pipelock-verifier",
+      "version": "candidate tag",
+      "install_source": "candidate source build",
+      "artifact_digest": "computed at run time",
+      "publisher": {
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/release.yaml",
+        "environment": "tagged product release",
+        "source_ref": "candidate tag",
+        "source_commit": "candidate commit"
+      }
+    },
+    {
+      "language": "TypeScript",
+      "package": "@pipelock/verifier-ts",
+      "version": "0.3.0",
+      "install_source": "npm",
+      "artifact_digest": "REPLACE_WITH_NPM_DIST_INTEGRITY",
+      "publisher": {
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/publish-verifiers.yaml",
+        "environment": "verifier-release",
+        "source_ref": "verifier-v0.3.0",
+        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_0_TAG_COMMIT"
+      }
+    },
+    {
+      "language": "Rust",
+      "package": "pipelock-verifier-rs",
+      "version": "0.3.0",
+      "install_source": "crates.io",
+      "artifact_digest": "REPLACE_WITH_CRATES_IO_SHA256",
+      "publisher": {
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/publish-verifiers.yaml",
+        "environment": "verifier-release",
+        "source_ref": "verifier-v0.3.0",
+        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_0_TAG_COMMIT"
+      }
+    },
+    {
+      "language": "Python",
+      "package": "pipelock-verify",
+      "version": "0.4.0",
+      "install_source": "PyPI",
+      "artifact_digest": "sha256:b380cb3f51fadbbb34ddd264b588893c9ac1c676058225915a2679d0e34a47c6",
+      "publisher": {
+        "repository": "luckyPipewrench/pipelock-verify-python",
+        "workflow": ".github/workflows/release.yml",
+        "environment": "pypi",
+        "source_ref": "v0.4.0",
+        "source_commit": "f70bca2222466f1d8ce66a3c4a764ef43e57a5f0"
+      }
+    }
+  ]
+}

--- a/scripts/release-verifier-fixture.go
+++ b/scripts/release-verifier-fixture.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	receiptFileName  = "candidate-receipt.json"
-	tamperedFileName = "candidate-receipt-tampered.json"
-	keyFileName      = "candidate-receipt-public-key.txt"
+	receiptFileName           = "candidate-receipt.json"
+	tamperedFileName          = "candidate-receipt-payload-tampered.json"
+	signatureTamperedFileName = "candidate-receipt-signature-tampered.json"
+	keyFileName               = "candidate-receipt-public-key.txt"
 )
 
 var (
@@ -107,12 +108,29 @@ func writeFixture(outDir string) error {
 	if tampered == string(raw) {
 		return fmt.Errorf("replace signed target in receipt")
 	}
+	signatureTampered := r
+	signatureHex := strings.TrimPrefix(signatureTampered.Signature, "ed25519:")
+	if signatureHex == signatureTampered.Signature || len(signatureHex) == 0 {
+		return fmt.Errorf("locate receipt signature")
+	}
+	replacement := byte('0')
+	if signatureHex[0] == replacement {
+		replacement = '1'
+	}
+	signatureTampered.Signature = "ed25519:" + string(replacement) + signatureHex[1:]
+	signatureTamperedRaw, err := marshalReceipt(signatureTampered)
+	if err != nil {
+		return fmt.Errorf("marshal signature-tampered receipt: %w", err)
+	}
 
 	if err := os.WriteFile(filepath.Join(outDir, receiptFileName), raw, 0o600); err != nil {
 		return fmt.Errorf("write receipt: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(outDir, tamperedFileName), []byte(tampered), 0o600); err != nil {
 		return fmt.Errorf("write tampered receipt: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, signatureTamperedFileName), signatureTamperedRaw, 0o600); err != nil {
+		return fmt.Errorf("write signature-tampered receipt: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(outDir, keyFileName), []byte(hex.EncodeToString(publicKey)+"\n"), 0o600); err != nil {
 		return fmt.Errorf("write public key: %w", err)

--- a/scripts/release-verifier-fixture.go
+++ b/scripts/release-verifier-fixture.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// release-verifier-fixture emits the signed v1 receipt used by the release
+// installer gate. Keeping the generator in this module is intentional: the
+// receipt is produced by the exact candidate code being released, rather than
+// copied from a fixture created by some earlier version.
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	receiptFileName  = "candidate-receipt.json"
+	tamperedFileName = "candidate-receipt-tampered.json"
+	keyFileName      = "candidate-receipt-public-key.txt"
+)
+
+var (
+	generateSigningKey = ed25519.GenerateKey
+	signReceipt        = receipt.Sign
+	marshalReceipt     = receipt.Marshal
+)
+
+func main() {
+	os.Exit(releaseVerifierFixtureMain(os.Args[1:], os.Stderr))
+}
+
+func releaseVerifierFixtureMain(args []string, stderr io.Writer) int {
+	if err := runReleaseVerifierFixture(args); err != nil {
+		_, _ = fmt.Fprintf(stderr, "release verifier fixture: %v\n", err)
+		return 2
+	}
+	return 0
+}
+
+func runReleaseVerifierFixture(args []string) error {
+	var outDir string
+	flags := flag.NewFlagSet("release-verifier-fixture", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&outDir, "out-dir", "", "directory to write the receipt, tampered copy, and public key")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse arguments: %w", err)
+	}
+
+	if strings.TrimSpace(outDir) == "" {
+		return fmt.Errorf("--out-dir is required")
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments")
+	}
+
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := writeFixture(outDir); err != nil {
+		return fmt.Errorf("write fixture: %w", err)
+	}
+	return nil
+}
+
+func writeFixture(outDir string) error {
+	publicKey, privateKey, err := generateSigningKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate signing key: %w", err)
+	}
+
+	r, err := signReceipt(receipt.ActionRecord{
+		Version:         receipt.ActionRecordVersion,
+		ActionID:        receipt.NewActionID(),
+		ActionType:      receipt.ActionRead,
+		Timestamp:       time.Now().UTC(),
+		Principal:       "org:release-verifier-install-gate",
+		Actor:           "agent:release-candidate",
+		DelegationChain: []string{"release-candidate"},
+		Target:          "https://api.vendor.example/release-verifier-install-gate",
+		SideEffectClass: receipt.SideEffectExternalRead,
+		Reversibility:   receipt.ReversibilityFull,
+		PolicyHash:      "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Verdict:         "allow",
+		Transport:       "https",
+		Method:          "GET",
+		ChainPrevHash:   receipt.GenesisHash,
+		ChainSeq:        0,
+	}, privateKey)
+	if err != nil {
+		return fmt.Errorf("sign receipt: %w", err)
+	}
+
+	raw, err := marshalReceipt(r)
+	if err != nil {
+		return fmt.Errorf("marshal receipt: %w", err)
+	}
+	tampered := strings.Replace(string(raw), "api.vendor.example", "tampered.vendor.example", 1)
+	if tampered == string(raw) {
+		return fmt.Errorf("replace signed target in receipt")
+	}
+
+	if err := os.WriteFile(filepath.Join(outDir, receiptFileName), raw, 0o600); err != nil {
+		return fmt.Errorf("write receipt: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, tamperedFileName), []byte(tampered), 0o600); err != nil {
+		return fmt.Errorf("write tampered receipt: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, keyFileName), []byte(hex.EncodeToString(publicKey)+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write public key: %w", err)
+	}
+	return nil
+}

--- a/scripts/release-verifier-fixture_test.go
+++ b/scripts/release-verifier-fixture_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestReleaseVerifierFixtureMain(t *testing.T) {
 	if code := releaseVerifierFixtureMain([]string{"--out-dir", outDir}, &stderr); code != 0 {
 		t.Fatalf("successful CLI exit = %d, stderr = %q", code, stderr.String())
 	}
-	for _, name := range []string{receiptFileName, tamperedFileName, keyFileName} {
+	for _, name := range []string{receiptFileName, tamperedFileName, signatureTamperedFileName, keyFileName} {
 		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
 			t.Fatalf("stat %s: %v", name, err)
 		}
@@ -126,6 +127,7 @@ func TestWriteFixtureReportsEachOutputFailure(t *testing.T) {
 	}{
 		{name: "receipt", blocker: receiptFileName, want: "write receipt"},
 		{name: "tampered receipt", blocker: tamperedFileName, want: "write tampered receipt"},
+		{name: "signature-tampered receipt", blocker: signatureTamperedFileName, want: "write signature-tampered receipt"},
 		{name: "public key", blocker: keyFileName, want: "write public key"},
 	}
 	for _, test := range tests {
@@ -180,6 +182,21 @@ func TestWriteFixtureProducesSignedReceiptAndTamperedRejection(t *testing.T) {
 	if err := receipt.VerifyWithKey(tampered, publicKey); err == nil {
 		t.Fatal("tampered fixture receipt verified")
 	}
+
+	signatureTamperedRaw, err := os.ReadFile(filepath.Join(dir, signatureTamperedFileName)) // #nosec G304 -- fixed fixture name under t.TempDir.
+	if err != nil {
+		t.Fatalf("read signature-tampered receipt: %v", err)
+	}
+	signatureTampered, err := receipt.Unmarshal(signatureTamperedRaw)
+	if err != nil {
+		t.Fatalf("unmarshal signature-tampered receipt: %v", err)
+	}
+	if !reflect.DeepEqual(signatureTampered.ActionRecord, valid.ActionRecord) {
+		t.Fatal("signature tamper changed the signed payload")
+	}
+	if err := receipt.VerifyWithKey(signatureTampered, publicKey); err == nil {
+		t.Fatal("signature-tampered fixture receipt verified")
+	}
 }
 
 func TestReleaseVerifierInventoryRejectsTrailingDuplicate(t *testing.T) {
@@ -190,8 +207,9 @@ func TestReleaseVerifierInventoryRejectsTrailingDuplicate(t *testing.T) {
 		t.Fatalf("read staged inventory: %v", err)
 	}
 	var inventory struct {
-		SchemaVersion int                      `json:"schema_version"`
-		Verifiers     []map[string]interface{} `json:"verifiers"`
+		SchemaVersion  int                      `json:"schema_version"`
+		ReleaseBlocked bool                     `json:"release_blocked"`
+		Verifiers      []map[string]interface{} `json:"verifiers"`
 	}
 	if err := json.Unmarshal(raw, &inventory); err != nil {
 		t.Fatalf("decode staged inventory: %v", err)
@@ -236,8 +254,9 @@ func TestReleaseVerifierInventoryRejectsPackageSubstitution(t *testing.T) {
 		t.Fatalf("read staged inventory: %v", err)
 	}
 	var inventory struct {
-		SchemaVersion int                      `json:"schema_version"`
-		Verifiers     []map[string]interface{} `json:"verifiers"`
+		SchemaVersion  int                      `json:"schema_version"`
+		ReleaseBlocked bool                     `json:"release_blocked"`
+		Verifiers      []map[string]interface{} `json:"verifiers"`
 	}
 	if err := json.Unmarshal(raw, &inventory); err != nil {
 		t.Fatalf("decode staged inventory: %v", err)
@@ -335,6 +354,23 @@ func TestReleaseVerifierInventoryRejectsLockRootDriftWithPythonOptimize(t *testi
 
 func TestReleaseVerifierInstallGateRejectsMissingVerifierTag(t *testing.T) {
 	root := stageReleaseVerifierInventoryTest(t)
+	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
+	raw, err := os.ReadFile(inventoryPath) // #nosec G304 -- fixed inventory path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged inventory: %v", err)
+	}
+	var inventory map[string]interface{}
+	if err := json.Unmarshal(raw, &inventory); err != nil {
+		t.Fatalf("decode staged inventory: %v", err)
+	}
+	inventory["release_blocked"] = false
+	raw, err = json.Marshal(inventory)
+	if err != nil {
+		t.Fatalf("encode staged inventory: %v", err)
+	}
+	if err := os.WriteFile(inventoryPath, raw, 0o600); err != nil {
+		t.Fatalf("write staged inventory: %v", err)
+	}
 	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
 		"--tag", "v3.4.0")
 	output, err := command.CombinedOutput()
@@ -346,6 +382,77 @@ func TestReleaseVerifierInstallGateRejectsMissingVerifierTag(t *testing.T) {
 	}
 }
 
+func TestReleaseVerifierInstallGateHonorsExplicitReleaseBlock(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
+		"--tag", "v3.4.0")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("explicitly blocked release passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "release is explicitly blocked") {
+		t.Fatalf("release block error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInstallGateRejectsPostTagSourceDrift(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	gitHome := t.TempDir()
+	hooksDir := filepath.Join(gitHome, "empty-hooks")
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		t.Fatalf("create empty hooks directory: %v", err)
+	}
+	runGit := func(args ...string) string {
+		t.Helper()
+		gitArgs := append([]string{"-c", "core.hooksPath=" + hooksDir}, args...)
+		command := exec.CommandContext(t.Context(), "git", gitArgs...) // #nosec G204 -- arguments are fixed by this test.
+		command.Dir = root
+		command.Env = append(os.Environ(),
+			"HOME="+gitHome,
+			"GIT_CONFIG_GLOBAL="+os.DevNull,
+			"GIT_CONFIG_SYSTEM="+os.DevNull,
+		)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+
+	tagCommit := runGit("rev-parse", "HEAD")
+	runGit("tag", "verifier-v0.3.0")
+	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
+	raw, err := os.ReadFile(inventoryPath) // #nosec G304 -- fixed inventory path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged inventory: %v", err)
+	}
+	raw = bytes.ReplaceAll(raw, []byte("REPLACE_WITH_VERIFIER_V0_3_0_TAG_COMMIT"), []byte(tagCommit))
+	raw = bytes.Replace(raw, []byte(`"release_blocked": true`), []byte(`"release_blocked": false`), 1)
+	if err := os.WriteFile(inventoryPath, raw, 0o600); err != nil {
+		t.Fatalf("write staged inventory: %v", err)
+	}
+	sourcePath := filepath.Join(root, "sdk", "verifiers", "ts", "src", "types.ts")
+	source, err := os.ReadFile(sourcePath) // #nosec G304 -- fixed source path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged source: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, append(source, []byte("\n// post-tag drift\n")...), 0o600); err != nil {
+		t.Fatalf("write staged source drift: %v", err)
+	}
+	runGit("add", "release/verifier-installers.json", "sdk/verifiers/ts/src/types.ts")
+	runGit("-c", "user.name=Pipelock Test", "-c", "user.email=test@pipelock.invalid", "commit", "--no-gpg-sign", "-m", "post-tag drift")
+
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
+		"--tag", "v3.4.0")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("post-tag source drift passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "verifier package source differs from immutable tag") {
+		t.Fatalf("source drift error = %q", output)
+	}
+}
+
 func TestReleaseVerifierInstallGateRejectsVerifierThatAcceptsTampering(t *testing.T) {
 	root := stageReleaseVerifierInventoryTest(t)
 	verifier := filepath.Join(root, "accept-all")
@@ -353,27 +460,62 @@ func TestReleaseVerifierInstallGateRejectsVerifierThatAcceptsTampering(t *testin
 		t.Fatalf("write verifier: %v", err)
 	}
 	valid := filepath.Join(root, "valid.json")
-	tampered := filepath.Join(root, "tampered.json")
-	for _, path := range []string{valid, tampered} {
+	payloadTampered := filepath.Join(root, "payload-tampered.json")
+	signatureTampered := filepath.Join(root, "signature-tampered.json")
+	for _, path := range []string{valid, payloadTampered, signatureTampered} {
 		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
 			t.Fatalf("write receipt: %v", err)
 		}
 	}
 
 	command := exec.CommandContext(t.Context(), "bash", "-c", // #nosec G204 -- command text is constant and arguments are test-owned temp paths.
-		`source "$1"; verify_accepts_and_rejects Test "$2" "$3" "00" "$4"`,
-		"bash", filepath.Join(root, "scripts", "release-verifier-install-gate-lib.sh"), valid, tampered, verifier)
+		`source "$1"; verify_accepts_and_rejects Test "$2" "$3" "$4" "00" "$5"`,
+		"bash", filepath.Join(root, "scripts", "release-verifier-install-gate-lib.sh"), valid, payloadTampered, signatureTampered, verifier)
 	output, err := command.CombinedOutput()
 	if err == nil {
 		t.Fatalf("verifier that accepts tampering passed:\n%s", output)
 	}
-	if !strings.Contains(string(output), "ACCEPTED the tampered candidate receipt") {
+	if !strings.Contains(string(output), "ACCEPTED the payload-tampered candidate receipt") {
 		t.Fatalf("tamper error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInstallGateRejectsTargetAllowlistingFake(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	verifier := filepath.Join(root, "target-allowlist-only")
+	if err := os.WriteFile(verifier, []byte("#!/usr/bin/env bash\ngrep -q api.vendor.example \"$1\"\n"), 0o700); err != nil { // #nosec G306 -- executable permission is required for this test fixture.
+		t.Fatalf("write verifier: %v", err)
+	}
+	valid := filepath.Join(root, "valid.json")
+	payloadTampered := filepath.Join(root, "payload-tampered.json")
+	signatureTampered := filepath.Join(root, "signature-tampered.json")
+	for path, body := range map[string]string{
+		valid:             `{"target":"https://api.vendor.example","signature":"good"}`,
+		payloadTampered:   `{"target":"https://tampered.vendor.example","signature":"good"}`,
+		signatureTampered: `{"target":"https://api.vendor.example","signature":"bad"}`,
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write receipt: %v", err)
+		}
+	}
+
+	command := exec.CommandContext(t.Context(), "bash", "-c", // #nosec G204 -- command text is constant and arguments are test-owned temp paths.
+		`source "$1"; verify_accepts_and_rejects Test "$2" "$3" "$4" "00" "$5"`,
+		"bash", filepath.Join(root, "scripts", "release-verifier-install-gate-lib.sh"), valid, payloadTampered, signatureTampered, verifier)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("target-allowlisting fake passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "ACCEPTED the signature-tampered candidate receipt") {
+		t.Fatalf("signature tamper error = %q", output)
 	}
 }
 
 func stageReleaseVerifierInventoryTest(t *testing.T) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("release verifier gate tests require bash")
+	}
 	_, sourceFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("locate test source")
@@ -383,9 +525,11 @@ func stageReleaseVerifierInventoryTest(t *testing.T) string {
 	for _, relativePath := range []string{
 		"scripts/release-verifier-install-gate.sh",
 		"scripts/release-verifier-install-gate-lib.sh",
+		"scripts/ci-retry.sh",
 		"release/verifier-installers.json",
 		"sdk/verifiers/ts/package.json",
 		"sdk/verifiers/ts/package-lock.json",
+		"sdk/verifiers/ts/src/types.ts",
 		"sdk/verifiers/rust/Cargo.toml",
 		"sdk/verifiers/rust/Cargo.lock",
 	} {
@@ -401,15 +545,30 @@ func stageReleaseVerifierInventoryTest(t *testing.T) string {
 			t.Fatalf("stage %s: %v", relativePath, err)
 		}
 	}
+	gitHome := t.TempDir()
+	hooksDir := filepath.Join(gitHome, "empty-hooks")
+	templateDir := filepath.Join(gitHome, "empty-template")
+	if err := os.MkdirAll(hooksDir, 0o750); err != nil {
+		t.Fatalf("create empty hooks directory: %v", err)
+	}
+	if err := os.MkdirAll(templateDir, 0o750); err != nil {
+		t.Fatalf("create empty template directory: %v", err)
+	}
 	for _, args := range [][]string{
 		{"init", "-q"},
 		{"config", "user.name", "Pipelock Test"},
 		{"config", "user.email", "test@pipelock.invalid"},
-		{"add", "scripts/release-verifier-install-gate.sh", "scripts/release-verifier-install-gate-lib.sh", "release/verifier-installers.json", "sdk/verifiers/ts/package.json", "sdk/verifiers/ts/package-lock.json", "sdk/verifiers/rust/Cargo.toml", "sdk/verifiers/rust/Cargo.lock"},
-		{"commit", "-q", "-m", "test fixture"},
+		{"add", "scripts/release-verifier-install-gate.sh", "scripts/release-verifier-install-gate-lib.sh", "scripts/ci-retry.sh", "release/verifier-installers.json", "sdk/verifiers/ts/package.json", "sdk/verifiers/ts/package-lock.json", "sdk/verifiers/ts/src/types.ts", "sdk/verifiers/rust/Cargo.toml", "sdk/verifiers/rust/Cargo.lock"},
+		{"commit", "-q", "--no-gpg-sign", "-m", "test fixture"},
 	} {
-		command := exec.CommandContext(t.Context(), "git", args...) // #nosec G204 -- args come from the fixed fixture command list above.
+		gitArgs := append([]string{"-c", "core.hooksPath=" + hooksDir, "-c", "init.templateDir=" + templateDir}, args...)
+		command := exec.CommandContext(t.Context(), "git", gitArgs...) // #nosec G204 -- args come from the fixed fixture command list above.
 		command.Dir = root
+		command.Env = append(os.Environ(),
+			"HOME="+gitHome,
+			"GIT_CONFIG_GLOBAL="+os.DevNull,
+			"GIT_CONFIG_SYSTEM="+os.DevNull,
+		)
 		if output, err := command.CombinedOutput(); err != nil {
 			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
 		}

--- a/scripts/release-verifier-fixture_test.go
+++ b/scripts/release-verifier-fixture_test.go
@@ -522,7 +522,7 @@ func stageReleaseVerifierInventoryTest(t *testing.T) string {
 	}
 	repoRoot := filepath.Dir(filepath.Dir(sourceFile))
 	root := t.TempDir()
-	for _, relativePath := range []string{
+	stagedPaths := []string{
 		"scripts/release-verifier-install-gate.sh",
 		"scripts/release-verifier-install-gate-lib.sh",
 		"scripts/ci-retry.sh",
@@ -532,7 +532,8 @@ func stageReleaseVerifierInventoryTest(t *testing.T) string {
 		"sdk/verifiers/ts/src/types.ts",
 		"sdk/verifiers/rust/Cargo.toml",
 		"sdk/verifiers/rust/Cargo.lock",
-	} {
+	}
+	for _, relativePath := range stagedPaths {
 		raw, err := os.ReadFile(filepath.Join(repoRoot, relativePath)) // #nosec G304 -- relativePath comes from the fixed list above.
 		if err != nil {
 			t.Fatalf("read %s: %v", relativePath, err)
@@ -558,7 +559,7 @@ func stageReleaseVerifierInventoryTest(t *testing.T) string {
 		{"init", "-q"},
 		{"config", "user.name", "Pipelock Test"},
 		{"config", "user.email", "test@pipelock.invalid"},
-		{"add", "scripts/release-verifier-install-gate.sh", "scripts/release-verifier-install-gate-lib.sh", "scripts/ci-retry.sh", "release/verifier-installers.json", "sdk/verifiers/ts/package.json", "sdk/verifiers/ts/package-lock.json", "sdk/verifiers/ts/src/types.ts", "sdk/verifiers/rust/Cargo.toml", "sdk/verifiers/rust/Cargo.lock"},
+		append([]string{"add"}, stagedPaths...),
 		{"commit", "-q", "--no-gpg-sign", "-m", "test fixture"},
 	} {
 		gitArgs := append([]string{"-c", "core.hooksPath=" + hooksDir, "-c", "init.templateDir=" + templateDir}, args...)

--- a/scripts/release-verifier-fixture_test.go
+++ b/scripts/release-verifier-fixture_test.go
@@ -1,0 +1,426 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func TestReleaseVerifierFixtureMain(t *testing.T) {
+	var stderr bytes.Buffer
+	outDir := filepath.Join(t.TempDir(), "fixture")
+	if code := releaseVerifierFixtureMain([]string{"--out-dir", outDir}, &stderr); code != 0 {
+		t.Fatalf("successful CLI exit = %d, stderr = %q", code, stderr.String())
+	}
+	for _, name := range []string{receiptFileName, tamperedFileName, keyFileName} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+	}
+
+	stderr.Reset()
+	if code := releaseVerifierFixtureMain(nil, &stderr); code != 2 {
+		t.Fatalf("missing argument exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "--out-dir is required") {
+		t.Fatalf("missing argument stderr = %q", stderr.String())
+	}
+}
+
+func TestRunReleaseVerifierFixtureRejectsInvalidArgumentsAndPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "unknown flag", args: []string{"--unknown"}, want: "parse arguments"},
+		{name: "blank output", args: []string{"--out-dir", "  "}, want: "--out-dir is required"},
+		{name: "positional", args: []string{"--out-dir", t.TempDir(), "extra"}, want: "unexpected positional arguments"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := runReleaseVerifierFixture(test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("runReleaseVerifierFixture() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	err := runReleaseVerifierFixture([]string{"--out-dir", filepath.Join(blocker, "child")})
+	if err == nil || !strings.Contains(err.Error(), "create output directory") {
+		t.Fatalf("blocked output error = %v", err)
+	}
+
+	outDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outDir, receiptFileName), 0o750); err != nil {
+		t.Fatalf("create receipt blocker: %v", err)
+	}
+	err = runReleaseVerifierFixture([]string{"--out-dir", outDir})
+	if err == nil || !strings.Contains(err.Error(), "write fixture: write receipt") {
+		t.Fatalf("wrapped write error = %v", err)
+	}
+}
+
+func TestWriteFixtureReportsProducerFailures(t *testing.T) {
+	originalGenerate := generateSigningKey
+	originalSign := signReceipt
+	originalMarshal := marshalReceipt
+	t.Cleanup(func() {
+		generateSigningKey = originalGenerate
+		signReceipt = originalSign
+		marshalReceipt = originalMarshal
+	})
+
+	generateSigningKey = func(io.Reader) (ed25519.PublicKey, ed25519.PrivateKey, error) {
+		return nil, nil, errors.New("random source blocked")
+	}
+	if err := writeFixture(t.TempDir()); err == nil || !strings.Contains(err.Error(), "generate signing key") {
+		t.Fatalf("generate error = %v", err)
+	}
+	generateSigningKey = originalGenerate
+
+	signReceipt = func(receipt.ActionRecord, ed25519.PrivateKey) (receipt.Receipt, error) {
+		return receipt.Receipt{}, errors.New("sign blocked")
+	}
+	if err := writeFixture(t.TempDir()); err == nil || !strings.Contains(err.Error(), "sign receipt") {
+		t.Fatalf("sign error = %v", err)
+	}
+	signReceipt = originalSign
+
+	marshalReceipt = func(receipt.Receipt) ([]byte, error) {
+		return nil, errors.New("marshal blocked")
+	}
+	if err := writeFixture(t.TempDir()); err == nil || !strings.Contains(err.Error(), "marshal receipt") {
+		t.Fatalf("marshal error = %v", err)
+	}
+	marshalReceipt = func(receipt.Receipt) ([]byte, error) { return []byte("{}"), nil }
+	if err := writeFixture(t.TempDir()); err == nil || !strings.Contains(err.Error(), "replace signed target") {
+		t.Fatalf("replacement error = %v", err)
+	}
+}
+
+func TestWriteFixtureReportsEachOutputFailure(t *testing.T) {
+	tests := []struct {
+		name    string
+		blocker string
+		want    string
+	}{
+		{name: "receipt", blocker: receiptFileName, want: "write receipt"},
+		{name: "tampered receipt", blocker: tamperedFileName, want: "write tampered receipt"},
+		{name: "public key", blocker: keyFileName, want: "write public key"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(outDir, test.blocker), 0o750); err != nil {
+				t.Fatalf("create output blocker: %v", err)
+			}
+			err := writeFixture(outDir)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("writeFixture() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestWriteFixtureProducesSignedReceiptAndTamperedRejection(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFixture(dir); err != nil {
+		t.Fatalf("writeFixture() error = %v", err)
+	}
+
+	key, err := os.ReadFile(filepath.Join(dir, keyFileName)) // #nosec G304 -- fixed fixture name under t.TempDir.
+	if err != nil {
+		t.Fatalf("read public key: %v", err)
+	}
+	publicKey := strings.TrimSpace(string(key))
+	if _, err := hex.DecodeString(publicKey); err != nil {
+		t.Fatalf("fixture public key is not hex: %v", err)
+	}
+
+	validRaw, err := os.ReadFile(filepath.Join(dir, receiptFileName)) // #nosec G304 -- fixed fixture name under t.TempDir.
+	if err != nil {
+		t.Fatalf("read valid receipt: %v", err)
+	}
+	valid, err := receipt.Unmarshal(validRaw)
+	if err != nil {
+		t.Fatalf("unmarshal valid receipt: %v", err)
+	}
+	if err := receipt.VerifyWithKey(valid, publicKey); err != nil {
+		t.Fatalf("valid fixture receipt did not verify: %v", err)
+	}
+
+	tamperedRaw, err := os.ReadFile(filepath.Join(dir, tamperedFileName)) // #nosec G304 -- fixed fixture name under t.TempDir.
+	if err != nil {
+		t.Fatalf("read tampered receipt: %v", err)
+	}
+	tampered, err := receipt.Unmarshal(tamperedRaw)
+	if err != nil {
+		t.Fatalf("unmarshal tampered receipt: %v", err)
+	}
+	if err := receipt.VerifyWithKey(tampered, publicKey); err == nil {
+		t.Fatal("tampered fixture receipt verified")
+	}
+}
+
+func TestReleaseVerifierInventoryRejectsTrailingDuplicate(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
+	raw, err := os.ReadFile(inventoryPath) // #nosec G304 -- fixed inventory path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged inventory: %v", err)
+	}
+	var inventory struct {
+		SchemaVersion int                      `json:"schema_version"`
+		Verifiers     []map[string]interface{} `json:"verifiers"`
+	}
+	if err := json.Unmarshal(raw, &inventory); err != nil {
+		t.Fatalf("decode staged inventory: %v", err)
+	}
+	inventory.Verifiers = append(inventory.Verifiers, inventory.Verifiers[0])
+	raw, err = json.Marshal(inventory)
+	if err != nil {
+		t.Fatalf("encode duplicate inventory: %v", err)
+	}
+	if err := os.WriteFile(inventoryPath, raw, 0o600); err != nil {
+		t.Fatalf("write duplicate inventory: %v", err)
+	}
+
+	output, err := runReleaseVerifierInventory(t, root)
+	if err == nil {
+		t.Fatalf("duplicate inventory passed:\n%s", output)
+	}
+	if !strings.Contains(output, "incomplete or duplicate verifier inventory entry") ||
+		!strings.Contains(output, "verifier inventory validation failed") {
+		t.Fatalf("duplicate inventory error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInventoryAcceptsCompleteInventory(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	output, err := runReleaseVerifierInventory(t, root)
+	if err != nil {
+		t.Fatalf("complete inventory failed: %v\n%s", err, output)
+	}
+	for _, language := range []string{"Go", "TypeScript", "Rust", "Python"} {
+		if !strings.Contains(output, language) {
+			t.Errorf("inventory output missing %s: %q", language, output)
+		}
+	}
+}
+
+func TestReleaseVerifierInventoryRejectsPackageSubstitution(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
+	raw, err := os.ReadFile(inventoryPath) // #nosec G304 -- fixed inventory path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged inventory: %v", err)
+	}
+	var inventory struct {
+		SchemaVersion int                      `json:"schema_version"`
+		Verifiers     []map[string]interface{} `json:"verifiers"`
+	}
+	if err := json.Unmarshal(raw, &inventory); err != nil {
+		t.Fatalf("decode staged inventory: %v", err)
+	}
+	for _, verifier := range inventory.Verifiers {
+		if verifier["language"] == "TypeScript" {
+			verifier["package"] = "@vendor/lookalike"
+		}
+	}
+	raw, err = json.Marshal(inventory)
+	if err != nil {
+		t.Fatalf("encode substituted inventory: %v", err)
+	}
+	if err := os.WriteFile(inventoryPath, raw, 0o600); err != nil {
+		t.Fatalf("write substituted inventory: %v", err)
+	}
+
+	output, err := runReleaseVerifierInventory(t, root)
+	if err == nil {
+		t.Fatalf("substituted package passed:\n%s", output)
+	}
+	if !strings.Contains(output, "unexpected TypeScript verifier publication contract") {
+		t.Fatalf("substitution error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInventoryRejectsSourceVersionDrift(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	manifestPath := filepath.Join(root, "sdk", "verifiers", "ts", "package.json")
+	raw, err := os.ReadFile(manifestPath) // #nosec G304 -- fixed manifest path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged manifest: %v", err)
+	}
+	var manifest map[string]interface{}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode staged manifest: %v", err)
+	}
+	manifest["version"] = "9.9.9"
+	raw, err = json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("encode drifted manifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, raw, 0o600); err != nil {
+		t.Fatalf("write drifted manifest: %v", err)
+	}
+
+	output, err := runReleaseVerifierInventory(t, root)
+	if err == nil {
+		t.Fatalf("source version drift passed:\n%s", output)
+	}
+	if !strings.Contains(output, "source manifests declare") {
+		t.Fatalf("source drift error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInventoryRejectsLockRootDriftWithPythonOptimize(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	lockPath := filepath.Join(root, "sdk", "verifiers", "ts", "package-lock.json")
+	raw, err := os.ReadFile(lockPath) // #nosec G304 -- fixed lockfile path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged lockfile: %v", err)
+	}
+	var lock map[string]interface{}
+	if err := json.Unmarshal(raw, &lock); err != nil {
+		t.Fatalf("decode staged lockfile: %v", err)
+	}
+	packages, ok := lock["packages"].(map[string]interface{})
+	if !ok {
+		t.Fatal("staged lockfile packages is not an object")
+	}
+	rootPackage, ok := packages[""].(map[string]interface{})
+	if !ok {
+		t.Fatal("staged lockfile root package is not an object")
+	}
+	rootPackage["version"] = "9.9.9"
+	raw, err = json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("encode drifted lockfile: %v", err)
+	}
+	if err := os.WriteFile(lockPath, raw, 0o600); err != nil {
+		t.Fatalf("write drifted lockfile: %v", err)
+	}
+
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
+		"--tag", "v3.4.0", "--inventory-only")
+	command.Env = append(os.Environ(), "PYTHONOPTIMIZE=1")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("lockfile root drift passed with Python optimization enabled:\n%s", output)
+	}
+	if !strings.Contains(string(output), "package-lock root version mismatch") {
+		t.Fatalf("lockfile drift error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInstallGateRejectsMissingVerifierTag(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
+		"--tag", "v3.4.0")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("missing verifier tag passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "required verifier release tag is missing") {
+		t.Fatalf("missing tag error = %q", output)
+	}
+}
+
+func TestReleaseVerifierInstallGateRejectsVerifierThatAcceptsTampering(t *testing.T) {
+	root := stageReleaseVerifierInventoryTest(t)
+	verifier := filepath.Join(root, "accept-all")
+	if err := os.WriteFile(verifier, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o700); err != nil { // #nosec G306 -- executable permission is required for this test fixture.
+		t.Fatalf("write verifier: %v", err)
+	}
+	valid := filepath.Join(root, "valid.json")
+	tampered := filepath.Join(root, "tampered.json")
+	for _, path := range []string{valid, tampered} {
+		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write receipt: %v", err)
+		}
+	}
+
+	command := exec.CommandContext(t.Context(), "bash", "-c", // #nosec G204 -- command text is constant and arguments are test-owned temp paths.
+		`source "$1"; verify_accepts_and_rejects Test "$2" "$3" "00" "$4"`,
+		"bash", filepath.Join(root, "scripts", "release-verifier-install-gate-lib.sh"), valid, tampered, verifier)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("verifier that accepts tampering passed:\n%s", output)
+	}
+	if !strings.Contains(string(output), "ACCEPTED the tampered candidate receipt") {
+		t.Fatalf("tamper error = %q", output)
+	}
+}
+
+func stageReleaseVerifierInventoryTest(t *testing.T) string {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate test source")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(sourceFile))
+	root := t.TempDir()
+	for _, relativePath := range []string{
+		"scripts/release-verifier-install-gate.sh",
+		"scripts/release-verifier-install-gate-lib.sh",
+		"release/verifier-installers.json",
+		"sdk/verifiers/ts/package.json",
+		"sdk/verifiers/ts/package-lock.json",
+		"sdk/verifiers/rust/Cargo.toml",
+		"sdk/verifiers/rust/Cargo.lock",
+	} {
+		raw, err := os.ReadFile(filepath.Join(repoRoot, relativePath)) // #nosec G304 -- relativePath comes from the fixed list above.
+		if err != nil {
+			t.Fatalf("read %s: %v", relativePath, err)
+		}
+		target := filepath.Join(root, relativePath)
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+			t.Fatalf("create staged directory: %v", err)
+		}
+		if err := os.WriteFile(target, raw, 0o600); err != nil {
+			t.Fatalf("stage %s: %v", relativePath, err)
+		}
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.name", "Pipelock Test"},
+		{"config", "user.email", "test@pipelock.invalid"},
+		{"add", "scripts/release-verifier-install-gate.sh", "scripts/release-verifier-install-gate-lib.sh", "release/verifier-installers.json", "sdk/verifiers/ts/package.json", "sdk/verifiers/ts/package-lock.json", "sdk/verifiers/rust/Cargo.toml", "sdk/verifiers/rust/Cargo.lock"},
+		{"commit", "-q", "-m", "test fixture"},
+	} {
+		command := exec.CommandContext(t.Context(), "git", args...) // #nosec G204 -- args come from the fixed fixture command list above.
+		command.Dir = root
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+		}
+	}
+	return root
+}
+
+func runReleaseVerifierInventory(t *testing.T, root string) (string, error) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "release-verifier-install-gate.sh"), // #nosec G204 -- executes the checked-in script copied under t.TempDir.
+		"--tag", "v3.4.0", "--inventory-only")
+	output, err := command.CombinedOutput()
+	return string(output), err
+}

--- a/scripts/release-verifier-install-gate-lib.sh
+++ b/scripts/release-verifier-install-gate-lib.sh
@@ -5,16 +5,21 @@
 verify_accepts_and_rejects() {
 	local label="$1"
 	local receipt="$2"
-	local tampered="$3"
-	local public_key="$4"
-	shift 4
+	local payload_tampered="$3"
+	local signature_tampered="$4"
+	local public_key="$5"
+	shift 5
 	if ! "$@" "$receipt" --key "$public_key" >/dev/null; then
 		printf 'release verifier install gate: %s rejected the candidate receipt\n' "$label" >&2
 		return 1
 	fi
-	if "$@" "$tampered" --key "$public_key" >/dev/null 2>&1; then
-		printf 'release verifier install gate: %s ACCEPTED the tampered candidate receipt\n' "$label" >&2
+	if "$@" "$payload_tampered" --key "$public_key" >/dev/null 2>&1; then
+		printf 'release verifier install gate: %s ACCEPTED the payload-tampered candidate receipt\n' "$label" >&2
 		return 1
 	fi
-	printf '  [ok] %s accepts candidate receipt and rejects tampered copy\n' "$label"
+	if "$@" "$signature_tampered" --key "$public_key" >/dev/null 2>&1; then
+		printf 'release verifier install gate: %s ACCEPTED the signature-tampered candidate receipt\n' "$label" >&2
+		return 1
+	fi
+	printf '  [ok] %s accepts candidate receipt and rejects payload/signature tampering\n' "$label"
 }

--- a/scripts/release-verifier-install-gate-lib.sh
+++ b/scripts/release-verifier-install-gate-lib.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+verify_accepts_and_rejects() {
+	local label="$1"
+	local receipt="$2"
+	local tampered="$3"
+	local public_key="$4"
+	shift 4
+	if ! "$@" "$receipt" --key "$public_key" >/dev/null; then
+		printf 'release verifier install gate: %s rejected the candidate receipt\n' "$label" >&2
+		return 1
+	fi
+	if "$@" "$tampered" --key "$public_key" >/dev/null 2>&1; then
+		printf 'release verifier install gate: %s ACCEPTED the tampered candidate receipt\n' "$label" >&2
+		return 1
+	fi
+	printf '  [ok] %s accepts candidate receipt and rejects tampered copy\n' "$label"
+}

--- a/scripts/release-verifier-install-gate.sh
+++ b/scripts/release-verifier-install-gate.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Install every customer-facing verifier into an empty directory, then require
+# each one to accept a receipt emitted by this candidate and reject a changed
+# copy. This is intentionally separate from source-tree conformance: a green
+# local build does not prove that the package a customer receives works.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INVENTORY="$ROOT_DIR/release/verifier-installers.json"
+# shellcheck source=scripts/release-verifier-install-gate-lib.sh
+source "$ROOT_DIR/scripts/release-verifier-install-gate-lib.sh"
+
+usage() {
+	cat <<'EOF'
+Usage: scripts/release-verifier-install-gate.sh --tag vX.Y.Z [--inventory-only]
+
+Builds a signed receipt with the checked-out candidate, installs each public
+verifier into an empty directory, and proves every verifier accepts the
+candidate receipt while rejecting its tampered copy.
+EOF
+}
+
+tag=""
+inventory_only=0
+while (($#)); do
+	case "$1" in
+		--tag)
+			(($# >= 2)) || { usage >&2; exit 64; }
+			tag="$2"
+			shift 2
+			;;
+		--inventory-only)
+			inventory_only=1
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			printf 'release verifier install gate: unknown argument: %s\n' "$1" >&2
+			usage >&2
+			exit 64
+			;;
+	esac
+done
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+	printf 'release verifier install gate: --tag must be a release tag such as v3.4.0\n' >&2
+	exit 64
+fi
+if [[ ! -f "$INVENTORY" ]]; then
+	printf 'release verifier install gate: inventory is missing: %s\n' "$INVENTORY" >&2
+	exit 2
+fi
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		printf 'release verifier install gate: required command is unavailable: %s\n' "$1" >&2
+		exit 127
+	fi
+}
+
+require_command python3
+
+inventory_rows() {
+	python3 - "$INVENTORY" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    inventory = json.load(fh)
+
+if inventory.get("schema_version") != 1:
+    raise SystemExit("unsupported verifier installer inventory schema")
+
+required_languages = {"Go", "TypeScript", "Rust", "Python"}
+expected = {
+    "Go": {
+        "package": "pipelock-verifier",
+        "install_source": "candidate source build",
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/release.yaml",
+        "environment": "tagged product release",
+    },
+    "TypeScript": {
+        "package": "@pipelock/verifier-ts",
+        "install_source": "npm",
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/publish-verifiers.yaml",
+        "environment": "verifier-release",
+    },
+    "Rust": {
+        "package": "pipelock-verifier-rs",
+        "install_source": "crates.io",
+        "repository": "luckyPipewrench/pipelock",
+        "workflow": ".github/workflows/publish-verifiers.yaml",
+        "environment": "verifier-release",
+    },
+    "Python": {
+        "package": "pipelock-verify",
+        "install_source": "PyPI",
+        "repository": "luckyPipewrench/pipelock-verify-python",
+        "workflow": ".github/workflows/release.yml",
+        "environment": "pypi",
+    },
+}
+seen = set()
+for entry in inventory.get("verifiers", []):
+    publisher = entry.get("publisher", {})
+    language = entry.get("language", "")
+    required = ("package", "version", "install_source", "artifact_digest")
+    if language not in required_languages or any(not entry.get(key) for key in required):
+        raise SystemExit(f"invalid verifier inventory entry: {entry!r}")
+    if language in seen or any(
+        not publisher.get(key)
+        for key in ("repository", "workflow", "environment", "source_ref", "source_commit")
+    ):
+        raise SystemExit(f"incomplete or duplicate verifier inventory entry: {entry!r}")
+    contract = expected[language]
+    actual = {
+        "package": entry["package"],
+        "install_source": entry["install_source"],
+        "repository": publisher["repository"],
+        "workflow": publisher["workflow"],
+        "environment": publisher["environment"],
+    }
+    if actual != contract:
+        raise SystemExit(f"unexpected {language} verifier publication contract: {actual!r}")
+    seen.add(language)
+    print("\t".join((
+        language,
+        entry["package"],
+        entry["version"],
+        entry["install_source"],
+        entry["artifact_digest"],
+        publisher["repository"],
+        publisher["workflow"],
+        publisher["environment"],
+        publisher["source_ref"],
+        publisher["source_commit"],
+    )))
+
+if seen != required_languages:
+    missing = ", ".join(sorted(required_languages - seen))
+    raise SystemExit(f"verifier inventory missing: {missing}")
+PY
+}
+
+if ! inventory_output="$(inventory_rows)"; then
+	printf 'release verifier install gate: verifier inventory validation failed\n' >&2
+	exit 2
+fi
+mapfile -t rows <<<"$inventory_output"
+if ((${#rows[@]} != 4)); then
+	printf 'release verifier install gate: expected four verifier inventory entries\n' >&2
+	exit 2
+fi
+
+printf 'Customer-installable verifier inventory for %s:\n' "$tag"
+printf '%-11s %-28s %-16s %-24s %-46s %s\n' LANGUAGE PACKAGE VERSION ARTIFACT_DIGEST INSTALL_SOURCE TRUSTED_PUBLISHER
+for row in "${rows[@]}"; do
+	IFS=$'\t' read -r language package version install_source artifact_digest repository workflow environment source_ref source_commit <<<"$row"
+	if [[ "$language" == "Go" ]]; then
+		version="$tag"
+		source_ref="$tag"
+		source_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+	fi
+	printf '%-11s %-28s %-16s %-24s %-46s %s via %s (%s)\n' \
+		"$language" "$package" "$version" "$artifact_digest" "$install_source" "$repository" "$workflow" "$environment; $source_ref@$source_commit"
+done
+
+inventory_field() {
+	local wanted_language="$1"
+	local wanted_field="$2"
+	local row
+	for row in "${rows[@]}"; do
+		local row_language package version install_source artifact_digest repository workflow environment source_ref source_commit
+		IFS=$'\t' read -r row_language package version install_source artifact_digest repository workflow environment source_ref source_commit <<<"$row"
+		if [[ "$row_language" != "$wanted_language" ]]; then
+			continue
+		fi
+		case "$wanted_field" in
+			version) printf '%s\n' "$version" ;;
+			artifact_digest) printf '%s\n' "$artifact_digest" ;;
+			repository) printf '%s\n' "$repository" ;;
+			source_ref) printf '%s\n' "$source_ref" ;;
+			source_commit) printf '%s\n' "$source_commit" ;;
+			*) return 2 ;;
+		esac
+		return 0
+	done
+	return 1
+}
+
+ts_version="$(inventory_field TypeScript version)"
+rust_version="$(inventory_field Rust version)"
+ts_ref="$(inventory_field TypeScript source_ref)"
+rust_ref="$(inventory_field Rust source_ref)"
+ts_source_commit="$(inventory_field TypeScript source_commit)"
+rust_source_commit="$(inventory_field Rust source_commit)"
+ts_artifact_digest="$(inventory_field TypeScript artifact_digest)"
+rust_artifact_digest="$(inventory_field Rust artifact_digest)"
+python_version="$(inventory_field Python version)"
+python_artifact_digest="$(inventory_field Python artifact_digest)"
+python_repository="$(inventory_field Python repository)"
+python_ref="$(inventory_field Python source_ref)"
+python_source_commit="$(inventory_field Python source_commit)"
+
+tree_ts_version="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' "$ROOT_DIR/sdk/verifiers/ts/package.json")"
+tree_ts_lock_version="$(python3 -c 'import json, sys; lock=json.load(open(sys.argv[1], encoding="utf-8")); print(lock["version"]); lock["packages"][""]["version"] == lock["version"] or sys.exit("package-lock root version mismatch")' "$ROOT_DIR/sdk/verifiers/ts/package-lock.json")"
+tree_rust_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT_DIR/sdk/verifiers/rust/Cargo.toml" | head -n 1)"
+tree_rust_lock_version="$(awk '
+	$0 == "name = \"pipelock-verifier-rs\"" { found = 1; next }
+	found && /^version = / { gsub(/version = |"/, ""); print; exit }
+' "$ROOT_DIR/sdk/verifiers/rust/Cargo.lock")"
+if [[ "$tree_ts_version" != "$ts_version" || "$tree_ts_lock_version" != "$ts_version" \
+	|| "$tree_rust_version" != "$rust_version" || "$tree_rust_lock_version" != "$rust_version" ]]; then
+	printf 'release verifier install gate: source manifests declare TS %s/%s and Rust %s/%s, inventory requires %s/%s\n' \
+		"$tree_ts_version" "$tree_ts_lock_version" "$tree_rust_version" "$tree_rust_lock_version" "$ts_version" "$rust_version" >&2
+	exit 2
+fi
+
+if ((inventory_only)); then
+	exit 0
+fi
+
+require_command git
+
+# A product candidate may only certify the verifier package that contains its
+# verifier changes. The verifier tag must name the inventory version, resolve
+# to one commit, be reachable from this candidate, and carry matching TS and
+# Rust manifests. This makes a stale registry package or a stray tag fail
+# before any customer-install simulation starts.
+if [[ "$ts_version" != "$rust_version" || "$ts_ref" != "$rust_ref" ]]; then
+	printf 'release verifier install gate: TypeScript and Rust inventory entries must name one shared verifier release\n' >&2
+	exit 2
+fi
+if [[ "$ts_ref" != "verifier-v$ts_version" ]]; then
+	printf 'release verifier install gate: verifier source ref %s does not match inventory version %s\n' "$ts_ref" "$ts_version" >&2
+	exit 2
+fi
+if ! verifier_commit="$(git -C "$ROOT_DIR" rev-parse --verify "$ts_ref^{}" 2>/dev/null)"; then
+	printf 'release verifier install gate: required verifier release tag is missing: %s\n' "$ts_ref" >&2
+	exit 2
+fi
+if [[ ! "$ts_source_commit" =~ ^[0-9a-f]{40}$ || ! "$rust_source_commit" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'release verifier install gate: inventory must pin the 40-character peeled commit for %s before the product release can proceed\n' "$ts_ref" >&2
+	exit 2
+fi
+if [[ "$ts_source_commit" != "$rust_source_commit" || "$ts_source_commit" != "$verifier_commit" ]]; then
+	printf 'release verifier install gate: inventory source commit does not equal the peeled %s commit\n' "$ts_ref" >&2
+	exit 2
+fi
+if ! git -C "$ROOT_DIR" merge-base --is-ancestor "$verifier_commit" HEAD; then
+	printf 'release verifier install gate: verifier tag %s (%s) is not part of this product candidate\n' "$ts_ref" "$verifier_commit" >&2
+	exit 2
+fi
+mapfile -t tagged_versions < <(
+	git -C "$ROOT_DIR" show "$verifier_commit:sdk/verifiers/ts/package.json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])'
+	git -C "$ROOT_DIR" show "$verifier_commit:sdk/verifiers/ts/package-lock.json" | python3 -c 'import json, sys; lock=json.load(sys.stdin); print(lock["version"]); lock["packages"][""]["version"] == lock["version"] or sys.exit("package-lock root version mismatch")'
+	git -C "$ROOT_DIR" show "$verifier_commit:sdk/verifiers/rust/Cargo.toml" | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -n 1
+	git -C "$ROOT_DIR" show "$verifier_commit:sdk/verifiers/rust/Cargo.lock" | awk '
+		$0 == "name = \"pipelock-verifier-rs\"" { found = 1; next }
+		found && /^version = / { gsub(/version = |"/, ""); print; exit }
+	'
+)
+if ((${#tagged_versions[@]} != 4)); then
+	printf 'release verifier install gate: could not read TS/Rust manifest and lockfile versions from %s\n' "$ts_ref" >&2
+	exit 2
+fi
+tagged_ts_version="${tagged_versions[0]}"
+tagged_ts_lock_version="${tagged_versions[1]}"
+tagged_rust_version="${tagged_versions[2]}"
+tagged_rust_lock_version="${tagged_versions[3]}"
+if [[ "$tagged_ts_version" != "$ts_version" || "$tagged_ts_lock_version" != "$ts_version" \
+	|| "$tagged_rust_version" != "$rust_version" || "$tagged_rust_lock_version" != "$rust_version" ]]; then
+	printf 'release verifier install gate: %s manifest/lock versions are TS %s/%s and Rust %s/%s, expected %s/%s\n' \
+		"$ts_ref" "$tagged_ts_version" "$tagged_ts_lock_version" "$tagged_rust_version" "$tagged_rust_lock_version" "$ts_version" "$rust_version" >&2
+	exit 2
+fi
+
+# The release workflow and these checks use the same source of truth. Refuse a
+# quiet inventory/workflow drift before talking to a registry.
+if ! publisher_workflow="$(git -C "$ROOT_DIR" show "$verifier_commit:.github/workflows/publish-verifiers.yaml")"; then
+	printf 'release verifier install gate: %s does not contain the trusted-publisher workflow\n' "$ts_ref" >&2
+	exit 2
+fi
+if ! grep -Fq 'environment: verifier-release' <<<"$publisher_workflow" \
+	|| ! grep -Fq 'id-token: write' <<<"$publisher_workflow"; then
+	printf 'release verifier install gate: tagged TypeScript/Rust trusted-publisher workflow contract is missing\n' >&2
+	exit 2
+fi
+
+if [[ "$python_ref" != "v$python_version" || ! "$python_source_commit" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'release verifier install gate: Python source ref or commit does not match version %s\n' "$python_version" >&2
+	exit 2
+fi
+if ! python_tag_refs="$(git ls-remote --tags "https://github.com/$python_repository.git" \
+	"refs/tags/$python_ref" "refs/tags/$python_ref^{}")"; then
+	printf 'release verifier install gate: could not resolve Python source tag %s from %s\n' "$python_ref" "$python_repository" >&2
+	exit 2
+fi
+python_tag_commit="$(awk '/\^\{\}$/ { print $1; found=1 } END { if (!found && NR == 1) print first } NR == 1 { first=$1 }' <<<"$python_tag_refs")"
+if [[ "$python_tag_commit" != "$python_source_commit" ]]; then
+	printf 'release verifier install gate: Python source tag %s resolves to %s, inventory requires %s\n' \
+		"$python_ref" "${python_tag_commit:-missing}" "$python_source_commit" >&2
+	exit 2
+fi
+
+require_command npm
+require_command curl
+
+if [[ ! "$ts_artifact_digest" =~ ^sha512-[A-Za-z0-9+/]+={0,2}$ ]]; then
+	printf 'release verifier install gate: inventory must pin npm dist.integrity for @pipelock/verifier-ts@%s\n' "$ts_version" >&2
+	exit 2
+fi
+published_ts_digest="$(npm view "@pipelock/verifier-ts@$ts_version" dist.integrity)"
+if [[ "$published_ts_digest" != "$ts_artifact_digest" ]]; then
+	printf 'release verifier install gate: npm integrity for @pipelock/verifier-ts@%s is %s, inventory requires %s\n' \
+		"$ts_version" "${published_ts_digest:-missing}" "$ts_artifact_digest" >&2
+	exit 2
+fi
+
+if [[ ! "$rust_artifact_digest" =~ ^[0-9a-f]{64}$ ]]; then
+	printf 'release verifier install gate: inventory must pin the crates.io checksum for pipelock-verifier-rs@%s\n' "$rust_version" >&2
+	exit 2
+fi
+published_rust_digest="$(curl -fsSL https://index.crates.io/pi/pe/pipelock-verifier-rs | python3 -c '
+import json, sys
+version = sys.argv[1]
+matches = [row for line in sys.stdin if (row := json.loads(line)).get("vers") == version]
+if len(matches) != 1:
+    raise SystemExit(f"expected one crates.io index row for {version}, found {len(matches)}")
+print(matches[0]["cksum"])
+' "$rust_version")"
+if [[ "$published_rust_digest" != "$rust_artifact_digest" ]]; then
+	printf 'release verifier install gate: crates.io checksum for pipelock-verifier-rs@%s is %s, inventory requires %s\n' \
+		"$rust_version" "${published_rust_digest:-missing}" "$rust_artifact_digest" >&2
+	exit 2
+fi
+
+if [[ ! "$python_artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+	printf 'release verifier install gate: inventory must pin the PyPI wheel SHA-256 for pipelock-verify@%s\n' "$python_version" >&2
+	exit 2
+fi
+
+for command in go node cargo sha256sum find; do
+	require_command "$command"
+done
+
+scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/pipelock-verifier-install.XXXXXX")"
+cleanup() {
+	# Go marks downloaded modules read-only. Restore write permission before
+	# removal so a successful verification cannot be reported as failed merely
+	# because the disposable cache is protected.
+	chmod -R u+w "$scratch_dir" 2>/dev/null || true
+	rm -rf "$scratch_dir" || true
+}
+trap cleanup EXIT
+
+fixture_dir="$scratch_dir/fixture"
+go_cache="$scratch_dir/go-cache"
+go_mod_cache="$scratch_dir/go-mod-cache"
+go_bin_dir="$scratch_dir/go/bin"
+mkdir -p "$fixture_dir" "$go_cache" "$go_mod_cache" "$go_bin_dir"
+candidate_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+candidate_short_commit="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+candidate_date="$(git -C "$ROOT_DIR" log -1 --format=%cI)"
+go_version="$(go env GOVERSION)"
+
+# This is the exact candidate source. The Go binary uses the same standalone
+# command and release flags as GoReleaser, then is placed in an otherwise empty
+# customer-style bin directory.
+GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" go run "$ROOT_DIR/scripts/release-verifier-fixture.go" --out-dir "$fixture_dir"
+GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" go build -trimpath -buildvcs=false \
+	-ldflags "-s -w \
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=${tag#v} \
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate=$candidate_date \
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit=$candidate_short_commit \
+	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion=$go_version" \
+	-o "$go_bin_dir/pipelock-verifier" "$ROOT_DIR/cmd/pipelock-verifier"
+
+receipt="$fixture_dir/candidate-receipt.json"
+tampered="$fixture_dir/candidate-receipt-tampered.json"
+key="$(tr -d '[:space:]' < "$fixture_dir/candidate-receipt-public-key.txt")"
+if [[ ! "$key" =~ ^[0-9a-f]{64}$ ]]; then
+	printf 'release verifier install gate: candidate fixture did not produce a valid public key\n' >&2
+	exit 2
+fi
+
+# No global package manager state is reused. Each installer gets a new prefix,
+# cache, and interpreter environment, so this detects bad package contents,
+# entrypoints, and runtime dependencies instead of exercising our source tree.
+npm_config_cache="$scratch_dir/npm-cache" npm install --ignore-scripts --omit=dev --no-save --prefix "$scratch_dir/typescript" "@pipelock/verifier-ts@$ts_version"
+if [[ ! -f "$scratch_dir/typescript/package-lock.json" ]]; then
+	printf 'release verifier install gate: npm install did not produce the lockfile required for signature auditing\n' >&2
+	exit 2
+fi
+npm_config_cache="$scratch_dir/npm-cache" npm audit signatures --prefix "$scratch_dir/typescript"
+CARGO_HOME="$scratch_dir/cargo-home" cargo install --locked --root "$scratch_dir/rust" "pipelock-verifier-rs@$rust_version"
+python3 -m venv "$scratch_dir/python"
+mkdir -p "$scratch_dir/python-dist"
+PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip download --isolated --no-deps \
+	--only-binary=:all: --dest "$scratch_dir/python-dist" "pipelock-verify==$python_version"
+mapfile -t python_wheels < <(find "$scratch_dir/python-dist" -maxdepth 1 -type f -name '*.whl')
+if ((${#python_wheels[@]} != 1)); then
+	printf 'release verifier install gate: expected one Python wheel, found %d\n' "${#python_wheels[@]}" >&2
+	exit 2
+fi
+printf '%s  %s\n' "${python_artifact_digest#sha256:}" "${python_wheels[0]}" | sha256sum --check --status
+PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip install --isolated "${python_wheels[0]}"
+
+go_reported_version="$($go_bin_dir/pipelock-verifier --version)"
+if [[ "$go_reported_version" != "pipelock-verifier ${tag#v} "* ]]; then
+	printf 'release verifier install gate: Go verifier reports unexpected version: %s\n' "$go_reported_version" >&2
+	exit 2
+fi
+ts_installed_version="$(node -p "require('$scratch_dir/typescript/node_modules/@pipelock/verifier-ts/package.json').version")"
+if [[ "$ts_installed_version" != "$ts_version" ]]; then
+	printf 'release verifier install gate: installed TypeScript verifier reports %s, expected %s\n' "$ts_installed_version" "$ts_version" >&2
+	exit 2
+fi
+mapfile -t rust_manifests < <(find "$scratch_dir/cargo-home/registry/src" -type f -path "*/pipelock-verifier-rs-$rust_version/Cargo.toml")
+if ((${#rust_manifests[@]} != 1)); then
+	printf 'release verifier install gate: expected one installed Rust manifest, found %d\n' "${#rust_manifests[@]}" >&2
+	exit 2
+fi
+rust_installed_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "${rust_manifests[0]}" | head -n 1)"
+if [[ "$rust_installed_version" != "$rust_version" ]]; then
+	printf 'release verifier install gate: installed Rust verifier reports %s, expected %s\n' "$rust_installed_version" "$rust_version" >&2
+	exit 2
+fi
+rust_vcs_info="$(dirname "${rust_manifests[0]}")/.cargo_vcs_info.json"
+rust_source_sha="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git"]["sha1"])' "$rust_vcs_info")"
+if [[ "$rust_source_sha" != "$rust_source_commit" ]]; then
+	printf 'release verifier install gate: installed Rust crate records source %s, expected %s\n' \
+		"$rust_source_sha" "$rust_source_commit" >&2
+	exit 2
+fi
+python_installed_version="$($scratch_dir/python/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("pipelock-verify"))')"
+if [[ "$python_installed_version" != "$python_version" ]]; then
+	printf 'release verifier install gate: installed Python verifier reports %s, expected %s\n' "$python_installed_version" "$python_version" >&2
+	exit 2
+fi
+
+verify_accepts_and_rejects Go "$receipt" "$tampered" "$key" "$go_bin_dir/pipelock-verifier" receipt
+verify_accepts_and_rejects TypeScript "$receipt" "$tampered" "$key" "$scratch_dir/typescript/node_modules/.bin/pipelock-verifier-ts" receipt
+verify_accepts_and_rejects Rust "$receipt" "$tampered" "$key" "$scratch_dir/rust/bin/pipelock-verifier-rs" receipt
+verify_accepts_and_rejects Python "$receipt" "$tampered" "$key" "$scratch_dir/python/bin/pipelock-verify"
+
+printf 'release verifier install gate: OK (%s at %s)\n' "$tag" "$candidate_commit"

--- a/scripts/release-verifier-install-gate.sh
+++ b/scripts/release-verifier-install-gate.sh
@@ -425,14 +425,22 @@ go_version="$(go env GOVERSION)"
 # This is the exact candidate source. The Go binary uses the same standalone
 # command and release flags as GoReleaser, then is placed in an otherwise empty
 # customer-style bin directory.
-GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" go run "$ROOT_DIR/scripts/release-verifier-fixture.go" --out-dir "$fixture_dir"
-GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" go build -trimpath -buildvcs=false \
+if ! "$CI_RETRY" env GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" \
+	go run "$ROOT_DIR/scripts/release-verifier-fixture.go" --out-dir "$fixture_dir"; then
+	printf 'release verifier install gate: could not build the candidate receipt fixture after retries\n' >&2
+	exit 2
+fi
+if ! "$CI_RETRY" env GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" \
+	go build -trimpath -buildvcs=false \
 	-ldflags "-s -w \
 	-X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=${tag#v} \
 	-X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate=$candidate_date \
 	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GitCommit=$candidate_short_commit \
 	-X github.com/luckyPipewrench/pipelock/internal/cliutil.GoVersion=$go_version" \
-	-o "$go_bin_dir/pipelock-verifier" "$ROOT_DIR/cmd/pipelock-verifier"
+	-o "$go_bin_dir/pipelock-verifier" "$ROOT_DIR/cmd/pipelock-verifier"; then
+	printf 'release verifier install gate: could not build the Go verifier after retries\n' >&2
+	exit 2
+fi
 
 receipt="$fixture_dir/candidate-receipt.json"
 payload_tampered="$fixture_dir/candidate-receipt-payload-tampered.json"
@@ -447,7 +455,11 @@ fi
 # cache, and interpreter environment, so this detects bad package contents,
 # entrypoints, and runtime dependencies instead of exercising our source tree.
 printf '{"private":true}\n' >"$scratch_dir/typescript/package.json"
-npm_config_cache="$scratch_dir/npm-cache" npm install --ignore-scripts --omit=dev --prefix "$scratch_dir/typescript" "@pipelock/verifier-ts@$ts_version"
+if ! "$CI_RETRY" env npm_config_cache="$scratch_dir/npm-cache" \
+	npm install --ignore-scripts --omit=dev --prefix "$scratch_dir/typescript" "@pipelock/verifier-ts@$ts_version"; then
+	printf 'release verifier install gate: could not install the TypeScript verifier after retries\n' >&2
+	exit 2
+fi
 if [[ ! -f "$scratch_dir/typescript/package-lock.json" ]]; then
 	printf 'release verifier install gate: npm install did not produce the lockfile required for signature auditing\n' >&2
 	exit 2
@@ -463,7 +475,10 @@ if (withInstallScripts.length) {
   process.exit(2)
 }
 NODE
-npm_config_cache="$scratch_dir/npm-cache" npm audit signatures --prefix "$scratch_dir/typescript"
+if ! "$CI_RETRY" env npm_config_cache="$scratch_dir/npm-cache" npm audit signatures --prefix "$scratch_dir/typescript"; then
+	printf 'release verifier install gate: could not verify npm signatures after retries\n' >&2
+	exit 2
+fi
 if ! npm_attestations="$("$CI_RETRY" curl -fsSL \
 	"https://registry.npmjs.org/-/npm/v1/attestations/@pipelock%2fverifier-ts@$ts_version")"; then
 	printf 'release verifier install gate: could not fetch npm provenance for @pipelock/verifier-ts@%s\n' "$ts_version" >&2
@@ -509,17 +524,31 @@ if not any(
 ):
     raise SystemExit("npm provenance does not bind the pinned source commit")
 PY
-CARGO_HOME="$scratch_dir/cargo-home" cargo install --locked --root "$scratch_dir/rust" "pipelock-verifier-rs@$rust_version"
+if ! "$CI_RETRY" env CARGO_HOME="$scratch_dir/cargo-home" \
+	cargo install --locked --root "$scratch_dir/rust" "pipelock-verifier-rs@$rust_version"; then
+	printf 'release verifier install gate: could not install the Rust verifier after retries\n' >&2
+	exit 2
+fi
 python3 -m venv "$scratch_dir/python"
 mkdir -p "$scratch_dir/python-dist"
-PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip download --isolated --no-deps \
-	--only-binary=:all: --dest "$scratch_dir/python-dist" "pipelock-verify==$python_version"
+if ! "$CI_RETRY" env PIP_DISABLE_PIP_VERSION_CHECK=1 \
+	"$scratch_dir/python/bin/python" -m pip download --isolated --no-deps \
+	--only-binary=:all: --dest "$scratch_dir/python-dist" "pipelock-verify==$python_version"; then
+	printf 'release verifier install gate: could not download the Python verifier after retries\n' >&2
+	exit 2
+fi
 mapfile -t python_wheels < <(find "$scratch_dir/python-dist" -maxdepth 1 -type f -name '*.whl')
 if ((${#python_wheels[@]} != 1)); then
 	printf 'release verifier install gate: expected one Python wheel, found %d\n' "${#python_wheels[@]}" >&2
 	exit 2
 fi
-printf '%s  %s\n' "${python_artifact_digest#sha256:}" "${python_wheels[0]}" | sha256sum --check --status
+calculated_python_digest="$(sha256sum "${python_wheels[0]}")"
+calculated_python_digest="${calculated_python_digest%% *}"
+if [[ "$calculated_python_digest" != "${python_artifact_digest#sha256:}" ]]; then
+	printf 'release verifier install gate: downloaded pipelock-verify@%s wheel digest is sha256:%s, expected %s\n' \
+		"$python_version" "$calculated_python_digest" "$python_artifact_digest" >&2
+	exit 2
+fi
 if ! "$CI_RETRY" git clone --quiet --filter=blob:none --no-checkout \
 	"https://github.com/$python_repository.git" "$scratch_dir/python-source"; then
 	printf 'release verifier install gate: could not fetch Python verifier source from %s\n' "$python_repository" >&2
@@ -531,8 +560,12 @@ if [[ "$(git -C "$scratch_dir/python-source" rev-parse HEAD)" != "$python_source
 	exit 2
 fi
 mkdir -p "$scratch_dir/python-rebuilt"
-PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip wheel --isolated --no-deps \
-	--wheel-dir "$scratch_dir/python-rebuilt" "$scratch_dir/python-source"
+if ! "$CI_RETRY" env PIP_DISABLE_PIP_VERSION_CHECK=1 \
+	"$scratch_dir/python/bin/python" -m pip wheel --isolated --no-deps \
+	--wheel-dir "$scratch_dir/python-rebuilt" "$scratch_dir/python-source"; then
+	printf 'release verifier install gate: could not rebuild the Python verifier after retries\n' >&2
+	exit 2
+fi
 mapfile -t rebuilt_python_wheels < <(find "$scratch_dir/python-rebuilt" -maxdepth 1 -type f -name '*.whl')
 if ((${#rebuilt_python_wheels[@]} != 1)); then
 	printf 'release verifier install gate: expected one rebuilt Python wheel, found %d\n' "${#rebuilt_python_wheels[@]}" >&2
@@ -553,7 +586,11 @@ def content(path):
 if content(sys.argv[1]) != content(sys.argv[2]):
     raise SystemExit("published Python wheel contents differ from the pinned source commit")
 PY
-PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip install --isolated "${python_wheels[0]}"
+if ! "$CI_RETRY" env PIP_DISABLE_PIP_VERSION_CHECK=1 \
+	"$scratch_dir/python/bin/python" -m pip install --isolated "${python_wheels[0]}"; then
+	printf 'release verifier install gate: could not install the Python verifier after retries\n' >&2
+	exit 2
+fi
 
 go_reported_version="$("$go_bin_dir/pipelock-verifier" --version)"
 if [[ "$go_reported_version" != "pipelock-verifier ${tag#v} "* ]]; then

--- a/scripts/release-verifier-install-gate.sh
+++ b/scripts/release-verifier-install-gate.sh
@@ -13,6 +13,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INVENTORY="$ROOT_DIR/release/verifier-installers.json"
 # shellcheck source=scripts/release-verifier-install-gate-lib.sh
 source "$ROOT_DIR/scripts/release-verifier-install-gate-lib.sh"
+CI_RETRY="$ROOT_DIR/scripts/ci-retry.sh"
 
 usage() {
 	cat <<'EOF'
@@ -77,6 +78,8 @@ with open(sys.argv[1], encoding="utf-8") as fh:
 
 if inventory.get("schema_version") != 1:
     raise SystemExit("unsupported verifier installer inventory schema")
+if not isinstance(inventory.get("release_blocked"), bool):
+    raise SystemExit("verifier installer inventory must declare release_blocked")
 
 required_languages = {"Go", "TypeScript", "Rust", "Python"}
 expected = {
@@ -229,6 +232,12 @@ if ((inventory_only)); then
 	exit 0
 fi
 
+release_blocked="$(python3 -c 'import json, sys; print(str(json.load(open(sys.argv[1], encoding="utf-8"))["release_blocked"]).lower())' "$INVENTORY")"
+if [[ "$release_blocked" == "true" ]]; then
+	printf 'release verifier install gate: release is explicitly blocked until verifier-v0.3.0 is published and its immutable registry digests replace the inventory placeholders\n' >&2
+	exit 2
+fi
+
 require_command git
 
 # A product candidate may only certify the verifier package that contains its
@@ -252,6 +261,7 @@ if [[ ! "$ts_source_commit" =~ ^[0-9a-f]{40}$ || ! "$rust_source_commit" =~ ^[0-
 	printf 'release verifier install gate: inventory must pin the 40-character peeled commit for %s before the product release can proceed\n' "$ts_ref" >&2
 	exit 2
 fi
+# shellcheck disable=SC2055 # Deliberate: either mismatch must block the release.
 if [[ "$ts_source_commit" != "$rust_source_commit" || "$ts_source_commit" != "$verifier_commit" ]]; then
 	printf 'release verifier install gate: inventory source commit does not equal the peeled %s commit\n' "$ts_ref" >&2
 	exit 2
@@ -284,6 +294,18 @@ if [[ "$tagged_ts_version" != "$ts_version" || "$tagged_ts_lock_version" != "$ts
 	exit 2
 fi
 
+# A verifier version cannot continue to certify new implementation bytes after
+# its immutable source tag. Documentation may evolve independently, but every
+# file that can change package behavior or contents must still match the tag.
+if ! git -C "$ROOT_DIR" diff --quiet "$verifier_commit" HEAD -- \
+	sdk/verifiers/ts/src sdk/verifiers/ts/scripts \
+	sdk/verifiers/ts/package.json sdk/verifiers/ts/package-lock.json sdk/verifiers/ts/tsconfig.json \
+	sdk/verifiers/rust/src sdk/verifiers/rust/build.rs \
+	sdk/verifiers/rust/Cargo.toml sdk/verifiers/rust/Cargo.lock; then
+	printf 'release verifier install gate: verifier package source differs from immutable tag %s\n' "$ts_ref" >&2
+	exit 2
+fi
+
 # The release workflow and these checks use the same source of truth. Refuse a
 # quiet inventory/workflow drift before talking to a registry.
 if ! publisher_workflow="$(git -C "$ROOT_DIR" show "$verifier_commit:.github/workflows/publish-verifiers.yaml")"; then
@@ -300,7 +322,7 @@ if [[ "$python_ref" != "v$python_version" || ! "$python_source_commit" =~ ^[0-9a
 	printf 'release verifier install gate: Python source ref or commit does not match version %s\n' "$python_version" >&2
 	exit 2
 fi
-if ! python_tag_refs="$(git ls-remote --tags "https://github.com/$python_repository.git" \
+if ! python_tag_refs="$("$CI_RETRY" git ls-remote --tags "https://github.com/$python_repository.git" \
 	"refs/tags/$python_ref" "refs/tags/$python_ref^{}")"; then
 	printf 'release verifier install gate: could not resolve Python source tag %s from %s\n' "$python_ref" "$python_repository" >&2
 	exit 2
@@ -319,7 +341,10 @@ if [[ ! "$ts_artifact_digest" =~ ^sha512-[A-Za-z0-9+/]+={0,2}$ ]]; then
 	printf 'release verifier install gate: inventory must pin npm dist.integrity for @pipelock/verifier-ts@%s\n' "$ts_version" >&2
 	exit 2
 fi
-published_ts_digest="$(npm view "@pipelock/verifier-ts@$ts_version" dist.integrity)"
+if ! published_ts_digest="$("$CI_RETRY" npm view "@pipelock/verifier-ts@$ts_version" dist.integrity)"; then
+	printf 'release verifier install gate: could not reach npm for @pipelock/verifier-ts@%s\n' "$ts_version" >&2
+	exit 2
+fi
 if [[ "$published_ts_digest" != "$ts_artifact_digest" ]]; then
 	printf 'release verifier install gate: npm integrity for @pipelock/verifier-ts@%s is %s, inventory requires %s\n' \
 		"$ts_version" "${published_ts_digest:-missing}" "$ts_artifact_digest" >&2
@@ -330,14 +355,21 @@ if [[ ! "$rust_artifact_digest" =~ ^[0-9a-f]{64}$ ]]; then
 	printf 'release verifier install gate: inventory must pin the crates.io checksum for pipelock-verifier-rs@%s\n' "$rust_version" >&2
 	exit 2
 fi
-published_rust_digest="$(curl -fsSL https://index.crates.io/pi/pe/pipelock-verifier-rs | python3 -c '
+if ! rust_index="$("$CI_RETRY" curl -fsSL https://index.crates.io/pi/pe/pipelock-verifier-rs)"; then
+	printf 'release verifier install gate: could not reach crates.io for pipelock-verifier-rs@%s\n' "$rust_version" >&2
+	exit 2
+fi
+if ! published_rust_digest="$(python3 -c '
 import json, sys
 version = sys.argv[1]
 matches = [row for line in sys.stdin if (row := json.loads(line)).get("vers") == version]
 if len(matches) != 1:
     raise SystemExit(f"expected one crates.io index row for {version}, found {len(matches)}")
 print(matches[0]["cksum"])
-' "$rust_version")"
+' "$rust_version" <<<"$rust_index")"; then
+	printf 'release verifier install gate: crates.io did not return one checksum for pipelock-verifier-rs@%s\n' "$rust_version" >&2
+	exit 2
+fi
 if [[ "$published_rust_digest" != "$rust_artifact_digest" ]]; then
 	printf 'release verifier install gate: crates.io checksum for pipelock-verifier-rs@%s is %s, inventory requires %s\n' \
 		"$rust_version" "${published_rust_digest:-missing}" "$rust_artifact_digest" >&2
@@ -348,8 +380,25 @@ if [[ ! "$python_artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
 	printf 'release verifier install gate: inventory must pin the PyPI wheel SHA-256 for pipelock-verify@%s\n' "$python_version" >&2
 	exit 2
 fi
+if ! python_release_metadata="$("$CI_RETRY" curl -fsSL \
+	"https://pypi.org/pypi/pipelock-verify/$python_version/json")"; then
+	printf 'release verifier install gate: could not reach PyPI for pipelock-verify@%s\n' "$python_version" >&2
+	exit 2
+fi
+python3 - "$python_version" "${python_artifact_digest#sha256:}" "$python_release_metadata" <<'PY'
+import json
+import sys
 
-for command in go node cargo sha256sum find; do
+version, expected_digest, metadata = sys.argv[1:]
+wheels = [entry for entry in json.loads(metadata).get("urls", []) if entry.get("packagetype") == "bdist_wheel"]
+expected_name = f"pipelock_verify-{version}-py3-none-any.whl"
+if len(wheels) != 1 or wheels[0].get("filename") != expected_name:
+    raise SystemExit(f"expected exactly one universal Python wheel named {expected_name}")
+if wheels[0].get("digests", {}).get("sha256") != expected_digest:
+    raise SystemExit("PyPI release metadata does not bind the pinned wheel digest")
+PY
+
+for command in go node cargo sha256sum find diff cmp; do
 	require_command "$command"
 done
 
@@ -367,7 +416,7 @@ fixture_dir="$scratch_dir/fixture"
 go_cache="$scratch_dir/go-cache"
 go_mod_cache="$scratch_dir/go-mod-cache"
 go_bin_dir="$scratch_dir/go/bin"
-mkdir -p "$fixture_dir" "$go_cache" "$go_mod_cache" "$go_bin_dir"
+mkdir -p "$fixture_dir" "$go_cache" "$go_mod_cache" "$go_bin_dir" "$scratch_dir/typescript"
 candidate_commit="$(git -C "$ROOT_DIR" rev-parse HEAD)"
 candidate_short_commit="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
 candidate_date="$(git -C "$ROOT_DIR" log -1 --format=%cI)"
@@ -386,7 +435,8 @@ GOCACHE="$go_cache" GOMODCACHE="$go_mod_cache" go build -trimpath -buildvcs=fals
 	-o "$go_bin_dir/pipelock-verifier" "$ROOT_DIR/cmd/pipelock-verifier"
 
 receipt="$fixture_dir/candidate-receipt.json"
-tampered="$fixture_dir/candidate-receipt-tampered.json"
+payload_tampered="$fixture_dir/candidate-receipt-payload-tampered.json"
+signature_tampered="$fixture_dir/candidate-receipt-signature-tampered.json"
 key="$(tr -d '[:space:]' < "$fixture_dir/candidate-receipt-public-key.txt")"
 if [[ ! "$key" =~ ^[0-9a-f]{64}$ ]]; then
 	printf 'release verifier install gate: candidate fixture did not produce a valid public key\n' >&2
@@ -396,12 +446,69 @@ fi
 # No global package manager state is reused. Each installer gets a new prefix,
 # cache, and interpreter environment, so this detects bad package contents,
 # entrypoints, and runtime dependencies instead of exercising our source tree.
-npm_config_cache="$scratch_dir/npm-cache" npm install --ignore-scripts --omit=dev --no-save --prefix "$scratch_dir/typescript" "@pipelock/verifier-ts@$ts_version"
+printf '{"private":true}\n' >"$scratch_dir/typescript/package.json"
+npm_config_cache="$scratch_dir/npm-cache" npm install --ignore-scripts --omit=dev --prefix "$scratch_dir/typescript" "@pipelock/verifier-ts@$ts_version"
 if [[ ! -f "$scratch_dir/typescript/package-lock.json" ]]; then
 	printf 'release verifier install gate: npm install did not produce the lockfile required for signature auditing\n' >&2
 	exit 2
 fi
+node - "$scratch_dir/typescript/package-lock.json" <<'NODE'
+const fs = require('node:fs')
+const lock = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+const withInstallScripts = Object.entries(lock.packages || {})
+  .filter(([, metadata]) => metadata && metadata.hasInstallScript)
+  .map(([path]) => path || '(root)')
+if (withInstallScripts.length) {
+  console.error(`release verifier install gate: npm dependency tree contains lifecycle install scripts: ${withInstallScripts.join(', ')}`)
+  process.exit(2)
+}
+NODE
 npm_config_cache="$scratch_dir/npm-cache" npm audit signatures --prefix "$scratch_dir/typescript"
+if ! npm_attestations="$("$CI_RETRY" curl -fsSL \
+	"https://registry.npmjs.org/-/npm/v1/attestations/@pipelock%2fverifier-ts@$ts_version")"; then
+	printf 'release verifier install gate: could not fetch npm provenance for @pipelock/verifier-ts@%s\n' "$ts_version" >&2
+	exit 2
+fi
+printf '%s\n' "$npm_attestations" >"$scratch_dir/npm-attestations.json"
+python3 - "$ts_version" "$ts_artifact_digest" "$ts_ref" "$ts_source_commit" "$scratch_dir/npm-attestations.json" <<'PY'
+import base64
+import json
+import sys
+
+version, integrity, source_ref, source_commit, attestation_path = sys.argv[1:]
+with open(attestation_path, encoding="utf-8") as fh:
+    attestations = json.load(fh).get("attestations", [])
+statements = []
+for attestation in attestations:
+    envelope = attestation.get("bundle", {}).get("dsseEnvelope", {})
+    payload = envelope.get("payload")
+    if payload:
+        statements.append(json.loads(base64.b64decode(payload)))
+matches = [statement for statement in statements if statement.get("predicateType") == "https://slsa.dev/provenance/v1"]
+if len(matches) != 1:
+    raise SystemExit(f"expected one npm SLSA provenance statement, found {len(matches)}")
+statement = matches[0]
+expected_digest = base64.b64decode(integrity.removeprefix("sha512-")).hex()
+subject = statement.get("subject", [])
+if len(subject) != 1 or subject[0].get("name") != f"pkg:npm/%40pipelock/verifier-ts@{version}" or subject[0].get("digest", {}).get("sha512") != expected_digest:
+    raise SystemExit("npm provenance subject does not bind the pinned package digest")
+definition = statement.get("predicate", {}).get("buildDefinition", {})
+workflow = definition.get("externalParameters", {}).get("workflow", {})
+expected_workflow = {
+    "ref": f"refs/tags/{source_ref}",
+    "repository": "https://github.com/luckyPipewrench/pipelock",
+    "path": ".github/workflows/publish-verifiers.yaml",
+}
+if workflow != expected_workflow:
+    raise SystemExit(f"npm provenance workflow mismatch: {workflow!r}")
+dependencies = definition.get("resolvedDependencies", [])
+if not any(
+    dependency.get("uri") == f"git+https://github.com/luckyPipewrench/pipelock@refs/tags/{source_ref}"
+    and dependency.get("digest", {}).get("gitCommit") == source_commit
+    for dependency in dependencies
+):
+    raise SystemExit("npm provenance does not bind the pinned source commit")
+PY
 CARGO_HOME="$scratch_dir/cargo-home" cargo install --locked --root "$scratch_dir/rust" "pipelock-verifier-rs@$rust_version"
 python3 -m venv "$scratch_dir/python"
 mkdir -p "$scratch_dir/python-dist"
@@ -413,9 +520,42 @@ if ((${#python_wheels[@]} != 1)); then
 	exit 2
 fi
 printf '%s  %s\n' "${python_artifact_digest#sha256:}" "${python_wheels[0]}" | sha256sum --check --status
+if ! "$CI_RETRY" git clone --quiet --filter=blob:none --no-checkout \
+	"https://github.com/$python_repository.git" "$scratch_dir/python-source"; then
+	printf 'release verifier install gate: could not fetch Python verifier source from %s\n' "$python_repository" >&2
+	exit 2
+fi
+git -C "$scratch_dir/python-source" checkout --quiet --detach "$python_source_commit"
+if [[ "$(git -C "$scratch_dir/python-source" rev-parse HEAD)" != "$python_source_commit" ]]; then
+	printf 'release verifier install gate: Python source checkout did not resolve to %s\n' "$python_source_commit" >&2
+	exit 2
+fi
+mkdir -p "$scratch_dir/python-rebuilt"
+PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip wheel --isolated --no-deps \
+	--wheel-dir "$scratch_dir/python-rebuilt" "$scratch_dir/python-source"
+mapfile -t rebuilt_python_wheels < <(find "$scratch_dir/python-rebuilt" -maxdepth 1 -type f -name '*.whl')
+if ((${#rebuilt_python_wheels[@]} != 1)); then
+	printf 'release verifier install gate: expected one rebuilt Python wheel, found %d\n' "${#rebuilt_python_wheels[@]}" >&2
+	exit 2
+fi
+python3 - "${python_wheels[0]}" "${rebuilt_python_wheels[0]}" <<'PY'
+import sys
+import zipfile
+
+def content(path):
+    with zipfile.ZipFile(path) as wheel:
+        return {
+            name: wheel.read(name)
+            for name in wheel.namelist()
+            if not name.endswith(".dist-info/WHEEL") and not name.endswith(".dist-info/RECORD")
+        }
+
+if content(sys.argv[1]) != content(sys.argv[2]):
+    raise SystemExit("published Python wheel contents differ from the pinned source commit")
+PY
 PIP_DISABLE_PIP_VERSION_CHECK=1 "$scratch_dir/python/bin/python" -m pip install --isolated "${python_wheels[0]}"
 
-go_reported_version="$($go_bin_dir/pipelock-verifier --version)"
+go_reported_version="$("$go_bin_dir/pipelock-verifier" --version)"
 if [[ "$go_reported_version" != "pipelock-verifier ${tag#v} "* ]]; then
 	printf 'release verifier install gate: Go verifier reports unexpected version: %s\n' "$go_reported_version" >&2
 	exit 2
@@ -436,21 +576,27 @@ if [[ "$rust_installed_version" != "$rust_version" ]]; then
 	exit 2
 fi
 rust_vcs_info="$(dirname "${rust_manifests[0]}")/.cargo_vcs_info.json"
+rust_package_dir="$(dirname "${rust_manifests[0]}")"
+if ! diff -qr "$ROOT_DIR/sdk/verifiers/rust/src" "$rust_package_dir/src" >/dev/null \
+	|| ! cmp -s "$ROOT_DIR/sdk/verifiers/rust/build.rs" "$rust_package_dir/build.rs"; then
+	printf 'release verifier install gate: installed Rust implementation differs from source tag %s\n' "$rust_ref" >&2
+	exit 2
+fi
 rust_source_sha="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git"]["sha1"])' "$rust_vcs_info")"
 if [[ "$rust_source_sha" != "$rust_source_commit" ]]; then
 	printf 'release verifier install gate: installed Rust crate records source %s, expected %s\n' \
 		"$rust_source_sha" "$rust_source_commit" >&2
 	exit 2
 fi
-python_installed_version="$($scratch_dir/python/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("pipelock-verify"))')"
+python_installed_version="$("$scratch_dir/python/bin/python" -c 'import importlib.metadata; print(importlib.metadata.version("pipelock-verify"))')"
 if [[ "$python_installed_version" != "$python_version" ]]; then
 	printf 'release verifier install gate: installed Python verifier reports %s, expected %s\n' "$python_installed_version" "$python_version" >&2
 	exit 2
 fi
 
-verify_accepts_and_rejects Go "$receipt" "$tampered" "$key" "$go_bin_dir/pipelock-verifier" receipt
-verify_accepts_and_rejects TypeScript "$receipt" "$tampered" "$key" "$scratch_dir/typescript/node_modules/.bin/pipelock-verifier-ts" receipt
-verify_accepts_and_rejects Rust "$receipt" "$tampered" "$key" "$scratch_dir/rust/bin/pipelock-verifier-rs" receipt
-verify_accepts_and_rejects Python "$receipt" "$tampered" "$key" "$scratch_dir/python/bin/pipelock-verify"
+verify_accepts_and_rejects Go "$receipt" "$payload_tampered" "$signature_tampered" "$key" "$go_bin_dir/pipelock-verifier" receipt
+verify_accepts_and_rejects TypeScript "$receipt" "$payload_tampered" "$signature_tampered" "$key" "$scratch_dir/typescript/node_modules/.bin/pipelock-verifier-ts" receipt
+verify_accepts_and_rejects Rust "$receipt" "$payload_tampered" "$signature_tampered" "$key" "$scratch_dir/rust/bin/pipelock-verifier-rs" receipt
+verify_accepts_and_rejects Python "$receipt" "$payload_tampered" "$signature_tampered" "$key" "$scratch_dir/python/bin/pipelock-verify"
 
 printf 'release verifier install gate: OK (%s at %s)\n' "$tag" "$candidate_commit"

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -89,6 +89,19 @@ class TestReleaseArtifacts(unittest.TestCase):
             self.assertNotIn(f'name_template: "{repository}:{{{{ .Version }}}}"', self.goreleaser)
             self.assertNotIn(f'name_template: "{repository}:latest"', self.goreleaser)
 
+    def test_release_waits_for_customer_verifier_install_gate(self) -> None:
+        gate = self.workflow.index("  release-verifier-install:")
+        release = self.workflow.index("\n  release:\n", gate)
+        gate_block = self.workflow[gate:release]
+
+        self.assertIn("needs: [release-tests]", gate_block)
+        self.assertIn("fetch-depth: 0", gate_block)
+        self.assertIn(
+            'scripts/release-verifier-install-gate.sh --tag "$GITHUB_REF_NAME"',
+            gate_block,
+        )
+        self.assertIn("needs: [release-tests, release-verifier-install]", self.workflow[release:])
+
     def test_other_release_tools_are_exactly_pinned_and_verified(self) -> None:
         expected_tools = (
             (

--- a/sdk/verifiers/PUBLISHING.md
+++ b/sdk/verifiers/PUBLISHING.md
@@ -10,11 +10,9 @@ so third parties can install a Pipelock receipt verifier with one command:
 | Python     | PyPI      | `pipelock-verify`        | `pip install pipelock-verify` (separate repo) |
 | Go         | —         | `cmd/pipelock-verifier`  | built from this repo / release binaries |
 
-**Target: publish automatically when a release is tagged.** The goal is that
-cutting a Pipelock release also ships the verifiers, with no passwords stored in
-the repository (GitHub OIDC "trusted publishing" to both registries). Until that
-is wired, and to claim each package name the first time, use the one-time manual
-steps below.
+The TypeScript and Rust packages publish from their own `verifier-v*` tag. A
+Pipelock product tag does not publish them. GitHub OIDC trusted publishing sends
+both packages to their registries without stored npm or crates.io tokens.
 
 > Why automate: the Python verifier (`pipelock-verify`) was published once by
 > hand and then fell behind the receipt format because nobody re-ran the manual
@@ -97,6 +95,32 @@ Verify: the crate appears at <https://crates.io/crates/pipelock-verifier-rs>, an
 The README install lines (`npm install -g …` / `cargo install …`) only become
 true once the publish succeeds. Publish first, then merge / release the docs that
 point at the published packages, so the public docs are never ahead of reality.
+
+## Product release gate
+
+Do not publish a new verifier version while product or live-proof changes may
+still alter verifier source. After the candidate survives those checks:
+
+A verifier version bump intentionally blocks product releases until its tag is
+published and the registry digests are pinned in the installer inventory.
+
+1. Create the approved annotated `verifier-vX.Y.Z` tag and let
+   `publish-verifiers.yaml` publish both packages.
+2. Wait until npm and crates.io expose the new version. Record the peeled source
+   commit, npm `dist.integrity`, and crates.io checksum in
+   `release/verifier-installers.json`.
+3. Merge that metadata-only update and use the resulting product commit as the
+   new candidate. Runtime proof that does not consume this CI-only change stays
+   valid.
+4. Run `scripts/release-verifier-install-gate.sh --tag vX.Y.Z`. The gate builds
+   the Go verifier from the candidate, installs the exact public TypeScript,
+   Rust, and Python packages in empty directories, and requires every verifier
+   to accept a candidate receipt and reject its changed copy.
+
+The product release workflow repeats this gate before it builds or uploads
+release artifacts. A missing verifier tag, stale package, mismatched source
+commit, changed registry digest, install failure, valid-receipt rejection, or
+tampered-receipt acceptance stops the release.
 
 ## Auto-publish on release tag
 


### PR DESCRIPTION
## What changed

- Block tagged product releases before artifact construction unless the candidate Go verifier and exact public TypeScript, Rust, and Python packages install in isolated environments, accept a freshly signed candidate receipt, and reject its changed copy.
- Bind package identity, publisher workflow, source commit, and registry digest in one inventory. Missing tags, stale packages, digest drift, install failures, valid-receipt rejection, or tamper acceptance fail closed. Reviewers should distrust any path that substitutes source-tree conformance for the package customers install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a release verification gate that installs and validates Go, TypeScript, Rust, and Python verifiers before publication.
  - Verifies package versions, source commits, artifact integrity, publishing provenance, and receipt tamper detection.

- **Bug Fixes**
  - Prevents releases when verifier packages or metadata do not match expected release information.

- **Documentation**
  - Clarified independent verifier publishing and release validation requirements.

- **Tests**
  - Added comprehensive coverage for installation, inventory validation, metadata drift, and tampered receipt rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->