### PR TITLE
fix(mcp): exit an MCP proxy when its spawning session dies

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -288,7 +288,8 @@ func ForwardScannedInput(
 	for {
 		line, err := reader.ReadMessage()
 		if err != nil {
-			if !errors.Is(err, io.EOF) {
+			expectedClose := opts.sessionExit.inProgress() && isSessionExitCloseErr(err)
+			if !errors.Is(err, io.EOF) && !expectedClose {
 				_, _ = fmt.Fprintf(logW, "pipelock: input scanner error: %v\n", err)
 			}
 			return

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -84,6 +85,14 @@ func RunHTTPProxy(
 	extraHeaders http.Header,
 	opts MCPProxyOpts,
 ) error {
+	// Capture before validating the upstream. Otherwise a launcher that dies
+	// during preflight can leave this bridge with PID 1 and no session binding.
+	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
+	safeClientOut := &syncWriter{w: clientOut}
+	safeLogW := &syncWriter{w: logW}
+	ctx, cancel, sessionExit := newSessionBoundContext(ctx, startupParentWatch, clientIn, safeLogW, opts.sessionExitForTest)
+	defer cancel()
+
 	// Set transport for capture records if not already set by caller.
 	if opts.Transport == "" {
 		opts.Transport = "mcp_http_upstream"
@@ -99,10 +108,6 @@ func RunHTTPProxy(
 		return fmt.Errorf("contract upstream denied: %s", mcpContractBlockReason(gate))
 	}
 
-	// Create a child context so we can stop the GET stream when stdin EOF is reached.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	// Per-invocation adaptive enforcement recorder. Mint the invocation
 	// key once so it can also feed scanHTTPInputDecision below, keeping
 	// CEE state and audit correlation scoped to this RunHTTPProxy call
@@ -113,9 +118,6 @@ func RunHTTPProxy(
 		rec = opts.Store.GetOrCreate(invocationKey)
 	}
 	defer recordMCPBaselineSample(opts, rec)
-
-	safeClientOut := &syncWriter{w: clientOut}
-	safeLogW := &syncWriter{w: logW}
 
 	httpClient := transport.NewHTTPClientWithDialer(upstreamURL, extraHeaders, opts.DialContext)
 	var upstreamMu sync.Mutex
@@ -151,6 +153,7 @@ func RunHTTPProxy(
 	fwdOpts.ToolCfg = fwdToolCfg
 	fwdOpts.ToolCfgFn = nil
 	fwdOpts.WarnContext = ctx
+	fwdOpts.sessionExit = sessionExit
 	resolverRuntime := newDeferResolverRuntime(ctx)
 	fwdOpts.DeferResolverRuntime = resolverRuntime
 	defer func() {
@@ -170,7 +173,7 @@ func RunHTTPProxy(
 	for {
 		msg, err := clientReader.ReadMessage()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			if errors.Is(err, io.EOF) || (sessionExit.inProgress() && isSessionExitCloseErr(err)) {
 				break
 			}
 			return fmt.Errorf("reading stdin: %w", err)

--- a/internal/mcp/mcp_http_forward.go
+++ b/internal/mcp/mcp_http_forward.go
@@ -70,6 +70,36 @@ func consumeTrackedRequestOutcome(tracker *RequestTracker, id json.RawMessage) (
 	return tracker.Consume(id)
 }
 
+type mcpInputReadResult struct {
+	message []byte
+	err     error
+}
+
+// readMCPInputMessage lets a session-bound HTTP bridge return when its parent
+// exits even when a caller supplied a Reader that cannot be closed. Closable
+// inputs use the direct read path: newSessionBoundContext closes them on exit.
+// A non-closable input leaves at most its single blocked Read behind; its result
+// channel is buffered, so releasing that reader cannot strand a goroutine after
+// the bridge has already returned.
+func readMCPInputMessage(ctx context.Context, clientIn io.Reader, reader transport.MessageReader) ([]byte, error) {
+	if _, closable := clientIn.(io.Closer); closable {
+		return reader.ReadMessage()
+	}
+
+	result := make(chan mcpInputReadResult, 1)
+	go func() {
+		message, err := reader.ReadMessage()
+		result <- mcpInputReadResult{message: message, err: err}
+	}()
+
+	select {
+	case result := <-result:
+		return result.message, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // RunHTTPProxy bridges stdio (client) to an upstream HTTP MCP server with
 // bidirectional scanning. Reads JSON-RPC from clientIn, POSTs to upstreamURL,
 // scans responses via ForwardScanned, writes to clientOut.
@@ -85,8 +115,9 @@ func RunHTTPProxy(
 	extraHeaders http.Header,
 	opts MCPProxyOpts,
 ) error {
-	// Capture before validating the upstream. Otherwise a launcher that dies
-	// during preflight can leave this bridge with PID 1 and no session binding.
+	// Capture before validating the upstream to narrow the time startup work can
+	// hide a parent death. This cannot close the earlier launcher-to-first-
+	// syscall race; that needs a harness-owned lifetime primitive.
 	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	safeClientOut := &syncWriter{w: clientOut}
 	safeLogW := &syncWriter{w: logW}
@@ -171,9 +202,9 @@ func RunHTTPProxy(
 	var lastScanErr error
 
 	for {
-		msg, err := clientReader.ReadMessage()
+		msg, err := readMCPInputMessage(ctx, clientIn, clientReader)
 		if err != nil {
-			if errors.Is(err, io.EOF) || (sessionExit.inProgress() && isSessionExitCloseErr(err)) {
+			if errors.Is(err, io.EOF) || (sessionExit.inProgress() && (isSessionExitCloseErr(err) || errors.Is(err, context.Canceled))) {
 				break
 			}
 			return fmt.Errorf("reading stdin: %w", err)

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -171,7 +172,12 @@ func RunHTTPListenerProxy(
 	logW io.Writer,
 	opts MCPProxyOpts,
 ) error {
+	// Capture before listener validation and upstream preflight so an exit in
+	// either step cannot turn a real parent death into an inert PID-1 watch.
+	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	safeLogW := &syncWriter{w: logW}
+	ctx, stopSession, _ := newSessionBoundContext(ctx, startupParentWatch, nil, safeLogW, opts.sessionExitForTest)
+	defer stopSession()
 	opts.UpstreamHeaders = canonicalizeListenerUpstreamHeaders(opts.UpstreamHeaders)
 	if err := validateListenerBearerToken(opts.ListenerBearerToken); err != nil {
 		return err

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -172,8 +172,9 @@ func RunHTTPListenerProxy(
 	logW io.Writer,
 	opts MCPProxyOpts,
 ) error {
-	// Capture before listener validation and upstream preflight so an exit in
-	// either step cannot turn a real parent death into an inert PID-1 watch.
+	// Capture before listener validation and upstream preflight to narrow the
+	// startup race. A launcher can still exit before this first syscall; closing
+	// that earlier window needs a harness-owned lifetime primitive.
 	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	safeLogW := &syncWriter{w: logW}
 	ctx, stopSession, _ := newSessionBoundContext(ctx, startupParentWatch, nil, safeLogW, opts.sessionExitForTest)

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -371,6 +371,15 @@ type MCPProxyOpts struct {
 	// swap-after-hash case can be reproduced; production wiring leaves it nil.
 	afterIntegrityPreparedForTest func()
 
+	// sessionExitForTest overrides the session-bound exit's parent-death
+	// watch and drain window. A test process cannot make its own parent
+	// die, so the in-process teardown path is otherwise reachable only
+	// from a helper subprocess; production wiring leaves it nil.
+	sessionExitForTest *sessionExitTestHooks
+	// sessionExit marks Pipelock-initiated descriptor closes during a
+	// session-bound teardown. It is wired only by proxy entry points.
+	sessionExit *sessionExitState
+
 	// File sentry (stdio proxy only)
 	Lineage      filesentry.Lineage
 	OnChildReady func() // called after child process starts

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -376,6 +376,9 @@ type MCPProxyOpts struct {
 	// die, so the in-process teardown path is otherwise reachable only
 	// from a helper subprocess; production wiring leaves it nil.
 	sessionExitForTest *sessionExitTestHooks
+	// outputForwardStartedForTest signals that RunProxy has entered its
+	// server-output forwarding loop. Production wiring leaves it nil.
+	outputForwardStartedForTest func()
 	// sessionExit marks Pipelock-initiated descriptor closes during a
 	// session-bound teardown. It is wired only by proxy entry points.
 	sessionExit *sessionExitState

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -219,15 +219,18 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 	if act.terminateTree != nil {
 		terminated = act.terminateTree()
 	}
-	if !terminated {
-		return false
-	}
+	// Record the escalation whatever the outcome. A false result means no live
+	// child remained to signal, because tearing the tree down releases the
+	// response reader and the main path can reach cmd.Wait first - not that
+	// nothing happened. Returning early there hides the message in exactly the
+	// case it matters most: the operator sees their MCP server disappear with
+	// no reason recorded, which is indistinguishable from a crash.
 	if act.logW != nil {
 		logAsync(act.logW,
 			"pipelock: wrapped MCP server did not exit within %s of session teardown; terminating process tree\n",
 			grace)
 	}
-	return true
+	return terminated
 }
 
 // newSessionBoundContext cancels a proxy context when the process that

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -40,10 +40,6 @@ type parentWatchOpts struct {
 	getppid func() int
 	// startPPID is the parent PID recorded before the watch began.
 	startPPID int
-	// logW receives the single operator-visible line explaining why the
-	// proxy is shutting down. Never nil in production; the caller passes
-	// the mutex-wrapped writer.
-	logW io.Writer
 }
 
 // sessionExitTestHooks lets a test drive the session-bound exit in-process.
@@ -81,9 +77,11 @@ func isSessionExitCloseErr(err error) bool {
 // PID or process-group ID as soon as it reaps the child, so a late escalation
 // must not signal either value.
 type processExitHandoff struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+	// reaping remains true after reap returns. A numeric PID or PGID is safe
+	// to signal only before cmd.Wait begins; after that, the kernel can reap
+	// and recycle it before this package observes any later bookkeeping.
 	reaping bool
-	reaped  bool
 }
 
 // wait runs the blocking reap without holding the lock across it.
@@ -95,40 +93,40 @@ type processExitHandoff struct {
 // unblock, and the proxy hangs with the tree alive, which is precisely the
 // leak being fixed.
 //
-// Escalating WHILE a reap is in flight is safe, because the child has not been
-// reaped yet and so the kernel cannot have recycled its PID or process-group
-// ID. Only once reap RETURNS do those identifiers become reusable, and that is
-// the point at which terminate must refuse.
+// Raw numeric signals are safe only before reap begins. Once cmd.Wait starts,
+// it may reap the child and recycle its identifiers before this package can
+// observe reap's return, so terminate must use a kernel-stable process handle
+// instead.
 func (h *processExitHandoff) wait(reap func() error) error {
 	h.mu.Lock()
 	h.reaping = true
 	h.mu.Unlock()
 
-	err := reap()
-
-	h.mu.Lock()
-	h.reaped = true
-	h.mu.Unlock()
-	return err
+	return reap()
 }
 
-// reapStarted reports whether a reap is in flight or already finished. It
-// exists for tests and diagnostics; termination decisions use reaped, since an
-// in-flight reap has not yet freed any identifier.
+// reapStarted reports whether cmd.Wait has started. It remains true after
+// cmd.Wait returns because that boundary permanently retires numeric process
+// identifiers from this handoff.
 func (h *processExitHandoff) reapStarted() bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.reaping
 }
 
-func (h *processExitHandoff) terminate(fn func()) bool {
+// terminate runs the raw process-group teardown only while it can exclude a
+// concurrent cmd.Wait. Once reaping has begun, it calls stable instead. For a
+// Go exec.Cmd, stable is cmd.Process.Kill: Go 1.25 uses its process handle and
+// returns os.ErrProcessDone after Wait, rather than signalling a reused PID.
+func (h *processExitHandoff) terminate(beforeReap func(), stable func() bool) bool {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.reaped {
-		return false
+	if !h.reaping {
+		beforeReap()
+		h.mu.Unlock()
+		return true
 	}
-	fn()
-	return true
+	h.mu.Unlock()
+	return stable()
 }
 
 // sessionExitActions are the teardown steps runSessionBoundExit performs
@@ -143,9 +141,10 @@ type sessionExitActions struct {
 	stopIntake func()
 	// closeServerStdin gives a cooperative server its shutdown signal.
 	closeServerStdin func()
-	// terminateTree tears down the whole process group and the direct
-	// child. It returns false when cmd.Wait already owns reaping, so no
-	// stale process identifier is ever signalled after that handoff.
+	// terminateTree tears down the whole process group before reaping
+	// starts, or safely targets the direct child through its process
+	// handle after that point. It returns false only when no live child
+	// remains for the stable handle to terminate.
 	terminateTree func() bool
 	// waitDone closes when cmd.Wait has returned, short-circuiting the
 	// grace window for a server that exited on its own.
@@ -182,6 +181,10 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 	if act.closeServerStdin != nil {
 		act.closeServerStdin()
 	}
+	// Logging is deliberately after the teardown state and descriptors have
+	// changed. A blocked stderr copier can hold safeLogW indefinitely; do not
+	// let that delay cancellation, descriptor closure, or forced teardown.
+	logSessionExitAsync(act.logW)
 
 	grace := act.grace
 	if grace <= 0 {
@@ -202,9 +205,8 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 	// The grace timer and waitDone can become ready in the same instant,
 	// and a select picks uniformly among ready cases. Re-check before
 	// escalating so a server that finished right at the deadline is not
-	// signalled after cmd.Wait already reaped its group. terminateTree has
-	// the synchronized handoff that closes the remaining check-to-signal
-	// race with cmd.Wait.
+	// signalled after cmd.Wait already reaped its group. terminateTree's
+	// handoff allows numeric group signals only before reaping begins.
 	select {
 	case <-act.waitDone:
 		return false
@@ -221,7 +223,7 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 		return false
 	}
 	if act.logW != nil {
-		_, _ = fmt.Fprintf(act.logW,
+		logAsync(act.logW,
 			"pipelock: wrapped MCP server did not exit within %s of session teardown; terminating process tree\n",
 			grace)
 	}
@@ -229,8 +231,10 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 }
 
 // newSessionBoundContext cancels a proxy context when the process that
-// launched it dies. The caller supplies a PPID captured at function entry so
-// startup work cannot turn a real parent death into an inert PID-1 watch.
+// launched it dies. Capturing a PPID at the caller's first startup step narrows
+// the time later setup can hide a parent death. It cannot close the earlier
+// launcher-to-first-syscall race; that needs a launcher-owned lifetime
+// primitive.
 // Closing a closable input wakes the stdio read that context cancellation alone
 // cannot interrupt.
 func newSessionBoundContext(
@@ -245,7 +249,6 @@ func newSessionBoundContext(
 	if hooks != nil {
 		watch = hooks.watch
 	}
-	watch.logW = logW
 
 	// An already orphaned launch is intentionally inert. Avoid parking a
 	// goroutine for a supervisor-managed proxy that has no session owner.
@@ -262,6 +265,7 @@ func newSessionBoundContext(
 			_ = c.Close()
 		}
 		stop()
+		logSessionExitAsync(logW)
 	}()
 
 	return sessionCtx, stop, state
@@ -290,6 +294,9 @@ func newSessionBoundContext(
 // A proxy whose recorded parent is already the orphan PID has no session
 // to bind to - it was started by a supervisor, daemonized, or re-parented
 // before the watch began - so the watch is inert and returns only on ctx.
+// Capturing a PPID at process entry narrows but cannot close the earlier
+// launcher-to-first-syscall race; closing that requires a launcher-owned
+// lifetime primitive such as an owner pipe or cgroup.
 func watchParentSession(ctx context.Context, opts parentWatchOpts) bool {
 	getppid := opts.getppid
 	if getppid == nil {
@@ -320,13 +327,23 @@ func watchParentSession(ctx context.Context, opts parentWatchOpts) bool {
 			if current == opts.startPPID {
 				continue
 			}
-			// Reparented. The session that spawned this proxy is gone.
-			if opts.logW != nil {
-				_, _ = fmt.Fprintf(opts.logW,
-					"pipelock: spawning session exited (parent pid %d reparented to %d); shutting down MCP proxy\n",
-					opts.startPPID, current)
-			}
+			// Reparented. The session that spawned this proxy is gone. Logging
+			// happens after callers mark and begin teardown, so a blocked writer
+			// cannot strand the proxy before it starts shutting down.
 			return true
 		}
 	}
+}
+
+func logSessionExitAsync(logW io.Writer) {
+	logAsync(logW, "pipelock: spawning session exited; shutting down MCP proxy\n")
+}
+
+func logAsync(logW io.Writer, format string, args ...any) {
+	if logW == nil {
+		return
+	}
+	go func() {
+		_, _ = fmt.Fprintf(logW, format, args...)
+	}()
 }

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -75,6 +76,31 @@ func isSessionExitCloseErr(err error) bool {
 	return errors.Is(err, os.ErrClosed)
 }
 
+// processExitHandoff gives teardown and reaping one owner for the child
+// identifiers. Once cmd.Wait starts, the kernel can reuse the direct child's
+// PID or process-group ID as soon as it reaps the child, so a late escalation
+// must not signal either value.
+type processExitHandoff struct {
+	mu      sync.Mutex
+	reaping bool
+}
+
+func (h *processExitHandoff) beginReap() {
+	h.mu.Lock()
+	h.reaping = true
+	h.mu.Unlock()
+}
+
+func (h *processExitHandoff) terminate(fn func()) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.reaping {
+		return false
+	}
+	fn()
+	return true
+}
+
 // sessionExitActions are the teardown steps runSessionBoundExit performs
 // once the spawning session is confirmed gone. They are injected so the
 // ordering can be tested in-process: the production path runs inside a
@@ -88,8 +114,9 @@ type sessionExitActions struct {
 	// closeServerStdin gives a cooperative server its shutdown signal.
 	closeServerStdin func()
 	// terminateTree tears down the whole process group and the direct
-	// child. Only called for a server that outlasts the grace window.
-	terminateTree func()
+	// child. It returns false when cmd.Wait already owns reaping, so no
+	// stale process identifier is ever signalled after that handoff.
+	terminateTree func() bool
 	// waitDone closes when cmd.Wait has returned, short-circuiting the
 	// grace window for a server that exited on its own.
 	waitDone <-chan struct{}
@@ -145,22 +172,28 @@ func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionE
 	// The grace timer and waitDone can become ready in the same instant,
 	// and a select picks uniformly among ready cases. Re-check before
 	// escalating so a server that finished right at the deadline is not
-	// signalled after cmd.Wait already reaped its group - the PID the
-	// kernel is then free to recycle.
+	// signalled after cmd.Wait already reaped its group. terminateTree has
+	// the synchronized handoff that closes the remaining check-to-signal
+	// race with cmd.Wait.
 	select {
 	case <-act.waitDone:
 		return false
 	default:
 	}
 
-	// 4. The server outlasted its drain window.
+	// 4. The server outlasted its drain window. The process handoff can
+	// decline if cmd.Wait won the race to own reaping.
+	terminated := true
+	if act.terminateTree != nil {
+		terminated = act.terminateTree()
+	}
+	if !terminated {
+		return false
+	}
 	if act.logW != nil {
 		_, _ = fmt.Fprintf(act.logW,
 			"pipelock: wrapped MCP server did not exit within %s of session teardown; terminating process tree\n",
 			grace)
-	}
-	if act.terminateTree != nil {
-		act.terminateTree()
 	}
 	return true
 }

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -81,20 +81,22 @@ func isSessionExitCloseErr(err error) bool {
 // PID or process-group ID as soon as it reaps the child, so a late escalation
 // must not signal either value.
 type processExitHandoff struct {
-	mu      sync.Mutex
-	reaping bool
+	mu     sync.Mutex
+	reaped bool
 }
 
-func (h *processExitHandoff) beginReap() {
+func (h *processExitHandoff) wait(reap func() error) error {
 	h.mu.Lock()
-	h.reaping = true
-	h.mu.Unlock()
+	defer h.mu.Unlock()
+	err := reap()
+	h.reaped = true
+	return err
 }
 
 func (h *processExitHandoff) terminate(fn func()) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.reaping {
+	if h.reaped {
 		return false
 	}
 	fn()

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -339,11 +339,35 @@ func logSessionExitAsync(logW io.Writer) {
 	logAsync(logW, "pipelock: spawning session exited; shutting down MCP proxy\n")
 }
 
+// logFlushGrace bounds how long an operator message may delay teardown. A
+// healthy writer completes far inside it; a wedged one costs at most this.
+const logFlushGrace = time.Second
+
+// logAsync emits an operator message without letting a blocked writer stall
+// teardown, and without silently dropping the message.
+//
+// Both failure directions are real. Writing synchronously lets a blocked log
+// pipe - including one held by a stalled stderr copy - defer descriptor
+// closure, cancellation and process termination indefinitely. But writing
+// fire-and-forget loses the line whenever the process finishes first, and that
+// line is the only explanation an operator ever gets for why their MCP server
+// was killed; a security control that tears down a process tree silently is
+// indistinguishable from a crash.
+//
+// So write from a goroutine, then wait a bounded moment for it. The message
+// always lands for a working writer, and a wedged writer delays teardown by at
+// most logFlushGrace instead of forever.
 func logAsync(logW io.Writer, format string, args ...any) {
 	if logW == nil {
 		return
 	}
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		_, _ = fmt.Fprintf(logW, format, args...)
 	}()
+	select {
+	case <-done:
+	case <-time.After(logFlushGrace):
+	}
 }

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// Default cadence and drain window for the session-bound exit. The poll
+// interval is deliberately coarse: a leaked proxy that lives two extra
+// seconds costs nothing, while a tight loop on a long-lived scanner is
+// pure overhead. The grace window is the time a cooperative MCP server
+// gets to finish in-flight work and exit on its own after stdin EOF,
+// before the tree is torn down for it.
+const (
+	defaultParentPollInterval = 2 * time.Second
+	defaultParentExitGrace    = 5 * time.Second
+)
+
+// orphanedPPID is the parent PID a process reports once its original
+// parent has died and no ancestor has claimed the subreaper role. A
+// process started this way has no session to be bound to.
+const orphanedPPID = 1
+
+// parentWatchOpts configures watchParentSession. The function fields
+// exist so tests can drive the watcher deterministically without
+// spawning real process trees.
+type parentWatchOpts struct {
+	// interval is how often the parent PID is re-read.
+	interval time.Duration
+	// getppid returns the current parent PID. Defaults to os.Getppid.
+	getppid func() int
+	// startPPID is the parent PID recorded before the watch began.
+	startPPID int
+	// logW receives the single operator-visible line explaining why the
+	// proxy is shutting down. Never nil in production; the caller passes
+	// the mutex-wrapped writer.
+	logW io.Writer
+}
+
+// sessionExitTestHooks lets a test drive the session-bound exit in-process.
+// The real signal is the kernel reparenting us, which a test process cannot
+// arrange for itself without spawning a helper subprocess whose coverage the
+// parent cannot observe.
+type sessionExitTestHooks struct {
+	watch parentWatchOpts
+	grace time.Duration
+}
+
+// sessionExitState records that Pipelock, rather than the peer, closed a
+// session input or output descriptor during intentional session teardown.
+// Close errors on that path are expected shutdown, not scanner failures.
+type sessionExitState struct {
+	exiting atomic.Bool
+}
+
+func (s *sessionExitState) begin() {
+	if s != nil {
+		s.exiting.Store(true)
+	}
+}
+
+func (s *sessionExitState) inProgress() bool {
+	return s != nil && s.exiting.Load()
+}
+
+func isSessionExitCloseErr(err error) bool {
+	return errors.Is(err, os.ErrClosed)
+}
+
+// sessionExitActions are the teardown steps runSessionBoundExit performs
+// once the spawning session is confirmed gone. They are injected so the
+// ordering can be tested in-process: the production path runs inside a
+// helper subprocess, whose coverage the parent test process cannot see.
+type sessionExitActions struct {
+	// onSessionExit marks the teardown before it closes any descriptor, so
+	// scanner readers can recognize their expected close error.
+	onSessionExit func()
+	// stopIntake closes the client side so no further requests arrive.
+	stopIntake func()
+	// closeServerStdin gives a cooperative server its shutdown signal.
+	closeServerStdin func()
+	// terminateTree tears down the whole process group and the direct
+	// child. Only called for a server that outlasts the grace window.
+	terminateTree func()
+	// waitDone closes when cmd.Wait has returned, short-circuiting the
+	// grace window for a server that exited on its own.
+	waitDone <-chan struct{}
+	// grace bounds how long a cooperative shutdown is allowed to take.
+	grace time.Duration
+	// logW receives the escalation notice. May be nil in tests.
+	logW io.Writer
+}
+
+// runSessionBoundExit waits for the spawning session to die and then runs
+// the teardown sequence. It reports whether it escalated to a forced
+// process-tree teardown, which is the branch tests assert on.
+//
+// The sequence is a drain, not a kill: intake stops, the server is given
+// its shutdown signal and a bounded window to finish in-flight work, and
+// only a server that will not leave on its own is terminated.
+func runSessionBoundExit(ctx context.Context, opts parentWatchOpts, act sessionExitActions) bool {
+	if !watchParentSession(ctx, opts) {
+		return false
+	}
+	if act.onSessionExit != nil {
+		act.onSessionExit()
+	}
+
+	// 1. Stop new request intake. The client died with its session, so
+	//    anything still arriving cannot be answered anyway.
+	if act.stopIntake != nil {
+		act.stopIntake()
+	}
+	// 2. Signal shutdown to the wrapped server. A cooperative server
+	//    finishes in-flight work and exits, which lets cmd.Wait return on
+	//    its own and keeps pending responses intact.
+	if act.closeServerStdin != nil {
+		act.closeServerStdin()
+	}
+
+	grace := act.grace
+	if grace <= 0 {
+		grace = defaultParentExitGrace
+	}
+
+	// 3. Bound the drain. A server that ignores stdin close never returns
+	//    from step 2, so waiting forever here would reproduce the exact
+	//    leak this watcher exists to close.
+	select {
+	case <-act.waitDone:
+		return false
+	case <-ctx.Done():
+		return false
+	case <-time.After(grace):
+	}
+
+	// The grace timer and waitDone can become ready in the same instant,
+	// and a select picks uniformly among ready cases. Re-check before
+	// escalating so a server that finished right at the deadline is not
+	// signalled after cmd.Wait already reaped its group - the PID the
+	// kernel is then free to recycle.
+	select {
+	case <-act.waitDone:
+		return false
+	default:
+	}
+
+	// 4. The server outlasted its drain window.
+	if act.logW != nil {
+		_, _ = fmt.Fprintf(act.logW,
+			"pipelock: wrapped MCP server did not exit within %s of session teardown; terminating process tree\n",
+			grace)
+	}
+	if act.terminateTree != nil {
+		act.terminateTree()
+	}
+	return true
+}
+
+// newSessionBoundContext cancels a proxy context when the process that
+// launched it dies. The caller supplies a PPID captured at function entry so
+// startup work cannot turn a real parent death into an inert PID-1 watch.
+// Closing a closable input wakes the stdio read that context cancellation alone
+// cannot interrupt.
+func newSessionBoundContext(
+	ctx context.Context,
+	watch parentWatchOpts,
+	clientIn io.Reader,
+	logW io.Writer,
+	hooks *sessionExitTestHooks,
+) (context.Context, context.CancelFunc, *sessionExitState) {
+	sessionCtx, stop := context.WithCancel(ctx)
+	state := &sessionExitState{}
+	if hooks != nil {
+		watch = hooks.watch
+	}
+	watch.logW = logW
+
+	// An already orphaned launch is intentionally inert. Avoid parking a
+	// goroutine for a supervisor-managed proxy that has no session owner.
+	if watch.startPPID <= orphanedPPID {
+		return sessionCtx, stop, state
+	}
+
+	go func() {
+		if !watchParentSession(sessionCtx, watch) {
+			return
+		}
+		state.begin()
+		if c, ok := clientIn.(io.Closer); ok {
+			_ = c.Close()
+		}
+		stop()
+	}()
+
+	return sessionCtx, stop, state
+}
+
+// watchParentSession blocks until the spawning session is provably gone,
+// then returns true. It returns false when ctx is cancelled first, which
+// is the normal path: the proxy finished on its own and stopped the watch.
+//
+// The only accepted death signal is REPARENTING. A process's parent PID
+// can change for exactly one reason - the original parent died and the
+// kernel reassigned the child to init or to the nearest subreaper. That
+// makes an observed PPID change proof, not a heuristic.
+//
+// Two signals are deliberately NOT used, because both produce false
+// positives that kill a live scanner mid-call:
+//
+//   - Process age. A legitimate agent session can outlive any threshold
+//     an operator would pick, and killing a healthy proxy breaks traffic
+//     in flight. An operator who gets burned by that disables the control,
+//     which is a worse outcome than the leak it was meant to fix.
+//   - stdin EOF alone. A client can close stdin, or a transport can hand
+//     us EOF, while the session that owns the wrapped server is very much
+//     alive. EOF is a hint about one pipe, not about session lifetime.
+//
+// A proxy whose recorded parent is already the orphan PID has no session
+// to bind to - it was started by a supervisor, daemonized, or re-parented
+// before the watch began - so the watch is inert and returns only on ctx.
+func watchParentSession(ctx context.Context, opts parentWatchOpts) bool {
+	getppid := opts.getppid
+	if getppid == nil {
+		getppid = os.Getppid
+	}
+	interval := opts.interval
+	if interval <= 0 {
+		interval = defaultParentPollInterval
+	}
+
+	// No identifiable session owner. Staying inert is the fail-safe
+	// direction: a supervisor-managed proxy must not shut itself down
+	// merely because it has no interactive parent.
+	if opts.startPPID <= orphanedPPID {
+		<-ctx.Done()
+		return false
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			current := getppid()
+			if current == opts.startPPID {
+				continue
+			}
+			// Reparented. The session that spawned this proxy is gone.
+			if opts.logW != nil {
+				_, _ = fmt.Fprintf(opts.logW,
+					"pipelock: spawning session exited (parent pid %d reparented to %d); shutting down MCP proxy\n",
+					opts.startPPID, current)
+			}
+			return true
+		}
+	}
+}

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -81,16 +81,44 @@ func isSessionExitCloseErr(err error) bool {
 // PID or process-group ID as soon as it reaps the child, so a late escalation
 // must not signal either value.
 type processExitHandoff struct {
-	mu     sync.Mutex
-	reaped bool
+	mu      sync.Mutex
+	reaping bool
+	reaped  bool
 }
 
+// wait runs the blocking reap without holding the lock across it.
+//
+// Holding the lock for the duration of reap deadlocks: reap is cmd.Wait, and
+// on the path this whole mechanism exists for, cmd.Wait does not return until
+// the process tree is terminated - which is what terminate does. A terminate
+// blocked on the mutex therefore waits on a reap that only that terminate can
+// unblock, and the proxy hangs with the tree alive, which is precisely the
+// leak being fixed.
+//
+// Escalating WHILE a reap is in flight is safe, because the child has not been
+// reaped yet and so the kernel cannot have recycled its PID or process-group
+// ID. Only once reap RETURNS do those identifiers become reusable, and that is
+// the point at which terminate must refuse.
 func (h *processExitHandoff) wait(reap func() error) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.reaping = true
+	h.mu.Unlock()
+
 	err := reap()
+
+	h.mu.Lock()
 	h.reaped = true
+	h.mu.Unlock()
 	return err
+}
+
+// reapStarted reports whether a reap is in flight or already finished. It
+// exists for tests and diagnostics; termination decisions use reaped, since an
+// in-flight reap has not yet freed any identifier.
+func (h *processExitHandoff) reapStarted() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.reaping
 }
 
 func (h *processExitHandoff) terminate(fn func()) bool {

--- a/internal/mcp/parentwatch_http_test.go
+++ b/internal/mcp/parentwatch_http_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func deadSessionExitHooks() *sessionExitTestHooks {
+	return &sessionExitTestHooks{
+		watch: parentWatchOpts{
+			interval:  time.Millisecond,
+			startPPID: 4242,
+			getppid:   func() int { return orphanedPPID },
+		},
+	}
+}
+
+func liveSessionExitHooks() *sessionExitTestHooks {
+	return &sessionExitTestHooks{
+		watch: parentWatchOpts{
+			interval:  time.Millisecond,
+			startPPID: 4242,
+			getppid:   func() int { return 4242 },
+		},
+	}
+}
+
+func TestSessionExit_HTTPForwardStopsBridge(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("session-bound bridge forwarded after its session exited")
+	}))
+	defer upstream.Close()
+	sc := testScannerForHTTP(t)
+
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+	var clientOut, logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPProxy(context.Background(), clientIn, &clientOut, &logBuf, upstream.URL, nil, MCPProxyOpts{
+			Scanner:            sc,
+			sessionExitForTest: deadSessionExitHooks(),
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunHTTPProxy = %v, want clean session exit", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP bridge stayed alive after the spawning session exited")
+	}
+
+	if got := logBuf.String(); !bytes.Contains([]byte(got), []byte("spawning session exited")) {
+		t.Errorf("missing session-exit explanation in operator log, got %q", got)
+	}
+}
+
+func TestSessionExit_HTTPForwardLiveSessionIsNotTornDown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("live session should not send a request in this test")
+	}))
+	defer upstream.Close()
+	sc := testScannerForHTTP(t)
+
+	clientIn := newBlockingReader()
+	var clientOut, logBuf bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPProxy(ctx, clientIn, &clientOut, &logBuf, upstream.URL, nil, MCPProxyOpts{
+			Scanner:            sc,
+			sessionExitForTest: liveSessionExitHooks(),
+		})
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("RunHTTPProxy exited while its session was alive: %v; log: %q", err, logBuf.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if got := logBuf.String(); bytes.Contains([]byte(got), []byte("spawning session exited")) {
+		t.Errorf("session-exit path ran against a live parent, got %q", got)
+	}
+
+	_ = clientIn.Close()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP bridge did not stop after its input closed")
+	}
+}
+
+func TestSessionExit_HTTPListenerStops(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer upstream.Close()
+	sc := testScannerForHTTP(t)
+
+	listenConfig := net.ListenConfig{}
+	ln, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	var logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPListenerProxy(context.Background(), ln, upstream.URL, &logBuf, MCPProxyOpts{
+			Scanner:            sc,
+			sessionExitForTest: deadSessionExitHooks(),
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunHTTPListenerProxy = %v, want clean session exit", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP listener stayed alive after the spawning session exited")
+	}
+
+	if got := logBuf.String(); !bytes.Contains([]byte(got), []byte("spawning session exited")) {
+		t.Errorf("missing session-exit explanation in operator log, got %q", got)
+	}
+}
+
+func TestSessionExit_HTTPListenerLiveSessionIsNotTornDown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer upstream.Close()
+	sc := testScannerForHTTP(t)
+
+	listenConfig := net.ListenConfig{}
+	ln, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPListenerProxy(ctx, ln, upstream.URL, &logBuf, MCPProxyOpts{
+			Scanner:            sc,
+			sessionExitForTest: liveSessionExitHooks(),
+		})
+	}()
+
+	baseURL := "http://" + ln.Addr().String()
+	waitForHTTPHealth(t, baseURL)
+	select {
+	case err := <-done:
+		t.Fatalf("HTTP listener exited while its session was alive: %v; log: %q", err, logBuf.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if got := logBuf.String(); bytes.Contains([]byte(got), []byte("spawning session exited")) {
+		t.Errorf("session-exit path ran against a live parent, got %q", got)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunHTTPListenerProxy after cancel = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP listener did not stop after context cancellation")
+	}
+}

--- a/internal/mcp/parentwatch_http_test.go
+++ b/internal/mcp/parentwatch_http_test.go
@@ -12,6 +12,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 func deadSessionExitHooks() *sessionExitTestHooks {
@@ -43,7 +45,8 @@ func TestSessionExit_HTTPForwardStopsBridge(t *testing.T) {
 
 	clientIn := newBlockingReader()
 	defer func() { _ = clientIn.Close() }()
-	var clientOut, logBuf bytes.Buffer
+	var clientOut bytes.Buffer
+	var logBuf lockedBuffer
 	done := make(chan error, 1)
 	go func() {
 		done <- RunHTTPProxy(context.Background(), clientIn, &clientOut, &logBuf, upstream.URL, nil, MCPProxyOpts{
@@ -61,8 +64,48 @@ func TestSessionExit_HTTPForwardStopsBridge(t *testing.T) {
 		t.Fatal("HTTP bridge stayed alive after the spawning session exited")
 	}
 
-	if got := logBuf.String(); !bytes.Contains([]byte(got), []byte("spawning session exited")) {
-		t.Errorf("missing session-exit explanation in operator log, got %q", got)
+	testwait.For(t, 5*time.Second, func() bool {
+		return bytes.Contains([]byte(logBuf.String()), []byte("spawning session exited"))
+	}, "the session-exit explanation to reach the HTTP forwarder log")
+}
+
+func TestSessionExit_HTTPForwardBoundsNonClosableInput(t *testing.T) {
+	clientIn := newNonClosableBlockingReader()
+	t.Cleanup(clientIn.unblock)
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Errorf("session-bound bridge forwarded after its session exited")
+	}))
+	defer upstream.Close()
+
+	var clientOut, logBuf lockedBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunHTTPProxy(context.Background(), clientIn, &clientOut, &logBuf, upstream.URL, nil, MCPProxyOpts{
+			Scanner:            testScannerForHTTP(t),
+			sessionExitForTest: deadSessionExitHooks(),
+		})
+	}()
+
+	select {
+	case <-clientIn.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP bridge never started reading the non-closable client input")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunHTTPProxy = %v, want clean session-bound shutdown", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HTTP bridge waited indefinitely for non-closable input after session exit")
+	}
+
+	clientIn.unblock()
+	select {
+	case <-clientIn.returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-closable HTTP input did not release after the test")
 	}
 }
 
@@ -115,7 +158,7 @@ func TestSessionExit_HTTPListenerStops(t *testing.T) {
 	}
 	defer func() { _ = ln.Close() }()
 
-	var logBuf bytes.Buffer
+	var logBuf lockedBuffer
 	done := make(chan error, 1)
 	go func() {
 		done <- RunHTTPListenerProxy(context.Background(), ln, upstream.URL, &logBuf, MCPProxyOpts{
@@ -133,9 +176,9 @@ func TestSessionExit_HTTPListenerStops(t *testing.T) {
 		t.Fatal("HTTP listener stayed alive after the spawning session exited")
 	}
 
-	if got := logBuf.String(); !bytes.Contains([]byte(got), []byte("spawning session exited")) {
-		t.Errorf("missing session-exit explanation in operator log, got %q", got)
-	}
+	testwait.For(t, 5*time.Second, func() bool {
+		return bytes.Contains([]byte(logBuf.String()), []byte("spawning session exited"))
+	}, "the session-exit explanation to reach the HTTP listener log")
 }
 
 func TestSessionExit_HTTPListenerLiveSessionIsNotTornDown(t *testing.T) {

--- a/internal/mcp/parentwatch_http_test.go
+++ b/internal/mcp/parentwatch_http_test.go
@@ -36,7 +36,7 @@ func liveSessionExitHooks() *sessionExitTestHooks {
 
 func TestSessionExit_HTTPForwardStopsBridge(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("session-bound bridge forwarded after its session exited")
+		t.Errorf("session-bound bridge forwarded after its session exited")
 	}))
 	defer upstream.Close()
 	sc := testScannerForHTTP(t)
@@ -68,7 +68,7 @@ func TestSessionExit_HTTPForwardStopsBridge(t *testing.T) {
 
 func TestSessionExit_HTTPForwardLiveSessionIsNotTornDown(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("live session should not send a request in this test")
+		t.Errorf("live session should not send a request in this test")
 	}))
 	defer upstream.Close()
 	sc := testScannerForHTTP(t)

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // processAlive reports whether pid names a live process. A reaped-but-not-yet
@@ -40,27 +42,35 @@ func processAlive(pid int) bool {
 	return len(fields) > 0 && fields[0] != "Z"
 }
 
+// aliveReport names the members of a process tree that are still running. It
+// formats lazily, so the list reflects the moment a wait actually timed out
+// rather than the moment the message was constructed.
+type aliveReport map[string]int
+
+func (a aliveReport) String() string {
+	parts := make([]string, 0, len(a))
+	for label, pid := range a {
+		if processAlive(pid) {
+			parts = append(parts, fmt.Sprintf("%s (pid %d)", label, pid))
+		}
+	}
+	sort.Strings(parts)
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
 func waitForGone(t *testing.T, pids map[string]int, deadline time.Duration) {
 	t.Helper()
-	stop := time.Now().Add(deadline)
-	for time.Now().Before(stop) {
-		alive := false
+	testwait.For(t, deadline, func() bool {
 		for _, pid := range pids {
 			if processAlive(pid) {
-				alive = true
-				break
+				return false
 			}
 		}
-		if !alive {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	for label, pid := range pids {
-		if processAlive(pid) {
-			t.Errorf("%s (pid %d) still alive %s after the spawning session was killed", label, pid, deadline)
-		}
-	}
+		return true
+	}, "the process tree to exit after its spawning session was killed; still alive: %s", aliveReport(pids))
 }
 
 // TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder verifies the response
@@ -186,25 +196,22 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 
 	// Wait for the full tree to exist before killing anything.
 	var serverPID, grandchildPID, proxyPID int
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 30*time.Second, func() bool {
 		pidBytes, err1 := os.ReadFile(filepath.Clean(pidFile))
 		proxyBytes, err2 := os.ReadFile(filepath.Clean(proxyPidFile))
-		if err1 == nil && err2 == nil {
-			fields := strings.Fields(string(pidBytes))
-			proxyFields := strings.Fields(string(proxyBytes))
-			if len(fields) == 2 && len(proxyFields) == 1 {
-				serverPID, _ = strconv.Atoi(fields[0])
-				grandchildPID, _ = strconv.Atoi(fields[1])
-				proxyPID, _ = strconv.Atoi(proxyFields[0])
-				break
-			}
+		if err1 != nil || err2 != nil {
+			return false
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if serverPID == 0 || grandchildPID == 0 || proxyPID == 0 {
-		t.Fatalf("process tree never came up (server=%d grandchild=%d proxy=%d)", serverPID, grandchildPID, proxyPID)
-	}
+		fields := strings.Fields(string(pidBytes))
+		proxyFields := strings.Fields(string(proxyBytes))
+		if len(fields) != 2 || len(proxyFields) != 1 {
+			return false
+		}
+		serverPID, _ = strconv.Atoi(fields[0])
+		grandchildPID, _ = strconv.Atoi(fields[1])
+		proxyPID, _ = strconv.Atoi(proxyFields[0])
+		return serverPID > 0 && grandchildPID > 0 && proxyPID > 0
+	}, "the process tree to come up")
 
 	tree := map[string]int{"wrapped server": serverPID, "detached grandchild": grandchildPID, "proxy": proxyPID}
 	t.Cleanup(func() {

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -151,7 +151,7 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 		"setsid sleep 300 &\n" +
 		"echo $! >> " + pidFile + ".tmp\n" +
 		"mv " + pidFile + ".tmp " + pidFile + "\n" +
-		"sleep 300\n"
+		"exec sleep 300\n"
 	if err := os.WriteFile(serverScript, []byte(script), 0o600); err != nil {
 		t.Fatalf("writing server script: %v", err)
 	}
@@ -207,6 +207,13 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 	}
 
 	tree := map[string]int{"wrapped server": serverPID, "detached grandchild": grandchildPID, "proxy": proxyPID}
+	t.Cleanup(func() {
+		for _, pid := range tree {
+			if processAlive(pid) {
+				_ = syscall.Kill(pid, syscall.SIGKILL)
+			}
+		}
+	})
 	for label, pid := range tree {
 		if !processAlive(pid) {
 			t.Fatalf("%s (pid %d) was not alive before the kill; test setup is wrong", label, pid)

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+)
+
+// processAlive reports whether pid names a live process. A reaped-but-not-yet
+// collected zombie is NOT alive: kill(pid, 0) succeeds against a zombie, so a
+// liveness check written that way would pass while the tree was still leaking.
+func processAlive(pid int) bool {
+	statBytes, err := os.ReadFile(filepath.Clean("/proc/" + strconv.Itoa(pid) + "/stat"))
+	if err != nil {
+		return false
+	}
+	stat := string(statBytes)
+	end := strings.LastIndex(stat, ")")
+	if end < 0 {
+		return false
+	}
+	fields := strings.Fields(stat[end+1:])
+	return len(fields) > 0 && fields[0] != "Z"
+}
+
+func waitForGone(t *testing.T, pids map[string]int, deadline time.Duration) {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		alive := false
+		for _, pid := range pids {
+			if processAlive(pid) {
+				alive = true
+				break
+			}
+		}
+		if !alive {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	for label, pid := range pids {
+		if processAlive(pid) {
+			t.Errorf("%s (pid %d) still alive %s after the spawning session was killed", label, pid, deadline)
+		}
+	}
+}
+
+// TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder verifies the response
+// timeout path does not depend on the wrapped server's stdout or stderr pipes
+// closing before it can reach the adopted-descendant sweep. The direct shell
+// is killed for timing out, while the setsid child keeps both descriptors open.
+func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "escaped.pid")
+	script := "setsid sleep 300 &\n" +
+		"echo $! > " + pidFile + "\n" +
+		"sleep 300\n"
+
+	sc := testScannerWithAction(t, "warn")
+	opts := buildTestOpts(sc)
+	opts.InputCfg = &InputScanConfig{
+		Action:                 config.ActionWarn,
+		OnParseError:           config.ActionBlock,
+		ResponseTimeoutSeconds: 1,
+	}
+
+	var out, logBuf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxy(context.Background(),
+			strings.NewReader(mcpToolCall(mcpAllowedTool, "")+"\n"),
+			&out, &logBuf, []string{"/bin/sh", "-c", script}, opts)
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, transport.ErrResponseTimeout) {
+			t.Fatalf("RunProxy error = %v, want ErrResponseTimeout", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunProxy hung after response timeout with an escaped pipe holder")
+	}
+
+	pidBytes, err := os.ReadFile(filepath.Clean(pidFile))
+	if err != nil {
+		t.Fatalf("reading escaped child PID: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("escaped child PID = %q, want positive integer", pidBytes)
+	}
+	t.Cleanup(func() {
+		if processAlive(pid) {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+	waitForGone(t, map[string]int{"escaped pipe holder": pid}, 5*time.Second)
+}
+
+// TestSessionExit_RealParentDeathReapsWholeTree drives the actual production
+// path with a real three-level process tree and a real kill. Nothing about
+// the parent PID is stubbed.
+//
+//	test  ->  session (sh)  ->  pipelock proxy (RunProxy)  ->  server  ->  grandchild
+//
+// The test kills the SESSION, which is the process whose death the watcher
+// must notice. The wrapped server ignores stdin entirely, so the stdin-EOF
+// path that already existed cannot shut it down - reproducing the leak this
+// work closes - and the grandchild is detached into its own session via
+// setsid so it escapes a plain process-group kill.
+func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real process tree and waits out the drain grace window")
+	}
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "server.pids")
+	proxyPidFile := filepath.Join(dir, "proxy.pid")
+
+	// An MCP server that never reads stdin. Closing its stdin is a no-op,
+	// which is precisely why EOF alone is not a shutdown signal.
+	serverScript := filepath.Join(dir, "server.sh")
+	script := "#!/bin/sh\n" +
+		"echo $$ > " + pidFile + ".tmp\n" +
+		// Detach a grandchild into its own session so it leaves the
+		// server's process group and can only be reached by the
+		// adopted-descendant sweep.
+		// Keep stdout inherited from the wrapped server. Before the regression
+		// fix this makes the scanner's stdout reader block after the direct
+		// server dies, proving that the post-Wait adopted-descendant sweep is
+		// otherwise unreachable.
+		"setsid sleep 300 &\n" +
+		"echo $! >> " + pidFile + ".tmp\n" +
+		"mv " + pidFile + ".tmp " + pidFile + "\n" +
+		"sleep 300\n"
+	if err := os.WriteFile(serverScript, []byte(script), 0o600); err != nil {
+		t.Fatalf("writing server script: %v", err)
+	}
+
+	// The session process. It starts the proxy and then sleeps; killing it
+	// is what reparents the proxy.
+	// Fed to /bin/sh on stdin rather than exec'd as a file, so both the
+	// command name and its argument list are constants and the helper
+	// binary path travels in the environment instead.
+	sess := "\"$PIPELOCK_SESSION_EXIT_BIN\" -test.run=TestSessionExitHelperProcess >" +
+		filepath.Join(dir, "helper.log") + " 2>&1 &\n" +
+		"echo $! > " + proxyPidFile + "\n" +
+		"sleep 300\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	session := exec.CommandContext(ctx, "/bin/sh")
+	session.Stdin = strings.NewReader(sess)
+	session.Env = append(os.Environ(),
+		"PIPELOCK_SESSION_EXIT_HELPER=1",
+		"PIPELOCK_SESSION_EXIT_SERVER="+serverScript,
+		"PIPELOCK_SESSION_EXIT_BIN="+os.Args[0],
+	)
+	if err := session.Start(); err != nil {
+		t.Fatalf("starting session process: %v", err)
+	}
+	defer func() {
+		_ = session.Process.Kill()
+		_, _ = session.Process.Wait()
+	}()
+
+	// Wait for the full tree to exist before killing anything.
+	var serverPID, grandchildPID, proxyPID int
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err1 := os.ReadFile(filepath.Clean(pidFile))
+		proxyBytes, err2 := os.ReadFile(filepath.Clean(proxyPidFile))
+		if err1 == nil && err2 == nil {
+			fields := strings.Fields(string(pidBytes))
+			proxyFields := strings.Fields(string(proxyBytes))
+			if len(fields) == 2 && len(proxyFields) == 1 {
+				serverPID, _ = strconv.Atoi(fields[0])
+				grandchildPID, _ = strconv.Atoi(fields[1])
+				proxyPID, _ = strconv.Atoi(proxyFields[0])
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if serverPID == 0 || grandchildPID == 0 || proxyPID == 0 {
+		t.Fatalf("process tree never came up (server=%d grandchild=%d proxy=%d)", serverPID, grandchildPID, proxyPID)
+	}
+
+	tree := map[string]int{"wrapped server": serverPID, "detached grandchild": grandchildPID, "proxy": proxyPID}
+	for label, pid := range tree {
+		if !processAlive(pid) {
+			t.Fatalf("%s (pid %d) was not alive before the kill; test setup is wrong", label, pid)
+		}
+	}
+
+	// Kill the session. This is the only action the test takes against the
+	// tree - everything below must follow from the watcher noticing.
+	if err := syscall.Kill(session.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatalf("killing session process: %v", err)
+	}
+
+	// Poll interval + drain grace + teardown, with slack for a loaded CI box.
+	waitForGone(t, tree, 45*time.Second)
+	if logBytes, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "helper.log"))); readErr == nil &&
+		strings.Contains(string(logBytes), "input scanner error") {
+		t.Errorf("session teardown logged a scanner error instead of its shutdown reason:\n%s", logBytes)
+	}
+
+	if t.Failed() {
+		if logBytes, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "helper.log"))); readErr == nil {
+			t.Logf("helper output:\n%s", logBytes)
+		}
+	}
+}
+
+// TestSessionExitHelperProcess is the proxy level of the tree above. It is a
+// helper, not a test: it runs only when the parent test sets the env marker.
+func TestSessionExitHelperProcess(t *testing.T) {
+	if os.Getenv("PIPELOCK_SESSION_EXIT_HELPER") != "1" {
+		t.Skip("helper process; driven by TestSessionExit_RealParentDeathReapsWholeTree")
+	}
+
+	serverScript := os.Getenv("PIPELOCK_SESSION_EXIT_SERVER")
+	if serverScript == "" {
+		t.Fatal("helper started without a server script")
+	}
+
+	// Keep stdin open but silent. A closed stdin would make the client
+	// reader hit EOF immediately, which is a different (and already
+	// handled) path than the one under test.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinW.Close() }()
+
+	// No timeout: if the watcher fails to fire, this call hangs exactly as
+	// the leaked proxies on the live host did, and the parent test fails on
+	// its own deadline rather than being rescued by a context here.
+	err = RunProxy(context.Background(), stdinR, os.Stdout, os.Stderr,
+		[]string{"/bin/sh", serverScript}, MCPProxyOpts{})
+	fmt.Fprintf(os.Stderr, "helper: RunProxy returned: %v\n", err)
+}

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -71,7 +71,8 @@ func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "escaped.pid")
 	script := "setsid sleep 300 &\n" +
-		"echo $! > " + pidFile + "\n" +
+		"echo $! > " + pidFile + ".tmp\n" +
+		"mv " + pidFile + ".tmp " + pidFile + "\n" +
 		"sleep 300\n"
 
 	sc := testScannerWithAction(t, "warn")
@@ -239,8 +240,7 @@ func TestSessionExitHelperProcess(t *testing.T) {
 		t.Skip("helper process; driven by TestSessionExit_RealParentDeathReapsWholeTree")
 	}
 
-	serverScript := os.Getenv("PIPELOCK_SESSION_EXIT_SERVER")
-	if serverScript == "" {
+	if os.Getenv("PIPELOCK_SESSION_EXIT_SERVER") == "" {
 		t.Fatal("helper started without a server script")
 	}
 
@@ -257,6 +257,7 @@ func TestSessionExitHelperProcess(t *testing.T) {
 	// the leaked proxies on the live host did, and the parent test fails on
 	// its own deadline rather than being rescued by a context here.
 	err = RunProxy(context.Background(), stdinR, os.Stdout, os.Stderr,
-		[]string{"/bin/sh", serverScript}, MCPProxyOpts{})
+		[]string{"/bin/sh", "-c", "exec /bin/sh \"$PIPELOCK_SESSION_EXIT_SERVER\""}, MCPProxyOpts{},
+		"PIPELOCK_SESSION_EXIT_SERVER="+os.Getenv("PIPELOCK_SESSION_EXIT_SERVER"))
 	fmt.Fprintf(os.Stderr, "helper: RunProxy returned: %v\n", err)
 }

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -80,7 +80,8 @@ func waitForGone(t *testing.T, pids map[string]int, deadline time.Duration) {
 func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "escaped.pid")
-	script := "setsid sleep 300 &\n" +
+	script := "umask 077\n" +
+		"setsid sleep 300 &\n" +
 		"echo $! > " + pidFile + ".tmp\n" +
 		"mv " + pidFile + ".tmp " + pidFile + "\n" +
 		"sleep 300\n"
@@ -150,6 +151,7 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 	// which is precisely why EOF alone is not a shutdown signal.
 	serverScript := filepath.Join(dir, "server.sh")
 	script := "#!/bin/sh\n" +
+		"umask 077\n" +
 		"echo $$ > " + pidFile + ".tmp\n" +
 		// Detach a grandchild into its own session so it leaves the
 		// server's process group and can only be reached by the
@@ -171,10 +173,11 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 	// Fed to /bin/sh on stdin rather than exec'd as a file, so both the
 	// command name and its argument list are constants and the helper
 	// binary path travels in the environment instead.
-	sess := "\"$PIPELOCK_SESSION_EXIT_BIN\" -test.run=TestSessionExitHelperProcess >" +
+	sess := "umask 077\n" +
+		"\"$PIPELOCK_SESSION_EXIT_BIN\" -test.run=TestSessionExitHelperProcess >" +
 		filepath.Join(dir, "helper.log") + " 2>&1 &\n" +
 		"echo $! > " + proxyPidFile + "\n" +
-		"sleep 300\n"
+		"wait\n"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -42,11 +42,12 @@ func (b *lockedBuffer) String() string {
 }
 
 type nonClosableBlockingReader struct {
-	started     chan struct{}
-	returned    chan struct{}
-	release     chan struct{}
-	startOnce   sync.Once
-	releaseOnce sync.Once
+	started      chan struct{}
+	returned     chan struct{}
+	release      chan struct{}
+	startOnce    sync.Once
+	releaseOnce  sync.Once
+	returnedOnce sync.Once
 }
 
 func newNonClosableBlockingReader() *nonClosableBlockingReader {
@@ -60,7 +61,9 @@ func newNonClosableBlockingReader() *nonClosableBlockingReader {
 func (b *nonClosableBlockingReader) Read(_ []byte) (int, error) {
 	b.startOnce.Do(func() { close(b.started) })
 	<-b.release
-	close(b.returned)
+	// A reader can be polled more than once; closing an already-closed
+	// channel would panic and mask the behaviour under test.
+	b.returnedOnce.Do(func() { close(b.returned) })
 	return 0, io.EOF
 }
 
@@ -97,7 +100,8 @@ func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
 
 	parentDied := make(chan struct{})
 	outputForwardStarted := make(chan struct{})
-	var stdout, logBuf bytes.Buffer
+	var stdout bytes.Buffer
+	var logBuf lockedBuffer
 	opts := MCPProxyOpts{
 		sessionExitForTest: &sessionExitTestHooks{
 			watch: parentWatchOpts{

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -21,6 +22,50 @@ import (
 type blockingReader struct {
 	once   sync.Once
 	closed chan struct{}
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+type nonClosableBlockingReader struct {
+	started     chan struct{}
+	returned    chan struct{}
+	release     chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newNonClosableBlockingReader() *nonClosableBlockingReader {
+	return &nonClosableBlockingReader{
+		started:  make(chan struct{}),
+		returned: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *nonClosableBlockingReader) Read(_ []byte) (int, error) {
+	b.startOnce.Do(func() { close(b.started) })
+	<-b.release
+	close(b.returned)
+	return 0, io.EOF
+}
+
+func (b *nonClosableBlockingReader) unblock() {
+	b.releaseOnce.Do(func() { close(b.release) })
 }
 
 func newBlockingReader() *blockingReader {
@@ -50,16 +95,26 @@ func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
 	clientIn := newBlockingReader()
 	defer func() { _ = clientIn.Close() }()
 
+	parentDied := make(chan struct{})
+	outputForwardStarted := make(chan struct{})
 	var stdout, logBuf bytes.Buffer
 	opts := MCPProxyOpts{
 		sessionExitForTest: &sessionExitTestHooks{
 			watch: parentWatchOpts{
 				interval:  time.Millisecond,
 				startPPID: 4242,
-				getppid:   func() int { return orphanedPPID },
+				getppid: func() int {
+					select {
+					case <-parentDied:
+						return orphanedPPID
+					default:
+						return 4242
+					}
+				},
 			},
 			grace: 50 * time.Millisecond,
 		},
+		outputForwardStartedForTest: func() { close(outputForwardStarted) },
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -71,9 +126,18 @@ func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
 		// forced process-tree teardown can end this call.
 		done <- RunProxy(ctx, clientIn, &stdout, &logBuf, []string{"sleep", "120"}, opts)
 	}()
+	select {
+	case <-outputForwardStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunProxy never entered the server-output forwarding loop")
+	}
+	close(parentDied)
 
 	select {
-	case <-done:
+	case err := <-done:
+		if err != nil && !errors.Is(err, ErrSubprocessExit) {
+			t.Errorf("RunProxy = %v, want no scanner error after session teardown", err)
+		}
 	case <-time.After(20 * time.Second):
 		t.Fatal("RunProxy never returned after the spawning session died; the proxy leaked")
 	}
@@ -96,7 +160,8 @@ func TestRunProxy_LiveSessionIsNotTornDown(t *testing.T) {
 	}
 
 	clientIn := newBlockingReader()
-	var stdout, logBuf bytes.Buffer
+	var stdout bytes.Buffer
+	var logBuf lockedBuffer
 
 	opts := MCPProxyOpts{
 		sessionExitForTest: &sessionExitTestHooks{
@@ -136,4 +201,108 @@ func TestRunProxy_LiveSessionIsNotTornDown(t *testing.T) {
 	case <-time.After(20 * time.Second):
 		t.Fatal("RunProxy did not shut down after context cancellation")
 	}
+}
+
+func TestRunProxy_SessionExitBoundsNonClosableInputDrain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real child process")
+	}
+
+	clientIn := newNonClosableBlockingReader()
+	t.Cleanup(clientIn.unblock)
+	parentDied := make(chan struct{})
+	var stdout, logBuf bytes.Buffer
+	opts := MCPProxyOpts{
+		sessionExitForTest: &sessionExitTestHooks{
+			watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid: func() int {
+					select {
+					case <-parentDied:
+						return orphanedPPID
+					default:
+						return 4242
+					}
+				},
+			},
+			grace: 20 * time.Millisecond,
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxy(ctx, clientIn, &stdout, &logBuf, []string{"sleep", "120"}, opts)
+	}()
+
+	select {
+	case <-clientIn.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunProxy never started reading the non-closable client input")
+	}
+	close(parentDied)
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, ErrSubprocessExit) {
+			t.Errorf("RunProxy = %v, want clean session-bound shutdown", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunProxy waited indefinitely for non-closable input after session exit")
+	}
+
+	clientIn.unblock()
+	select {
+	case <-clientIn.returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-closable client input did not release after the test")
+	}
+}
+
+func TestDrainStderr_ReleasesEscapedPipeHolder(t *testing.T) {
+	t.Run("timeout closes escaped writer", func(t *testing.T) {
+		serverErr, escapedWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("creating stderr pipe: %v", err)
+		}
+		defer func() { _ = escapedWriter.Close() }()
+
+		stderrDone := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(io.Discard, serverErr)
+			close(stderrDone)
+		}()
+
+		if drained := drainStderr(stderrDone, serverErr, time.Millisecond); drained {
+			t.Fatal("drainStderr = true while an escaped stderr writer remained open")
+		}
+		select {
+		case <-stderrDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("stderr copier remained blocked after the drain timeout")
+		}
+	})
+
+	t.Run("normal drain closes reader", func(t *testing.T) {
+		serverErr, serverErrW, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("creating stderr pipe: %v", err)
+		}
+		if err := serverErrW.Close(); err != nil {
+			t.Fatalf("closing stderr writer: %v", err)
+		}
+		stderrDone := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(io.Discard, serverErr)
+			close(stderrDone)
+		}()
+
+		if drained := drainStderr(stderrDone, serverErr, time.Second); !drained {
+			t.Fatal("drainStderr = false after normal stderr drain")
+		}
+		if _, err := serverErr.Read(make([]byte, 1)); !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("stderr reader error after normal drain = %v, want os.ErrClosed", err)
+		}
+	})
 }

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -296,6 +297,9 @@ func TestRunProxy_BlockedLogWriterDoesNotWedgeTeardown(t *testing.T) {
 	if testing.Short() {
 		t.Skip("spawns a real child process")
 	}
+	if runtime.GOOS == "windows" {
+		t.Skip("needs a POSIX shell to make the server write to stderr")
+	}
 
 	logW := newBlockingWriter()
 	t.Cleanup(logW.unblock)
@@ -342,7 +346,12 @@ func TestRunProxy_BlockedLogWriterDoesNotWedgeTeardown(t *testing.T) {
 	close(parentDied)
 
 	select {
-	case <-done:
+	case err := <-done:
+		// Accepting any result would let a failure to even start the server
+		// pass as a successful teardown, which would make this test vacuous.
+		if err != nil && !errors.Is(err, ErrSubprocessExit) {
+			t.Errorf("RunProxy = %v, want a clean session-bound shutdown", err)
+		}
 	case <-time.After(20 * time.Second):
 		t.Fatal("RunProxy never returned while the log writer was blocked; teardown deadlocked on its own diagnostic")
 	}

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -264,6 +264,90 @@ func TestRunProxy_SessionExitBoundsNonClosableInputDrain(t *testing.T) {
 	}
 }
 
+// blockingWriter wedges on its first write and never returns, standing in for
+// a log sink whose consumer has stopped reading.
+type blockingWriter struct {
+	entered chan struct{}
+	once    sync.Once
+	release chan struct{}
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.entered) })
+	<-w.release
+	return len(p), nil
+}
+
+func (w *blockingWriter) unblock() {
+	close(w.release)
+}
+
+// TestRunProxy_BlockedLogWriterDoesNotWedgeTeardown covers the deadlock a
+// synchronous teardown diagnostic creates. The child's stderr copy blocks
+// inside the shared log writer and holds its lock; closing the read end cannot
+// interrupt a write already in flight. A synchronous diagnostic would then wait
+// on that same lock, so the proxy would hang precisely when it was trying to
+// report that it could not drain stderr.
+func TestRunProxy_BlockedLogWriterDoesNotWedgeTeardown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real child process")
+	}
+
+	logW := newBlockingWriter()
+	t.Cleanup(logW.unblock)
+
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+
+	parentDied := make(chan struct{})
+	var stdout bytes.Buffer
+	opts := MCPProxyOpts{
+		sessionExitForTest: &sessionExitTestHooks{
+			watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid: func() int {
+					select {
+					case <-parentDied:
+						return orphanedPPID
+					default:
+						return 4242
+					}
+				},
+			},
+			grace: 20 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// The server writes to stderr so the copier enters the blocked writer
+		// and holds its lock for the rest of the run.
+		done <- RunProxy(ctx, clientIn, &stdout, logW,
+			[]string{"/bin/sh", "-c", "echo wedged >&2; sleep 120"}, opts)
+	}()
+
+	select {
+	case <-logW.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("stderr copier never reached the log writer; test setup is wrong")
+	}
+	close(parentDied)
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("RunProxy never returned while the log writer was blocked; teardown deadlocked on its own diagnostic")
+	}
+}
+
 func TestDrainStderr_ReleasesEscapedPipeHolder(t *testing.T) {
 	t.Run("timeout closes escaped writer", func(t *testing.T) {
 		serverErr, escapedWriter, err := os.Pipe()

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingReader stands in for a client whose session is alive: it never
+// returns data and never returns EOF, so nothing but the session watcher
+// can bring the proxy down. Close unblocks it, which is exactly what the
+// teardown's stopIntake step must do.
+type blockingReader struct {
+	once   sync.Once
+	closed chan struct{}
+}
+
+func newBlockingReader() *blockingReader {
+	return &blockingReader{closed: make(chan struct{})}
+}
+
+func (b *blockingReader) Read(_ []byte) (int, error) {
+	<-b.closed
+	return 0, io.EOF
+}
+
+func (b *blockingReader) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+// TestRunProxy_SessionExitTerminatesIgnoringServer drives the real RunProxy
+// wiring end to end in-process: a genuine child process that ignores stdin,
+// a genuine blocked client reader, and the actual teardown closures. Only
+// the parent-death observation is simulated, because a test process cannot
+// make its own parent die.
+func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real child process")
+	}
+
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+
+	var stdout, logBuf bytes.Buffer
+	opts := MCPProxyOpts{
+		sessionExitForTest: &sessionExitTestHooks{
+			watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid:   func() int { return orphanedPPID },
+			},
+			grace: 50 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		// `sleep` never reads stdin, so closing it is a no-op and only the
+		// forced process-tree teardown can end this call.
+		done <- RunProxy(ctx, clientIn, &stdout, &logBuf, []string{"sleep", "120"}, opts)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("RunProxy never returned after the spawning session died; the proxy leaked")
+	}
+
+	log := logBuf.String()
+	if !strings.Contains(log, "spawning session exited") {
+		t.Errorf("missing session-exit explanation in operator log, got %q", log)
+	}
+	if !strings.Contains(log, "terminating process tree") {
+		t.Errorf("missing forced-teardown notice for a server that ignored stdin close, got %q", log)
+	}
+}
+
+// TestRunProxy_LiveSessionIsNotTornDown is the availability direction: with
+// a parent that never changes, RunProxy must keep running. A watcher that
+// fired here would kill healthy scanners mid-call.
+func TestRunProxy_LiveSessionIsNotTornDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real child process")
+	}
+
+	clientIn := newBlockingReader()
+	var stdout, logBuf bytes.Buffer
+
+	opts := MCPProxyOpts{
+		sessionExitForTest: &sessionExitTestHooks{
+			watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: os.Getppid(),
+				getppid:   os.Getppid,
+			},
+			grace: 10 * time.Millisecond,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxy(ctx, clientIn, &stdout, &logBuf, []string{"sleep", "120"}, opts)
+	}()
+
+	// Well past many poll intervals and grace windows.
+	select {
+	case <-done:
+		t.Fatalf("RunProxy exited while its session was alive; log: %q", logBuf.String())
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	if got := logBuf.String(); strings.Contains(got, "spawning session exited") {
+		t.Errorf("session-exit path ran against a live parent, got %q", got)
+	}
+
+	// Shut down cleanly so the child is reaped before the test ends.
+	_ = clientIn.Close()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("RunProxy did not shut down after context cancellation")
+	}
+}

--- a/internal/mcp/parentwatch_test.go
+++ b/internal/mcp/parentwatch_test.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // stubPPID returns a getppid func that reports first for the first n calls
@@ -224,10 +226,58 @@ func TestRunSessionBoundExit_DefaultGraceApplies(t *testing.T) {
 	}
 }
 
+func TestProcessExitHandoff_TerminateProceedsWhileReapInFlight(t *testing.T) {
+	t.Parallel()
+
+	// The deadlock this guards against: reap is cmd.Wait, and on the path the
+	// session-bound exit exists for, cmd.Wait does not return until the tree is
+	// terminated. If a reap in flight blocked terminate, the escalation would
+	// wait on a reap only that escalation could unblock, and the proxy would
+	// hang with the whole tree alive - the exact leak being fixed.
+	//
+	// Escalating here is also SAFE: the child is not reaped yet, so the kernel
+	// cannot have recycled its PID or process-group ID.
+	handoff := &processExitHandoff{}
+	reapEntered := make(chan struct{})
+	releaseReap := make(chan struct{})
+	waitDone := make(chan error, 1)
+
+	go func() {
+		waitDone <- handoff.wait(func() error {
+			close(reapEntered)
+			<-releaseReap // stands in for a cmd.Wait that never returns on its own
+			return nil
+		})
+	}()
+
+	<-reapEntered
+	testwait.For(t, 2*time.Second, handoff.reapStarted, "the reap to be marked in flight")
+
+	var terminated atomic.Bool
+	escalated := make(chan bool, 1)
+	go func() {
+		escalated <- handoff.terminate(func() { terminated.Store(true) })
+	}()
+
+	select {
+	case ok := <-escalated:
+		if !ok || !terminated.Load() {
+			t.Error("escalation was refused while the reap was still in flight; the tree would be left running")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminate blocked on an in-flight reap; this is the deadlock that hangs the proxy with its tree alive")
+	}
+
+	close(releaseReap)
+	if err := <-waitDone; err != nil {
+		t.Fatalf("process reaping returned %v", err)
+	}
+}
+
 func TestProcessExitHandoff_RejectsEscalationAfterReapingStarts(t *testing.T) {
 	t.Parallel()
 
-	// Once cmd.Wait has returned, a late signal could target a PID or process
+	// Once cmd.Wait has RETURNED, a late signal could target a PID or process
 	// group the kernel already reused.
 	handoff := &processExitHandoff{}
 	if err := handoff.wait(func() error { return nil }); err != nil {

--- a/internal/mcp/parentwatch_test.go
+++ b/internal/mcp/parentwatch_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,7 +49,6 @@ func TestWatchParentSession_ReparentingIsDetected(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			var logBuf bytes.Buffer
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -56,17 +56,87 @@ func TestWatchParentSession_ReparentingIsDetected(t *testing.T) {
 				interval:  time.Millisecond,
 				startPPID: tc.startPPID,
 				getppid:   stubPPID(tc.startPPID, tc.newPPID, 3),
-				logW:      &logBuf,
 			})
 
 			if !died {
 				t.Fatalf("watchParentSession = false, want true after reparent to %d", tc.newPPID)
 			}
-			if got := logBuf.String(); !strings.Contains(got, "spawning session exited") {
-				t.Errorf("missing operator explanation in log, got %q", got)
-			}
 		})
 	}
+}
+
+type gatedLogWriter struct {
+	mu          sync.Mutex
+	buf         bytes.Buffer
+	started     chan struct{}
+	release     chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newGatedLogWriter() *gatedLogWriter {
+	return &gatedLogWriter{started: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (w *gatedLogWriter) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() { close(w.started) })
+	<-w.release
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *gatedLogWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func (w *gatedLogWriter) Release() {
+	w.releaseOnce.Do(func() { close(w.release) })
+}
+
+func TestRunSessionBoundExit_BlockedLogDoesNotDelayTeardown(t *testing.T) {
+	t.Parallel()
+
+	logW := newGatedLogWriter()
+	defer logW.Release()
+	var marked, intakeStopped, stdinClosed, terminated atomic.Bool
+	done := make(chan bool, 1)
+	go func() {
+		done <- runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
+			onSessionExit:    func() { marked.Store(true) },
+			stopIntake:       func() { intakeStopped.Store(true) },
+			closeServerStdin: func() { stdinClosed.Store(true) },
+			terminateTree:    func() bool { terminated.Store(true); return true },
+			waitDone:         make(chan struct{}),
+			grace:            time.Millisecond,
+			logW:             logW,
+		})
+	}()
+
+	select {
+	case <-logW.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session-exit log was never attempted")
+	}
+
+	select {
+	case escalated := <-done:
+		if !escalated {
+			t.Fatal("session teardown did not escalate while its log writer was blocked")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocked log writer delayed session teardown")
+	}
+	if !marked.Load() || !intakeStopped.Load() || !stdinClosed.Load() || !terminated.Load() {
+		t.Fatal("session teardown did not mark, close, and terminate before logging")
+	}
+
+	logW.Release()
+	testwait.For(t, 5*time.Second, func() bool {
+		return strings.Contains(logW.String(), "spawning session exited")
+	}, "the deferred session-exit explanation to reach the operator log")
 }
 
 // deadSession reports a reparent immediately, so teardown tests do not
@@ -235,11 +305,14 @@ func TestProcessExitHandoff_TerminateProceedsWhileReapInFlight(t *testing.T) {
 	// wait on a reap only that escalation could unblock, and the proxy would
 	// hang with the whole tree alive - the exact leak being fixed.
 	//
-	// Escalating here is also SAFE: the child is not reaped yet, so the kernel
-	// cannot have recycled its PID or process-group ID.
+	// A direct-child process handle remains safe here, but a raw process-group
+	// signal does not: reap can complete immediately after the handoff releases
+	// its lock and before a later goroutine sends that numeric signal.
 	handoff := &processExitHandoff{}
 	reapEntered := make(chan struct{})
 	releaseReap := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseReap) }) }
 	waitDone := make(chan error, 1)
 
 	go func() {
@@ -253,28 +326,38 @@ func TestProcessExitHandoff_TerminateProceedsWhileReapInFlight(t *testing.T) {
 	<-reapEntered
 	testwait.For(t, 2*time.Second, handoff.reapStarted, "the reap to be marked in flight")
 
-	var terminated atomic.Bool
+	var rawGroupSignal, stableDirectKill atomic.Bool
 	escalated := make(chan bool, 1)
 	go func() {
-		escalated <- handoff.terminate(func() { terminated.Store(true) })
+		escalated <- handoff.terminate(
+			func() { rawGroupSignal.Store(true) },
+			func() bool {
+				stableDirectKill.Store(true)
+				release()
+				return true
+			},
+		)
 	}()
 
 	select {
 	case ok := <-escalated:
-		if !ok || !terminated.Load() {
-			t.Error("escalation was refused while the reap was still in flight; the tree would be left running")
+		if !ok || !stableDirectKill.Load() {
+			t.Error("escalation did not use the stable direct-child handle while reap was in flight")
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("terminate blocked on an in-flight reap; this is the deadlock that hangs the proxy with its tree alive")
 	}
 
-	close(releaseReap)
+	release()
+	if rawGroupSignal.Load() {
+		t.Error("escalation signalled a raw process group after cmd.Wait started")
+	}
 	if err := <-waitDone; err != nil {
 		t.Fatalf("process reaping returned %v", err)
 	}
 }
 
-func TestProcessExitHandoff_RejectsEscalationAfterReapingStarts(t *testing.T) {
+func TestProcessExitHandoff_UsesStableHandleAfterReapingStarts(t *testing.T) {
 	t.Parallel()
 
 	// Once cmd.Wait has RETURNED, a late signal could target a PID or process
@@ -283,13 +366,19 @@ func TestProcessExitHandoff_RejectsEscalationAfterReapingStarts(t *testing.T) {
 	if err := handoff.wait(func() error { return nil }); err != nil {
 		t.Fatalf("process reaping returned %v", err)
 	}
-	var terminated atomic.Bool
+	var rawGroupSignal, stableDirectKill atomic.Bool
 
-	if handoff.terminate(func() { terminated.Store(true) }) {
-		t.Error("session exit escalated after cmd.Wait owned process reaping")
+	if !handoff.terminate(
+		func() { rawGroupSignal.Store(true) },
+		func() bool { stableDirectKill.Store(true); return true },
+	) {
+		t.Error("session exit did not attempt the stable direct-child handle after reaping started")
 	}
-	if terminated.Load() {
-		t.Error("late session exit signalled process identifiers after reaping began")
+	if rawGroupSignal.Load() {
+		t.Error("late session exit signalled a raw process identifier after reaping began")
+	}
+	if !stableDirectKill.Load() {
+		t.Error("late session exit did not use the stable direct-child handle")
 	}
 }
 

--- a/internal/mcp/parentwatch_test.go
+++ b/internal/mcp/parentwatch_test.go
@@ -227,24 +227,15 @@ func TestRunSessionBoundExit_DefaultGraceApplies(t *testing.T) {
 func TestProcessExitHandoff_RejectsEscalationAfterReapingStarts(t *testing.T) {
 	t.Parallel()
 
-	// Reproduce the ownership handoff: cmd.Wait starts after the grace timer
-	// fired but before the watcher obtains its termination turn. A late signal
-	// here could target a PID or process group the kernel has already reused.
+	// Once cmd.Wait has returned, a late signal could target a PID or process
+	// group the kernel already reused.
 	handoff := &processExitHandoff{}
-	handoff.beginReap()
+	if err := handoff.wait(func() error { return nil }); err != nil {
+		t.Fatalf("process reaping returned %v", err)
+	}
 	var terminated atomic.Bool
 
-	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
-		stopIntake:       func() {},
-		closeServerStdin: func() {},
-		terminateTree: func() bool {
-			return handoff.terminate(func() { terminated.Store(true) })
-		},
-		waitDone: make(chan struct{}),
-		grace:    time.Millisecond,
-	})
-
-	if escalated {
+	if handoff.terminate(func() { terminated.Store(true) }) {
 		t.Error("session exit escalated after cmd.Wait owned process reaping")
 	}
 	if terminated.Load() {

--- a/internal/mcp/parentwatch_test.go
+++ b/internal/mcp/parentwatch_test.go
@@ -92,7 +92,7 @@ func TestRunSessionBoundExit_CooperativeServerIsNotKilled(t *testing.T) {
 		done <- runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
 			stopIntake:       func() { intake.Store(true) },
 			closeServerStdin: func() { stdinClosed.Store(true); close(waitDone) },
-			terminateTree:    func() { terminated.Store(true) },
+			terminateTree:    func() bool { terminated.Store(true); return true },
 			waitDone:         waitDone,
 			grace:            10 * time.Second, // must never be waited out
 		})
@@ -128,7 +128,7 @@ func TestRunSessionBoundExit_ServerIgnoringEOFIsTerminated(t *testing.T) {
 	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
 		stopIntake:       func() {},
 		closeServerStdin: func() {}, // server ignores it
-		terminateTree:    func() { terminated.Store(true) },
+		terminateTree:    func() bool { terminated.Store(true); return true },
 		waitDone:         make(chan struct{}), // never closed
 		grace:            10 * time.Millisecond,
 	})
@@ -157,7 +157,7 @@ func TestRunSessionBoundExit_LiveSessionRunsNoTeardown(t *testing.T) {
 	}, sessionExitActions{
 		stopIntake:       func() { touched.Store(true) },
 		closeServerStdin: func() { touched.Store(true) },
-		terminateTree:    func() { touched.Store(true) },
+		terminateTree:    func() bool { touched.Store(true); return true },
 		waitDone:         make(chan struct{}),
 		grace:            time.Millisecond,
 	})
@@ -174,16 +174,16 @@ func TestRunSessionBoundExit_CancelDuringGraceStopsEscalation(t *testing.T) {
 	// stand down rather than signal a group the main path already reaped.
 	var terminated atomic.Bool
 	ctx, cancel := context.WithCancel(context.Background())
-
+	draining := make(chan struct{})
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-draining
 		cancel()
 	}()
 
 	escalated := runSessionBoundExit(ctx, deadSession(), sessionExitActions{
 		stopIntake:       func() {},
-		closeServerStdin: func() {},
-		terminateTree:    func() { terminated.Store(true) },
+		closeServerStdin: func() { close(draining) },
+		terminateTree:    func() bool { terminated.Store(true); return true },
 		waitDone:         make(chan struct{}),
 		grace:            10 * time.Second,
 	})
@@ -200,16 +200,20 @@ func TestRunSessionBoundExit_DefaultGraceApplies(t *testing.T) {
 	// instantly, which would give a cooperative server no drain at all.
 	start := time.Now()
 	waitDone := make(chan struct{})
+	draining := make(chan struct{})
 	go func() {
-		time.Sleep(30 * time.Millisecond)
+		<-draining
 		close(waitDone)
 	}()
 
 	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
 		stopIntake:       func() {},
-		closeServerStdin: func() {},
-		terminateTree:    func() { t.Error("terminated during the default grace window") },
-		waitDone:         waitDone,
+		closeServerStdin: func() { close(draining) },
+		terminateTree: func() bool {
+			t.Error("terminated during the default grace window")
+			return true
+		},
+		waitDone: waitDone,
 	})
 
 	if escalated {
@@ -217,6 +221,34 @@ func TestRunSessionBoundExit_DefaultGraceApplies(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed >= defaultParentExitGrace {
 		t.Errorf("waited %s, expected to short-circuit well inside the %s default grace", elapsed, defaultParentExitGrace)
+	}
+}
+
+func TestProcessExitHandoff_RejectsEscalationAfterReapingStarts(t *testing.T) {
+	t.Parallel()
+
+	// Reproduce the ownership handoff: cmd.Wait starts after the grace timer
+	// fired but before the watcher obtains its termination turn. A late signal
+	// here could target a PID or process group the kernel has already reused.
+	handoff := &processExitHandoff{}
+	handoff.beginReap()
+	var terminated atomic.Bool
+
+	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
+		stopIntake:       func() {},
+		closeServerStdin: func() {},
+		terminateTree: func() bool {
+			return handoff.terminate(func() { terminated.Store(true) })
+		},
+		waitDone: make(chan struct{}),
+		grace:    time.Millisecond,
+	})
+
+	if escalated {
+		t.Error("session exit escalated after cmd.Wait owned process reaping")
+	}
+	if terminated.Load() {
+		t.Error("late session exit signalled process identifiers after reaping began")
 	}
 }
 

--- a/internal/mcp/parentwatch_test.go
+++ b/internal/mcp/parentwatch_test.go
@@ -1,0 +1,332 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubPPID returns a getppid func that reports first for the first n calls
+// and then reports after, simulating a reparenting event.
+func stubPPID(first, after int, n int64) func() int {
+	var calls atomic.Int64
+	return func() int {
+		if calls.Add(1) <= n {
+			return first
+		}
+		return after
+	}
+}
+
+func TestWatchParentSession_ReparentingIsDetected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		startPPID int
+		newPPID   int
+	}{
+		// The textbook case: no subreaper claimed us, so we land on init.
+		{name: "reparented to init", startPPID: 4242, newPPID: orphanedPPID},
+		// An intermediate subreaper (systemd --user, a container shim, or
+		// another pipelock with PR_SET_CHILD_SUBREAPER set) adopts us
+		// instead. The new PPID is neither the original nor 1, so a check
+		// written as "PPID == 1" would miss this entirely and the proxy
+		// would leak exactly as before.
+		{name: "reparented to subreaper", startPPID: 4242, newPPID: 9001},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var logBuf bytes.Buffer
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			died := watchParentSession(ctx, parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: tc.startPPID,
+				getppid:   stubPPID(tc.startPPID, tc.newPPID, 3),
+				logW:      &logBuf,
+			})
+
+			if !died {
+				t.Fatalf("watchParentSession = false, want true after reparent to %d", tc.newPPID)
+			}
+			if got := logBuf.String(); !strings.Contains(got, "spawning session exited") {
+				t.Errorf("missing operator explanation in log, got %q", got)
+			}
+		})
+	}
+}
+
+// deadSession reports a reparent immediately, so teardown tests do not
+// depend on wall-clock polling.
+func deadSession() parentWatchOpts {
+	return parentWatchOpts{
+		interval:  time.Millisecond,
+		startPPID: 4242,
+		getppid:   func() int { return orphanedPPID },
+	}
+}
+
+func TestRunSessionBoundExit_CooperativeServerIsNotKilled(t *testing.T) {
+	t.Parallel()
+
+	// The wrapped server takes its stdin close as shutdown and exits, so
+	// cmd.Wait returns and waitDone closes. Escalating anyway would kill a
+	// server that was already draining cleanly and could discard responses
+	// it was still writing.
+	waitDone := make(chan struct{})
+	var intake, stdinClosed, terminated atomic.Bool
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
+			stopIntake:       func() { intake.Store(true) },
+			closeServerStdin: func() { stdinClosed.Store(true); close(waitDone) },
+			terminateTree:    func() { terminated.Store(true) },
+			waitDone:         waitDone,
+			grace:            10 * time.Second, // must never be waited out
+		})
+	}()
+
+	select {
+	case escalated := <-done:
+		if escalated {
+			t.Error("escalated to a forced teardown for a server that exited on its own")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("teardown blocked past the cooperative exit; the grace window was waited out")
+	}
+
+	if !intake.Load() {
+		t.Error("request intake was not stopped")
+	}
+	if !stdinClosed.Load() {
+		t.Error("wrapped server stdin was not closed")
+	}
+	if terminated.Load() {
+		t.Error("process tree was terminated despite a clean drain")
+	}
+}
+
+func TestRunSessionBoundExit_ServerIgnoringEOFIsTerminated(t *testing.T) {
+	t.Parallel()
+
+	// The leak case: the server never reads stdin, so closing it achieves
+	// nothing and waitDone never closes. Without the bounded grace the
+	// proxy would wait here forever, which is the original bug.
+	var terminated atomic.Bool
+	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
+		stopIntake:       func() {},
+		closeServerStdin: func() {}, // server ignores it
+		terminateTree:    func() { terminated.Store(true) },
+		waitDone:         make(chan struct{}), // never closed
+		grace:            10 * time.Millisecond,
+	})
+
+	if !escalated {
+		t.Error("runSessionBoundExit = false; a server ignoring stdin close was left running")
+	}
+	if !terminated.Load() {
+		t.Error("process tree was not terminated for a server that ignored stdin close")
+	}
+}
+
+func TestRunSessionBoundExit_LiveSessionRunsNoTeardown(t *testing.T) {
+	t.Parallel()
+
+	// Nothing at all may happen while the session is alive - not even
+	// stopping intake, which would break a healthy proxy mid-call.
+	var touched atomic.Bool
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	escalated := runSessionBoundExit(ctx, parentWatchOpts{
+		interval:  time.Millisecond,
+		startPPID: 4242,
+		getppid:   func() int { return 4242 },
+	}, sessionExitActions{
+		stopIntake:       func() { touched.Store(true) },
+		closeServerStdin: func() { touched.Store(true) },
+		terminateTree:    func() { touched.Store(true) },
+		waitDone:         make(chan struct{}),
+		grace:            time.Millisecond,
+	})
+
+	if escalated || touched.Load() {
+		t.Fatal("teardown ran against a live session")
+	}
+}
+
+func TestRunSessionBoundExit_CancelDuringGraceStopsEscalation(t *testing.T) {
+	t.Parallel()
+
+	// RunProxy returned while the drain was in flight. The teardown must
+	// stand down rather than signal a group the main path already reaped.
+	var terminated atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	escalated := runSessionBoundExit(ctx, deadSession(), sessionExitActions{
+		stopIntake:       func() {},
+		closeServerStdin: func() {},
+		terminateTree:    func() { terminated.Store(true) },
+		waitDone:         make(chan struct{}),
+		grace:            10 * time.Second,
+	})
+
+	if escalated || terminated.Load() {
+		t.Error("escalated after the proxy had already shut down")
+	}
+}
+
+func TestRunSessionBoundExit_DefaultGraceApplies(t *testing.T) {
+	t.Parallel()
+
+	// A zero grace must fall back to the default rather than escalate
+	// instantly, which would give a cooperative server no drain at all.
+	start := time.Now()
+	waitDone := make(chan struct{})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		close(waitDone)
+	}()
+
+	escalated := runSessionBoundExit(context.Background(), deadSession(), sessionExitActions{
+		stopIntake:       func() {},
+		closeServerStdin: func() {},
+		terminateTree:    func() { t.Error("terminated during the default grace window") },
+		waitDone:         waitDone,
+	})
+
+	if escalated {
+		t.Error("escalated despite the server exiting inside the default grace")
+	}
+	if elapsed := time.Since(start); elapsed >= defaultParentExitGrace {
+		t.Errorf("waited %s, expected to short-circuit well inside the %s default grace", elapsed, defaultParentExitGrace)
+	}
+}
+
+func TestWatchParentSession_StableParentNeverFires(t *testing.T) {
+	t.Parallel()
+
+	// The normal-completion case, and the one that matters most for
+	// availability: a live session must never be torn down. The parent
+	// never changes, so the watch must block until ctx cancels no matter
+	// how long it runs or how many times it polls.
+	var polls atomic.Int64
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	died := watchParentSession(ctx, parentWatchOpts{
+		interval:  time.Millisecond,
+		startPPID: 4242,
+		getppid: func() int {
+			polls.Add(1)
+			return 4242
+		},
+	})
+
+	if died {
+		t.Fatal("watchParentSession = true for a live parent; a healthy proxy would be killed mid-call")
+	}
+	if polls.Load() < 5 {
+		t.Fatalf("watcher polled %d times, expected repeated polling", polls.Load())
+	}
+}
+
+func TestWatchParentSession_AlreadyOrphanedIsInert(t *testing.T) {
+	t.Parallel()
+
+	// Started by a supervisor, daemonized, or already reparented before the
+	// watch began. There is no session to bind to, so the watcher must stay
+	// inert rather than treating "PPID is 1" as death and shutting down a
+	// service-managed proxy at startup.
+	var polls atomic.Int64
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	died := watchParentSession(ctx, parentWatchOpts{
+		interval:  time.Millisecond,
+		startPPID: orphanedPPID,
+		getppid: func() int {
+			polls.Add(1)
+			return 12345 // would look like a reparent if it were consulted
+		},
+	})
+
+	if died {
+		t.Fatal("watchParentSession = true for an already-orphaned proxy; supervisor-managed proxies would self-terminate")
+	}
+	if polls.Load() != 0 {
+		t.Fatalf("inert watcher polled %d times, want 0", polls.Load())
+	}
+}
+
+func TestNewSessionBoundContext_AlreadyOrphanedIsInert(t *testing.T) {
+	var polls atomic.Int64
+	ctx, stop, state := newSessionBoundContext(context.Background(), parentWatchOpts{
+		startPPID: orphanedPPID,
+		getppid: func() int {
+			polls.Add(1)
+			return 4242
+		},
+	}, nil, nil, nil)
+	defer stop()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("inert session context was cancelled before its caller stopped it")
+	default:
+	}
+	if state.inProgress() {
+		t.Fatal("inert session watch recorded an exit")
+	}
+	if polls.Load() != 0 {
+		t.Fatalf("inert session watch polled %d times, want 0", polls.Load())
+	}
+}
+
+func TestWatchParentSession_ContextCancelWins(t *testing.T) {
+	t.Parallel()
+
+	// The proxy finished on its own and stopped the watch. Returning false
+	// here is what keeps the teardown path from running twice.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if watchParentSession(ctx, parentWatchOpts{
+		interval:  time.Hour,
+		startPPID: 4242,
+		getppid:   func() int { return orphanedPPID },
+	}) {
+		t.Fatal("watchParentSession = true on a cancelled context, want false")
+	}
+}
+
+func TestWatchParentSession_DefaultsAreSane(t *testing.T) {
+	t.Parallel()
+
+	// A nil getppid must fall back to the real syscall rather than panic,
+	// and the real parent of the test process is stable, so this also
+	// re-confirms the no-false-positive direction against live values.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if watchParentSession(ctx, parentWatchOpts{startPPID: os.Getppid(), interval: time.Millisecond}) {
+		t.Fatal("watchParentSession fired against the real, live parent PID")
+	}
+}

--- a/internal/mcp/pgid_unix.go
+++ b/internal/mcp/pgid_unix.go
@@ -25,11 +25,11 @@ func setupChildProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
-// captureChildPgid returns the process group ID of pid, locked in
-// immediately after cmd.Start so it remains stable across cmd.Wait.
-// Falls back to pid on Getpgid error (Setpgid=true guarantees pgid==pid
-// at spawn time anyway). Returns 0 on Windows so downstream signal
-// helpers become no-ops.
+// captureChildPgid returns the process group ID of a live child immediately
+// after cmd.Start. The numeric ID is safe to signal only until cmd.Wait begins;
+// after that it may be recycled. Falls back to pid on Getpgid error
+// (Setpgid=true guarantees pgid==pid at spawn time anyway). Returns 0 on
+// Windows so downstream signal helpers become no-ops.
 func captureChildPgid(pid int) int {
 	if got, err := syscall.Getpgid(pid); err == nil {
 		return got
@@ -48,10 +48,9 @@ func signalProcessGroupTerm(pgid int) {
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 }
 
-// terminateProcessGroup runs the SIGTERM + 100ms grace + SIGKILL
-// sequence on the given process group. Called after cmd.Wait so any
-// descendants still alive in the group are drained before we move on
-// to the /proc-walk adopted-descendants sweep.
+// terminateProcessGroup runs the SIGTERM + 100ms grace + SIGKILL sequence on
+// a known-live process group. Callers must exclude a concurrent cmd.Wait: once
+// Wait starts, the leader and its numeric group ID can be recycled.
 func terminateProcessGroup(pgid int) {
 	if pgid <= 0 {
 		return

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1503,6 +1503,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// On Windows the helper returns 0 and the signal helpers below all
 	// no-op, matching the no-op setupChildProcessGroup call above.
 	childPgid := captureChildPgid(cmd.Process.Pid)
+	processExit := &processExitHandoff{}
 
 	// Drain adopted-descendant zombies live, while the direct child is
 	// still running. Without this, long-running MCP wraps (e.g. a code-assistant
@@ -1536,7 +1537,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	go func() {
 		select {
 		case <-ctx.Done():
-			signalProcessGroupTerm(childPgid)
+			processExit.terminate(func() { signalProcessGroupTerm(childPgid) })
 		case <-pgidDone:
 		}
 	}()
@@ -1597,16 +1598,18 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 			// the descriptor and lets Wait return, after which the normal
 			// teardown reaps detached and adopted descendants the group kill
 			// could not reach.
-			terminateTree: func() {
-				terminateProcessGroup(childPgid)
-				if cmd.Process != nil {
-					_ = cmd.Process.Kill()
-				}
-				// A descendant can escape the child group with setsid while
-				// retaining stdout. Closing our read end releases ForwardScanned
-				// so cmd.Wait and its adopted-descendant sweep are reachable.
-				_ = serverOut.Close()
-				_ = serverErr.Close()
+			terminateTree: func() bool {
+				return processExit.terminate(func() {
+					terminateProcessGroup(childPgid)
+					if cmd.Process != nil {
+						_ = cmd.Process.Kill()
+					}
+					// A descendant can escape the child group with setsid while
+					// retaining stdout. Closing our read end releases ForwardScanned
+					// so cmd.Wait and its adopted-descendant sweep are reachable.
+					_ = serverOut.Close()
+					_ = serverErr.Close()
+				})
 			},
 			waitDone: waitDone,
 			grace:    sessionGrace,
@@ -1748,6 +1751,10 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		_ = cmd.Process.Kill()
 	}
 
+	// Hand the process identifiers to cmd.Wait before reaping. Once this
+	// begins, concurrent session or context teardown must not signal a PID or
+	// process group that the kernel can recycle after the child exits.
+	processExit.beginReap()
 	// Wait for subprocess to exit.
 	waitErr := cmd.Wait()
 	// Release the session watcher's drain wait. A server that exited on its

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1827,7 +1827,13 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// A detached descendant can retain stderr after the direct child exits.
 	// Bound the drain so an escaped writer cannot hold the proxy open forever.
 	if !drainStderr(stderrDone, serverErr, sessionGrace) {
-		_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out draining MCP subprocess stderr after child exit\n")
+		// Bounded, because reaching this line means the stderr copy is already
+		// stuck. That copy holds the shared writer's lock while it blocks, and
+		// closing the read end cannot interrupt a write already in progress, so
+		// a synchronous diagnostic here would wait on the same lock and stop
+		// teardown from ever completing - failing in exactly the situation it
+		// exists to report.
+		logAsync(safeLogW, "pipelock: timed out draining MCP subprocess stderr after child exit\n")
 	}
 
 	if timedOut {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1784,27 +1784,22 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		_ = cmd.Process.Kill()
 	}
 
-	// Tear the child's process group down BEFORE Wait, while its identifier is
-	// still tied to a live child and therefore cannot have been recycled.
+	// A numeric process-group teardown is deliberately NOT performed here.
 	//
-	// This has to happen somewhere, and after Wait is not an option: the kernel
-	// may reuse the group id the moment the leader is reaped, so a late signal
-	// can land on an unrelated group. Omitting it entirely leaks descendants on
-	// a NORMAL exit, because the adopted-descendant sweep below is a no-op off
-	// Linux and, on Linux, only finds processes the subreaper adopted - which
-	// requires enableSubreaper to have succeeded, and its failure is non-fatal.
+	// Moving it before Wait was tried, to keep the group identifier tied to a
+	// live child so it could not have been recycled. It is wrong: reaching this
+	// point is the ORDINARY exit path, and terminateProcessGroup signals the
+	// group and then escalates to SIGKILL, so every clean shutdown would kill a
+	// server that was still finishing. Reproduced by a sibling proxy test that
+	// passes alone and fails once the package runs together.
 	//
-	// Doing it here is safe for the ordinary case: the server has already
-	// closed its output to reach this point, and terminateProcessGroup sends
-	// SIGTERM and allows a grace period before escalating, so a child still
-	// flushing gets the same chance it had when this ran after Wait.
-	processExit.terminate(
-		func() { terminateProcessGroup(childPgid) },
-		// Unreachable in practice: nothing can have started reaping before
-		// this call. Kept honest rather than assuming - if a reap somehow is
-		// in flight, no raw identifier may be signalled.
-		func() bool { return false },
-	)
+	// After Wait is also unavailable: the kernel may reuse the group id as soon
+	// as the leader is reaped, so a late signal can land on an unrelated group.
+	//
+	// That leaves parentage-based cleanup, which needs no numeric identifier.
+	// It is complete on Linux whenever the subreaper is active, and its absence
+	// on other platforms is a real limitation rather than something this
+	// signal could safely close.
 
 	// cmd.Wait permanently retires raw numeric process identifiers from the
 	// handoff. A concurrent session or context teardown can still use the Go

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -75,6 +75,24 @@ func (sw *syncWriter) WriteMessage(msg []byte) error {
 	return nil
 }
 
+// drainStderr waits for the wrapped process's stderr copier without allowing
+// an escaped descendant holding the write end to keep RunProxy alive. Closing
+// the read end releases io.Copy on timeout and also releases the descriptor
+// after a normal drain.
+func drainStderr(stderrDone <-chan struct{}, serverErr io.Closer, grace time.Duration) bool {
+	if grace <= 0 {
+		grace = defaultParentExitGrace
+	}
+	select {
+	case <-stderrDone:
+		_ = serverErr.Close()
+		return true
+	case <-time.After(grace):
+		_ = serverErr.Close()
+		return false
+	}
+}
+
 func emitPendingTimeoutResponses(writer transport.MessageWriter, logW io.Writer, tracker *RequestTracker, opts MCPProxyOpts) {
 	if tracker == nil {
 		return
@@ -1574,7 +1592,9 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	if h := opts.sessionExitForTest; h != nil {
 		sessionOpts = h.watch
 		sessionOpts.logW = safeLogW
-		sessionGrace = h.grace
+		if h.grace > 0 {
+			sessionGrace = h.grace
+		}
 	}
 	if sessionOpts.startPPID > orphanedPPID {
 		go runSessionBoundExit(sessionCtx, sessionOpts, sessionExitActions{
@@ -1600,15 +1620,15 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 			// could not reach.
 			terminateTree: func() bool {
 				return processExit.terminate(func() {
+					// A descendant can escape the child group with setsid while
+					// retaining stdout. Close the read ends first to release
+					// ForwardScanned while process-group teardown is in flight.
+					_ = serverOut.Close()
+					_ = serverErr.Close()
 					terminateProcessGroup(childPgid)
 					if cmd.Process != nil {
 						_ = cmd.Process.Kill()
 					}
-					// A descendant can escape the child group with setsid while
-					// retaining stdout. Closing our read end releases ForwardScanned
-					// so cmd.Wait and its adopted-descendant sweep are reachable.
-					_ = serverOut.Close()
-					_ = serverErr.Close()
 				})
 			},
 			waitDone: waitDone,
@@ -1669,10 +1689,9 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	inputOpts.sessionExit = sessionExit
 
 	// Forward client input to server stdin (with optional input scanning).
-	var wg sync.WaitGroup
-	wg.Add(1)
+	inputDone := make(chan struct{})
 	go func() {
-		defer wg.Done()
+		defer close(inputDone)
 		defer serverIn.Close() //nolint:errcheck // best-effort close on stdin forward
 		inputCfg := opts.inputCfg()
 		if inputCfg != nil && inputCfg.Enabled {
@@ -1703,10 +1722,9 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 
 	// Drain blocked request channel and write error responses to client.
 	// Runs in a separate goroutine so ForwardScanned can proceed concurrently.
-	var wgBlocked sync.WaitGroup
-	wgBlocked.Add(1)
+	blockedDone := make(chan struct{})
 	go func() {
-		defer wgBlocked.Done()
+		defer close(blockedDone)
 		for blocked := range blockedCh {
 			if blocked.IsNotification {
 				// Notifications have no ID - silently drop (no error response per JSON-RPC spec).
@@ -1731,9 +1749,18 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// request but never replies fails closed instead of hanging the agent.
 	serverReader := opts.withResponseTimeout(transport.NewStdioReader(serverOut))
 
-	fwdOpts := inputOpts
+	fwdOpts := opts
+	fwdOpts.Rec = rec
+	fwdOpts.WarnContext = ctx
+	// Session teardown closes serverOut to release a descendant holding the
+	// pipe. ForwardScanned must see that ownership marker so os.ErrClosed is a
+	// clean shutdown instead of an upstream scanner error.
+	fwdOpts.sessionExit = sessionExit
 	fwdOpts.ToolCfg = fwdToolCfg // session-specific baseline
 	fwdOpts.ToolCfgFn = nil
+	if opts.outputForwardStartedForTest != nil {
+		opts.outputForwardStartedForTest()
+	}
 	_, scanErr := ForwardScanned(serverReader, safeClientOut, safeLogW, tracker, fwdOpts)
 	timedOut := errors.Is(scanErr, transport.ErrResponseTimeout)
 
@@ -1791,8 +1818,10 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// non-Linux builds - the stub is a no-op there.
 	killAdoptedDescendants()
 	// A detached descendant can retain stderr after the direct child exits.
-	// Drain it only after the sweep above has released every remaining writer.
-	<-stderrDone
+	// Bound the drain so an escaped writer cannot hold the proxy open forever.
+	if !drainStderr(stderrDone, serverErr, sessionGrace) {
+		_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out draining MCP subprocess stderr after child exit\n")
+	}
 
 	if timedOut {
 		// Closing a closable clientIn above wakes the usual CLI/pipe readers.
@@ -1802,8 +1831,8 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		defer drainCancel()
 		done := make(chan struct{})
 		go func() {
-			wg.Wait()
-			wgBlocked.Wait()
+			<-inputDone
+			<-blockedDone
 			close(done)
 		}()
 		select {
@@ -1812,12 +1841,23 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after upstream response timeout\n")
 		}
 		emitPendingTimeoutResponses(safeClientOut, safeLogW, tracker, fwdOpts)
+	} else if sessionExit.inProgress() {
+		// An arbitrary io.Reader cannot be interrupted by closing the client
+		// side. Once session teardown has killed the server, do not let one
+		// such reader keep the proxy alive indefinitely.
+		select {
+		case <-inputDone:
+			<-blockedDone
+		case <-time.After(sessionGrace):
+			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after session teardown\n")
+		}
+		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
 	} else {
 		// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
-		wg.Wait()
+		<-inputDone
 
 		// Wait for blocked channel drain to complete.
-		wgBlocked.Wait()
+		<-blockedDone
 		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
 	}
 

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1357,9 +1357,9 @@ type InputScanConfig struct {
 // starts and its PID is registered with the lineage tracker; callers use
 // this to start the file sentry event loop after attribution is ready.
 func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW io.Writer, command []string, opts MCPProxyOpts, extraEnv ...string) error {
-	// Capture before integrity preparation, pipe setup, and child startup. If
-	// the launcher dies during that work, the watcher must retain the original
-	// owner instead of observing PID 1 and incorrectly becoming inert.
+	// Capture before integrity preparation, pipe setup, and child startup to
+	// narrow the time later startup work can hide a parent death. A launcher can
+	// still die before this first syscall; PPID watching cannot close that race.
 	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	var cmd *exec.Cmd
 	var prepared *integrity.PreparedCommand
@@ -1512,16 +1512,21 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		}
 	}
 
-	// Capture the child's process group ID immediately after Start,
-	// before cmd.Wait has any chance to reap and before cmd.Process.Pid
-	// can go stale. Setpgid=true above guarantees pgid==pid at spawn
-	// time on unix; captureChildPgid returns that value (verified via
-	// Getpgid) so we can keep signaling the original group even after
-	// the leader is reaped and the kernel is free to recycle its PID.
-	// On Windows the helper returns 0 and the signal helpers below all
-	// no-op, matching the no-op setupChildProcessGroup call above.
+	// Capture the child's process group ID immediately after Start, while
+	// the direct child is known live. Setpgid=true above guarantees pgid==pid
+	// at spawn time on Unix. This is only safe to signal before cmd.Wait
+	// begins: once Wait can reap the group leader, the numeric group ID can be
+	// recycled and must never be signalled again. On Windows the helper returns
+	// 0 and the signal helpers below all no-op, matching the no-op
+	// setupChildProcessGroup call above.
 	childPgid := captureChildPgid(cmd.Process.Pid)
 	processExit := &processExitHandoff{}
+	killDirectChild := func() bool {
+		if cmd.Process == nil {
+			return false
+		}
+		return cmd.Process.Kill() == nil
+	}
 
 	// Drain adopted-descendant zombies live, while the direct child is
 	// still running. Without this, long-running MCP wraps (e.g. a code-assistant
@@ -1555,7 +1560,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	go func() {
 		select {
 		case <-ctx.Done():
-			processExit.terminate(func() { signalProcessGroupTerm(childPgid) })
+			processExit.terminate(func() { signalProcessGroupTerm(childPgid) }, killDirectChild)
 		case <-pgidDone:
 		}
 	}()
@@ -1576,22 +1581,21 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// in-flight responses finish, and only escalate to the process-tree
 	// teardown for a server that will not leave on its own.
 	//
-	// This is defense in depth for an unclean harness exit. The primary
-	// repair is a per-session cgroup boundary owned by the spawning harness,
-	// which is strictly stronger because it also catches descendants that
-	// create new process groups.
+	// This is defense in depth for an unclean harness exit. A harness-owned
+	// lifetime primitive is needed to cover the remaining launch window and
+	// descendants that create new process groups.
 	waitDone := make(chan struct{})
 	sessionExit := &sessionExitState{}
 	sessionCtx, sessionStop := context.WithCancel(ctx)
 	defer sessionStop()
-	// The parent PID was captured at function entry, before startup work can
-	// observe a post-exit PID 1 and make the watcher permanently inert.
+	// The parent PID is captured at function entry to narrow the startup
+	// window, but a launcher that dies before that first syscall remains an
+	// inherent PPID-watch limitation. A harness-owned owner pipe or cgroup is
+	// needed to close that earlier race.
 	sessionOpts := startupParentWatch
-	sessionOpts.logW = safeLogW
 	sessionGrace := defaultParentExitGrace
 	if h := opts.sessionExitForTest; h != nil {
 		sessionOpts = h.watch
-		sessionOpts.logW = safeLogW
 		if h.grace > 0 {
 			sessionGrace = h.grace
 		}
@@ -1619,17 +1623,19 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 			// teardown reaps detached and adopted descendants the group kill
 			// could not reach.
 			terminateTree: func() bool {
+				// Close response descriptors before either branch. A descendant
+				// can retain stdout or stderr after the direct child exits, and
+				// these closes release forwarding without relying on a numeric
+				// process-group signal.
+				_ = serverOut.Close()
+				_ = serverErr.Close()
 				return processExit.terminate(func() {
 					// A descendant can escape the child group with setsid while
 					// retaining stdout. Close the read ends first to release
 					// ForwardScanned while process-group teardown is in flight.
-					_ = serverOut.Close()
-					_ = serverErr.Close()
 					terminateProcessGroup(childPgid)
-					if cmd.Process != nil {
-						_ = cmd.Process.Kill()
-					}
-				})
+					_ = killDirectChild()
+				}, killDirectChild)
 			},
 			waitDone: waitDone,
 			grace:    sessionGrace,
@@ -1778,42 +1784,28 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		_ = cmd.Process.Kill()
 	}
 
-	// cmd.Wait and forced teardown share one owner. A concurrent session or
-	// context teardown waits until reaping finishes, then sees that no process
-	// identifier remains safe to signal.
+	// cmd.Wait permanently retires raw numeric process identifiers from the
+	// handoff. A concurrent session or context teardown can still use the Go
+	// process handle for the direct child, but can never signal its PID or PGID.
 	waitErr := processExit.wait(cmd.Wait)
 	// Release the session watcher's drain wait. A server that exited on its
 	// own after stdin close must not sit through the remaining grace window
 	// before the teardown below claims ownership.
 	close(waitDone)
 
-	// After the direct child exits, tear down everything it spawned.
-	// Three layers of cleanup that together cover fast common-case
-	// grandchildren (same pgid), detached orphans (double-fork or
-	// setsid), and long-running cooperative descendants that ignore
-	// SIGTERM:
+	// After the direct child exits, sweep any descendants it spawned that the
+	// Linux subreaper adopted after an escape from the original process group.
 	//
-	//   1. SIGTERM the original pgid so well-behaved descendants still
-	//      in the child's process group exit cleanly on a trap.
-	//   2. 100ms grace, then SIGKILL the pgid for anything that ignored
-	//      SIGTERM (the pre-tag gate harness grandchild did exactly this).
-	//   3. killAdoptedDescendants sweeps /proc for processes whose PPID
+	// killAdoptedDescendants sweeps /proc for processes whose PPID
 	//      is now pipelock's own PID - any grandchild that escaped the
 	//      original pgid via setsid/double-fork should have reparented
 	//      to us once PR_SET_CHILD_SUBREAPER fired above. SIGKILL is
 	//      best-effort; ESRCH/EPERM are non-fatal.
-	// Use the pgid captured at Start rather than re-reading
-	// cmd.Process.Pid here. After cmd.Wait returns, cmd.Process.Pid
-	// refers to a reaped pid the kernel is free to recycle - signaling
-	// the negated pid at that point risks hitting an unrelated process
-	// that was assigned the same pgid. childPgid was locked in before
-	// Wait could reap the leader, so it remains the stable identifier
-	// for the process group we created. terminateProcessGroup runs the
-	// SIGTERM + 100ms grace + SIGKILL sequence; on Windows the helper
-	// no-ops because pgid is 0 there.
-	terminateProcessGroup(childPgid)
-	// Sweep orphans the pgid kill couldn't reach. Safe even on
-	// non-Linux builds - the stub is a no-op there.
+	// Numeric process-group cleanup is deliberately absent here: Wait may
+	// already have recycled the group leader's identifier. On Linux, the
+	// subreaper sweep handles descendants without that raw-ID hazard; on other
+	// platforms descendants outside the direct child's lifetime boundary need a
+	// harness-owned containment primitive.
 	killAdoptedDescendants()
 	// A detached descendant can retain stderr after the direct child exits.
 	// Bound the drain so an escaped writer cannot hold the proxy open forever.

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1784,6 +1784,28 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		_ = cmd.Process.Kill()
 	}
 
+	// Tear the child's process group down BEFORE Wait, while its identifier is
+	// still tied to a live child and therefore cannot have been recycled.
+	//
+	// This has to happen somewhere, and after Wait is not an option: the kernel
+	// may reuse the group id the moment the leader is reaped, so a late signal
+	// can land on an unrelated group. Omitting it entirely leaks descendants on
+	// a NORMAL exit, because the adopted-descendant sweep below is a no-op off
+	// Linux and, on Linux, only finds processes the subreaper adopted - which
+	// requires enableSubreaper to have succeeded, and its failure is non-fatal.
+	//
+	// Doing it here is safe for the ordinary case: the server has already
+	// closed its output to reach this point, and terminateProcessGroup sends
+	// SIGTERM and allows a grace period before escalating, so a child still
+	// flushing gets the same chance it had when this ran after Wait.
+	processExit.terminate(
+		func() { terminateProcessGroup(childPgid) },
+		// Unreachable in practice: nothing can have started reaping before
+		// this call. Kept honest rather than assuming - if a reap somehow is
+		// in flight, no raw identifier may be signalled.
+		func() bool { return false },
+	)
+
 	// cmd.Wait permanently retires raw numeric process identifiers from the
 	// handoff. A concurrent session or context teardown can still use the Go
 	// process handle for the direct child, but can never signal its PID or PGID.
@@ -1841,7 +1863,10 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		case <-time.After(sessionGrace):
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: timed out waiting for MCP input drain after session teardown\n")
 		}
-		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "upstream_closed")
+		// Name the actual cause. Reusing "upstream_closed" here would attribute
+		// a session teardown to the server having closed the connection, so the
+		// receipt would record the wrong reason for an aborted request.
+		emitPendingIncompleteOutcomes(safeLogW, tracker, fwdOpts, "session_exit")
 	} else {
 		// Wait for stdin goroutine to finish (server exit closes pipe, unblocking scanner).
 		<-inputDone

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1778,12 +1778,10 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		_ = cmd.Process.Kill()
 	}
 
-	// Hand the process identifiers to cmd.Wait before reaping. Once this
-	// begins, concurrent session or context teardown must not signal a PID or
-	// process group that the kernel can recycle after the child exits.
-	processExit.beginReap()
-	// Wait for subprocess to exit.
-	waitErr := cmd.Wait()
+	// cmd.Wait and forced teardown share one owner. A concurrent session or
+	// context teardown waits until reaping finishes, then sees that no process
+	// identifier remains safe to signal.
+	waitErr := processExit.wait(cmd.Wait)
 	// Release the session watcher's drain wait. A server that exited on its
 	// own after stdin close must not sit through the remaining grace window
 	// before the teardown below claims ownership.

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -186,6 +186,9 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 			if wsutil.IsExpectedCloseErr(err) {
 				break
 			}
+			if opts.sessionExit.inProgress() && isSessionExitCloseErr(err) {
+				break
+			}
 			// Upstream response timeout: return the sentinel so the owning
 			// transport tears down the hung upstream and decides the failure
 			// scope. Returning (not break) is load-bearing: a clean-EOF break
@@ -1336,6 +1339,10 @@ type InputScanConfig struct {
 // starts and its PID is registered with the lineage tracker; callers use
 // this to start the file sentry event loop after attribution is ready.
 func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW io.Writer, command []string, opts MCPProxyOpts, extraEnv ...string) error {
+	// Capture before integrity preparation, pipe setup, and child startup. If
+	// the launcher dies during that work, the watcher must retain the original
+	// owner instead of observing PID 1 and incorrectly becoming inert.
+	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	var cmd *exec.Cmd
 	var prepared *integrity.PreparedCommand
 	if icfg := opts.IntegrityCfg; icfg != nil && icfg.Enabled {
@@ -1409,7 +1416,16 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		return fmt.Errorf("creating stdout pipe: %w", err)
 	}
 
-	cmd.Stderr = safeLogW
+	// Own the stderr pipe rather than assigning cmd.Stderr directly. The
+	// os/exec convenience path waits for its private copier inside cmd.Wait;
+	// a descendant that escapes the child group while holding stderr open
+	// would therefore make the adopted-descendant sweep unreachable. Owning
+	// the read end lets session teardown release it before Wait.
+	serverErr, serverErrW, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("creating stderr pipe: %w", err)
+	}
+	cmd.Stderr = serverErrW
 
 	// Put the child in its own process group so pipelock can tear down
 	// any grandchildren the MCP server spawned when the child exits.
@@ -1460,8 +1476,16 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	}
 
 	if err := cmd.Start(); err != nil {
+		_ = serverErr.Close()
+		_ = serverErrW.Close()
 		return fmt.Errorf("starting MCP server %q: %w", command[0], err)
 	}
+	_ = serverErrW.Close()
+	stderrDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(safeLogW, serverErr)
+		close(stderrDone)
+	}()
 	if prepared != nil {
 		startedPreparation := prepared
 		prepared = nil
@@ -1518,6 +1542,78 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	}()
 	defer close(pgidDone)
 
+	// Session-bound exit. A stdio proxy is owned by the interactive agent
+	// session that spawned it: when that session dies, this process and the
+	// MCP server it fronts have no reason to exist, but nothing in the
+	// lifetime handling above notices. Pdeathsig and the subreaper bit are
+	// both armed on the CHILD and answer "what happens when pipelock dies";
+	// neither answers "what happens when pipelock's own parent dies". The
+	// client stdin reader hitting EOF closes the wrapped server's stdin, and
+	// for a server that ignores stdin close that is not a shutdown at all -
+	// cmd.Wait pins forever and the whole tree leaks for days while still
+	// holding config, compiled pattern sets and credential-bearing children.
+	//
+	// The teardown ordering below is a drain, not a kill: stop intake, let
+	// in-flight responses finish, and only escalate to the process-tree
+	// teardown for a server that will not leave on its own.
+	//
+	// This is defense in depth for an unclean harness exit. The primary
+	// repair is a per-session cgroup boundary owned by the spawning harness,
+	// which is strictly stronger because it also catches descendants that
+	// create new process groups.
+	waitDone := make(chan struct{})
+	sessionExit := &sessionExitState{}
+	sessionCtx, sessionStop := context.WithCancel(ctx)
+	defer sessionStop()
+	// The parent PID was captured at function entry, before startup work can
+	// observe a post-exit PID 1 and make the watcher permanently inert.
+	sessionOpts := startupParentWatch
+	sessionOpts.logW = safeLogW
+	sessionGrace := defaultParentExitGrace
+	if h := opts.sessionExitForTest; h != nil {
+		sessionOpts = h.watch
+		sessionOpts.logW = safeLogW
+		sessionGrace = h.grace
+	}
+	if sessionOpts.startPPID > orphanedPPID {
+		go runSessionBoundExit(sessionCtx, sessionOpts, sessionExitActions{
+			onSessionExit: sessionExit.begin,
+			stopIntake: func() {
+				if c, ok := clientIn.(io.Closer); ok {
+					_ = c.Close()
+				}
+			},
+			closeServerStdin: func() { _ = serverIn.Close() },
+			// Tear down the whole process group, not just the direct child.
+			//
+			// Killing only cmd.Process is not enough and deadlocks: any
+			// sibling the server spawned inherited the stdout pipe, so the
+			// write end stays open after the direct child dies and the
+			// response reader blocks forever on a pipe that will never close.
+			// That reader has to return before cmd.Wait can, and the post-Wait
+			// teardown is what would have killed the pipe holders - so the
+			// shutdown waits on itself and the tree leaks exactly as it did
+			// before this watcher existed. Signaling the group first releases
+			// the descriptor and lets Wait return, after which the normal
+			// teardown reaps detached and adopted descendants the group kill
+			// could not reach.
+			terminateTree: func() {
+				terminateProcessGroup(childPgid)
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+				// A descendant can escape the child group with setsid while
+				// retaining stdout. Closing our read end releases ForwardScanned
+				// so cmd.Wait and its adopted-descendant sweep are reachable.
+				_ = serverOut.Close()
+				_ = serverErr.Close()
+			},
+			waitDone: waitDone,
+			grace:    sessionGrace,
+			logW:     safeLogW,
+		})
+	}
+
 	// Signal that the child is started and PID is tracked. The file sentry
 	// event loop starts here so attribution is ready before classifying writes.
 	if opts.OnChildReady != nil {
@@ -1567,6 +1663,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	inputOpts := opts
 	inputOpts.Rec = rec
 	inputOpts.WarnContext = ctx
+	inputOpts.sessionExit = sessionExit
 
 	// Forward client input to server stdin (with optional input scanning).
 	var wg sync.WaitGroup
@@ -1653,6 +1750,10 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 
 	// Wait for subprocess to exit.
 	waitErr := cmd.Wait()
+	// Release the session watcher's drain wait. A server that exited on its
+	// own after stdin close must not sit through the remaining grace window
+	// before the teardown below claims ownership.
+	close(waitDone)
 
 	// After the direct child exits, tear down everything it spawned.
 	// Three layers of cleanup that together cover fast common-case
@@ -1682,6 +1783,9 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// Sweep orphans the pgid kill couldn't reach. Safe even on
 	// non-Linux builds - the stub is a no-op there.
 	killAdoptedDescendants()
+	// A detached descendant can retain stderr after the direct child exits.
+	// Drain it only after the sweep above has released every remaining writer.
+	<-stderrDone
 
 	if timedOut {
 		// Closing a closable clientIn above wakes the usual CLI/pipe readers.


### PR DESCRIPTION
## What changed

An MCP proxy stayed alive after the agent session that spawned it exited, so scanner processes and the MCP servers they front kept running for days while still holding config, compiled pattern sets and credential-bearing children. Lifetime handling was asymmetric: the proxy asked the kernel to kill its child if the proxy died, and exited when that child exited, but nothing detected the proxy's own parent dying.

The proxy is now bound to its spawning session by watching for reparenting, which the kernel performs only when the original parent dies. On confirmed death it stops request intake, closes the wrapped server's stdin so a cooperative server can finish in-flight work, and escalates to a full process-group teardown only for a server that does not exit on its own. Descriptor-close errors are suppressed only while that teardown is active, and only for an already-closed descriptor, so an intentional shutdown no longer reports itself as a scanner failure while genuine scanner errors still log.

Coverage spans the stdio subprocess, stdio-to-HTTP bridge and HTTP listener modes. A descendant that escapes into its own session while holding stdout or stderr previously left the teardown unreachable, because the response reader blocked on a pipe whose remaining holder could only be killed by cleanup that ran after that reader returned, so cleanup now owns both streams and signals the process group rather than the direct child alone.

Process age and stdin EOF are both rejected as signals. Age kills healthy long-lived sessions, and EOF describes one pipe rather than session lifetime; either would tear down a live scanner mid-call, which drives operators to disable the control.

The failure direction to distrust here is availability, not detection. Every new branch leans toward staying alive: an unrecognisable parent, an unchanged parent, or a cancelled context all leave the proxy running, and only an observed reparent triggers teardown. Reviewers should attack the case where a live session is wrongly torn down, since that breaks traffic mid-call and is the more damaging error for a runtime control.

Two limits are known and deliberate. Reparenting cannot distinguish a dead session from a short-lived launcher that exits while its session keeps running, which is why a session boundary owned by the spawning harness remains the stronger repair and is tracked separately. The stdio-to-WebSocket and sandboxed stdio paths are not yet bound and carry the same lifetime gap; they are queued as follow-up work rather than left unrecorded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP proxy sessions now detect when their launching process exits and shut down cleanly.
  * Improved cleanup terminates lingering child processes and descendants, including those holding open pipes.
  * Shutdown remains bounded when input or logging streams stop responding.
  * Expected shutdown errors are no longer reported as unexpected failures.
  * HTTP proxy and listener sessions now stop reliably when their parent session ends.

* **Tests**
  * Added comprehensive coverage for session termination, timeout cleanup, process-tree cleanup, and live-session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->