### PR TITLE
fix(sandbox): isolate tests from host state, bound the socket path

### DIFF
--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -200,11 +200,25 @@ func TestLoadRuntimeUnsetUsesDefaultPath(t *testing.T) {
 	// A machine with containment installed is a production state, not an exotic
 	// one, so this must distinguish absence from refusal rather than collapse
 	// them.
-	if _, err := os.Stat(DefaultContainRunProofPath); !errors.Is(err, fs.ErrNotExist) {
-		t.Skipf(
-			"default proof path %s is not provably absent (%v); skipping missing-default assertion",
-			DefaultContainRunProofPath, err,
-		)
+	_, statErr := os.Stat(DefaultContainRunProofPath)
+	switch {
+	case statErr == nil:
+		t.Skipf("default proof path %s exists; skipping missing-default assertion",
+			DefaultContainRunProofPath)
+	case errors.Is(statErr, fs.ErrNotExist):
+		// Provably absent, which is the state this assertion is about.
+	case errors.Is(statErr, fs.ErrPermission):
+		// `pipelock contain install` creates the posture directory 0o750 owned
+		// by pipelock-proxy, so an ordinary user cannot tell whether the proof
+		// is there. Absence is unprovable, so the assertion is skipped rather
+		// than failed: a machine with containment installed is a production
+		// state, and failing here would be the defect this test was fixed for.
+		t.Skipf("default proof path %s is unreadable (%v); absence cannot be established",
+			DefaultContainRunProofPath, statErr)
+	default:
+		// Anything else is a genuine filesystem fault and must not be hidden
+		// behind a skip.
+		t.Fatalf("stat default proof path %s: %v", DefaultContainRunProofPath, statErr)
 	}
 	t.Setenv(RuntimeProofEnv, "")
 	got, err := LoadRuntime()

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -14,6 +14,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -184,11 +186,25 @@ func TestLoadRuntimeAbsoluteOverrideWorks(t *testing.T) {
 }
 
 func TestLoadRuntimeUnsetUsesDefaultPath(t *testing.T) {
-	// With no override, LoadRuntime reads DefaultContainRunProofPath. Skip if a
-	// real proof exists on the host so the test never depends on (or reads) live
-	// local state; the missing-default case is what we assert here.
-	if _, err := os.Stat(DefaultContainRunProofPath); err == nil {
-		t.Skipf("host has a real proof at %s; skipping missing-default assertion", DefaultContainRunProofPath)
+	// With no override, LoadRuntime reads DefaultContainRunProofPath, so this
+	// assertion is only meaningful when that path is provably absent.
+	//
+	// Skipping on `err == nil` alone was not that check. It treats every error
+	// as absence, and the error a containment host actually returns is
+	// permission denied: `pipelock contain install` creates the posture
+	// directory 0o750 owned by pipelock-proxy, so an ordinary user's stat fails
+	// without the file being missing. The guard then declined to skip,
+	// LoadRuntime surfaced that refusal, and the test failed for a reason that
+	// has nothing to do with the missing-default behavior it asserts.
+	//
+	// A machine with containment installed is a production state, not an exotic
+	// one, so this must distinguish absence from refusal rather than collapse
+	// them.
+	if _, err := os.Stat(DefaultContainRunProofPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Skipf(
+			"default proof path %s is not provably absent (%v); skipping missing-default assertion",
+			DefaultContainRunProofPath, err,
+		)
 	}
 	t.Setenv(RuntimeProofEnv, "")
 	got, err := LoadRuntime()

--- a/internal/sandbox/landlock_test.go
+++ b/internal/sandbox/landlock_test.go
@@ -80,6 +80,10 @@ func TestMain(m *testing.M) {
 	// test reports a sandbox failure that has nothing to do with sandboxing.
 	posturePin, err := testposture.PinAbsent()
 	if err != nil {
+		// PinAbsent creates its temporary directory before it pins, and returns
+		// the cleanup either way, so exiting without calling it leaks that
+		// directory and can leave a partial environment override behind.
+		posturePin()
 		fmt.Fprintf(os.Stderr, "pinning posture proof: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/sandbox/landlock_test.go
+++ b/internal/sandbox/landlock_test.go
@@ -8,6 +8,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	guardruntime "github.com/luckyPipewrench/pipelock/internal/guard"
+	"github.com/luckyPipewrench/pipelock/internal/testposture"
 )
 
 // Landlock tests use subprocess execution because Landlock restrictions are
@@ -62,6 +64,26 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	// Isolate the pipelock processes these tests spawn from the host's
+	// containment posture state. They inherit this process's environment, so
+	// pinning the proof path here reaches the child, which is where the read
+	// actually happens.
+	//
+	// The pin goes after the re-exec entry points above and before m.Run: a
+	// child that re-enters this binary as an init or exec helper must not take
+	// this path, and no ordinary test may run without it.
+	//
+	// Same cause as the runtime and proxy packages: without an override the
+	// child reads an absolute path under /var/lib/pipelock, which is absent on
+	// a clean runner and unreadable once `pipelock contain install` has created
+	// it 0o750 owned by pipelock-proxy. The child then fails to start and the
+	// test reports a sandbox failure that has nothing to do with sandboxing.
+	posturePin, err := testposture.PinAbsent()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pinning posture proof: %v\n", err)
+		os.Exit(1)
+	}
+
 	var proofBuildDir string
 	if runtime.GOARCH == "amd64" && os.Getenv("PIPELOCK_MCP_ENVIRON_PROOF_HELPER") == "" {
 		proofBuildDir, errMCPEnvironProofBuild = os.MkdirTemp("", "pipelock-mcp-environ-proof-")
@@ -78,6 +100,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 	code := m.Run()
+	posturePin()
 	if proofBuildDir != "" {
 		_ = os.RemoveAll(proofBuildDir)
 	}

--- a/internal/sandbox/socketpath_test.go
+++ b/internal/sandbox/socketpath_test.go
@@ -49,10 +49,15 @@ func TestCheckSocketPathLength_RefusesOverLongPathAndSaysWhy(t *testing.T) {
 func TestNewStandaloneControlDir_RefusesALongTMPDIR(t *testing.T) {
 	base := t.TempDir()
 	deep := filepath.Join(base, strings.Repeat("d", 90))
-	if err := os.MkdirAll(deep, 0o700); err != nil {
+	if err := os.MkdirAll(deep, 0o750); err != nil {
 		t.Skipf("cannot build a long temp path here: %v", err)
 	}
 	t.Setenv("TMPDIR", deep)
+
+	// Snapshot before and after. newStandaloneControlDir returns "" on this
+	// failure, so a check guarded on a non-empty return can never observe a
+	// leak; the directory listing can.
+	before := sandboxDirEntries(t, deep)
 
 	dir, err := newStandaloneControlDir()
 	if err == nil {
@@ -62,11 +67,8 @@ func TestNewStandaloneControlDir_RefusesALongTMPDIR(t *testing.T) {
 	if !strings.Contains(err.Error(), "TMPDIR") {
 		t.Errorf("refusal does not name TMPDIR, so an operator cannot act on it: %v", err)
 	}
-	// A rejected directory must not be left behind.
-	if dir != "" {
-		if _, statErr := os.Stat(dir); statErr == nil {
-			t.Errorf("rejected control dir %s was left on disk", dir)
-		}
+	if after := sandboxDirEntries(t, deep); len(after) != len(before) {
+		t.Errorf("rejected control dir left behind: before %v, after %v", before, after)
 	}
 }
 
@@ -90,4 +92,20 @@ func TestNewStandaloneControlDir_AcceptsAShortTMPDIR(t *testing.T) {
 	if got := len(ProxySocketPath(dir)); got > maxUnixSocketPath {
 		t.Fatalf("accepted a control dir whose socket path is %d bytes", got)
 	}
+}
+
+// sandboxDirEntries lists the per-invocation control directories under dir.
+func sandboxDirEntries(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "pipelock-sandbox-") {
+			names = append(names, e.Name())
+		}
+	}
+	return names
 }

--- a/internal/sandbox/socketpath_test.go
+++ b/internal/sandbox/socketpath_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckSocketPathLength_AcceptsAPathTheKernelCanBind(t *testing.T) {
+	if err := checkSocketPathLength("/tmp/pipelock-sandbox-123456789/proxy.sock"); err != nil {
+		t.Fatalf("ordinary path rejected: %v", err)
+	}
+}
+
+func TestCheckSocketPathLength_AcceptsExactlyTheLimit(t *testing.T) {
+	path := "/" + strings.Repeat("a", maxUnixSocketPath-1)
+	if len(path) != maxUnixSocketPath {
+		t.Fatalf("fixture is %d bytes, want %d", len(path), maxUnixSocketPath)
+	}
+	if err := checkSocketPathLength(path); err != nil {
+		t.Fatalf("path at exactly the limit rejected: %v", err)
+	}
+}
+
+// The failure this guard exists for. Without it bind returns EINVAL, which
+// reaches the operator as "invalid argument" and names neither the length nor
+// TMPDIR.
+func TestCheckSocketPathLength_RefusesOverLongPathAndSaysWhy(t *testing.T) {
+	path := "/" + strings.Repeat("a", maxUnixSocketPath)
+	err := checkSocketPathLength(path)
+	if err == nil {
+		t.Fatal("a path one byte over the limit was accepted")
+	}
+	for _, want := range []string{"TMPDIR", "kernel limit"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %q, so it is not actionable: %v", want, err)
+		}
+	}
+}
+
+// The real production shape: a long TMPDIR is what makes the derived path
+// exceed the limit, and it is the only input an operator controls.
+func TestNewStandaloneControlDir_RefusesALongTMPDIR(t *testing.T) {
+	base := t.TempDir()
+	deep := filepath.Join(base, strings.Repeat("d", 90))
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Skipf("cannot build a long temp path here: %v", err)
+	}
+	t.Setenv("TMPDIR", deep)
+
+	dir, err := newStandaloneControlDir()
+	if err == nil {
+		_ = os.Remove(dir)
+		t.Fatalf("control dir accepted under a TMPDIR that cannot hold a bindable socket: %s", dir)
+	}
+	if !strings.Contains(err.Error(), "TMPDIR") {
+		t.Errorf("refusal does not name TMPDIR, so an operator cannot act on it: %v", err)
+	}
+	// A rejected directory must not be left behind.
+	if dir != "" {
+		if _, statErr := os.Stat(dir); statErr == nil {
+			t.Errorf("rejected control dir %s was left on disk", dir)
+		}
+	}
+}
+
+func TestNewStandaloneControlDir_AcceptsAShortTMPDIR(t *testing.T) {
+	// Deliberately not t.TempDir(). It embeds the test name, and this test's
+	// name alone pushes the derived socket path to 130 bytes -- the guard above
+	// refuses it, correctly. Any test that needs a bindable unix socket has to
+	// build a short directory rather than take the framework's.
+	short, err := os.MkdirTemp("/tmp", "plk")
+	if err != nil {
+		t.Skipf("cannot create a short temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(short) }()
+	t.Setenv("TMPDIR", short)
+
+	dir, err := newStandaloneControlDir()
+	if err != nil {
+		t.Fatalf("short TMPDIR rejected: %v", err)
+	}
+	defer func() { _ = os.Remove(dir) }()
+	if got := len(ProxySocketPath(dir)); got > maxUnixSocketPath {
+		t.Fatalf("accepted a control dir whose socket path is %d bytes", got)
+	}
+}

--- a/internal/sandbox/standalone_launch.go
+++ b/internal/sandbox/standalone_launch.go
@@ -531,7 +531,40 @@ func newStandaloneControlDir() (retDir string, retErr error) {
 	if int(stat.Uid) != os.Geteuid() {
 		return "", fmt.Errorf("sandbox control dir %s is owned by uid %d, not this process (uid %d)", sandboxDir, stat.Uid, os.Geteuid())
 	}
+	if err := checkSocketPathLength(ProxySocketPath(sandboxDir)); err != nil {
+		return "", err
+	}
 	return sandboxDir, nil
+}
+
+// maxUnixSocketPath is the usable length of sockaddr_un.sun_path.
+//
+// The kernel struct reserves 108 bytes on Linux and 104 on Darwin, including
+// the terminating NUL, so 103 is the longest path that is safe on both. The
+// limit is a fixed-size C array rather than anything configurable, which is why
+// this is a constant and not a knob.
+const maxUnixSocketPath = 103
+
+// checkSocketPathLength refuses a control socket path the kernel cannot bind.
+//
+// The path is derived from TMPDIR, and bind() answers an over-long one with
+// EINVAL, which surfaces as "invalid argument" naming neither the length nor
+// the variable that caused it. An operator on a host with a long TMPDIR -- a
+// container whose temp lives under an overlay storage path, for instance --
+// would see the sandbox fail to start with nothing to act on.
+//
+// Checked at directory creation rather than at bind so it fails before any
+// listener, child process or proxy has been set up, and so the message can name
+// the fix.
+func checkSocketPathLength(path string) error {
+	if len(path) <= maxUnixSocketPath {
+		return nil
+	}
+	return fmt.Errorf(
+		"sandbox control socket path is %d bytes, over the %d-byte kernel limit: %s; "+
+			"set TMPDIR to a shorter directory",
+		len(path), maxUnixSocketPath, path,
+	)
 }
 
 type standaloneProxyServer struct {


### PR DESCRIPTION
## What changed

Two packages stop reading the host's containment posture state during tests, and the sandbox refuses a control socket path the kernel cannot bind.

`pipelock contain install` creates the posture directory `0o750` owned by the proxy user, so an ordinary user's read is refused and the binary fails closed, which is correct. A clean CI runner has no such directory, reads the proof as absent, and proceeds. The two environments therefore assert different things, and the one that disagrees is the machine in production shape. An earlier change fixed this for the runtime and proxy packages; `posturebinding` and `sandbox` had the same defect and were missed.

The `posturebinding` guard is the more interesting half. It skipped on `os.Stat(...) == nil`, which treats every error as absence, and the error a containment host returns is permission denied. The guard declined to skip and the test then failed on the refusal it existed to avoid. It now skips unless the path is provably absent, and names the error it saw.

The sandbox control socket lives under a directory derived from `TMPDIR`, and `sockaddr_un.sun_path` is a fixed 108-byte array on Linux and 104 on Darwin, including the terminating NUL. Nothing checked the length, so a host whose `TMPDIR` pushes the derived path past the limit fails at bind with `EINVAL`, reaching the operator as "invalid argument" and naming neither the length nor the variable responsible. A container whose temporary directory sits under an overlay storage path reaches that length without doing anything unusual. The check runs at control-directory creation, before a listener or child process exists, so the message can name the fix.

Reviewers should distrust the direction of the new skip. A guard that makes a test SKIP rather than run is a way to hide a real failure, so the skip condition is deliberately narrow: absent only, never unreadable, and it reports the error it observed. Verified by neutralization: inverting it reproduces the original failure exactly, and restoring it makes the test skip with the real error named.

The socket-path limit was found because a private red-team test hit it through `t.TempDir`, which embeds the test name. That test passes under a short `TMPDIR` and fails under a longer one, which is how it stayed green on CI while failing on a developer host. The test written here to verify the guard hit the same limit at 130 bytes and was rewritten to build a short directory rather than take the framework's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone mode now detects temporary-directory paths that would exceed Unix socket limits before launching.
  * Error messages identify the path length, system limit, and recommended `TMPDIR` adjustment.
  * Improved handling of missing default proof paths while preserving permission and other filesystem errors.

* **Tests**
  * Expanded coverage for socket path limits, temporary-directory configurations, cleanup behavior, and standalone control-directory creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->