### PR TITLE
fix(ci): restore the permission the review command needs to comment

### DIFF
--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -29,9 +29,13 @@ on:
 permissions:
   contents: read
   issues: write
-  # Results post through the issue-comments API, which issues: write covers.
-  # No pull-request write operation is performed, so this stays read.
-  pull-requests: read
+  # Both are required. Posting a comment on a PULL REQUEST needs
+  # pull-requests: write even though the call goes to the issue-comments
+  # endpoint; issues: write alone covers issues only, and the comment-create
+  # call returns 403. Verified live: this was reduced to read and every
+  # /review in the repository failed until it was restored. Do not narrow it
+  # again without running a real /review against a pull request.
+  pull-requests: write
 
 jobs:
   admit:

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -7,9 +7,13 @@ on:
 permissions:
   contents: read
   issues: write
-  # Results post through the issue-comments API, which issues: write covers.
-  # No pull-request write operation is performed, so this stays read.
-  pull-requests: read
+  # Both are required. Posting a comment on a PULL REQUEST needs
+  # pull-requests: write even though the call goes to the issue-comments
+  # endpoint; issues: write alone covers issues only, and the comment-create
+  # call returns 403. Verified live: this was reduced to read and every
+  # /review in the repository failed until it was restored. Do not narrow it
+  # again without running a real /review against a pull request.
+  pull-requests: write
 
 jobs:
   review:

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -120,7 +120,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   review:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -26,6 +26,30 @@ sys.modules[SPEC.name] = pr_review
 SPEC.loader.exec_module(pr_review)
 
 
+def top_level_permissions(text: str) -> dict[str, str]:
+    """Read a workflow's top-level permissions mapping, ignoring comments.
+
+    Deliberately dependency-free: the CI job that runs these tests installs no
+    Python packages, and an import failure there would take down the whole test
+    discovery run rather than just this assertion.
+    """
+    permissions: dict[str, str] = {}
+    inside = False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line:
+            continue
+        if line == "permissions:":
+            inside = True
+            continue
+        if inside:
+            if not line.startswith("  "):
+                break
+            key, _, value = line.strip().partition(":")
+            permissions[key.strip()] = value.strip()
+    return permissions
+
+
 def unit(identifier: int, path: str, category: str, *, additions: int = 1, tokens: int = 2) -> object:
     return pr_review.DiffUnit(
         identifier=identifier,
@@ -65,10 +89,21 @@ class WorkflowPackagingTest(unittest.TestCase):
         # though the call targets the issue-comments endpoint. Reducing this to
         # read reads like least privilege and returned 403 on comment-create,
         # which broke /review across the whole repository until it was restored.
+        # This reads the parsed mapping rather than searching the file, because
+        # the comment above the key contains the same words and a substring
+        # search passed with the real key deleted.
         for path in (CALLER_WORKFLOW, REUSABLE_WORKFLOW):
-            workflow = path.read_text(encoding="utf-8")
-            self.assertIn("pull-requests: write", workflow, f"{path.name} must keep pull-requests: write")
-            self.assertNotIn("pull-requests: read", workflow, f"{path.name} cannot post comments with read")
+            permissions = top_level_permissions(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                permissions.get("pull-requests"),
+                "write",
+                f"{path.name} must set permissions.pull-requests to write",
+            )
+            self.assertEqual(
+                permissions.get("issues"),
+                "write",
+                f"{path.name} must set permissions.issues to write",
+            )
 
     def test_composite_action_owns_runner_requirements_and_single_provider_inputs(self) -> None:
         action = ACTION_YAML.read_text(encoding="utf-8")

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -35,6 +35,7 @@ def top_level_permissions(text: str) -> dict[str, str]:
     """
     permissions: dict[str, str] = {}
     inside = False
+    child_indent: int | None = None
     for raw in text.splitlines():
         line = raw.split("#", 1)[0].rstrip()
         if not line:
@@ -43,8 +44,18 @@ def top_level_permissions(text: str) -> dict[str, str]:
             inside = True
             continue
         if inside:
-            if not line.startswith("  "):
+            indent = len(line) - len(line.lstrip(" "))
+            if indent == 0:
                 break
+            if child_indent is None:
+                child_indent = indent
+            if indent < child_indent:
+                break
+            # Only direct children count. A deeper entry reusing a permission
+            # name would otherwise overwrite the real top-level value, so a
+            # nested write could mask a top-level none.
+            if indent != child_indent:
+                continue
             key, _, value = line.strip().partition(":")
             permissions[key.strip()] = value.strip()
     return permissions
@@ -83,6 +94,27 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertNotRegex(workflow, r"(?m)^\s*if:\s*.*secrets\.")
         # The explicit mapping must not accidentally turn into a secret inherit.
         self.assertNotRegex(workflow, r"(?m)^\s*secrets:\s*inherit\s*$")
+
+    def test_permission_reader_ignores_nested_entries_and_comments(self) -> None:
+        # A deeper entry reusing a permission name must not mask the real
+        # top-level value, and a permission named only in a comment must not
+        # count as set. Both would let the guard below pass on a workflow that
+        # cannot post comments.
+        document = "\n".join(
+            [
+                "permissions:",
+                "  pull-requests: none",
+                "  nested:",
+                "    pull-requests: write",
+                "  # pull-requests: write in prose only",
+                "",
+                "jobs:",
+                "  build:",
+                "    permissions:",
+                "      pull-requests: write",
+            ]
+        )
+        self.assertEqual(top_level_permissions(document).get("pull-requests"), "none")
 
     def test_both_workflows_keep_pull_request_write_for_comment_creation(self) -> None:
         # Posting a comment on a pull request needs pull-requests: write even

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -60,6 +60,16 @@ class WorkflowPackagingTest(unittest.TestCase):
         # The explicit mapping must not accidentally turn into a secret inherit.
         self.assertNotRegex(workflow, r"(?m)^\s*secrets:\s*inherit\s*$")
 
+    def test_both_workflows_keep_pull_request_write_for_comment_creation(self) -> None:
+        # Posting a comment on a pull request needs pull-requests: write even
+        # though the call targets the issue-comments endpoint. Reducing this to
+        # read reads like least privilege and returned 403 on comment-create,
+        # which broke /review across the whole repository until it was restored.
+        for path in (CALLER_WORKFLOW, REUSABLE_WORKFLOW):
+            workflow = path.read_text(encoding="utf-8")
+            self.assertIn("pull-requests: write", workflow, f"{path.name} must keep pull-requests: write")
+            self.assertNotIn("pull-requests: read", workflow, f"{path.name} cannot post comments with read")
+
     def test_composite_action_owns_runner_requirements_and_single_provider_inputs(self) -> None:
         action = ACTION_YAML.read_text(encoding="utf-8")
         self.assertTrue((ACTION_DIR / "requirements.txt").is_file())


### PR DESCRIPTION
## What changed

The review workflows keep `pull-requests: write`. Posting a comment on a pull request requires it even though the call targets the issue-comments endpoint, so reducing it to read made comment creation return 403 and every `/review` in the repository failed before publishing anything.

**Failure direction, and what to distrust:** this reads like least privilege and is not, which is why it needs a test rather than a comment. The workflow serving this command runs from the default branch, so a permission mistake in it cannot fail on the pull request that introduces it and only appears once merged. Treat any future narrowing of these two permissions as unverified until someone has run a real `/review` against a pull request and seen a comment posted.

A regression test pins the permission in both the caller and the reusable workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request review automation can now create and update pull request comments.

* **Documentation**
  * Updated workflow guidance to reflect the required write access for pull request reviews.

* **Tests**
  * Added coverage to ensure review workflows retain the permissions needed for commenting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->