### PR TITLE
Assert the image toolchain and require a verified release manifest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -493,6 +493,14 @@ jobs:
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
+      # The release-tooling tests read the release workflow as parsed YAML rather
+      # than as text, so PyYAML is a real dependency of this job. It is installed
+      # hash-pinned rather than taken from whatever the runner image happens to
+      # ship, because an undeclared dependency that works today breaks silently
+      # when the image changes.
+      - name: Install pinned release-tooling test dependencies
+        run: pip install --require-hashes -r .github/requirements-pr-review-test.txt
+
       # Release-tooling tests had no PR-time runner, so breaks stayed invisible
       # until tag time. The pattern covers both test_*.py and *_test.py modules.
       - name: Release tooling unit tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -953,6 +953,28 @@ jobs:
       # have all succeeded. The draft kept GitHub Release assets private while
       # those checks ran. Container images and Homebrew remain separate
       # publication surfaces and are not made atomic by this promotion.
+      # `pipelock update` verifies release.json against release.json.sig before
+      # trusting an update, so a release published without that signature leaves
+      # self-update unable to verify anything. v3.1.0 shipped in exactly that
+      # state. Signing is offline by design and cannot move into CI, so this
+      # refuses to leave draft until the signature has been uploaded, rather
+      # than publishing and discovering the gap from a user report.
+      - name: Require a verified release manifest signature
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
+        run: |
+          set -euo pipefail
+          verify_dir="$RUNNER_TEMP/release-manifest-verify"
+          mkdir -p "$verify_dir"
+          if ! gh release download "$GITHUB_REF_NAME" \
+                 --pattern release.json --pattern release.json.sig \
+                 --dir "$verify_dir" --clobber; then
+            echo "::error::release.json.sig is not attached to ${GITHUB_REF_NAME}. Sign dist/release.json offline (pipelock-release-manifest --sign-only) and upload it before publishing."
+            exit 1
+          fi
+          go run ./cmd/pipelock-release-manifest --verify --manifest "$verify_dir/release.json"
+
       - name: Publish GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -959,13 +959,22 @@ jobs:
       # state. Signing is offline by design and cannot move into CI, so this
       # refuses to leave draft until the signature has been uploaded, rather
       # than publishing and discovering the gap from a user report.
-      - name: Require a verified release manifest signature
+      # Verification and promotion share one step on purpose. Release assets stay
+      # mutable while the release is a draft, so a separate verify step leaves a
+      # window in which the verified manifest or signature can be replaced before
+      # the release goes public. Re-reading the assets and promoting without an
+      # intervening step boundary keeps that window as small as this surface
+      # allows. It does not make the pair atomic, which GitHub does not offer, so
+      # the digests that were verified are recorded in the job log as the record
+      # of what the decision was made against.
+      - name: Verify the release manifest signature and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
         run: |
           set -euo pipefail
           verify_dir="$RUNNER_TEMP/release-manifest-verify"
+          rm -rf "$verify_dir"
           mkdir -p "$verify_dir"
           if ! gh release download "$GITHUB_REF_NAME" \
                  --pattern release.json --pattern release.json.sig \
@@ -974,11 +983,9 @@ jobs:
             exit 1
           fi
           go run ./cmd/pipelock-release-manifest --verify --manifest "$verify_dir/release.json"
-
-      - name: Publish GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+          echo "verified asset digests:"
+          sha256sum "$verify_dir/release.json" "$verify_dir/release.json.sig"
+          gh release edit "$GITHUB_REF_NAME" --draft=false
 
       # Move the v2 floating tag only for the newest stable product release.
       # A prerelease or an older-line backport still publishes its immutable

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,15 @@ FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a
 # reintroduces the stdlib advisories that release pins away from. The tag above
 # and this expectation are updated together, and a mismatch stops the build here
 # instead of producing an image whose Go version nothing states.
-ARG EXPECTED_GO_VERSION=go1.26.6
+# The expected version is written literally rather than taken from an ARG. A
+# build argument can be overridden on the command line, so an assertion that
+# reads one can be satisfied by whoever is building instead of by the toolchain,
+# which is the opposite of what this check is for. Change the tag, the digest
+# and this literal together.
 RUN got="$(go env GOVERSION)"; \
-    if [ "$got" != "$EXPECTED_GO_VERSION" ]; then \
-      echo "toolchain mismatch: base image reports $got, expected $EXPECTED_GO_VERSION" >&2; \
-      echo "update the golang base image tag and digest together with EXPECTED_GO_VERSION" >&2; \
+    if [ "$got" != "go1.26.6" ]; then \
+      echo "toolchain mismatch: base image reports $got, expected go1.26.6" >&2; \
+      echo "update the golang base image tag and digest together with this expectation" >&2; \
       exit 1; \
     fi; \
     echo "toolchain verified: $got"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Multi-stage build for minimal image size
-FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be AS builder
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
+
+# The image builds the binary that ships in the container, so its toolchain is
+# a security input rather than a build detail: govulncheck analyses the active
+# toolchain's stdlib, and a base image that drifts behind the pinned release
+# reintroduces the stdlib advisories that release pins away from. The tag above
+# and this expectation are updated together, and a mismatch stops the build here
+# instead of producing an image whose Go version nothing states.
+ARG EXPECTED_GO_VERSION=go1.26.6
+RUN got="$(go env GOVERSION)"; \
+    if [ "$got" != "$EXPECTED_GO_VERSION" ]; then \
+      echo "toolchain mismatch: base image reports $got, expected $EXPECTED_GO_VERSION" >&2; \
+      echo "update the golang base image tag and digest together with EXPECTED_GO_VERSION" >&2; \
+      exit 1; \
+    fi; \
+    echo "toolchain verified: $got"
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/cmd/pipelock-release-manifest/main.go
+++ b/cmd/pipelock-release-manifest/main.go
@@ -49,8 +49,13 @@ func run(args []string, stdout, stderr io.Writer) error {
 	signOnly := fs.Bool("sign-only", false, "sign an existing release.json without regenerating it")
 	manifestPath := fs.String("manifest", "", "release.json path for --sign-only; defaults to <dist>/release.json")
 	genKey := fs.Bool("gen-key", false, "generate a fresh Ed25519 release-signing keypair and print private_hex + public_hex (private -> offline key safe; public -> RELEASE_KEYRING_HEX)")
+	verify := fs.Bool("verify", false, "verify an existing release.json against its release.json.sig and the release keyring; exits non-zero when the signature is missing or does not verify")
+	keyringHex := fs.String("keyring-hex", os.Getenv("RELEASE_KEYRING_HEX"), "hex Ed25519 public keys accepted as release signers; defaults to RELEASE_KEYRING_HEX")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if *verify {
+		return runVerify(*dist, *manifestPath, *keyringHex, stdout)
 	}
 	if *genKey {
 		privHex, pubHex, err := generateReleaseKeypair()
@@ -113,6 +118,44 @@ func run(args []string, stdout, stderr io.Writer) error {
 	}
 	if err := os.WriteFile(filepath.Join(*dist, releasetrust.ManifestFile), data, 0o600); err != nil {
 		return fmt.Errorf("write release.json: %w", err)
+	}
+	return nil
+}
+
+// runVerify checks that a release manifest carries a signature that verifies
+// against the release keyring.
+//
+// Signing happens offline, so no CI job can produce release.json.sig and no
+// test before the tag can prove it exists. What CI can do is refuse to publish
+// without it. `pipelock update` reads that signature to decide whether an update
+// is genuine, so a release that ships the manifest and not the signature leaves
+// self-update unable to verify anything, which is how v3.1.0 shipped.
+//
+// A missing signature file and a signature that does not verify are both
+// failures here. Treating absence as "nothing to check" is the fail-open
+// direction and is exactly the state this guard exists to catch.
+func runVerify(dist, manifestPath, keyringHex string, stdout io.Writer) error {
+	if strings.TrimSpace(keyringHex) == "" {
+		return errors.New("--keyring-hex or RELEASE_KEYRING_HEX is required to verify a release manifest")
+	}
+	if strings.TrimSpace(manifestPath) == "" {
+		manifestPath = filepath.Join(dist, releasetrust.ManifestFile)
+	}
+	data, err := readReleaseMetadata(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", releasetrust.ManifestFile, err)
+	}
+	sigPath := filepath.Join(filepath.Dir(manifestPath), releasetrust.ManifestSigFile)
+	sig, err := readReleaseMetadata(sigPath)
+	if err != nil {
+		return fmt.Errorf("read %s (sign the manifest offline with --sign-only before publishing): %w", releasetrust.ManifestSigFile, err)
+	}
+	verification, err := releasetrust.VerifyManifest(data, sig, keyringHex)
+	if err != nil {
+		return fmt.Errorf("verify %s: %w", releasetrust.ManifestFile, err)
+	}
+	if _, err := fmt.Fprintf(stdout, "release manifest signature verified by %s (keyring index %d)\n", verification.SignerKeyHex, verification.SignerKeyIndex); err != nil {
+		return fmt.Errorf("write verification result: %w", err)
 	}
 	return nil
 }

--- a/cmd/pipelock-release-manifest/verify_test.go
+++ b/cmd/pipelock-release-manifest/verify_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	releasetrust "github.com/luckyPipewrench/pipelock/internal/release"
+)
+
+// buildDist writes a dist directory holding one archive, its checksums file and
+// a generated release.json, optionally signed, and returns the dist path and the
+// signer's public key hex.
+func buildDist(t *testing.T, sign bool) (string, string) {
+	t.Helper()
+	dist := t.TempDir()
+	archiveName := "pipelock_3.9.9_linux_amd64.tar.gz"
+	archive := []byte("fake archive bytes")
+	if err := os.WriteFile(filepath.Join(dist, archiveName), archive, 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	checksums := []byte(sha256Hex(archive) + "  " + archiveName + "\n")
+	if err := os.WriteFile(filepath.Join(dist, "checksums.txt"), checksums, 0o600); err != nil {
+		t.Fatalf("write checksums: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5c}, ed25519.SeedSize))
+	pubHex := hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+	if err := run([]string{
+		"-dist", dist,
+		"-tag", "v3.9.9",
+		"-commit", "0123456789abcdef0123456789abcdef01234567",
+		"-signer-key-id", pubHex,
+	}, ioDiscard{}, ioDiscard{}); err != nil {
+		t.Fatalf("generate manifest: %v", err)
+	}
+	if sign {
+		if err := run([]string{
+			"-sign-only",
+			"-dist", dist,
+			"-private-key-hex", hex.EncodeToString(priv.Seed()),
+		}, ioDiscard{}, ioDiscard{}); err != nil {
+			t.Fatalf("sign manifest: %v", err)
+		}
+	}
+	return dist, pubHex
+}
+
+// A release whose manifest was never signed is the state v3.1.0 published in.
+// Absence must fail rather than read as nothing to check.
+func TestRunVerifyFailsWhenSignatureIsMissing(t *testing.T) {
+	dist, pubHex := buildDist(t, false)
+
+	err := run([]string{"-verify", "-dist", dist, "-keyring-hex", pubHex}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("verify succeeded with no release.json.sig present")
+	}
+	if !strings.Contains(err.Error(), releasetrust.ManifestSigFile) {
+		t.Fatalf("error does not name the missing signature file: %v", err)
+	}
+}
+
+func TestRunVerifyAcceptsAnOfflineSignedManifest(t *testing.T) {
+	dist, pubHex := buildDist(t, true)
+
+	var out bytes.Buffer
+	if err := run([]string{"-verify", "-dist", dist, "-keyring-hex", pubHex}, &out, ioDiscard{}); err != nil {
+		t.Fatalf("verify offline-signed manifest: %v", err)
+	}
+	if !strings.Contains(out.String(), pubHex) {
+		t.Fatalf("verification output does not name the signing key: %q", out.String())
+	}
+}
+
+// A manifest edited after signing still carries a well-formed signature, so
+// verification has to reject it on content rather than on the signature's shape.
+func TestRunVerifyRejectsATamperedManifest(t *testing.T) {
+	dist, pubHex := buildDist(t, true)
+
+	manifestPath := filepath.Join(dist, releasetrust.ManifestFile)
+	data, err := os.ReadFile(manifestPath) // #nosec G304 -- test reads release.json from its own temp dist dir
+	if err != nil {
+		t.Fatalf("read release.json: %v", err)
+	}
+	tampered := bytes.Replace(data,
+		[]byte("0123456789abcdef0123456789abcdef01234567"),
+		[]byte("fedcba9876543210fedcba9876543210fedcba98"), 1)
+	if bytes.Equal(tampered, data) {
+		t.Fatal("test did not modify the manifest")
+	}
+	if err := os.WriteFile(manifestPath, tampered, 0o600); err != nil {
+		t.Fatalf("write tampered manifest: %v", err)
+	}
+
+	if err := run([]string{"-verify", "-dist", dist, "-keyring-hex", pubHex}, ioDiscard{}, ioDiscard{}); err == nil {
+		t.Fatal("verify accepted a manifest edited after signing")
+	}
+}
+
+// A signature from a key outside the keyring must not verify, or the keyring
+// places no constraint on who may sign a release.
+func TestRunVerifyRejectsAKeyOutsideTheKeyring(t *testing.T) {
+	dist, _ := buildDist(t, true)
+
+	other := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x11}, ed25519.SeedSize))
+	otherHex := hex.EncodeToString(other.Public().(ed25519.PublicKey))
+
+	if err := run([]string{"-verify", "-dist", dist, "-keyring-hex", otherHex}, ioDiscard{}, ioDiscard{}); err == nil {
+		t.Fatal("verify accepted a signature from a key outside the keyring")
+	}
+}
+
+func TestRunVerifyRequiresAKeyring(t *testing.T) {
+	dist, _ := buildDist(t, true)
+	t.Setenv("RELEASE_KEYRING_HEX", "")
+
+	if err := run([]string{"-verify", "-dist", dist}, ioDiscard{}, ioDiscard{}); err == nil {
+		t.Fatal("verify succeeded with no keyring configured")
+	}
+}
+
+// An absent manifest must fail as loudly as an absent signature; a dist that
+// never produced release.json is not a verified release.
+func TestRunVerifyFailsWhenManifestIsMissing(t *testing.T) {
+	priv := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x5c}, ed25519.SeedSize))
+	pubHex := hex.EncodeToString(priv.Public().(ed25519.PublicKey))
+
+	err := run([]string{"-verify", "-dist", t.TempDir(), "-keyring-hex", pubHex}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("verify succeeded with no release.json present")
+	}
+	if !strings.Contains(err.Error(), releasetrust.ManifestFile) {
+		t.Fatalf("error does not name the missing manifest: %v", err)
+	}
+}
+
+// Reporting a successful verification is part of the result, so a failed write
+// must surface rather than leave the caller believing the check reported.
+func TestRunVerifyReportsAFailedResultWrite(t *testing.T) {
+	dist, pubHex := buildDist(t, true)
+
+	if err := run([]string{"-verify", "-dist", dist, "-keyring-hex", pubHex}, failingWriter{}, ioDiscard{}); err == nil {
+		t.Fatal("verify succeeded despite failing to write its result")
+	}
+}

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -265,8 +265,18 @@ class TestReleaseArtifacts(unittest.TestCase):
         bundle_gate = self.workflow.index("- name: Verify Kubernetes image digest bundle attestation")
         upload = self.workflow.index("- name: Upload Kubernetes image digest bundle")
         chart = self.workflow.index("- name: Publish Helm chart")
-        promotion = self.workflow.index("- name: Publish GitHub release")
+        promotion = self.workflow.index("- name: Verify the release manifest signature and publish")
         self.assertIn('gh release edit "$GITHUB_REF_NAME" --draft=false', self.workflow)
+
+        # Verification and promotion share one step so that release assets, which
+        # stay mutable while the release is a draft, cannot be replaced between
+        # the two. A separate promotion step would reopen that window, so assert
+        # the order inside the step rather than only the step's position.
+        verify = self.workflow.index("--verify --manifest")
+        undraft = self.workflow.index('gh release edit "$GITHUB_REF_NAME" --draft=false')
+        self.assertLess(promotion, verify)
+        self.assertLess(verify, undraft)
+        self.assertNotIn("- name: Publish GitHub release", self.workflow)
 
         self.assertLess(goreleaser, proof_gate)
         self.assertLess(proof_gate, bundle)

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -336,13 +336,24 @@ class TestReleaseArtifacts(unittest.TestCase):
             f"draft removal must happen only in the promotion step, found {undrafting_steps}",
         )
 
-        # Both commands must EXECUTE here, not merely appear. A comment or an
-        # echo mentioning the verifier would satisfy a text search and would
-        # verify nothing.
-        verify_at = [i for i, line in enumerate(promotion_lines) if line.startswith(verify_cmd)]
-        undraft_at = [i for i, line in enumerate(promotion_lines) if line.startswith(undraft_cmd)]
+        # Both commands must EXECUTE here, not merely appear, and the verifier
+        # must be able to stop the publish. `... --verify --manifest x || true`
+        # starts with the verifier and permits an invalid signature through, so
+        # the line is required to be the canonical command exactly: no shell
+        # operator, no error suppression, no redirection appended to it.
+        canonical_verify = f'{verify_cmd} "$verify_dir/release.json"'
+        verify_at = [i for i, line in enumerate(promotion_lines) if canonical_verify in line]
+        undraft_at = [i for i, line in enumerate(promotion_lines) if undraft_cmd in line]
         self.assertEqual(len(verify_at), 1, "promotion step must run the verifier exactly once")
         self.assertEqual(len(undraft_at), 1, "promotion step must undraft exactly once")
+        for i in verify_at + undraft_at:
+            self.assertNotRegex(
+                promotion_lines[i],
+                r"(\|\||&&|;|\||>|<|\btrue\b)",
+                f"release-gating command must fail closed, found: {promotion_lines[i]}",
+            )
+        self.assertEqual(promotion_lines[verify_at[0]], canonical_verify)
+        self.assertEqual(promotion_lines[undraft_at[0]], undraft_cmd)
         self.assertLess(verify_at[0], undraft_at[0])
         self.assertNotIn("- name: Publish GitHub release", self.workflow)
 

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -257,6 +257,17 @@ class TestReleaseArtifacts(unittest.TestCase):
                     self.workflow,
                 )
 
+    def _step_block(self, start: int) -> str:
+        """Return one workflow step's text, from its name to the next step's.
+
+        Assertions about what a step does have to read that step. A search over
+        the whole workflow answers a different question: whether the strings
+        appear anywhere in that order.
+        """
+        rest = self.workflow[start:]
+        nxt = rest.find("\n      - name: ", 1)
+        return rest if nxt == -1 else rest[:nxt]
+
     def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
         goreleaser = self.workflow.index("- name: Run GoReleaser")
         proof_gate = self.workflow.index("- name: Verify attestation")
@@ -268,13 +279,20 @@ class TestReleaseArtifacts(unittest.TestCase):
         promotion = self.workflow.index("- name: Verify the release manifest signature and publish")
         self.assertIn('gh release edit "$GITHUB_REF_NAME" --draft=false', self.workflow)
 
-        # Verification and promotion share one step so that release assets, which
-        # stay mutable while the release is a draft, cannot be replaced between
-        # the two. A separate promotion step would reopen that window, so assert
-        # the order inside the step rather than only the step's position.
-        verify = self.workflow.index("--verify --manifest")
-        undraft = self.workflow.index('gh release edit "$GITHUB_REF_NAME" --draft=false')
-        self.assertLess(promotion, verify)
+        # Release assets stay mutable while the release is a draft, and the job
+        # holds contents: write, so verifying and then promoting in one step
+        # NARROWS the window in which a verified manifest could be replaced. It
+        # does not close it. Preventing the substitution outright needs an
+        # immutable or pinned publication mechanism, which GitHub releases do not
+        # provide.
+        #
+        # Both commands must live inside the promotion step for even that
+        # narrowing to hold, so the ordering is asserted within the step's own
+        # text. Searching the whole workflow would pass while the two sat in
+        # different steps, which is the arrangement this is meant to rule out.
+        promotion_block = self._step_block(promotion)
+        verify = promotion_block.index("--verify --manifest")
+        undraft = promotion_block.index('gh release edit "$GITHUB_REF_NAME" --draft=false')
         self.assertLess(verify, undraft)
         self.assertNotIn("- name: Publish GitHub release", self.workflow)
 

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -13,6 +13,8 @@ that introduced the drift.
 from __future__ import annotations
 
 import unittest
+
+import yaml
 from pathlib import Path
 
 
@@ -257,16 +259,35 @@ class TestReleaseArtifacts(unittest.TestCase):
                     self.workflow,
                 )
 
-    def _step_block(self, start: int) -> str:
-        """Return one workflow step's text, from its name to the next step's.
+    def _release_job_runs(self) -> list[tuple[str, str]]:
+        """Return (step name, run script) for every step of the release job.
 
-        Assertions about what a step does have to read that step. A search over
-        the whole workflow answers a different question: whether the strings
-        appear anywhere in that order.
+        Reading the parsed workflow rather than its text is the point. A string
+        search is satisfied by a comment or an echo that merely mentions a
+        command, and it cannot tell which step a command belongs to.
         """
-        rest = self.workflow[start:]
-        nxt = rest.find("\n      - name: ", 1)
-        return rest if nxt == -1 else rest[:nxt]
+        parsed = yaml.safe_load(WORKFLOW.read_text())
+        steps = parsed["jobs"]["release"]["steps"]
+        return [
+            (step.get("name", ""), step["run"])
+            for step in steps
+            if isinstance(step, dict) and isinstance(step.get("run"), str)
+        ]
+
+    @staticmethod
+    def _executable_lines(script: str) -> list[str]:
+        """Return the lines of a run script that actually execute.
+
+        Comments do not run, so a check that accepts them proves nothing about
+        what the step does.
+        """
+        lines = []
+        for raw in script.splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            lines.append(line)
+        return lines
 
     def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
         goreleaser = self.workflow.index("- name: Run GoReleaser")
@@ -290,10 +311,39 @@ class TestReleaseArtifacts(unittest.TestCase):
         # narrowing to hold, so the ordering is asserted within the step's own
         # text. Searching the whole workflow would pass while the two sat in
         # different steps, which is the arrangement this is meant to rule out.
-        promotion_block = self._step_block(promotion)
-        verify = promotion_block.index("--verify --manifest")
-        undraft = promotion_block.index('gh release edit "$GITHUB_REF_NAME" --draft=false')
-        self.assertLess(verify, undraft)
+        undraft_cmd = 'gh release edit "$GITHUB_REF_NAME" --draft=false'
+        verify_cmd = "go run ./cmd/pipelock-release-manifest --verify --manifest"
+
+        runs = self._release_job_runs()
+        promotion_steps = [
+            script
+            for name, script in runs
+            if name == "Verify the release manifest signature and publish"
+        ]
+        self.assertEqual(len(promotion_steps), 1, "expected exactly one promotion step")
+        promotion_lines = self._executable_lines(promotion_steps[0])
+
+        # The release must leave draft in exactly one place. An undraft anywhere
+        # else could publish before verification while a check scoped to this
+        # step still passed.
+        undrafting_steps = [
+            name for name, script in runs
+            if any(undraft_cmd in line for line in self._executable_lines(script))
+        ]
+        self.assertEqual(
+            undrafting_steps,
+            ["Verify the release manifest signature and publish"],
+            f"draft removal must happen only in the promotion step, found {undrafting_steps}",
+        )
+
+        # Both commands must EXECUTE here, not merely appear. A comment or an
+        # echo mentioning the verifier would satisfy a text search and would
+        # verify nothing.
+        verify_at = [i for i, line in enumerate(promotion_lines) if line.startswith(verify_cmd)]
+        undraft_at = [i for i, line in enumerate(promotion_lines) if line.startswith(undraft_cmd)]
+        self.assertEqual(len(verify_at), 1, "promotion step must run the verifier exactly once")
+        self.assertEqual(len(undraft_at), 1, "promotion step must undraft exactly once")
+        self.assertLess(verify_at[0], undraft_at[0])
         self.assertNotIn("- name: Publish GitHub release", self.workflow)
 
         self.assertLess(goreleaser, proof_gate)


### PR DESCRIPTION
## What changed

The container image now builds on Go 1.26.6 and refuses to build on anything else. It previously built on 1.26.5, which carries six stdlib advisories across `crypto/tls`, `html/template`, `net/http` and `net/url` that this repository's own govulncheck job names as reachable through the proxy and MCP transport call paths. Released binaries already build on a pinned patched toolchain and assert it at release time; the image asserted nothing, so a container user received weaker code than a binary user and no check said so. The assertion lives in the Dockerfile rather than in CI, so a local `make docker` fails the same way the pipeline does, and the base image tag and the expected version are updated together or the build stops.

`pipelock update` verifies `release.json` against `release.json.sig` before trusting an update, and the release workflow never produced or checked that signature. Version 3.1.0 published in exactly that state, leaving self-update with nothing to verify against. Signing happens offline by design and cannot move into CI, so this adds a verify mode to the release manifest command and a workflow step that refuses to take the release out of draft until a signature that verifies against the release keyring is attached.

The failure direction is the point of the second change, and it is what a reviewer should distrust. A missing signature must fail rather than read as nothing to check, because the fail-open form of this guard would have passed every release including the one that shipped without a signature. Verification is refused for an absent signature, a manifest edited after signing, and a signature from a key outside the keyring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added signed release manifest verification with trusted-key checks.
  - Verification results identify the validating key and keyring entry.
  - Release artifact digests are logged before publication.

- **Bug Fixes**
  - Releases remain unpublished when manifests or signatures are missing, invalid, tampered with, or untrusted.
  - Builds fail if the expected Go toolchain version is not detected.

- **Chores**
  - Upgraded the build environment to Go 1.26.6.

- **Tests**
  - Expanded coverage for release verification and publication safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->