### PR TITLE
fix(mcp): bind WebSocket and sandbox proxy sessions to their spawner

### DIFF
--- a/internal/mcp/defer_resolver.go
+++ b/internal/mcp/defer_resolver.go
@@ -202,7 +202,8 @@ func executeDeferApprovalResolver(
 		return config.ActionBlock, fmt.Errorf("defer resolver failed to start: %w", err)
 	}
 	pgid := captureChildPgid(cmd.Process.Pid)
-	waitErr := waitForCommandWithProcessGroup(ctx, cmd, pgid)
+	processExit := &processExitHandoff{}
+	waitErr := waitForCommandWithProcessGroup(ctx, cmd, pgid, processExit)
 	if waitErr != nil {
 		if ctx.Err() != nil {
 			return config.ActionBlock, ctx.Err()

--- a/internal/mcp/defer_resolver.go
+++ b/internal/mcp/defer_resolver.go
@@ -202,18 +202,7 @@ func executeDeferApprovalResolver(
 		return config.ActionBlock, fmt.Errorf("defer resolver failed to start: %w", err)
 	}
 	pgid := captureChildPgid(cmd.Process.Pid)
-	waitCh := make(chan error, 1)
-	go func() {
-		waitCh <- cmd.Wait()
-	}()
-
-	var waitErr error
-	select {
-	case waitErr = <-waitCh:
-	case <-ctx.Done():
-		terminateProcessGroup(pgid)
-		waitErr = <-waitCh
-	}
+	waitErr := waitForCommandWithProcessGroup(ctx, cmd, pgid)
 	if waitErr != nil {
 		if ctx.Err() != nil {
 			return config.ActionBlock, ctx.Err()

--- a/internal/mcp/defer_resolver.go
+++ b/internal/mcp/defer_resolver.go
@@ -204,10 +204,14 @@ func executeDeferApprovalResolver(
 	pgid := captureChildPgid(cmd.Process.Pid)
 	processExit := &processExitHandoff{}
 	waitErr := waitForCommandWithProcessGroup(ctx, cmd, pgid, processExit)
+	return finalizeDeferApprovalResolver(ctx, waitErr, &stdout, &stderr)
+}
+
+func finalizeDeferApprovalResolver(ctx context.Context, waitErr error, stdout, stderr *cappedOutputBuffer) (string, error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return config.ActionBlock, ctxErr
+	}
 	if waitErr != nil {
-		if ctx.Err() != nil {
-			return config.ActionBlock, ctx.Err()
-		}
 		return config.ActionBlock, fmt.Errorf("defer resolver failed: %w (stderr: %s)", waitErr, stderr.String())
 	}
 	if stdout.truncated || stderr.truncated {

--- a/internal/mcp/defer_resolver_test.go
+++ b/internal/mcp/defer_resolver_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -131,6 +132,24 @@ func TestExecuteDeferApprovalResolverStrictResults(t *testing.T) {
 		Action:       config.ActionBlock,
 	}, io.Discard); err == nil {
 		t.Fatal("resolver bypassed blocking binary integrity failure")
+	}
+}
+
+func TestFinalizeDeferApprovalResolver_CanceledContextBlocksCleanExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var stdout, stderr cappedOutputBuffer
+	stdout.limit = maxDeferResolverOutputBytes
+	if _, err := stdout.Write([]byte(config.ActionAllow)); err != nil {
+		t.Fatalf("writing resolver output: %v", err)
+	}
+
+	got, err := finalizeDeferApprovalResolver(ctx, nil, &stdout, &stderr)
+	if got != config.ActionBlock {
+		t.Errorf("decision = %q, want %q after cancellation", got, config.ActionBlock)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context cancellation", err)
 	}
 }
 

--- a/internal/mcp/opts.go
+++ b/internal/mcp/opts.go
@@ -382,6 +382,9 @@ type MCPProxyOpts struct {
 	// sessionExit marks Pipelock-initiated descriptor closes during a
 	// session-bound teardown. It is wired only by proxy entry points.
 	sessionExit *sessionExitState
+	// enableSubreaperForTest supplies a deterministic subreaper setup result.
+	// Production wiring leaves it nil and calls the platform implementation.
+	enableSubreaperForTest func() error
 
 	// File sentry (stdio proxy only)
 	Lineage      filesentry.Lineage

--- a/internal/mcp/parentwatch.go
+++ b/internal/mcp/parentwatch.go
@@ -98,11 +98,17 @@ type processExitHandoff struct {
 // observe reap's return, so terminate must use a kernel-stable process handle
 // instead.
 func (h *processExitHandoff) wait(reap func() error) error {
+	h.beginReaping()
+	return reap()
+}
+
+// beginReaping permanently retires raw numeric process identifiers from this
+// handoff. It is separate from wait so callers that must observe an exit before
+// reaping can still make the same boundary explicit and testable.
+func (h *processExitHandoff) beginReaping() {
 	h.mu.Lock()
 	h.reaping = true
 	h.mu.Unlock()
-
-	return reap()
 }
 
 // reapStarted reports whether cmd.Wait has started. It remains true after

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -10,12 +10,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -247,6 +249,137 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 		if logBytes, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "helper.log"))); readErr == nil {
 			t.Logf("helper output:\n%s", logBytes)
 		}
+	}
+}
+
+// TestSessionExit_SandboxTreeIsReaped drives the sandbox proxy entry point
+// through its real child process tree. The watch uses a controllable PPID so
+// the test can first prove the sandbox command and its detached descendant
+// exist, then trigger the same teardown production runs after reparenting.
+func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real sandbox proxy process tree")
+	}
+
+	dir := t.TempDir()
+	grandchildFile := filepath.Join(dir, "grandchild.pid")
+	serverScript := "setsid sleep 300 &\n" +
+		"echo $! > " + grandchildFile + "\n" +
+		"sleep 300\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", serverScript)
+	sc := testScannerWithAction(t, config.ActionWarn)
+	var logBuf syncBuffer
+	var parentDied atomic.Bool
+	opts := testOpts(sc)
+	opts.sessionExitForTest = &sessionExitTestHooks{watch: parentWatchOpts{
+		interval:  time.Millisecond,
+		startPPID: 4242,
+		getppid: func() int {
+			if parentDied.Load() {
+				return orphanedPPID
+			}
+			return 4242
+		},
+	}, grace: 50 * time.Millisecond}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxyWithSandbox(ctx, cmd, clientIn, io.Discard, &logBuf, opts)
+	}()
+
+	var grandchildPID int
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err := os.ReadFile(filepath.Clean(grandchildFile))
+		if err == nil {
+			grandchildPID, _ = strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if grandchildPID > 0 && cmd.Process != nil {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if grandchildPID <= 0 || cmd.Process == nil {
+		t.Fatalf("sandbox tree never came up (sandbox=%v grandchild=%d)", cmd.Process, grandchildPID)
+	}
+
+	tree := map[string]int{
+		"sandbox command":        cmd.Process.Pid,
+		"detached sandbox child": grandchildPID,
+	}
+	for label, pid := range tree {
+		if !processAlive(pid) {
+			t.Fatalf("%s (pid %d) was not alive before session exit", label, pid)
+		}
+	}
+
+	parentDied.Store(true)
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("sandbox proxy stayed alive after the spawning session exited")
+	}
+
+	waitForGone(t, tree, 10*time.Second)
+	if !strings.Contains(logBuf.String(), "spawning session exited") {
+		t.Errorf("missing session-exit explanation in operator log, got %q", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "terminating process tree") {
+		t.Errorf("missing sandbox process-tree teardown notice, got %q", logBuf.String())
+	}
+}
+
+func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real sandbox proxy process")
+	}
+
+	dir := t.TempDir()
+	readyFile := filepath.Join(dir, "ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientIn := newBlockingReader()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "touch "+readyFile+"; sleep 300")
+	sc := testScannerWithAction(t, config.ActionWarn)
+	var logBuf syncBuffer
+	opts := testOpts(sc)
+	opts.sessionExitForTest = liveSessionExitHooks()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxyWithSandbox(ctx, cmd, clientIn, io.Discard, &logBuf, opts)
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("sandbox command never became ready: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("sandbox proxy exited while its session was alive: %v; log: %q", err, logBuf.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+	if strings.Contains(logBuf.String(), "spawning session exited") {
+		t.Errorf("session-exit path ran against a live parent, got %q", logBuf.String())
+	}
+
+	_ = clientIn.Close()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("sandbox proxy did not stop after context cancellation")
 	}
 }
 

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -463,6 +463,54 @@ func TestRunProxyWithSandbox_SubreaperFailureDirections(t *testing.T) {
 	})
 }
 
+// TestRunProxyWithSandbox_BestEffortChildSurvivesSiblingReaper is the
+// cross-session direction of the subreaper failure case above.
+//
+// reapAdoptedZombies walks /proc and reaps any zombie parented to this process
+// except the direct children sessions have claimed. A session whose subreaper
+// setup was refused still owns a direct child, so if it does not claim that
+// child, a concurrent session's reaper consumes its exit status and the owning
+// cmd.Wait fails with ECHILD, surfacing as "waitid: no child processes".
+//
+// The sweeper here stands in for that concurrent session's reaper. It is
+// deliberately continuous: the theft window is between the child exiting and
+// this session reaping it, which is narrow and load-dependent, and is why this
+// reproduced on a loaded CI runner rather than on a development host.
+func TestRunProxyWithSandbox_BestEffortChildSurvivesSiblingReaper(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	opts := testOpts(testScannerWithAction(t, config.ActionWarn))
+	opts.enableSubreaperForTest = func() error { return errors.New("subreaper unavailable") }
+
+	// A PID that is never one of ours, so the sweeper protects nothing of the
+	// session under test and behaves exactly like a foreign session's reaper.
+	const foreignDirectPID = -1
+	sweeperDone := make(chan struct{})
+	sweeperStopped := make(chan struct{})
+	go func() {
+		defer close(sweeperStopped)
+		for {
+			select {
+			case <-sweeperDone:
+				return
+			default:
+				reapAdoptedZombies(foreignDirectPID)
+			}
+		}
+	}()
+	defer func() {
+		close(sweeperDone)
+		<-sweeperStopped
+	}()
+
+	var logBuf syncBuffer
+	cmd := exec.CommandContext(ctx, "cat")
+	if err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), io.Discard, &logBuf, opts); err != nil {
+		t.Fatalf("best-effort sandbox proxy with a concurrent sibling reaper = %v, want the session to keep its own child", err)
+	}
+}
+
 func TestRunProxyWithSandbox_OrphanedParentStaysInert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -130,12 +130,15 @@ func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
 }
 
 func TestWaitForCommandWithProcessGroupSignalsBeforeReap(t *testing.T) {
+	const resolverScript = "sleep 300 & child=$!; printf '%s\\n' \"$child\" > \"$MCP_TEST_PID_FILE\"; wait"
+
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "resolver-child.pid")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cmd := exec.Command("/bin/sh", "-c", "sleep 300 & child=$!; echo $child > "+pidFile+"; wait")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", resolverScript)
+	cmd.Env = append(os.Environ(), "MCP_TEST_PID_FILE="+pidFile)
 	setupChildProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting resolver tree: %v", err)
@@ -307,19 +310,21 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 		t.Skip("spawns a real sandbox proxy process tree")
 	}
 
+	const sandboxScript = "echo $$ > \"$MCP_TEST_SANDBOX_FILE\"\nsetsid sleep 300 &\necho $! > \"$MCP_TEST_GRANDCHILD_FILE\"\nsleep 300"
+
 	dir := t.TempDir()
 	sandboxFile := filepath.Join(dir, "sandbox.pid")
 	grandchildFile := filepath.Join(dir, "grandchild.pid")
-	serverScript := "echo $$ > " + sandboxFile + "\n" +
-		"setsid sleep 300 &\n" +
-		"echo $! > " + grandchildFile + "\n" +
-		"sleep 300\n"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 	clientIn := newBlockingReader()
 	defer func() { _ = clientIn.Close() }()
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", serverScript)
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", sandboxScript)
+	cmd.Env = append(os.Environ(),
+		"MCP_TEST_SANDBOX_FILE="+sandboxFile,
+		"MCP_TEST_GRANDCHILD_FILE="+grandchildFile,
+	)
 	sc := testScannerWithAction(t, config.ActionWarn)
 	var logBuf syncBuffer
 	var parentDied atomic.Bool
@@ -380,6 +385,8 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 }
 
 func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
+	const liveSessionScript = "touch \"$MCP_TEST_READY_FILE\"; sleep 300"
+
 	if testing.Short() {
 		t.Skip("spawns a real sandbox proxy process")
 	}
@@ -389,7 +396,8 @@ func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	clientIn := newBlockingReader()
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "touch "+readyFile+"; sleep 300")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", liveSessionScript)
+	cmd.Env = append(os.Environ(), "MCP_TEST_READY_FILE="+readyFile)
 	sc := testScannerWithAction(t, config.ActionWarn)
 	var logBuf syncBuffer
 	opts := testOpts(sc)

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -432,6 +432,52 @@ func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
 	}
 }
 
+func TestRunProxyWithSandbox_SubreaperFailureDirections(t *testing.T) {
+	failure := errors.New("subreaper unavailable")
+
+	t.Run("best effort continues with warning", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		var logBuf syncBuffer
+		opts := testOpts(testScannerWithAction(t, config.ActionWarn))
+		opts.enableSubreaperForTest = func() error { return failure }
+		cmd := exec.CommandContext(ctx, "cat")
+		if err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), io.Discard, &logBuf, opts); err != nil {
+			t.Fatalf("best-effort sandbox proxy = %v", err)
+		}
+		if !strings.Contains(logBuf.String(), "subtree teardown will be incomplete") {
+			t.Errorf("missing subreaper warning, got %q", logBuf.String())
+		}
+	})
+
+	t.Run("strict fails closed", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		opts := testOpts(testScannerWithAction(t, config.ActionWarn))
+		opts.enableSubreaperForTest = func() error { return failure }
+		cmd := exec.CommandContext(ctx, "cat")
+		err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), io.Discard, io.Discard, opts, true)
+		if !errors.Is(err, failure) {
+			t.Fatalf("strict sandbox proxy error = %v, want subreaper failure", err)
+		}
+	})
+}
+
+func TestRunProxyWithSandbox_OrphanedParentStaysInert(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var logBuf syncBuffer
+	opts := testOpts(testScannerWithAction(t, config.ActionWarn))
+	opts.sessionExitForTest = &sessionExitTestHooks{watch: parentWatchOpts{startPPID: orphanedPPID}}
+	cmd := exec.CommandContext(ctx, "cat")
+	if err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), io.Discard, &logBuf, opts); err != nil {
+		t.Fatalf("sandbox proxy with an unbound parent = %v", err)
+	}
+	if strings.Contains(logBuf.String(), "spawning session exited") {
+		t.Errorf("unbound parent ran the session-exit path, got %q", logBuf.String())
+	}
+}
+
 // TestSessionExitHelperProcess is the proxy level of the tree above. It is a
 // helper, not a test: it runs only when the parent test sets the env marker.
 func TestSessionExitHelperProcess(t *testing.T) {

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -428,7 +428,65 @@ func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(20 * time.Second):
-		t.Fatal("sandbox proxy did not stop after context cancellation")
+		// Report the operator log and the surviving processes. This assertion
+		// has failed on CI while passing on a development host, and a bare
+		// timeout says nothing about which stage did not finish.
+		t.Fatalf("sandbox proxy did not stop after context cancellation; log: %q; surviving descendants: %s",
+			logBuf.String(), describeOwnDescendants())
+	}
+}
+
+// TestSessionExit_SandboxCancellationWithSurvivingPipeHolder is the CI-shaped
+// version of the cancellation case above.
+//
+// The sibling test runs "sh -c '...; sleep 300'", which on many shells execs
+// the final sleep in place, so the direct-child SIGKILL that
+// exec.CommandContext sends happens to reach the process holding stdout. That
+// makes the test pass without any cancellation teardown at all, and it is why
+// it passed on a development host while failing on CI.
+//
+// Here the shell keeps a detached descendant that holds stdout and does not
+// exec in place, so the direct kill cannot reach the pipe holder. Without a
+// cancellation teardown the output reader never sees EOF and this call never
+// returns.
+func TestSessionExit_SandboxCancellationWithSurvivingPipeHolder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real sandbox proxy process")
+	}
+
+	dir := t.TempDir()
+	readyFile := filepath.Join(dir, "ready")
+	// setsid moves the descendant into its own session, so it survives both
+	// the direct-child kill and a plain process-group signal, while keeping
+	// the inherited stdout it was given.
+	script := "umask 077; setsid sleep 300 & touch \"$MCP_TEST_READY_FILE\"; wait"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", script)
+	cmd.Env = append(os.Environ(), "MCP_TEST_READY_FILE="+readyFile)
+	var logBuf syncBuffer
+	opts := testOpts(testScannerWithAction(t, config.ActionWarn))
+	opts.sessionExitForTest = liveSessionExitHooks()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunProxyWithSandbox(ctx, cmd, clientIn, io.Discard, &logBuf, opts)
+	}()
+
+	testwait.For(t, 10*time.Second, func() bool {
+		_, err := os.Stat(readyFile)
+		return err == nil
+	}, "the sandbox command to become ready")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatalf("sandbox proxy did not stop after cancellation while a detached descendant held stdout; log: %q; surviving descendants: %s",
+			logBuf.String(), describeOwnDescendants())
 	}
 }
 
@@ -445,7 +503,7 @@ func TestRunProxyWithSandbox_SubreaperFailureDirections(t *testing.T) {
 		if err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), io.Discard, &logBuf, opts); err != nil {
 			t.Fatalf("best-effort sandbox proxy = %v", err)
 		}
-		if !strings.Contains(logBuf.String(), "subtree teardown will be incomplete") {
+		if !strings.Contains(logBuf.String(), "session descendant cleanup degraded") {
 			t.Errorf("missing subreaper warning, got %q", logBuf.String())
 		}
 	})
@@ -553,4 +611,48 @@ func TestSessionExitHelperProcess(t *testing.T) {
 		[]string{"/bin/sh", "-c", "exec /bin/sh \"$PIPELOCK_SESSION_EXIT_SERVER\""}, MCPProxyOpts{},
 		"PIPELOCK_SESSION_EXIT_SERVER="+os.Getenv("PIPELOCK_SESSION_EXIT_SERVER"))
 	fmt.Fprintf(os.Stderr, "helper: RunProxy returned: %v\n", err)
+}
+
+// describeOwnDescendants lists the live processes still parented to this
+// process, with their state and command name. It exists for one reason: a
+// teardown assertion that times out on CI and passes on a development host
+// says nothing about WHAT failed to finish, and a process holding a pipe open
+// is the difference between a hung wait and a hung scan.
+func describeOwnDescendants() string {
+	selfPID := os.Getpid()
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return "unreadable /proc: " + err.Error()
+	}
+	var found []string
+	for _, entry := range entries {
+		name := entry.Name()
+		pid, convErr := strconv.Atoi(name)
+		if convErr != nil || pid == selfPID {
+			continue
+		}
+		statBytes, readErr := os.ReadFile(filepath.Clean("/proc/" + name + "/stat"))
+		if readErr != nil {
+			continue
+		}
+		stat := string(statBytes)
+		cmdEnd := strings.LastIndex(stat, ")")
+		cmdStart := strings.Index(stat, "(")
+		if cmdEnd < 0 || cmdStart < 0 || cmdEnd <= cmdStart || cmdEnd+2 > len(stat) {
+			continue
+		}
+		rest := strings.Fields(stat[cmdEnd+1:])
+		if len(rest) < 2 {
+			continue
+		}
+		if rest[1] != strconv.Itoa(selfPID) {
+			continue
+		}
+		found = append(found, fmt.Sprintf("pid=%d state=%s comm=%s", pid, rest[0], stat[cmdStart+1:cmdEnd]))
+	}
+	if len(found) == 0 {
+		return "none"
+	}
+	sort.Strings(found)
+	return strings.Join(found, "; ")
 }

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -130,7 +130,7 @@ func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
 }
 
 func TestWaitForCommandWithProcessGroupSignalsBeforeReap(t *testing.T) {
-	const resolverScript = "sleep 300 & child=$!; printf '%s\\n' \"$child\" > \"$MCP_TEST_PID_FILE\"; wait"
+	const resolverScript = "umask 077; sleep 300 & child=$!; printf '%s\\n' \"$child\" > \"$MCP_TEST_PID_FILE\"; wait"
 
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "resolver-child.pid")
@@ -163,7 +163,7 @@ func TestWaitForCommandWithProcessGroupSignalsBeforeReap(t *testing.T) {
 	}, "the resolver child to write its PID")
 
 	done := make(chan error, 1)
-	go func() { done <- waitForCommandWithProcessGroup(ctx, cmd, pgid) }()
+	go func() { done <- waitForCommandWithProcessGroup(ctx, cmd, pgid, &processExitHandoff{}) }()
 	cancel()
 	select {
 	case err := <-done:
@@ -310,7 +310,7 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 		t.Skip("spawns a real sandbox proxy process tree")
 	}
 
-	const sandboxScript = "echo $$ > \"$MCP_TEST_SANDBOX_FILE\"\nsetsid sleep 300 &\necho $! > \"$MCP_TEST_GRANDCHILD_FILE\"\nsleep 300"
+	const sandboxScript = "umask 077\necho $$ > \"$MCP_TEST_SANDBOX_FILE\"\nsetsid sleep 300 &\necho $! > \"$MCP_TEST_GRANDCHILD_FILE\"\nsleep 300"
 
 	dir := t.TempDir()
 	sandboxFile := filepath.Join(dir, "sandbox.pid")
@@ -385,7 +385,7 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 }
 
 func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
-	const liveSessionScript = "touch \"$MCP_TEST_READY_FILE\"; sleep 300"
+	const liveSessionScript = "umask 077; touch \"$MCP_TEST_READY_FILE\"; sleep 300"
 
 	if testing.Short() {
 		t.Skip("spawns a real sandbox proxy process")

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -129,6 +129,59 @@ func TestRunProxy_ResponseTimeoutReapsEscapedPipeHolder(t *testing.T) {
 	waitForGone(t, map[string]int{"escaped pipe holder": pid}, 5*time.Second)
 }
 
+func TestWaitForCommandWithProcessGroupSignalsBeforeReap(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "resolver-child.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.Command("/bin/sh", "-c", "sleep 300 & child=$!; echo $child > "+pidFile+"; wait")
+	setupChildProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting resolver tree: %v", err)
+	}
+	pgid := captureChildPgid(cmd.Process.Pid)
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			terminateProcessGroup(pgid)
+			_ = cmd.Wait()
+		}
+	})
+
+	var childPID int
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err := os.ReadFile(filepath.Clean(pidFile))
+		if err == nil {
+			childPID, err = strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+			if err != nil || childPID <= 0 {
+				t.Fatalf("resolver child PID = %q, want positive integer", pidBytes)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if childPID == 0 {
+		t.Fatal("resolver child never wrote its PID")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- waitForCommandWithProcessGroup(ctx, cmd, pgid) }()
+	cancel()
+	select {
+	case err := <-done:
+		reaped = true
+		if err == nil {
+			t.Fatal("resolver tree exited cleanly after forced teardown")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolver tree was not reaped after cancellation")
+	}
+
+	waitForGone(t, map[string]int{"resolver child": childPID}, 5*time.Second)
+}
+
 // TestSessionExit_RealParentDeathReapsWholeTree drives the actual production
 // path with a real three-level process tree and a real kill. Nothing about
 // the parent PID is stubbed.

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -150,21 +150,14 @@ func TestWaitForCommandWithProcessGroupSignalsBeforeReap(t *testing.T) {
 	})
 
 	var childPID int
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 5*time.Second, func() bool {
 		pidBytes, err := os.ReadFile(filepath.Clean(pidFile))
-		if err == nil {
-			childPID, err = strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-			if err != nil || childPID <= 0 {
-				t.Fatalf("resolver child PID = %q, want positive integer", pidBytes)
-			}
-			break
+		if err != nil {
+			return false
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if childPID == 0 {
-		t.Fatal("resolver child never wrote its PID")
-	}
+		childPID, err = strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+		return err == nil && childPID > 0
+	}, "the resolver child to write its PID")
 
 	done := make(chan error, 1)
 	go func() { done <- waitForCommandWithProcessGroup(ctx, cmd, pgid) }()
@@ -315,8 +308,10 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	sandboxFile := filepath.Join(dir, "sandbox.pid")
 	grandchildFile := filepath.Join(dir, "grandchild.pid")
-	serverScript := "setsid sleep 300 &\n" +
+	serverScript := "echo $$ > " + sandboxFile + "\n" +
+		"setsid sleep 300 &\n" +
 		"echo $! > " + grandchildFile + "\n" +
 		"sleep 300\n"
 
@@ -345,24 +340,21 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 		done <- RunProxyWithSandbox(ctx, cmd, clientIn, io.Discard, &logBuf, opts)
 	}()
 
-	var grandchildPID int
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		pidBytes, err := os.ReadFile(filepath.Clean(grandchildFile))
-		if err == nil {
-			grandchildPID, _ = strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-			if grandchildPID > 0 && cmd.Process != nil {
-				break
-			}
+	var sandboxPID, grandchildPID int
+	testwait.For(t, 15*time.Second, func() bool {
+		sandboxBytes, sandboxErr := os.ReadFile(filepath.Clean(sandboxFile))
+		grandchildBytes, grandchildErr := os.ReadFile(filepath.Clean(grandchildFile))
+		if sandboxErr != nil || grandchildErr != nil {
+			return false
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if grandchildPID <= 0 || cmd.Process == nil {
-		t.Fatalf("sandbox tree never came up (sandbox=%v grandchild=%d)", cmd.Process, grandchildPID)
-	}
+		var sandboxPIDErr, grandchildPIDErr error
+		sandboxPID, sandboxPIDErr = strconv.Atoi(strings.TrimSpace(string(sandboxBytes)))
+		grandchildPID, grandchildPIDErr = strconv.Atoi(strings.TrimSpace(string(grandchildBytes)))
+		return sandboxPIDErr == nil && grandchildPIDErr == nil && sandboxPID > 0 && grandchildPID > 0
+	}, "the sandbox tree to come up")
 
 	tree := map[string]int{
-		"sandbox command":        cmd.Process.Pid,
+		"sandbox command":        sandboxPID,
 		"detached sandbox child": grandchildPID,
 	}
 	for label, pid := range tree {
@@ -407,16 +399,12 @@ func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
 		done <- RunProxyWithSandbox(ctx, cmd, clientIn, io.Discard, &logBuf, opts)
 	}()
 
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	testwait.For(t, 10*time.Second, func() bool {
 		if _, err := os.Stat(readyFile); err == nil {
-			break
+			return true
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if _, err := os.Stat(readyFile); err != nil {
-		t.Fatalf("sandbox command never became ready: %v", err)
-	}
+		return false
+	}, "the sandbox command to become ready")
 
 	select {
 	case err := <-done:

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -152,6 +152,13 @@ func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
 	testwait.For(t, 5*time.Second, func() bool {
 		return strings.Contains(logBuf.String(), "spawning session exited")
 	}, "asynchronous session-exit log message")
+	// `sleep` never reads stdin, so the cooperative shutdown cannot end it and
+	// the drain window has to expire into a forced teardown. That escalation is
+	// the behavior this test is named for, and this is the only assertion of it
+	// that runs on a non-Linux build.
+	testwait.For(t, 5*time.Second, func() bool {
+		return strings.Contains(logBuf.String(), "terminating process tree")
+	}, "forced process-tree teardown log message")
 }
 
 // TestRunProxy_LiveSessionIsNotTornDown is the availability direction: with

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
 // blockingReader stands in for a client whose session is alive: it never
@@ -147,13 +149,9 @@ func TestRunProxy_SessionExitTerminatesIgnoringServer(t *testing.T) {
 		t.Fatal("RunProxy never returned after the spawning session died; the proxy leaked")
 	}
 
-	log := logBuf.String()
-	if !strings.Contains(log, "spawning session exited") {
-		t.Errorf("missing session-exit explanation in operator log, got %q", log)
-	}
-	if !strings.Contains(log, "terminating process tree") {
-		t.Errorf("missing forced-teardown notice for a server that ignored stdin close, got %q", log)
-	}
+	testwait.For(t, 5*time.Second, func() bool {
+		return strings.Contains(logBuf.String(), "spawning session exited")
+	}, "asynchronous session-exit log message")
 }
 
 // TestRunProxy_LiveSessionIsNotTornDown is the availability direction: with

--- a/internal/mcp/parentwatch_proxy_test.go
+++ b/internal/mcp/parentwatch_proxy_test.go
@@ -403,3 +403,20 @@ func TestDrainStderr_ReleasesEscapedPipeHolder(t *testing.T) {
 		}
 	})
 }
+
+func TestRunProxy_OrphanedParentStaysInert(t *testing.T) {
+	sc := testScannerWithAction(t, "warn")
+	var stdout, logBuf bytes.Buffer
+	err := RunProxy(context.Background(), strings.NewReader(""), &stdout, &logBuf, []string{"cat"}, MCPProxyOpts{
+		Scanner: sc,
+		sessionExitForTest: &sessionExitTestHooks{watch: parentWatchOpts{
+			startPPID: orphanedPPID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunProxy with an unbound parent = %v", err)
+	}
+	if strings.Contains(logBuf.String(), "spawning session exited") {
+		t.Errorf("unbound parent ran the session-exit path, got %q", logBuf.String())
+	}
+}

--- a/internal/mcp/parentwatch_ws_test.go
+++ b/internal/mcp/parentwatch_ws_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	gobwasutil "github.com/gobwas/ws/wsutil"
+)
+
+func wsSessionExitServer(t *testing.T) (*httptest.Server, <-chan struct{}) {
+	t.Helper()
+	connected := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		close(connected)
+		for {
+			if _, err := gobwasutil.ReadClientMessage(conn, nil); err != nil {
+				return
+			}
+		}
+	}))
+	return srv, connected
+}
+
+func TestSessionExit_WSStopsBridge(t *testing.T) {
+	upstream, connected := wsSessionExitServer(t)
+	defer upstream.Close()
+
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+	sc := testScannerForWS(t)
+	var parentDied atomic.Bool
+	var clientOut, logBuf lockedHTTPBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, wsURL(upstream), MCPProxyOpts{
+			Scanner: sc,
+			sessionExitForTest: &sessionExitTestHooks{watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid: func() int {
+					if parentDied.Load() {
+						return orphanedPPID
+					}
+					return 4242
+				},
+			}},
+		})
+	}()
+
+	select {
+	case <-connected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket bridge never connected to its upstream")
+	}
+	parentDied.Store(true)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunWSProxy after session exit = %v, want clean teardown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket bridge stayed alive after the spawning session exited")
+	}
+
+	if !logBuf.contains("spawning session exited") {
+		t.Errorf("missing session-exit explanation in operator log, got %q", logBuf.String())
+	}
+}
+
+func TestSessionExit_WSLiveSessionIsNotTornDown(t *testing.T) {
+	upstream, connected := wsSessionExitServer(t)
+	defer upstream.Close()
+
+	clientIn := newBlockingReader()
+	sc := testScannerForWS(t)
+	var clientOut, logBuf lockedHTTPBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, wsURL(upstream), MCPProxyOpts{
+			Scanner:            sc,
+			sessionExitForTest: liveSessionExitHooks(),
+		})
+	}()
+
+	select {
+	case <-connected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket bridge never connected to its upstream")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("RunWSProxy exited while its session was alive: %v; log: %q", err, logBuf.String())
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	if logBuf.contains("spawning session exited") {
+		t.Errorf("session-exit path ran against a live parent, got %q", logBuf.String())
+	}
+
+	_ = clientIn.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunWSProxy after input close = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket bridge did not stop after its input closed")
+	}
+}

--- a/internal/mcp/parentwatch_ws_test.go
+++ b/internal/mcp/parentwatch_ws_test.go
@@ -5,8 +5,9 @@ package mcp
 
 import (
 	"context"
+	"net"
 	"net/http"
-	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,28 +16,49 @@ import (
 	gobwasutil "github.com/gobwas/ws/wsutil"
 )
 
-func wsSessionExitServer(t *testing.T) (*httptest.Server, <-chan struct{}) {
+// wsSessionExitServer serves the WebSocket upstream these tests dial, and
+// returns its ws:// URL plus a channel closed on the first successful upgrade.
+//
+// It uses a raw listener and http.Server rather than httptest.Server on
+// purpose. ws.UpgradeHTTP hijacks the connection, and httptest.Server.Close
+// blocks waiting for outstanding requests, so a test that leaves the
+// connection open would hang on cleanup rather than fail. Closing the listener
+// does not have that dependency.
+func wsSessionExitServer(t *testing.T) (string, <-chan struct{}) {
 	t.Helper()
 	connected := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _, _, err := ws.UpgradeHTTP(r, w)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		close(connected)
-		for {
-			if _, err := gobwasutil.ReadClientMessage(conn, nil); err != nil {
+	// The handler can be entered more than once. Closing an already-closed
+	// channel panics in the server goroutine, which takes down the whole test
+	// binary rather than failing one test.
+	var once sync.Once
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening for WebSocket upstream: %v", err)
+	}
+	srv := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, _, _, err := ws.UpgradeHTTP(r, w)
+			if err != nil {
 				return
 			}
-		}
-	}))
-	return srv, connected
+			defer func() { _ = conn.Close() }()
+			once.Do(func() { close(connected) })
+			for {
+				if _, err := gobwasutil.ReadClientMessage(conn, nil); err != nil {
+					return
+				}
+			}
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = ln.Close() })
+	return "ws://" + ln.Addr().String(), connected
 }
 
 func TestSessionExit_WSStopsBridge(t *testing.T) {
-	upstream, connected := wsSessionExitServer(t)
-	defer upstream.Close()
+	upstreamURL, connected := wsSessionExitServer(t)
 
 	clientIn := newBlockingReader()
 	defer func() { _ = clientIn.Close() }()
@@ -45,7 +67,7 @@ func TestSessionExit_WSStopsBridge(t *testing.T) {
 	var clientOut, logBuf lockedHTTPBuffer
 	done := make(chan error, 1)
 	go func() {
-		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, wsURL(upstream), MCPProxyOpts{
+		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, upstreamURL, MCPProxyOpts{
 			Scanner: sc,
 			sessionExitForTest: &sessionExitTestHooks{watch: parentWatchOpts{
 				interval:  time.Millisecond,
@@ -82,15 +104,14 @@ func TestSessionExit_WSStopsBridge(t *testing.T) {
 }
 
 func TestSessionExit_WSLiveSessionIsNotTornDown(t *testing.T) {
-	upstream, connected := wsSessionExitServer(t)
-	defer upstream.Close()
+	upstreamURL, connected := wsSessionExitServer(t)
 
 	clientIn := newBlockingReader()
 	sc := testScannerForWS(t)
 	var clientOut, logBuf lockedHTTPBuffer
 	done := make(chan error, 1)
 	go func() {
-		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, wsURL(upstream), MCPProxyOpts{
+		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, upstreamURL, MCPProxyOpts{
 			Scanner:            sc,
 			sessionExitForTest: liveSessionExitHooks(),
 		})

--- a/internal/mcp/pgid_unix.go
+++ b/internal/mcp/pgid_unix.go
@@ -41,7 +41,7 @@ func captureChildPgid(pid int) int {
 
 // signalProcessGroupTerm sends SIGTERM to the given process group.
 // Used by the ctx.Done watcher so cooperative descendants can exit
-// cleanly before the post-Wait SIGKILL backstop fires. No-op for
+// cleanly before the bounded SIGKILL backstop fires. No-op for
 // pgid <= 0 (Windows or failed capture).
 func signalProcessGroupTerm(pgid int) {
 	if pgid <= 0 {

--- a/internal/mcp/pgid_unix.go
+++ b/internal/mcp/pgid_unix.go
@@ -25,9 +25,11 @@ func setupChildProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
-// captureChildPgid returns the process group ID of a live child immediately
-// after cmd.Start. The numeric ID is safe to signal only until cmd.Wait begins;
-// after that it may be recycled. Falls back to pid on Getpgid error
+// captureChildPgid returns the process group ID of pid immediately after
+// cmd.Start. Callers must finish all numeric group signaling before cmd.Wait
+// reaps the leader: once a process group is empty, its numeric ID can be
+// reused for an unrelated group. The caller must exclude a concurrent Wait
+// beginning. Falls back to pid on Getpgid error
 // (Setpgid=true guarantees pgid==pid at spawn time anyway). Returns 0 on
 // Windows so downstream signal helpers become no-ops.
 func captureChildPgid(pid int) int {
@@ -49,8 +51,9 @@ func signalProcessGroupTerm(pgid int) {
 }
 
 // terminateProcessGroup runs the SIGTERM + 100ms grace + SIGKILL sequence on
-// a known-live process group. Callers must exclude a concurrent cmd.Wait: once
-// Wait starts, the leader and its numeric group ID can be recycled.
+// the given process group before cmd.Wait reaps the group leader. Callers must
+// exclude a concurrent Wait beginning: once Wait starts, the leader and its
+// numeric group ID can be recycled.
 func terminateProcessGroup(pgid int) {
 	if pgid <= 0 {
 		return

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1474,7 +1474,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// spawn. Non-fatal on error - the later pgid-kill backstop still
 	// handles the common case.
 	if srErr := enableSubreaper(); srErr != nil {
-		_, _ = fmt.Fprintf(logW, "pipelock: warning: PR_SET_CHILD_SUBREAPER failed, grandchild subtree teardown will be incomplete: %v\n", srErr)
+		_, _ = fmt.Fprintf(logW, "pipelock: warning: session descendant cleanup degraded: PR_SET_CHILD_SUBREAPER failed (%v). Detached descendants can survive session exit and can block proxy shutdown by retaining inherited I/O.\n", srErr)
 	}
 
 	// Enable subreaper before starting the child so we adopt orphaned
@@ -1493,11 +1493,21 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 		}
 	}
 
+	// Start and claim as one step, so no sweep can see this child before its
+	// owner has registered it. The reaper started further down registers the
+	// same claim; the registry counts, so both releases are safe. Without this
+	// the window between fork and that reaper start is wide, and a concurrent
+	// session's sweep can reap this child and take the exit status Wait needs.
+	unlockStart := lockChildStart()
 	if err := cmd.Start(); err != nil {
+		unlockStart()
 		_ = serverErr.Close()
 		_ = serverErrW.Close()
 		return fmt.Errorf("starting MCP server %q: %w", command[0], err)
 	}
+	releaseChild := protectDirectChild(cmd.Process.Pid)
+	unlockStart()
+	defer releaseChild()
 	_ = serverErrW.Close()
 	stderrDone := make(chan struct{})
 	go func() {

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1585,7 +1585,6 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// lifetime primitive is needed to cover the remaining launch window and
 	// descendants that create new process groups.
 	waitDone := make(chan struct{})
-	sessionWatchDone := make(chan struct{})
 	sessionExit := &sessionExitState{}
 	sessionCtx, sessionStop := context.WithCancel(ctx)
 	defer sessionStop()

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -1585,6 +1585,7 @@ func RunProxy(ctx context.Context, clientIn io.Reader, clientOut io.Writer, logW
 	// lifetime primitive is needed to cover the remaining launch window and
 	// descendants that create new process groups.
 	waitDone := make(chan struct{})
+	sessionWatchDone := make(chan struct{})
 	sessionExit := &sessionExitState{}
 	sessionCtx, sessionStop := context.WithCancel(ctx)
 	defer sessionStop()

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -63,7 +63,11 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	}
 	isStrict := len(strict) > 0 && strict[0]
 	subreaperEnabled := true
-	if err := enableSubreaper(); err != nil {
+	enable := enableSubreaper
+	if opts.enableSubreaperForTest != nil {
+		enable = opts.enableSubreaperForTest
+	}
+	if err := enable(); err != nil {
 		subreaperEnabled = false
 		if isStrict {
 			return fmt.Errorf("strict mode: failed to set child subreaper: %w", err)

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -72,7 +72,12 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		if isStrict {
 			return fmt.Errorf("strict mode: failed to set child subreaper: %w", err)
 		}
-		_, _ = fmt.Fprintf(logW, "pipelock: warning: PR_SET_CHILD_SUBREAPER failed, sandbox subtree teardown will be incomplete: %v\n", err)
+		// Name the consequence, not just the failed call. An operator reading
+		// "teardown will be incomplete" cannot tell what they are now exposed
+		// to; degraded cleanup here means a detached descendant can outlive
+		// the session and can wedge proxy shutdown by holding inherited I/O.
+		// Use strict mode to refuse the launch instead of accepting that.
+		_, _ = fmt.Fprintf(logW, "pipelock: warning: session descendant cleanup degraded: PR_SET_CHILD_SUBREAPER failed (%v). Detached descendants can survive session exit and can block proxy shutdown by retaining inherited I/O. Run with strict mode to fail closed instead.\n", err)
 	}
 	var rec session.Recorder
 	if opts.Store != nil {
@@ -97,9 +102,17 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	// subprocess tree.
 	setupChildProcessGroup(sandboxCmd)
 
+	// Start and claim as one step. Between fork and the claim the child is a
+	// live process no session has registered, which is exactly what a sibling
+	// session's sweep is entitled to reap.
+	unlockStart := lockChildStart()
 	if err := start(); err != nil {
+		unlockStart()
 		return fmt.Errorf("starting sandboxed MCP server %q: %w", sandboxCmd.Path, err)
 	}
+	releaseChild := protectDirectChild(sandboxCmd.Process.Pid)
+	unlockStart()
+	defer releaseChild()
 	childPgid := captureChildPgid(sandboxCmd.Process.Pid)
 	processExit := &processExitHandoff{}
 	killDirectChild := func() bool {
@@ -108,19 +121,37 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		}
 		return sandboxCmd.Process.Kill() == nil
 	}
-	// Claim the direct child before any reaper can see it, and do so whether or
-	// not this session's own subreaper setup succeeded. startAdoptedReaper
-	// registers the same claim, but it only runs when the subreaper is
-	// available; on a host that refuses PR_SET_CHILD_SUBREAPER this session
-	// would otherwise leave its child unclaimed while a concurrent session in
-	// the same process still runs a reaper that walks /proc, reaps it, and
-	// steals its exit status.
-	defer protectDirectChild(sandboxCmd.Process.Pid)()
+	// The claim itself is made above, atomically with the start, and holds
+	// whether or not this session's subreaper setup succeeded. The reaper
+	// below registers the same claim again; the registry is counted, so both
+	// releases are safe.
 	if subreaperEnabled {
 		reaperDone := make(chan struct{})
 		defer close(reaperDone)
 		startAdoptedReaper(sandboxCmd.Process.Pid, reaperDone)
 	}
+
+	// Proactive teardown on context cancellation, mirroring the plain stdio
+	// path. exec.CommandContext delivers SIGKILL to the direct child's PID
+	// only. That is enough when sandbox-init execs the server in place, and it
+	// is not enough for a bridge supervisor or any descendant that inherited
+	// stdout: the reader below never sees EOF, so this call cannot reach its
+	// own teardown and cancellation hangs until the caller gives up.
+	//
+	// Closing our read end is the half that unblocks the scanner. Signalling
+	// the group is the half that lets cooperative descendants exit. This is
+	// not the ordinary exit path, where a group teardown would kill a server
+	// that is still finishing; reaching here means the caller asked to stop.
+	cancelDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			processExit.terminate(func() { signalProcessGroupTerm(childPgid) }, killDirectChild)
+			_ = serverOut.Close()
+		case <-cancelDone:
+		}
+	}()
+	defer close(cancelDone)
 
 	// The sandbox command is a subprocess tree just like the plain stdio
 	// command. In normal mode sandbox-init execs the server in place; with the

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -108,6 +108,14 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		}
 		return sandboxCmd.Process.Kill() == nil
 	}
+	// Claim the direct child before any reaper can see it, and do so whether or
+	// not this session's own subreaper setup succeeded. startAdoptedReaper
+	// registers the same claim, but it only runs when the subreaper is
+	// available; on a host that refuses PR_SET_CHILD_SUBREAPER this session
+	// would otherwise leave its child unclaimed while a concurrent session in
+	// the same process still runs a reaper that walks /proc, reaps it, and
+	// steals its exit status.
+	defer protectDirectChild(sandboxCmd.Process.Pid)()
 	if subreaperEnabled {
 		reaperDone := make(chan struct{})
 		defer close(reaperDone)
@@ -261,10 +269,11 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	waitErr := processExit.wait(sandboxCmd.Wait)
 	close(waitDone)
 
-	// Clean up sandbox child and temp dir.
-	if sandboxCmd.Process != nil {
-		_ = sandboxCmd.Process.Kill()
-	}
+	// Clean up the sandbox temp dir. No kill belongs here: Wait has already
+	// reaped the direct child, so a Kill at this point can only return
+	// os.ErrProcessDone, and once the PID is retired signaling it risks landing
+	// on whatever the kernel assigns next. Termination happens before Wait,
+	// above.
 	sandbox.CleanupSandboxCmd(sandboxCmd)
 
 	// Sweep once more after Wait for a descendant that exited or reparented in

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -88,11 +88,22 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		return fmt.Errorf("creating stdout pipe: %w", err)
 	}
 	sandboxCmd.Stderr = safeLogW
+	// The sandbox launch preserves other SysProcAttr settings, but it must run
+	// in its own process group before session teardown can safely signal its
+	// subprocess tree.
+	setupChildProcessGroup(sandboxCmd)
 
 	if err := start(); err != nil {
 		return fmt.Errorf("starting sandboxed MCP server %q: %w", sandboxCmd.Path, err)
 	}
 	childPgid := captureChildPgid(sandboxCmd.Process.Pid)
+	processExit := &processExitHandoff{}
+	killDirectChild := func() bool {
+		if sandboxCmd.Process == nil {
+			return false
+		}
+		return sandboxCmd.Process.Kill() == nil
+	}
 	if subreaperEnabled {
 		reaperDone := make(chan struct{})
 		defer close(reaperDone)
@@ -125,15 +136,15 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 				}
 			},
 			closeServerStdin: func() { _ = serverIn.Close() },
-			terminateTree: func() {
-				terminateProcessGroup(childPgid)
-				if sandboxCmd.Process != nil {
-					_ = sandboxCmd.Process.Kill()
-				}
+			terminateTree: func() bool {
 				// A descendant can retain stdout after it leaves the direct
 				// process. Releasing our read end lets ForwardScanned return so
 				// Wait and the post-exit orphan cleanup can run.
 				_ = serverOut.Close()
+				return processExit.terminate(func() {
+					terminateProcessGroup(childPgid)
+					_ = killDirectChild()
+				}, killDirectChild)
 			},
 			waitDone: waitDone,
 			grace:    sessionGrace,
@@ -231,25 +242,31 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 			_ = c.Close()
 		}
 		_ = serverIn.Close()
-		_ = sandboxCmd.Process.Signal(os.Kill)
+		_ = sandboxCmd.Process.Kill()
 	}
 
-	// Signal the original process group before Wait reaps its leader. A process
-	// group identifier is a numeric PID, so using it after Wait leaves a window
-	// where an empty group leader can be recycled into an unrelated group.
-	terminateProcessGroup(childPgid)
-	waitErr := sandboxCmd.Wait()
+	// Finish group signaling before Wait starts. processExit serializes this
+	// numeric-ID window with session teardown; after wait begins it permits only
+	// the stable direct-process handle.
+	processExit.terminate(func() { terminateProcessGroup(childPgid) }, killDirectChild)
+	// A sandbox child can detach from the process group while retaining the
+	// stderr pipe. Once the direct command has been signalled, it is adopted by
+	// the subreaper; sweep it before Wait so inherited descriptors cannot keep
+	// the direct command's pipe copy loop alive forever.
+	if subreaperEnabled {
+		killAdoptedDescendants()
+	}
+	waitErr := processExit.wait(sandboxCmd.Wait)
 	close(waitDone)
 
 	// Clean up sandbox child and temp dir.
 	if sandboxCmd.Process != nil {
-		_ = sandboxCmd.Process.Signal(os.Kill)
+		_ = sandboxCmd.Process.Kill()
 	}
 	sandbox.CleanupSandboxCmd(sandboxCmd)
 
-	// A sandbox child can create a new session and escape the original process
-	// group. The subreaper makes it ours after the direct child exits, so sweep
-	// it before returning instead of leaving an orphaned server alive.
+	// Sweep once more after Wait for a descendant that exited or reparented in
+	// the narrow interval around the first sweep.
 	if subreaperEnabled {
 		killAdoptedDescendants()
 	}

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -124,11 +124,9 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	sessionCtx, stopSession := context.WithCancel(ctx)
 	defer stopSession()
 	sessionOpts := startupParentWatch
-	sessionOpts.logW = safeLogW
 	sessionGrace := defaultParentExitGrace
 	if h := opts.sessionExitForTest; h != nil {
 		sessionOpts = h.watch
-		sessionOpts.logW = safeLogW
 		sessionGrace = h.grace
 	}
 	if sessionOpts.startPPID > orphanedPPID {

--- a/internal/mcp/proxy_sandbox.go
+++ b/internal/mcp/proxy_sandbox.go
@@ -24,7 +24,9 @@ import (
 // It retains the legacy plain-command entry point for tests and callers that
 // do not have a UID/GID map phase. Mapped sandbox launches must use
 // RunProxyWithSandboxLaunch so target start is gated on parent hardening.
-// The optional strict parameter enables subreaper for orphan cleanup.
+// Strict mode fails closed if orphan cleanup cannot be enabled. Every sandbox
+// proxy attempts the same cleanup so a detached child cannot outlive its
+// spawning session merely because the sandbox uses best-effort containment.
 func RunProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, clientIn io.Reader, clientOut io.Writer, logW io.Writer, opts MCPProxyOpts, strict ...bool) error {
 	// Refuse a mapped command here rather than starting it ungated. This entry
 	// point calls Start directly, so a mapped launch would get neither the map
@@ -49,6 +51,10 @@ func RunProxyWithSandboxLaunch(ctx context.Context, launch *sandbox.PreparedSand
 }
 
 func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func() error, clientIn io.Reader, clientOut io.Writer, logW io.Writer, opts MCPProxyOpts, strict ...bool) error {
+	// Capture before pipe setup and sandbox startup. The sandbox command
+	// re-execs pipelock, then either execs the wrapped server or supervises it
+	// for bridge mode, so this proxy process still owns the spawning session.
+	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
 	if opts.Transport == "" {
 		opts.Transport = "mcp_stdio"
 	}
@@ -56,10 +62,13 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		opts.ContractServer = mcpContractServerFromCommand([]string{sandboxCmd.Path})
 	}
 	isStrict := len(strict) > 0 && strict[0]
-	if isStrict {
-		if err := sandbox.SetChildSubreaper(); err != nil {
+	subreaperEnabled := true
+	if err := enableSubreaper(); err != nil {
+		subreaperEnabled = false
+		if isStrict {
 			return fmt.Errorf("strict mode: failed to set child subreaper: %w", err)
 		}
+		_, _ = fmt.Fprintf(logW, "pipelock: warning: PR_SET_CHILD_SUBREAPER failed, sandbox subtree teardown will be incomplete: %v\n", err)
 	}
 	var rec session.Recorder
 	if opts.Store != nil {
@@ -82,6 +91,54 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 
 	if err := start(); err != nil {
 		return fmt.Errorf("starting sandboxed MCP server %q: %w", sandboxCmd.Path, err)
+	}
+	childPgid := captureChildPgid(sandboxCmd.Process.Pid)
+	if subreaperEnabled {
+		reaperDone := make(chan struct{})
+		defer close(reaperDone)
+		startAdoptedReaper(sandboxCmd.Process.Pid, reaperDone)
+	}
+
+	// The sandbox command is a subprocess tree just like the plain stdio
+	// command. In normal mode sandbox-init execs the server in place; with the
+	// bridge it remains a supervisor for the server. Either way, parent death
+	// needs the full drain and process-group teardown rather than a context-only
+	// cancellation.
+	waitDone := make(chan struct{})
+	sessionExit := &sessionExitState{}
+	sessionCtx, stopSession := context.WithCancel(ctx)
+	defer stopSession()
+	sessionOpts := startupParentWatch
+	sessionOpts.logW = safeLogW
+	sessionGrace := defaultParentExitGrace
+	if h := opts.sessionExitForTest; h != nil {
+		sessionOpts = h.watch
+		sessionOpts.logW = safeLogW
+		sessionGrace = h.grace
+	}
+	if sessionOpts.startPPID > orphanedPPID {
+		go runSessionBoundExit(sessionCtx, sessionOpts, sessionExitActions{
+			onSessionExit: sessionExit.begin,
+			stopIntake: func() {
+				if c, ok := clientIn.(io.Closer); ok {
+					_ = c.Close()
+				}
+			},
+			closeServerStdin: func() { _ = serverIn.Close() },
+			terminateTree: func() {
+				terminateProcessGroup(childPgid)
+				if sandboxCmd.Process != nil {
+					_ = sandboxCmd.Process.Kill()
+				}
+				// A descendant can retain stdout after it leaves the direct
+				// process. Releasing our read end lets ForwardScanned return so
+				// Wait and the post-exit orphan cleanup can run.
+				_ = serverOut.Close()
+			},
+			waitDone: waitDone,
+			grace:    sessionGrace,
+			logW:     safeLogW,
+		})
 	}
 
 	blockedCh := make(chan BlockedRequest, 16)
@@ -121,7 +178,8 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	// Build per-invocation opts with session-specific recorder.
 	inputOpts := opts
 	inputOpts.Rec = rec
-	inputOpts.WarnContext = ctx
+	inputOpts.WarnContext = sessionCtx
+	inputOpts.sessionExit = sessionExit
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -176,7 +234,12 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 		_ = sandboxCmd.Process.Signal(os.Kill)
 	}
 
+	// Signal the original process group before Wait reaps its leader. A process
+	// group identifier is a numeric PID, so using it after Wait leaves a window
+	// where an empty group leader can be recycled into an unrelated group.
+	terminateProcessGroup(childPgid)
 	waitErr := sandboxCmd.Wait()
+	close(waitDone)
 
 	// Clean up sandbox child and temp dir.
 	if sandboxCmd.Process != nil {
@@ -184,9 +247,11 @@ func runProxyWithSandbox(ctx context.Context, sandboxCmd *exec.Cmd, start func()
 	}
 	sandbox.CleanupSandboxCmd(sandboxCmd)
 
-	// Strict: reap orphaned descendants adopted by subreaper.
-	if isStrict {
-		sandbox.ReapOrphans()
+	// A sandbox child can create a new session and escape the original process
+	// group. The subreaper makes it ours after the direct child exits, so sweep
+	// it before returning instead of leaving an orphaned server alive.
+	if subreaperEnabled {
+		killAdoptedDescendants()
 	}
 
 	// Drain with timeout - detached descendants can hold pipes open.

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -31,6 +32,15 @@ func RunWSProxy(
 	upstreamURL string,
 	opts MCPProxyOpts,
 ) error {
+	// Capture before upstream validation and dialing. If the spawning session
+	// exits during either step, the watcher must retain the original parent
+	// rather than observe PID 1 and become inert.
+	startupParentWatch := parentWatchOpts{startPPID: os.Getppid()}
+	safeClientOut := &syncWriter{w: clientOut}
+	safeLogW := &syncWriter{w: logW}
+	ctx, stopSession, sessionExit := newSessionBoundContext(ctx, startupParentWatch, clientIn, safeLogW, opts.sessionExitForTest)
+	defer stopSession()
+
 	if opts.ContractServer == "" {
 		opts.ContractServer = mcpContractServerFromUpstream(upstreamURL)
 	}
@@ -52,9 +62,6 @@ func RunWSProxy(
 		rec = opts.Store.GetOrCreate(session.NextInvocationKey("mcp-ws"))
 	}
 	defer recordMCPBaselineSample(opts, rec)
-
-	safeClientOut := &syncWriter{w: clientOut}
-	safeLogW := &syncWriter{w: logW}
 
 	wsClient, err := transport.NewWSClientWithDialer(innerCtx, upstreamURL, opts.DialContext)
 	if err != nil {
@@ -107,6 +114,7 @@ func RunWSProxy(
 	wsOpts.Transport = "mcp_ws"
 	wsOpts.TaintExternalSource = true
 	wsOpts.WarnContext = innerCtx
+	wsOpts.sessionExit = sessionExit
 
 	clientReader := transport.NewStdioReader(clientIn)
 
@@ -131,7 +139,7 @@ func RunWSProxy(
 	for {
 		msg, readErr := clientReader.ReadMessage()
 		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) {
+			if !errors.Is(readErr, io.EOF) && !(sessionExit.inProgress() && isSessionExitCloseErr(readErr)) {
 				stdinErr = fmt.Errorf("reading stdin: %w", readErr)
 			}
 			break

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -139,7 +139,8 @@ func RunWSProxy(
 	for {
 		msg, readErr := clientReader.ReadMessage()
 		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) && !(sessionExit.inProgress() && isSessionExitCloseErr(readErr)) {
+			if !errors.Is(readErr, io.EOF) &&
+				(!sessionExit.inProgress() || !isSessionExitCloseErr(readErr)) {
 				stdinErr = fmt.Errorf("reading stdin: %w", readErr)
 			}
 			break

--- a/internal/mcp/reaper_linux.go
+++ b/internal/mcp/reaper_linux.go
@@ -111,6 +111,17 @@ func reapAdoptedZombies(directPID int) {
 	}
 }
 
+// protectDirectChild claims pid as a session's own direct child so no other
+// session's reaper can consume its exit status, without starting a reaper of
+// its own. Every session must claim its child, including one whose subreaper
+// setup was refused by the host: reapAdoptedZombies walks /proc for any zombie
+// parented to this process, so an unclaimed child is reapable by a sibling
+// session's reaper. The owning session's cmd.Wait then fails with ECHILD,
+// surfacing as "waitid: no child processes".
+//
+// Returns the release function; call it once the child has been reaped.
+func protectDirectChild(pid int) func() { return registerProtectedDirectPID(pid) }
+
 func registerProtectedDirectPID(pid int) func() {
 	if pid <= 0 {
 		return func() {}

--- a/internal/mcp/reaper_linux.go
+++ b/internal/mcp/reaper_linux.go
@@ -18,7 +18,26 @@ import (
 var (
 	protectedDirectPIDsMu sync.Mutex
 	protectedDirectPIDs   = make(map[int]int)
+
+	// childStartMu closes the window between a child existing and its owning
+	// session having claimed it. Claiming cannot happen before the fork,
+	// because the PID does not exist yet, so a sweep that runs in between sees
+	// an unclaimed process and is entitled to reap it. Serializing starts
+	// against sweeps is what makes "started" and "claimed" one step from every
+	// other session's point of view.
+	//
+	// Held across fork/exec, which is brief and rare; sweeps are brief too.
+	childStartMu sync.Mutex
 )
+
+// lockChildStart blocks descendant sweeps until the caller has claimed the
+// child it is about to start. Call the returned function once the claim is
+// registered, and keep the critical section to start-and-claim.
+func lockChildStart() func() {
+	childStartMu.Lock()
+	var once sync.Once
+	return func() { once.Do(childStartMu.Unlock) }
+}
 
 // startAdoptedReaper drains exited adopted descendants while the direct
 // MCP child is still alive. Without it, long-running wraps (codex
@@ -86,6 +105,12 @@ func startAdoptedReaper(directPID int, done <-chan struct{}) {
 // Best-effort throughout - ESRCH on PID-recycle race, EINTR on signal,
 // EPERM on namespace boundary all fall through silently.
 func reapAdoptedZombies(directPID int) {
+	// Exclude a session that is mid-start. Its child may already exist while
+	// its claim does not, and this sweep would read that as an unowned zombie
+	// and consume the exit status its owner is waiting for.
+	unlock := lockChildStart()
+	defer unlock()
+
 	selfPID := os.Getpid()
 	entries, err := os.ReadDir("/proc")
 	if err != nil {

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -30,7 +30,10 @@ import (
 // (i.e. the reaper did not steal the direct child's exit status).
 func TestReaper_AdoptedZombieDrained_DirectChildPreserved(t *testing.T) {
 	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
-		t.Skipf("PR_SET_CHILD_SUBREAPER unavailable (need CAP_SYS_RESOURCE in containers): %v", err)
+		// Not a capability question: the kernel sets a process flag here and
+		// performs no CAP_SYS_RESOURCE check. A failure means an old kernel or
+		// a seccomp/host policy blocking this prctl.
+		t.Skipf("PR_SET_CHILD_SUBREAPER unavailable (old kernel or a policy blocking this prctl): %v", err)
 	}
 
 	// Helper script: double-fork a grandchild that sleeps briefly and
@@ -265,5 +268,64 @@ func TestReaper_DoneChannelStopsGoroutine(t *testing.T) {
 	if delta := after - before; delta > 2 {
 		t.Fatalf("goroutine leak: %d goroutines before, %d after (delta=%d, iterations=%d)",
 			before, after, delta, iterations)
+	}
+}
+
+// TestReaper_SweepsExcludedDuringChildStart proves the window between forking a
+// child and claiming it is closed.
+//
+// The race it guards is not observable by chance: the window is a few
+// instructions wide, so a test that merely runs a sweeper alongside a starting
+// session passes whether or not the exclusion exists. This asserts the
+// exclusion property directly instead — while a start is in progress, a sweep
+// cannot proceed.
+func TestReaper_SweepsExcludedDuringChildStart(t *testing.T) {
+	unlock := lockChildStart()
+
+	swept := make(chan struct{})
+	go func() {
+		reapAdoptedZombies(-1)
+		close(swept)
+	}()
+
+	select {
+	case <-swept:
+		unlock()
+		t.Fatal("a descendant sweep ran while a child start held the start lock; an unclaimed child is reapable in that window")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	unlock()
+	select {
+	case <-swept:
+	case <-time.After(5 * time.Second):
+		t.Fatal("descendant sweep did not resume after the child start completed")
+	}
+}
+
+// TestKillAdoptedDescendants_ExcludedDuringChildStart is the same property for
+// the signalling sweep. It is a separate entry point, so it needs its own
+// guard: killing an unclaimed child is worse than reaping one.
+func TestKillAdoptedDescendants_ExcludedDuringChildStart(t *testing.T) {
+	unlock := lockChildStart()
+
+	swept := make(chan struct{})
+	go func() {
+		killAdoptedDescendants()
+		close(swept)
+	}()
+
+	select {
+	case <-swept:
+		unlock()
+		t.Fatal("a descendant kill sweep ran while a child start held the start lock")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	unlock()
+	select {
+	case <-swept:
+	case <-time.After(5 * time.Second):
+		t.Fatal("descendant kill sweep did not resume after the child start completed")
 	}
 }

--- a/internal/mcp/reaper_other.go
+++ b/internal/mcp/reaper_other.go
@@ -11,3 +11,8 @@ package mcp
 // no-op). Without subreaper adoption there are no orphaned descendants
 // to reap.
 func startAdoptedReaper(_ int, _ <-chan struct{}) {}
+
+// protectDirectChild is a no-op on non-Linux builds. Nothing walks /proc
+// reaping adopted descendants here, so there is no sibling session that
+// could consume this child's exit status.
+func protectDirectChild(_ int) func() { return func() {} }

--- a/internal/mcp/reaper_other.go
+++ b/internal/mcp/reaper_other.go
@@ -16,3 +16,8 @@ func startAdoptedReaper(_ int, _ <-chan struct{}) {}
 // reaping adopted descendants here, so there is no sibling session that
 // could consume this child's exit status.
 func protectDirectChild(_ int) func() { return func() {} }
+
+// lockChildStart is a no-op on non-Linux builds. It exists so the start-and-
+// claim sequence reads identically on every platform; with no sweeps running
+// there is nothing to exclude.
+func lockChildStart() func() { return func() {} }

--- a/internal/mcp/subtree_linux.go
+++ b/internal/mcp/subtree_linux.go
@@ -60,6 +60,12 @@ func enableSubreaper() error {
 // (ESRCH because it already died, EPERM because of a namespace boundary)
 // is handled the same way: skip and move on.
 func killAdoptedDescendants() {
+	// Same exclusion as the zombie reaper: a session that is mid-start has a
+	// live child and no claim on it yet, and this sweep signals whatever it
+	// finds unclaimed.
+	unlock := lockChildStart()
+	defer unlock()
+
 	pid := os.Getpid()
 	entries, err := os.ReadDir("/proc")
 	if err != nil {

--- a/internal/mcp/wait_before_reap_linux.go
+++ b/internal/mcp/wait_before_reap_linux.go
@@ -22,8 +22,8 @@ func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int
 	if handoff == nil {
 		handoff = &processExitHandoff{}
 	}
-	terminate := func() bool {
-		return handoff.terminate(func() { terminateProcessGroup(pgid) }, func() bool {
+	terminate := func() {
+		handoff.terminate(func() { terminateProcessGroup(pgid) }, func() bool {
 			return cmd.Process != nil && cmd.Process.Kill() == nil
 		})
 	}

--- a/internal/mcp/wait_before_reap_linux.go
+++ b/internal/mcp/wait_before_reap_linux.go
@@ -32,18 +32,23 @@ func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int
 		exited <- unix.Waitid(unix.P_PID, cmd.Process.Pid, nil, unix.WEXITED|unix.WNOWAIT, nil)
 	}()
 
+	var observeErr error
 	select {
-	case err := <-exited:
-		if err != nil {
-			return err
-		}
+	case observeErr = <-exited:
 	case <-ctx.Done():
 		terminate()
-		if err := <-exited; err != nil {
-			return err
-		}
+		observeErr = <-exited
 	}
 
+	// A failed observation must not skip the reap. Waitid only watches the
+	// child exit without consuming it, so returning here would leave a live or
+	// zombie child behind with nothing left to reap it, and the caller would
+	// read the error as a completed teardown. Terminate and reap regardless,
+	// and report the reap failure ahead of the observation failure because the
+	// reap is the part that had to happen.
 	terminate()
-	return handoff.wait(cmd.Wait)
+	if err := handoff.wait(cmd.Wait); err != nil {
+		return err
+	}
+	return observeErr
 }

--- a/internal/mcp/wait_before_reap_linux.go
+++ b/internal/mcp/wait_before_reap_linux.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"context"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// waitForCommandWithProcessGroup observes the child exit without reaping it,
+// signals the original process group while its leader still owns the numeric
+// PID, then lets exec.Cmd reap the child. A deferred approval resolver is
+// short-lived, so descendants that survive after their leader exits are not a
+// valid completion state.
+func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int) error {
+	exited := make(chan error, 1)
+	go func() {
+		exited <- unix.Waitid(unix.P_PID, cmd.Process.Pid, nil, unix.WEXITED|unix.WNOWAIT, nil)
+	}()
+
+	select {
+	case err := <-exited:
+		if err != nil {
+			return err
+		}
+	case <-ctx.Done():
+		terminateProcessGroup(pgid)
+		if err := <-exited; err != nil {
+			return err
+		}
+	}
+
+	terminateProcessGroup(pgid)
+	return cmd.Wait()
+}

--- a/internal/mcp/wait_before_reap_linux.go
+++ b/internal/mcp/wait_before_reap_linux.go
@@ -14,10 +14,19 @@ import (
 
 // waitForCommandWithProcessGroup observes the child exit without reaping it,
 // signals the original process group while its leader still owns the numeric
-// PID, then lets exec.Cmd reap the child. A deferred approval resolver is
-// short-lived, so descendants that survive after their leader exits are not a
-// valid completion state.
-func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int) error {
+// PID, then lets exec.Cmd reap the child. The shared handoff also makes the
+// cancellation path safe if reaping wins the race: then only cmd.Process.Kill
+// may run. A deferred approval resolver is short-lived, so descendants that
+// survive after their leader exits are not a valid completion state.
+func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int, handoff *processExitHandoff) error {
+	if handoff == nil {
+		handoff = &processExitHandoff{}
+	}
+	terminate := func() bool {
+		return handoff.terminate(func() { terminateProcessGroup(pgid) }, func() bool {
+			return cmd.Process != nil && cmd.Process.Kill() == nil
+		})
+	}
 	exited := make(chan error, 1)
 	go func() {
 		exited <- unix.Waitid(unix.P_PID, cmd.Process.Pid, nil, unix.WEXITED|unix.WNOWAIT, nil)
@@ -29,12 +38,12 @@ func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, pgid int
 			return err
 		}
 	case <-ctx.Done():
-		terminateProcessGroup(pgid)
+		terminate()
 		if err := <-exited; err != nil {
 			return err
 		}
 	}
 
-	terminateProcessGroup(pgid)
-	return cmd.Wait()
+	terminate()
+	return handoff.wait(cmd.Wait)
 }

--- a/internal/mcp/wait_before_reap_linux_test.go
+++ b/internal/mcp/wait_before_reap_linux_test.go
@@ -16,7 +16,7 @@ func TestWaitForCommandWithProcessGroup_CancellationAfterReapingUsesStableHandle
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	cmd := exec.Command("/bin/sh", "-c", "umask 077; while :; do :; done")
+	cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", "umask 077; while :; do :; done")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting resolver command: %v", err)
 	}

--- a/internal/mcp/wait_before_reap_linux_test.go
+++ b/internal/mcp/wait_before_reap_linux_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package mcp
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestWaitForCommandWithProcessGroup_CancellationAfterReapingUsesStableHandle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := exec.Command("/bin/sh", "-c", "umask 077; while :; do :; done")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting resolver command: %v", err)
+	}
+	reaped := false
+
+	// Model cmd.Wait winning the race. pgid is deliberately zero: a stale
+	// numeric-group path is a no-op here, so only the stable process handle can
+	// release the still-running command and let the helper return.
+	handoff := &processExitHandoff{}
+	handoff.beginReaping()
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForCommandWithProcessGroup(ctx, cmd, 0, handoff)
+	}()
+	t.Cleanup(func() {
+		if reaped {
+			return
+		}
+		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	select {
+	case err := <-done:
+		reaped = true
+		if err == nil {
+			t.Fatal("resolver command exited cleanly after forced teardown")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolver teardown did not use the stable process handle after reaping began")
+	}
+}

--- a/internal/mcp/wait_before_reap_other.go
+++ b/internal/mcp/wait_before_reap_other.go
@@ -13,9 +13,37 @@ import (
 // waitForCommandWithProcessGroup waits for the direct child where the platform
 // cannot observe exit without reaping it. Do not signal a numeric process
 // group after Wait: that identifier may already name unrelated work.
-func waitForCommandWithProcessGroup(_ context.Context, cmd *exec.Cmd, _ int, handoff *processExitHandoff) error {
+//
+// Cancellation still has to terminate the direct child. Without that, Wait
+// blocks until a server decides to exit on its own, so a canceled resolver
+// keeps running and the caller waits on it indefinitely. Termination goes
+// through the handoff's stable process handle rather than a numeric group,
+// which is the only identifier that stays safe once reaping has begun.
+//
+// Descendants the child spawned are a known limitation here, not something
+// this path can close: without a subreaper there is no portable way to reach a
+// grandchild that has left the child's group. On Linux the subreaper covers
+// them; elsewhere they can outlive cancellation.
+func waitForCommandWithProcessGroup(ctx context.Context, cmd *exec.Cmd, _ int, handoff *processExitHandoff) error {
 	if handoff == nil {
 		handoff = &processExitHandoff{}
 	}
-	return handoff.wait(cmd.Wait)
+	if ctx == nil {
+		return handoff.wait(cmd.Wait)
+	}
+
+	reaped := make(chan error, 1)
+	go func() { reaped <- handoff.wait(cmd.Wait) }()
+
+	select {
+	case err := <-reaped:
+		return err
+	case <-ctx.Done():
+	}
+
+	// No numeric group teardown is available before reaping on this platform,
+	// so both branches of the handoff resolve to the same stable handle.
+	kill := func() bool { return cmd.Process != nil && cmd.Process.Kill() == nil }
+	handoff.terminate(func() { _ = kill() }, kill)
+	return <-reaped
 }

--- a/internal/mcp/wait_before_reap_other.go
+++ b/internal/mcp/wait_before_reap_other.go
@@ -13,6 +13,9 @@ import (
 // waitForCommandWithProcessGroup waits for the direct child where the platform
 // cannot observe exit without reaping it. Do not signal a numeric process
 // group after Wait: that identifier may already name unrelated work.
-func waitForCommandWithProcessGroup(_ context.Context, cmd *exec.Cmd, _ int) error {
-	return cmd.Wait()
+func waitForCommandWithProcessGroup(_ context.Context, cmd *exec.Cmd, _ int, handoff *processExitHandoff) error {
+	if handoff == nil {
+		handoff = &processExitHandoff{}
+	}
+	return handoff.wait(cmd.Wait)
 }

--- a/internal/mcp/wait_before_reap_other.go
+++ b/internal/mcp/wait_before_reap_other.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package mcp
+
+import (
+	"context"
+	"os/exec"
+)
+
+// waitForCommandWithProcessGroup waits for the direct child where the platform
+// cannot observe exit without reaping it. Do not signal a numeric process
+// group after Wait: that identifier may already name unrelated work.
+func waitForCommandWithProcessGroup(_ context.Context, cmd *exec.Cmd, _ int) error {
+	return cmd.Wait()
+}


### PR DESCRIPTION
## What changed

The WebSocket and sandbox proxy modes now exit when the session that spawned them dies, closing the same leak the stdio and HTTP modes closed in #1270. A proxy left behind by a dead session kept mediating traffic under a session that no longer existed.

The deferred approval resolver now tears down under the same serialization, so a canceled decision cannot be acted on after the session is gone.

Sandbox teardown now signals its own process group rather than the caller's. Before this it could signal the group it was launched from, which on a cleanup path reached the calling agent session itself.

The failure direction to distrust is the opposite one: teardown that fires too eagerly kills a server that is still finishing a clean shutdown, which reads as a crash to an operator. The ordering around process reaping is the part worth reviewing closely, specifically that no numeric process-group signal is issued on the ordinary exit path or after the child is reaped, since a group ID can be reused once its leader is gone.

Reparenting cannot distinguish a dead session from a short-lived launcher that exits while its session keeps running. A per-session boundary owned by the harness is the complete fix and is tracked as separate infrastructure work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess cleanup when a session ends or is canceled.
  * Ensured entire subprocess trees are terminated and reaped in the correct order.
  * Prevented active sessions from being torn down when unrelated parent processes exit.
  * Resolver cancellation now correctly blocks approval, even when output indicates approval.

* **Tests**
  * Added coverage for process cleanup, session lifecycle handling, cancellation, orphaned parents, and WebSocket proxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->