### PR TITLE
fix(ci): stop early on a moved head and fail closed on admission

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -945,6 +945,57 @@ def display_path(path: str) -> str:
     return text[:512] or "unspecified"
 
 
+def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, reviewer_sha: str) -> bool:
+    """Whether the pull request head no longer matches the reviewed commit.
+
+    A transient read failure returns False so a flaky API call cannot abandon a
+    review that is otherwise progressing; the authoritative check still runs at
+    the end, where a genuine move is recorded.
+    """
+    try:
+        return get_pull_binding(repo, pr_number, token, reviewer_sha).head_sha != binding.head_sha
+    except (FetchError, requests.RequestException):
+        return False
+
+
+def publish_progress(
+    repo: str,
+    comment_id: int,
+    token: str,
+    binding: PullBinding,
+    mode: str,
+    classification: list[str],
+    progress: ReviewProgress,
+    phase: str,
+) -> None:
+    """Advance the running status comment so a long review is visibly alive.
+
+    A deep pass legitimately runs for many minutes. Without this the comment
+    reads "pending immutable diff fetch" for the whole run, which is
+    indistinguishable from a hung job. Failures here are ignored: progress
+    reporting must never end a review that is working.
+    """
+    body = "\n".join(
+        [
+            "## AI PR Review",
+            "",
+            "**Status:** `running`",
+            f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
+            f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
+            f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
+            f"**Review identity:** `{binding.correlation}`",
+            f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
+            f"**Progress:** {phase}; {progress.reviewed_units}/{progress.expected_units} representable units reviewed.",
+            "",
+            f"<!-- {STATUS_MARKER} state=running identity={binding.correlation} -->",
+        ]
+    )
+    try:
+        update_comment(repo, comment_id, token, body, binding.correlation)
+    except (ReviewError, requests.RequestException):
+        log_phase("progress", status="update-failed", correlation=binding.correlation)
+
+
 def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]]) -> str:
     model = model_for_mode(mode)
     severity_order = {"high": 0, "medium": 1, "low": 2}
@@ -1092,7 +1143,16 @@ def run_review(
             progress.incomplete_reasons.append("one or more deletion hunks were collapsed")
         reviewed_changes: list[dict[str, str]] = []
         candidates: list[Finding] = []
+        publish_progress(repo, comment["id"], token, binding, mode, classification, progress, f"reviewing 0/{len(chunks)} chunks")
         for chunk_index, chunk in enumerate(chunks, 1):
+            # Checked before each chunk rather than only at the end. A deep pass
+            # runs for many minutes, and a head that moved early would otherwise
+            # spend the whole budget and the provider spend producing a review
+            # that can only be published as historical.
+            if head_has_moved(repo, pr_number, token, binding, reviewer_sha):
+                progress.head_changed = True
+                progress.incomplete_reasons.append("the pull request head moved while the review was running")
+                break
             if not budget_allows(deadline, mode):
                 progress.incomplete_reasons.append("wall-clock budget exhausted before every chunk was reviewed")
                 break
@@ -1111,6 +1171,9 @@ def run_review(
             progress.reviewed_units += len(chunk)
             candidates.extend(findings)
             reviewed_changes.extend(changes)
+            publish_progress(
+                repo, comment["id"], token, binding, mode, classification, progress, f"reviewing {chunk_index}/{len(chunks)} chunks"
+            )
         synthesis_ready = (
             progress.reviewed_units == progress.expected_units
             and not progress.aggregation_failed

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -859,26 +859,29 @@ def judge_findings(
     if not candidates:
         return [], True, []
     budget, _ = input_limits(mode)
+    # Fetched contexts are cached and counted separately from the ones that end
+    # up in the payload. Counting only payload entries bounded nothing: a path
+    # fetched and then dropped by the token budget was never recorded, so an
+    # over-budget candidate set kept issuing requests. Measured at 60 requests
+    # against a limit of 20 before this split.
+    fetched: dict[str, str] = {}
     contexts: dict[str, str] = {}
     retained: list[Finding] = []
     excluded: list[Finding] = []
     used = 0
     for finding in candidates:
         addition = estimate_tokens(finding.title + finding.why + finding.fix + finding.path)
-        context = contexts.get(finding.path)
-        if context is None and len(contexts) >= MAX_JUDGE_CONTEXT_FETCHES:
-            # Bound the fetches themselves, not just the payload. Context was
-            # previously fetched for every distinct path before the budget
-            # excluded most of them, so a large candidate set could spend more
-            # time on requests than the job is allowed to run and be killed
-            # before it could publish partial.
-            excluded.append(finding)
-            continue
+        context = fetched.get(finding.path)
         if context is None:
+            if len(fetched) >= MAX_JUDGE_CONTEXT_FETCHES:
+                excluded.append(finding)
+                continue
             content = fetch_file_context(repo, finding.path, binding.head_sha, token, binding.correlation)
             if content is None:
                 return [], False, []
             context = _line_context(content, finding.line)
+            fetched[finding.path] = context
+        if finding.path not in contexts:
             addition += estimate_tokens(context)
         if retained and used + addition > budget:
             excluded.append(finding)

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -57,6 +57,9 @@ DEEP_INPUT_TOKEN_BUDGET = 16_000
 FAST_MAX_CHUNKS = 3
 DEEP_MAX_CHUNKS = 8
 MAX_UNITS_PER_CHUNK = 20
+# Each judge context fetch allows 30 seconds, so an unbounded candidate set
+# could spend longer on requests than the whole job is permitted to run.
+MAX_JUDGE_CONTEXT_FETCHES = 20
 MAX_DELETION_LINES_PER_HUNK = 24
 REPO_PATTERN = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
 RUBRIC_VERSION = "2026-08-14.1"
@@ -747,13 +750,18 @@ def _running_marker_is_stale(comment: dict[str, Any]) -> bool:
     return age > datetime.timedelta(minutes=STALE_RUNNING_MINUTES)
 
 
-def find_running_comment(repo: str, pr_number: str, token: str, correlation: str) -> dict[str, Any] | None:
-    """Find a running status comment, reading every page of issue comments.
+def find_running_comment(repo: str, pr_number: str, token: str, correlation: str) -> tuple[dict[str, Any] | None, bool]:
+    """Find a running status comment, and report whether the scan was complete.
 
     This endpoint returns comments oldest first, so a single unpaginated request
     holds the 100 OLDEST comments.  On a busy pull request the running marker is
     on a later page, the admission check would miss it, and a second review
     would start concurrently against the same head.
+
+    Returns (marker, complete).  An unreadable page, a non-200 response, or
+    exhausting the page cap yields complete=False: the caller cannot conclude
+    that no review is running, and must fail closed rather than authorize a
+    second provider run against the same head.
     """
     marker = f"<!-- {STATUS_MARKER} state=running"
     found: dict[str, Any] | None = None
@@ -767,16 +775,18 @@ def find_running_comment(repo: str, pr_number: str, token: str, correlation: str
             )
         except requests.RequestException:
             log_phase("admission-check", attempt=page, status="request-error", correlation=correlation)
-            return found
+            return found, False
         log_phase("admission-check", attempt=page, status=response.status_code, correlation=correlation)
         if response.status_code != 200:
-            return found
+            return found, False
         try:
             comments = response.json()
         except ValueError:
-            return found
-        if not isinstance(comments, list) or not comments:
-            return found
+            return found, False
+        if not isinstance(comments, list):
+            return found, False
+        if not comments:
+            return found, True
         for comment in reversed(comments):
             if not isinstance(comment, dict):
                 continue
@@ -789,8 +799,8 @@ def find_running_comment(repo: str, pr_number: str, token: str, correlation: str
                 found = comment
                 break
         if len(comments) < 100:
-            return found
-    return found
+            return found, True
+    return found, False
 
 
 def fetch_file_context(repo: str, path: str, head_sha: str, token: str, correlation: str) -> str | None:
@@ -856,6 +866,14 @@ def judge_findings(
     for finding in candidates:
         addition = estimate_tokens(finding.title + finding.why + finding.fix + finding.path)
         context = contexts.get(finding.path)
+        if context is None and len(contexts) >= MAX_JUDGE_CONTEXT_FETCHES:
+            # Bound the fetches themselves, not just the payload. Context was
+            # previously fetched for every distinct path before the budget
+            # excluded most of them, so a large candidate set could spend more
+            # time on requests than the job is allowed to run and be killed
+            # before it could publish partial.
+            excluded.append(finding)
+            continue
         if context is None:
             content = fetch_file_context(repo, finding.path, binding.head_sha, token, binding.correlation)
             if content is None:
@@ -958,44 +976,6 @@ def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, 
         return False
 
 
-def publish_progress(
-    repo: str,
-    comment_id: int,
-    token: str,
-    binding: PullBinding,
-    mode: str,
-    classification: list[str],
-    progress: ReviewProgress,
-    phase: str,
-) -> None:
-    """Advance the running status comment so a long review is visibly alive.
-
-    A deep pass legitimately runs for many minutes. Without this the comment
-    reads "pending immutable diff fetch" for the whole run, which is
-    indistinguishable from a hung job. Failures here are ignored: progress
-    reporting must never end a review that is working.
-    """
-    body = "\n".join(
-        [
-            "## AI PR Review",
-            "",
-            "**Status:** `running`",
-            f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
-            f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
-            f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
-            f"**Review identity:** `{binding.correlation}`",
-            f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
-            f"**Progress:** {phase}; {progress.reviewed_units}/{progress.expected_units} representable units reviewed.",
-            "",
-            f"<!-- {STATUS_MARKER} state=running identity={binding.correlation} -->",
-        ]
-    )
-    try:
-        update_comment(repo, comment_id, token, body, binding.correlation)
-    except (ReviewError, requests.RequestException):
-        log_phase("progress", status="update-failed", correlation=binding.correlation)
-
-
 def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]]) -> str:
     model = model_for_mode(mode)
     severity_order = {"high": 0, "medium": 1, "low": 2}
@@ -1046,30 +1026,66 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     return "\n".join(lines)
 
 
+def workflow_run_url() -> str | None:
+    """Link to this run so a long review is visibly alive.
+
+    Liveness deliberately comes from a link rather than from editing this
+    comment as the review proceeds. A progress edit is a second writer of the
+    same comment, and a PATCH that times out may still have been applied, so a
+    late progress write can land after the terminal write and revert a finished
+    review to running. GitHub already reports progress on the run page.
+    """
+    server = os.environ.get("GITHUB_SERVER_URL", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if not all((server, repository, run_id)):
+        return None
+    return f"{server}/{repository}/actions/runs/{run_id}"
+
+
 def _initial_status(binding: PullBinding, mode: str) -> str:
-    return "\n".join(
+    deep = mode == "deep"
+    run_url = workflow_run_url()
+    lines = [
+        "## AI PR Review",
+        "",
+        "**Status:** `running`",
+        f"**Command:** `{'/review deep' if deep else '/review'}`",
+        f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
+        f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
+        f"**Review identity:** `{binding.correlation}`",
+        "**Classification:** pending immutable diff fetch",
+    ]
+    if run_url:
+        lines.append(f"**Progress:** [live run log]({run_url})")
+    lines.extend(
         [
-            "## AI PR Review",
             "",
-            "**Status:** `running`",
-            f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
-            f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
-            f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
-            f"**Review identity:** `{binding.correlation}`",
-            "**Classification:** pending immutable diff fetch",
+            "A deep review reasons over the diff in bounded chunks and commonly takes several minutes."
+            if deep
+            else "This comment is replaced with the result when the review finishes.",
             "",
             f"<!-- {STATUS_MARKER} state=running identity={binding.correlation} -->",
         ]
     )
+    return "\n".join(lines)
 
 
 def claim_review(repo: str, pr_number: str, token: str, mode: str, reviewer_sha: str) -> None:
     """Atomically enough for one operator: persist a running marker before review work."""
     binding = get_pull_binding(repo, pr_number, token, reviewer_sha)
-    active = find_running_comment(repo, pr_number, token, binding.correlation)
-    if active:
-        link = active.get("html_url") if isinstance(active.get("html_url"), str) else "the existing review status"
-        create_comment(repo, pr_number, token, f"A review is already running: {link}", binding.correlation)
+    active, scanned = find_running_comment(repo, pr_number, token, binding.correlation)
+    if active or not scanned:
+        # Fail closed on an incomplete scan. Not finding a marker is only
+        # evidence that none exists when every page was read; otherwise a
+        # transient error would authorize a second concurrent provider run
+        # against the same head.
+        if active:
+            link = active.get("html_url") if isinstance(active.get("html_url"), str) else "the existing review status"
+            message = f"A review is already running: {link}"
+        else:
+            message = "Could not confirm whether a review is already running, so this command did not start one. Try again."
+        create_comment(repo, pr_number, token, message, binding.correlation)
         write_action_outputs(claimed="false")
         return
     comment = create_comment(repo, pr_number, token, _initial_status(binding, mode), binding.correlation)
@@ -1098,9 +1114,9 @@ def run_review(
     deadline = time.monotonic() + REVIEW_WALL_CLOCK_SECONDS
     binding = binding or get_pull_binding(repo, pr_number, token, reviewer_sha)
     if status_comment_id is None:
-        active = find_running_comment(repo, pr_number, token, binding.correlation)
-        if active:
-            link = active.get("html_url") if isinstance(active.get("html_url"), str) else "the existing review status"
+        active, scanned = find_running_comment(repo, pr_number, token, binding.correlation)
+        if active or not scanned:
+            link = active.get("html_url") if isinstance(active, dict) and isinstance(active.get("html_url"), str) else "the existing review status"
             create_comment(repo, pr_number, token, f"A review is already running: {link}", binding.correlation)
             return "already-running", ReviewProgress()
         comment = create_comment(repo, pr_number, token, _initial_status(binding, mode), binding.correlation)
@@ -1143,7 +1159,6 @@ def run_review(
             progress.incomplete_reasons.append("one or more deletion hunks were collapsed")
         reviewed_changes: list[dict[str, str]] = []
         candidates: list[Finding] = []
-        publish_progress(repo, comment["id"], token, binding, mode, classification, progress, f"reviewing 0/{len(chunks)} chunks")
         for chunk_index, chunk in enumerate(chunks, 1):
             # Checked before each chunk rather than only at the end. A deep pass
             # runs for many minutes, and a head that moved early would otherwise
@@ -1171,9 +1186,6 @@ def run_review(
             progress.reviewed_units += len(chunk)
             candidates.extend(findings)
             reviewed_changes.extend(changes)
-            publish_progress(
-                repo, comment["id"], token, binding, mode, classification, progress, f"reviewing {chunk_index}/{len(chunks)} chunks"
-            )
         synthesis_ready = (
             progress.reviewed_units == progress.expected_units
             and not progress.aggregation_failed

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -265,18 +265,52 @@ class ImmutableBindingTest(unittest.TestCase):
             "findings": [],
             "changes": [{"path": "internal/a.go", "summary": "changes enforcement"}],
         }
-        with mock.patch.object(pr_review, "get_pull_binding", side_effect=[original, moved]), mock.patch.object(
+        # The head moves immediately, so the run must stop before spending the
+        # provider budget on a commit whose result can only be historical.
+        with mock.patch.object(pr_review, "get_pull_binding", side_effect=[original, moved, moved]), mock.patch.object(
             pr_review, "find_running_comment", return_value=None
         ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
             pr_review, "fetch_bound_diff", return_value=diff
         ), mock.patch.object(
             pr_review, "call_model", side_effect=[review_payload, {"findings": []}]
-        ), mock.patch.object(pr_review, "update_comment"), mock.patch.object(
+        ) as call_model, mock.patch.object(pr_review, "update_comment"), mock.patch.object(
             pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")
         ), mock.patch.object(pr_review, "compare_incompleteness", return_value=None):
             state, progress = pr_review.run_review("owner/repo", "42", "token", "default", "c" * 40)
         self.assertEqual(state, "superseded")
         self.assertTrue(progress.head_changed)
+        self.assertEqual(call_model.call_count, 0, "a moved head must not spend a provider call")
+
+    def test_running_comment_advances_while_the_review_works(self) -> None:
+        # A deep pass runs for many minutes. Without an advancing comment the
+        # status is indistinguishable from a hung job, which is what made a
+        # working review look broken.
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        diff = "\n".join(
+            [
+                "diff --git a/internal/a.go b/internal/a.go",
+                "--- a/internal/a.go",
+                "+++ b/internal/a.go",
+                "@@ -1 +1 @@",
+                "-old",
+                "+new",
+            ]
+        )
+        payload = {"findings": [], "changes": [{"path": "internal/a.go", "summary": "changes enforcement"}]}
+        with mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
+            pr_review, "find_running_comment", return_value=None
+        ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
+            pr_review, "fetch_bound_diff", return_value=diff
+        ), mock.patch.object(pr_review, "call_model", side_effect=[payload, {"findings": []}]), mock.patch.object(
+            pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")
+        ), mock.patch.object(pr_review, "compare_incompleteness", return_value=None), mock.patch.object(
+            pr_review, "update_comment"
+        ) as update:
+            pr_review.run_review("owner/repo", "42", "token", "default", "c" * 40)
+        bodies = [call.args[3] for call in update.call_args_list]
+        self.assertGreater(len(bodies), 1, "the comment must advance, not only publish a final result")
+        self.assertTrue(any("**Progress:**" in body for body in bodies))
+        self.assertTrue(any("chunks" in body for body in bodies))
 
     def test_claim_persists_binding_and_one_status_comment_id(self) -> None:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -513,6 +513,22 @@ class JudgeContextBoundTest(unittest.TestCase):
         self.assertTrue(excluded)
 
 
+class JudgeFetchCapTest(unittest.TestCase):
+    def test_paths_dropped_by_the_token_budget_still_count_as_fetches(self) -> None:
+        # The cap previously counted payload entries, so a path fetched and then
+        # dropped by the token budget was never recorded and requests kept
+        # going. Measured at 60 requests against a limit of 20.
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        candidates = [pr_review.Finding("low", f"p{index}/a.go", 1, "t", "w", "f") for index in range(60)]
+        with mock.patch.object(pr_review, "fetch_file_context", return_value="x" * 80_000) as fetch, mock.patch.object(
+            pr_review, "call_model", return_value={"findings": [{"index": 0, "verdict": "keep", "reason": "r"}]}
+        ):
+            _, judged, excluded = pr_review.judge_findings("owner/repo", "token", binding, "deep", candidates)
+        self.assertTrue(judged)
+        self.assertEqual(fetch.call_count, pr_review.MAX_JUDGE_CONTEXT_FETCHES)
+        self.assertEqual(len(excluded), len(candidates) - 1)
+
+
 class WallClockBudgetTest(unittest.TestCase):
     def test_budget_refuses_a_call_that_cannot_finish_before_the_job_timeout(self) -> None:
         now = 1_000.0

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -268,7 +268,7 @@ class ImmutableBindingTest(unittest.TestCase):
         # The head moves immediately, so the run must stop before spending the
         # provider budget on a commit whose result can only be historical.
         with mock.patch.object(pr_review, "get_pull_binding", side_effect=[original, moved, moved]), mock.patch.object(
-            pr_review, "find_running_comment", return_value=None
+            pr_review, "find_running_comment", return_value=(None, True)
         ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
             pr_review, "fetch_bound_diff", return_value=diff
         ), mock.patch.object(
@@ -281,43 +281,12 @@ class ImmutableBindingTest(unittest.TestCase):
         self.assertTrue(progress.head_changed)
         self.assertEqual(call_model.call_count, 0, "a moved head must not spend a provider call")
 
-    def test_running_comment_advances_while_the_review_works(self) -> None:
-        # A deep pass runs for many minutes. Without an advancing comment the
-        # status is indistinguishable from a hung job, which is what made a
-        # working review look broken.
-        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
-        diff = "\n".join(
-            [
-                "diff --git a/internal/a.go b/internal/a.go",
-                "--- a/internal/a.go",
-                "+++ b/internal/a.go",
-                "@@ -1 +1 @@",
-                "-old",
-                "+new",
-            ]
-        )
-        payload = {"findings": [], "changes": [{"path": "internal/a.go", "summary": "changes enforcement"}]}
-        with mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
-            pr_review, "find_running_comment", return_value=None
-        ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
-            pr_review, "fetch_bound_diff", return_value=diff
-        ), mock.patch.object(pr_review, "call_model", side_effect=[payload, {"findings": []}]), mock.patch.object(
-            pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")
-        ), mock.patch.object(pr_review, "compare_incompleteness", return_value=None), mock.patch.object(
-            pr_review, "update_comment"
-        ) as update:
-            pr_review.run_review("owner/repo", "42", "token", "default", "c" * 40)
-        bodies = [call.args[3] for call in update.call_args_list]
-        self.assertGreater(len(bodies), 1, "the comment must advance, not only publish a final result")
-        self.assertTrue(any("**Progress:**" in body for body in bodies))
-        self.assertTrue(any("chunks" in body for body in bodies))
-
     def test_claim_persists_binding_and_one_status_comment_id(self) -> None:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
             pr_review.os.environ, {"GITHUB_OUTPUT": output.name}, clear=False
         ), mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
-            pr_review, "find_running_comment", return_value=None
+            pr_review, "find_running_comment", return_value=(None, True)
         ), mock.patch.object(pr_review, "create_comment", return_value={"id": 17}) as create:
             pr_review.claim_review("owner/repo", "42", "token", "default", "c" * 40)
             output.seek(0)
@@ -335,7 +304,7 @@ class ProviderConfigurationFinalizationTest(unittest.TestCase):
         # the claimed comment on running, which then refused later reviews.
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         with mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
-            pr_review, "find_running_comment", return_value=None
+            pr_review, "find_running_comment", return_value=(None, True)
         ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
             pr_review, "provider_configuration", side_effect=pr_review.ProviderConfigurationError("none")
         ), mock.patch.object(pr_review, "update_comment") as update:
@@ -460,8 +429,9 @@ class AdmissionMarkerTest(unittest.TestCase):
                 return self._payload
 
         with mock.patch.object(pr_review.requests, "get", side_effect=[Response(page1), Response(page2)]) as get:
-            found = pr_review.find_running_comment("owner/repo", "42", "token", "corr")
+            found, scanned = pr_review.find_running_comment("owner/repo", "42", "token", "corr")
         self.assertIsNotNone(found)
+        self.assertTrue(scanned)
         self.assertEqual(get.call_count, 2)
 
     def test_an_ancient_running_marker_does_not_wedge_later_reviews(self) -> None:
@@ -486,7 +456,61 @@ class AdmissionMarkerTest(unittest.TestCase):
                 ]
 
         with mock.patch.object(pr_review.requests, "get", return_value=Response()):
-            self.assertIsNone(pr_review.find_running_comment("owner/repo", "42", "token", "corr"))
+            found, scanned = pr_review.find_running_comment("owner/repo", "42", "token", "corr")
+            self.assertIsNone(found)
+            self.assertTrue(scanned)
+
+
+class AdmissionFailsClosedTest(unittest.TestCase):
+    def test_an_unreadable_page_reports_an_incomplete_scan(self) -> None:
+        # Not finding a marker is only evidence that none exists when every
+        # page was read. A transient error previously read as "nothing running"
+        # and authorized a second concurrent provider run on the same head.
+        with mock.patch.object(pr_review.requests, "get", side_effect=pr_review.requests.RequestException()):
+            found, scanned = pr_review.find_running_comment("owner/repo", "42", "token", "corr")
+        self.assertIsNone(found)
+        self.assertFalse(scanned)
+
+    def test_claim_refuses_when_the_scan_could_not_complete(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
+            pr_review.os.environ, {"GITHUB_OUTPUT": output.name}, clear=False
+        ), mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
+            pr_review, "find_running_comment", return_value=(None, False)
+        ), mock.patch.object(pr_review, "create_comment", return_value={"id": 11}):
+            pr_review.claim_review("owner/repo", "42", "token", "default", "c" * 40)
+            output.seek(0)
+            values = output.read().decode("utf-8")
+        self.assertIn("claimed=false", values)
+
+
+class JudgeContextBoundTest(unittest.TestCase):
+    def test_context_fetches_are_bounded_not_only_the_payload(self) -> None:
+        # Context was fetched for every distinct path before the budget excluded
+        # most of them, so a large candidate set could spend longer on requests
+        # than the job is allowed to run and be killed before publishing partial.
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        candidates = [
+            pr_review.Finding("low", f"internal/pkg{index}/a.go", 1, "t", "w", "f")
+            for index in range(pr_review.MAX_JUDGE_CONTEXT_FETCHES + 25)
+        ]
+        judged_counts: list[int] = []
+        real_prompt = pr_review.build_judge_prompt
+
+        def record(kept: list[object], contexts: dict[str, str]) -> tuple[str, str]:
+            judged_counts.append(len(kept))
+            return real_prompt(kept, contexts)
+
+        def decide(*_args: object, **_kwargs: object) -> dict[str, object]:
+            return {"findings": [{"index": i, "verdict": "keep", "reason": "r"} for i in range(judged_counts[-1])]}
+
+        with mock.patch.object(pr_review, "fetch_file_context", return_value="line\n" * 10) as fetch, mock.patch.object(
+            pr_review, "build_judge_prompt", side_effect=record
+        ), mock.patch.object(pr_review, "call_model", side_effect=decide):
+            _, judged, excluded = pr_review.judge_findings("owner/repo", "token", binding, "deep", candidates)
+        self.assertTrue(judged)
+        self.assertLessEqual(fetch.call_count, pr_review.MAX_JUDGE_CONTEXT_FETCHES)
+        self.assertTrue(excluded)
 
 
 class WallClockBudgetTest(unittest.TestCase):
@@ -515,7 +539,7 @@ class WallClockBudgetTest(unittest.TestCase):
         clock = iter([0.0] + [pr_review.REVIEW_WALL_CLOCK_SECONDS + 1_000.0] * 50)
         with mock.patch.object(pr_review.time, "monotonic", side_effect=lambda: next(clock)), mock.patch.object(
             pr_review, "get_pull_binding", return_value=binding
-        ), mock.patch.object(pr_review, "find_running_comment", return_value=None), mock.patch.object(
+        ), mock.patch.object(pr_review, "find_running_comment", return_value=(None, True)), mock.patch.object(
             pr_review, "create_comment", return_value={"id": 7}
         ), mock.patch.object(pr_review, "fetch_bound_diff", return_value=diff), mock.patch.object(
             pr_review, "call_model"


### PR DESCRIPTION
## What changed

The pull request head is compared before each chunk rather than only at finalization, so a head that moves early in a long review ends the run promptly instead of spending the whole wall-clock budget and provider spend on a commit whose result could only be published as historical. The initial status comment links the run, so a multi-minute review is visibly alive.

The admission scan reports whether it read every page of comments, and a claim refuses when it did not. An unreadable page, a non-200 response, or exhausting the page cap previously read as no review running and authorized a second concurrent provider run against the same head.

The judge bounds how many file contexts it requests rather than only the payload it sends. Contexts were fetched for every distinct candidate path before the token budget excluded most of them, so a large candidate set could spend longer on requests than the job is allowed to run and be killed before publishing its partial result.

**Failure direction, and what to distrust:** an earlier revision of this change edited the status comment as chunks completed. That made a second writer of one comment, and a PATCH that times out may still have been applied, so a late write could revert a finished review to running while the job exited successfully. Liveness is a link for that reason. The remaining thing to distrust is that the final head read and the final comment write are not atomic, so a clean result means clean for the head shown in the comment, not proof the head never moved between those two calls.
