### PR TITLE
Stop runtime and proxy tests reading host containment state

### DIFF
--- a/internal/cli/runtime/main_test.go
+++ b/internal/cli/runtime/main_test.go
@@ -5,39 +5,21 @@ package runtime
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+	"github.com/luckyPipewrench/pipelock/internal/testposture"
 )
 
-// TestMain pins the posture proof path into a temporary directory so this
-// package's tests never read the host's containment state.
-//
-// Without the override, posturebinding.LoadRuntime falls back to the absolute
-// DefaultContainRunProofPath under /var/lib/pipelock, which `pipelock contain
-// install` creates 0o750 and owns as pipelock-proxy. A clean CI runner has no
-// such directory, so the proof reads as absent and server construction takes
-// its no-attested-containment path; a developer machine with containment
-// installed cannot traverse it, so the same construction fails with a
-// permission error and every server- or guard-building test in this package
-// fails for a reason unrelated to the code under test.
-//
-// The pinned path names a file that is deliberately never created. An absent
-// proof yields the zero binding, which is exactly the state CI runs in, so the
-// tests assert the same behavior on both. Writing a synthetic proof here would
-// instead silently move every test into the attested-containment path and
-// change what they cover.
+// TestMain isolates this package's tests from the host's containment posture
+// state. Server and guard construction here call posturebinding.LoadRuntime;
+// testposture.PinAbsent documents why an absent proof is the state under test.
 func TestMain(m *testing.M) {
-	dir, err := os.MkdirTemp("", "pipelock-runtime-test-posture-*")
+	cleanup, err := testposture.PinAbsent()
 	if err != nil {
-		panic(err)
-	}
-	if err := os.Setenv(posturebinding.RuntimeProofEnv, filepath.Join(dir, "absent-proof.json")); err != nil {
 		panic(err)
 	}
 
 	code := m.Run()
-	_ = os.RemoveAll(dir)
+	cleanup()
 	os.Exit(code)
 }

--- a/internal/cli/runtime/main_test.go
+++ b/internal/cli/runtime/main_test.go
@@ -16,6 +16,7 @@ import (
 func TestMain(m *testing.M) {
 	cleanup, err := testposture.PinAbsent()
 	if err != nil {
+		cleanup()
 		panic(err)
 	}
 

--- a/internal/cli/runtime/main_test.go
+++ b/internal/cli/runtime/main_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+)
+
+// TestMain pins the posture proof path into a temporary directory so this
+// package's tests never read the host's containment state.
+//
+// Without the override, posturebinding.LoadRuntime falls back to the absolute
+// DefaultContainRunProofPath under /var/lib/pipelock, which `pipelock contain
+// install` creates 0o750 and owns as pipelock-proxy. A clean CI runner has no
+// such directory, so the proof reads as absent and server construction takes
+// its no-attested-containment path; a developer machine with containment
+// installed cannot traverse it, so the same construction fails with a
+// permission error and every server- or guard-building test in this package
+// fails for a reason unrelated to the code under test.
+//
+// The pinned path names a file that is deliberately never created. An absent
+// proof yields the zero binding, which is exactly the state CI runs in, so the
+// tests assert the same behavior on both. Writing a synthetic proof here would
+// instead silently move every test into the attested-containment path and
+// change what they cover.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pipelock-runtime-test-posture-*")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv(posturebinding.RuntimeProofEnv, filepath.Join(dir, "absent-proof.json")); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/proxy/main_test.go
+++ b/internal/proxy/main_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+)
+
+// TestMain pins the posture proof path into a temporary directory so this
+// package's tests never read the host's containment state.
+//
+// buildReceiptEmitterStage calls posturebinding.LoadRuntime, which without an
+// override reads the absolute DefaultContainRunProofPath under
+// /var/lib/pipelock. That directory does not exist on a clean CI runner, so the
+// proof reads as absent and the emitter is built; `pipelock contain install`
+// creates it 0o750 owned by pipelock-proxy, so on a developer machine the read
+// fails and the stage returns an error instead. The receipt reload tests then
+// fail reporting a nil emitter, which names the symptom rather than the cause
+// and sends the reader looking for a receipt bug that is not there.
+//
+// The pinned path names a file that is deliberately never created, matching the
+// absent-proof state CI runs in. See internal/cli/runtime/main_test.go, which
+// pins the same variable for the same reason.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pipelock-proxy-test-posture-*")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv(posturebinding.RuntimeProofEnv, filepath.Join(dir, "absent-proof.json")); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/proxy/main_test.go
+++ b/internal/proxy/main_test.go
@@ -5,37 +5,23 @@ package proxy
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+	"github.com/luckyPipewrench/pipelock/internal/testposture"
 )
 
-// TestMain pins the posture proof path into a temporary directory so this
-// package's tests never read the host's containment state.
-//
-// buildReceiptEmitterStage calls posturebinding.LoadRuntime, which without an
-// override reads the absolute DefaultContainRunProofPath under
-// /var/lib/pipelock. That directory does not exist on a clean CI runner, so the
-// proof reads as absent and the emitter is built; `pipelock contain install`
-// creates it 0o750 owned by pipelock-proxy, so on a developer machine the read
-// fails and the stage returns an error instead. The receipt reload tests then
-// fail reporting a nil emitter, which names the symptom rather than the cause
-// and sends the reader looking for a receipt bug that is not there.
-//
-// The pinned path names a file that is deliberately never created, matching the
-// absent-proof state CI runs in. See internal/cli/runtime/main_test.go, which
-// pins the same variable for the same reason.
+// TestMain isolates this package's tests from the host's containment posture
+// state. buildReceiptEmitterStage calls posturebinding.LoadRuntime, and when
+// that read fails the stage returns an error, so the receipt reload tests fail
+// reporting a nil emitter rather than the underlying cause. See
+// testposture.PinAbsent.
 func TestMain(m *testing.M) {
-	dir, err := os.MkdirTemp("", "pipelock-proxy-test-posture-*")
+	cleanup, err := testposture.PinAbsent()
 	if err != nil {
-		panic(err)
-	}
-	if err := os.Setenv(posturebinding.RuntimeProofEnv, filepath.Join(dir, "absent-proof.json")); err != nil {
 		panic(err)
 	}
 
 	code := m.Run()
-	_ = os.RemoveAll(dir)
+	cleanup()
 	os.Exit(code)
 }

--- a/internal/proxy/main_test.go
+++ b/internal/proxy/main_test.go
@@ -18,6 +18,7 @@ import (
 func TestMain(m *testing.M) {
 	cleanup, err := testposture.PinAbsent()
 	if err != nil {
+		cleanup()
 		panic(err)
 	}
 

--- a/internal/testposture/testposture.go
+++ b/internal/testposture/testposture.go
@@ -13,47 +13,57 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
 )
 
-// dirMode matches the repository's directory permission convention.
-const dirMode os.FileMode = 0o750
-
 // PinAbsent points posturebinding.RuntimeProofEnv at a file that does not exist,
-// inside a temporary directory, and returns a cleanup function that removes it.
+// inside a temporary directory, and returns a cleanup function that removes the
+// directory and restores the previous override.
 //
 // Packages that build a server, guard, or receipt emitter call
 // posturebinding.LoadRuntime, which without an override reads an absolute path
 // under /var/lib/pipelock. A clean CI runner has no such directory, so the proof
 // reads as absent and construction proceeds. `pipelock contain install` creates
-// it 0o750 owned by pipelock-proxy, so on a machine with containment installed
-// the read fails instead and tests fail for a reason unrelated to the code under
-// test. Pinning an absent proof reproduces the CI state, so both environments
-// assert the same behavior.
+// it owned by pipelock-proxy and unreadable by other users, so on a machine with
+// containment installed the read fails instead and tests fail for a reason
+// unrelated to the code under test. Pinning an absent proof reproduces the CI
+// state, so both environments assert the same behavior.
 //
 // The proof file is deliberately never created. An absent proof yields the zero
 // binding, which is the state under test. Writing a synthetic proof would
 // instead move every caller into the attested-containment path and silently
 // change what those tests cover.
 //
-// The temporary directory is normalized to an absolute path because
-// os.MkdirTemp returns a relative path when TMPDIR is relative, and LoadRuntime
-// rejects a relative override rather than resolving it against an ambiguous
-// working directory. Callers run as TestMain, before any test has run, so an
-// error here is returned rather than reported through testing.TB.
+// cleanup is returned even when pinning fails, so a caller can defer it
+// unconditionally. Callers run as TestMain, before any test has run, so an error
+// here is returned rather than reported through testing.TB. The override is
+// process-wide, so callers must pin once per binary rather than per test.
 func PinAbsent() (cleanup func(), err error) {
 	dir, err := os.MkdirTemp("", "pipelock-test-posture-*")
 	if err != nil {
 		return func() {}, fmt.Errorf("creating posture temp dir: %w", err)
 	}
 
-	// cleanup is returned even when pinning fails, so a caller can defer it
-	// unconditionally and cannot leak the directory by handling the error first.
-	return func() { _ = os.RemoveAll(dir) }, pinInto(dir)
+	prior, hadPrior := os.LookupEnv(posturebinding.RuntimeProofEnv)
+	restore := func() {
+		if hadPrior {
+			_ = os.Setenv(posturebinding.RuntimeProofEnv, prior)
+		} else {
+			_ = os.Unsetenv(posturebinding.RuntimeProofEnv)
+		}
+		_ = os.RemoveAll(dir)
+	}
+
+	return restore, pinInto(dir)
 }
+
+// dirMode grants the owner alone access to the pinned directory. os.MkdirTemp
+// already creates it this way; setting it explicitly states the requirement
+// rather than inheriting it from the standard library's current behavior.
+const dirMode os.FileMode = 0o700
 
 // pinInto prepares dir and points the override at an absent proof inside it.
 //
-// os.MkdirTemp creates 0o700, so the mode is widened to the repository's
-// directory convention. filepath.Abs resolves the relative path os.MkdirTemp
-// returns when TMPDIR is relative, which LoadRuntime would otherwise reject.
+// filepath.Abs resolves the relative path os.MkdirTemp returns when TMPDIR is
+// relative, which LoadRuntime rejects rather than resolving against an ambiguous
+// working directory.
 func pinInto(dir string) error {
 	absDir, err := filepath.Abs(dir)
 	if err == nil {

--- a/internal/testposture/testposture.go
+++ b/internal/testposture/testposture.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testposture isolates a test binary from the host's containment
+// posture state.
+package testposture
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+)
+
+// dirMode matches the repository's directory permission convention.
+const dirMode os.FileMode = 0o750
+
+// PinAbsent points posturebinding.RuntimeProofEnv at a file that does not exist,
+// inside a temporary directory, and returns a cleanup function that removes it.
+//
+// Packages that build a server, guard, or receipt emitter call
+// posturebinding.LoadRuntime, which without an override reads an absolute path
+// under /var/lib/pipelock. A clean CI runner has no such directory, so the proof
+// reads as absent and construction proceeds. `pipelock contain install` creates
+// it 0o750 owned by pipelock-proxy, so on a machine with containment installed
+// the read fails instead and tests fail for a reason unrelated to the code under
+// test. Pinning an absent proof reproduces the CI state, so both environments
+// assert the same behavior.
+//
+// The proof file is deliberately never created. An absent proof yields the zero
+// binding, which is the state under test. Writing a synthetic proof would
+// instead move every caller into the attested-containment path and silently
+// change what those tests cover.
+//
+// The temporary directory is normalized to an absolute path because
+// os.MkdirTemp returns a relative path when TMPDIR is relative, and LoadRuntime
+// rejects a relative override rather than resolving it against an ambiguous
+// working directory. Callers run as TestMain, before any test has run, so an
+// error here is returned rather than reported through testing.TB.
+func PinAbsent() (cleanup func(), err error) {
+	dir, err := os.MkdirTemp("", "pipelock-test-posture-*")
+	if err != nil {
+		return func() {}, fmt.Errorf("creating posture temp dir: %w", err)
+	}
+
+	// cleanup is returned even when pinning fails, so a caller can defer it
+	// unconditionally and cannot leak the directory by handling the error first.
+	return func() { _ = os.RemoveAll(dir) }, pinInto(dir)
+}
+
+// pinInto prepares dir and points the override at an absent proof inside it.
+//
+// os.MkdirTemp creates 0o700, so the mode is widened to the repository's
+// directory convention. filepath.Abs resolves the relative path os.MkdirTemp
+// returns when TMPDIR is relative, which LoadRuntime would otherwise reject.
+func pinInto(dir string) error {
+	absDir, err := filepath.Abs(dir)
+	if err == nil {
+		err = os.Chmod(dir, dirMode)
+	}
+	if err == nil {
+		err = os.Setenv(posturebinding.RuntimeProofEnv, filepath.Join(absDir, "absent-proof.json"))
+	}
+	if err != nil {
+		return fmt.Errorf("pinning %s: %w", posturebinding.RuntimeProofEnv, err)
+	}
+	return nil
+}

--- a/internal/testposture/testposture_test.go
+++ b/internal/testposture/testposture_test.go
@@ -6,6 +6,7 @@ package testposture
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
@@ -51,13 +52,7 @@ func TestPinAbsentIsolatesFromHostPosture(t *testing.T) {
 	}
 
 	dir := filepath.Dir(got)
-	info, statErr := os.Stat(dir)
-	if statErr != nil {
-		t.Fatalf("stat pinned dir: %v", statErr)
-	}
-	if perm := info.Mode().Perm(); perm != dirMode {
-		t.Fatalf("pinned dir mode = %#o, want %#o", perm, dirMode)
-	}
+	assertOwnerOnlyDir(t, dir)
 
 	cleanup()
 	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
@@ -112,5 +107,58 @@ func TestPinIntoRefusesAMissingDirectory(t *testing.T) {
 
 	if err := pinInto(dir); err == nil {
 		t.Fatal("expected an error for a missing directory")
+	}
+}
+
+// assertOwnerOnlyDir checks the pinned directory grants nobody but its owner.
+// Windows does not model POSIX permission bits, so the check is Unix-only.
+func assertOwnerOnlyDir(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat pinned dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != dirMode {
+		t.Fatalf("pinned dir mode = %#o, want %#o", perm, dirMode)
+	}
+}
+
+func TestPinAbsentRestoresThePriorOverride(t *testing.T) {
+	// The override is process-wide, so cleanup must put back whatever was there
+	// rather than leave a path to a directory it just deleted.
+	const prior = "/var/lib/pipelock/contain/posture/prior-proof.json"
+	t.Setenv(posturebinding.RuntimeProofEnv, prior)
+
+	cleanup, err := PinAbsent()
+	if err != nil {
+		t.Fatalf("PinAbsent: %v", err)
+	}
+	if got := os.Getenv(posturebinding.RuntimeProofEnv); got == prior {
+		t.Fatal("PinAbsent did not replace the prior override")
+	}
+
+	cleanup()
+	if got := os.Getenv(posturebinding.RuntimeProofEnv); got != prior {
+		t.Fatalf("cleanup left the override as %q, want %q", got, prior)
+	}
+}
+
+func TestPinAbsentUnsetsAnOverrideItIntroduced(t *testing.T) {
+	t.Setenv(posturebinding.RuntimeProofEnv, "")
+	if err := os.Unsetenv(posturebinding.RuntimeProofEnv); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
+
+	cleanup, err := PinAbsent()
+	if err != nil {
+		t.Fatalf("PinAbsent: %v", err)
+	}
+	cleanup()
+
+	if got, ok := os.LookupEnv(posturebinding.RuntimeProofEnv); ok {
+		t.Fatalf("cleanup left the override set to %q", got)
 	}
 }

--- a/internal/testposture/testposture_test.go
+++ b/internal/testposture/testposture_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package testposture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+func TestPinAbsentIsolatesFromHostPosture(t *testing.T) {
+	t.Setenv(posturebinding.RuntimeProofEnv, "")
+
+	cleanup, err := PinAbsent()
+	if err != nil {
+		t.Fatalf("PinAbsent: %v", err)
+	}
+
+	got := os.Getenv(posturebinding.RuntimeProofEnv)
+	if got == "" {
+		t.Fatal("PinAbsent left the override unset")
+	}
+	if got == posturebinding.DefaultContainRunProofPath {
+		t.Fatalf("PinAbsent pinned the host path %q", got)
+	}
+
+	// LoadRuntime rejects a relative override outright, so the pinned path must
+	// be absolute no matter what TMPDIR held.
+	if !filepath.IsAbs(got) {
+		t.Fatalf("pinned path is not absolute: %q", got)
+	}
+
+	// The proof must be absent: that is the state CI runs in, and the state the
+	// zero binding represents.
+	if _, statErr := os.Stat(got); !os.IsNotExist(statErr) {
+		t.Fatalf("pinned proof should not exist, stat error = %v", statErr)
+	}
+
+	// An absent proof yields the zero binding rather than an error, which is what
+	// makes callers take their no-attested-containment path.
+	binding, loadErr := posturebinding.LoadRuntime()
+	if loadErr != nil {
+		t.Fatalf("LoadRuntime with an absent pinned proof: %v", loadErr)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("expected the zero binding, got %+v", binding)
+	}
+
+	dir := filepath.Dir(got)
+	info, statErr := os.Stat(dir)
+	if statErr != nil {
+		t.Fatalf("stat pinned dir: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != dirMode {
+		t.Fatalf("pinned dir mode = %#o, want %#o", perm, dirMode)
+	}
+
+	cleanup()
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Fatalf("cleanup left the directory behind, stat error = %v", statErr)
+	}
+}
+
+func TestPinAbsentSurvivesRelativeTempDir(t *testing.T) {
+	// os.MkdirTemp returns a relative path when TMPDIR is relative, and an
+	// unnormalized override would then be rejected by LoadRuntime.
+	base := t.TempDir()
+	t.Chdir(base)
+	if err := os.Mkdir("relative-tmp", dirMode); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Setenv("TMPDIR", "relative-tmp")
+
+	cleanup, err := PinAbsent()
+	if err != nil {
+		t.Fatalf("PinAbsent: %v", err)
+	}
+	defer cleanup()
+
+	got := os.Getenv(posturebinding.RuntimeProofEnv)
+	if !filepath.IsAbs(got) {
+		t.Fatalf("relative TMPDIR produced a relative override: %q", got)
+	}
+	if _, loadErr := posturebinding.LoadRuntime(); loadErr != nil {
+		t.Fatalf("LoadRuntime rejected the pinned path: %v", loadErr)
+	}
+}
+
+func TestPinAbsentReportsUnusableTempDir(t *testing.T) {
+	// A TMPDIR that cannot be created under makes setup fail rather than leaving
+	// the tests pointed at the host proof.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	cleanup, err := PinAbsent()
+	if cleanup == nil {
+		t.Fatal("cleanup must be safe to defer even when pinning fails")
+	}
+	defer cleanup()
+	if err == nil {
+		t.Fatal("expected an error for an unusable TMPDIR")
+	}
+}
+
+func TestPinIntoRefusesAMissingDirectory(t *testing.T) {
+	// A directory that no longer exists makes the mode change fail, which must
+	// refuse rather than leave the override pointed at the host proof.
+	dir := filepath.Join(t.TempDir(), "gone")
+
+	if err := pinInto(dir); err == nil {
+		t.Fatal("expected an error for a missing directory")
+	}
+}


### PR DESCRIPTION
## What changed

Tests in `internal/cli/runtime` and `internal/proxy` no longer read the host's containment state. Both packages call `posturebinding.LoadRuntime` while building a server or a receipt emitter, and without an override that reads an absolute path under `/var/lib/pipelock`. A clean CI runner has no such directory, so the proof reads as absent and construction proceeds normally. `pipelock contain install` creates that directory `0o750` owned by `pipelock-proxy`, so on a machine with containment installed the read fails instead, and 44 tests in `internal/cli/runtime` plus 3 in `internal/proxy` fail for a reason unrelated to the code under test.

Each package now pins the proof path to an absent file in a temporary directory, which is the state CI already runs in, so both environments assert the same behavior.

Product code is unchanged. Both call paths already fail closed on a posture bind error, and this does not alter that.

The two packages presented the same defect differently, which is worth a reviewer's attention. `internal/cli/runtime` failed naming the permission error. `internal/proxy` failed reporting a nil receipt emitter, because the bind error is handled upstream before the assertion runs, so the symptom named a receipt defect that does not exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring runtime and proxy tests use temporary, unavailable posture-proof files.
  * Added automatic setup and cleanup to prevent interference from host posture state.
  * Added coverage for temporary-directory handling, secure permissions, cleanup, setup failures, and restoration of prior settings.
  * Ensured test behavior remains consistent across different temporary-directory configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->