### PR TITLE
fix(action): tell a failed scan apart from a secret finding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -321,13 +321,34 @@ runs:
           done <<< "$PIPELOCK_EXCLUDE"
         fi
 
-        if ! git diff "origin/${BASE_REF}...HEAD" | pipelock git scan-diff "${SCAN_ARGS[@]}"; then
+        # A non-zero exit from scan-diff means EITHER findings OR that the scan
+        # could not run, and reporting both as "secrets detected" sends the
+        # operator hunting a leak that was never found. The two are told apart
+        # by the output rather than the exit status: a scan that ran emits a
+        # JSON array, and one that failed emits a diagnostic instead.
+        SCAN_OUT="$(mktemp)"
+        SCAN_RC=0
+        git diff "origin/${BASE_REF}...HEAD" | pipelock git scan-diff --json "${SCAN_ARGS[@]}" > "$SCAN_OUT" 2>&1 || SCAN_RC=$?
+
+        if ! FINDINGS="$(jq -e 'if type == "array" then length else empty end' < "$SCAN_OUT" 2>/dev/null)"; then
+          # Fail closed regardless of fail-on-findings. That input decides what
+          # to do about secrets that were found; it cannot speak for a diff that
+          # was never examined, and treating an unscanned diff as clean is the
+          # one outcome this step exists to prevent.
+          echo "::error::Pipelock could not scan the PR diff, so it is unverified. This is a scan failure, not a secret finding."
+          sed 's/^/  /' "$SCAN_OUT"
+          exit 1
+        fi
+
+        if [ "$FINDINGS" -gt 0 ]; then
+          jq -r '.[] | "  \(.file):\(.line)  \(.pattern) (\(.severity))"' < "$SCAN_OUT"
           if [ "$PIPELOCK_FAIL_ON_FINDINGS" = "true" ]; then
-            echo "::error::Secrets detected in PR diff. Failing because fail-on-findings is enabled."
+            echo "::error::Secrets detected in PR diff (${FINDINGS}). Failing because fail-on-findings is enabled."
             exit 1
-          else
-            echo "::warning::Potential secrets detected in PR diff. Review the output above."
           fi
+          echo "::warning::Potential secrets detected in PR diff (${FINDINGS}). Review the output above."
+        else
+          echo "No secrets found in diff."
         fi
 
     - name: Upload audit report


### PR DESCRIPTION
## What changed

`pipelock git scan-diff` exits non-zero for two unrelated reasons, findings and failure to run, and this step reported both as findings. A scanner that crashed announced `Secrets detected in PR diff`, which sends the operator looking for a leak that was never found while saying nothing about the actual problem. This was observed on a live pull request whose only fault was deleting a file, which the released scanner cannot parse.

The second consequence was worse and silent. With `fail-on-findings` disabled, a crash took the warning branch and the build went green on a diff that nothing had examined, so the failure direction of an unusable scanner was to pass. That input decides what to do about secrets that were found and cannot speak for a diff that was never scanned, so a scan failure now fails the step regardless of it.

The two cases are separated by the output rather than the exit status, because the exit status cannot distinguish them: a scan that ran emits a JSON array, and one that failed emits a diagnostic. Unparseable output is therefore treated as a failed scan, which also covers an empty result, a truncated result, and a missing binary.

What a reviewer should distrust here: this step is the last thing standing between a diff and a merge, so the direction of every new branch matters more than its wording. The case worth checking is a scan that fails while `fail-on-findings` is false, which previously passed and now fails, and confirming that a genuine finding still reports as a finding rather than being folded into the failure path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request scanning to correctly process JSON results.
  * Scans now distinguish between scan errors and detected findings.
  * Invalid or unexpected scan output reliably fails the check.
  * Valid findings are counted and displayed with additional details.
  * Findings only fail the check when the configured setting requires it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->