### PR TITLE
fix(proxy,contain): close the mediated metrics oracle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1405,6 +1405,29 @@ When a session is at a `block_all` level, blocked retries do not refresh the ses
 
 Session profiling detects domain bursts (many unique domains in a short window). When the burst threshold is crossed, the anomaly is signaled once per window with the configured score. Subsequent requests in the same window still trigger the configured `anomaly_action` (block or warn) but do not add further adaptive score, preventing burst detection from driving sessions to critical on its own. IP-wide domain bursts are tracked separately to catch agent-identity rotation from a single client IP. When `cooperative_tool_downweight` is enabled, burst signals from known cooperative tool user agents are reduced instead of scored at full browser-like weight.
 
+## Metrics listener
+
+Set `metrics_listen` to place `/metrics` and `/stats` on a dedicated address and port. The metrics port must differ from the proxy port. An ordinary deployment may use its own network controls for that listener.
+
+Containment uses loopback by default. A contained runtime can expose `/metrics` on an assigned numeric non-loopback address only with this explicit, time-limited policy:
+
+```yaml
+metrics_listen: 192.0.2.20:9091
+
+containment:
+  metrics_exposure:
+    allow_full_metrics: true
+    allowed_source_cidrs:
+      - 192.0.2.42/32
+    owner: observability
+    reason: Prometheus scrape from the monitoring host
+    expires_at: 2026-12-01T00:00:00Z
+```
+
+`allowed_source_cidrs` lists the only sources that may read `/metrics`. Use exact CIDRs for the scraper hosts. Wildcard source ranges, wildcard binds, and hostname binds are rejected. `owner`, `reason`, and `expires_at` make the exception reviewable during an incident. The expiry is RFC3339 and the listener stops serving remote metrics when it passes. `/stats` remains loopback-only.
+
+The proxy will not dial its own configured metrics address and port. That rule runs before trusted domains, `ssrf.ip_allowlist`, and grants, so a generic SSRF exception cannot expose metrics to a contained agent through the proxy.
+
 ## Kill Switch
 
 Emergency deny-all with six independent activation sources: `enabled`,

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -178,11 +178,11 @@ pipelock contain verify
 | 10 | `binary_integrity_pin` | The installed pipelock binary hash matches `/etc/pipelock/integrity/binary-pin.sha256`. |
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
 | 12 | `listed_tool_targets_resolvable` | Every entry in `tools.list` resolves to an executable absolute path in the agent user's PATH. |
-| 13 | `managed_config_metrics` | The managed config keeps `metrics_listen` on a dedicated numeric loopback port. It skips only when the config file is missing or permission is denied, and reports unknown for any other read failure. |
+| 13 | `managed_config_metrics` | The managed config keeps metrics on a dedicated numeric loopback port or verifies a current, source-scoped remote metrics exception. It skips only when the config file is missing or permission is denied, and reports unknown for any other read failure. |
 
 ### Managed metrics invariant
 
-Containment requires `metrics_listen` to remain a numeric loopback address on a port other than the agent-accessible proxy port. Keep the key present. Removing it registers `/metrics` and `/stats` on the proxy listener, where the contained agent can reach them.
+Containment keeps `metrics_listen` on a numeric loopback address and a port other than the agent-accessible proxy port by default. Keep the key present. Removing it registers `/metrics` and `/stats` on the proxy listener, where the contained agent can reach them.
 
 Repair the managed config with a dedicated loopback listener such as:
 
@@ -191,6 +191,25 @@ metrics_listen: 127.0.0.1:9091
 ```
 
 Choose another unused non-proxy port if `9091` is unavailable. Do not delete `metrics_listen` to disable metrics.
+
+When a Prometheus server must scrape from another host, declare a short-lived exception with the listener's assigned numeric address and the exact source CIDRs that may scrape it. `allow_full_metrics` is deliberately explicit because `/metrics` contains live enforcement data. `owner` and `reason` record who accepted that exposure and why. `expires_at` uses RFC3339 and must remain in the future.
+
+```yaml
+metrics_listen: 192.0.2.20:9091
+
+containment:
+  metrics_exposure:
+    allow_full_metrics: true
+    allowed_source_cidrs:
+      - 192.0.2.42/32
+    owner: observability
+    reason: Prometheus scrape from the monitoring host
+    expires_at: 2026-12-01T00:00:00Z
+```
+
+Replace the documentation addresses with addresses assigned to the host and scraper. Wildcard and hostname binds are rejected. An absent, malformed, or expired exception denies remote metrics requests, and probe 13 fails. `/metrics` returns 403 to every source outside `allowed_source_cidrs`. `/stats` remains loopback-only because it includes blocked domains and scanner categories.
+
+The proxy also refuses to dial its configured metrics address and port. An `ssrf.ip_allowlist`, trusted domain, or grant cannot reopen this path through the agent's permitted proxy connection.
 
 The nftables probes fail closed when attribution is ambiguous. A regular
 lookalike chain, a table-wide listing that happens to contain matching-looking

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,8 @@
 # Metrics Reference
 
-Pipelock exposes Prometheus metrics at `/metrics` on the proxy listen port
-(default 8888). All metric names are prefixed with `pipelock_` (or
-`pipelock_learn_` for the observation-pipeline family).
+Pipelock exposes Prometheus metrics at `/metrics` on the proxy listen port (default 8888). Set `metrics_listen` to move `/metrics` and `/stats` to a dedicated address and port. All metric names are prefixed with `pipelock_` (or `pipelock_learn_` for the observation-pipeline family).
+
+Contained deployments keep the dedicated listener on loopback by default. A contained listener on another numeric address needs a current `containment.metrics_exposure` policy that lists the exact scraper source CIDRs. That policy permits `/metrics` only. `/stats` remains loopback-only because it includes blocked domains and scanner categories. See [`pipelock contain`](contain-cli.md#managed-metrics-invariant) for the required policy fields and expiry behavior.
 
 ## Scrape Configuration
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -399,6 +399,7 @@ const (
 	EventLicenseExpiry          EventType = "license_expiry"
 	EventRuleBundleDegraded     EventType = "rule_bundle_degraded"
 	EventCommitmentKeyLifecycle EventType = "commitment_key_lifecycle"
+	EventContainmentMetricsDeny EventType = "containment_metrics_access_denied"
 )
 
 const responseScanExemptFullTrustEffect = "response_scanning.exempt_domains is a full-trust valve: injection scanning is disabled for ALL responses from this host, including oversized over-cap responses that stream unscanned"
@@ -1152,6 +1153,23 @@ func (l *Logger) LogAnomaly(ctx LogContext, scanner, reason string, score float6
 
 	if l.emitter != nil {
 		l.emitter.Emit(context.Background(), string(EventAnomaly), e.fields)
+	}
+}
+
+// LogContainmentMetricsDeny records a refused read of the containment-managed
+// observability listener. Callers pass only the parsed peer IP and fixed
+// endpoint path; request headers and metric contents are intentionally absent.
+func (l *Logger) LogContainmentMetricsDeny(endpoint, sourceIP, configuredListener, reason string) {
+	e := newLogEntry(l.zl.Warn(), EventContainmentMetricsDeny).
+		str("endpoint", endpoint).
+		str("client_ip", sourceIP).
+		str("configured_listener", configuredListener).
+		str("reason", reason).
+		str("outcome", "denied")
+	e.msg("containment metrics access denied")
+
+	if l.emitter != nil {
+		l.emitter.EmitWithSeverity(context.Background(), emit.SeverityWarn, string(EventContainmentMetricsDeny), e.fields)
 	}
 }
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -2885,6 +2885,32 @@ func newLoggerWithEmitter(t *testing.T) (*Logger, *collectingSink) {
 	return logger, sink
 }
 
+func TestLogContainmentMetricsDenyEmitsStructuredFields(t *testing.T) {
+	logger, sink := newLoggerWithEmitter(t)
+	defer logger.Close()
+
+	logger.LogContainmentMetricsDeny("/metrics", "192.0.2.42", "192.0.2.20:9091", "source_cidr_mismatch")
+	event, ok := sink.lastEvent()
+	if !ok {
+		t.Fatal("expected emitted containment metrics denial")
+	}
+	if event.Type != string(EventContainmentMetricsDeny) || event.Severity != emit.SeverityWarn {
+		t.Fatalf("event type/severity = %q/%v", event.Type, event.Severity)
+	}
+	want := map[string]any{
+		"endpoint":            "/metrics",
+		"client_ip":           "192.0.2.42",
+		"configured_listener": "192.0.2.20:9091",
+		"reason":              "source_cidr_mismatch",
+		"outcome":             "denied",
+	}
+	for field, value := range want {
+		if got := event.Fields[field]; got != value {
+			t.Errorf("%s = %v, want %v", field, got, value)
+		}
+	}
+}
+
 func mustHTTPLogContext(t *testing.T, method, targetURL, requestID string) LogContext {
 	t.Helper()
 	ctx, err := NewHTTPLogContext(method, targetURL, testClientIP, requestID, testAgentName)

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -85,6 +86,10 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 	// port and drop agent-owned traffic to other loopback ports.
 	metricsListen := strings.TrimSpace(scalarValue(mappingValue(mapping, "metrics_listen")))
 	proxyPort := effectiveProxyPort(mapping, env.proxyPort)
+	metricsExposure, err := containmentMetricsExposureFromMapping(mapping)
+	if err != nil {
+		return nil, nil, err
+	}
 	if metricsListen == "" {
 		// The value we are about to write gets the same check as one the
 		// operator wrote. It is a fixed port, so on a host whose proxy already
@@ -92,13 +97,13 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 		// have the installer produce a config its own runtime refuses: metrics
 		// come up disabled and the reason points at a line the operator never
 		// typed.
-		if err := config.ValidateContainmentMetricsListen(containMetricsListen, proxyPort); err != nil {
+		if err := config.ValidateContainmentMetricsExposure(containMetricsListen, proxyPort, metricsExposure, time.Now()); err != nil {
 			return nil, nil, fmt.Errorf("cannot migrate %s: the default containment metrics listener %s collides with this host's proxy port %d; "+
 				"set metrics_listen to another loopback port, or move fetch_proxy.listen: %w",
 				"metrics_listen", containMetricsListen, proxyPort, err)
 		}
 		setMappingScalar(mapping, "metrics_listen", containMetricsListen)
-	} else if err := config.ValidateContainmentMetricsListen(metricsListen, proxyPort); err != nil {
+	} else if err := config.ValidateContainmentMetricsExposure(metricsListen, proxyPort, metricsExposure, time.Now()); err != nil {
 		return nil, nil, err
 	}
 
@@ -174,10 +179,42 @@ func containServiceReadOnlyPaths(data []byte, proxyPort int) ([]string, error) {
 	if metricsListen == "" {
 		return nil, errors.New("metrics_listen must use a dedicated loopback port; rerun contain install with --config to migrate the managed config safely")
 	}
-	if err := config.ValidateContainmentMetricsListen(metricsListen, effectiveProxyPort(mapping, proxyPort)); err != nil {
+	metricsExposure, err := containmentMetricsExposureFromMapping(mapping)
+	if err != nil {
+		return nil, err
+	}
+	if err := config.ValidateContainmentMetricsExposure(metricsListen, effectiveProxyPort(mapping, proxyPort), metricsExposure, time.Now()); err != nil {
 		return nil, err
 	}
 	return containServiceReadOnlyPathsFromMapping(mapping)
+}
+
+func containmentMetricsExposureFromMapping(root *yaml.Node) (*config.ContainmentMetricsExposure, error) {
+	containment := mappingValue(root, "containment")
+	if containment == nil {
+		return nil, nil
+	}
+	if containment.Kind != yaml.MappingNode {
+		return nil, errors.New("containment must be a mapping")
+	}
+	exposure := mappingValue(containment, "metrics_exposure")
+	if exposure == nil {
+		return nil, nil
+	}
+	if exposure.Kind != yaml.MappingNode {
+		return nil, errors.New("containment.metrics_exposure must be a mapping")
+	}
+	data, err := yaml.Marshal(exposure)
+	if err != nil {
+		return nil, fmt.Errorf("encode containment.metrics_exposure: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	var policy config.ContainmentMetricsExposure
+	if err := decoder.Decode(&policy); err != nil {
+		return nil, fmt.Errorf("parse containment.metrics_exposure: %w", err)
+	}
+	return &policy, nil
 }
 
 // effectiveProxyPort returns the port the contained agent can actually reach.

--- a/internal/cli/contain/config_migrate.go
+++ b/internal/cli/contain/config_migrate.go
@@ -91,6 +91,9 @@ func migratePipelockConfigForContain(env *installEnv, configSource string, data 
 		return nil, nil, err
 	}
 	if metricsListen == "" {
+		if metricsExposure != nil {
+			return nil, nil, fmt.Errorf("containment.metrics_exposure requires an explicit non-loopback metrics_listen; set metrics_listen or remove the exposure policy")
+		}
 		// The value we are about to write gets the same check as one the
 		// operator wrote. It is a fixed port, so on a host whose proxy already
 		// runs there the default collides, and inserting it unchecked would

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -210,6 +210,26 @@ func TestMigratePipelockConfigForContain_PreservesApprovedMetricsExposure(t *tes
 	}
 }
 
+func TestMigratePipelockConfigForContain_RequiresExplicitListenerForMetricsExposure(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	configBody := []byte("containment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2099-01-01T00:00:00Z\n")
+	_, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), configBody)
+	if err == nil || !strings.Contains(err.Error(), "requires an explicit non-loopback metrics_listen") {
+		t.Fatalf("migrate error = %v, want explicit-listener remediation", err)
+	}
+	if strings.Contains(err.Error(), "collides") {
+		t.Fatalf("migrate error misreported a proxy-port collision: %v", err)
+	}
+}
+
 func TestMigratePipelockConfigForContain_RejectsAgentReachableMetricsListener(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	home := t.TempDir()

--- a/internal/cli/contain/config_migrate_test.go
+++ b/internal/cli/contain/config_migrate_test.go
@@ -188,6 +188,28 @@ func TestMigratePipelockConfigForContain_PreservesExplicitMetricsListener(t *tes
 	}
 }
 
+func TestMigratePipelockConfigForContain_PreservesApprovedMetricsExposure(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	home := t.TempDir()
+	origLookup := env.lookupUser
+	env.lookupUser = func(name string) (*user.User, error) {
+		if name == containInstallOperatorUser {
+			return &user.User{Uid: "1000", Gid: "1000", Username: name, HomeDir: home}, nil
+		}
+		return origLookup(name)
+	}
+	configBody := []byte("metrics_listen: 192.0.2.20:9191\ncontainment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2099-01-01T00:00:00Z\n")
+	out, _, err := migratePipelockConfigForContain(env, filepath.Join(home, "pipelock.yaml"), configBody)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, want := range []string{"192.0.2.20:9191", "metrics_exposure", "192.0.2.42/32", "observability"} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("migrated config missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestMigratePipelockConfigForContain_RejectsAgentReachableMetricsListener(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	home := t.TempDir()

--- a/internal/cli/contain/upgrade_test.go
+++ b/internal/cli/contain/upgrade_test.go
@@ -145,7 +145,7 @@ func TestUpgrade_UnsafeManagedConfigRefusesBeforeMutation(t *testing.T) {
 	if !errors.Is(err, errUpgradeConfig) {
 		t.Fatalf("error = %v, want errUpgradeConfig", err)
 	}
-	if !strings.Contains(err.Error(), "dedicated port") {
+	if !strings.Contains(err.Error(), "wildcard binds") {
 		t.Fatalf("error = %q, want containment metrics remediation", err)
 	}
 	if len(calls) != 0 {

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -336,7 +336,7 @@ func allProbes() []probe {
 		{10, "binary_integrity_pin", "deployed and running pipelock binary match TOFU pin", probeBinaryIntegrity},
 		{11, "cc_launch_allow_list_enforced", "plk-launch rejects tools missing from the allow-list", probeCCLaunchAllowList},
 		{12, "listed_tool_targets_resolvable", "tools.list entries resolve for pipelock-agent", probeListedToolTargets},
-		{13, "managed_config_metrics", "managed config keeps metrics on a dedicated loopback port", probeManagedConfigMetrics},
+		{13, "managed_config_metrics", "managed config keeps metrics on loopback or a current, source-scoped exception", probeManagedConfigMetrics},
 	}
 }
 
@@ -766,7 +766,7 @@ directly; the operator user must still reach the internet), verify the
 deployed and running service binaries match the TOFU integrity pin written at
 install time, exercise plk-launch end-to-end with a sentinel tool to confirm
 the allow-list enforcement path actually fires, and check that the managed
-config keeps metrics on a dedicated loopback port. Pass --workspace to also
+config keeps metrics on loopback or uses a current, source-scoped exception. Pass --workspace to also
 verify that pipelock-agent can read/traverse real project directories.
 Pass --enforcement-only when another process owns the proxy lifecycle;
 that mode verifies the kernel/user/wrapper controls and the pinned file at the

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -495,7 +495,7 @@ func TestProbeManagedConfigMetrics(t *testing.T) {
 				return []byte("metrics_listen: 192.0.2.20:9091\ncontainment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2099-01-01T00:00:00Z\n    typo: true\n"), nil
 			},
 			wantStatus: statusFail,
-			wantDetail: "field typo not found",
+			wantDetail: "parse containment.metrics_exposure",
 		},
 		{
 			name: "expired metrics exposure policy fails",

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -476,6 +476,36 @@ func TestProbeManagedConfigMetrics(t *testing.T) {
 			wantDetail: "keeps metrics off",
 		},
 		{
+			name: "current metrics exposure policy passes",
+			read: func(string) ([]byte, error) {
+				return []byte("metrics_listen: 192.0.2.20:9091\ncontainment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2099-01-01T00:00:00Z\n"), nil
+			},
+			wantStatus: statusPass,
+			wantDetail: "keeps metrics off",
+		},
+		{
+			name:       "non-loopback listener without exposure policy fails",
+			read:       func(string) ([]byte, error) { return []byte("metrics_listen: 192.0.2.20:9091\n"), nil },
+			wantStatus: statusFail,
+			wantDetail: "requires containment.metrics_exposure",
+		},
+		{
+			name: "malformed metrics exposure policy fails",
+			read: func(string) ([]byte, error) {
+				return []byte("metrics_listen: 192.0.2.20:9091\ncontainment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2099-01-01T00:00:00Z\n    typo: true\n"), nil
+			},
+			wantStatus: statusFail,
+			wantDetail: "field typo not found",
+		},
+		{
+			name: "expired metrics exposure policy fails",
+			read: func(string) ([]byte, error) {
+				return []byte("metrics_listen: 192.0.2.20:9091\ncontainment:\n  metrics_exposure:\n    allow_full_metrics: true\n    allowed_source_cidrs: [192.0.2.42/32]\n    owner: observability\n    reason: Prometheus scrape\n    expires_at: 2000-01-01T00:00:00Z\n"), nil
+			},
+			wantStatus: statusFail,
+			wantDetail: "expired at",
+		},
+		{
 			name:       "wildcard listener fails",
 			read:       func(string) ([]byte, error) { return []byte("metrics_listen: 0.0.0.0:9091\n"), nil },
 			wantStatus: statusFail,

--- a/internal/cli/runtime/containment_metrics.go
+++ b/internal/cli/runtime/containment_metrics.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
@@ -45,9 +46,16 @@ func validateContainmentMetricsConfig(cfg *config.Config) error {
 // containmentMetricsHandler enforces the source policy at request time. The
 // policy is read from the live config for every scrape so expiry and an
 // accepted hot reload take effect without rebinding the metrics listener.
-func containmentMetricsHandler(currentConfig func() *config.Config, denyAll func() bool, next http.Handler) http.Handler {
+func containmentMetricsHandler(currentConfig func() *config.Config, denyAll func() bool, report containmentMetricsDenyReporter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if denyAll() || !containmentMetricsRequestAllowed(currentConfig(), r.RemoteAddr, time.Now()) {
+		if denyAll() {
+			reportContainmentMetricsRequestDenied(report, "/metrics", r.RemoteAddr, "deny_all")
+			http.Error(w, "metrics access denied", http.StatusForbidden)
+			return
+		}
+		allowed, reason := containmentMetricsRequestDecision(currentConfig(), r.RemoteAddr, time.Now())
+		if !allowed {
+			reportContainmentMetricsRequestDenied(report, "/metrics", r.RemoteAddr, reason)
 			http.Error(w, "metrics access denied", http.StatusForbidden)
 			return
 		}
@@ -57,9 +65,10 @@ func containmentMetricsHandler(currentConfig func() *config.Config, denyAll func
 
 // containmentLoopbackHandler keeps the more detailed /stats endpoint local
 // even when an operator has approved remote Prometheus metrics collection.
-func containmentLoopbackHandler(next http.Handler) http.Handler {
+func containmentLoopbackHandler(report containmentMetricsDenyReporter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !containmentRequestSourceIP(r.RemoteAddr).IsLoopback() {
+			reportContainmentMetricsRequestDenied(report, "/stats", r.RemoteAddr, "non_loopback_stats")
 			http.Error(w, "stats access denied", http.StatusForbidden)
 			return
 		}
@@ -68,36 +77,50 @@ func containmentLoopbackHandler(next http.Handler) http.Handler {
 }
 
 func containmentMetricsRequestAllowed(cfg *config.Config, remoteAddr string, now time.Time) bool {
+	allowed, _ := containmentMetricsRequestDecision(cfg, remoteAddr, now)
+	return allowed
+}
+
+func containmentMetricsRequestDecision(cfg *config.Config, remoteAddr string, now time.Time) (bool, string) {
 	if cfg == nil {
-		return false
+		return false, "malformed_live_config"
 	}
 	_, port, err := net.SplitHostPort(cfg.FetchProxy.Listen)
 	if err != nil {
-		return false
+		return false, "malformed_live_config"
 	}
 	proxyPort, err := strconv.Atoi(port)
 	if err != nil || proxyPort < 1 || proxyPort > 65535 {
-		return false
+		return false, "malformed_live_config"
 	}
 	if err := config.ValidateContainmentMetricsExposure(cfg.MetricsListen, proxyPort, cfg.Containment.MetricsExposure, now); err != nil {
-		return false
+		if strings.Contains(err.Error(), "expired at") {
+			return false, "expired_policy"
+		}
+		return false, "malformed_live_config"
 	}
 	source := containmentRequestSourceIP(remoteAddr)
 	if source == nil {
-		return false
+		return false, "malformed_source"
 	}
 	host, _, err := net.SplitHostPort(cfg.MetricsListen)
 	if err != nil {
-		return false
+		return false, "malformed_live_config"
 	}
 	metricsIP := net.ParseIP(host)
 	if metricsIP == nil {
-		return false
+		return false, "malformed_live_config"
 	}
 	if metricsIP.IsLoopback() {
-		return source.IsLoopback()
+		if source.IsLoopback() {
+			return true, ""
+		}
+		return false, "source_cidr_mismatch"
 	}
-	return config.ContainmentMetricsExposureAllowsSource(cfg.Containment.MetricsExposure, source)
+	if config.ContainmentMetricsExposureAllowsSource(cfg.Containment.MetricsExposure, source) {
+		return true, ""
+	}
+	return false, "source_cidr_mismatch"
 }
 
 func containmentRequestSourceIP(remoteAddr string) net.IP {
@@ -106,6 +129,29 @@ func containmentRequestSourceIP(remoteAddr string) net.IP {
 		return nil
 	}
 	return net.ParseIP(host)
+}
+
+type containmentMetricsDenyReporter func(endpoint, remoteAddr, reason string)
+
+func reportContainmentMetricsRequestDenied(reporter containmentMetricsDenyReporter, endpoint, remoteAddr, reason string) {
+	if reporter != nil {
+		reporter(endpoint, remoteAddr, reason)
+	}
+}
+
+func (s *Server) reportContainmentMetricsRequestDenied(endpoint, remoteAddr, reason string) {
+	if s == nil || s.logger == nil || s.containmentMetricsDenyLog == nil || !s.containmentMetricsDenyLog.Allow() {
+		return
+	}
+	source := containmentRequestSourceIP(remoteAddr)
+	if source == nil {
+		source = net.IPv4zero
+	}
+	configured := ""
+	if cfg := s.proxy.CurrentConfig(); cfg != nil {
+		configured = cfg.MetricsListen
+	}
+	s.logger.LogContainmentMetricsDeny(endpoint, source.String(), configured, reason)
 }
 
 // reportContainmentMetricsDrift makes the degraded state visible to both the

--- a/internal/cli/runtime/containment_metrics.go
+++ b/internal/cli/runtime/containment_metrics.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -37,7 +39,73 @@ func validateContainmentMetricsConfig(cfg *config.Config) error {
 	if proxyPort < 1 || proxyPort > 65535 {
 		return fmt.Errorf("fetch_proxy.listen port %d is out of range for containment metrics policy", proxyPort)
 	}
-	return config.ValidateContainmentMetricsListen(cfg.MetricsListen, proxyPort)
+	return config.ValidateContainmentMetricsExposure(cfg.MetricsListen, proxyPort, cfg.Containment.MetricsExposure, time.Now())
+}
+
+// containmentMetricsHandler enforces the source policy at request time. The
+// policy is read from the live config for every scrape so expiry and an
+// accepted hot reload take effect without rebinding the metrics listener.
+func containmentMetricsHandler(currentConfig func() *config.Config, denyAll func() bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if denyAll() || !containmentMetricsRequestAllowed(currentConfig(), r.RemoteAddr, time.Now()) {
+			http.Error(w, "metrics access denied", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// containmentLoopbackHandler keeps the more detailed /stats endpoint local
+// even when an operator has approved remote Prometheus metrics collection.
+func containmentLoopbackHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !containmentRequestSourceIP(r.RemoteAddr).IsLoopback() {
+			http.Error(w, "stats access denied", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func containmentMetricsRequestAllowed(cfg *config.Config, remoteAddr string, now time.Time) bool {
+	if cfg == nil {
+		return false
+	}
+	_, port, err := net.SplitHostPort(cfg.FetchProxy.Listen)
+	if err != nil {
+		return false
+	}
+	proxyPort, err := strconv.Atoi(port)
+	if err != nil || proxyPort < 1 || proxyPort > 65535 {
+		return false
+	}
+	if err := config.ValidateContainmentMetricsExposure(cfg.MetricsListen, proxyPort, cfg.Containment.MetricsExposure, now); err != nil {
+		return false
+	}
+	source := containmentRequestSourceIP(remoteAddr)
+	if source == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(cfg.MetricsListen)
+	if err != nil {
+		return false
+	}
+	metricsIP := net.ParseIP(host)
+	if metricsIP == nil {
+		return false
+	}
+	if metricsIP.IsLoopback() {
+		return source.IsLoopback()
+	}
+	return config.ContainmentMetricsExposureAllowsSource(cfg.Containment.MetricsExposure, source)
+}
+
+func containmentRequestSourceIP(remoteAddr string) net.IP {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return nil
+	}
+	return net.ParseIP(host)
 }
 
 // reportContainmentMetricsDrift makes the degraded state visible to both the
@@ -49,7 +117,13 @@ func (s *Server) reportContainmentMetricsDrift(cfg *config.Config, phase string,
 	if cfg != nil {
 		configured = cfg.MetricsListen
 	}
-	detail := fmt.Sprintf("containment managed config drift: metrics listener %q disabled: %v; set metrics_listen to a numeric loopback address on a non-proxy port and do not delete the key", configured, drift)
+	state := "disabled"
+	outcome := "metrics_disabled"
+	if phase == "reload" {
+		state = "access denied"
+		outcome = "metrics_access_denied"
+	}
+	detail := fmt.Sprintf("containment managed config drift: metrics listener %q %s: %v; use a numeric loopback address on a non-proxy port, or provide a current containment.metrics_exposure policy for a specific non-loopback address", configured, state, drift)
 	_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: CRITICAL: %s\n", detail)
 	if s.logger != nil {
 		s.logger.LogError(audit.NewResourceLogContext("CONTAINMENT_MANAGED_CONFIG", s.opts.ConfigFile), errors.New(detail))
@@ -60,7 +134,7 @@ func (s *Server) reportContainmentMetricsDrift(cfg *config.Config, phase string,
 			"configured_listen": configured,
 			"phase":             phase,
 			"reason":            drift.Error(),
-			"outcome":           "metrics_disabled",
+			"outcome":           outcome,
 		})
 	}
 }

--- a/internal/cli/runtime/containment_metrics_policy_test.go
+++ b/internal/cli/runtime/containment_metrics_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -42,18 +43,20 @@ func TestContainmentMetricsRequestAllowedFailureDirections(t *testing.T) {
 		cfg        *config.Config
 		remoteAddr string
 		want       bool
+		wantReason string
 	}{
 		{name: "allowed source succeeds", cfg: newConfig(validPolicy()), remoteAddr: "192.0.2.42:49152", want: true},
-		{name: "source mismatch denies", cfg: newConfig(validPolicy()), remoteAddr: "192.0.2.43:49152"},
-		{name: "absent policy denies", cfg: newConfig(nil), remoteAddr: "192.0.2.42:49152"},
-		{name: "malformed policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"not-a-cidr"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-15T12:00:00Z"}), remoteAddr: "192.0.2.42:49152"},
-		{name: "expired policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"192.0.2.42/32"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-14T12:00:00Z"}), remoteAddr: "192.0.2.42:49152"},
+		{name: "source mismatch denies", cfg: newConfig(validPolicy()), remoteAddr: "192.0.2.43:49152", wantReason: "source_cidr_mismatch"},
+		{name: "absent policy denies", cfg: newConfig(nil), remoteAddr: "192.0.2.42:49152", wantReason: "malformed_live_config"},
+		{name: "malformed policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"not-a-cidr"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-15T12:00:00Z"}), remoteAddr: "192.0.2.42:49152", wantReason: "malformed_live_config"},
+		{name: "expired policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"192.0.2.42/32"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-14T12:00:00Z"}), remoteAddr: "192.0.2.42:49152", wantReason: "expired_policy"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := containmentMetricsRequestAllowed(tt.cfg, tt.remoteAddr, now); got != tt.want {
-				t.Fatalf("containmentMetricsRequestAllowed = %v, want %v", got, tt.want)
+			got, reason := containmentMetricsRequestDecision(tt.cfg, tt.remoteAddr, now)
+			if got != tt.want || reason != tt.wantReason {
+				t.Fatalf("containmentMetricsRequestDecision = %v, %q; want %v, %q", got, reason, tt.want, tt.wantReason)
 			}
 		})
 	}
@@ -72,7 +75,11 @@ func TestContainmentMetricsHandlersEnforceSourcePolicyAndStatsLoopback(t *testin
 		ExpiresAt:          now,
 	}
 	var metricsHits atomic.Int64
-	metricsHandler := containmentMetricsHandler(func() *config.Config { return cfg }, func() bool { return false }, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var denials []string
+	report := func(endpoint, _, reason string) {
+		denials = append(denials, endpoint+":"+reason)
+	}
+	metricsHandler := containmentMetricsHandler(func() *config.Config { return cfg }, func() bool { return false }, report, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		metricsHits.Add(1)
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -98,7 +105,7 @@ func TestContainmentMetricsHandlersEnforceSourcePolicyAndStatsLoopback(t *testin
 		t.Fatalf("metrics handler calls = %d, want 1", got)
 	}
 
-	statsHandler := containmentLoopbackHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	statsHandler := containmentLoopbackHandler(report, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	for _, tt := range []struct {
@@ -118,6 +125,9 @@ func TestContainmentMetricsHandlersEnforceSourcePolicyAndStatsLoopback(t *testin
 				t.Fatalf("stats status = %d, want %d", rec.Code, tt.wantStatus)
 			}
 		})
+	}
+	if got, want := denials, []string{"/metrics:source_cidr_mismatch", "/stats:non_loopback_stats"}; !slices.Equal(got, want) {
+		t.Fatalf("denial reports = %v, want %v", got, want)
 	}
 }
 
@@ -154,7 +164,14 @@ containment:
 	defer cancel()
 	done := make(chan error, 1)
 	go func() { done <- s.Start(ctx) }()
-	client := &http.Client{Transport: &http.Transport{Proxy: nil}, Timeout: time.Second}
+	dialer := &net.Dialer{LocalAddr: &net.TCPAddr{IP: net.ParseIP(host)}}
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:       nil,
+			DialContext: dialer.DialContext,
+		},
+		Timeout: time.Second,
+	}
 	get := func(path string) int {
 		t.Helper()
 		status := 0

--- a/internal/cli/runtime/containment_metrics_policy_test.go
+++ b/internal/cli/runtime/containment_metrics_policy_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/testport"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+func TestContainmentMetricsRequestAllowedFailureDirections(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	validPolicy := func() *config.ContainmentMetricsExposure {
+		return &config.ContainmentMetricsExposure{
+			AllowFullMetrics:   true,
+			AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+			Owner:              "observability",
+			Reason:             "Prometheus scrape",
+			ExpiresAt:          "2026-08-15T12:00:00Z",
+		}
+	}
+	newConfig := func(policy *config.ContainmentMetricsExposure) *config.Config {
+		cfg := config.Defaults()
+		cfg.FetchProxy.Listen = "127.0.0.1:8888"
+		cfg.MetricsListen = "192.0.2.20:9091"
+		cfg.Containment.MetricsExposure = policy
+		return cfg
+	}
+
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		remoteAddr string
+		want       bool
+	}{
+		{name: "allowed source succeeds", cfg: newConfig(validPolicy()), remoteAddr: "192.0.2.42:49152", want: true},
+		{name: "source mismatch denies", cfg: newConfig(validPolicy()), remoteAddr: "192.0.2.43:49152"},
+		{name: "absent policy denies", cfg: newConfig(nil), remoteAddr: "192.0.2.42:49152"},
+		{name: "malformed policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"not-a-cidr"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-15T12:00:00Z"}), remoteAddr: "192.0.2.42:49152"},
+		{name: "expired policy denies", cfg: newConfig(&config.ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"192.0.2.42/32"}, Owner: "observability", Reason: "Prometheus scrape", ExpiresAt: "2026-08-14T12:00:00Z"}), remoteAddr: "192.0.2.42:49152"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containmentMetricsRequestAllowed(tt.cfg, tt.remoteAddr, now); got != tt.want {
+				t.Fatalf("containmentMetricsRequestAllowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainmentMetricsHandlersEnforceSourcePolicyAndStatsLoopback(t *testing.T) {
+	now := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	cfg := config.Defaults()
+	cfg.FetchProxy.Listen = "127.0.0.1:8888"
+	cfg.MetricsListen = "192.0.2.20:9091"
+	cfg.Containment.MetricsExposure = &config.ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+		Owner:              "observability",
+		Reason:             "Prometheus scrape",
+		ExpiresAt:          now,
+	}
+	var metricsHits atomic.Int64
+	metricsHandler := containmentMetricsHandler(func() *config.Config { return cfg }, func() bool { return false }, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		metricsHits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for _, tt := range []struct {
+		name       string
+		remoteAddr string
+		wantStatus int
+	}{
+		{name: "allowed scraper", remoteAddr: "192.0.2.42:49152", wantStatus: http.StatusNoContent},
+		{name: "other source", remoteAddr: "192.0.2.43:49152", wantStatus: http.StatusForbidden},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = tt.remoteAddr
+			rec := httptest.NewRecorder()
+			metricsHandler.ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("metrics status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+	if got := metricsHits.Load(); got != 1 {
+		t.Fatalf("metrics handler calls = %d, want 1", got)
+	}
+
+	statsHandler := containmentLoopbackHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for _, tt := range []struct {
+		name       string
+		remoteAddr string
+		wantStatus int
+	}{
+		{name: "remote metrics source cannot read stats", remoteAddr: "192.0.2.42:49152", wantStatus: http.StatusForbidden},
+		{name: "loopback can read stats", remoteAddr: "127.0.0.1:49152", wantStatus: http.StatusNoContent},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil)
+			req.RemoteAddr = tt.remoteAddr
+			rec := httptest.NewRecorder()
+			statsHandler.ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("stats status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestServer_ContainmentMetricsExposureServesOnlyAllowedScraper(t *testing.T) {
+	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
+	host := containmentNonLoopbackIPv4(t)
+	metricsAddr := reserveTCPAddress(t, host)
+	fetchListen := testport.ListenAddrs(t, 1)[0]
+	configBody := fmt.Sprintf(`mode: balanced
+metrics_listen: %q
+containment:
+  metrics_exposure:
+    allow_full_metrics: true
+    allowed_source_cidrs:
+      - %q
+    owner: observability
+    reason: Prometheus scrape
+    expires_at: %q
+`, metricsAddr, host+"/32", time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
+	stderr := &syncBuffer{}
+	s, err := NewServer(ServerOpts{
+		ConfigFile:                        writeServerTestConfig(t, configBody),
+		Listen:                            fetchListen,
+		ListenChanged:                     true,
+		Stdout:                            stderr,
+		Stderr:                            stderr,
+		allowEphemeralListenersForTesting: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(s.cleanup)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Start(ctx) }()
+	client := &http.Client{Transport: &http.Transport{Proxy: nil}, Timeout: time.Second}
+	get := func(path string) int {
+		t.Helper()
+		status := 0
+		testwait.For(t, 3*time.Second, func() bool {
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+metricsAddr+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := client.Do(request)
+			if err != nil {
+				return false
+			}
+			defer func() { _ = response.Body.Close() }()
+			status = response.StatusCode
+			return true
+		}, "configured metrics listener to accept a scrape")
+		return status
+	}
+
+	metricsStatus := get("/metrics")
+	if metricsStatus != http.StatusOK {
+		t.Fatalf("allowed scraper status = %d, want %d", metricsStatus, http.StatusOK)
+	}
+	statsStatus := get("/stats")
+	if statsStatus != http.StatusForbidden {
+		t.Fatalf("remote stats status = %d, want %d", statsStatus, http.StatusForbidden)
+	}
+
+	expired := s.proxy.CurrentConfig().Clone()
+	expired.Containment.MetricsExposure.ExpiresAt = time.Now().UTC().Add(-time.Second).Format(time.RFC3339)
+	if err := s.Reload(expired); err == nil {
+		t.Fatal("Reload accepted an expired containment metrics exposure")
+	}
+	deniedStatus := get("/metrics")
+	if deniedStatus != http.StatusForbidden {
+		t.Fatalf("expired-policy scrape status = %d, want %d", deniedStatus, http.StatusForbidden)
+	}
+	if !s.containmentMetricsDenied.Load() {
+		t.Fatal("rejected containment reload left metrics access enabled")
+	}
+
+	if err := s.Reload(s.proxy.CurrentConfig().Clone()); err != nil {
+		t.Fatalf("Reload valid containment metrics policy: %v", err)
+	}
+	restoredStatus := get("/metrics")
+	if restoredStatus != http.StatusOK {
+		t.Fatalf("restored-policy scrape status = %d, want %d", restoredStatus, http.StatusOK)
+	}
+	if s.containmentMetricsDenied.Load() {
+		t.Fatal("valid containment reload did not restore metrics access")
+	}
+
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for containment metrics server shutdown")
+	}
+}
+
+func containmentNonLoopbackIPv4(t *testing.T) string {
+	t.Helper()
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addresses, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, address := range addresses {
+			ip, _, err := net.ParseCIDR(address.String())
+			if err == nil && ip.To4() != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+				return ip.String()
+			}
+		}
+	}
+	t.Skip("no non-loopback IPv4 address is available for containment metrics listener test")
+	return ""
+}
+
+func reserveTCPAddress(t *testing.T, host string) string {
+	t.Helper()
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}

--- a/internal/cli/runtime/containment_metrics_refusals_test.go
+++ b/internal/cli/runtime/containment_metrics_refusals_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestContainmentMetricsRequestAllowedRefusesUnusableInput covers every way the
+// decision can fail to establish that a request is permitted.
+//
+// This function answers one question, may this caller read the metrics, and its
+// only safe default is no. Each branch below returns false because something
+// could not be determined rather than because a rule said deny, and an
+// undetermined answer resolving to yes is how a policy check becomes decoration.
+func TestContainmentMetricsRequestAllowedRefusesUnusableInput(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	valid := &config.ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"10.20.0.42/32"},
+		Owner:              "observability",
+		Reason:             "workstation scrape",
+		ExpiresAt:          now.Add(24 * time.Hour).UTC().Format(time.RFC3339),
+	}
+
+	withConfig := func(fetchListen, metricsListen string, policy *config.ContainmentMetricsExposure) *config.Config {
+		c := config.Defaults()
+		c.ApplyDefaults()
+		c.FetchProxy.Listen = fetchListen
+		c.MetricsListen = metricsListen
+		c.Containment.MetricsExposure = policy
+		return c
+	}
+
+	tests := []struct {
+		name   string
+		cfg    *config.Config
+		remote string
+		want   bool
+	}{
+		{"nil config", nil, "10.20.0.42:5000", false},
+		{
+			"unparsable proxy listener",
+			withConfig("not-a-host-port", "10.20.0.20:9091", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"non-numeric proxy port",
+			withConfig("127.0.0.1:proxy", "10.20.0.20:9091", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"proxy port out of range",
+			withConfig("127.0.0.1:70000", "10.20.0.20:9091", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"no exposure policy for a routable listener",
+			withConfig("127.0.0.1:8888", "10.20.0.20:9091", nil),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"remote address is not host:port",
+			withConfig("127.0.0.1:8888", "10.20.0.20:9091", valid),
+			"garbage", false,
+		},
+		{
+			"remote host is not an IP",
+			withConfig("127.0.0.1:8888", "10.20.0.20:9091", valid),
+			"scraper.internal:5000", false,
+		},
+		{
+			"metrics listener is not host:port",
+			withConfig("127.0.0.1:8888", "not-a-host-port", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"metrics host is not an IP",
+			withConfig("127.0.0.1:8888", "localhost:9091", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			// A loopback listener answers loopback callers and nobody else,
+			// whatever the policy says. The policy governs a routable listener.
+			"loopback listener refuses a remote caller",
+			withConfig("127.0.0.1:8888", "127.0.0.1:9091", valid),
+			"10.20.0.42:5000", false,
+		},
+		{
+			"loopback listener allows a loopback caller",
+			withConfig("127.0.0.1:8888", "127.0.0.1:9091", nil),
+			"127.0.0.1:5000", true,
+		},
+		{
+			"routable listener allows a declared source",
+			withConfig("127.0.0.1:8888", "10.20.0.20:9091", valid),
+			"10.20.0.42:5000", true,
+		},
+		{
+			"routable listener refuses an undeclared source",
+			withConfig("127.0.0.1:8888", "10.20.0.20:9091", valid),
+			"10.20.0.99:5000", false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containmentMetricsRequestAllowed(tt.cfg, tt.remote, now); got != tt.want {
+				t.Errorf("allowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime/containment_metrics_test.go
+++ b/internal/cli/runtime/containment_metrics_test.go
@@ -157,15 +157,15 @@ func TestNewServer_ContainmentLoopbackMetricsRemainEnabled(t *testing.T) {
 	}
 }
 
-func TestServer_ReloadContainmentUnsafeMetricsPreservesLiveListenerAndReportsCritical(t *testing.T) {
+func TestServer_ReloadContainmentUnsafeMetricsRejectsAndReportsCritical(t *testing.T) {
 	t.Setenv(config.ContainmentManagedEnvKey, config.ContainmentManagedEnvValue)
 	s, stderr := newContainmentMetricsTestServer(t, "127.0.0.1:19091", "")
 	oldCfg := s.proxy.CurrentConfig()
 	newCfg := oldCfg.Clone()
 	newCfg.MetricsListen = "0.0.0.0:19092"
 
-	if err := s.Reload(newCfg); err != nil {
-		t.Fatalf("Reload: %v", err)
+	if err := s.Reload(newCfg); err == nil {
+		t.Fatal("Reload accepted an unsafe containment metrics listener")
 	}
 	if got := s.proxy.CurrentConfig().MetricsListen; got != oldCfg.MetricsListen {
 		t.Fatalf("live metrics listener = %q, want preserved %q", got, oldCfg.MetricsListen)

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 	plsentry "github.com/luckyPipewrench/pipelock/internal/sentry"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
+	"golang.org/x/time/rate"
 )
 
 // ServerOpts carries the CLI-flag surface and I/O bindings for a runtime
@@ -108,6 +109,9 @@ type Server struct {
 	// invalid metrics listener or policy. The bound listener stays up, but its handler
 	// denies every request until a valid policy is reloaded.
 	containmentMetricsDenied atomic.Bool
+	// containmentMetricsDenyLog bounds attacker-driven audit volume from the
+	// unauthenticated observability listener.
+	containmentMetricsDenyLog *rate.Limiter
 
 	cfg          *config.Config
 	bundleResult *rules.LoadResult
@@ -326,9 +330,10 @@ func NewServer(opts ServerOpts) (*Server, error) {
 	}
 
 	s := &Server{
-		opts:               opts,
-		hasMCPListen:       hasMCPListen,
-		containmentManaged: containmentManagedRuntime(),
+		opts:                      opts,
+		hasMCPListen:              hasMCPListen,
+		containmentManaged:        containmentManagedRuntime(),
+		containmentMetricsDenyLog: rate.NewLimiter(rate.Every(time.Second), 5),
 	}
 	s.mcpListenerBearerToken = mcpAuthToken
 	if cfg.EvidenceProvenance.CommitmentKeyringPath != "" {

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -104,6 +104,10 @@ type Server struct {
 	hasApprover        bool
 	containmentManaged bool
 	metricsDisabled    bool
+	// containmentMetricsDenied is set when a containment reload presents an
+	// invalid metrics listener or policy. The bound listener stays up, but its handler
+	// denies every request until a valid policy is reloaded.
+	containmentMetricsDenied atomic.Bool
 
 	cfg          *config.Config
 	bundleResult *rules.LoadResult

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -683,8 +683,8 @@ func (s *Server) Start(ctx context.Context) error {
 	if cfg.MetricsListen != "" && !s.metricsDisabled {
 		metricsMux := http.NewServeMux()
 		if s.containmentManaged {
-			metricsMux.Handle("/metrics", containmentMetricsHandler(s.proxy.CurrentConfig, s.containmentMetricsDenied.Load, s.metrics.PrometheusHandler()))
-			metricsMux.Handle("/stats", containmentLoopbackHandler(s.metrics.StatsHandler()))
+			metricsMux.Handle("/metrics", containmentMetricsHandler(s.proxy.CurrentConfig, s.containmentMetricsDenied.Load, s.reportContainmentMetricsRequestDenied, s.metrics.PrometheusHandler()))
+			metricsMux.Handle("/stats", containmentLoopbackHandler(s.reportContainmentMetricsRequestDenied, s.metrics.StatsHandler()))
 		} else {
 			metricsMux.Handle("/metrics", s.metrics.PrometheusHandler())
 			metricsMux.HandleFunc("/stats", s.metrics.StatsHandler())

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -682,8 +682,13 @@ func (s *Server) Start(ctx context.Context) error {
 	var metricsErr chan error
 	if cfg.MetricsListen != "" && !s.metricsDisabled {
 		metricsMux := http.NewServeMux()
-		metricsMux.Handle("/metrics", s.metrics.PrometheusHandler())
-		metricsMux.HandleFunc("/stats", s.metrics.StatsHandler())
+		if s.containmentManaged {
+			metricsMux.Handle("/metrics", containmentMetricsHandler(s.proxy.CurrentConfig, s.containmentMetricsDenied.Load, s.metrics.PrometheusHandler()))
+			metricsMux.Handle("/stats", containmentLoopbackHandler(s.metrics.StatsHandler()))
+		} else {
+			metricsMux.Handle("/metrics", s.metrics.PrometheusHandler())
+			metricsMux.HandleFunc("/stats", s.metrics.StatsHandler())
+		}
 
 		metricsLn, lnErr := (&net.ListenConfig{}).Listen(ctx, "tcp", cfg.MetricsListen)
 		if lnErr != nil {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -57,6 +57,13 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 		return rejectErr
 	}
+	if s.containmentManaged {
+		if containmentErr := validateContainmentMetricsConfig(newCfg); containmentErr != nil {
+			s.containmentMetricsDenied.Store(true)
+			s.reportContainmentMetricsDrift(newCfg, "reload", containmentErr)
+			return fmt.Errorf("rejected: invalid containment metrics configuration: %w", containmentErr)
+		}
+	}
 
 	oldCfg := s.proxy.CurrentConfig()
 	flightRecorderAnchorChanged := oldCfg != nil && !reflect.DeepEqual(oldCfg.FlightRecorder.Anchor, newCfg.FlightRecorder.Anchor)
@@ -94,18 +101,12 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// Block metrics_listen changes via reload. The metrics server
 		// binds at startup and can't rebind at runtime.
 		if oldCfg.MetricsListen != newCfg.MetricsListen {
-			if s.containmentManaged {
-				if containmentErr := validateContainmentMetricsConfig(newCfg); containmentErr != nil {
-					s.reportContainmentMetricsDrift(newCfg, "reload", containmentErr)
-				} else {
-					_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
-						oldCfg.MetricsListen, newCfg.MetricsListen)
-				}
-			} else {
-				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
-					oldCfg.MetricsListen, newCfg.MetricsListen)
-			}
+			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: metrics_listen changed from %q to %q — requires restart, ignoring\n",
+				oldCfg.MetricsListen, newCfg.MetricsListen)
 			newCfg.MetricsListen = oldCfg.MetricsListen
+			if s.containmentManaged {
+				newCfg.Containment.MetricsExposure = oldCfg.Containment.MetricsExposure
+			}
 		}
 		// Block scan_api listener setting changes via reload. The Scan
 		// API server binds at startup and cannot rebind or reconfigure
@@ -491,6 +492,9 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 	})
 	if !s.proxy.Reload(newCfg, newSc) {
 		return errors.New("reload failed: proxy kept previous config")
+	}
+	if s.containmentManaged {
+		s.containmentMetricsDenied.Store(false)
 	}
 	fireReloadAfterProxySwapHook(s)
 	s.refreshRuntimeState(oldCfg, newCfg, reloadBundleResult, s.proxy.ScannerPtr().Load())

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -97,6 +97,18 @@ func TestCanonicalPolicyHash_NoiseFieldsDoNotAffect(t *testing.T) {
 			mut:  func(c *Config) { c.MetricsListen = ":19997" },
 		},
 		{
+			name: "containment.metrics_exposure",
+			mut: func(c *Config) {
+				c.Containment.MetricsExposure = &ContainmentMetricsExposure{
+					AllowFullMetrics:   true,
+					AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+					Owner:              "observability",
+					Reason:             "Prometheus scrape",
+					ExpiresAt:          "2026-12-01T00:00:00Z",
+				}
+			},
+		},
+		{
 			// fetch_proxy.listen is operational plumbing - rebinding the
 			// port does not change any enforcement decision. Explicitly
 			// excluded in policySemanticView so ops can move the listen

--- a/internal/config/containment.go
+++ b/internal/config/containment.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // ContainmentManagedEnvKey and ContainmentManagedEnvValue identify a Pipelock
@@ -24,6 +25,32 @@ const (
 // non-proxy TCP port. It does not participate in Config.Validate, because
 // ordinary Pipelock deployments may intentionally expose metrics on a LAN.
 func ValidateContainmentMetricsListen(listen string, proxyPort int) error {
+	return ValidateContainmentMetricsExposure(listen, proxyPort, nil, time.Now())
+}
+
+// ContainmentConfig holds settings that are enforced only by the containment
+// lifecycle. It is kept separate from ordinary proxy configuration because
+// the containment runtime owns the kernel boundary around the agent.
+type ContainmentConfig struct {
+	MetricsExposure *ContainmentMetricsExposure `yaml:"metrics_exposure"`
+}
+
+// ContainmentMetricsExposure records the deliberate exception required to
+// serve full Prometheus metrics beyond loopback from a contained runtime.
+// Every field is required so an operator can identify who accepted the
+// exposure, why, when it ends, and which scrapers may use it.
+type ContainmentMetricsExposure struct {
+	AllowFullMetrics   bool     `yaml:"allow_full_metrics"`
+	AllowedSourceCIDRs []string `yaml:"allowed_source_cidrs"`
+	Owner              string   `yaml:"owner"`
+	Reason             string   `yaml:"reason"`
+	ExpiresAt          string   `yaml:"expires_at"`
+}
+
+// ValidateContainmentMetricsExposure enforces the containment metrics
+// listener invariant. Loopback needs no exception. Any other numeric address
+// requires a complete, current metrics exposure policy.
+func ValidateContainmentMetricsExposure(listen string, proxyPort int, policy *ContainmentMetricsExposure, now time.Time) error {
 	if strings.TrimSpace(listen) == "" {
 		return fmt.Errorf("metrics_listen is unsafe for containment: set a numeric loopback address on a dedicated port and do not delete the key")
 	}
@@ -32,12 +59,79 @@ func ValidateContainmentMetricsListen(listen string, proxyPort int) error {
 		return fmt.Errorf("metrics_listen %q is unsafe for containment: %w", listen, err)
 	}
 	ip := net.ParseIP(host)
-	if ip == nil || !ip.IsLoopback() {
-		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric loopback address on a dedicated port", listen)
+	if ip == nil {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a numeric address, not a hostname", listen)
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("metrics_listen %q is unsafe for containment: wildcard binds are not allowed", listen)
 	}
 	parsedPort, err := strconv.ParseUint(port, 10, 16)
 	if err != nil || parsedPort == 0 || int(parsedPort) == proxyPort {
 		return fmt.Errorf("metrics_listen %q is unsafe for containment: use a port other than the agent-accessible proxy port %d", listen, proxyPort)
 	}
+	if ip.IsLoopback() {
+		if policy != nil {
+			return fmt.Errorf("containment.metrics_exposure requires a non-loopback metrics_listen address")
+		}
+		return nil
+	}
+	if err := validateContainmentMetricsExposurePolicy(policy, now); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateContainmentMetricsExposurePolicy(policy *ContainmentMetricsExposure, now time.Time) error {
+	if policy == nil {
+		return fmt.Errorf("non-loopback metrics_listen requires containment.metrics_exposure")
+	}
+	if !policy.AllowFullMetrics {
+		return fmt.Errorf("containment.metrics_exposure.allow_full_metrics must be true")
+	}
+	if strings.TrimSpace(policy.Owner) == "" {
+		return fmt.Errorf("containment.metrics_exposure.owner is required")
+	}
+	if strings.TrimSpace(policy.Reason) == "" {
+		return fmt.Errorf("containment.metrics_exposure.reason is required")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, strings.TrimSpace(policy.ExpiresAt))
+	if err != nil {
+		return fmt.Errorf("containment.metrics_exposure.expires_at must use RFC3339: %w", err)
+	}
+	if !expiresAt.After(now) {
+		return fmt.Errorf("containment.metrics_exposure expired at %s", expiresAt.UTC().Format(time.RFC3339))
+	}
+	if len(policy.AllowedSourceCIDRs) == 0 {
+		return fmt.Errorf("containment.metrics_exposure.allowed_source_cidrs must name at least one source")
+	}
+	for i, source := range policy.AllowedSourceCIDRs {
+		ip, cidr, err := net.ParseCIDR(strings.TrimSpace(source))
+		if err != nil {
+			return fmt.Errorf("containment.metrics_exposure.allowed_source_cidrs[%d] %q is invalid: %w", i, source, err)
+		}
+		if !ip.Equal(cidr.IP) {
+			return fmt.Errorf("containment.metrics_exposure.allowed_source_cidrs[%d] %q must use a network address", i, source)
+		}
+		ones, bits := cidr.Mask.Size()
+		if ones == 0 && (bits == 32 || bits == 128) {
+			return fmt.Errorf("containment.metrics_exposure.allowed_source_cidrs[%d] %q must not allow every source", i, source)
+		}
+	}
+	return nil
+}
+
+// ContainmentMetricsExposureAllowsSource reports whether an already-validated
+// policy permits the connecting address. Invalid policies deny by returning
+// false so callers never turn a parse failure into an open metrics endpoint.
+func ContainmentMetricsExposureAllowsSource(policy *ContainmentMetricsExposure, source net.IP) bool {
+	if policy == nil || source == nil {
+		return false
+	}
+	for _, rawCIDR := range policy.AllowedSourceCIDRs {
+		_, cidr, err := net.ParseCIDR(strings.TrimSpace(rawCIDR))
+		if err == nil && cidr.Contains(source) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/containment_error_paths_test.go
+++ b/internal/config/containment_error_paths_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestValidateContainmentMetricsListenRefusals covers every refusal branch.
@@ -43,21 +44,21 @@ func TestValidateContainmentMetricsListenRefusals(t *testing.T) {
 		},
 		{
 			name:       "LAN address",
-			listen:     "10.20.0.20:9091",
+			listen:     "192.0.2.20:9091",
 			wantErr:    true,
-			wantDetail: "numeric loopback address",
+			wantDetail: "metrics_exposure",
 		},
 		{
 			name:       "wildcard address",
 			listen:     "0.0.0.0:9091",
 			wantErr:    true,
-			wantDetail: "numeric loopback address",
+			wantDetail: "wildcard binds",
 		},
 		{
 			name:       "hostname rather than a numeric address",
 			listen:     "localhost:9091",
 			wantErr:    true,
-			wantDetail: "numeric loopback address",
+			wantDetail: "numeric address, not a hostname",
 		},
 		{
 			name:       "loopback on the proxy port is refused",
@@ -97,6 +98,48 @@ func TestValidateContainmentMetricsListenRefusals(t *testing.T) {
 			if !strings.Contains(err.Error(), tt.wantDetail) {
 				t.Errorf("error %q does not carry the remediation %q; an operator reads this to know what to change",
 					err.Error(), tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestValidateContainmentMetricsExposurePolicy(t *testing.T) {
+	now := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	valid := &ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+		Owner:              "observability",
+		Reason:             "Prometheus scrape",
+		ExpiresAt:          "2026-08-15T12:00:00Z",
+	}
+	tests := []struct {
+		name       string
+		policy     *ContainmentMetricsExposure
+		wantDetail string
+	}{
+		{name: "complete current policy", policy: valid},
+		{name: "absent policy", wantDetail: "requires containment.metrics_exposure"},
+		{name: "allow is not explicit", policy: &ContainmentMetricsExposure{AllowedSourceCIDRs: valid.AllowedSourceCIDRs, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: valid.ExpiresAt}, wantDetail: "allow_full_metrics"},
+		{name: "missing owner", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: valid.AllowedSourceCIDRs, Reason: valid.Reason, ExpiresAt: valid.ExpiresAt}, wantDetail: "owner is required"},
+		{name: "missing reason", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: valid.AllowedSourceCIDRs, Owner: valid.Owner, ExpiresAt: valid.ExpiresAt}, wantDetail: "reason is required"},
+		{name: "malformed expiry", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: valid.AllowedSourceCIDRs, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: "tomorrow"}, wantDetail: "expires_at must use RFC3339"},
+		{name: "expired", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: valid.AllowedSourceCIDRs, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: "2026-08-14T12:00:00Z"}, wantDetail: "expired at"},
+		{name: "malformed source CIDR", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"not-a-cidr"}, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: valid.ExpiresAt}, wantDetail: "is invalid"},
+		{name: "source CIDR with host bits", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"192.0.2.42/24"}, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: valid.ExpiresAt}, wantDetail: "network address"},
+		{name: "all sources", policy: &ContainmentMetricsExposure{AllowFullMetrics: true, AllowedSourceCIDRs: []string{"0.0.0.0/0"}, Owner: valid.Owner, Reason: valid.Reason, ExpiresAt: valid.ExpiresAt}, wantDetail: "must not allow every source"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateContainmentMetricsExposure("192.0.2.20:9091", 8888, tt.policy, now)
+			if tt.wantDetail == "" {
+				if err != nil {
+					t.Fatalf("ValidateContainmentMetricsExposure = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantDetail) {
+				t.Fatalf("ValidateContainmentMetricsExposure = %v, want error containing %q", err, tt.wantDetail)
 			}
 		})
 	}

--- a/internal/config/containment_exposure_policy_test.go
+++ b/internal/config/containment_exposure_policy_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func validExposure(now time.Time) *ContainmentMetricsExposure {
+	return &ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"10.20.0.42/32"},
+		Owner:              "observability",
+		Reason:             "workstation scrape",
+		ExpiresAt:          now.Add(24 * time.Hour).UTC().Format(time.RFC3339),
+	}
+}
+
+// TestContainmentMetricsExposureRejectsUnusablePolicy pins each way a declared
+// exposure fails to be a real declaration.
+//
+// This policy widens a containment control, so the value of the fields is the
+// whole point: an exposure with no owner, no reason or no expiry is an
+// exception nobody can review later, and one that names every source is not an
+// exception at all.
+func TestContainmentMetricsExposureRejectsUnusablePolicy(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	const listen = "10.20.0.20:9091"
+	const proxyPort = 8888
+
+	tests := []struct {
+		name   string
+		mutate func(p *ContainmentMetricsExposure)
+		want   string
+	}{
+		{
+			name:   "a source that is not a CIDR",
+			mutate: func(p *ContainmentMetricsExposure) { p.AllowedSourceCIDRs = []string{"10.20.0.42"} },
+			want:   "is invalid",
+		},
+		{
+			name:   "a host address written as a network",
+			mutate: func(p *ContainmentMetricsExposure) { p.AllowedSourceCIDRs = []string{"10.20.0.42/24"} },
+			want:   "must use a network address",
+		},
+		{
+			// An exposure open to everything is indistinguishable from no rule,
+			// which is the state this vocabulary exists to replace.
+			name:   "every IPv4 source",
+			mutate: func(p *ContainmentMetricsExposure) { p.AllowedSourceCIDRs = []string{"0.0.0.0/0"} },
+			want:   "must not allow every source",
+		},
+		{
+			name:   "every IPv6 source",
+			mutate: func(p *ContainmentMetricsExposure) { p.AllowedSourceCIDRs = []string{"::/0"} },
+			want:   "must not allow every source",
+		},
+		{
+			name:   "no sources at all",
+			mutate: func(p *ContainmentMetricsExposure) { p.AllowedSourceCIDRs = nil },
+			want:   "must name at least one source",
+		},
+		{
+			name:   "expiry that already passed",
+			mutate: func(p *ContainmentMetricsExposure) { p.ExpiresAt = now.Add(-time.Hour).UTC().Format(time.RFC3339) },
+			want:   "expired at",
+		},
+		{
+			name:   "expiry that is not a timestamp",
+			mutate: func(p *ContainmentMetricsExposure) { p.ExpiresAt = "next tuesday" },
+			want:   "RFC3339",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := validExposure(now)
+			tt.mutate(policy)
+			err := ValidateContainmentMetricsExposure(listen, proxyPort, policy, now)
+			if err == nil {
+				t.Fatal("an unusable exposure policy was accepted")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tt.want)
+			}
+		})
+	}
+
+	t.Run("a complete policy is accepted", func(t *testing.T) {
+		if err := ValidateContainmentMetricsExposure(listen, proxyPort, validExposure(now), now); err != nil {
+			t.Fatalf("a complete policy was refused: %v", err)
+		}
+	})
+}
+
+// TestContainmentMetricsExposureRefusesAPolicyOnALoopbackListener covers the
+// combination that means the operator misunderstood the feature: an exposure
+// declared for a listener nothing remote can reach anyway.
+func TestContainmentMetricsExposureRefusesAPolicyOnALoopbackListener(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	err := ValidateContainmentMetricsExposure("127.0.0.1:9091", 8888, validExposure(now), now)
+	if err == nil {
+		t.Fatal("an exposure policy was accepted for a loopback listener")
+	}
+	if !strings.Contains(err.Error(), "non-loopback") {
+		t.Errorf("error = %q, want it to say the policy needs a non-loopback listener", err.Error())
+	}
+}
+
+// TestContainmentMetricsExposureAllowsSourceDeniesOnAnythingUnusable pins the
+// runtime side. It answers a per-request question, so anything it cannot
+// evaluate has to mean no.
+func TestContainmentMetricsExposureAllowsSourceDeniesOnAnythingUnusable(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	policy := validExposure(now)
+
+	tests := []struct {
+		name   string
+		policy *ContainmentMetricsExposure
+		source net.IP
+		want   bool
+	}{
+		{"nil policy", nil, net.ParseIP("10.20.0.42"), false},
+		{"nil source", policy, nil, false},
+		{"source outside every range", policy, net.ParseIP("10.20.0.99"), false},
+		{"source inside a range", policy, net.ParseIP("10.20.0.42"), true},
+		{
+			// A malformed entry is skipped rather than treated as a wildcard, and
+			// a later valid entry still decides.
+			name: "an unparsable entry does not open the range",
+			policy: &ContainmentMetricsExposure{
+				AllowedSourceCIDRs: []string{"not-a-cidr", "10.20.0.42/32"},
+			},
+			source: net.ParseIP("10.20.0.99"),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainmentMetricsExposureAllowsSource(tt.policy, tt.source); got != tt.want {
+				t.Errorf("allowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/containment_exposure_policy_test.go
+++ b/internal/config/containment_exposure_policy_test.go
@@ -129,14 +129,24 @@ func TestContainmentMetricsExposureAllowsSourceDeniesOnAnythingUnusable(t *testi
 		{"source outside every range", policy, net.ParseIP("10.20.0.99"), false},
 		{"source inside a range", policy, net.ParseIP("10.20.0.42"), true},
 		{
-			// A malformed entry is skipped rather than treated as a wildcard, and
-			// a later valid entry still decides.
+			// A malformed entry is skipped rather than treated as a wildcard and
+			// cannot open the range by itself.
 			name: "an unparsable entry does not open the range",
 			policy: &ContainmentMetricsExposure{
 				AllowedSourceCIDRs: []string{"not-a-cidr", "10.20.0.42/32"},
 			},
 			source: net.ParseIP("10.20.0.99"),
 			want:   false,
+		},
+		{
+			// Evaluation continues after a malformed entry, so a later valid
+			// entry still decides.
+			name: "a valid entry after an unparsable entry still allows",
+			policy: &ContainmentMetricsExposure{
+				AllowedSourceCIDRs: []string{"not-a-cidr", "10.20.0.42/32"},
+			},
+			source: net.ParseIP("10.20.0.42"),
+			want:   true,
 		},
 	}
 

--- a/internal/config/containment_runtime_test.go
+++ b/internal/config/containment_runtime_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestConfigClone_ContainmentMetricsExposureDoesNotAlias(t *testing.T) {
+	original := Defaults()
+	original.Containment.MetricsExposure = &ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+		Owner:              "observability",
+		Reason:             "Prometheus scrape",
+		ExpiresAt:          "2026-08-15T12:00:00Z",
+	}
+
+	clone := original.Clone()
+	clone.Containment.MetricsExposure.Owner = "platform"
+	clone.Containment.MetricsExposure.AllowedSourceCIDRs[0] = "192.0.2.43/32"
+
+	if original.Containment.MetricsExposure.Owner != "observability" {
+		t.Fatalf("original owner = %q, want observability", original.Containment.MetricsExposure.Owner)
+	}
+	if original.Containment.MetricsExposure.AllowedSourceCIDRs[0] != "192.0.2.42/32" {
+		t.Fatalf("original allowed source = %q, want independent clone", original.Containment.MetricsExposure.AllowedSourceCIDRs[0])
+	}
+}

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -275,6 +275,11 @@ func (c *Config) Clone() *Config {
 	if c.Taint.TrustedMCPServers != nil {
 		clone.Taint.TrustedMCPServers = append([]string(nil), c.Taint.TrustedMCPServers...)
 	}
+	if c.Containment.MetricsExposure != nil {
+		exposure := *c.Containment.MetricsExposure
+		exposure.AllowedSourceCIDRs = append([]string(nil), c.Containment.MetricsExposure.AllowedSourceCIDRs...)
+		clone.Containment.MetricsExposure = &exposure
+	}
 	clone.MCPToolPolicy.Rules = cloneToolPolicyRules(c.MCPToolPolicy.Rules)
 	// Deep-copy the follower audience-labels map so a runtime caller that
 	// mutates clone.Conductor.Labels never aliases back into the loaded config,

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -407,7 +407,8 @@ type Config struct {
 	KillSwitch               KillSwitch              `yaml:"kill_switch"`
 	HealthWatchdog           HealthWatchdog          `yaml:"health_watchdog" json:"-"` // operational liveness, excluded from canonical policy hash
 	Sentry                   SentryConfig            `yaml:"sentry"`
-	MetricsListen            string                  `yaml:"metrics_listen"` // separate listen address for /metrics and /stats
+	MetricsListen            string                  `yaml:"metrics_listen"`       // separate listen address for /metrics and /stats
+	Containment              ContainmentConfig       `yaml:"containment" json:"-"` // containment service listener policy, excluded from request-policy hash
 	Emit                     EmitConfig              `yaml:"emit"`
 	ToolChainDetection       ToolChainDetection      `yaml:"tool_chain_detection"`
 	MCPWSListener            MCPWSListener           `yaml:"mcp_ws_listener"`

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/destination"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestConfiguredMetricsListenerBlocksMediatedAgentTraffic proves the
+// containment oracle cannot be reopened by the generic SSRF IP allowlist.
+// Each subtest reaches the same configured metrics address through a separate
+// proxy transport surface and requires the dial path to refuse it before any
+// request reaches the endpoint.
+func TestConfiguredMetricsListenerBlocksMediatedAgentTraffic(t *testing.T) {
+	var hits atomic.Int64
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer metricsServer.Close()
+
+	metricsAddr := strings.TrimPrefix(metricsServer.URL, "http://")
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Internal = config.Defaults().Internal
+		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
+		cfg.MetricsListen = metricsAddr
+	})
+	defer cleanup()
+
+	assertBlocked := func(t *testing.T, status int, body string) {
+		t.Helper()
+		if status != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d; body=%s", status, http.StatusForbidden, body)
+		}
+		if got := hits.Load(); got != 0 {
+			t.Fatalf("metrics listener received %d request(s), want 0", got)
+		}
+	}
+
+	t.Run("fetch", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+url.QueryEscape(metricsServer.URL+"/metrics"), nil)
+		rec := httptest.NewRecorder()
+		p.handleFetch(rec, req)
+		assertBlocked(t, rec.Code, rec.Body.String())
+	})
+
+	t.Run("forward proxy", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, metricsServer.URL+"/metrics", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := proxyClient(proxyAddr).Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBlocked(t, resp.StatusCode, string(body))
+	})
+
+	t.Run("CONNECT", func(t *testing.T) {
+		conn := dialProxy(t, proxyAddr)
+		defer func() { _ = conn.Close() }()
+		if _, err := fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", metricsAddr, metricsAddr); err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBlocked(t, resp.StatusCode, string(body))
+	})
+
+	t.Run("absolute URI", func(t *testing.T) {
+		conn := dialProxy(t, proxyAddr)
+		defer func() { _ = conn.Close() }()
+		if _, err := fmt.Fprintf(conn, "GET %s/metrics HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", metricsServer.URL, metricsAddr); err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBlocked(t, resp.StatusCode, string(body))
+	})
+}
+
+func TestConfiguredMetricsListenerDenyPrecedesGenericExceptions(t *testing.T) {
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer metricsServer.Close()
+
+	metricsAddr := strings.TrimPrefix(metricsServer.URL, "http://")
+	_, metricsPort, err := net.SplitHostPort(metricsAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newMetricsProxy := func(t *testing.T, cfg *config.Config, options scanner.Options) (*Proxy, *scanner.Scanner) {
+		t.Helper()
+		sc, err := scanner.NewWithOptions(cfg, options)
+		if err != nil {
+			t.Fatalf("scanner.NewWithOptions: %v", err)
+		}
+		p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+		if err != nil {
+			sc.Close()
+			t.Fatalf("proxy.New: %v", err)
+		}
+		t.Cleanup(p.Close)
+		return p, sc
+	}
+	assertBlocked := func(t *testing.T, p *Proxy, ctx context.Context, target string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		conn, err := p.ssrfSafeDialContext(ctx, "tcp", target)
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if err == nil {
+			t.Fatalf("dial to configured metrics listener succeeded through %s", target)
+		}
+		var blocked *ssrfDialBlockError
+		if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "configured metrics listener") {
+			t.Fatalf("dial error = %T %v, want configured-metrics denial", err, err)
+		}
+	}
+
+	t.Run("trusted domain", func(t *testing.T) {
+		const host = "metrics-trusted.example"
+		cfg := config.Defaults()
+		cfg.Internal = config.Defaults().Internal
+		cfg.MetricsListen = metricsAddr
+		cfg.TrustedDomains = []string{host}
+		cfg.DNS.HostOverrides = map[string][]string{host: {"127.0.0.1"}}
+		p, sc := newMetricsProxy(t, cfg, scanner.Options{})
+		scan := sc.Scan(t.Context(), "http://"+net.JoinHostPort(host, metricsPort)+"/metrics")
+		if !scan.Allowed {
+			t.Fatalf("trusted-domain scan blocked: %+v", scan)
+		}
+		assertBlocked(t, p, t.Context(), net.JoinHostPort(host, metricsPort))
+	})
+
+	t.Run("destination grant", func(t *testing.T) {
+		const host = "metrics-grant.example"
+		cfg := config.Defaults()
+		cfg.Internal = config.Defaults().Internal
+		cfg.MetricsListen = metricsAddr
+		cfg.DNS.HostOverrides = map[string][]string{host: {"127.0.0.1"}}
+		grantPort, err := destination.ParsePort(metricsPort)
+		if err != nil {
+			t.Fatal(err)
+		}
+		grant, err := destination.NewGrant(destination.NetworkTCP, host, grantPort)
+		if err != nil {
+			t.Fatal(err)
+		}
+		grants, err := destination.NewGrantSet(grant)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p, sc := newMetricsProxy(t, cfg, scanner.Options{DestinationGrants: grants})
+		scan := sc.Scan(t.Context(), "http://"+net.JoinHostPort(host, metricsPort)+"/metrics")
+		if !scan.Allowed {
+			t.Fatalf("guard-granted scan blocked: %+v", scan)
+		}
+		if !scannerDestinationGranted(sc, host, metricsPort) {
+			t.Fatal("destination grant did not authorize the metrics host and port")
+		}
+		ctx := withAllowedSSRFDialScanSnapshot(t.Context(), sc, host, metricsPort, scan)
+		assertBlocked(t, p, ctx, net.JoinHostPort(host, metricsPort))
+	})
+
+	t.Run("IP allowlist", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.Internal = config.Defaults().Internal
+		cfg.MetricsListen = metricsAddr
+		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
+		p, _ := newMetricsProxy(t, cfg, scanner.Options{})
+		assertBlocked(t, p, t.Context(), metricsAddr)
+	})
+}

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -29,7 +29,9 @@ import (
 // containment oracle cannot be reopened by the generic SSRF IP allowlist.
 // Each subtest reaches the same configured metrics address through a separate
 // proxy transport surface and requires the dial path to refuse it before any
-// request reaches the endpoint.
+// request reaches the endpoint. WebSocket, MCP stdio, and MCP HTTP/SSE are not
+// repeated here because their network paths converge on the same
+// ssrfSafeDialContext covered below.
 func TestConfiguredMetricsListenerBlocksMediatedAgentTraffic(t *testing.T) {
 	var hits atomic.Int64
 	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -212,5 +214,32 @@ func TestConfiguredMetricsListenerDenyPrecedesGenericExceptions(t *testing.T) {
 		cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
 		p, _ := newMetricsProxy(t, cfg, scanner.Options{})
 		assertBlocked(t, p, t.Context(), metricsAddr)
+	})
+}
+
+func TestConfiguredWildcardMetricsListenerBlocksLocalAddressesOnNumericPort(t *testing.T) {
+	for _, listen := range []string{":09091", "0.0.0.0:9091", "[::]:9091"} {
+		t.Run(listen, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.MetricsListen = listen
+			p := &Proxy{}
+			p.ConfigPtr().Store(cfg)
+
+			err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1"))
+			var blocked *ssrfDialBlockError
+			if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "configured metrics listener") {
+				t.Fatalf("blockIfConfiguredMetricsTarget error = %T %v, want configured-metrics denial", err, err)
+			}
+		})
+	}
+
+	t.Run("different port remains available", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.MetricsListen = ":9091"
+		p := &Proxy{}
+		p.ConfigPtr().Store(cfg)
+		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9092", net.ParseIP("127.0.0.1")); err != nil {
+			t.Fatalf("different port blocked: %v", err)
+		}
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3507,6 +3507,32 @@ func blockIfNonOverridableSSRFTarget(ctx context.Context, host string, ip net.IP
 	return nil
 }
 
+// blockIfConfiguredMetricsTarget keeps the contained agent from using a broad
+// SSRF exception to query the proxy's own metrics listener. This check belongs
+// in the dial path, before trusted-domain, IP-allowlist, and grant exceptions,
+// because every mediated transport that can reach an address converges here.
+func (p *Proxy) blockIfConfiguredMetricsTarget(ctx context.Context, host, port string, ip net.IP) error {
+	cfg := p.CurrentConfig()
+	if cfg == nil || cfg.MetricsListen == "" {
+		return nil
+	}
+	metricsHost, metricsPort, err := net.SplitHostPort(cfg.MetricsListen)
+	if err != nil || metricsPort != port {
+		return nil
+	}
+	metricsIP := net.ParseIP(metricsHost)
+	if metricsIP == nil || ip == nil {
+		return nil
+	}
+	if metricsV4 := metricsIP.To4(); metricsV4 != nil {
+		metricsIP = metricsV4
+	}
+	if !metricsIP.Equal(ip) {
+		return nil
+	}
+	return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port))
+}
+
 func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	currentSc, _ := ctx.Value(ctxKeyAgentScanner).(*scanner.Scanner)
 	if currentSc == nil {
@@ -3530,6 +3556,9 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		// consistent with the DNS resolution path below.
 		if v4 := ip.To4(); v4 != nil {
 			ip = v4
+		}
+		if err := p.blockIfConfiguredMetricsTarget(ctx, host, port, ip); err != nil {
+			return nil, err
 		}
 		if err := blockIfNonOverridableSSRFTarget(ctx, host, ip); err != nil {
 			return nil, err
@@ -3561,6 +3590,9 @@ func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (
 		// Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) to 4-byte form.
 		if v4 := ip.To4(); v4 != nil {
 			ip = v4
+		}
+		if err := p.blockIfConfiguredMetricsTarget(ctx, host, port, ip); err != nil {
+			return nil, err
 		}
 		if err := blockIfNonOverridableSSRFTarget(ctx, host, ip); err != nil {
 			return nil, err

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3517,11 +3517,26 @@ func (p *Proxy) blockIfConfiguredMetricsTarget(ctx context.Context, host, port s
 		return nil
 	}
 	metricsHost, metricsPort, err := net.SplitHostPort(cfg.MetricsListen)
-	if err != nil || metricsPort != port {
+	if err != nil {
+		return nil
+	}
+	wantPort, wantErr := strconv.ParseUint(metricsPort, 10, 16)
+	gotPort, gotErr := strconv.ParseUint(port, 10, 16)
+	if wantErr != nil || gotErr != nil || wantPort == 0 || wantPort != gotPort || ip == nil {
 		return nil
 	}
 	metricsIP := net.ParseIP(metricsHost)
-	if metricsIP == nil || ip == nil {
+	if strings.TrimSpace(metricsHost) == "" || (metricsIP != nil && metricsIP.IsUnspecified()) {
+		local, localErr := isLocalInterfaceIP(ip)
+		if localErr != nil {
+			return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: cannot verify whether %s:%s reaches the wildcard metrics listener: %v", host, port, localErr))
+		}
+		if !local {
+			return nil
+		}
+		return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port))
+	}
+	if metricsIP == nil {
 		return nil
 	}
 	if metricsV4 := metricsIP.To4(); metricsV4 != nil {
@@ -3531,6 +3546,29 @@ func (p *Proxy) blockIfConfiguredMetricsTarget(ctx context.Context, host, port s
 		return nil
 	}
 	return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port))
+}
+
+func isLocalInterfaceIP(ip net.IP) (bool, error) {
+	if ip.IsLoopback() {
+		return true, nil
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false, fmt.Errorf("list local interface addresses: %w", err)
+	}
+	for _, addr := range addrs {
+		var localIP net.IP
+		switch value := addr.(type) {
+		case *net.IPNet:
+			localIP = value.IP
+		case *net.IPAddr:
+			localIP = value.IP
+		}
+		if localIP != nil && localIP.Equal(ip) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (p *Proxy) ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -164,6 +164,15 @@ environment_failure_reason() {
         return
     fi
 
+    # RFC 5737 documentation addresses are valid numeric examples but are not
+    # assigned to the CI host. Skip only when runtime reached the bind and the
+    # kernel refused that exact environmental precondition.
+    if grep -qE '^[[:space:]]*metrics_listen:[[:space:]]*["'"'"']?(192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)' "$cfg" \
+        && grep -qiE 'metrics_listen bind .*cannot assign requested address' "$out"; then
+        echo "placeholder listener address is unavailable"
+        return
+    fi
+
     if grep -qE '^[[:space:]-]*required:[[:space:]]*true([[:space:]]*(#.*)?)?$' "$cfg" \
         && grep -qiE '(file sentry|watch).*(failed|missing|no such file|permission denied)' "$out"; then
         echo "required resource is unavailable"


### PR DESCRIPTION
## What changed

Containment keeps the proxy's own metrics off the one address a contained agent may reach, so the agent cannot use them as an oracle for what the scanner caught and blocked. The agent may still talk to the proxy, and the proxy dials on its behalf, so an `ssrf.ip_allowlist` entry covering loopback or the host address reopened that oracle without violating any firewall rule. The dial path now refuses the configured metrics address ahead of trusted domains, the IP allowlist and destination grants, on fetch, forward proxy, CONNECT and absolute-URI alike.

The rule that hid those metrics was loopback-or-nothing, with no way to record a deliberate exposure. A host publishing metrics to a monitoring system had to choose between a green containment probe and working monitoring, which is the shape of a control an operator eventually switches off rather than tunes. An explicit exposure policy now carries owner, reason, expiry and allowed source CIDRs. `/metrics` answers only those sources, `/stats` stays on loopback because it exposes top blocked domains and scanner categories, and an absent, malformed, expired or source-mismatched policy denies rather than degrades.

There is no exception for a named network. A bind address proves nothing about the access controls on that interface and Pipelock cannot verify them, so an operator declares exact sources and records the rest in the reason field.

The failure direction to distrust here is the second half rather than the first. The dial-path refusal only ever denies more, but the exposure policy exists to permit something, so the checks a reviewer should read hardest are the ones that decide a request is allowed: expiry is enforced on the live request path and on reload rather than only at parse time, a loopback listener answers loopback callers whatever the policy says, and a policy that cannot be evaluated denies instead of falling through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controlled remote access to `/metrics` using approved source networks, ownership details, reasons, and expiration dates.
  - Kept `/stats` restricted to local access.
  - Added safeguards preventing proxy traffic from reaching the configured metrics listener.

- **Bug Fixes**
  - Unsafe or expired exposure settings now deny metrics access safely.
  - Configuration reloads reject unsafe metrics changes while preserving the active listener.
  - Updated verification checks and error guidance.

- **Documentation**
  - Documented listener defaults, exposure policies, restrictions, and expiry requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->