### PR TITLE
fix(ci): authenticate the review ledger and correct delta coverage

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -92,14 +92,22 @@ LEDGER_MARKER = "pr-review-ledger:v1"
 MAX_LEDGER_ENTRIES = 24
 MAX_LEDGER_TITLE = 160
 LEDGER_SIGNATURE_FIELD = "signature"
+# coverage_base is signed with the rest because it is what lets a delta review
+# claim the whole pull request. An unsigned one would let a writer relabel a
+# narrow review as a complete one, which is the exact claim this field makes.
+# Adding it also retires every ledger written before it: the binding set no
+# longer matches, so an older record cannot be a baseline and its next review
+# is whole. That costs one full review per open pull request and is the safe
+# direction, since the alternative is inheriting a coverage claim from a record
+# that never made one.
 LEDGER_BINDING_FIELDS = frozenset(
-    {"state", "identity", "mode", "model", "findings", "reviewed_head", "scope"}
+    {"state", "identity", "mode", "model", "findings", "reviewed_head", "scope", "coverage_base"}
 )
 NOTICE_MARKER = "pr-review-notice:v1"
 STATUS_MARKER_REQUIRED_FIELDS = frozenset({"state", "identity", "mode", "findings"})
 # Older markers carry fewer fields. They are still readable, and simply do
 # not qualify as a baseline, which is the safe direction.
-STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"model", "reviewed_head", "scope"}
+STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"model", "reviewed_head", "scope", "coverage_base"}
 FINDING_FINGERPRINTS_RE = re.compile(r"(?:[0-9a-f]{12}(?:,[0-9a-f]{12})*)?")
 
 PUBLISHED_REVIEW_STATES = frozenset({"already-running", "clean", "failed", "findings", "partial", "superseded"})
@@ -198,6 +206,19 @@ class ReviewProgress:
     incomplete_reasons: list[str] = field(default_factory=list)
     findings: list[Finding] = field(default_factory=list)
     scope: str = "full"
+    # The commit this review's coverage reaches back to, counting the baseline
+    # chain it was built on. A full review covers from the pull request base, so
+    # scope and coverage agree. A delta covers only its own span, but inherits
+    # the base its baseline already covered, so a chain of deltas on top of one
+    # full review still accounts for the whole range. Kept as the base itself
+    # rather than a complete flag so it can be checked against the CURRENT base:
+    # if the pull request is rebased or retargeted, the inherited value stops
+    # matching and coverage correctly reads incomplete instead of stale-true.
+    coverage_base: str = ""
+    # The pull request base this run was bound to, carried so completeness can
+    # be judged where the run's result is published without threading the
+    # binding through. Coverage is only whole while these two agree.
+    base_sha: str = ""
 
 
 def log_phase(phase: str, *, attempt: int = 1, status: int | str = "n/a", correlation: str = "pending") -> None:
@@ -1847,6 +1868,11 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
         "findings": fingerprints,
         "reviewed_head": binding.head_sha,
         "scope": scope,
+        # What this review's coverage reaches back to, including the baselines
+        # it built on. scope says how this run was performed; coverage_base says
+        # how much of the pull request the result actually accounts for, and
+        # only the second one can answer whether the diff was covered.
+        "coverage_base": progress.coverage_base or binding.base_sha,
     }
     lines.extend(
         [
@@ -2034,6 +2060,10 @@ def run_review(
     seen_before: set[str] = set()
     scope = "full"
     scope_base: str | None = None
+    # A full review of this range is the default claim, and every fallback below
+    # lands here, so an unreadable or unusable baseline yields a whole review
+    # that honestly covers from the current base.
+    coverage_base = binding.base_sha
     carried: list[Finding] = []
     try:
         prior, _, _ = scan_status_comments(repo, pr_number, token, binding.correlation)
@@ -2051,10 +2081,23 @@ def run_review(
         # Missing, malformed, or clipped by the cap all mean the same thing
         # here: this run cannot know what it would be carrying forward.
         if previous and ledger and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
-            scope = "delta"
-            scope_base = str(previous["reviewed_head"])
-            carried = ledger_findings(ledger)
-            log_phase("scope", status=f"delta-from-{scope_base[:12]}", correlation=binding.correlation)
+            # The baseline covered its own coverage_base up to reviewed_head,
+            # and this run covers reviewed_head up to the current head, so the
+            # two together account for the baseline's coverage_base up to here.
+            # Inherit it rather than recomputing: it is the signed record of what
+            # was actually reviewed, and it is only trusted after usable_ledger
+            # has authenticated it above.
+            inherited = str(previous.get("coverage_base", ""))
+            if re.fullmatch(r"[0-9a-f]{40}", inherited):
+                scope = "delta"
+                scope_base = str(previous["reviewed_head"])
+                coverage_base = inherited
+                carried = ledger_findings(ledger)
+                log_phase("scope", status=f"delta-from-{scope_base[:12]}", correlation=binding.correlation)
+            else:
+                # Authenticated, but it does not say what it covered. Reviewing
+                # the whole range is the only claim this run can then make.
+                log_phase("scope", status="full-unknown-coverage", correlation=binding.correlation)
         else:
             log_phase("scope", status="full", correlation=binding.correlation)
     except Exception:  # noqa: BLE001
@@ -2066,6 +2109,8 @@ def run_review(
         # label is not worth that.
         log_phase("prior-findings", status="unavailable", correlation=binding.correlation)
     progress.scope = scope
+    progress.coverage_base = coverage_base
+    progress.base_sha = binding.base_sha
     try:
         # Checked before any provider work so a missing credential ends the run
         # as a configuration failure rather than a partial review, and checked
@@ -2342,7 +2387,22 @@ def main() -> None:
     # made a nine-finding review look like a crashed job, and inverting the
     # collapse would instead let an incomplete review show an all-green pull
     # request, which reads as reviewed when it was not.
-    complete = state in COMPLETE_REVIEW_STATES and progress.scope == "full"
+    # Coverage, not scope. A delta review performed on top of a chain that
+    # reaches the current base has accounted for the whole pull request, and
+    # gating on scope instead failed every review after the first while the
+    # diff was in fact fully covered. A gate that is red on a correct run is one
+    # an operator switches off, which costs more than it protects. Comparing
+    # against the CURRENT base is what keeps this honest: a rebase or retarget
+    # moves it, the inherited value stops matching, and coverage reads
+    # incomplete until a full review re-establishes it.
+    # Both sides must be present as well as equal. Two empty strings compare
+    # equal, and a run that never recorded either did not establish coverage,
+    # so requiring a real base keeps an unset pair from reading as complete.
+    complete = (
+        state in COMPLETE_REVIEW_STATES
+        and bool(progress.base_sha)
+        and progress.coverage_base == progress.base_sha
+    )
     write_action_outputs(state=state, complete="true" if complete else "false")
     if exit_code_for_state(state):
         raise SystemExit(1)

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import datetime
 import hashlib
+import hmac
 import json
 import math
 import os
@@ -90,6 +91,10 @@ LEDGER_MARKER = "pr-review-ledger:v1"
 # published, and the cap keeps the comment well inside its size limit.
 MAX_LEDGER_ENTRIES = 24
 MAX_LEDGER_TITLE = 160
+LEDGER_SIGNATURE_FIELD = "signature"
+LEDGER_BINDING_FIELDS = frozenset(
+    {"state", "identity", "mode", "model", "findings", "reviewed_head", "scope"}
+)
 NOTICE_MARKER = "pr-review-notice:v1"
 STATUS_MARKER_REQUIRED_FIELDS = frozenset({"state", "identity", "mode", "findings"})
 # Older markers carry fewer fields. They are still readable, and simply do
@@ -192,6 +197,7 @@ class ReviewProgress:
     head_changed: bool = False
     incomplete_reasons: list[str] = field(default_factory=list)
     findings: list[Finding] = field(default_factory=list)
+    scope: str = "full"
 
 
 def log_phase(phase: str, *, attempt: int = 1, status: int | str = "n/a", correlation: str = "pending") -> None:
@@ -1029,7 +1035,35 @@ def model_binding(mode: str) -> str:
     return hashlib.sha256(model_for_mode(mode).encode("utf-8")).hexdigest()
 
 
-def render_ledger(findings: list[Finding], head_sha: str) -> str:
+def ledger_signature(payload: dict[str, object]) -> str | None:
+    """Authenticate continuity state with the credential already needed to review.
+
+    A pull-request comment is readable by everyone with repository access and
+    editable by writers. Its author remains github-actions[bot] after an edit,
+    so author filtering cannot establish that the ledger still says what this
+    action published. A later run must therefore refuse unsigned continuity
+    state rather than treating an edited empty ledger as an honest clean
+    baseline. Rotating the provider credential invalidates old signatures and
+    deliberately falls back to a full review.
+    """
+    key = os.environ.get("OPENAI_API_KEY", "")
+    if not key:
+        return None
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hmac.new(
+        key.encode("utf-8"), b"pr-review-ledger:v1:" + encoded, hashlib.sha256
+    ).hexdigest()
+
+
+def render_ledger(
+    findings: list[Finding],
+    head_sha: str,
+    marker: dict[str, str] | None = None,
+    repository: str | None = None,
+    pr_number: str | None = None,
+) -> str:
     """Record what was published, so a later run can ask whether it still holds.
 
     Fingerprints alone cannot be re-checked: they say a finding of some shape
@@ -1055,7 +1089,22 @@ def render_ledger(findings: list[Finding], head_sha: str) -> str:
     # Says whether this record is the whole set. A ledger clipped by the cap
     # cannot be used as a baseline: the findings it dropped are still open and
     # a later delta review would never look at them again.
-    payload = {"head": head_sha, "open": entries, "complete": len(findings) <= MAX_LEDGER_ENTRIES}
+    payload: dict[str, object] = {
+        "head": head_sha,
+        "open": entries,
+        "complete": len(findings) <= MAX_LEDGER_ENTRIES,
+    }
+    if marker is not None and repository is not None and pr_number is not None:
+        # Bind the ledger to every status-marker field that admits it as a
+        # baseline. Signing only the entries would still let a comment editor
+        # relabel an old review as one for a different head, mode, or verdict.
+        payload["binding"] = {field: marker[field] for field in LEDGER_BINDING_FIELDS}
+        # A valid record from another pull request is not evidence about this
+        # one. Without this context, an editor could replay a genuine signed
+        # comment from a sibling pull request whose old head is an ancestor.
+        payload["context"] = {"repository": repository, "pr_number": pr_number}
+        if signature := ledger_signature(payload):
+            payload[LEDGER_SIGNATURE_FIELD] = signature
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return f"<!-- {LEDGER_MARKER} {encoded} -->"
 
@@ -1137,6 +1186,41 @@ def ledger_findings(payload: dict[str, object]) -> list[Finding]:
             )
         )
     return rebuilt
+
+
+def usable_ledger(
+    marker: dict[str, object], repository: str, pr_number: str
+) -> dict[str, object] | None:
+    """Return a whole, authenticated ledger bound to this status marker.
+
+    The comment is presentation, not a trust root. A writer may still delete
+    or corrupt it, which costs the optimization and makes the next review
+    whole. They cannot edit any field that selects a smaller diff or carries
+    fewer findings without the provider credential used to make the MAC.
+    """
+    ledger = marker.get("ledger")
+    if not isinstance(ledger, dict) or ledger.get("complete") is not True:
+        return None
+    binding = ledger.get("binding")
+    if not isinstance(binding, dict) or set(binding) != LEDGER_BINDING_FIELDS:
+        return None
+    if any(
+        not isinstance(binding.get(field), str) or binding[field] != marker.get(field)
+        for field in LEDGER_BINDING_FIELDS
+    ):
+        return None
+    if ledger.get("head") != marker.get("reviewed_head"):
+        return None
+    if ledger.get("context") != {"repository": repository, "pr_number": pr_number}:
+        return None
+    signature = ledger.get(LEDGER_SIGNATURE_FIELD)
+    if not isinstance(signature, str) or not re.fullmatch(r"[0-9a-f]{64}", signature):
+        return None
+    signed = {field: value for field, value in ledger.items() if field != LEDGER_SIGNATURE_FIELD}
+    expected = ledger_signature(signed)
+    if expected is None or not hmac.compare_digest(signature, expected):
+        return None
+    return ledger
 
 
 def parse_status_marker(body: str) -> dict[str, str] | None:
@@ -1627,7 +1711,7 @@ def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, 
         return False
 
 
-def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None) -> str:
+def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None, repository: str | None = None, pr_number: str | None = None) -> str:
     seen_before = seen_before or set()
     # `full` means base..head. `delta` means a prior completed review's head
     # ..head, which is a smaller question and must never be read as a
@@ -1755,13 +1839,22 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     # fingerprints let a later review say which of its findings a reader has
     # already seen, which is presentation only and never suppression.
     fingerprints = ",".join(sorted({finding_fingerprint(finding) for finding in findings}))
+    marker = {
+        "state": state,
+        "identity": binding.correlation,
+        "mode": mode,
+        "model": model_binding(mode),
+        "findings": fingerprints,
+        "reviewed_head": binding.head_sha,
+        "scope": scope,
+    }
     lines.extend(
         [
             "",
-            f"<!-- {STATUS_MARKER} state={state} identity={binding.correlation} "
-            f"mode={mode} model={model_binding(mode)} findings={fingerprints} "
-            f"reviewed_head={binding.head_sha} scope={scope} -->",
-            render_ledger(findings, binding.head_sha),
+            f"<!-- {STATUS_MARKER} "
+            + " ".join(f"{field}={value}" for field, value in marker.items())
+            + " -->",
+            render_ledger(findings, binding.head_sha, marker, repository, pr_number),
         ]
     )
     return "\n".join(lines)
@@ -1953,12 +2046,11 @@ def run_review(
         # Every condition here falls back to a full review, because a full
         # review is only expensive while a wrongly-scoped one is wrong.
         previous = previous_review_for_mode(prior, mode, binding.head_sha)
-        ledger = previous.get("ledger") if previous else None
+        ledger = usable_ledger(previous, repo, pr_number) if previous else None
         # A baseline is only usable when its record of open findings is whole.
         # Missing, malformed, or clipped by the cap all mean the same thing
         # here: this run cannot know what it would be carrying forward.
-        usable = isinstance(ledger, dict) and ledger.get("complete") is True
-        if previous and usable and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
+        if previous and ledger and is_ancestor(repo, str(previous["reviewed_head"]), binding.head_sha, token, binding.correlation):
             scope = "delta"
             scope_base = str(previous["reviewed_head"])
             carried = ledger_findings(ledger)
@@ -1973,6 +2065,7 @@ def run_review(
         # its stale timeout and block every later review of the same head. A
         # label is not worth that.
         log_phase("prior-findings", status="unavailable", correlation=binding.correlation)
+    progress.scope = scope
     try:
         # Checked before any provider work so a missing credential ends the run
         # as a configuration failure rather than a partial review, and checked
@@ -2165,7 +2258,25 @@ def run_review(
         manifest = [unit.manifest() for unit in units]
         state = derive_state(progress)
         try:
-            update_comment(repo, comment["id"], token, render_status(binding, mode, classification, progress, state, manifest, seen_before, scope, scope_base), binding.correlation)
+            update_comment(
+                repo,
+                comment["id"],
+                token,
+                render_status(
+                    binding,
+                    mode,
+                    classification,
+                    progress,
+                    state,
+                    manifest,
+                    seen_before,
+                    scope,
+                    scope_base,
+                    repo,
+                    pr_number,
+                ),
+                binding.correlation,
+            )
         except (requests.RequestException, ReviewError):
             log_phase("comment-update", status="failed", correlation=binding.correlation)
             raise ReviewError("final status comment update failed") from None
@@ -2210,7 +2321,7 @@ def main() -> None:
         if any((base_sha, head_sha, comment_id)):
             if not all((base_sha, head_sha, comment_id)) or not comment_id.isdigit():
                 raise ReviewError("review operation received incomplete admission data")
-            state, _ = run_review(
+            state, progress = run_review(
                 repo,
                 pr_number,
                 github_token,
@@ -2220,7 +2331,7 @@ def main() -> None:
                 status_comment_id=int(comment_id),
             )
         else:
-            state, _ = run_review(repo, pr_number, github_token, mode, reviewer_sha)
+            state, progress = run_review(repo, pr_number, github_token, mode, reviewer_sha)
     except (FetchError, ReviewError, requests.RequestException):
         print("pr-review phase=terminal attempt=1 status=failed correlation=pending", file=sys.stderr)
         raise SystemExit(1) from None
@@ -2231,7 +2342,8 @@ def main() -> None:
     # made a nine-finding review look like a crashed job, and inverting the
     # collapse would instead let an incomplete review show an all-green pull
     # request, which reads as reviewed when it was not.
-    write_action_outputs(state=state, complete="true" if state in COMPLETE_REVIEW_STATES else "false")
+    complete = state in COMPLETE_REVIEW_STATES and progress.scope == "full"
+    write_action_outputs(state=state, complete="true" if complete else "false")
     if exit_code_for_state(state):
         raise SystemExit(1)
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -2296,6 +2296,18 @@ def run_review(
         try:
             latest = get_pull_binding(repo, pr_number, token, reviewer_sha)
             progress.head_changed = latest.head_sha != binding.head_sha
+            # The head can hold still while the base moves under it, because
+            # retargeting a pull request changes the range without producing a
+            # commit. Both bases recorded by this run are then the OLD base, so
+            # they still agree with each other and coverage would read complete
+            # for a range this review never saw. The equality check downstream
+            # cannot catch that on its own: it compares two values this run
+            # captured, and they are consistently stale together. Comparing
+            # against what the pull request says NOW is what closes it.
+            if latest.base_sha != binding.base_sha:
+                progress.incomplete_reasons.append(
+                    "the pull request base changed while the review was running"
+                )
         except FetchError:
             progress.incomplete_reasons.append("final head binding could not be re-read")
         return derive_state(progress), progress

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -208,6 +208,10 @@ jobs:
             echo "pr-review coverage: complete (${STATE})"
             exit 0
           fi
+          if [ "${STATE}" = "clean" ] || [ "${STATE}" = "findings" ]; then
+            echo "pr-review coverage: delta only (${STATE}); this is not a whole-pull-request review" >&2
+            exit 1
+          fi
           echo "pr-review coverage: NOT complete (state=${STATE:-none}, review job ${REVIEW_RESULT})" >&2
           echo "The review comment carries the verdict and the reasons it is incomplete." >&2
           exit 1

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -209,7 +209,9 @@ jobs:
             exit 0
           fi
           if [ "${STATE}" = "clean" ] || [ "${STATE}" = "findings" ]; then
-            echo "pr-review coverage: delta only (${STATE}); this is not a whole-pull-request review" >&2
+            echo "pr-review coverage: ${STATE}, but the reviewed range does not reach the current base" >&2
+            echo "A review chain covers the whole pull request only while the base it started from is still the base." >&2
+            echo "Re-run the review to cover the range whole." >&2
             exit 1
           fi
           echo "pr-review coverage: NOT complete (state=${STATE:-none}, review job ${REVIEW_RESULT})" >&2

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -318,7 +318,65 @@ class ExitSemanticsTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
             pr_review.os.environ, {**environment, "GITHUB_OUTPUT": output.name}, clear=True
         ), mock.patch.object(
-            pr_review, "run_review", return_value=("clean", pr_review.ReviewProgress(scope="delta"))
+            pr_review,
+            "run_review",
+            # A delta whose chain starts somewhere other than the current base.
+            # This is the shape a rebase or a retarget produces: the reviews
+            # happened, but the range they account for is no longer the range
+            # the pull request presents.
+            return_value=(
+                "clean",
+                pr_review.ReviewProgress(scope="delta", coverage_base="b" * 40, base_sha="c" * 40),
+            ),
+        ):
+            self.assertIsNone(pr_review.main())
+            output.seek(0)
+            self.assertIn("complete=false", output.read().decode("utf-8"))
+
+    def test_a_delta_whose_chain_reaches_the_base_reports_whole_coverage(self) -> None:
+        # The counterpart to the case above, and the reason coverage is tracked
+        # as a base rather than as the scope of the last run. Gating on scope
+        # failed every review after the first even though the chain accounted
+        # for the whole diff, and a gate that is red on a correct run gets
+        # switched off.
+        environment = {
+            "GITHUB_TOKEN": "token",
+            "REPO": "owner/repo",
+            "PR_NUMBER": "42",
+            "REVIEW_MODE": "deep",
+            "REVIEWER_SHA": "a" * 40,
+            "REVIEW_OPERATION": "review",
+        }
+        with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
+            pr_review.os.environ, {**environment, "GITHUB_OUTPUT": output.name}, clear=True
+        ), mock.patch.object(
+            pr_review,
+            "run_review",
+            return_value=(
+                "clean",
+                pr_review.ReviewProgress(scope="delta", coverage_base="c" * 40, base_sha="c" * 40),
+            ),
+        ):
+            self.assertIsNone(pr_review.main())
+            output.seek(0)
+            self.assertIn("complete=true", output.read().decode("utf-8"))
+
+    def test_a_run_that_recorded_no_base_does_not_report_whole_coverage(self) -> None:
+        # Two unset fields compare equal. Without the presence check that reads
+        # as complete coverage established by a run that never bound itself to
+        # a base at all.
+        environment = {
+            "GITHUB_TOKEN": "token",
+            "REPO": "owner/repo",
+            "PR_NUMBER": "42",
+            "REVIEW_MODE": "deep",
+            "REVIEWER_SHA": "a" * 40,
+            "REVIEW_OPERATION": "review",
+        }
+        with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
+            pr_review.os.environ, {**environment, "GITHUB_OUTPUT": output.name}, clear=True
+        ), mock.patch.object(
+            pr_review, "run_review", return_value=("clean", pr_review.ReviewProgress(scope="full"))
         ):
             self.assertIsNone(pr_review.main())
             output.seek(0)
@@ -2136,6 +2194,32 @@ class LedgerTest(unittest.TestCase):
 
             self.assertIsNone(pr_review.usable_ledger(marker, "owner/other", "42"))
             self.assertIsNone(pr_review.usable_ledger(marker, "owner/repo", "43"))
+
+    def test_a_consistent_relabel_is_caught_only_by_the_signature(self) -> None:
+        # Its own test on purpose. The relabel cases in the test above are
+        # rejected by the binding and head equality checks, which run BEFORE
+        # the signature is compared, so they hold with the MAC deleted and
+        # prove nothing about it. Sharing a method with them would also hide
+        # this: the plain assertion there fails first and aborts before these
+        # ever run, so a neutralization check could not see them either.
+        #
+        # Moving the ledger's own copy of a field in step with the marker keeps
+        # every equality check satisfied, which leaves the signature as the
+        # only thing that can still catch the edit.
+        marker = self.trusted_marker()
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "ledger-test-key"}, clear=False):
+            self.assertIsNotNone(pr_review.usable_ledger(marker, "owner/repo", "42"))
+            for field, replacement in (("mode", "default"), ("state", "clean"), ("scope", "delta")):
+                with self.subTest(signed_field=field):
+                    consistent = {
+                        **marker,
+                        field: replacement,
+                        "ledger": {
+                            **marker["ledger"],
+                            "binding": {**marker["ledger"]["binding"], field: replacement},
+                        },
+                    }
+                    self.assertIsNone(pr_review.usable_ledger(consistent, "owner/repo", "42"))
 
     def test_a_missing_or_rotated_secret_forces_a_full_review(self) -> None:
         marker = self.trusted_marker()

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -490,6 +490,47 @@ class ImmutableBindingTest(unittest.TestCase):
         self.assertTrue(progress.head_changed)
         self.assertEqual(call_model.call_count, 0, "a moved head must not spend a provider call")
 
+    def test_run_marks_review_incomplete_when_the_base_moves_under_a_still_head(self) -> None:
+        # Retargeting a pull request changes the range it presents without
+        # producing a commit, so the head check cannot see it. Both bases this
+        # run recorded are then the old base and agree with each other, which is
+        # exactly the shape that would otherwise report complete coverage for a
+        # range the review never read.
+        original = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        retargeted = pr_review.PullBinding("f" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        diff = "\n".join(
+            [
+                "diff --git a/internal/a.go b/internal/a.go",
+                "--- a/internal/a.go",
+                "+++ b/internal/a.go",
+                "@@ -1 +1 @@",
+                "-old",
+                "+new",
+            ]
+        )
+        review_payload = {
+            "findings": [],
+            "changes": [{"path": "internal/a.go", "summary": "changes enforcement"}],
+        }
+        with mock.patch.object(
+            pr_review, "get_pull_binding", side_effect=[original, original, retargeted]
+        ), mock.patch.object(
+            pr_review, "find_running_comment", return_value=(None, True)
+        ), mock.patch.object(pr_review, "create_comment", return_value={"id": 7}), mock.patch.object(
+            pr_review, "fetch_bound_diff", return_value=diff
+        ), mock.patch.object(
+            pr_review, "call_model", side_effect=[review_payload, {"findings": []}]
+        ), mock.patch.object(pr_review, "update_comment"), mock.patch.object(
+            pr_review, "provider_configuration", return_value=("https://provider.example/v1/chat/completions", "key")
+        ), mock.patch.object(pr_review, "compare_incompleteness", return_value=None):
+            state, progress = pr_review.run_review("owner/repo", "42", "token", "default", "c" * 40)
+        self.assertFalse(progress.head_changed, "the head did not move; only the base did")
+        self.assertIn(
+            "the pull request base changed while the review was running",
+            progress.incomplete_reasons,
+        )
+        self.assertNotIn(state, pr_review.COMPLETE_REVIEW_STATES)
+
     def test_claim_persists_binding_and_one_status_comment_id(self) -> None:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         with tempfile.NamedTemporaryFile() as output, mock.patch.dict(

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -306,6 +306,24 @@ class ExitSemanticsTest(unittest.TestCase):
             ):
                 self.assertIsNone(pr_review.main())
 
+    def test_a_delta_clean_result_does_not_claim_whole_pull_request_coverage(self) -> None:
+        environment = {
+            "GITHUB_TOKEN": "token",
+            "REPO": "owner/repo",
+            "PR_NUMBER": "42",
+            "REVIEW_MODE": "deep",
+            "REVIEWER_SHA": "a" * 40,
+            "REVIEW_OPERATION": "review",
+        }
+        with tempfile.NamedTemporaryFile() as output, mock.patch.dict(
+            pr_review.os.environ, {**environment, "GITHUB_OUTPUT": output.name}, clear=True
+        ), mock.patch.object(
+            pr_review, "run_review", return_value=("clean", pr_review.ReviewProgress(scope="delta"))
+        ):
+            self.assertIsNone(pr_review.main())
+            output.seek(0)
+            self.assertIn("complete=false", output.read().decode("utf-8"))
+
 
 class CompressionAndClassificationTest(unittest.TestCase):
     def test_deep_plan_covers_321_small_units_in_six_chunks(self) -> None:
@@ -2079,6 +2097,106 @@ class DeltaScopeTest(unittest.TestCase):
 
 class LedgerTest(unittest.TestCase):
     """The record that lets a later run re-check what was left open."""
+
+    def trusted_marker(self, head: str = "c" * 40) -> dict[str, object]:
+        binding = pr_review.PullBinding("a" * 40, head, "e" * 40, pr_review.RUBRIC_VERSION)
+        progress = pr_review.ReviewProgress(
+            expected_units=1,
+            reviewed_units=1,
+            findings=[pr_review.Finding("high", "policy.go", 7, "Existing deny bypass", "why", "fix")],
+        )
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "ledger-test-key"}, clear=False):
+            body = pr_review.render_status(
+                binding, "deep", [], progress, "findings", [], repository="owner/repo", pr_number="42"
+            )
+            marker = pr_review.parse_status_marker(body)
+            self.assertIsNotNone(marker)
+            ledger = pr_review.parse_ledger(body)
+            self.assertIsNotNone(ledger)
+            marker["ledger"] = ledger
+            return marker
+
+    def test_only_an_authenticated_ledger_can_select_delta_scope(self) -> None:
+        # A writer can edit an issue comment without changing its displayed
+        # author. Before the MAC, clearing `open` below selected a delta with
+        # no carried finding even though the status marker still named one.
+        marker = self.trusted_marker()
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "ledger-test-key"}, clear=False):
+            self.assertIsNotNone(pr_review.usable_ledger(marker, "owner/repo", "42"))
+            tampered = {**marker, "ledger": {**marker["ledger"], "open": []}}
+            self.assertIsNone(pr_review.usable_ledger(tampered, "owner/repo", "42"))
+
+            # The signature covers the fields that admit a baseline as well
+            # as the findings. Relabelling an old review must not turn it into
+            # a review of a different head, depth, or verdict.
+            for field, replacement in (("reviewed_head", "d" * 40), ("mode", "default"), ("state", "clean")):
+                with self.subTest(field=field):
+                    changed = {**marker, field: replacement}
+                    self.assertIsNone(pr_review.usable_ledger(changed, "owner/repo", "42"))
+
+            self.assertIsNone(pr_review.usable_ledger(marker, "owner/other", "42"))
+            self.assertIsNone(pr_review.usable_ledger(marker, "owner/repo", "43"))
+
+    def test_a_missing_or_rotated_secret_forces_a_full_review(self) -> None:
+        marker = self.trusted_marker()
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": ""}, clear=False):
+            self.assertIsNone(pr_review.usable_ledger(marker, "owner/repo", "42"))
+
+    def test_a_tampered_ledger_fetches_the_whole_pull_request(self) -> None:
+        old_head = "b" * 40
+        current = pr_review.PullBinding("a" * 40, "c" * 40, "e" * 40, pr_review.RUBRIC_VERSION)
+        marker = self.trusted_marker(old_head)
+        marker["ledger"] = {**marker["ledger"], "open": []}
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "ledger-test-key"}, clear=False), mock.patch.object(
+            pr_review, "provider_configuration", return_value=("u", "ledger-test-key")
+        ), mock.patch.object(
+            pr_review, "scan_status_comments", return_value=([marker], set(), True)
+        ), mock.patch.object(
+            pr_review, "is_ancestor"
+        ) as ancestry, mock.patch.object(
+            pr_review, "fetch_bound_diff", return_value=""
+        ) as fetch, mock.patch.object(
+            pr_review, "compare_incompleteness", return_value=None
+        ), mock.patch.object(
+            pr_review, "get_pull_binding", return_value=current
+        ), mock.patch.object(
+            pr_review, "judge_findings", return_value=([], True, [], [], [])
+        ), mock.patch.object(pr_review, "update_comment"):
+            _state, progress = pr_review.run_review(
+                "owner/repo", "42", "token", "deep", "e" * 40, binding=current, status_comment_id=7
+            )
+        ancestry.assert_not_called()
+        self.assertEqual(progress.scope, "full")
+        self.assertEqual(fetch.call_args.args[1], current)
+
+    def test_an_authenticated_ledger_still_selects_the_delta(self) -> None:
+        old_head = "b" * 40
+        current = pr_review.PullBinding("a" * 40, "c" * 40, "e" * 40, pr_review.RUBRIC_VERSION)
+        marker = self.trusted_marker(old_head)
+        with mock.patch.dict(pr_review.os.environ, {"OPENAI_API_KEY": "ledger-test-key"}, clear=False), mock.patch.object(
+            pr_review, "provider_configuration", return_value=("u", "ledger-test-key")
+        ), mock.patch.object(
+            pr_review, "scan_status_comments", return_value=([marker], set(), True)
+        ), mock.patch.object(
+            pr_review, "is_ancestor", return_value=True
+        ) as ancestry, mock.patch.object(
+            pr_review, "fetch_bound_diff", return_value=""
+        ) as fetch, mock.patch.object(
+            pr_review, "compare_incompleteness", return_value=None
+        ), mock.patch.object(
+            pr_review, "get_pull_binding", return_value=current
+        ), mock.patch.object(
+            pr_review, "judge_findings", return_value=([], True, [], [], [])
+        ), mock.patch.object(pr_review, "update_comment"):
+            _state, progress = pr_review.run_review(
+                "owner/repo", "42", "token", "deep", "e" * 40, binding=current, status_comment_id=7
+            )
+        ancestry.assert_called_once()
+        self.assertEqual(progress.scope, "delta")
+        self.assertEqual(
+            fetch.call_args.args[1],
+            pr_review.PullBinding(old_head, current.head_sha, current.reviewer_sha, current.rubric_version),
+        )
 
     def test_a_ledger_round_trips(self) -> None:
         findings = [


### PR DESCRIPTION
## What changed

The carried-findings ledger travelled as plain text in a comment body, so anyone able to edit that comment could drop carried findings and still authorize a narrowed delta review. The ledger is now authenticated and bound to the exact status marker, repository, and pull request, and an unreadable, unauthenticated, or cross-pull-request ledger falls back to a full review rather than a narrowed one.

A delta review also reported complete coverage, which turned the coverage check green for a run that had examined only part of the change. Delta results now report incomplete coverage and the workflow fails with the reason stated.

Both changes fail toward reviewing more rather than less. Every uncertain ledger state produces a full review, and deleting or corrupting the comment costs only the delta optimization. Rotating the provider credential invalidates existing records and causes one full review, not an unsafe narrow one.

The signal worth distrusting here is the coverage result itself. A green check on a partially reviewed change is the defect being fixed, and any future narrowing of review scope would present exactly the same way, so a reviewer should confirm that an incomplete review can still only report incomplete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review reliability by validating review history before reusing previous findings.
  * Automatically falls back to a full review when prior review information is missing, altered, or no longer valid.
  * Prevents incomplete “clean” or “findings” results from being reported as complete reviews.

* **Improvements**
  * Review status now clearly identifies partial coverage and reflects whether the review reaches the current pull request base.
  * Review progress and completion reporting are more accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->