### PR TITLE
fix(ci): drop the pip cache that stopped every review from starting

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -69,8 +69,12 @@ runs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
       with:
         python-version: '3.12'
-        cache: pip
-        cache-dependency-path: ${{ github.action_path }}/requirements.txt
+        # No pip cache here. github.action_path resolves with a "." segment
+        # when this action is used from a checked-out path, and
+        # cache-dependency-path rejects relative components, which failed setup
+        # and stopped every review before it began. The install is two seconds
+        # against a review measured in minutes, so the cache is not worth
+        # another way to break the run.
 
     - name: Install reviewer dependencies
       shell: bash

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -148,16 +148,29 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("openai-api-key", action)
         self.assertIn("PR_REVIEW_MODEL_FAST", action)
         self.assertIn("PR_REVIEW_MODEL_DEEP", action)
-        # There is deliberately no assertion here about pip caching. Four
-        # attempts to express one in this file were each bypassed a different
-        # way, by a comment naming the key, by a quoted value, by a flow
-        # mapping, and by whitespace before the colon, because each was a
-        # hand-rolled reader standing in for a YAML parser. A guard that keeps
-        # being wrong is worse than none: it reports safety it does not have.
-        # Reintroducing either cache key fails setup on the next review and is
-        # therefore loud and immediate, which is the detection that matters
-        # here. The reason it must not come back is recorded where the setting
-        # would live, in action.yml.
+        # Either cache key breaks setup for this action and stops every review
+        # before it starts, so this asserts against the parsed document rather
+        # than the file's text. Four text-matching versions were each bypassed
+        # a different way: by the comment that named the key, by a quoted
+        # value, by a flow mapping, and by whitespace before the colon. Those
+        # are parser differentials, and the answer to a parser differential is
+        # a parser.
+        #
+        # The import is local and its absence is a hard failure rather than a
+        # skip. The job that runs these tests installs no Python packages, so
+        # PyYAML being present is an assumption; a skip would turn that
+        # assumption into silent lost coverage, which is the whole failure
+        # class here. If this ever goes red on a missing module, that is the
+        # fact worth learning, and it is one dependency line to fix.
+        try:
+            import yaml
+        except ImportError:  # pragma: no cover
+            self.fail("PyYAML is required to verify this action's setup keys")
+        document = yaml.safe_load(action)
+        for step in document["runs"]["steps"]:
+            settings = step.get("with") or {}
+            self.assertNotIn("cache", settings, f"{step.get('name')} must not enable pip caching")
+            self.assertNotIn("cache-dependency-path", settings, f"{step.get('name')} must not set a cache path")
 
 
 class StateMachineTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -61,36 +61,6 @@ def top_level_permissions(text: str) -> dict[str, str]:
     return permissions
 
 
-def setting_keys(text: str) -> set[str]:
-    """Every mapping key that is actually in effect in a workflow document.
-
-    Comment lines are dropped so prose naming a key cannot satisfy or defeat an
-    assertion, and only the key is returned, so however a value is quoted makes
-    no difference. Deliberately dependency-free: the CI job that runs these
-    tests installs no Python packages, and an import failure there would take
-    down the whole discovery run rather than one assertion.
-    """
-    keys: set[str] = set()
-    for raw in text.splitlines():
-        line = raw.split("#", 1)[0].strip()
-        if line.startswith("- "):
-            line = line[2:].strip()
-        key, separator, value = line.partition(":")
-        if not (separator and key and " " not in key):
-            continue
-        keys.add(key.strip().strip("'\""))
-        # A flow mapping puts real settings on the same line, so "with:
-        # {cache: pip}" would otherwise report only "with" and let a
-        # setup-breaking key back in green. Reported reproduction.
-        value = value.strip()
-        if value.startswith("{") and value.endswith("}"):
-            for entry in value[1:-1].split(","):
-                inner, inner_separator, _ = entry.partition(":")
-                if inner_separator and inner.strip():
-                    keys.add(inner.strip().strip("'\""))
-    return keys
-
-
 def unit(identifier: int, path: str, category: str, *, additions: int = 1, tokens: int = 2) -> object:
     return pr_review.DiffUnit(
         identifier=identifier,
@@ -178,17 +148,16 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("openai-api-key", action)
         self.assertIn("PR_REVIEW_MODEL_FAST", action)
         self.assertIn("PR_REVIEW_MODEL_DEEP", action)
-        # Either cache key breaks setup for this action, which stops every
-        # review before it starts: a dependency path built from the action path
-        # carries a dot segment that setup rejects, and enabling the cache
-        # without one makes setup search the workspace for a requirements file
-        # and fail when it finds none.
-        #
-        # This matches the KEY rather than a key and value. Earlier revisions
-        # matched "cache: pip", which any of pip, 'pip' or "pip" would have
-        # slipped past, and matched raw text, which the comment above tripped
-        # over by naming the key it forbids. A key match has neither problem.
-        self.assertEqual(setting_keys(action) & {"cache", "cache-dependency-path"}, set())
+        # There is deliberately no assertion here about pip caching. Four
+        # attempts to express one in this file were each bypassed a different
+        # way, by a comment naming the key, by a quoted value, by a flow
+        # mapping, and by whitespace before the colon, because each was a
+        # hand-rolled reader standing in for a YAML parser. A guard that keeps
+        # being wrong is worse than none: it reports safety it does not have.
+        # Reintroducing either cache key fails setup on the next review and is
+        # therefore loud and immediate, which is the detection that matters
+        # here. The reason it must not come back is recorded where the setting
+        # would live, in action.yml.
 
 
 class StateMachineTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -61,6 +61,36 @@ def top_level_permissions(text: str) -> dict[str, str]:
     return permissions
 
 
+def setting_keys(text: str) -> set[str]:
+    """Every mapping key that is actually in effect in a workflow document.
+
+    Comment lines are dropped so prose naming a key cannot satisfy or defeat an
+    assertion, and only the key is returned, so however a value is quoted makes
+    no difference. Deliberately dependency-free: the CI job that runs these
+    tests installs no Python packages, and an import failure there would take
+    down the whole discovery run rather than one assertion.
+    """
+    keys: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line.startswith("- "):
+            line = line[2:].strip()
+        key, separator, value = line.partition(":")
+        if not (separator and key and " " not in key):
+            continue
+        keys.add(key.strip().strip("'\""))
+        # A flow mapping puts real settings on the same line, so "with:
+        # {cache: pip}" would otherwise report only "with" and let a
+        # setup-breaking key back in green. Reported reproduction.
+        value = value.strip()
+        if value.startswith("{") and value.endswith("}"):
+            for entry in value[1:-1].split(","):
+                inner, inner_separator, _ = entry.partition(":")
+                if inner_separator and inner.strip():
+                    keys.add(inner.strip().strip("'\""))
+    return keys
+
+
 def unit(identifier: int, path: str, category: str, *, additions: int = 1, tokens: int = 2) -> object:
     return pr_review.DiffUnit(
         identifier=identifier,
@@ -148,17 +178,17 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("openai-api-key", action)
         self.assertIn("PR_REVIEW_MODEL_FAST", action)
         self.assertIn("PR_REVIEW_MODEL_DEEP", action)
-        # Asserting a cache setting appeared in the file proved only that the
-        # text was present, and the setting it described failed at runtime and
-        # stopped every review. This checks the settings actually in effect,
-        # ignoring comments, because the comment explaining the removal names
-        # the very key it must not find.
-        effective = "\n".join(line for line in action.splitlines() if not line.strip().startswith("#"))
-        # Both keys, not just the one that failed. Enabling the cache without a
-        # dependency path makes setup search the workspace for a requirements
-        # file and fail when it finds none, which breaks setup the same way.
-        self.assertNotIn("cache: pip", effective)
-        self.assertNotIn("cache-dependency-path", effective)
+        # Either cache key breaks setup for this action, which stops every
+        # review before it starts: a dependency path built from the action path
+        # carries a dot segment that setup rejects, and enabling the cache
+        # without one makes setup search the workspace for a requirements file
+        # and fail when it finds none.
+        #
+        # This matches the KEY rather than a key and value. Earlier revisions
+        # matched "cache: pip", which any of pip, 'pip' or "pip" would have
+        # slipped past, and matched raw text, which the comment above tripped
+        # over by naming the key it forbids. A key match has neither problem.
+        self.assertEqual(setting_keys(action) & {"cache", "cache-dependency-path"}, set())
 
 
 class StateMachineTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -148,8 +148,13 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("openai-api-key", action)
         self.assertIn("PR_REVIEW_MODEL_FAST", action)
         self.assertIn("PR_REVIEW_MODEL_DEEP", action)
-        self.assertIn("cache: pip", action)
-        self.assertIn("cache-dependency-path: ${{ github.action_path }}/requirements.txt", action)
+        # Asserting a cache setting appeared in the file proved only that the
+        # text was present, and the setting it described failed at runtime and
+        # stopped every review. This checks the settings actually in effect,
+        # ignoring comments, because the comment explaining the removal names
+        # the very key it must not find.
+        effective = [line for line in action.splitlines() if not line.strip().startswith("#")]
+        self.assertNotIn("cache-dependency-path", "\n".join(effective))
 
 
 class StateMachineTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -153,8 +153,12 @@ class WorkflowPackagingTest(unittest.TestCase):
         # stopped every review. This checks the settings actually in effect,
         # ignoring comments, because the comment explaining the removal names
         # the very key it must not find.
-        effective = [line for line in action.splitlines() if not line.strip().startswith("#")]
-        self.assertNotIn("cache-dependency-path", "\n".join(effective))
+        effective = "\n".join(line for line in action.splitlines() if not line.strip().startswith("#"))
+        # Both keys, not just the one that failed. Enabling the cache without a
+        # dependency path makes setup search the workspace for a requirements
+        # file and fail when it finds none, which breaks setup the same way.
+        self.assertNotIn("cache: pip", effective)
+        self.assertNotIn("cache-dependency-path", effective)
 
 
 class StateMachineTest(unittest.TestCase):


### PR DESCRIPTION
## What changed

The review action no longer passes a pip cache dependency path. That path was built from the action path, which resolves with a dot segment when the action runs from a checked-out directory, and the setup step rejects relative components. Python setup failed, the admission job failed with it, and no review ran at all.

The install it was avoiding takes about two seconds against a review measured in minutes, so the cache is removed rather than repaired.

**Failure direction, and what to distrust:** this restores the behaviour that was working before the cache was added, so the risk is a slower install rather than a broken run. The wider problem it exposes is that this workflow only executes from the default branch, so a change to it cannot fail on the pull request that introduces it. Its test asserted that the cache setting appeared in the file, which said nothing about whether the setting worked, and the setting was wrong. Treat any assertion about this action's setup keys as unverified until a review has actually run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified Python environment setup by removing pip caching configuration.
  * Updated validation checks to reflect the streamlined setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->