### PR TITLE
fix(sandbox): preserve capacity on busy shared users

### DIFF
--- a/internal/sandbox/rlimit_linux.go
+++ b/internal/sandbox/rlimit_linux.go
@@ -22,7 +22,7 @@ import (
 // These prevent fork bombs, disk fill, FD exhaustion, and core dumps.
 const (
 	rlimitNProc           uint64 = 4096    // absolute shared-UID task ceiling
-	rlimitNProcHeadroom   uint64 = 1024    // tasks reserved for each admitted sandbox launch
+	rlimitNProcHeadroom   uint64 = 1024    // maximum additional task capacity per launch
 	rlimitNoFile          uint64 = 4096    // max open file descriptors
 	rlimitFSize           uint64 = 1 << 30 // 1 GB max file size (prevents disk fill)
 	rlimitCore            uint64 = 0       // disable core dumps (prevents memory leak to disk)
@@ -45,14 +45,13 @@ func boundedNProcLimit(inherited unix.Rlimit) uint64 {
 }
 
 func requestedNProcLimit(tasks, ceiling uint64) (uint64, error) {
-	if tasks > math.MaxUint64-rlimitNProcHeadroom {
-		return 0, errors.New("shared UID task headroom overflows")
+	if tasks >= ceiling {
+		return 0, fmt.Errorf("shared UID has %d tasks at or above sandbox RLIMIT_NPROC ceiling %d", tasks, ceiling)
 	}
-	requested := tasks + rlimitNProcHeadroom
-	if requested > ceiling {
-		return 0, fmt.Errorf("shared UID has %d tasks; reserving %d tasks exceeds sandbox RLIMIT_NPROC ceiling %d", tasks, rlimitNProcHeadroom, ceiling)
+	if ceiling-tasks < rlimitNProcHeadroom {
+		return ceiling, nil
 	}
-	return requested, nil
+	return tasks + rlimitNProcHeadroom, nil
 }
 
 // currentUIDTaskCount counts tasks for this real UID without retaining the
@@ -98,11 +97,11 @@ func currentUIDTaskCount(stopAt uint64) (uint64, error) {
 				}
 				return 0, fmt.Errorf("reading /proc/%s/status: %w", pid, statusErr)
 			}
-			realUID, threads, err := processUIDAndThreads(status)
+			threads, belongsToUID, err := processTaskCount(status, uid)
 			if err != nil {
 				return 0, fmt.Errorf("parsing /proc/%s/status: %w", pid, err)
 			}
-			if realUID != uid {
+			if !belongsToUID {
 				continue
 			}
 			if threads > math.MaxUint64-tasks {
@@ -139,10 +138,17 @@ func procEntryUnavailable(err error) bool {
 		errors.Is(err, unix.ESRCH) || errors.Is(err, unix.EACCES)
 }
 
-func processUIDAndThreads(status []byte) (int, uint64, error) {
-	var uid int
-	var threads uint64
-	foundUID, foundThreads := false, false
+// processTaskCount returns the thread count only for the requested real UID.
+// An empty status is the observable /proc exit race after a successful open;
+// the process no longer contributes stable tasks and is skipped. Foreign
+// processes are identified and skipped before their Threads field is parsed,
+// so their unrelated status shape cannot deny this UID's sandbox launch.
+func processTaskCount(status []byte, targetUID int) (uint64, bool, error) {
+	if len(bytes.TrimSpace(status)) == 0 {
+		return 0, false, nil
+	}
+
+	foundUID := false
 	for len(status) > 0 {
 		line, rest, _ := bytes.Cut(status, []byte{'\n'})
 		status = rest
@@ -154,29 +160,35 @@ func processUIDAndThreads(status []byte) (int, uint64, error) {
 		case "Uid:":
 			parsed, err := strconv.Atoi(string(fields[1]))
 			if err != nil {
-				return 0, 0, fmt.Errorf("real UID %q: %w", fields[1], err)
+				return 0, false, fmt.Errorf("real UID %q: %w", fields[1], err)
 			}
-			uid, foundUID = parsed, true
+			foundUID = true
+			if parsed != targetUID {
+				return 0, false, nil
+			}
 		case "Threads:":
+			if !foundUID {
+				continue
+			}
 			parsed, err := strconv.ParseUint(string(fields[1]), 10, 64)
 			if err != nil {
-				return 0, 0, fmt.Errorf("thread count %q: %w", fields[1], err)
+				return 0, false, fmt.Errorf("thread count %q: %w", fields[1], err)
 			}
-			threads, foundThreads = parsed, true
-		}
-		if foundUID && foundThreads {
-			return uid, threads, nil
+			return parsed, true, nil
 		}
 	}
-	return 0, 0, errors.New("uid or threads field is missing")
+	if !foundUID {
+		return 0, false, errors.New("uid field is missing")
+	}
+	return 0, false, errors.New("threads field is missing")
 }
 
 // ApplyRlimits sets resource limits on the calling process. Linux accounts
 // RLIMIT_NPROC against the real UID shared with the host even for mapped
 // sandbox launches, so every mode receives the same absolute shared-UID
-// ceiling. Each admitted launch receives 1,024 tasks above current shared-UID
-// usage without ever raising that absolute ceiling. A launch that cannot
-// receive the full headroom fails before the target executes.
+// ceiling. Each admitted launch receives up to 1,024 tasks above current
+// shared-UID usage without ever raising that absolute ceiling. A launch fails
+// before the target executes only when the UID is already at the ceiling.
 func ApplyRlimits() error {
 	var inherited unix.Rlimit
 	if err := unix.Getrlimit(unix.RLIMIT_NPROC, &inherited); err != nil {

--- a/internal/sandbox/rlimit_linux_test.go
+++ b/internal/sandbox/rlimit_linux_test.go
@@ -92,6 +92,11 @@ func TestProcessTaskCount(t *testing.T) {
 	if _, _, err := processTaskCount([]byte("Name:\ttest\n"), 1000); err == nil {
 		t.Fatal("missing UID and thread fields accepted")
 	}
+	t.Run("missing threads", func(t *testing.T) {
+		if _, _, err := processTaskCount([]byte("Uid:\t1000\n"), 1000); err == nil {
+			t.Fatal("missing thread field accepted for target UID")
+		}
+	})
 	t.Run("malformed UID", func(t *testing.T) {
 		if _, _, err := processTaskCount([]byte("Uid:\tinvalid\nThreads:\t7\n"), 1000); err == nil {
 			t.Fatal("malformed UID accepted")

--- a/internal/sandbox/rlimit_linux_test.go
+++ b/internal/sandbox/rlimit_linux_test.go
@@ -42,8 +42,11 @@ func TestRequestedNProcLimit(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "reserves headroom", tasks: 100, ceiling: 2048, want: 1124},
-		{name: "rejects insufficient headroom", tasks: 1025, ceiling: 2048, wantErr: true},
-		{name: "rejects overflow", tasks: ^uint64(0), ceiling: ^uint64(0), wantErr: true},
+		{name: "caps partial headroom at ceiling", tasks: 1025, ceiling: 2048, want: 2048},
+		{name: "allows final task below ceiling", tasks: 2047, ceiling: 2048, want: 2048},
+		{name: "rejects at ceiling", tasks: 2048, ceiling: 2048, wantErr: true},
+		{name: "rejects above ceiling", tasks: 2049, ceiling: 2048, wantErr: true},
+		{name: "avoids overflow near uint maximum", tasks: ^uint64(0) - 1, ceiling: ^uint64(0), want: ^uint64(0)},
 	}
 
 	for _, tt := range tests {
@@ -59,22 +62,56 @@ func TestRequestedNProcLimit(t *testing.T) {
 	}
 }
 
-func TestProcessUIDAndThreads(t *testing.T) {
-	uid, threads, err := processUIDAndThreads([]byte("Name:\ttest\nUid:\t1000\t1000\t1000\t1000\nThreads:\t7\n"))
-	if err != nil || uid != 1000 || threads != 7 {
-		t.Fatalf("processUIDAndThreads = (%d, %d, %v), want (1000, 7, nil)", uid, threads, err)
+func TestCurrentUIDTaskCountLive(t *testing.T) {
+	var inherited unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NPROC, &inherited); err != nil {
+		t.Fatalf("get inherited RLIMIT_NPROC: %v", err)
 	}
-	if _, _, err := processUIDAndThreads([]byte("Name:\ttest\n")); err == nil {
+	ceiling := boundedNProcLimit(inherited)
+	tasks, err := currentUIDTaskCount(ceiling)
+	if err != nil {
+		t.Fatalf("count current UID tasks: %v", err)
+	}
+	if tasks >= ceiling {
+		t.Skipf("shared UID is already at sandbox task ceiling: tasks=%d ceiling=%d", tasks, ceiling)
+	}
+	limit, err := requestedNProcLimit(tasks, ceiling)
+	if err != nil {
+		t.Fatalf("request limit below ceiling: tasks=%d ceiling=%d: %v", tasks, ceiling, err)
+	}
+	if limit <= tasks || limit > ceiling {
+		t.Fatalf("requested limit = %d, want (%d, %d]", limit, tasks, ceiling)
+	}
+}
+
+func TestProcessTaskCount(t *testing.T) {
+	threads, belongs, err := processTaskCount([]byte("Name:\ttest\nUid:\t1000\t1000\t1000\t1000\nThreads:\t7\n"), 1000)
+	if err != nil || !belongs || threads != 7 {
+		t.Fatalf("processTaskCount = (%d, %t, %v), want (7, true, nil)", threads, belongs, err)
+	}
+	if _, _, err := processTaskCount([]byte("Name:\ttest\n"), 1000); err == nil {
 		t.Fatal("missing UID and thread fields accepted")
 	}
 	t.Run("malformed UID", func(t *testing.T) {
-		if _, _, err := processUIDAndThreads([]byte("Uid:\tinvalid\nThreads:\t7\n")); err == nil {
+		if _, _, err := processTaskCount([]byte("Uid:\tinvalid\nThreads:\t7\n"), 1000); err == nil {
 			t.Fatal("malformed UID accepted")
 		}
 	})
 	t.Run("malformed threads", func(t *testing.T) {
-		if _, _, err := processUIDAndThreads([]byte("Uid:\t1000\nThreads:\tinvalid\n")); err == nil {
+		if _, _, err := processTaskCount([]byte("Uid:\t1000\nThreads:\tinvalid\n"), 1000); err == nil {
 			t.Fatal("malformed thread count accepted")
+		}
+	})
+	t.Run("foreign process does not require threads", func(t *testing.T) {
+		threads, belongs, err := processTaskCount([]byte("Uid:\t2000\nThreads:\tinvalid\n"), 1000)
+		if err != nil || belongs || threads != 0 {
+			t.Fatalf("foreign process = (%d, %t, %v), want (0, false, nil)", threads, belongs, err)
+		}
+	})
+	t.Run("empty status is transient", func(t *testing.T) {
+		threads, belongs, err := processTaskCount(nil, 1000)
+		if err != nil || belongs || threads != 0 {
+			t.Fatalf("empty status = (%d, %t, %v), want (0, false, nil)", threads, belongs, err)
 		}
 	})
 }


### PR DESCRIPTION
## What changed
- Keep sandbox launches available on busy shared-user hosts by granting up to 1,024 tasks of headroom without exceeding the absolute 4,096-task ceiling.
- Ignore transient and foreign process-status entries while counting the sandbox user's tasks; launch still fails closed at the ceiling or on malformed accounting for that user. Reviewers should distrust any path that can set the limit below current usage or above the ceiling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux process-limit handling so requests below the configured ceiling are accepted reliably.
  * Requests exceeding available capacity are safely capped instead of failing unnecessarily.
  * Requests at or above the ceiling are rejected consistently.
  * Process and thread counts now handle empty, incomplete, or unrelated system entries more reliably.
  * Added safeguards for maximum-value and live-system scenarios to prevent overflow-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->