### PR TITLE
fix(ci): stop a published review from reporting itself as a failure

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -16,6 +16,12 @@ outputs:
   correlation:
     description: Review identity written into the status comment marker.
     value: ${{ steps.run.outputs.correlation }}
+  state:
+    description: Published verdict for this review.
+    value: ${{ steps.run.outputs.state }}
+  complete:
+    description: Whether the review reached a verdict over the whole diff.
+    value: ${{ steps.run.outputs.complete }}
 inputs:
   github-token:
     description: Token permitted to read pull requests and update their status

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -16,6 +16,7 @@ import sys
 import time
 import unicodedata
 import urllib.parse
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -40,6 +41,12 @@ DEEP_LLM_TIMEOUT_SECONDS = 720
 # timeout so the run can refuse a call it cannot finish and report partial.
 REVIEW_WALL_CLOCK_SECONDS = 2_100
 DIFF_FETCH_ATTEMPTS = 2
+# A connection failure before the provider returns a response is the one
+# request-error class worth retrying: it costs no completed review result and
+# frequently represents a transient runner-to-provider path failure. Keep the
+# bound literal and small; a second connection failure remains incomplete work,
+# not an invitation to keep spending the review budget.
+MODEL_CONNECTION_ATTEMPTS = 2
 # Bounds the admission scan on a pull request with a very long comment history.
 ADMISSION_COMMENT_PAGES = 10
 # A running marker older than any possible job (10-minute admit plus 45-minute
@@ -86,6 +93,10 @@ class ModelTimeout(ReviewError):
 
 class ModelOutputError(ReviewError):
     """A provider response was not a complete, valid structured result."""
+
+
+class ModelConnectionError(ModelOutputError):
+    """The provider connection failed before either of two attempts completed."""
 
 
 class ProviderConfigurationError(ReviewError):
@@ -536,26 +547,45 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
     api_url, api_key = provider_configuration()
     model = model_for_mode(mode)
     timeout = llm_timeout_for(mode)
-    try:
-        response = requests.post(
-            api_url,
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json=build_llm_payload(model, system, user, mode),
-            timeout=timeout,
-        )
-    except requests.Timeout as exc:
-        log_phase(phase, status="timeout", correlation=correlation)
-        raise ModelTimeout("provider timed out") from exc
-    except requests.RequestException as exc:
-        log_phase(phase, status="request-error", correlation=correlation)
-        raise ModelOutputError("provider request failed") from exc
-    log_phase(phase, status=response.status_code, correlation=correlation)
-    if response.status_code != 200:
-        raise ModelOutputError(f"provider returned HTTP {response.status_code}")
-    try:
-        return json.loads(_content_from_response(response.json()))
-    except (ValueError, json.JSONDecodeError) as exc:
-        raise ModelOutputError("provider did not return JSON") from exc
+    # This is a correlation key, not an idempotency promise: the direct and
+    # LiteLLM-compatible endpoints do not share a documented deduplication
+    # contract. It stays stable across the one permitted retry so a provider
+    # can trace both attempts if a connection fault needs investigation.
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Client-Request-Id": str(uuid.uuid4()),
+    }
+    payload = build_llm_payload(model, system, user, mode)
+    for attempt in range(1, MODEL_CONNECTION_ATTEMPTS + 1):
+        try:
+            response = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
+        except requests.Timeout as exc:
+            # A timeout is ambiguous: the provider may complete and bill it
+            # after this runner stops waiting, so it is deliberately never
+            # retried.
+            log_phase(phase, attempt=attempt, status="timeout", correlation=correlation)
+            raise ModelTimeout("provider timed out") from exc
+        except requests.ConnectionError as exc:
+            log_phase(phase, attempt=attempt, status="connection-error", correlation=correlation)
+            if attempt == MODEL_CONNECTION_ATTEMPTS:
+                raise ModelConnectionError("provider connection failed after one retry") from exc
+            continue
+        except requests.RequestException as exc:
+            # A response-path failure, protocol error, or any other request
+            # error may have reached the provider. Retrying it could bill the
+            # same review twice, so only a connection error gets the bounded
+            # retry above.
+            log_phase(phase, attempt=attempt, status="request-error", correlation=correlation)
+            raise ModelOutputError("provider request failed") from exc
+        log_phase(phase, attempt=attempt, status=response.status_code, correlation=correlation)
+        if response.status_code != 200:
+            raise ModelOutputError(f"provider returned HTTP {response.status_code}")
+        try:
+            return json.loads(_content_from_response(response.json()))
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise ModelOutputError("provider did not return JSON") from exc
+    raise AssertionError("connection retry loop must return or raise")
 
 
 def _required_string(value: object, field_name: str, *, limit: int) -> str:
@@ -1251,6 +1281,14 @@ def run_review(
                     f"review chunk {chunk_index} timed out and was not retried to avoid a duplicate charge"
                 )
                 continue
+            except ModelConnectionError:
+                # This distinct reason tells the reader that the runner made
+                # the one safe retry, then retained the missing chunk as
+                # incomplete rather than hiding it behind later success.
+                progress.incomplete_reasons.append(
+                    f"review chunk {chunk_index} could not connect after one retry"
+                )
+                continue
             except ModelOutputError:
                 # A provider 500 or malformed response is localized to this
                 # chunk. Later chunks remain independently reviewable; the
@@ -1281,6 +1319,9 @@ def run_review(
             except ModelTimeout:
                 progress.timed_out = True
                 progress.incomplete_reasons.append("cross-file synthesis timed out")
+            except ModelConnectionError:
+                progress.aggregation_failed = True
+                progress.incomplete_reasons.append("cross-file synthesis could not connect after one retry")
             except ModelOutputError:
                 progress.aggregation_failed = True
                 progress.incomplete_reasons.append("cross-file synthesis was incomplete or invalid")
@@ -1306,6 +1347,9 @@ def run_review(
             except ModelTimeout:
                 progress.timed_out = True
                 progress.incomplete_reasons.append("judge pass timed out")
+            except ModelConnectionError:
+                progress.aggregation_failed = True
+                progress.incomplete_reasons.append("judge pass could not connect after one retry")
             except ModelOutputError:
                 progress.aggregation_failed = True
                 progress.incomplete_reasons.append("judge pass was incomplete or invalid")
@@ -1323,6 +1367,19 @@ def run_review(
         except (requests.RequestException, ReviewError):
             log_phase("comment-update", status="failed", correlation=binding.correlation)
             raise ReviewError("final status comment update failed") from None
+
+
+PUBLISHED_REVIEW_STATES = frozenset({"already-running", "clean", "failed", "findings", "partial", "superseded"})
+
+
+def exit_code_for_state(state: str) -> int:
+    """Map a published terminal outcome to its runner result.
+
+    The status comment is the review result. A green job means that result was
+    published, including an explicit `failed`, `partial`, or `superseded`
+    verdict; red means setup failed or the runner could not publish a verdict.
+    """
+    return 0 if state in PUBLISHED_REVIEW_STATES else 1
 
 
 def main() -> None:
@@ -1368,7 +1425,8 @@ def main() -> None:
     except (FetchError, ReviewError, requests.RequestException):
         print("pr-review phase=terminal attempt=1 status=failed correlation=pending", file=sys.stderr)
         raise SystemExit(1) from None
-    if state not in {"clean", "findings", "already-running"}:
+    print(f"pr-review phase=terminal attempt=1 status={state} correlation=published")
+    if exit_code_for_state(state):
         raise SystemExit(1)
 
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1370,6 +1370,9 @@ def run_review(
 
 
 PUBLISHED_REVIEW_STATES = frozenset({"already-running", "clean", "failed", "findings", "partial", "superseded"})
+# A review that reached a verdict over the whole diff. Everything else left
+# something unreviewed, however cleanly it reported that.
+COMPLETE_REVIEW_STATES = frozenset({"clean", "findings"})
 
 
 def exit_code_for_state(state: str) -> int:
@@ -1426,6 +1429,13 @@ def main() -> None:
         print("pr-review phase=terminal attempt=1 status=failed correlation=pending", file=sys.stderr)
         raise SystemExit(1) from None
     print(f"pr-review phase=terminal attempt=1 status={state} correlation=published")
+    # Published separately from the exit code because these answer different
+    # questions. The exit code says whether the runner worked; this says
+    # whether the review actually covered the diff. Collapsing them is what
+    # made a nine-finding review look like a crashed job, and inverting the
+    # collapse would instead let an incomplete review show an all-green pull
+    # request, which reads as reviewed when it was not.
+    write_action_outputs(state=state, complete="true" if state in COMPLETE_REVIEW_STATES else "false")
     if exit_code_for_state(state):
         raise SystemExit(1)
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -560,22 +560,26 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
     for attempt in range(1, MODEL_CONNECTION_ATTEMPTS + 1):
         try:
             response = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
-        except requests.Timeout as exc:
-            # A timeout is ambiguous: the provider may complete and bill it
-            # after this runner stops waiting, so it is deliberately never
-            # retried.
-            log_phase(phase, attempt=attempt, status="timeout", correlation=correlation)
-            raise ModelTimeout("provider timed out") from exc
-        except requests.ConnectionError as exc:
-            log_phase(phase, attempt=attempt, status="connection-error", correlation=correlation)
+        except requests.ConnectTimeout as exc:
+            # The only failure that proves the request was never delivered: the
+            # connection itself was never established, so the provider cannot
+            # have seen or billed it. This clause must stay ABOVE Timeout,
+            # which ConnectTimeout also subclasses, or it never runs.
+            log_phase(phase, attempt=attempt, status="connect-timeout", correlation=correlation)
             if attempt == MODEL_CONNECTION_ATTEMPTS:
                 raise ModelConnectionError("provider connection failed after one retry") from exc
             continue
+        except requests.Timeout as exc:
+            # Ambiguous: the provider may complete and bill this after the
+            # runner stops waiting, so it is deliberately never retried.
+            log_phase(phase, attempt=attempt, status="timeout", correlation=correlation)
+            raise ModelTimeout("provider timed out") from exc
         except requests.RequestException as exc:
-            # A response-path failure, protocol error, or any other request
-            # error may have reached the provider. Retrying it could bill the
-            # same review twice, so only a connection error gets the bounded
-            # retry above.
+            # Everything else, including a connection reset or a protocol
+            # error, can occur after the request reached the provider. None of
+            # them prove non-delivery, and X-Client-Request-Id above is a
+            # correlation key rather than a deduplication contract, so retrying
+            # any of them risks paying for the same review twice.
             log_phase(phase, attempt=attempt, status="request-error", correlation=correlation)
             raise ModelOutputError("provider request failed") from exc
         log_phase(phase, attempt=attempt, status=response.status_code, correlation=correlation)

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -95,6 +95,9 @@ jobs:
     if: needs.admit.outputs.claimed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      state: ${{ steps.litellm.outputs.state || steps.openai.outputs.state || steps.nocreds.outputs.state }}
+      complete: ${{ steps.litellm.outputs.complete || steps.openai.outputs.complete || steps.nocreds.outputs.complete }}
     env:
       HAS_LITELLM: >-
         ${{ secrets.litellm_base_url != '' && secrets.litellm_api_key != '' && 'true' || 'false' }}
@@ -112,6 +115,7 @@ jobs:
       # mappings are required because personal-account repositories cannot use
       # secrets: inherit with a reusable workflow.
       - name: Run review through LiteLLM
+        id: litellm
         if: env.HAS_LITELLM == 'true'
         uses: ./trusted-pr-review/.github/actions/pr-review
         with:
@@ -130,6 +134,7 @@ jobs:
           model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
 
       - name: Run review through OpenAI
+        id: openai
         if: env.HAS_LITELLM != 'true' && env.HAS_OPENAI == 'true'
         uses: ./trusted-pr-review/.github/actions/pr-review
         with:
@@ -147,6 +152,7 @@ jobs:
           model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
 
       - name: Report missing provider credential
+        id: nocreds
         if: env.HAS_LITELLM != 'true' && env.HAS_OPENAI != 'true'
         uses: ./trusted-pr-review/.github/actions/pr-review
         with:
@@ -162,6 +168,17 @@ jobs:
           model-fast: ${{ vars.PR_REVIEW_MODEL_FAST }}
           model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
 
+
+  # Separate from the review job on purpose. Inside it, this was skipped in the
+  # one case it most needs to cover: admission claims the status comment and the
+  # review job never starts, leaving the comment reading running until its stale
+  # timeout blocks later reviews.
+  finalize:
+    needs: [admit, review]
+    if: always() && needs.admit.outputs.claimed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
       # The job timeout, a cancellation, or a failed checkout all end this job
       # before any step above finalizes the status comment. Left running, the
       # admission check treats it as an active review and refuses later reviews
@@ -171,7 +188,6 @@ jobs:
       # the comment this run claimed, and only while that comment still reads
       # running, so a completed review is never overwritten.
       - name: Finalize an abandoned review
-        if: always()
         env:
           GH_TOKEN: ${{ secrets.review_token }}
           REPO: ${{ github.repository }}
@@ -197,3 +213,24 @@ jobs:
             "${BASE_SHA}" "${HEAD_SHA}" "${IDENTITY}" "${IDENTITY}" > /tmp/pr-review-finalize.md
           gh api --method PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -F body=@/tmp/pr-review-finalize.md >/dev/null
           echo "pr-review phase=finalize status=closed"
+
+  completeness:
+    needs: [admit, review]
+    if: always() && needs.admit.outputs.claimed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require a review that covered the whole diff
+        env:
+          STATE: ${{ needs.review.outputs.state }}
+          COMPLETE: ${{ needs.review.outputs.complete }}
+          REVIEW_RESULT: ${{ needs.review.result }}
+        run: |
+          set -euo pipefail
+          if [ "${COMPLETE}" = "true" ]; then
+            echo "pr-review coverage: complete (${STATE})"
+            exit 0
+          fi
+          echo "pr-review coverage: NOT complete (state=${STATE:-none}, review job ${REVIEW_RESULT})" >&2
+          echo "The review comment carries the verdict and the reasons it is incomplete." >&2
+          exit 1

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -3,6 +3,23 @@ name: AI PR Review
 on:
   issue_comment:
     types: [created]
+  # This workflow is evaluated only from the default branch. It cannot test a
+  # workflow change before that change merges, but it makes the next change
+  # exercisable without relying on an issue comment.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review.
+        required: true
+        type: string
+      review_mode:
+        description: Review depth.
+        required: true
+        default: default
+        type: choice
+        options:
+          - default
+          - deep
 
 permissions:
   contents: read
@@ -20,16 +37,25 @@ jobs:
     # This gate authorizes the external provider call and outbound PR-code
     # review. The reusable workflow runs only immutable Pipelock action code.
     if: >-
-      github.event.comment.user.login == 'luckyPipewrench' &&
-      github.event.comment.author_association == 'OWNER' &&
-      github.event.issue.pull_request &&
-      (github.event.comment.body == '/review' ||
-       github.event.comment.body == '/review deep')
+      github.actor == 'luckyPipewrench' &&
+      github.triggering_actor == 'luckyPipewrench' &&
+      ((github.event_name == 'issue_comment' &&
+        github.event.comment.user.login == 'luckyPipewrench' &&
+        github.event.comment.author_association == 'OWNER' &&
+        github.event.issue.pull_request &&
+        (github.event.comment.body == '/review' ||
+         github.event.comment.body == '/review deep')) ||
+       github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/pr-review-reusable.yaml
     with:
-      pr_number: ${{ github.event.issue.number }}
+      pr_number: >-
+        ${{ github.event_name == 'issue_comment' &&
+            github.event.issue.number || inputs.pr_number }}
       review_mode: >-
-        ${{ github.event.comment.body == '/review deep' && 'deep' || 'default' }}
+        ${{ github.event_name == 'issue_comment' &&
+            (github.event.comment.body == '/review deep' && 'deep' ||
+             'default') ||
+            inputs.review_mode }}
       # A same-repository reusable call resolves this workflow at github.sha.
       # External callers use an explicit full SHA in both positions instead.
       reviewer_sha: ${{ github.sha }}

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -13,8 +13,13 @@ from unittest import mock
 
 try:
     import yaml
-except ImportError as exc:  # pragma: no cover
-    raise RuntimeError("PyYAML is required to verify PR-review workflow structure") from exc
+except ImportError:  # pragma: no cover
+    # Absent PyYAML fails the tests that need it and nothing else. Raising here
+    # would abort collection for this whole module, taking down every unrelated
+    # assertion in it, and a skip would quietly drop the coverage instead. The
+    # job that runs these tests installs no packages, so whether PyYAML is
+    # present on the runner is an open question that CI answers directly.
+    yaml = None
 
 
 ROOT = pathlib.Path(__file__).parents[1]
@@ -33,6 +38,15 @@ SPEC.loader.exec_module(pr_review)
 
 def parse_yaml(text: str) -> dict[str, object]:
     """Parse workflow YAML without YAML 1.1 coercing GitHub's `on` key."""
+    if yaml is None:  # pragma: no cover
+        # A failure, never a skip. A skipped structural check reports the same
+        # green as a passing one, which is the exact class of defect these
+        # tests exist to catch.
+        raise AssertionError("PyYAML is required to verify workflow structure and is not installed here")
+    # BaseLoader constructs nothing but strings, lists and dicts, so it cannot
+    # instantiate arbitrary Python the way the default loader can. It is also
+    # the only loader that leaves GitHub's `on:` key alone, which YAML 1.1
+    # otherwise reads as the boolean true.
     document = yaml.load(text, Loader=yaml.BaseLoader)
     if not isinstance(document, dict):
         raise RuntimeError("expected a YAML mapping")
@@ -70,16 +84,23 @@ class WorkflowPackagingTest(unittest.TestCase):
 
         review = caller["jobs"]["review"]
         self.assertEqual(review["uses"], "./.github/workflows/pr-review-reusable.yaml")
-        gate = review["if"]
-        for requirement in (
-            "github.actor == 'luckyPipewrench'",
-            "github.triggering_actor == 'luckyPipewrench'",
-            "github.event.comment.user.login == 'luckyPipewrench'",
-            "github.event.comment.author_association == 'OWNER'",
-            "github.event.issue.pull_request",
-            "github.event_name == 'workflow_dispatch'",
-        ):
-            self.assertIn(requirement, gate)
+        # The WHOLE expression, not its parts. Requiring only substrings would
+        # accept a gate rewritten as "dispatch || (everything else)", which
+        # still contains every required string while letting an unauthorized
+        # manual dispatch through. Authorization is a property of the
+        # expression's structure, so the assertion has to be the expression.
+        expected = (
+            "github.actor == 'luckyPipewrench' && "
+            "github.triggering_actor == 'luckyPipewrench' && "
+            "((github.event_name == 'issue_comment' && "
+            "github.event.comment.user.login == 'luckyPipewrench' && "
+            "github.event.comment.author_association == 'OWNER' && "
+            "github.event.issue.pull_request && "
+            "(github.event.comment.body == '/review' || "
+            "github.event.comment.body == '/review deep')) || "
+            "github.event_name == 'workflow_dispatch')"
+        )
+        self.assertEqual(" ".join(review["if"].split()), expected)
         self.assertIn("inputs.pr_number", review["with"]["pr_number"])
         self.assertIn("inputs.review_mode", review["with"]["review_mode"])
 
@@ -737,7 +758,9 @@ class FailureDirectionTest(unittest.TestCase):
                 pr_review.call_model("system", "user", "deep", "review-chunk-1", "correlation")
         self.assertEqual(post.call_count, 1, "an ambiguous timeout must not be retried")
 
-    def test_connection_error_retries_once_with_one_provider_correlation_id(self) -> None:
+    def test_connect_timeout_retries_once_with_one_provider_correlation_id(self) -> None:
+        # A connect timeout is the only failure proving the request was
+        # never delivered, so it is the only one safe to repeat.
         class Response:
             status_code = 200
 
@@ -746,7 +769,7 @@ class FailureDirectionTest(unittest.TestCase):
                 return {"choices": [{"message": {"content": '{"findings":[]}'}}]}
 
         with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
-            pr_review.requests, "post", side_effect=[pr_review.requests.ConnectionError("offline"), Response()]
+            pr_review.requests, "post", side_effect=[pr_review.requests.ConnectTimeout("no route"), Response()]
         ) as post:
             self.assertEqual(pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation"), {"findings": []})
         self.assertEqual(pr_review.MODEL_CONNECTION_ATTEMPTS, 2)
@@ -756,13 +779,24 @@ class FailureDirectionTest(unittest.TestCase):
             post.call_args_list[1].kwargs["headers"]["X-Client-Request-Id"],
         )
 
-    def test_connection_error_after_retry_is_distinct_from_other_provider_failures(self) -> None:
+    def test_connect_timeout_after_retry_is_distinct_from_other_provider_failures(self) -> None:
         with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
-            pr_review.requests, "post", side_effect=pr_review.requests.ConnectionError("offline")
+            pr_review.requests, "post", side_effect=pr_review.requests.ConnectTimeout("no route")
         ) as post:
             with self.assertRaises(pr_review.ModelConnectionError):
                 pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation")
         self.assertEqual(post.call_count, 2)
+
+    def test_a_dropped_connection_is_not_retried(self) -> None:
+        # ConnectionError covers resets that can occur after the provider has
+        # the request. Only a connect timeout proves non-delivery, so anything
+        # broader would risk paying for the same review twice.
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
+            pr_review.requests, "post", side_effect=pr_review.requests.ConnectionError("reset by peer")
+        ) as post:
+            with self.assertRaises(pr_review.ModelOutputError):
+                pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation")
+        self.assertEqual(post.call_count, 1)
 
     def test_non_connection_request_error_is_not_retried(self) -> None:
         # A response-path failure can happen after the provider receives the

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -11,6 +11,11 @@ import tempfile
 import unittest
 from unittest import mock
 
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError("PyYAML is required to verify PR-review workflow structure") from exc
+
 
 ROOT = pathlib.Path(__file__).parents[1]
 ACTION_DIR = ROOT / ".github" / "actions" / "pr-review"
@@ -26,39 +31,16 @@ sys.modules[SPEC.name] = pr_review
 SPEC.loader.exec_module(pr_review)
 
 
-def top_level_permissions(text: str) -> dict[str, str]:
-    """Read a workflow's top-level permissions mapping, ignoring comments.
+def parse_yaml(text: str) -> dict[str, object]:
+    """Parse workflow YAML without YAML 1.1 coercing GitHub's `on` key."""
+    document = yaml.load(text, Loader=yaml.BaseLoader)
+    if not isinstance(document, dict):
+        raise RuntimeError("expected a YAML mapping")
+    return document
 
-    Deliberately dependency-free: the CI job that runs these tests installs no
-    Python packages, and an import failure there would take down the whole test
-    discovery run rather than just this assertion.
-    """
-    permissions: dict[str, str] = {}
-    inside = False
-    child_indent: int | None = None
-    for raw in text.splitlines():
-        line = raw.split("#", 1)[0].rstrip()
-        if not line:
-            continue
-        if line == "permissions:":
-            inside = True
-            continue
-        if inside:
-            indent = len(line) - len(line.lstrip(" "))
-            if indent == 0:
-                break
-            if child_indent is None:
-                child_indent = indent
-            if indent < child_indent:
-                break
-            # Only direct children count. A deeper entry reusing a permission
-            # name would otherwise overwrite the real top-level value, so a
-            # nested write could mask a top-level none.
-            if indent != child_indent:
-                continue
-            key, _, value = line.strip().partition(":")
-            permissions[key.strip()] = value.strip()
-    return permissions
+
+def load_yaml(path: pathlib.Path) -> dict[str, object]:
+    return parse_yaml(path.read_text(encoding="utf-8"))
 
 
 def unit(identifier: int, path: str, category: str, *, additions: int = 1, tokens: int = 2) -> object:
@@ -74,26 +56,49 @@ def unit(identifier: int, path: str, category: str, *, additions: int = 1, token
 
 
 class WorkflowPackagingTest(unittest.TestCase):
-    def test_only_supported_commands_reach_the_reusable_workflow(self) -> None:
-        caller = CALLER_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("github.event.comment.body == '/review'", caller)
-        self.assertIn("github.event.comment.body == '/review deep'", caller)
-        self.assertIn("uses: ./.github/workflows/pr-review-reusable.yaml", caller)
-        self.assertIn("author_association == 'OWNER'", caller)
-        self.assertIn("user.login == 'luckyPipewrench'", caller)
+    def test_caller_authorizes_comments_and_dispatches_to_the_same_identity(self) -> None:
+        # Exercise the parsed workflow shape. String searches against a YAML
+        # file were bypassed before by a comment or an unrelated scalar with
+        # the same words.
+        caller = load_yaml(CALLER_WORKFLOW)
+        events = caller["on"]
+        self.assertEqual(events["issue_comment"]["types"], ["created"])
+        dispatch = events["workflow_dispatch"]
+        self.assertEqual(dispatch["inputs"]["pr_number"]["required"], "true")
+        self.assertEqual(dispatch["inputs"]["review_mode"]["type"], "choice")
+        self.assertEqual(dispatch["inputs"]["review_mode"]["options"], ["default", "deep"])
+
+        review = caller["jobs"]["review"]
+        self.assertEqual(review["uses"], "./.github/workflows/pr-review-reusable.yaml")
+        gate = review["if"]
+        for requirement in (
+            "github.actor == 'luckyPipewrench'",
+            "github.triggering_actor == 'luckyPipewrench'",
+            "github.event.comment.user.login == 'luckyPipewrench'",
+            "github.event.comment.author_association == 'OWNER'",
+            "github.event.issue.pull_request",
+            "github.event_name == 'workflow_dispatch'",
+        ):
+            self.assertIn(requirement, gate)
+        self.assertIn("inputs.pr_number", review["with"]["pr_number"])
+        self.assertIn("inputs.review_mode", review["with"]["review_mode"])
 
     def test_reusable_workflow_uses_non_cancelling_pr_concurrency(self) -> None:
-        workflow = REUSABLE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("group: pr-review-${{ github.repository }}-${{ inputs.pr_number }}", workflow)
-        self.assertIn("cancel-in-progress: false", workflow)
-        self.assertIn("Claim review status", workflow)
-        self.assertIn("needs: admit", workflow)
-        self.assertIn("repository: luckyPipewrench/pipelock", workflow)
-        self.assertIn("ref: ${{ inputs.reviewer_sha }}", workflow)
-        self.assertIn("HAS_LITELLM", workflow)
-        self.assertNotRegex(workflow, r"(?m)^\s*if:\s*.*secrets\.")
-        # The explicit mapping must not accidentally turn into a secret inherit.
-        self.assertNotRegex(workflow, r"(?m)^\s*secrets:\s*inherit\s*$")
+        workflow = load_yaml(REUSABLE_WORKFLOW)
+        admit = workflow["jobs"]["admit"]
+        self.assertEqual(admit["concurrency"]["group"], "pr-review-${{ github.repository }}-${{ inputs.pr_number }}")
+        self.assertEqual(admit["concurrency"]["cancel-in-progress"], "false")
+        self.assertTrue(any(step.get("name") == "Claim review status" for step in admit["steps"]))
+
+        review = workflow["jobs"]["review"]
+        self.assertEqual(review["needs"], "admit")
+        self.assertIn("HAS_LITELLM", review["env"])
+        checkout = review["steps"][0]
+        self.assertEqual(checkout["with"]["repository"], "luckyPipewrench/pipelock")
+        self.assertEqual(checkout["with"]["ref"], "${{ inputs.reviewer_sha }}")
+        self.assertTrue(any(step.get("name") == "Finalize an abandoned review" and step.get("if") == "always()" for step in review["steps"]))
+        for step in review["steps"]:
+            self.assertNotIn("secrets.", step.get("if", ""))
 
     def test_permission_reader_ignores_nested_entries_and_comments(self) -> None:
         # A deeper entry reusing a permission name must not mask the real
@@ -114,7 +119,7 @@ class WorkflowPackagingTest(unittest.TestCase):
                 "      pull-requests: write",
             ]
         )
-        self.assertEqual(top_level_permissions(document).get("pull-requests"), "none")
+        self.assertEqual(parse_yaml(document)["permissions"].get("pull-requests"), "none")
 
     def test_both_workflows_keep_pull_request_write_for_comment_creation(self) -> None:
         # Posting a comment on a pull request needs pull-requests: write even
@@ -125,7 +130,7 @@ class WorkflowPackagingTest(unittest.TestCase):
         # the comment above the key contains the same words and a substring
         # search passed with the real key deleted.
         for path in (CALLER_WORKFLOW, REUSABLE_WORKFLOW):
-            permissions = top_level_permissions(path.read_text(encoding="utf-8"))
+            permissions = load_yaml(path)["permissions"]
             self.assertEqual(
                 permissions.get("pull-requests"),
                 "write",
@@ -138,16 +143,11 @@ class WorkflowPackagingTest(unittest.TestCase):
             )
 
     def test_composite_action_owns_runner_requirements_and_single_provider_inputs(self) -> None:
-        action = ACTION_YAML.read_text(encoding="utf-8")
+        action = load_yaml(ACTION_YAML)
         self.assertTrue((ACTION_DIR / "requirements.txt").is_file())
-        self.assertIn("$GITHUB_ACTION_PATH/pr_review.py", action)
-        self.assertIn("$GITHUB_ACTION_PATH/requirements.txt", action)
-        self.assertIn("status_comment_id", action)
-        self.assertIn("operation", action)
-        self.assertIn("litellm-api-key", action)
-        self.assertIn("openai-api-key", action)
-        self.assertIn("PR_REVIEW_MODEL_FAST", action)
-        self.assertIn("PR_REVIEW_MODEL_DEEP", action)
+        self.assertEqual(action["inputs"]["operation"]["default"], "review")
+        for name in ("status-comment-id", "operation", "litellm-api-key", "openai-api-key", "model-fast", "model-deep"):
+            self.assertIn(name, action["inputs"])
         # Either cache key breaks setup for this action and stops every review
         # before it starts, so this asserts against the parsed document rather
         # than the file's text. Four text-matching versions were each bypassed
@@ -156,18 +156,7 @@ class WorkflowPackagingTest(unittest.TestCase):
         # are parser differentials, and the answer to a parser differential is
         # a parser.
         #
-        # The import is local and its absence is a hard failure rather than a
-        # skip. The job that runs these tests installs no Python packages, so
-        # PyYAML being present is an assumption; a skip would turn that
-        # assumption into silent lost coverage, which is the whole failure
-        # class here. If this ever goes red on a missing module, that is the
-        # fact worth learning, and it is one dependency line to fix.
-        try:
-            import yaml
-        except ImportError:  # pragma: no cover
-            self.fail("PyYAML is required to verify this action's setup keys")
-        document = yaml.safe_load(action)
-        for step in document["runs"]["steps"]:
+        for step in action["runs"]["steps"]:
             settings = step.get("with") or {}
             self.assertNotIn("cache", settings, f"{step.get('name')} must not enable pip caching")
             self.assertNotIn("cache-dependency-path", settings, f"{step.get('name')} must not set a cache path")
@@ -211,6 +200,33 @@ class StateMachineTest(unittest.TestCase):
         )
         self.assertEqual(pr_review.derive_state(clean), "clean")
         self.assertEqual(pr_review.derive_state(finding), "findings")
+
+
+class ExitSemanticsTest(unittest.TestCase):
+    def test_every_published_outcome_is_green_but_an_unknown_state_is_red(self) -> None:
+        # A terminal verdict is useful even when it is partial, superseded, or
+        # failed. The status comment is its authoritative surface; the runner
+        # goes red only if it cannot publish a known verdict.
+        expected = {"already-running", "clean", "failed", "findings", "partial", "superseded"}
+        self.assertEqual(pr_review.PUBLISHED_REVIEW_STATES, expected)
+        for state in expected:
+            self.assertEqual(pr_review.exit_code_for_state(state), 0, state)
+        self.assertEqual(pr_review.exit_code_for_state("unexpected"), 1)
+
+    def test_main_accepts_each_published_review_outcome(self) -> None:
+        environment = {
+            "GITHUB_TOKEN": "token",
+            "REPO": "owner/repo",
+            "PR_NUMBER": "42",
+            "REVIEW_MODE": "default",
+            "REVIEWER_SHA": "a" * 40,
+            "REVIEW_OPERATION": "review",
+        }
+        for state in pr_review.PUBLISHED_REVIEW_STATES:
+            with self.subTest(state=state), mock.patch.dict(pr_review.os.environ, environment, clear=True), mock.patch.object(
+                pr_review, "run_review", return_value=(state, pr_review.ReviewProgress())
+            ):
+                self.assertIsNone(pr_review.main())
 
 
 class CompressionAndClassificationTest(unittest.TestCase):
@@ -686,9 +702,48 @@ class FailureDirectionTest(unittest.TestCase):
     def test_provider_timeout_is_distinguished_from_schema_failure(self) -> None:
         with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
             pr_review.requests, "post", side_effect=pr_review.requests.Timeout()
-        ):
+        ) as post:
             with self.assertRaises(pr_review.ModelTimeout):
                 pr_review.call_model("system", "user", "deep", "review-chunk-1", "correlation")
+        self.assertEqual(post.call_count, 1, "an ambiguous timeout must not be retried")
+
+    def test_connection_error_retries_once_with_one_provider_correlation_id(self) -> None:
+        class Response:
+            status_code = 200
+
+            @staticmethod
+            def json() -> object:
+                return {"choices": [{"message": {"content": '{"findings":[]}'}}]}
+
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
+            pr_review.requests, "post", side_effect=[pr_review.requests.ConnectionError("offline"), Response()]
+        ) as post:
+            self.assertEqual(pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation"), {"findings": []})
+        self.assertEqual(pr_review.MODEL_CONNECTION_ATTEMPTS, 2)
+        self.assertEqual(post.call_count, 2)
+        self.assertEqual(
+            post.call_args_list[0].kwargs["headers"]["X-Client-Request-Id"],
+            post.call_args_list[1].kwargs["headers"]["X-Client-Request-Id"],
+        )
+
+    def test_connection_error_after_retry_is_distinct_from_other_provider_failures(self) -> None:
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
+            pr_review.requests, "post", side_effect=pr_review.requests.ConnectionError("offline")
+        ) as post:
+            with self.assertRaises(pr_review.ModelConnectionError):
+                pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation")
+        self.assertEqual(post.call_count, 2)
+
+    def test_non_connection_request_error_is_not_retried(self) -> None:
+        # A response-path failure can happen after the provider receives the
+        # request, so unlike a connection error it must preserve the one-call
+        # rule that avoids duplicate review charges.
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True), mock.patch.object(
+            pr_review.requests, "post", side_effect=pr_review.requests.exceptions.ChunkedEncodingError("connection reset")
+        ) as post:
+            with self.assertRaises(pr_review.ModelOutputError):
+                pr_review.call_model("system", "user", "default", "review-chunk-1", "correlation")
+        self.assertEqual(post.call_count, 1)
 
 
 class ChunkResilienceTest(unittest.TestCase):
@@ -741,6 +796,15 @@ class ChunkResilienceTest(unittest.TestCase):
         self.assertEqual(progress.reviewed_units, 2)
         self.assertEqual(call_model.call_count, 3)
         self.assertTrue(any("not retried" in reason for reason in progress.incomplete_reasons))
+
+    def test_connection_retry_exhaustion_is_partial_but_later_chunks_continue(self) -> None:
+        state, progress, call_model = self._run_with_chunk_outcomes(
+            [pr_review.ModelConnectionError("offline after retry"), "ok", "ok"]
+        )
+        self.assertEqual(state, "partial")
+        self.assertEqual(progress.reviewed_units, 2)
+        self.assertEqual(call_model.call_count, 3)
+        self.assertTrue(any("review chunk 1 could not connect after one retry" == reason for reason in progress.incomplete_reasons))
 
 
 class StructuredOutputSafetyTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -96,7 +96,23 @@ class WorkflowPackagingTest(unittest.TestCase):
         checkout = review["steps"][0]
         self.assertEqual(checkout["with"]["repository"], "luckyPipewrench/pipelock")
         self.assertEqual(checkout["with"]["ref"], "${{ inputs.reviewer_sha }}")
-        self.assertTrue(any(step.get("name") == "Finalize an abandoned review" and step.get("if") == "always()" for step in review["steps"]))
+        # Finalization is its own job, not a step inside review. As a step it
+        # was skipped in the case it most needs to cover: admission claims the
+        # status comment and the review job never starts, leaving the comment
+        # reading running until its stale timeout blocks later reviews.
+        finalize = workflow["jobs"]["finalize"]
+        self.assertEqual(finalize["needs"], ["admit", "review"])
+        self.assertIn("always()", finalize["if"])
+        self.assertNotIn("Finalize an abandoned review", [step.get("name") for step in review["steps"]])
+
+        # Coverage is a separate check from whether the runner published. One
+        # signal cannot carry both: collapsing them either makes a working
+        # review look crashed, or lets an incomplete review show an all-green
+        # pull request, which reads as reviewed when it was not.
+        completeness = workflow["jobs"]["completeness"]
+        self.assertEqual(completeness["needs"], ["admit", "review"])
+        self.assertIn("always()", completeness["if"])
+        self.assertEqual(review["outputs"]["complete"].count("outputs.complete"), 3)
         for step in review["steps"]:
             self.assertNotIn("secrets.", step.get("if", ""))
 
@@ -212,6 +228,20 @@ class ExitSemanticsTest(unittest.TestCase):
         for state in expected:
             self.assertEqual(pr_review.exit_code_for_state(state), 0, state)
         self.assertEqual(pr_review.exit_code_for_state("unexpected"), 1)
+
+    def test_only_a_whole_diff_review_counts_as_complete(self) -> None:
+        # The green exit says the runner published. This says the review
+        # covered the diff. Every state that left something unreviewed must
+        # report incomplete, however cleanly it reported that, or a partial
+        # review shows an all-green pull request and reads as reviewed.
+        self.assertEqual(pr_review.COMPLETE_REVIEW_STATES, {"clean", "findings"})
+        for state in pr_review.PUBLISHED_REVIEW_STATES - pr_review.COMPLETE_REVIEW_STATES:
+            self.assertNotIn(state, pr_review.COMPLETE_REVIEW_STATES, state)
+        # partial and superseded both publish a verdict and both left work
+        # undone, so they are green to run and not complete.
+        for state in ("partial", "superseded", "failed", "already-running"):
+            self.assertEqual(pr_review.exit_code_for_state(state), 0, state)
+            self.assertNotIn(state, pr_review.COMPLETE_REVIEW_STATES, state)
 
     def test_main_accepts_each_published_review_outcome(self) -> None:
         environment = {


### PR DESCRIPTION
## What changed

A review that published a verdict still exited non-zero unless that verdict was clean or findings, so an incomplete but useful result painted the whole run red. One live review on a seven thousand line pull request delivered nine findings, two of them high severity, and read as a crashed job. The exit code now means only that the runner failed to publish a verdict: every published outcome, including partial, superseded and an explicit failed, exits zero, while an unknown state or a runner that never published stays red.

A connection error to the provider is retried once. It was previously treated like every other request failure and never retried, on the reasoning that a request may have reached the provider and could be billed twice. That reasoning holds for a timeout and for a response-path error, and does not hold for a connection that never completed. One chunk of that same live review was lost this way. Timeouts and all other request errors remain single-attempt, and a connection error that fails its retry still records the chunk as incomplete.

The command can also be dispatched manually against a pull request. This workflow only ever executes the copy on the default branch, so a change to it cannot run on the pull request that introduces it, and every defect in it so far has reached production before failing. The dispatch path carries the same identity requirement as the comment path, and requires it of the account re-running a workflow as well as the one that started it.

**Failure direction, and what to distrust:** the exit change makes runs greener, so the thing to check is that it cannot hide a genuine crash. An unknown state and a runner that dies before publishing both remain red, and the always-run finalizer still marks an abandoned status comment failed. The retry is bounded to one attempt and applies only to a connection that did not complete, so it cannot replay a request the provider may already have charged for. The remaining weakness is that a green run no longer means a complete review: partial is now green, and its incompleteness is stated only in the comment, which is where the verdict has always lived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual review triggering with required pull request number and review mode selection.
  - Added bounded retries for provider connection failures and request correlation tracking.
  - Added review state and completeness outputs for workflow integrations.
  - Added clearer handling for partial reviews when some checks cannot connect.

- **Bug Fixes**
  - Published failed, partial, and superseded reviews now exit successfully after results are available.
  - Incomplete reviews are reported separately, and abandoned reviews are finalized as failed.
  - Timeouts and other non-connection failures are not retried.

- **Tests**
  - Expanded coverage for triggers, authorization, review states, retries, partial results, and workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->