### PR TITLE
fix(ci): make a green review mean the pull request was covered

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -39,12 +39,6 @@ inputs:
   reviewer-sha:
     description: Immutable Pipelock source commit containing this action.
     required: true
-  litellm-base-url:
-    description: Optional LiteLLM-compatible base URL.
-    required: false
-  litellm-api-key:
-    description: Optional LiteLLM credential.
-    required: false
   openai-api-key:
     description: Optional direct OpenAI credential.
     required: false
@@ -97,8 +91,6 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
         REVIEW_MODE: ${{ inputs.review-mode }}
         REVIEWER_SHA: ${{ inputs.reviewer-sha }}
-        LITELLM_BASE_URL: ${{ inputs.litellm-base-url }}
-        LITELLM_API_KEY: ${{ inputs.litellm-api-key }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         PR_REVIEW_MODEL_FAST: ${{ inputs.model-fast }}
         PR_REVIEW_MODEL_DEEP: ${{ inputs.model-deep }}

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -262,7 +262,20 @@ def _path_from_file_block(lines: list[str]) -> str | None:
     return None
 
 
-def _collapse_deletions(lines: list[str]) -> tuple[list[str], int]:
+def _collapse_deletions(lines: list[str], mode: str) -> tuple[list[str], int]:
+    """Summarize the middle of a large deletion hunk, except in deep mode.
+
+    Removing code is a real change, and on a security product it is often the
+    change that matters most: deleting a guard reads as a deletion hunk. A deep
+    review is the one asked to see everything, and it has the budget to, so it
+    reads deletions in full.
+
+    A default review still collapses them, because it is the cheap pass and
+    additions carry most of what it is looking for. That is disclosed on the
+    review rather than treated as a gap in coverage.
+    """
+    if mode == "deep":
+        return lines, 0
     deletion_indexes = [
         index
         for index, line in enumerate(lines)
@@ -285,7 +298,7 @@ def _collapse_deletions(lines: list[str]) -> tuple[list[str], int]:
     return result, collapsed
 
 
-def parse_diff(diff: str) -> tuple[list[DiffUnit], list[str]]:
+def parse_diff(diff: str, mode: str = "default") -> tuple[list[DiffUnit], list[str]]:
     """Split an exact-commit unified diff into hunk-addressable review units."""
     lines = diff.splitlines()
     starts = [index for index, line in enumerate(lines) if line.startswith("diff --git ")]
@@ -330,7 +343,7 @@ def parse_diff(diff: str) -> tuple[list[DiffUnit], list[str]]:
         for hunk_number, hunk_start in enumerate(hunk_starts):
             hunk_end = hunk_starts[hunk_number + 1] if hunk_number + 1 < len(hunk_starts) else len(block)
             hunk = block[hunk_start:hunk_end]
-            collapsed_hunk, collapsed = _collapse_deletions(hunk)
+            collapsed_hunk, collapsed = _collapse_deletions(hunk, mode)
             body = "\n".join(header + collapsed_hunk)
             additions = sum(1 for line in hunk if line.startswith("+") and not line.startswith("+++"))
             units.append(
@@ -499,11 +512,15 @@ def build_llm_payload(model: str, system: str, user: str, mode: str) -> dict[str
 
 
 def provider_configuration() -> tuple[str, str]:
-    litellm_url = os.environ.get("LITELLM_BASE_URL", "")
-    litellm_key = os.environ.get("LITELLM_API_KEY", "")
+    """Resolve the single supported provider.
+
+    This previously preferred a LiteLLM gateway and fell back to OpenAI. No
+    repository ever set the gateway secrets, so the preferred branch never ran
+    and every review has always taken the fallback. Carrying an unreachable
+    provider branch on the path that authorizes an outbound call is a liability
+    with no user, so the fallback is now simply the path.
+    """
     openai_key = os.environ.get("OPENAI_API_KEY", "")
-    if litellm_url and litellm_key:
-        return litellm_url.rstrip("/") + "/chat/completions", litellm_key
     if openai_key:
         return "https://api.openai.com/v1/chat/completions", openai_key
     raise ProviderConfigurationError("no LLM credential was supplied")
@@ -970,6 +987,30 @@ def judge_findings(
     return verified, True, excluded
 
 
+def coverage_gaps(units: list[DiffUnit], omitted: list[DiffUnit], parse_errors: list[str]) -> list[str]:
+    """Name only the things the review should have read and did not.
+
+    Separated from the caller so the policy can be tested directly. It was
+    inline, and the one rule that mattered here was therefore only assertable
+    by hand-building the state it produces, which tests the consequence rather
+    than the decision.
+
+    A collapsed deletion hunk is deliberately NOT a gap. It is a disclosed
+    compression that the default mode applies uniformly, reported under its own
+    heading on the review, and deep mode does not apply it at all. Counting it
+    as incompleteness made the completeness check fail on any pull request
+    removing a block of more than MAX_DELETION_LINES_PER_HUNK lines, which is
+    most of them: an observed review read 321 of 321 units, omitted nothing,
+    and still reported partial behind a failing check. A signal that is red on
+    complete reviews is one an operator learns to ignore, and then it protects
+    nothing on the review that really is short.
+    """
+    gaps = list(parse_errors)
+    if omitted:
+        gaps.append("one or more units were omitted or unrepresentable")
+    return gaps
+
+
 def derive_state(progress: ReviewProgress) -> str:
     """Own status transitions in code; model prose never decides completeness."""
     if progress.head_changed:
@@ -1246,16 +1287,11 @@ def run_review(
         truncation = compare_incompleteness(repo, binding, token)
         if truncation:
             progress.incomplete_reasons.append(truncation)
-        units, parse_errors = parse_diff(diff)
+        units, parse_errors = parse_diff(diff, mode)
         classification = classify_units(units)
         progress.expected_units = sum(1 for unit in units if unit.representable)
-        if parse_errors:
-            progress.incomplete_reasons.extend(parse_errors)
         chunks, omitted = plan_chunks(units, mode)
-        if omitted:
-            progress.incomplete_reasons.append("one or more units were omitted or unrepresentable")
-        if any(unit.collapsed_deletions for unit in units):
-            progress.incomplete_reasons.append("one or more deletion hunks were collapsed")
+        progress.incomplete_reasons.extend(coverage_gaps(units, omitted, parse_errors))
         reviewed_changes: list[dict[str, str]] = []
         candidates: list[Finding] = []
         for chunk_index, chunk in enumerate(chunks, 1):

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -298,6 +298,36 @@ def _collapse_deletions(lines: list[str], mode: str) -> tuple[list[str], int]:
     return result, collapsed
 
 
+def _split_oversized_deep_hunk(header: list[str], hunk: list[str]) -> list[list[str]]:
+    """Bound a deep-review hunk without dropping or summarizing its lines.
+
+    A deep review keeps deletion hunks intact. A sufficiently large deletion
+    hunk can therefore exceed the per-call input budget, which made the chunk
+    planner omit the entire hunk. Repeat the file and hunk headers around
+    bounded contiguous pieces so every changed line remains available to the
+    reviewer. A single oversized line is deliberately left whole: splitting a
+    source line would alter the diff's meaning, so the normal omission path can
+    report that it could not be reviewed.
+    """
+    prefix = header + hunk[:1]
+    content = hunk[1:]
+    if estimate_tokens("\n".join(prefix + content)) <= DEEP_INPUT_TOKEN_BUDGET:
+        return [hunk]
+
+    parts: list[list[str]] = []
+    current: list[str] = []
+    for line in content:
+        candidate = prefix + current + [line]
+        if current and estimate_tokens("\n".join(candidate)) > DEEP_INPUT_TOKEN_BUDGET:
+            parts.append(hunk[:1] + current)
+            current = [line]
+            continue
+        current.append(line)
+    if current:
+        parts.append(hunk[:1] + current)
+    return parts or [hunk]
+
+
 def parse_diff(diff: str, mode: str = "default") -> tuple[list[DiffUnit], list[str]]:
     """Split an exact-commit unified diff into hunk-addressable review units."""
     lines = diff.splitlines()
@@ -343,21 +373,23 @@ def parse_diff(diff: str, mode: str = "default") -> tuple[list[DiffUnit], list[s
         for hunk_number, hunk_start in enumerate(hunk_starts):
             hunk_end = hunk_starts[hunk_number + 1] if hunk_number + 1 < len(hunk_starts) else len(block)
             hunk = block[hunk_start:hunk_end]
-            collapsed_hunk, collapsed = _collapse_deletions(hunk, mode)
-            body = "\n".join(header + collapsed_hunk)
-            additions = sum(1 for line in hunk if line.startswith("+") and not line.startswith("+++"))
-            units.append(
-                DiffUnit(
-                    identifier=len(units) + 1,
-                    path=path,
-                    hunk_header=hunk[0],
-                    body=body,
-                    category=category,
-                    additions=additions,
-                    estimated_tokens=estimate_tokens(body),
-                    collapsed_deletions=collapsed,
+            review_hunks = _split_oversized_deep_hunk(header, hunk) if mode == "deep" else [hunk]
+            for review_hunk in review_hunks:
+                collapsed_hunk, collapsed = _collapse_deletions(review_hunk, mode)
+                body = "\n".join(header + collapsed_hunk)
+                additions = sum(1 for line in review_hunk if line.startswith("+") and not line.startswith("+++"))
+                units.append(
+                    DiffUnit(
+                        identifier=len(units) + 1,
+                        path=path,
+                        hunk_header=hunk[0],
+                        body=body,
+                        category=category,
+                        additions=additions,
+                        estimated_tokens=estimate_tokens(body),
+                        collapsed_deletions=collapsed,
+                    )
                 )
-            )
     return units, errors
 
 
@@ -564,10 +596,10 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
     api_url, api_key = provider_configuration()
     model = model_for_mode(mode)
     timeout = llm_timeout_for(mode)
-    # This is a correlation key, not an idempotency promise: the direct and
-    # LiteLLM-compatible endpoints do not share a documented deduplication
-    # contract. It stays stable across the one permitted retry so a provider
-    # can trace both attempts if a connection fault needs investigation.
+    # This is a correlation key, not an idempotency promise: the direct OpenAI
+    # endpoint has no documented deduplication contract. It stays stable across
+    # the one permitted retry so the provider can trace both attempts if a
+    # connection fault needs investigation.
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -75,6 +75,9 @@ MAX_JUDGE_CONTEXT_FETCHES = 20
 MAX_DELETION_LINES_PER_HUNK = 24
 MAX_RENDERED_MANIFEST_ENTRIES = 8
 REPO_PATTERN = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
+# @@ -old_start,old_count +new_start,new_count @@ optional section heading.
+# Counts are optional in unified diff when they are 1.
+HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$")
 RUBRIC_VERSION = "2026-08-14.1"
 STATUS_MARKER = "pr-review-status:v1"
 
@@ -314,18 +317,70 @@ def _split_oversized_deep_hunk(header: list[str], hunk: list[str]) -> list[list[
     if estimate_tokens("\n".join(prefix + content)) <= DEEP_INPUT_TOKEN_BUDGET:
         return [hunk]
 
+    # Track the joined length instead of rebuilding the candidate string each
+    # time. estimate_tokens is ceil(len / 4), so the length is enough and the
+    # loop stays linear. Re-joining made it quadratic in characters, which on a
+    # 16,000-line deletion is around a billion characters copied per piece.
+    prefix_length = _joined_length(prefix)
+    old_cursor, new_cursor = _hunk_start_offsets(hunk[0])
+
     parts: list[list[str]] = []
     current: list[str] = []
+    current_length = 0
     for line in content:
-        candidate = prefix + current + [line]
-        if current and estimate_tokens("\n".join(candidate)) > DEEP_INPUT_TOKEN_BUDGET:
-            parts.append(hunk[:1] + current)
+        candidate_length = prefix_length + current_length + len(line) + 1
+        if current and math.ceil(candidate_length / 4) > DEEP_INPUT_TOKEN_BUDGET:
+            piece, old_cursor, new_cursor = _emit_piece(hunk[0], old_cursor, new_cursor, current)
+            parts.append(piece)
             current = [line]
+            current_length = len(line) + 1
             continue
         current.append(line)
+        current_length += len(line) + 1
     if current:
-        parts.append(hunk[:1] + current)
+        piece, old_cursor, new_cursor = _emit_piece(hunk[0], old_cursor, new_cursor, current)
+        parts.append(piece)
     return parts or [hunk]
+
+
+def _joined_length(lines: list[str]) -> int:
+    """Length of "\\n".join(lines), computed without building the string."""
+    if not lines:
+        return 0
+    return sum(len(line) for line in lines) + len(lines) - 1
+
+
+def _hunk_start_offsets(hunk_header: str) -> tuple[int, int]:
+    """Old-side and new-side starting line numbers from an @@ header."""
+    match = HUNK_HEADER_RE.match(hunk_header)
+    if not match:
+        return 1, 1
+    return int(match.group(1)), int(match.group(3))
+
+
+def _side_line_counts(lines: list[str]) -> tuple[int, int]:
+    """How many lines a piece occupies on the old side and the new side."""
+    old = sum(1 for line in lines if not line or line.startswith(("-", " ")))
+    new = sum(1 for line in lines if not line or line.startswith(("+", " ")))
+    return old, new
+
+
+def _emit_piece(
+    original_header: str, old_start: int, new_start: int, lines: list[str]
+) -> tuple[list[str], int, int]:
+    """Give a piece its own accurate @@ header and advance the cursors.
+
+    Every piece previously repeated the original hunk header, so a continuation
+    starting thousands of lines into a file still announced the whole hunk's
+    starting line. The reviewer anchors findings to that header, so deep mode
+    reported real findings against the wrong lines: the split was added to
+    preserve line-addressed output and was silently corrupting it.
+    """
+    old_count, new_count = _side_line_counts(lines)
+    match = HUNK_HEADER_RE.match(original_header)
+    suffix = match.group(5) if match else ""
+    piece_header = f"@@ -{old_start},{old_count} +{new_start},{new_count} @@{suffix}"
+    return [piece_header] + lines, old_start + old_count, new_start + new_count
 
 
 def parse_diff(diff: str, mode: str = "default") -> tuple[list[DiffUnit], list[str]]:
@@ -382,7 +437,11 @@ def parse_diff(diff: str, mode: str = "default") -> tuple[list[DiffUnit], list[s
                     DiffUnit(
                         identifier=len(units) + 1,
                         path=path,
-                        hunk_header=hunk[0],
+                        # The piece's own header, not the original hunk's. A
+                        # split piece carries different line numbers, and this
+                        # value is what the manifest and the review prompt use
+                        # to locate a finding.
+                        hunk_header=review_hunk[0],
                         body=body,
                         category=category,
                         additions=additions,
@@ -1019,7 +1078,7 @@ def judge_findings(
     return verified, True, excluded
 
 
-def coverage_gaps(units: list[DiffUnit], omitted: list[DiffUnit], parse_errors: list[str]) -> list[str]:
+def coverage_gaps(_units: list[DiffUnit], omitted: list[DiffUnit], parse_errors: list[str]) -> list[str]:
     """Name only the things the review should have read and did not.
 
     Separated from the caller so the policy can be tested directly. It was

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -327,20 +327,44 @@ def _split_oversized_deep_hunk(header: list[str], hunk: list[str]) -> list[list[
     parts: list[list[str]] = []
     current: list[str] = []
     current_length = 0
-    for line in content:
-        candidate_length = prefix_length + current_length + len(line) + 1
+    for record in _atomic_records(content):
+        record_length = _joined_length(record) + 1
+        candidate_length = prefix_length + current_length + record_length
         if current and math.ceil(candidate_length / 4) > DEEP_INPUT_TOKEN_BUDGET:
             piece, old_cursor, new_cursor = _emit_piece(hunk[0], old_cursor, new_cursor, current)
             parts.append(piece)
-            current = [line]
-            current_length = len(line) + 1
+            current = list(record)
+            current_length = record_length
             continue
-        current.append(line)
-        current_length += len(line) + 1
+        current.extend(record)
+        current_length += record_length
     if current:
         piece, old_cursor, new_cursor = _emit_piece(hunk[0], old_cursor, new_cursor, current)
         parts.append(piece)
     return parts or [hunk]
+
+
+NO_NEWLINE_MARKER = r"\ No newline at end of file"
+
+
+def _atomic_records(content: list[str]) -> list[list[str]]:
+    """Group diff lines that cannot be separated without changing meaning.
+
+    A "\\ No newline at end of file" marker describes the line immediately
+    before it. Packing them independently lets a boundary fall between the two,
+    which states the opposite of the truth twice over: the piece that keeps the
+    line now claims the file ended with a newline, and the next piece opens with
+    a marker describing a line the reviewer cannot see. Deep mode exists to
+    report findings against exact lines, so a silently altered line is the one
+    corruption it must not introduce.
+    """
+    records: list[list[str]] = []
+    for line in content:
+        if line == NO_NEWLINE_MARKER and records:
+            records[-1].append(line)
+            continue
+        records.append([line])
+    return records
 
 
 def _joined_length(lines: list[str]) -> int:

--- a/.github/requirements-pr-review-test.txt
+++ b/.github/requirements-pr-review-test.txt
@@ -1,0 +1,18 @@
+# Test-only dependency for the pr-review structural checks.
+#
+# The reviewer itself does not parse YAML; its tests do, to verify the review
+# workflow's triggers, permissions and authorization gate by structure rather
+# than by matching text. Text matching is how four earlier guards in this suite
+# were each satisfied without checking anything.
+#
+# Kept separate from .github/actions/pr-review/requirements.txt so the action
+# that runs a review installs nothing it does not need.
+#
+# Hashes from the PyPI release for 6.0.3, the newest stable release. Both the
+# cp312 and cp313 wheels are listed so the install survives a runner Python
+# upgrade, plus the sdist for any interpreter without a matching wheel.
+# Regenerate: pip download PyYAML --no-deps, then pip hash <file>.
+PyYAML==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
+    --hash=sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6 \
+    --hash=sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -431,6 +431,41 @@ jobs:
           GOOS=aix GOARCH=ppc64 go test -c -o /tmp/recorder-aix.test ./internal/recorder
           GOOS=aix GOARCH=ppc64 go test -c -o /tmp/license-aix.test ./internal/license
 
+  # The reviewer's own tests, which no pull request has ever run.
+  #
+  # The repositories that kept their own copy of the reviewer ran these as a
+  # step inside the review itself. That never gated anything: a review is
+  # triggered by a comment, so it only ever executes the copy already on the
+  # default branch, and by then the change is merged. Consolidating onto one
+  # shared workflow then dropped even that step. So the suite has been proving
+  # nothing in either arrangement, while every guard in it reported green.
+  #
+  # This job is what makes them load-bearing, because it runs on the pull
+  # request that changes them. It covers the reviewer, the review workflow's
+  # permissions and authorization gate, and the adoption stub that other
+  # repositories copy.
+  pr-review-tests:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned dependencies
+        run: |
+          pip install --require-hashes -r .github/actions/pr-review/requirements.txt
+          pip install --require-hashes -r .github/requirements-pr-review-test.txt
+
+      - name: Run reviewer tests
+        run: python -m unittest scripts.pr_review_test
+
   lint:
     needs: [security-scan]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -19,10 +19,6 @@ on:
     secrets:
       review_token:
         required: true
-      litellm_base_url:
-        required: false
-      litellm_api_key:
-        required: false
       openai_api_key:
         required: false
 
@@ -96,11 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
-      state: ${{ steps.litellm.outputs.state || steps.openai.outputs.state || steps.nocreds.outputs.state }}
-      complete: ${{ steps.litellm.outputs.complete || steps.openai.outputs.complete || steps.nocreds.outputs.complete }}
+      state: ${{ steps.openai.outputs.state || steps.nocreds.outputs.state }}
+      complete: ${{ steps.openai.outputs.complete || steps.nocreds.outputs.complete }}
     env:
-      HAS_LITELLM: >-
-        ${{ secrets.litellm_base_url != '' && secrets.litellm_api_key != '' && 'true' || 'false' }}
       HAS_OPENAI: ${{ secrets.openai_api_key != '' && 'true' || 'false' }}
     steps:
       - name: Check out immutable Pipelock review source
@@ -114,28 +108,9 @@ jobs:
       # The runner receives one provider credential, never both. Named secret
       # mappings are required because personal-account repositories cannot use
       # secrets: inherit with a reusable workflow.
-      - name: Run review through LiteLLM
-        id: litellm
-        if: env.HAS_LITELLM == 'true'
-        uses: ./trusted-pr-review/.github/actions/pr-review
-        with:
-          github-token: ${{ secrets.review_token }}
-          repo: ${{ github.repository }}
-          pr-number: ${{ inputs.pr_number }}
-          review-mode: ${{ inputs.review_mode }}
-          reviewer-sha: ${{ inputs.reviewer_sha }}
-          operation: review
-          base-sha: ${{ needs.admit.outputs.base_sha }}
-          head-sha: ${{ needs.admit.outputs.head_sha }}
-          status-comment-id: ${{ needs.admit.outputs.status_comment_id }}
-          litellm-base-url: ${{ secrets.litellm_base_url }}
-          litellm-api-key: ${{ secrets.litellm_api_key }}
-          model-fast: ${{ vars.PR_REVIEW_MODEL_FAST }}
-          model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
-
       - name: Run review through OpenAI
         id: openai
-        if: env.HAS_LITELLM != 'true' && env.HAS_OPENAI == 'true'
+        if: env.HAS_OPENAI == 'true'
         uses: ./trusted-pr-review/.github/actions/pr-review
         with:
           github-token: ${{ secrets.review_token }}
@@ -153,7 +128,7 @@ jobs:
 
       - name: Report missing provider credential
         id: nocreds
-        if: env.HAS_LITELLM != 'true' && env.HAS_OPENAI != 'true'
+        if: env.HAS_OPENAI != 'true'
         uses: ./trusted-pr-review/.github/actions/pr-review
         with:
           github-token: ${{ secrets.review_token }}

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -61,6 +61,4 @@ jobs:
       reviewer_sha: ${{ github.sha }}
     secrets:
       review_token: ${{ secrets.GITHUB_TOKEN }}
-      litellm_base_url: ${{ secrets.LITELLM_BASE_URL }}
-      litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -103,12 +103,28 @@ PR_REVIEW_MODEL_FAST=groq/llama-3.3-70b-versatile
 
 ## Reusing the reviewer in another repository
 
-Copy this workflow stub and make two replacements. Replace both occurrences of
-`PINNED_PIPELOCK_REVIEW_COMMIT_SHA` with the same full, immutable Pipelock
-commit SHA; do not use a branch or tag. Replace `YOUR_GITHUB_LOGIN` with the
-login allowed to trigger a review, or drop that clause and rely on
-`author_association == 'OWNER'` alone. Personal-account repositories must map
-each named secret explicitly; `secrets: inherit` is not available here.
+The stub below carries nothing specific to any one repository, so every adopting
+repository holds the same file. Make two replacements. Replace both occurrences
+of `PINNED_PIPELOCK_REVIEW_COMMIT_SHA` with the same full, immutable Pipelock
+commit SHA; do not use a branch or tag, because either can move the reviewer
+code under the pin. Replace `YOUR_GITHUB_LOGIN` with the login allowed to
+trigger a review, or drop those clauses and rely on `author_association ==
+'OWNER'` alone.
+
+Grant both `issues: write` and `pull-requests: write`. A called workflow cannot
+hold a permission its caller withheld, so dropping either one silently strips it
+from the reviewer rather than failing at load, and the review then ends on a
+permission error when it tries to post.
+
+Personal-account repositories must map each named secret explicitly, because
+`secrets: inherit` is not available to them. Map the LiteLLM secrets even where
+they do not exist; an absent secret resolves to an empty string and the reviewer
+falls back to the direct OpenAI path.
+
+Keep the manual dispatch. A comment-triggered workflow only ever executes the
+copy on the default branch, so a change to this file cannot run on the pull
+request that introduces it, and the dispatch is the only way to exercise a
+change here before it lands.
 
 ```yaml
 name: AI PR Review
@@ -116,6 +132,18 @@ name: AI PR Review
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request to review with the workflow on this branch.
+        required: true
+        type: string
+      review_mode:
+        description: default or deep.
+        required: true
+        default: default
+        type: choice
+        options: [default, deep]
 
 permissions:
   contents: read
@@ -125,15 +153,25 @@ permissions:
 jobs:
   review:
     if: >-
-      github.event.comment.user.login == 'YOUR_GITHUB_LOGIN' &&
-      github.event.comment.author_association == 'OWNER' &&
-      github.event.issue.pull_request &&
-      (github.event.comment.body == '/review' ||
-       github.event.comment.body == '/review deep')
+      github.actor == 'YOUR_GITHUB_LOGIN' &&
+      github.triggering_actor == 'YOUR_GITHUB_LOGIN' &&
+      ((github.event_name == 'issue_comment' &&
+        github.event.comment.user.login == 'YOUR_GITHUB_LOGIN' &&
+        github.event.comment.author_association == 'OWNER' &&
+        github.event.issue.pull_request &&
+        (github.event.comment.body == '/review' ||
+         github.event.comment.body == '/review deep')) ||
+       github.event_name == 'workflow_dispatch')
     uses: luckyPipewrench/pipelock/.github/workflows/pr-review-reusable.yaml@PINNED_PIPELOCK_REVIEW_COMMIT_SHA
     with:
-      pr_number: ${{ github.event.issue.number }}
-      review_mode: ${{ github.event.comment.body == '/review deep' && 'deep' || 'default' }}
+      pr_number: >-
+        ${{ github.event_name == 'issue_comment' &&
+        github.event.issue.number || inputs.pr_number }}
+      review_mode: >-
+        ${{ github.event_name == 'issue_comment' &&
+        (github.event.comment.body == '/review deep' && 'deep' ||
+         'default') ||
+        inputs.review_mode }}
       reviewer_sha: PINNED_PIPELOCK_REVIEW_COMMIT_SHA
     secrets:
       review_token: ${{ secrets.GITHUB_TOKEN }}
@@ -141,6 +179,10 @@ jobs:
       litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
+
+`github.triggering_actor` names the account that started the current attempt,
+which differs from `github.actor` when someone re-runs an existing workflow.
+Requiring both means a re-run cannot widen who is able to start a review.
 
 ## Files
 

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -117,9 +117,7 @@ from the reviewer rather than failing at load, and the review then ends on a
 permission error when it tries to post.
 
 Personal-account repositories must map each named secret explicitly, because
-`secrets: inherit` is not available to them. Map the LiteLLM secrets even where
-they do not exist; an absent secret resolves to an empty string and the reviewer
-falls back to the direct OpenAI path.
+`secrets: inherit` is not available to them.
 
 Keep the manual dispatch. A comment-triggered workflow only ever executes the
 copy on the default branch, so a change to this file cannot run on the pull
@@ -175,8 +173,6 @@ jobs:
       reviewer_sha: PINNED_PIPELOCK_REVIEW_COMMIT_SHA
     secrets:
       review_token: ${{ secrets.GITHUB_TOKEN }}
-      litellm_base_url: ${{ secrets.LITELLM_BASE_URL }}
-      litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 ```
 

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -34,7 +34,8 @@ and marks the result `superseded` if the head changes before finalization. It
 uses deterministic token budgeting instead of character slicing: Go source and
 additions rank above tests, configuration, and documentation. The final comment
 contains an omission manifest and never reports `clean` when a unit was omitted,
-collapsed, unparseable, or left without a valid structured result.
+unparseable, or left without a valid structured result. Default-mode deletion
+compression is disclosed separately; deep mode reads deletions in full.
 
 Each run creates one bot-owned status comment and edits it in place. The runner
 uses strict JSON output, a cross-file synthesis pass, and a second actual-code
@@ -43,15 +44,13 @@ text from model-supplied fields.
 
 ## Setup
 
-### Required GitHub Secrets
+### Required GitHub Secret
 
 Set these in **Settings > Secrets and variables > Actions**:
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `LITELLM_BASE_URL` | If using LiteLLM | Your LiteLLM proxy URL (e.g., `https://litellm.example.com/v1`) |
-| `LITELLM_API_KEY` | If using LiteLLM | API key for LiteLLM proxy |
-| `OPENAI_API_KEY` | If not using LiteLLM | Direct OpenAI API key (fallback) |
+| `OPENAI_API_KEY` | Yes | Direct OpenAI API key for the reviewer |
 
 `GITHUB_TOKEN` is provided automatically by GitHub Actions.
 
@@ -69,13 +68,9 @@ The defaults live in `.github/actions/pr-review/pr_review.py`; the composite
 action passes optional repository variables through without maintaining another
 copy.
 
-### LiteLLM vs Direct OpenAI
+### Provider
 
-**LiteLLM (preferred):** Set `LITELLM_BASE_URL` and `LITELLM_API_KEY`. Point at whatever upstream model you want (OpenAI, Anthropic, local). The script sends OpenAI-compatible requests to your LiteLLM proxy.
-
-**Direct OpenAI (fallback):** Set only `OPENAI_API_KEY`. The script calls `api.openai.com` directly.
-
-If both are set, LiteLLM takes priority.
+Set `OPENAI_API_KEY`. The reviewer calls `api.openai.com` directly.
 
 ### Switching Models
 
@@ -86,18 +81,14 @@ PR_REVIEW_MODEL_FAST=gpt-5.6-luna
 PR_REVIEW_MODEL_DEEP=gpt-5.6-terra
 ```
 
-With LiteLLM, use any model your proxy supports:
-
-```
-PR_REVIEW_MODEL_DEEP=anthropic/claude-sonnet-4-20250514
-PR_REVIEW_MODEL_FAST=groq/llama-3.3-70b-versatile
-```
+Values must name models available through the direct OpenAI API.
 
 ## Cost Control
 
 - Only runs when manually triggered (no auto-review on push)
 - Never retries an ambiguous provider timeout, which could double-spend
-- Splits by complete hunks and explicit token budgets, never a character slice
+- Uses explicit token budgets; deep mode splits an oversized hunk into complete
+  contiguous review units rather than summarizing or dropping its deletion lines
 - `/review` uses the efficient model by default
 - `/review deep` is opt-in for the xhigh adversarial pass
 

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -113,7 +113,10 @@ class WorkflowPackagingTest(unittest.TestCase):
 
         review = workflow["jobs"]["review"]
         self.assertEqual(review["needs"], "admit")
-        self.assertIn("HAS_LITELLM", review["env"])
+        # One provider remains. A second was carried for a gateway no
+        # repository ever configured, so its branch never ran.
+        self.assertIn("HAS_OPENAI", review["env"])
+        self.assertNotIn("HAS_LITELLM", review["env"])
         checkout = review["steps"][0]
         self.assertEqual(checkout["with"]["repository"], "luckyPipewrench/pipelock")
         self.assertEqual(checkout["with"]["ref"], "${{ inputs.reviewer_sha }}")
@@ -133,7 +136,28 @@ class WorkflowPackagingTest(unittest.TestCase):
         completeness = workflow["jobs"]["completeness"]
         self.assertEqual(completeness["needs"], ["admit", "review"])
         self.assertIn("always()", completeness["if"])
-        self.assertEqual(review["outputs"]["complete"].count("outputs.complete"), 3)
+        # Every step that can run a review must feed both outputs. A hard-coded
+        # count went stale the moment a provider was removed, and a count is the
+        # wrong assertion anyway: it cannot tell which step was dropped. Derive
+        # the expected identifiers from the steps themselves, so adding or
+        # removing a provider without wiring its outputs fails here.
+        provider_ids = {
+            step["id"]
+            for step in review["steps"]
+            if step.get("id") and str(step.get("uses", "")).endswith("/actions/pr-review")
+        }
+        self.assertTrue(provider_ids, "the review job must run the review action")
+        for output in ("state", "complete"):
+            referenced = {
+                identifier
+                for identifier in provider_ids
+                if f"steps.{identifier}.outputs.{output}" in review["outputs"][output]
+            }
+            self.assertEqual(
+                referenced,
+                provider_ids,
+                f"every provider step must contribute to the {output} output",
+            )
         for step in review["steps"]:
             self.assertNotIn("secrets.", step.get("if", ""))
 
@@ -183,7 +207,7 @@ class WorkflowPackagingTest(unittest.TestCase):
         action = load_yaml(ACTION_YAML)
         self.assertTrue((ACTION_DIR / "requirements.txt").is_file())
         self.assertEqual(action["inputs"]["operation"]["default"], "review")
-        for name in ("status-comment-id", "operation", "litellm-api-key", "openai-api-key", "model-fast", "model-deep"):
+        for name in ("status-comment-id", "operation", "openai-api-key", "model-fast", "model-deep"):
             self.assertIn(name, action["inputs"])
         # Either cache key breaks setup for this action and stops every review
         # before it starts, so this asserts against the parsed document rather
@@ -998,6 +1022,100 @@ class StatusPresentationTest(unittest.TestCase):
         self.assertNotIn("**Binding:**", lead)
         self.assertNotIn("**Review identity:**", lead)
         self.assertIn("<summary>Review details: binding and planned review</summary>", status)
+
+
+class DeletionFidelityTest(unittest.TestCase):
+    """Deleting code is a change, and deep mode is the pass that must see it."""
+
+    @staticmethod
+    def diff_with_deletions(count: int) -> str:
+        removed = "\n".join(f"-old line {index}" for index in range(count))
+        return (
+            "diff --git a/internal/guard.go b/internal/guard.go\n"
+            "--- a/internal/guard.go\n"
+            "+++ b/internal/guard.go\n"
+            f"@@ -1,{count} +1,1 @@\n"
+            f"{removed}\n"
+            "+replacement\n"
+        )
+
+    def test_deep_mode_reads_every_deleted_line(self) -> None:
+        # Removing a guard reads as a deletion hunk, so summarizing deletions
+        # in the mode asked for full fidelity can hide the change that matters
+        # most on a security product.
+        count = pr_review.MAX_DELETION_LINES_PER_HUNK * 3
+        units, errors = pr_review.parse_diff(self.diff_with_deletions(count), "deep")
+        self.assertEqual(errors, [])
+        self.assertEqual(sum(item.collapsed_deletions for item in units), 0)
+        for index in range(count):
+            self.assertIn(f"-old line {index}", units[0].body)
+
+    def test_default_mode_still_collapses_and_discloses(self) -> None:
+        count = pr_review.MAX_DELETION_LINES_PER_HUNK * 3
+        units, _ = pr_review.parse_diff(self.diff_with_deletions(count), "default")
+        collapsed = sum(item.collapsed_deletions for item in units)
+        self.assertGreater(collapsed, 0)
+        self.assertIn("deletion lines collapsed", units[0].body)
+        self.assertEqual(units[0].manifest()["collapsed_deletions"], collapsed)
+
+    def test_a_collapsed_hunk_is_not_a_coverage_gap(self) -> None:
+        # An observed review read 321 of 321 units, omitted nothing, and still
+        # reported partial behind a failing check because six hunks were
+        # collapsed. A check that fails on complete reviews gets ignored, and
+        # then it protects nothing when a review really is short.
+        #
+        # This asserts the decision, not its consequence. Asserting that
+        # derive_state returns clean for a hand-built progress cannot catch
+        # this: the defect was in what the caller recorded, so a version that
+        # recorded the collapse again still passed that assertion.
+        units, _ = pr_review.parse_diff(
+            self.diff_with_deletions(pr_review.MAX_DELETION_LINES_PER_HUNK * 3), "default"
+        )
+        self.assertGreater(sum(item.collapsed_deletions for item in units), 0)
+        self.assertEqual(pr_review.coverage_gaps(units, [], []), [])
+
+    def test_a_genuinely_omitted_unit_is_a_coverage_gap(self) -> None:
+        units, _ = pr_review.parse_diff(self.diff_with_deletions(2), "deep")
+        gaps = pr_review.coverage_gaps(units, [units[0]], [])
+        self.assertEqual(gaps, ["one or more units were omitted or unrepresentable"])
+
+    def test_a_parse_error_is_carried_through_as_a_gap(self) -> None:
+        units, _ = pr_review.parse_diff(self.diff_with_deletions(2), "deep")
+        self.assertEqual(pr_review.coverage_gaps(units, [], ["diff has no file headers"]),
+                         ["diff has no file headers"])
+
+    def test_an_omitted_unit_still_reports_partial(self) -> None:
+        progress = pr_review.ReviewProgress()
+        progress.expected_units = 4
+        progress.reviewed_units = 3
+        self.assertEqual(pr_review.derive_state(progress), "partial")
+
+
+class SingleProviderTest(unittest.TestCase):
+    def test_openai_credential_selects_the_only_provider(self) -> None:
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
+            endpoint, key = pr_review.provider_configuration()
+        self.assertEqual(endpoint, "https://api.openai.com/v1/chat/completions")
+        self.assertEqual(key, "key")
+
+    def test_a_stale_gateway_variable_cannot_redirect_the_provider_call(self) -> None:
+        # The removed branch chose its endpoint from an environment variable.
+        # A leftover value in a repository or runner must not be able to send
+        # the review, its diff and its credential somewhere else.
+        environment = {
+            "OPENAI_API_KEY": "key",
+            "LITELLM_BASE_URL": "https://attacker.vendor.example/v1",
+            "LITELLM_API_KEY": "other",
+        }
+        with mock.patch.dict(pr_review.os.environ, environment, clear=True):
+            endpoint, key = pr_review.provider_configuration()
+        self.assertEqual(endpoint, "https://api.openai.com/v1/chat/completions")
+        self.assertEqual(key, "key")
+
+    def test_no_credential_is_a_configuration_failure(self) -> None:
+        with mock.patch.dict(pr_review.os.environ, {}, clear=True):
+            with self.assertRaises(pr_review.ProviderConfigurationError):
+                pr_review.provider_configuration()
 
 
 class AdoptionStubTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1083,6 +1083,47 @@ class DeletionFidelityTest(unittest.TestCase):
                 "a unit must carry changed lines after its hunk header",
             )
 
+    def test_split_pieces_carry_their_own_accurate_hunk_header(self) -> None:
+        # Every piece used to repeat the original @@ header, so a continuation
+        # starting thousands of lines in still announced the hunk's first line.
+        # The reviewer anchors findings to that header, so deep mode reported
+        # real findings against the wrong lines: the split exists to preserve
+        # line-addressed output and was quietly corrupting it.
+        count = 16_000
+        units, errors = pr_review.parse_diff(self.diff_with_deletions(count), "deep")
+        self.assertEqual(errors, [])
+        self.assertGreater(len(units), 1)
+
+        headers = [unit.hunk_header for unit in units]
+        self.assertEqual(len(headers), len(set(headers)), "pieces repeated one header")
+
+        old_cursor = 1
+        new_cursor = 1
+        for unit in units:
+            match = pr_review.HUNK_HEADER_RE.match(unit.hunk_header)
+            self.assertIsNotNone(match, f"unparseable piece header {unit.hunk_header!r}")
+            old_start, old_count = int(match.group(1)), int(match.group(2))
+            new_start, new_count = int(match.group(3)), int(match.group(4))
+
+            # A piece must start where the previous one ended on both sides.
+            self.assertEqual(old_start, old_cursor, f"old start drifted at {unit.hunk_header!r}")
+            self.assertEqual(new_start, new_cursor, f"new start drifted at {unit.hunk_header!r}")
+
+            # And its declared counts must match the lines it actually carries.
+            body = unit.body.splitlines()
+            piece = body[body.index(unit.hunk_header) + 1 :]
+            actual_old = sum(1 for line in piece if not line or line.startswith(("-", " ")))
+            actual_new = sum(1 for line in piece if not line or line.startswith(("+", " ")))
+            self.assertEqual(old_count, actual_old, f"old count wrong in {unit.hunk_header!r}")
+            self.assertEqual(new_count, actual_new, f"new count wrong in {unit.hunk_header!r}")
+
+            old_cursor += actual_old
+            new_cursor += actual_new
+
+        # The pieces together must still describe the whole original hunk.
+        self.assertEqual(old_cursor - 1, count)
+        self.assertEqual(new_cursor - 1, 1)
+
     def test_default_mode_still_collapses_and_discloses(self) -> None:
         count = pr_review.MAX_DELETION_LINES_PER_HUNK * 3
         units, _ = pr_review.parse_diff(self.diff_with_deletions(count), "default")

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -6,6 +6,7 @@
 
 import importlib.util
 import pathlib
+import re
 import sys
 import tempfile
 import unittest
@@ -113,10 +114,10 @@ class WorkflowPackagingTest(unittest.TestCase):
 
         review = workflow["jobs"]["review"]
         self.assertEqual(review["needs"], "admit")
-        # One provider remains. A second was carried for a gateway no
-        # repository ever configured, so its branch never ran.
-        self.assertIn("HAS_OPENAI", review["env"])
-        self.assertNotIn("HAS_LITELLM", review["env"])
+        # Exactly the provider-presence flags, stated positively. Asserting
+        # that one removed flag is absent would only catch that one spelling
+        # and would say nothing about a third provider added later.
+        self.assertEqual(set(review["env"]), {"HAS_OPENAI"})
         checkout = review["steps"][0]
         self.assertEqual(checkout["with"]["repository"], "luckyPipewrench/pipelock")
         self.assertEqual(checkout["with"]["ref"], "${{ inputs.reviewer_sha }}")
@@ -1130,15 +1131,19 @@ class SingleProviderTest(unittest.TestCase):
         self.assertEqual(endpoint, "https://api.openai.com/v1/chat/completions")
         self.assertEqual(key, "key")
 
-    def test_a_stale_gateway_variable_cannot_redirect_the_provider_call(self) -> None:
-        # The removed branch chose its endpoint from an environment variable.
-        # A leftover value in a repository or runner must not be able to send
-        # the review, its diff and its credential somewhere else.
-        environment = {
-            "OPENAI_API_KEY": "key",
-            "LITELLM_BASE_URL": "https://attacker.vendor.example/v1",
-            "LITELLM_API_KEY": "other",
-        }
+    def test_no_environment_value_can_redirect_the_provider_call(self) -> None:
+        # The endpoint is a constant, not something the environment supplies.
+        # This is the property worth holding: a review carries the repository's
+        # diff and a credential, so anything able to name the destination could
+        # send both somewhere else. Stated generally rather than against one
+        # variable, since the risk is any endpoint-shaped value on the runner,
+        # not the particular one a removed provider branch happened to read.
+        environment = {"OPENAI_API_KEY": "key"}
+        for name in (
+            "API_BASE", "API_BASE_URL", "BASE_URL", "OPENAI_API_BASE",
+            "OPENAI_BASE_URL", "PROVIDER_BASE_URL", "PR_REVIEW_API_BASE",
+        ):
+            environment[name] = "https://attacker.vendor.example/v1"
         with mock.patch.dict(pr_review.os.environ, environment, clear=True):
             endpoint, key = pr_review.provider_configuration()
         self.assertEqual(endpoint, "https://api.openai.com/v1/chat/completions")
@@ -1149,19 +1154,35 @@ class SingleProviderTest(unittest.TestCase):
             with self.assertRaises(pr_review.ProviderConfigurationError):
                 pr_review.provider_configuration()
 
-    def test_guide_does_not_advertise_removed_gateway_credentials(self) -> None:
-        # The provider branch, composite inputs, and reusable-workflow secrets
-        # are gone together. Leaving a gateway variable in the guide tells an
-        # adopter to configure a value the action no longer consumes.
-        #
-        # Matched case-insensitively against the whole name, not against a
-        # backtick-quoted variable. Prose reintroducing the gateway ("point
-        # LiteLLM at any upstream") tells an adopter the same wrong thing as a
-        # table row, and four earlier guards in this suite were each bypassed
-        # by matching a narrower spelling than the thing they guarded.
+    def test_every_secret_the_guide_requires_is_one_the_workflow_accepts(self) -> None:
+        # Setup instructions are the first thing an adopter follows, and a
+        # secret named there that the workflow never declares is a step that
+        # silently accomplishes nothing. Checked against the declared secrets
+        # rather than against any particular name, so it holds for a provider
+        # added or removed later and not only for one already gone.
         guide = (ROOT / "docs" / "guides" / "pr-review.md").read_text(encoding="utf-8")
-        self.assertIn("`OPENAI_API_KEY`", guide)
-        self.assertNotIn("litellm", guide.lower())
+        marker = "### Required GitHub Secret"
+        self.assertIn(marker, guide, "the guide must tell an adopter which secrets to set")
+        # Stop at the next heading of any level. Running to the next top-level
+        # heading swept in the optional-variables section, and a repository
+        # variable is not a secret: reporting one as an undeclared secret is a
+        # false alarm on correct documentation, which is how a check like this
+        # gets deleted rather than fixed.
+        section = re.split(r"\n#{2,}\s", guide.split(marker, 1)[1], maxsplit=1)[0]
+        advertised = {
+            name.strip("`")
+            for name in re.findall(r"`[A-Z][A-Z0-9_]{3,}`", section)
+        }
+        self.assertTrue(advertised, "the secrets section must name at least one secret")
+
+        declared = {name.upper() for name in load_yaml(REUSABLE_WORKFLOW)["on"]["workflow_call"]["secrets"]}
+        # GITHUB_TOKEN is supplied by Actions itself and mapped by the caller
+        # as review_token, so it is legitimately named without being declared.
+        self.assertEqual(
+            advertised - declared - {"GITHUB_TOKEN"},
+            set(),
+            "the guide names a secret the reusable workflow does not accept",
+        )
 
 
 class AdoptionStubTest(unittest.TestCase):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1000,5 +1000,126 @@ class StatusPresentationTest(unittest.TestCase):
         self.assertIn("<summary>Review details: binding and planned review</summary>", status)
 
 
+class AdoptionStubTest(unittest.TestCase):
+    """The stub in the guide is what other repositories copy, so it is code.
+
+    Six repositories each grew their own copy of this reviewer and drifted
+    apart, which is what made the command work in one repository and not the
+    next. Replacing the copies with a shared caller only holds if the
+    instructions for writing that caller cannot fall behind the caller this
+    repository actually runs. Prose cannot be relied on for that, so the
+    published stub is compared against the real caller here.
+    """
+
+    # A caller outside this repository must name the reviewer by immutable
+    # commit, where a same-repository call resolves it implicitly. Those two
+    # keys are expected to differ; nothing else is.
+    EXPECTED_DIFFERENCES = frozenset({"uses", "reviewer_sha"})
+    PLACEHOLDER_LOGIN = "YOUR_GITHUB_LOGIN"
+    REAL_LOGIN = "luckyPipewrench"
+
+    def documented_stub(self) -> dict[str, object]:
+        guide = (ROOT / "docs" / "guides" / "pr-review.md").read_text(encoding="utf-8")
+        marker = "## Reusing the reviewer in another repository"
+        self.assertIn(marker, guide, "the adoption section is what other repositories copy")
+        section = guide.split(marker, 1)[1]
+        blocks = section.split("```yaml")
+        self.assertGreater(len(blocks), 1, "the adoption section must publish a YAML stub")
+        body = blocks[1].split("```", 1)[0]
+        # The stub is written for another repository, so it carries a
+        # placeholder where this repository carries its own login.
+        self.assertIn(self.PLACEHOLDER_LOGIN, body, "the stub must not hard-code one account")
+        return parse_yaml(body.replace(self.PLACEHOLDER_LOGIN, self.REAL_LOGIN))
+
+    @staticmethod
+    def collapse(value: object) -> object:
+        """Compare meaning, not line breaks, since YAML folding is free."""
+        if isinstance(value, str):
+            return " ".join(value.split())
+        if isinstance(value, list):
+            return [AdoptionStubTest.collapse(item) for item in value]
+        if isinstance(value, dict):
+            return {key: AdoptionStubTest.collapse(item) for key, item in value.items()}
+        return value
+
+    @staticmethod
+    def triggers(document: dict[str, object]) -> object:
+        """Compare what a trigger accepts, not how it describes itself.
+
+        An input's description is text shown to whoever runs the dispatch. It
+        carries no behavior, and requiring two copies of it to match word for
+        word would fail on an improved wording. A guard that fails on
+        harmless edits gets removed, so this compares the contract instead:
+        which inputs exist, whether each is required, its type, its default
+        and its permitted values.
+        """
+        events = AdoptionStubTest.collapse(document.get("on"))
+        dispatch = events.get("workflow_dispatch") if isinstance(events, dict) else None
+        if isinstance(dispatch, dict) and isinstance(dispatch.get("inputs"), dict):
+            dispatch["inputs"] = {
+                name: {key: value for key, value in spec.items() if key != "description"}
+                for name, spec in dispatch["inputs"].items()
+            }
+        return events
+
+    def test_documented_stub_matches_the_caller_this_repository_runs(self) -> None:
+        stub = self.documented_stub()
+        real = load_yaml(CALLER_WORKFLOW)
+
+        self.assertEqual(
+            self.triggers(stub),
+            self.triggers(real),
+            "the stub must offer the same triggers, including the manual dispatch that "
+            "makes a change to a caller testable before it merges",
+        )
+        self.assertEqual(
+            stub.get("permissions"),
+            real.get("permissions"),
+            "a called workflow cannot hold a permission its caller withheld, so a stub "
+            "granting less silently strips it from the reviewer",
+        )
+
+        stub_job = stub["jobs"]["review"]
+        real_job = real["jobs"]["review"]
+        self.assertEqual(
+            self.collapse(stub_job.get("if")),
+            self.collapse(real_job.get("if")),
+            "the stub must authorize exactly who the real caller authorizes",
+        )
+        self.assertEqual(
+            stub_job.get("secrets"),
+            real_job.get("secrets"),
+            "every secret is mapped by name because personal accounts cannot inherit them",
+        )
+
+        stub_with = self.collapse(stub_job.get("with"))
+        real_with = self.collapse(real_job.get("with"))
+        self.assertEqual(
+            set(stub_with), set(real_with), "the stub must pass the same inputs"
+        )
+        differing = {key for key in stub_with if stub_with[key] != real_with[key]}
+        self.assertEqual(
+            differing,
+            self.EXPECTED_DIFFERENCES & set(stub_with),
+            "only the reviewer pin may differ between an external stub and this caller",
+        )
+
+    def test_stub_pins_the_reviewer_by_commit_in_both_positions(self) -> None:
+        stub = self.documented_stub()
+        job = stub["jobs"]["review"]
+        placeholder = "PINNED_PIPELOCK_REVIEW_COMMIT_SHA"
+        uses = job["uses"]
+        self.assertTrue(
+            uses.endswith("@" + placeholder),
+            "the stub must be pinned by commit; a branch or tag can move the reviewer "
+            "code under the pin",
+        )
+        self.assertEqual(
+            job["with"]["reviewer_sha"],
+            placeholder,
+            "the workflow and the reviewer it checks out must be pinned to one commit",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1083,6 +1083,45 @@ class DeletionFidelityTest(unittest.TestCase):
                 "a unit must carry changed lines after its hunk header",
             )
 
+    def test_no_newline_marker_never_separates_from_its_line(self) -> None:
+        # The marker describes the line immediately before it. A boundary
+        # falling between the two states the opposite of the truth twice: the
+        # first piece then claims the file ended with a newline, and the next
+        # opens with a marker for a line the reviewer cannot see. Deep mode
+        # exists to address exact lines, so this is the one corruption the
+        # split must not introduce.
+        marker = pr_review.NO_NEWLINE_MARKER
+        header = ["--- a/f.go", "+++ b/f.go"]
+
+        # Sweep line counts so a boundary lands on the marker for at least one
+        # of them rather than depending on one hand-computed offset.
+        for count in range(6, 40):
+            content = []
+            for index in range(count):
+                content.append(f"-old line {index}")
+                content.append(marker)
+            hunk = [f"@@ -1,{count} +1,1 @@", *content]
+
+            with mock.patch.object(pr_review, "DEEP_INPUT_TOKEN_BUDGET", 24):
+                pieces = pr_review._split_oversized_deep_hunk(header, hunk)
+
+            self.assertGreater(len(pieces), 1, f"count={count} did not split")
+            for piece in pieces:
+                body = piece[1:]
+                self.assertNotEqual(
+                    body[0], marker, f"count={count}: a piece opens with an orphan marker"
+                )
+                for position, line in enumerate(body):
+                    if line == marker:
+                        self.assertNotEqual(
+                            body[position - 1],
+                            marker,
+                            f"count={count}: marker lost the line it annotates",
+                        )
+            # No line may be dropped by the grouping.
+            emitted = [line for piece in pieces for line in piece[1:]]
+            self.assertEqual(emitted, content, f"count={count}: split altered the hunk")
+
     def test_split_pieces_carry_their_own_accurate_hunk_header(self) -> None:
         # Every piece used to repeat the original @@ header, so a continuation
         # starting thousands of lines in still announced the hunk's first line.

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1050,6 +1050,38 @@ class DeletionFidelityTest(unittest.TestCase):
         for index in range(count):
             self.assertIn(f"-old line {index}", units[0].body)
 
+    def test_deep_mode_splits_an_oversized_deletion_hunk_without_omission(self) -> None:
+        # The prior version collapsed this hunk before it reached the deep
+        # planner. Leaving it whole made it exceed that planner's per-chunk
+        # input budget and therefore omitted the entire deletion. Split it
+        # into bounded contiguous units instead: no deleted line is hidden or
+        # dropped, but each provider call remains within its budget.
+        count = 16_000
+        units, errors = pr_review.parse_diff(self.diff_with_deletions(count), "deep")
+        chunks, omitted = pr_review.plan_chunks(units, "deep")
+        deleted_lines = [
+            line
+            for unit in units
+            for line in unit.body.splitlines()
+            if line.startswith("-old line ")
+        ]
+        self.assertEqual(errors, [])
+        self.assertGreater(len(units), 1)
+        self.assertTrue(all(unit.estimated_tokens <= pr_review.DEEP_INPUT_TOKEN_BUDGET for unit in units))
+        self.assertEqual(sum(len(chunk) for chunk in chunks), len(units))
+        self.assertEqual(omitted, [])
+        self.assertEqual(deleted_lines, [f"-old line {index}" for index in range(count)])
+        # Every piece must still be a readable diff. Emitting a continuation
+        # without the hunk header hands the model file headers and a bare run
+        # of changed lines, which is not a diff and carries no line context.
+        for unit in units:
+            body = unit.body.splitlines()
+            self.assertIn(unit.hunk_header, body)
+            self.assertTrue(
+                body.index(unit.hunk_header) < len(body) - 1,
+                "a unit must carry changed lines after its hunk header",
+            )
+
     def test_default_mode_still_collapses_and_discloses(self) -> None:
         count = pr_review.MAX_DELETION_LINES_PER_HUNK * 3
         units, _ = pr_review.parse_diff(self.diff_with_deletions(count), "default")
@@ -1116,6 +1148,20 @@ class SingleProviderTest(unittest.TestCase):
         with mock.patch.dict(pr_review.os.environ, {}, clear=True):
             with self.assertRaises(pr_review.ProviderConfigurationError):
                 pr_review.provider_configuration()
+
+    def test_guide_does_not_advertise_removed_gateway_credentials(self) -> None:
+        # The provider branch, composite inputs, and reusable-workflow secrets
+        # are gone together. Leaving a gateway variable in the guide tells an
+        # adopter to configure a value the action no longer consumes.
+        #
+        # Matched case-insensitively against the whole name, not against a
+        # backtick-quoted variable. Prose reintroducing the gateway ("point
+        # LiteLLM at any upstream") tells an adopter the same wrong thing as a
+        # table row, and four earlier guards in this suite were each bypassed
+        # by matching a narrower spelling than the thing they guarded.
+        guide = (ROOT / "docs" / "guides" / "pr-review.md").read_text(encoding="utf-8")
+        self.assertIn("`OPENAI_API_KEY`", guide)
+        self.assertNotIn("litellm", guide.lower())
 
 
 class AdoptionStubTest(unittest.TestCase):


### PR DESCRIPTION
## What changed

A green review check now means the review read the pull request. Collapsing the middle of a large deletion hunk is a token-budget policy, and it was counted as a reason the review was incomplete, so the completeness check failed on any pull request that removes a block of more than twenty-four lines. One observed review read 321 of 321 units and omitted nothing, and still published partial behind a failing check. Incompleteness now names only what the review should have read and did not: omitted units, parse errors, a truncated compare, a timeout, a moved head, a failed fetch.

A deep review reads deletions in full. Removing a guard reads as a deletion hunk, so summarizing deletions in the pass asked for full fidelity can hide the change that matters most. Keeping them whole then risked the opposite failure, where a hunk larger than the per-call budget was dropped entirely, so a deep review splits an oversized hunk into bounded contiguous pieces that each repeat the hunk header. A single line too large to split stays whole and is reported as an omission. The default pass still collapses and still discloses which hunks.

The reviewer's own tests run on pull requests. Nothing ran them. Repositories holding their own copy ran them inside a review, which cannot gate anything, since a review is triggered by a comment and only executes the copy already on the default branch. Every check in that suite reported green while running nowhere, including the ones covering this workflow's permissions and its authorization gate.

The stub other repositories copy is compared against the caller this repository runs, and the provider gateway is removed. The gateway was preferred over the direct API whenever its two secrets were set, and no repository has ever set them, so that branch never ran.

**Failure direction, and what to distrust.** The completeness signal moved toward reporting green more often, which is the direction worth checking: the reasons it still fails are the ones where content went unread, and each is covered by a test that fails when the reason is removed. The deep-mode split is the opposite risk, since it raises tokens per unit and could push a large pull request past the chunk cap; a pull request beyond that cap reports partial rather than clean, so the failure stays visible. Removing a provider branch narrows what can name the outbound endpoint, and the endpoint is now a constant no environment value can supply. Split continuation pieces repeat the original hunk header, so a finding on a later piece of a very large hunk can carry a misleading line number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep reviews preserve deleted lines and split oversized changes into complete review units.
  * Added manual workflow dispatch support for pull-request reviews.
  * Standardized reviews on direct OpenAI configuration.

* **Bug Fixes**
  * Improved review coverage reporting and partial-state handling.
  * Strengthened validation for review requests and workflow configuration.

* **Documentation**
  * Updated setup guidance, security requirements, and OpenAI configuration details.

* **Chores**
  * Added automated CI coverage for review parsing, configuration, and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->