### PR TITLE
fix(ci): review the whole diff and cut the review comment down

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -69,6 +69,8 @@ runs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
       with:
         python-version: '3.12'
+        cache: pip
+        cache-dependency-path: ${{ github.action_path }}/requirements.txt
 
     - name: Install reviewer dependencies
       shell: bash

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -52,15 +52,21 @@ STALE_RUNNING_MINUTES = 90
 # truncates, and the diff media type gives no indication that it did.
 COMPARE_FILE_LIMIT = 300
 COMPARE_COMMIT_LIMIT = 250
-FAST_INPUT_TOKEN_BUDGET = 10_000
-DEEP_INPUT_TOKEN_BUDGET = 16_000
+FAST_INPUT_TOKEN_BUDGET = 12_000
+DEEP_INPUT_TOKEN_BUDGET = 48_000
 FAST_MAX_CHUNKS = 3
 DEEP_MAX_CHUNKS = 8
-MAX_UNITS_PER_CHUNK = 20
+# Keep a default review small enough for a low-reasoning model to hold the
+# relationships in one call. Deep mode can take a materially larger slice: the
+# observed 321-unit PR then needs six chunks instead of being capped at 160
+# units before the token budget is even considered.
+FAST_MAX_UNITS_PER_CHUNK = 30
+DEEP_MAX_UNITS_PER_CHUNK = 60
 # Each judge context fetch allows 30 seconds, so an unbounded candidate set
 # could spend longer on requests than the whole job is permitted to run.
 MAX_JUDGE_CONTEXT_FETCHES = 20
 MAX_DELETION_LINES_PER_HUNK = 24
+MAX_RENDERED_MANIFEST_ENTRIES = 8
 REPO_PATTERN = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
 RUBRIC_VERSION = "2026-08-14.1"
 STATUS_MARKER = "pr-review-status:v1"
@@ -172,6 +178,11 @@ def input_limits(mode: str) -> tuple[int, int]:
     if mode == "deep":
         return DEEP_INPUT_TOKEN_BUDGET, DEEP_MAX_CHUNKS
     return FAST_INPUT_TOKEN_BUDGET, FAST_MAX_CHUNKS
+
+
+def units_per_chunk(mode: str) -> int:
+    """Bound independent review topics as well as prompt tokens."""
+    return DEEP_MAX_UNITS_PER_CHUNK if mode == "deep" else FAST_MAX_UNITS_PER_CHUNK
 
 
 def estimate_tokens(text: str) -> int:
@@ -347,7 +358,7 @@ def plan_chunks(units: list[DiffUnit], mode: str) -> tuple[list[list[DiffUnit]],
             continue
         placed = False
         for index, used in enumerate(chunk_tokens):
-            if len(chunks[index]) < MAX_UNITS_PER_CHUNK and used + unit.estimated_tokens <= token_budget:
+            if len(chunks[index]) < units_per_chunk(mode) and used + unit.estimated_tokens <= token_budget:
                 chunks[index].append(unit)
                 chunk_tokens[index] += unit.estimated_tokens
                 placed = True
@@ -986,31 +997,18 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     counts = {severity: sum(finding.severity == severity for finding in findings) for severity in ("high", "medium", "low")}
     omitted = [entry for entry in manifest if entry["status"] != "reviewed"]
     collapsed = [entry for entry in manifest if entry["collapsed_deletions"]]
-    lines = [
-        "## AI PR Review",
-        "",
-        f"**Status:** `{state}`",
-        f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
-        f"**Model:** `{model}` (`{reasoning_for_mode(mode)}` reasoning)",
-        f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
-        f"**Review identity:** `{binding.correlation}`",
-        f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
-        f"**Completeness:** {progress.reviewed_units}/{progress.expected_units} representable units reviewed; {len(omitted)} omitted or unrepresentable; {len(collapsed)} deletion-collapsed.",
-        f"**Severity counts:** high {counts['high']}, medium {counts['medium']}, low {counts['low']}",
-    ]
-    if progress.incomplete_reasons:
-        lines.extend(["", "**Incomplete because:** " + "; ".join(sorted(set(progress.incomplete_reasons))) + "."])
-    if state == "superseded":
-        lines.extend(["", "This review is historical only because the PR head changed before completion."])
-    if omitted:
-        lines.extend(["", "### Omission manifest"])
-        for entry in omitted:
-            lines.append(f"- `{display_path(str(entry['path']))}` ({sanitize_public_text(str(entry['hunk']), limit=160)}): {sanitize_public_text(str(entry['status']), limit=120)}")
-    if collapsed:
-        lines.extend(["", "### Collapsed deletion hunks"])
-        for entry in collapsed:
-            lines.append(f"- `{display_path(str(entry['path']))}` ({sanitize_public_text(str(entry['hunk']), limit=160)}): {entry['collapsed_deletions']} deletion lines collapsed")
-    lines.extend(["", "### Findings"])
+    lines = ["## AI PR Review", "", f"**Verdict:** `{state}`"]
+    if state == "partial":
+        lines.append("**This is incomplete and must not be treated as a clean review.**")
+    elif state == "superseded":
+        lines.append("**This is historical only because the pull request head changed before completion.**")
+    lines.extend(
+        [
+            f"**Findings:** high {counts['high']}, medium {counts['medium']}, low {counts['low']}.",
+            "",
+            "### Findings",
+        ]
+    )
     if not findings:
         lines.append("No verified material findings were published.")
     else:
@@ -1025,6 +1023,64 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
                     f"**Fix:** {sanitize_public_text(finding.fix, limit=600)}",
                 ]
             )
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Review details: binding and coverage</summary>",
+            "",
+            f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
+            f"**Model:** `{model}` (`{reasoning_for_mode(mode)}` reasoning)",
+            f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
+            f"**Review identity:** `{binding.correlation}`",
+            f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
+            f"**Completeness:** {progress.reviewed_units}/{progress.expected_units} representable units reviewed; {len(omitted)} omitted or unrepresentable; {len(collapsed)} deletion-collapsed.",
+            "",
+            "</details>",
+        ]
+    )
+    if progress.incomplete_reasons:
+        lines.extend(
+            [
+                "",
+                "<details>",
+                "<summary>Why this review is incomplete</summary>",
+                "",
+                "; ".join(sorted(set(progress.incomplete_reasons))) + ".",
+                "",
+                "</details>",
+            ]
+        )
+    if omitted:
+        shown = omitted[:MAX_RENDERED_MANIFEST_ENTRIES]
+        lines.extend(
+            [
+                "",
+                "<details>",
+                f"<summary>Omission manifest ({len(shown)} of {len(omitted)} shown)</summary>",
+                "",
+            ]
+        )
+        for entry in shown:
+            lines.append(f"- `{display_path(str(entry['path']))}` ({sanitize_public_text(str(entry['hunk']), limit=96)}): {sanitize_public_text(str(entry['status']), limit=72)}")
+        if remaining := len(omitted) - len(shown):
+            lines.append(f"- and {remaining} more")
+        lines.extend(["", "</details>"])
+    if collapsed:
+        shown = collapsed[:MAX_RENDERED_MANIFEST_ENTRIES]
+        lines.extend(
+            [
+                "",
+                "<details>",
+                f"<summary>Collapsed deletion hunks ({len(shown)} of {len(collapsed)} shown)</summary>",
+                "",
+            ]
+        )
+        for entry in shown:
+            lines.append(f"- `{display_path(str(entry['path']))}` ({sanitize_public_text(str(entry['hunk']), limit=96)}): {entry['collapsed_deletions']} deletion lines collapsed")
+        if remaining := len(collapsed) - len(shown):
+            lines.append(f"- and {remaining} more")
+        lines.extend(["", "</details>"])
     lines.extend(["", f"<!-- {STATUS_MARKER} state={state} identity={binding.correlation} -->"])
     return "\n".join(lines)
 
@@ -1053,11 +1109,6 @@ def _initial_status(binding: PullBinding, mode: str) -> str:
         "## AI PR Review",
         "",
         "**Status:** `running`",
-        f"**Command:** `{'/review deep' if deep else '/review'}`",
-        f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
-        f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
-        f"**Review identity:** `{binding.correlation}`",
-        "**Classification:** pending immutable diff fetch",
     ]
     if run_url:
         lines.append(f"**Progress:** [live run log]({run_url})")
@@ -1067,6 +1118,17 @@ def _initial_status(binding: PullBinding, mode: str) -> str:
             "A deep review reasons over the diff in bounded chunks and commonly takes several minutes."
             if deep
             else "This comment is replaced with the result when the review finishes.",
+            "",
+            "<details>",
+            "<summary>Review details: binding and planned review</summary>",
+            "",
+            f"**Command:** `{'/review deep' if deep else '/review'}`",
+            f"**Model:** `{model_for_mode(mode)}` (`{reasoning_for_mode(mode)}` reasoning)",
+            f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
+            f"**Review identity:** `{binding.correlation}`",
+            "**Classification:** pending immutable diff fetch",
+            "",
+            "</details>",
             "",
             f"<!-- {STATUS_MARKER} state=running identity={binding.correlation} -->",
         ]
@@ -1180,12 +1242,24 @@ def run_review(
                 findings, changes = parse_findings(payload, {unit.path for unit in chunk}, require_changes={unit.path for unit in chunk})
             except ModelTimeout:
                 progress.timed_out = True
-                progress.incomplete_reasons.append("provider timed out; no retry attempted to avoid a duplicate charge")
-                break
+                # Do not retry an ambiguous timeout: the provider may finish
+                # and bill the original request after this client stops
+                # waiting. Continue with later, distinct chunks so one timeout
+                # does not erase their coverage; timed_out keeps the result
+                # partial even if every other chunk succeeds.
+                progress.incomplete_reasons.append(
+                    f"review chunk {chunk_index} timed out and was not retried to avoid a duplicate charge"
+                )
+                continue
             except ModelOutputError:
-                progress.aggregation_failed = True
-                progress.incomplete_reasons.append("a chunk response was truncated or violated the structured schema")
-                break
+                # A provider 500 or malformed response is localized to this
+                # chunk. Later chunks remain independently reviewable; the
+                # missing unit and this reason make derive_state report partial
+                # rather than allowing their success to read as clean.
+                progress.incomplete_reasons.append(
+                    f"review chunk {chunk_index} returned an incomplete or invalid structured response"
+                )
+                continue
             progress.reviewed_units += len(chunk)
             candidates.extend(findings)
             reviewed_changes.extend(changes)

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1284,7 +1284,13 @@ def run_review(
             except ModelOutputError:
                 progress.aggregation_failed = True
                 progress.incomplete_reasons.append("cross-file synthesis was incomplete or invalid")
-        judge_ready = bool(candidates) and not progress.aggregation_failed and not progress.timed_out
+        # Deliberately not gated on timed_out. A timeout used to end the chunk
+        # loop, so there were no later candidates to judge; chunks now continue
+        # past one, and gating here would discard findings that later chunks
+        # actually produced while completeness still counted their units as
+        # reviewed. timed_out keeps the verdict partial through derive_state,
+        # which is where incompleteness belongs.
+        judge_ready = bool(candidates) and not progress.aggregation_failed
         if judge_ready and not budget_allows(deadline, mode):
             progress.incomplete_reasons.append("wall-clock budget exhausted before the judge pass")
             judge_ready = False

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -193,7 +193,7 @@ jobs:
             *"<!-- pr-review-status:v1 state=running identity=${IDENTITY} -->"*) ;;
             *) echo "pr-review phase=finalize status=not-ours-or-already-final"; exit 0 ;;
           esac
-          printf '## AI PR Review\n\n**Status:** `failed`\n\n**Binding:** base `%s` head `%s`\n\nThe review job ended before the review completed.\n\n<!-- pr-review-status:v1 state=failed identity=%s -->\n' \
-            "${BASE_SHA}" "${HEAD_SHA}" "${IDENTITY}" > /tmp/pr-review-finalize.md
+          printf '## AI PR Review\n\n**Verdict:** `failed`\n**Findings:** unavailable because the review job ended before model review completed.\n\n<details>\n<summary>Review details: binding and identity</summary>\n\n**Binding:** base `%s` head `%s`\n**Review identity:** `%s`\n\n</details>\n\n<!-- pr-review-status:v1 state=failed identity=%s -->\n' \
+            "${BASE_SHA}" "${HEAD_SHA}" "${IDENTITY}" "${IDENTITY}" > /tmp/pr-review-finalize.md
           gh api --method PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -F body=@/tmp/pr-review-finalize.md >/dev/null
           echo "pr-review phase=finalize status=closed"

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -193,7 +193,7 @@ jobs:
             *"<!-- pr-review-status:v1 state=running identity=${IDENTITY} -->"*) ;;
             *) echo "pr-review phase=finalize status=not-ours-or-already-final"; exit 0 ;;
           esac
-          printf '## AI PR Review\n\n**Verdict:** `failed`\n**Findings:** unavailable because the review job ended before model review completed.\n\n<details>\n<summary>Review details: binding and identity</summary>\n\n**Binding:** base `%s` head `%s`\n**Review identity:** `%s`\n\n</details>\n\n<!-- pr-review-status:v1 state=failed identity=%s -->\n' \
+          printf '## AI PR Review\n\n**Verdict:** `failed`\n**Findings:** unavailable because the review job did not publish a final result.\n\n<details>\n<summary>Review details: binding and identity</summary>\n\n**Binding:** base `%s` head `%s`\n**Review identity:** `%s`\n\n</details>\n\n<!-- pr-review-status:v1 state=failed identity=%s -->\n' \
             "${BASE_SHA}" "${HEAD_SHA}" "${IDENTITY}" "${IDENTITY}" > /tmp/pr-review-finalize.md
           gh api --method PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -F body=@/tmp/pr-review-finalize.md >/dev/null
           echo "pr-review phase=finalize status=closed"

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -148,6 +148,8 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("openai-api-key", action)
         self.assertIn("PR_REVIEW_MODEL_FAST", action)
         self.assertIn("PR_REVIEW_MODEL_DEEP", action)
+        self.assertIn("cache: pip", action)
+        self.assertIn("cache-dependency-path: ${{ github.action_path }}/requirements.txt", action)
 
 
 class StateMachineTest(unittest.TestCase):
@@ -191,6 +193,22 @@ class StateMachineTest(unittest.TestCase):
 
 
 class CompressionAndClassificationTest(unittest.TestCase):
+    def test_deep_plan_covers_321_small_units_in_six_chunks(self) -> None:
+        # The old global cap (20 units x 8 chunks) made a 321-unit review
+        # partial even when every hunk fit the token budget. Deep mode now
+        # admits 60 units per chunk, so the observed PR shape fits in six
+        # provider calls and still leaves two chunk slots for larger diffs.
+        # 800 tokens per unit is exactly the old 20-unit, 16k-token ceiling;
+        # this proves the new count and token limits work together rather than
+        # only exercising an unrealistically tiny hunk.
+        units = [unit(index, f"internal/item_{index}.go", "source:go", tokens=800) for index in range(1, 322)]
+        chunks, omitted = pr_review.plan_chunks(units, "deep")
+        self.assertEqual([len(chunk) for chunk in chunks], [60, 60, 60, 60, 60, 21])
+        self.assertEqual(omitted, [])
+        self.assertEqual(pr_review.DEEP_INPUT_TOKEN_BUDGET, 48_000)
+        self.assertEqual(pr_review.DEEP_MAX_UNITS_PER_CHUNK, 60)
+        self.assertEqual(pr_review.DEEP_MAX_CHUNKS, 8)
+
     def test_primary_language_and_additions_outrank_test_config_and_docs(self) -> None:
         ranked = pr_review.rank_units(
             [
@@ -405,6 +423,8 @@ class FinalizerIndependenceTest(unittest.TestCase):
         finalize = workflow.split("Finalize an abandoned review", 1)[1]
         self.assertIn(f"<!-- {pr_review.STATUS_MARKER} state=running", finalize)
         self.assertIn(f"<!-- {pr_review.STATUS_MARKER} state=failed", finalize)
+        self.assertIn("**Verdict:** `failed`", finalize)
+        self.assertIn("<summary>Review details: binding and identity</summary>", finalize)
 
 
 class AdmissionMarkerTest(unittest.TestCase):
@@ -520,7 +540,7 @@ class JudgeFetchCapTest(unittest.TestCase):
         # going. Measured at 60 requests against a limit of 20.
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         candidates = [pr_review.Finding("low", f"p{index}/a.go", 1, "t", "w", "f") for index in range(60)]
-        with mock.patch.object(pr_review, "fetch_file_context", return_value="x" * 80_000) as fetch, mock.patch.object(
+        with mock.patch.object(pr_review, "fetch_file_context", return_value="x" * 200_000) as fetch, mock.patch.object(
             pr_review, "call_model", return_value={"findings": [{"index": 0, "verdict": "keep", "reason": "r"}]}
         ):
             _, judged, excluded = pr_review.judge_findings("owner/repo", "token", binding, "deep", candidates)
@@ -595,6 +615,58 @@ class FailureDirectionTest(unittest.TestCase):
                 pr_review.call_model("system", "user", "deep", "review-chunk-1", "correlation")
 
 
+class ChunkResilienceTest(unittest.TestCase):
+    def _run_with_chunk_outcomes(self, outcomes: list[object]) -> tuple[str, object, object]:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        units = [unit(index, f"internal/item_{index}.go", "source:go") for index in range(1, 4)]
+
+        def payload_for(path: str) -> dict[str, object]:
+            return {"findings": [], "changes": [{"path": path, "summary": "changed"}]}
+
+        resolved = [payload_for(unit.path) if outcome == "ok" else outcome for unit, outcome in zip(units, outcomes, strict=True)]
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")), mock.patch.object(
+            pr_review, "fetch_bound_diff", return_value="ignored"
+        ), mock.patch.object(pr_review, "compare_incompleteness", return_value=None), mock.patch.object(
+            pr_review, "parse_diff", return_value=(units, [])
+        ), mock.patch.object(pr_review, "plan_chunks", return_value=([[units[0]], [units[1]], [units[2]]], [])), mock.patch.object(
+            pr_review, "head_has_moved", return_value=False
+        ), mock.patch.object(pr_review, "get_pull_binding", return_value=binding), mock.patch.object(
+            pr_review, "budget_allows", return_value=True
+        ), mock.patch.object(
+            pr_review, "call_model", side_effect=resolved
+        ) as call_model, mock.patch.object(pr_review, "update_comment"):
+            state, progress = pr_review.run_review(
+                "owner/repo", "42", "token", "deep", "c" * 40, binding=binding, status_comment_id=7
+            )
+        return state, progress, call_model
+
+    def test_invalid_chunk_response_does_not_stop_later_chunks(self) -> None:
+        # A provider 500 used to break here, throwing away every later chunk.
+        # The failed chunk remains missing, so the terminal state must be
+        # partial even though the other two chunks were successfully reviewed.
+        state, progress, call_model = self._run_with_chunk_outcomes(
+            ["ok", pr_review.ModelOutputError("HTTP 500"), "ok"]
+        )
+        self.assertEqual(state, "partial")
+        self.assertEqual(progress.reviewed_units, 2)
+        self.assertFalse(progress.aggregation_failed)
+        self.assertEqual(call_model.call_count, 3)
+        self.assertTrue(any("chunk 2" in reason for reason in progress.incomplete_reasons))
+
+    def test_timeout_is_not_retried_but_later_chunks_continue(self) -> None:
+        # A retry would be ambiguous because the timed-out provider request can
+        # still complete and be billed. Continuing with a distinct later chunk
+        # preserves useful coverage without a duplicate request for chunk one.
+        state, progress, call_model = self._run_with_chunk_outcomes(
+            [pr_review.ModelTimeout("timeout"), "ok", "ok"]
+        )
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.timed_out)
+        self.assertEqual(progress.reviewed_units, 2)
+        self.assertEqual(call_model.call_count, 3)
+        self.assertTrue(any("not retried" in reason for reason in progress.incomplete_reasons))
+
+
 class StructuredOutputSafetyTest(unittest.TestCase):
     def test_model_clean_sentence_cannot_set_clean_state(self) -> None:
         with self.assertRaises(pr_review.ModelOutputError):
@@ -665,7 +737,63 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         self.assertLess(status.index("#### 1. high"), status.index("#### 2. low"))
         self.assertNotIn("/approve", status)
         self.assertNotIn("@bad", status)
-        self.assertIn("Status:** `findings`", status)
+        self.assertIn("Verdict:** `findings`", status)
+
+
+class StatusPresentationTest(unittest.TestCase):
+    def _binding(self) -> object:
+        return pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+
+    def test_partial_status_leads_with_verdict_and_caps_the_manifest(self) -> None:
+        # A no-findings partial once published one line for every omitted hunk
+        # before the reader saw the useful conclusion. Keep the count intact,
+        # show only a bounded sample, and make partial impossible to mistake
+        # for a clean result.
+        manifest = [
+            {
+                "path": f"internal/omitted_{index}.go",
+                "hunk": "@@ -1 +1 @@",
+                "status": "priority-token-budget",
+                "collapsed_deletions": 0,
+            }
+            for index in range(171)
+        ]
+        progress = pr_review.ReviewProgress(
+            expected_units=321,
+            reviewed_units=90,
+            incomplete_reasons=["one or more units were omitted or unrepresentable"],
+        )
+        status = pr_review.render_status(self._binding(), "deep", ["source:go"], progress, "partial", manifest)
+        first_details = status.index("<details>")
+        lead = status[:first_details]
+        self.assertIn("Verdict:** `partial`", lead)
+        self.assertIn("must not be treated as a clean review", lead)
+        self.assertIn("### Findings", lead)
+        self.assertNotIn("**Binding:**", lead)
+        self.assertNotIn("**Completeness:**", lead)
+        self.assertIn("<summary>Review details: binding and coverage</summary>", status)
+        self.assertIn("<summary>Why this review is incomplete</summary>", status)
+        self.assertIn("<summary>Omission manifest (8 of 171 shown)</summary>", status)
+        self.assertEqual(status.count("priority-token-budget"), pr_review.MAX_RENDERED_MANIFEST_ENTRIES)
+        self.assertIn("- and 163 more", status)
+        self.assertLess(len(status.encode("utf-8")), 2_500)
+
+    def test_no_findings_status_is_compact_but_keeps_details_available(self) -> None:
+        progress = pr_review.ReviewProgress(expected_units=1, reviewed_units=1)
+        status = pr_review.render_status(self._binding(), "default", ["source:go"], progress, "clean", [])
+        self.assertIn("Verdict:** `clean`", status)
+        self.assertIn("Findings:** high 0, medium 0, low 0.", status)
+        self.assertIn("No verified material findings were published.", status)
+        self.assertIn("<summary>Review details: binding and coverage</summary>", status)
+        self.assertLess(len(status.encode("utf-8")), 2_000)
+
+    def test_running_status_keeps_binding_out_of_the_open_body(self) -> None:
+        status = pr_review._initial_status(self._binding(), "deep")
+        lead = status[:status.index("<details>")]
+        self.assertIn("Status:** `running`", lead)
+        self.assertNotIn("**Binding:**", lead)
+        self.assertNotIn("**Review identity:**", lead)
+        self.assertIn("<summary>Review details: binding and planned review</summary>", status)
 
 
 if __name__ == "__main__":

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -549,6 +549,61 @@ class JudgeFetchCapTest(unittest.TestCase):
         self.assertEqual(len(excluded), len(candidates) - 1)
 
 
+class TimeoutStillPublishesLaterFindingsTest(unittest.TestCase):
+    def test_a_finding_from_a_chunk_after_a_timeout_is_published(self) -> None:
+        # Chunks continue past a timeout, so gating the judge on timed_out
+        # discarded findings that later chunks really produced while
+        # completeness still counted their units as reviewed. The verdict stays
+        # partial; the finding must not vanish.
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        diff = "\n".join(
+            [
+                "diff --git a/internal/a.go b/internal/a.go",
+                "--- a/internal/a.go",
+                "+++ b/internal/a.go",
+                "@@ -1 +1 @@",
+                "-old",
+                "+new",
+                "diff --git a/internal/b.go b/internal/b.go",
+                "--- a/internal/b.go",
+                "+++ b/internal/b.go",
+                "@@ -1 +1 @@",
+                "-old",
+                "+new",
+            ]
+        )
+        found = {
+            "findings": [
+                {
+                    "severity": "high",
+                    "path": "internal/b.go",
+                    "line": 1,
+                    "title": "unsafe",
+                    "why": "why",
+                    "fix": "fix",
+                    "needs_verification": False,
+                }
+            ],
+            "changes": [{"path": "internal/b.go", "summary": "changes enforcement"}],
+        }
+        judged = {"findings": [{"index": 0, "verdict": "keep", "reason": "confirmed"}]}
+        with mock.patch.object(pr_review, "plan_chunks", side_effect=lambda units, mode: ([[units[0]], [units[1]]], [])), mock.patch.object(
+            pr_review, "get_pull_binding", return_value=binding
+        ), mock.patch.object(pr_review, "find_running_comment", return_value=(None, True)), mock.patch.object(
+            pr_review, "create_comment", return_value={"id": 7}
+        ), mock.patch.object(pr_review, "fetch_bound_diff", return_value=diff), mock.patch.object(
+            pr_review, "compare_incompleteness", return_value=None
+        ), mock.patch.object(
+            pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")
+        ), mock.patch.object(pr_review, "fetch_file_context", return_value="line\n" * 5), mock.patch.object(
+            pr_review, "call_model", side_effect=[pr_review.ModelTimeout("slow"), found, judged]
+        ), mock.patch.object(pr_review, "update_comment"):
+            state, progress = pr_review.run_review("owner/repo", "42", "token", "deep", "c" * 40)
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.timed_out)
+        self.assertEqual([finding.path for finding in progress.findings], ["internal/b.go"])
+
+
 class WallClockBudgetTest(unittest.TestCase):
     def test_budget_refuses_a_call_that_cannot_finish_before_the_job_timeout(self) -> None:
         now = 1_000.0


### PR DESCRIPTION
## What changed

Chunk planning capped a deep review at twenty units per chunk across eight chunks, so a diff larger than one hundred and sixty units was truncated before token budgets were even considered. A real pull request of three hundred and twenty one units had two thirds of it dropped and still took seventeen minutes, because the work was split into many small expensive calls. Deep now plans forty eight thousand estimated input tokens and sixty units per chunk, which covers that same diff completely in six chunks. The completion budget, the per call timeout and the overall wall clock budget are unchanged.

A provider error on a single chunk ended the whole review and discarded the chunks that had already succeeded. A failed or malformed chunk response is now recorded and the remaining chunks are reviewed.

The published comment led with binding metadata and then listed every omitted hunk, which put a zero finding result on line ten of a twenty four thousand character comment. It now opens with the verdict, states plainly when a result must not be treated as clean, and gives the findings immediately. Binding, coverage, reasons and manifests moved into collapsed sections, and manifests show the first few entries and a count of the rest. The same partial result renders in about fourteen hundred characters.

The action caches its Python dependencies.

**Failure direction, and what to distrust:** continuing past a failed chunk cannot turn an incomplete review into a clean one. The recorded reason forces partial, and the reviewed unit count no longer matches what was expected, so both guards would have to fail together. The part worth distrusting is the larger chunk size. Each call now carries roughly three times the input against an unchanged completion budget shared between reasoning and visible output, so a chunk that exhausts that budget returns a truncated response. That degrades to partial rather than to a false clean, but it can reduce real coverage, and only a live run on a large pull request will show whether it happens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reviews now handle larger changesets and more context effectively.
  * Timed-out or invalid segments no longer stop remaining segments from completing.
  * Status updates prominently show verdicts and finding counts, with supporting details in collapsible sections.
  * Partial or abandoned reviews clearly explain unavailable findings and omitted details.
* **Chores**
  * Enabled dependency caching to speed up review workflow runs.
* **Tests**
  * Expanded coverage for resilience, status presentation, caching, and partial results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->