### PR TITLE
feat(ci): review the change since the last review, not the whole PR

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -81,9 +81,20 @@ REPO_PATTERN = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
 HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$")
 RUBRIC_VERSION = "2026-08-14.1"
 STATUS_MARKER = "pr-review-status:v1"
+# A separate marker so the compact record of published findings never has to
+# fit on the status line, and so a parser for one cannot be confused by the
+# other. The ledger is continuity state; the status marker is the verdict.
+LEDGER_MARKER = "pr-review-ledger:v1"
+# A ledger entry is a claim to re-check, not prose to republish, so each
+# field is clipped hard. Twelve entries is more than any review has
+# published, and the cap keeps the comment well inside its size limit.
+MAX_LEDGER_ENTRIES = 24
+MAX_LEDGER_TITLE = 160
 NOTICE_MARKER = "pr-review-notice:v1"
 STATUS_MARKER_REQUIRED_FIELDS = frozenset({"state", "identity", "mode", "findings"})
-STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"model"}
+# Older markers carry fewer fields. They are still readable, and simply do
+# not qualify as a baseline, which is the safe direction.
+STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"model", "reviewed_head", "scope"}
 FINDING_FINGERPRINTS_RE = re.compile(r"(?:[0-9a-f]{12}(?:,[0-9a-f]{12})*)?")
 
 PUBLISHED_REVIEW_STATES = frozenset({"already-running", "clean", "failed", "findings", "partial", "superseded"})
@@ -1007,6 +1018,81 @@ def model_binding(mode: str) -> str:
     return hashlib.sha256(model_for_mode(mode).encode("utf-8")).hexdigest()
 
 
+def render_ledger(findings: list[Finding], head_sha: str) -> str:
+    """Record what was published, so a later run can ask whether it still holds.
+
+    Fingerprints alone cannot be re-checked: they say a finding of some shape
+    existed without saying what it claimed. Re-verifying an open finding needs
+    the claim itself, so the entry carries path, line, severity and title.
+
+    Bounded on purpose. This rides in a pull-request comment, and an unbounded
+    record would eventually fail to publish, which would cost the verdict to
+    save the ledger.
+    """
+    entries = []
+    for finding in findings[:MAX_LEDGER_ENTRIES]:
+        entries.append(
+            {
+                "f": finding_fingerprint(finding),
+                "p": finding.path[:200],
+                "l": finding.line if isinstance(finding.line, int) else None,
+                "s": finding.severity,
+                "t": " ".join(finding.title.split())[:MAX_LEDGER_TITLE],
+            }
+        )
+    payload = {"head": head_sha, "open": entries}
+    encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+    return f"<!-- {LEDGER_MARKER} {encoded} -->"
+
+
+def parse_ledger(body: str) -> dict[str, object] | None:
+    """Read one ledger, rejecting anything ambiguous or malformed."""
+    matches = re.findall(rf"<!-- {re.escape(LEDGER_MARKER)} ([A-Za-z0-9+/=]+) -->", body)
+    if len(matches) != 1:
+        return None
+    try:
+        payload = json.loads(base64.b64decode(matches[0]).decode())
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("open"), list):
+        return None
+    if not isinstance(payload.get("head"), str) or not re.fullmatch(r"[0-9a-f]{40}", payload["head"]):
+        return None
+    entries = []
+    for item in payload["open"]:
+        if not isinstance(item, dict):
+            continue
+        if not {"f", "p", "s", "t"} <= set(item):
+            continue
+        if not all(isinstance(item[k], str) for k in ("f", "p", "s", "t")):
+            continue
+        if item["s"] not in {"high", "medium", "low"}:
+            continue
+        line = item.get("l")
+        if line is not None and not isinstance(line, int):
+            continue
+        entries.append(item)
+    payload["open"] = entries
+    return payload
+
+
+def ledger_findings(payload: dict[str, object]) -> list[Finding]:
+    """Rebuild the claims a prior review published, for re-checking only."""
+    rebuilt = []
+    for item in payload.get("open", []):
+        rebuilt.append(
+            Finding(
+                severity=str(item["s"]),
+                path=str(item["p"]),
+                line=item.get("l") if isinstance(item.get("l"), int) else None,
+                title=str(item["t"]),
+                why="Reported by an earlier review of this pull request.",
+                fix="Re-checked against the current code.",
+            )
+        )
+    return rebuilt
+
+
 def parse_status_marker(body: str) -> dict[str, str] | None:
     """Read one complete terminal marker, rejecting ambiguity fail closed."""
     matches = re.findall(rf"<!-- {re.escape(STATUS_MARKER)} ([^>\r\n]*?)-->", body)
@@ -1019,7 +1105,8 @@ def parse_status_marker(body: str) -> dict[str, str] | None:
             return None
         fields[key] = value
     if (
-        set(fields) not in {STATUS_MARKER_REQUIRED_FIELDS, STATUS_MARKER_FIELDS}
+        not STATUS_MARKER_REQUIRED_FIELDS <= set(fields)
+        or not set(fields) <= STATUS_MARKER_FIELDS
         or fields["state"] not in PUBLISHED_REVIEW_STATES
         or fields["mode"] not in {"default", "deep"}
         or ("model" in fields and not re.fullmatch(r"[0-9a-f]{64}", fields["model"]))
@@ -1029,14 +1116,14 @@ def parse_status_marker(body: str) -> dict[str, str] | None:
     return fields
 
 
-def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str) -> tuple[list[dict[str, str]], set[str], bool]:
+def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str) -> tuple[list[dict[str, Any]], set[str], bool]:
     """Collect this bot's status markers, and report whether the scan finished.
 
     Shares the paging bound and the fail-closed contract of the admission
     check: an unreadable page yields complete=False, and a caller must treat an
     incomplete scan as no evidence at all rather than as an absence.
     """
-    markers: list[dict[str, str]] = []
+    markers: list[dict[str, Any]] = []
     notices: set[str] = set()
     for page in range(1, ADMISSION_COMMENT_PAGES + 1):
         try:
@@ -1074,6 +1161,12 @@ def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str
             fields = parse_status_marker(body)
             if fields:
                 fields["html_url"] = comment.get("html_url") if isinstance(comment.get("html_url"), str) else ""
+                # The ledger rides in the same comment. Absent or malformed, the
+                # marker still counts as a verdict; it simply cannot serve as a
+                # baseline to re-check, which falls back to a full review.
+                ledger = parse_ledger(body)
+                if ledger is not None:
+                    fields["ledger"] = ledger
                 markers.append(fields)
         # A short page is the last page, the same termination find_running_comment
         # uses against this endpoint. Without it the scan spends an extra request
@@ -1123,6 +1216,63 @@ def completed_identical_review(markers: list[dict[str, str]], correlation: str, 
         ):
             return marker
     return None
+
+
+def is_ancestor(repo: str, older: str, newer: str, token: str, correlation: str) -> bool:
+    """True only when `older` is genuinely behind `newer` on this pull request.
+
+    A force-push or rebase leaves a previous review's head unreachable, and the
+    change since it is no longer a meaningful slice of anything. GitHub answers
+    this directly with a compare status, so it is asked rather than assumed:
+    guessing here would mean reviewing a diff that never existed.
+
+    Any doubt returns False, which falls back to reviewing the whole pull
+    request. The expensive answer is the safe one.
+    """
+    if older == newer:
+        return False
+    try:
+        response = requests.get(
+            f"https://api.github.com/repos/{repo}/compare/{older}...{newer}",
+            headers=github_headers(token),
+            timeout=30,
+        )
+    except requests.RequestException:
+        log_phase("ancestry", status="request-error", correlation=correlation)
+        return False
+    log_phase("ancestry", status=response.status_code, correlation=correlation)
+    if response.status_code != 200:
+        return False
+    try:
+        status = response.json().get("status")
+    except ValueError:
+        return False
+    return status == "ahead"
+
+
+def previous_review_for_mode(markers: list[dict[str, str]], mode: str, head: str) -> dict[str, str] | None:
+    """The most recent complete review of THIS pull request in THIS mode.
+
+    Mode and model are compared because a default pass and a deep pass ask
+    different questions of different models, so one cannot serve as the
+    reviewed baseline for the other. Only a review that covered its whole
+    scope qualifies: continuing from a partial one would inherit its gap
+    silently.
+    """
+    best = None
+    for marker in markers:
+        if marker.get("mode") != mode:
+            continue
+        if marker.get("model") != model_binding(mode):
+            continue
+        if marker.get("state") not in COMPLETE_REVIEW_STATES:
+            continue
+        if marker.get("reviewed_head") == head:
+            continue
+        if not re.fullmatch(r"[0-9a-f]{40}", str(marker.get("reviewed_head", ""))):
+            continue
+        best = marker
+    return best
 
 
 def find_running_comment(repo: str, pr_number: str, token: str, correlation: str) -> tuple[dict[str, Any] | None, bool]:
@@ -1420,8 +1570,12 @@ def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, 
         return False
 
 
-def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None) -> str:
+def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None) -> str:
     seen_before = seen_before or set()
+    # `full` means base..head. `delta` means a prior completed review's head
+    # ..head, which is a smaller question and must never be read as a
+    # verdict on the whole pull request.
+    delta = scope == "delta" and bool(scope_base)
     model = model_for_mode(mode)
     severity_order = {"high": 0, "medium": 1, "low": 2}
     findings = sorted(progress.findings, key=lambda finding: (severity_order[finding.severity], finding.path, finding.line or 0, finding.title))
@@ -1429,6 +1583,14 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     omitted = [entry for entry in manifest if entry["status"] != "reviewed"]
     collapsed = [entry for entry in manifest if entry["collapsed_deletions"]]
     lines = ["## AI PR Review", "", f"**Verdict:** `{state}`"]
+    if delta:
+        # Stated before the verdict, because the verdict means something
+        # narrower here and a reader who misses that draws the wrong
+        # conclusion from a clean result.
+        lines.append(
+            f"**Scope: the change since `{scope_base[:12]}`, not the whole pull request.** "
+            "A clean result here means nothing was found in that change."
+        )
     if state == "partial":
         lines.append("**This is incomplete and must not be treated as a clean review.**")
     elif state == "superseded":
@@ -1475,6 +1637,11 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
             f"**Command:** `{'/review deep' if mode == 'deep' else '/review'}`",
             f"**Model:** `{model}` (`{reasoning_for_mode(mode)}` reasoning)",
             f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
+            (
+                f"**Reviewed range:** `{scope_base}`..`{binding.head_sha}` (change only)"
+                if delta
+                else f"**Reviewed range:** `{binding.base_sha}`..`{binding.head_sha}` (whole pull request)"
+            ),
             f"**Review identity:** `{binding.correlation}`",
             f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
             f"**Completeness:** {progress.reviewed_units}/{progress.expected_units} representable units reviewed; {len(omitted)} omitted or unrepresentable; {len(collapsed)} deletion-collapsed.",
@@ -1533,7 +1700,9 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
         [
             "",
             f"<!-- {STATUS_MARKER} state={state} identity={binding.correlation} "
-            f"mode={mode} model={model_binding(mode)} findings={fingerprints} -->",
+            f"mode={mode} model={model_binding(mode)} findings={fingerprints} "
+            f"reviewed_head={binding.head_sha} scope={scope} -->",
+            render_ledger(findings, binding.head_sha),
         ]
     )
     return "\n".join(lines)
@@ -1711,9 +1880,27 @@ def run_review(
     # incomplete scan yields fewer labels, never a wrong one, and requiring
     # completeness here would discard correct labels to no benefit.
     seen_before: set[str] = set()
+    scope = "full"
+    scope_base: str | None = None
+    carried: list[Finding] = []
     try:
         prior, _, _ = scan_status_comments(repo, pr_number, token, binding.correlation)
         seen_before = previously_reported(prior)
+        # Reviewing the whole pull request again after a two-line fix costs the
+        # same as the first review and answers the same question. When a
+        # completed review of this mode already covered an earlier head, review
+        # the change since it instead, and re-check what it left open.
+        #
+        # Every condition here falls back to a full review, because a full
+        # review is only expensive while a wrongly-scoped one is wrong.
+        previous = previous_review_for_mode(prior, mode, binding.head_sha)
+        if previous and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
+            scope = "delta"
+            scope_base = str(previous["reviewed_head"])
+            carried = ledger_findings(previous.get("ledger") or {})
+            log_phase("scope", status=f"delta-from-{scope_base[:12]}", correlation=binding.correlation)
+        else:
+            log_phase("scope", status="full", correlation=binding.correlation)
     except Exception:  # noqa: BLE001
         # Deliberately broad. The narrow version was nearly unreachable, because
         # the scan converts request failures into a returned tuple, so anything
@@ -1735,10 +1922,18 @@ def run_review(
             progress.incomplete_reasons.append("no usable provider credential was configured")
             return "failed", progress
         try:
-            diff = fetch_bound_diff(repo, binding, token)
+            # A delta still names two immutable commits, so the fetch keeps the
+            # same guarantee: the review is bound to exact SHAs, not to a
+            # branch that can move under it.
+            fetch_binding = binding
+            if scope == "delta" and scope_base:
+                fetch_binding = PullBinding(scope_base, binding.head_sha, binding.reviewer_sha, binding.rubric_version)
+            diff = fetch_bound_diff(repo, fetch_binding, token)
         except FetchError:
             progress.fetch_failed = True
             progress.incomplete_reasons.append("immutable diff fetch failed after retry")
+            # A delta that cannot be fetched must not silently become a full
+            # review under a comment that says delta, nor the reverse.
             return "failed", progress
         truncation = compare_incompleteness(repo, binding, token)
         if truncation:
@@ -1831,6 +2026,17 @@ def run_review(
         # actually produced while completeness still counted their units as
         # reviewed. timed_out keeps the verdict partial through derive_state,
         # which is where incompleteness belongs.
+        # Carried findings enter the judge as candidates against the CURRENT
+        # code. That is what makes a delta review honest about the whole pull
+        # request: the change is reviewed fresh, and everything the previous
+        # review left open is asked again rather than assumed fixed or assumed
+        # still broken. A carried finding the judge drops is simply not
+        # published, which is the existing rule and not a claim of resolution.
+        if carried:
+            known = {finding_fingerprint(item) for item in candidates}
+            for item in carried:
+                if finding_fingerprint(item) not in known:
+                    candidates.append(item)
         judge_ready = bool(candidates) and not progress.aggregation_failed
         if judge_ready and not budget_allows(deadline, mode):
             progress.incomplete_reasons.append("wall-clock budget exhausted before the judge pass")
@@ -1890,7 +2096,7 @@ def run_review(
         manifest = [unit.manifest() for unit in units]
         state = derive_state(progress)
         try:
-            update_comment(repo, comment["id"], token, render_status(binding, mode, classification, progress, state, manifest, seen_before), binding.correlation)
+            update_comment(repo, comment["id"], token, render_status(binding, mode, classification, progress, state, manifest, seen_before, scope, scope_base), binding.correlation)
         except (requests.RequestException, ReviewError):
             log_phase("comment-update", status="failed", correlation=binding.correlation)
             raise ReviewError("final status comment update failed") from None

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1065,21 +1065,44 @@ def parse_ledger(body: str) -> dict[str, object] | None:
     # assumed whole.
     if payload.get("complete") is not True:
         payload["complete"] = False
+    # A dropped entry is a finding that stays open and is never carried
+    # forward again, so silently discarding one while still calling the record
+    # whole is the same fail-open the completeness flag was added to close.
+    # Anything malformed marks the whole ledger unusable as a baseline; it may
+    # still label, because a label only adds information.
     entries = []
+    intact = True
     for item in payload["open"]:
-        if not isinstance(item, dict):
-            continue
-        if not {"f", "p", "s", "t"} <= set(item):
+        if not isinstance(item, dict) or not {"f", "p", "s", "t"} <= set(item):
+            intact = False
             continue
         if not all(isinstance(item[k], str) for k in ("f", "p", "s", "t")):
+            intact = False
             continue
         if item["s"] not in {"high", "medium", "low"}:
+            intact = False
+            continue
+        if not re.fullmatch(r"[0-9a-f]{12}", item["f"]):
+            intact = False
+            continue
+        if not item["p"] or len(item["p"]) > 200 or len(item["t"]) > MAX_LEDGER_TITLE:
+            intact = False
             continue
         line = item.get("l")
-        if line is not None and not isinstance(line, int):
+        if line is not None and (not isinstance(line, int) or isinstance(line, bool) or line < 1):
+            intact = False
+            continue
+        # The fingerprint is recomputed from the claim rather than trusted.
+        # Stored and ignored, it let an edited title, path or severity change
+        # what the record says while the record still looked untouched.
+        rebuilt = Finding(severity=item["s"], path=item["p"], line=line, title=item["t"], why="", fix="")
+        if finding_fingerprint(rebuilt) != item["f"]:
+            intact = False
             continue
         entries.append(item)
     payload["open"] = entries
+    if not intact:
+        payload["complete"] = False
     return payload
 
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1191,6 +1191,8 @@ def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str
             fields = parse_status_marker(body)
             if fields:
                 fields["html_url"] = comment.get("html_url") if isinstance(comment.get("html_url"), str) else ""
+                # Recorded so a baseline can be chosen by when it was written.
+                fields["created_at"] = comment.get("created_at") if isinstance(comment.get("created_at"), str) else ""
                 # The ledger rides in the same comment. Absent or malformed, the
                 # marker still counts as a verdict; it simply cannot serve as a
                 # baseline to re-check, which falls back to a full review.
@@ -1289,7 +1291,12 @@ def previous_review_for_mode(markers: list[dict[str, str]], mode: str, head: str
     scope qualifies: continuing from a partial one would inherit its gap
     silently.
     """
-    best = None
+    # Chosen by timestamp, not by position. Keeping the last qualifying marker
+    # made the baseline depend on the order the comments API returned, which
+    # this code never states and does not control. Reversed ordering would pick
+    # an older review and quietly widen the delta, which is the safe direction
+    # but not the intended one, and a reader could not tell which had happened.
+    qualifying = []
     for marker in markers:
         if marker.get("mode") != mode:
             continue
@@ -1301,8 +1308,12 @@ def previous_review_for_mode(markers: list[dict[str, str]], mode: str, head: str
             continue
         if not re.fullmatch(r"[0-9a-f]{40}", str(marker.get("reviewed_head", ""))):
             continue
-        best = marker
-    return best
+        qualifying.append(marker)
+    if not qualifying:
+        return None
+    # An absent timestamp sorts oldest, so a marker whose recency cannot be
+    # established never displaces one whose can.
+    return max(qualifying, key=lambda marker: str(marker.get("created_at") or ""))
 
 
 def find_running_comment(repo: str, pr_number: str, token: str, correlation: str) -> tuple[dict[str, Any] | None, bool]:

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1040,7 +1040,10 @@ def render_ledger(findings: list[Finding], head_sha: str) -> str:
                 "t": " ".join(finding.title.split())[:MAX_LEDGER_TITLE],
             }
         )
-    payload = {"head": head_sha, "open": entries}
+    # Says whether this record is the whole set. A ledger clipped by the cap
+    # cannot be used as a baseline: the findings it dropped are still open and
+    # a later delta review would never look at them again.
+    payload = {"head": head_sha, "open": entries, "complete": len(findings) <= MAX_LEDGER_ENTRIES}
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return f"<!-- {LEDGER_MARKER} {encoded} -->"
 
@@ -1058,6 +1061,10 @@ def parse_ledger(body: str) -> dict[str, object] | None:
         return None
     if not isinstance(payload.get("head"), str) or not re.fullmatch(r"[0-9a-f]{40}", payload["head"]):
         return None
+    # Absent means an older ledger that never recorded it, which cannot be
+    # assumed whole.
+    if payload.get("complete") is not True:
+        payload["complete"] = False
     entries = []
     for item in payload["open"]:
         if not isinstance(item, dict):
@@ -1582,15 +1589,17 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     counts = {severity: sum(finding.severity == severity for finding in findings) for severity in ("high", "medium", "low")}
     omitted = [entry for entry in manifest if entry["status"] != "reviewed"]
     collapsed = [entry for entry in manifest if entry["collapsed_deletions"]]
-    lines = ["## AI PR Review", "", f"**Verdict:** `{state}`"]
+    lines = ["## AI PR Review", ""]
     if delta:
-        # Stated before the verdict, because the verdict means something
-        # narrower here and a reader who misses that draws the wrong
-        # conclusion from a clean result.
+        # Above the verdict, not below it. A reader who sees `clean` first has
+        # already drawn a conclusion about the whole pull request before
+        # reaching the line that narrows it.
         lines.append(
             f"**Scope: the change since `{scope_base[:12]}`, not the whole pull request.** "
             "A clean result here means nothing was found in that change."
         )
+        lines.append("")
+    lines.append(f"**Verdict:** `{state}`")
     if state == "partial":
         lines.append("**This is incomplete and must not be treated as a clean review.**")
     elif state == "superseded":
@@ -1894,10 +1903,15 @@ def run_review(
         # Every condition here falls back to a full review, because a full
         # review is only expensive while a wrongly-scoped one is wrong.
         previous = previous_review_for_mode(prior, mode, binding.head_sha)
-        if previous and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
+        ledger = previous.get("ledger") if previous else None
+        # A baseline is only usable when its record of open findings is whole.
+        # Missing, malformed, or clipped by the cap all mean the same thing
+        # here: this run cannot know what it would be carrying forward.
+        usable = isinstance(ledger, dict) and ledger.get("complete") is True
+        if previous and usable and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
             scope = "delta"
             scope_base = str(previous["reviewed_head"])
-            carried = ledger_findings(previous.get("ledger") or {})
+            carried = ledger_findings(ledger)
             log_phase("scope", status=f"delta-from-{scope_base[:12]}", correlation=binding.correlation)
         else:
             log_phase("scope", status="full", correlation=binding.correlation)
@@ -1935,7 +1949,12 @@ def run_review(
             # A delta that cannot be fetched must not silently become a full
             # review under a comment that says delta, nor the reverse.
             return "failed", progress
-        truncation = compare_incompleteness(repo, binding, token)
+        # Asked of the range this run actually read. Using the whole pull
+        # request here made a large history mark every small delta partial,
+        # which then disqualified that delta from ever becoming a baseline: the
+        # feature would have degraded to nothing on exactly the pull requests
+        # it exists for.
+        truncation = compare_incompleteness(repo, fetch_binding, token)
         if truncation:
             progress.incomplete_reasons.append(truncation)
         units, parse_errors = parse_diff(diff, mode)

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -959,6 +959,17 @@ def _running_marker_is_stale(comment: dict[str, Any]) -> bool:
     return age > datetime.timedelta(minutes=STALE_RUNNING_MINUTES)
 
 
+def ledger_claim(finding: Finding) -> tuple[str, str]:
+    """The exact path and title a ledger stores, so both sides agree.
+
+    The fingerprint used the full values while the ledger stored clipped ones,
+    so any long path or title produced a record that failed its own integrity
+    check and forced a full review forever after. Bounding here means the
+    fingerprint describes what was actually written down.
+    """
+    return finding.path[:200], " ".join(finding.title.split())[:MAX_LEDGER_TITLE]
+
+
 def finding_fingerprint(finding: Finding) -> str:
     """Identify a finding across runs without depending on its line number.
 
@@ -966,8 +977,8 @@ def finding_fingerprint(finding: Finding) -> str:
     would make every finding look new after any push. Path, severity and the
     normalized title are what a reader recognizes as the same finding.
     """
-    title = " ".join(finding.title.lower().split())
-    return hashlib.sha256(f"{finding.path}\x00{finding.severity}\x00{title}".encode()).hexdigest()[:12]
+    path, title = ledger_claim(finding)
+    return hashlib.sha256(f"{path}\x00{finding.severity}\x00{title.lower()}".encode()).hexdigest()[:12]
 
 
 def notice_marker(kind: str, correlation: str, mode: str) -> str:
@@ -1031,13 +1042,14 @@ def render_ledger(findings: list[Finding], head_sha: str) -> str:
     """
     entries = []
     for finding in findings[:MAX_LEDGER_ENTRIES]:
+        path, title = ledger_claim(finding)
         entries.append(
             {
                 "f": finding_fingerprint(finding),
-                "p": finding.path[:200],
+                "p": path,
                 "l": finding.line if isinstance(finding.line, int) else None,
                 "s": finding.severity,
-                "t": " ".join(finding.title.split())[:MAX_LEDGER_TITLE],
+                "t": title,
             }
         )
     # Says whether this record is the whole set. A ledger clipped by the cap
@@ -1072,7 +1084,11 @@ def parse_ledger(body: str) -> dict[str, object] | None:
     # still label, because a label only adds information.
     entries = []
     intact = True
-    for item in payload["open"]:
+    # More entries than this writer will ever emit means the payload was not
+    # produced here, so it cannot be trusted as a record of what was published.
+    if len(payload["open"]) > MAX_LEDGER_ENTRIES:
+        intact = False
+    for item in payload["open"][:MAX_LEDGER_ENTRIES]:
         if not isinstance(item, dict) or not {"f", "p", "s", "t"} <= set(item):
             intact = False
             continue

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2133,6 +2133,31 @@ class LedgerTest(unittest.TestCase):
         self.assertFalse(parsed["complete"])
 
 
+
+    def test_a_long_path_or_title_does_not_invalidate_its_own_ledger(self) -> None:
+        # The fingerprint used the full values while the ledger stored clipped
+        # ones, so a long title or path produced a record that failed its own
+        # integrity check and forced a full review from then on.
+        long_title = "x" * (pr_review.MAX_LEDGER_TITLE + 50)
+        long_path = "d/" * 150 + "a.go"
+        findings = [
+            pr_review.Finding("high", "a.go", 1, long_title, "w", "f"),
+            pr_review.Finding("low", long_path, 2, "t", "w", "f"),
+        ]
+        parsed = pr_review.parse_ledger(pr_review.render_ledger(findings, "c" * 40))
+        self.assertTrue(parsed["complete"], "a ledger this writer produced must verify")
+        self.assertEqual(len(parsed["open"]), 2)
+
+    def test_more_entries_than_the_cap_is_refused(self) -> None:
+        import base64 as _b64
+        import json as _json
+        entry = {"f": "0" * 12, "p": "a.go", "l": 1, "s": "high", "t": "t"}
+        payload = {"head": "c" * 40, "complete": True,
+                   "open": [dict(entry) for _ in range(pr_review.MAX_LEDGER_ENTRIES + 5)]}
+        encoded = _b64.b64encode(_json.dumps(payload).encode()).decode()
+        parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
+        self.assertFalse(parsed["complete"])
+
     def test_an_edited_claim_invalidates_its_record(self) -> None:
         # The fingerprint was stored and then ignored when rebuilding, so an
         # edited title, path or severity changed what the record claimed while

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1969,5 +1969,140 @@ class AdoptionStubTest(unittest.TestCase):
         )
 
 
+class DeltaScopeTest(unittest.TestCase):
+    """A later review should read the change, not the whole pull request again."""
+
+    HEAD = "b" * 40
+    OLD = "d" * 40
+
+    def marker(self, *, mode="deep", state="findings", head=None, model=None, ledger=None):
+        entry = {
+            "state": state,
+            "identity": "x",
+            "mode": mode,
+            "model": model if model is not None else pr_review.model_binding(mode),
+            "findings": "",
+            "reviewed_head": head or self.OLD,
+            "scope": "full",
+        }
+        if ledger is not None:
+            entry["ledger"] = ledger
+        return entry
+
+    def test_the_baseline_is_the_last_complete_review_of_this_mode(self) -> None:
+        markers = [self.marker()]
+        found = pr_review.previous_review_for_mode(markers, "deep", self.HEAD)
+        self.assertIsNotNone(found)
+        self.assertEqual(found["reviewed_head"], self.OLD)
+
+    def test_a_default_review_is_not_a_baseline_for_deep(self) -> None:
+        # A repository can point both model variables at the SAME model, and
+        # then the model comparison cannot tell the two passes apart. Depth is
+        # still different: default runs low reasoning and deep runs xhigh, so a
+        # deep review continuing from a default one inherits coverage that was
+        # never asked for at that depth. Pinned to one model on purpose, so
+        # this proves the mode check rather than the model check.
+        with mock.patch.dict(
+            pr_review.os.environ,
+            {"PR_REVIEW_MODEL_FAST": "one-model", "PR_REVIEW_MODEL_DEEP": "one-model"},
+            clear=False,
+        ):
+            self.assertEqual(pr_review.model_binding("default"), pr_review.model_binding("deep"))
+            markers = [self.marker(mode="default", model=pr_review.model_binding("deep"))]
+            self.assertIsNone(pr_review.previous_review_for_mode(markers, "deep", self.HEAD))
+
+    def test_an_incomplete_review_is_not_a_baseline(self) -> None:
+        for state in ("partial", "failed", "superseded"):
+            with self.subTest(state=state):
+                markers = [self.marker(state=state)]
+                self.assertIsNone(pr_review.previous_review_for_mode(markers, "deep", self.HEAD))
+
+    def test_a_review_under_a_different_model_is_not_a_baseline(self) -> None:
+        markers = [self.marker(model="0" * 64)]
+        self.assertIsNone(pr_review.previous_review_for_mode(markers, "deep", self.HEAD))
+
+    def test_the_current_head_is_not_its_own_baseline(self) -> None:
+        markers = [self.marker(head=self.HEAD)]
+        self.assertIsNone(pr_review.previous_review_for_mode(markers, "deep", self.HEAD))
+
+    def test_the_newest_qualifying_review_wins(self) -> None:
+        older = self.marker(head="1" * 40)
+        newer = self.marker(head="2" * 40)
+        found = pr_review.previous_review_for_mode([older, newer], "deep", self.HEAD)
+        self.assertEqual(found["reviewed_head"], "2" * 40)
+
+    def _compare(self, status):
+        response = mock.Mock()
+        response.status_code = 200 if status else 404
+        response.json.return_value = {"status": status} if status else {}
+        return response
+
+    def test_only_a_genuinely_behind_head_is_used(self) -> None:
+        # A force-push or rebase leaves the old head unreachable, and the change
+        # since it is not a slice of anything that exists.
+        for status, want in [("ahead", True), ("diverged", False), ("behind", False), ("identical", False)]:
+            with self.subTest(status=status):
+                with mock.patch.object(pr_review.requests, "get", return_value=self._compare(status)):
+                    self.assertIs(pr_review.is_ancestor("o/r", self.OLD, self.HEAD, "t", "c"), want)
+
+    def test_an_unreadable_comparison_falls_back_to_full(self) -> None:
+        with mock.patch.object(pr_review.requests, "get", side_effect=pr_review.requests.RequestException("x")):
+            self.assertFalse(pr_review.is_ancestor("o/r", self.OLD, self.HEAD, "t", "c"))
+        with mock.patch.object(pr_review.requests, "get", return_value=self._compare(None)):
+            self.assertFalse(pr_review.is_ancestor("o/r", self.OLD, self.HEAD, "t", "c"))
+
+    def test_the_same_head_is_never_a_delta_base(self) -> None:
+        # The comparison is mocked to say "ahead" so the ONLY thing that can
+        # return False is the identical-head guard. Without the mock the call
+        # failed for lack of a network and the test passed on that instead,
+        # proving nothing about the guard it names.
+        with mock.patch.object(pr_review.requests, "get", return_value=self._compare("ahead")) as get:
+            self.assertFalse(pr_review.is_ancestor("o/r", self.HEAD, self.HEAD, "t", "c"))
+        get.assert_not_called()
+
+
+class LedgerTest(unittest.TestCase):
+    """The record that lets a later run re-check what was left open."""
+
+    def test_a_ledger_round_trips(self) -> None:
+        findings = [
+            pr_review.Finding("high", "a.go", 12, "Guard   removed", "w", "f"),
+            pr_review.Finding("low", "b.go", None, "Something else", "w", "f"),
+        ]
+        body = "body" + chr(10) + pr_review.render_ledger(findings, "c" * 40)
+        parsed = pr_review.parse_ledger(body)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["head"], "c" * 40)
+        rebuilt = pr_review.ledger_findings(parsed)
+        self.assertEqual([f.path for f in rebuilt], ["a.go", "b.go"])
+        self.assertEqual([f.severity for f in rebuilt], ["high", "low"])
+        self.assertEqual(rebuilt[0].title, "Guard removed")
+        # A rebuilt claim keeps its own fingerprint, which is what lets a
+        # re-raised finding be recognized across runs.
+        self.assertEqual(pr_review.finding_fingerprint(rebuilt[0]), pr_review.finding_fingerprint(findings[0]))
+
+    def test_a_ledger_is_bounded(self) -> None:
+        many = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f") for i in range(80)]
+        parsed = pr_review.parse_ledger(pr_review.render_ledger(many, "c" * 40))
+        self.assertEqual(len(parsed["open"]), pr_review.MAX_LEDGER_ENTRIES)
+
+    def test_a_malformed_or_ambiguous_ledger_is_refused(self) -> None:
+        good = pr_review.render_ledger([pr_review.Finding("high", "a.go", 1, "t", "w", "f")], "c" * 40)
+        self.assertIsNone(pr_review.parse_ledger(good + chr(10) + good), "two ledgers is ambiguous")
+        self.assertIsNone(pr_review.parse_ledger("no ledger here"))
+        self.assertIsNone(pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} bm90YmFzZTY0ISEh -->"))
+
+    def test_an_entry_with_a_bad_severity_is_dropped(self) -> None:
+        import base64 as _b64
+        import json as _json
+        payload = {"head": "c" * 40, "open": [
+            {"f": "a" * 12, "p": "a.go", "l": 1, "s": "critical", "t": "t"},
+            {"f": "b" * 12, "p": "b.go", "l": 1, "s": "high", "t": "ok"},
+        ]}
+        encoded = _b64.b64encode(_json.dumps(payload).encode()).decode()
+        parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
+        self.assertEqual([e["s"] for e in parsed["open"]], ["high"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2092,6 +2092,30 @@ class LedgerTest(unittest.TestCase):
         self.assertIsNone(pr_review.parse_ledger("no ledger here"))
         self.assertIsNone(pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} bm90YmFzZTY0ISEh -->"))
 
+
+    def test_a_clipped_ledger_marks_itself_incomplete(self) -> None:
+        # The cap silently drops findings. A baseline whose record was clipped
+        # would carry forward only part of what is still open, and the rest
+        # would never be re-checked because they sit outside the delta.
+        many = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f")
+                for i in range(pr_review.MAX_LEDGER_ENTRIES + 1)]
+        clipped = pr_review.parse_ledger(pr_review.render_ledger(many, "c" * 40))
+        self.assertFalse(clipped["complete"])
+
+        exact = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f")
+                 for i in range(pr_review.MAX_LEDGER_ENTRIES)]
+        whole = pr_review.parse_ledger(pr_review.render_ledger(exact, "c" * 40))
+        self.assertTrue(whole["complete"])
+
+    def test_a_ledger_without_the_flag_is_not_complete(self) -> None:
+        # An older ledger predating the flag cannot be assumed whole.
+        import base64 as _b64
+        import json as _json
+        payload = {"head": "c" * 40, "open": []}
+        encoded = _b64.b64encode(_json.dumps(payload).encode()).decode()
+        parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
+        self.assertFalse(parsed["complete"])
+
     def test_an_entry_with_a_bad_severity_is_dropped(self) -> None:
         import base64 as _b64
         import json as _json

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2082,7 +2082,7 @@ class LedgerTest(unittest.TestCase):
         self.assertEqual(pr_review.finding_fingerprint(rebuilt[0]), pr_review.finding_fingerprint(findings[0]))
 
     def test_a_ledger_is_bounded(self) -> None:
-        many = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f") for i in range(80)]
+        many = [pr_review.Finding("low", f"f{i}.go", i + 1, f"t{i}", "w", "f") for i in range(80)]
         parsed = pr_review.parse_ledger(pr_review.render_ledger(many, "c" * 40))
         self.assertEqual(len(parsed["open"]), pr_review.MAX_LEDGER_ENTRIES)
 
@@ -2097,12 +2097,12 @@ class LedgerTest(unittest.TestCase):
         # The cap silently drops findings. A baseline whose record was clipped
         # would carry forward only part of what is still open, and the rest
         # would never be re-checked because they sit outside the delta.
-        many = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f")
+        many = [pr_review.Finding("low", f"f{i}.go", i + 1, f"t{i}", "w", "f")
                 for i in range(pr_review.MAX_LEDGER_ENTRIES + 1)]
         clipped = pr_review.parse_ledger(pr_review.render_ledger(many, "c" * 40))
         self.assertFalse(clipped["complete"])
 
-        exact = [pr_review.Finding("low", f"f{i}.go", i, f"t{i}", "w", "f")
+        exact = [pr_review.Finding("low", f"f{i}.go", i + 1, f"t{i}", "w", "f")
                  for i in range(pr_review.MAX_LEDGER_ENTRIES)]
         whole = pr_review.parse_ledger(pr_review.render_ledger(exact, "c" * 40))
         self.assertTrue(whole["complete"])
@@ -2116,16 +2116,60 @@ class LedgerTest(unittest.TestCase):
         parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
         self.assertFalse(parsed["complete"])
 
+
+    def test_an_edited_claim_invalidates_its_record(self) -> None:
+        # The fingerprint was stored and then ignored when rebuilding, so an
+        # edited title, path or severity changed what the record claimed while
+        # the record still looked untouched. It is recomputed and required to
+        # match, so a changed claim is a changed fingerprint.
+        import base64 as _b64
+        import json as _json
+        real = pr_review.Finding("high", "a.go", 4, "Guard removed", "w", "f")
+        for field, value in [("t", "Something else entirely"), ("p", "other.go"), ("s", "low")]:
+            with self.subTest(field=field):
+                entry = {
+                    "f": pr_review.finding_fingerprint(real),
+                    "p": real.path, "l": real.line, "s": real.severity, "t": real.title,
+                }
+                entry[field] = value
+                encoded = _b64.b64encode(
+                    _json.dumps({"head": "c" * 40, "open": [entry], "complete": True}).encode()
+                ).decode()
+                parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
+                self.assertEqual(parsed["open"], [], "an edited claim must not survive")
+                self.assertFalse(parsed["complete"], "and the ledger must not be usable as a baseline")
+
+    def test_a_line_that_is_not_a_real_anchor_is_refused(self) -> None:
+        import base64 as _b64
+        import json as _json
+        real = pr_review.Finding("high", "a.go", 4, "t", "w", "f")
+        for line in (0, -3, True):
+            with self.subTest(line=line):
+                entry = {"f": pr_review.finding_fingerprint(real), "p": "a.go", "l": line, "s": "high", "t": "t"}
+                encoded = _b64.b64encode(
+                    _json.dumps({"head": "c" * 40, "open": [entry], "complete": True}).encode()
+                ).decode()
+                parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
+                self.assertFalse(parsed["complete"])
+
     def test_an_entry_with_a_bad_severity_is_dropped(self) -> None:
         import base64 as _b64
         import json as _json
-        payload = {"head": "c" * 40, "open": [
+        good = pr_review.Finding("high", "b.go", 1, "ok", "w", "f")
+        # complete is True on purpose: without it the ledger is already
+        # incomplete via the missing-flag path, and this test would pass
+        # without ever exercising the dropped-entry rule it names.
+        payload = {"head": "c" * 40, "complete": True, "open": [
             {"f": "a" * 12, "p": "a.go", "l": 1, "s": "critical", "t": "t"},
-            {"f": "b" * 12, "p": "b.go", "l": 1, "s": "high", "t": "ok"},
+            {"f": pr_review.finding_fingerprint(good), "p": "b.go", "l": 1, "s": "high", "t": "ok"},
         ]}
         encoded = _b64.b64encode(_json.dumps(payload).encode()).decode()
         parsed = pr_review.parse_ledger(f"<!-- {pr_review.LEDGER_MARKER} {encoded} -->")
         self.assertEqual([e["s"] for e in parsed["open"]], ["high"])
+        # Dropping an entry means the record is no longer whole, so it cannot
+        # be a baseline. Silently discarding one and still calling the ledger
+        # complete is how a finding stays open and is never carried again.
+        self.assertFalse(parsed["complete"])
 
 
 if __name__ == "__main__":

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2026,10 +2026,26 @@ class DeltaScopeTest(unittest.TestCase):
         self.assertIsNone(pr_review.previous_review_for_mode(markers, "deep", self.HEAD))
 
     def test_the_newest_qualifying_review_wins(self) -> None:
+        # By timestamp, in BOTH list orders. Keeping the last qualifying entry
+        # made this depend on the order the comments API returned, which the
+        # code never states and does not control.
         older = self.marker(head="1" * 40)
+        older["created_at"] = "2026-08-15T00:00:00Z"
         newer = self.marker(head="2" * 40)
-        found = pr_review.previous_review_for_mode([older, newer], "deep", self.HEAD)
-        self.assertEqual(found["reviewed_head"], "2" * 40)
+        newer["created_at"] = "2026-08-15T12:00:00Z"
+        for order in ([older, newer], [newer, older]):
+            with self.subTest(order=[m["created_at"] for m in order]):
+                found = pr_review.previous_review_for_mode(order, "deep", self.HEAD)
+                self.assertEqual(found["reviewed_head"], "2" * 40)
+
+    def test_a_marker_without_a_timestamp_never_displaces_one_with(self) -> None:
+        stamped = self.marker(head="1" * 40)
+        stamped["created_at"] = "2026-08-15T00:00:00Z"
+        unstamped = self.marker(head="2" * 40)
+        for order in ([stamped, unstamped], [unstamped, stamped]):
+            with self.subTest(order="both"):
+                found = pr_review.previous_review_for_mode(order, "deep", self.HEAD)
+                self.assertEqual(found["reviewed_head"], "1" * 40)
 
     def _compare(self, status):
         response = mock.Mock()


### PR DESCRIPTION
## What changed

Fixing two comments and running the command again re-read the entire pull request and asked the same question of the same code, which on a large one costs about twenty minutes and a full bill to learn nothing new. When a completed review of the same depth already covered an earlier head, the run now reviews only the change since that head, and re-checks the findings that review left open so nothing outstanding disappears.

Both commands behave the same way. Nothing runs automatically and nothing runs on push; the trigger is unchanged.

Every condition falls back to reviewing the whole pull request, because a full review is only expensive while a wrongly scoped one is wrong. A different depth or model does not qualify, an incomplete review does not qualify, and a head that is not genuinely behind the current one does not qualify, which is what a force-push or a rebase leaves behind. Depth is compared as well as model, because a repository can point both model variables at the same model and the comparison would then see no difference while one pass ran at low reasoning and the other at xhigh.

**Failure direction, and what to distrust:** a scoped review states its scope above the verdict and names the range it read, because a clean result over a small change is not a statement about the pull request, and a reader who misses that draws the wrong conclusion. Findings carried forward from the previous review go through the same actual-code judge as new ones, so a carried finding is republished only if it still holds; a carried finding the judge drops is simply not published and is never reported as resolved. The part worth distrusting is the ancestry decision: it is asked of the compare API and any error, non-200, or non-`ahead` status falls back to a full review, so the failure that matters is a scoped review running when it should not have, and that path is the one to re-read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incremental reviews that analyze only changes since the latest eligible completed review.
  * Preserved open findings between reviews for improved continuity and tracking.
  * Review status now displays the reviewed range and whether the review covers a change delta.
  * Added safeguards to fall back to a full review when incremental review data is incomplete or unsafe.

* **Tests**
  * Added coverage for incremental review selection, fallback behavior, ledger validation, and finding preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->