### PR TITLE
chore(release): prepare v3.4.0 changelog, chart, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `chain_kind` and `writer_instance_id`. The recorder continues to emit v2
   entries during the compatibility window.
 
+## [3.4.0] - 2026-08-18
+
+### Breaking Changes / Upgrade Notes
+
+- **Three `airlock.triggers` fields are now rejected at config load.** `on_severity`,
+  `anomaly_count` and `anomaly_window_minutes` parsed and validated in 3.3.0 while never
+  being read by any code, so setting them changed nothing and said nothing. Loading a
+  config that still carries any of them now fails with the replacement named. Airlock
+  fires from `on_elevated`, `on_high` and `on_critical`; remove the three old keys and
+  set those instead. A silently inert knob is worse than a rejected one, which is why
+  this refuses rather than warning.
+- **`pipelock git scan-diff` has a three-value exit contract.** `0` means the diff was
+  scanned and is clean, `1` means secrets were found, and `2` means no verified result
+  was produced, covering unreadable or unparseable input and configuration, encoding or
+  report-writing failures. A caller that treats every non-zero status as "secrets found"
+  will report leaks that were never detected. CI steps keying on this should distinguish
+  1 from 2.
+- **The container image asserts its Go toolchain and fails the build on a mismatch.**
+  The base image tag, its digest and the expected version are changed together; a base
+  that drifts stops the build rather than producing an image whose Go version nothing
+  states.
+- **Release publication now requires a verified release manifest.** Tagging halts before
+  publication until `release.json.sig` is signed and uploaded, so a release cannot leave
+  draft with an unverified manifest.
+
+### Added
+
+- Guard manifests gain filesystem and command-execution enforcement, declared path types
+  that refuse credential paths, and path-decision explanations.
+- `pipelock contain upgrade`, a containment-aware upgrade command that re-pins integrity.
+- Commitment keys gain a durable operator-owned keyring with recorded lifecycle
+  operations.
+- Exact protocol, host and port guard grants, on a transport-neutral destination
+  evaluator that unifies alternative IP literal handling.
+- Assessments are signed, gating content rather than integrity.
+- Conductor reports fleet and evidence convergence as four denominators, and exposes
+  build information in its metrics.
+- The Helm chart publishes as an OCI artifact.
+- An explicit applicability vocabulary for verification status, separating a check that
+  cannot apply from one that applies and has no measurement.
+
+### Changed
+
+- Human-readable CLI results go to stdout and diagnostics to stderr, so a caller can pipe
+  one without the other.
+- `pipelock explain` discloses every enabled control an allowed verdict did not evaluate.
+  It does not fetch the URL or resolve DNS, so response scanning, request body scanning
+  and the SSRF layer can still block a request the explanation allowed.
+- `pipelock doctor` reports action divergence under its own check name.
+- Configuration warns when a sub-detector action is weaker than its section, and ranks
+  every enforcement action when combining findings.
+- The developer environment reaches a sandboxed process over a pipe rather than the
+  command line, keeping values out of `/proc/<pid>/cmdline`.
+- Release verification binds to one tag predicate and an exact identity, so the readiness
+  gate and the publication path agree on what a product tag is.
+
+### Fixed
+
+- MCP proxies exit when their spawning session dies, and WebSocket and sandbox proxy
+  sessions are bound to their spawner.
+- MCP capacity bounds fail closed and require signed resets. Reaching a bound refuses
+  rather than evicting live state, which would make a prior request replayable.
+- Listener state is bound to authenticated principals, and the listener state token
+  defaults off.
+- Tool definition drift is blocked on introduced content, `tools/list` is scanned for
+  HTTP listener clients without a session token, and fragmented tool arguments are
+  reassembled for cross-request detection.
+- The scanner detects external data transfer directives.
+- Local authority grants are canonicalized with JCS, so a re-encoded grant is not
+  interchangeable with the signed one.
+- Evidence provenance commitments are unambiguous, and the provenance profile describes
+  the scanner transforms that actually run.
+- Recorder evidence is preserved under concurrent writers, and anchor bundle and marker
+  state are fsynced before success is reported.
+- Metrics stop reporting a self-awarded evidence assurance level and cap the current
+  level at the honestly-earned ceiling.
+- Signing publishes agent key pairs as a transaction, and CLI, license and integrity
+  commands refuse an output path that names the signing key they just used.
+- The commitment keyring refuses content that fails its own check, so an altered or
+  truncated backup is not adopted.
+- `contain` verifies the deployed binary against the integrity pin and the running
+  service image, validates managed configuration on upgrade, and constrains metrics
+  exposure to loopback or a declared, expiring, source-scoped exception.
+- The proxy preserves detection state across reload, gates receipt headers on successful
+  recording, and binds the SSRF dial snapshot to the CONNECT port.
+- `scan-diff` accepts whole-file deletion hunks, which previously failed the scan and,
+  through fail-on-findings, CI.
+- A second release no longer overwrites the published Helm chart.
+- The sandbox preserves capacity on busy hosts and treats its network lifecycle as a
+  fail-closed required service.
+
 ## [3.3.0] - 2026-07-30
 
 ### Breaking Changes / Upgrade Notes

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 # gate enforces that both equal the release tag. The chart publishes to an
 # OCI registry under this version as the tag, so a version that did not move
 # every release would overwrite the previously published chart in place.
-version: 3.3.0
-appVersion: "3.3.0"
+version: 3.4.0
+appVersion: "3.4.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -9,6 +9,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 | [`pipelock baseline`](baseline.md) | Inspect, ratify, and relearn behavioral-baseline profiles through the admin API. |
 | [`pipelock demo`](demo.md) | Run self-contained attack scenarios that show what Pipelock catches. |
 | [`pipelock status`](operator.md) | Read-only operator setup and local inspection commands. |
+| [`pipelock git scan-diff`](git.md) | Scan a unified diff on stdin for credentials before it is committed or merged. |
 | [`pipelock scan`](scan.md) | Scan files for invisible-Unicode and bidi-control injection. |
 | [`pipelock skill-scan`](skill-scan.md) | Inventory skill files, compare lock drift, and flag conservative source-to-sink combinations. |
 | [`pipelock doctor`](doctor.md) | Audit whether configured protections are actually enforceable in the current topology. |

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -85,7 +85,7 @@ could run found nothing."
 Every enabled control the verdict did not evaluate is therefore named in the
 report, together with the fact that it can still block the request at runtime:
 
-```
+```text
 Verdict: ALLOWED
 note: this config's SSRF layer (layer 8) resolves DNS at runtime; explain did not
       resolve, so a private/metadata IP or DNS failure could still block this URL
@@ -94,6 +94,17 @@ note: this verdict covers URL-layer checks only; explain does not fetch the URL,
       so response scanning and request body scanning did not run and can still
       block this request at runtime
 ```
+
+Notes are emitted for each of these when the relevant control is enabled:
+
+| Not evaluated | Why explain cannot reach it |
+|---|---|
+| The hostname SSRF layer | It resolves DNS at runtime; `explain` does not resolve. |
+| Response scanning | Needs the response, which `explain` never requests. |
+| Request body scanning | Needs the request body. |
+| Cross-request detection | Accumulates across a session; `explain` holds no session history. |
+| Adaptive enforcement | Escalates from accumulated state, for the same reason. |
+| Kill switch | With `kill_switch.enabled` set, every request is refused at runtime except exempt endpoints and allowlisted IPs, whatever the verdict above says. |
 
 The notes follow the loaded config rather than printing unconditionally. With
 `response_scanning.enabled: false` the response-scanning note does not appear,

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -75,6 +75,31 @@ uses normal command success/failure semantics for log lookup and rendering.
 
 The non-zero exit on a block lets scripts branch on the verdict without parsing output.
 
+## An allowed verdict says what it did not check
+
+`explain` runs the pre-resolution layers with no network access and no session
+history, so it cannot evaluate anything that depends on state it does not hold.
+A bare `ALLOWED` would read as "this URL is fine" when it means "the layers I
+could run found nothing."
+
+Every enabled control the verdict did not evaluate is therefore named in the
+report, together with the fact that it can still block the request at runtime:
+
+```
+Verdict: ALLOWED
+note: this config's SSRF layer (layer 8) resolves DNS at runtime; explain did not
+      resolve, so a private/metadata IP or DNS failure could still block this URL
+      when proxied
+note: this verdict covers URL-layer checks only; explain does not fetch the URL,
+      so response scanning and request body scanning did not run and can still
+      block this request at runtime
+```
+
+The notes follow the loaded config rather than printing unconditionally. With
+`response_scanning.enabled: false` the response-scanning note does not appear,
+because no enabled control is being skipped. A note that printed either way would
+be a disclaimer rather than a disclosure.
+
 ## JSON report fields
 
 `--json` emits a stable report shape: `url`, `config_file`, `mode`, `version`, `allowed`, `scanner`, `layer`, `target_view` (`url_query` / `host` / `path` / `scheme` / `url`), `host`, `pattern_name` (for DLP/blocklist), `reason`, `score`, `dns_dependent`, `notes`, `warn_matches`, and a `remediation` object with `knob`, `broader`, and `immutable`.

--- a/docs/cli/git.md
+++ b/docs/cli/git.md
@@ -1,0 +1,69 @@
+# `pipelock git scan-diff`
+
+Reads a unified diff on stdin and scans its added lines for credential patterns.
+Built for a pre-commit hook or a CI step, where the thing you need to know is
+whether this change introduces a secret.
+
+```bash
+git diff HEAD~1 | pipelock git scan-diff
+git diff --cached | pipelock git scan-diff --config pipelock.yaml
+git diff HEAD~1 | pipelock git scan-diff --format sarif -o results.sarif
+```
+
+The diff arrives on stdin. Nothing is read from the repository directly, so the
+command scans exactly the range you pipe to it.
+
+## Exit codes
+
+The three values mean different things and a caller has to tell them apart.
+
+| Code | Meaning |
+|---|---|
+| `0` | The diff was scanned and no credential was found. |
+| `1` | The diff was scanned and secrets were found. |
+| `2` | No verified result was produced. |
+
+Exit `2` covers input that could not be read or parsed, and configuration,
+encoding, or report-writing failures. It is not a finding. **A caller that treats
+every non-zero status as "secrets found" reports leaks that were never
+detected**, and one that treats every non-zero status as failure-to-scan lets
+real findings through. Branch on the two separately:
+
+```bash
+git diff --cached | pipelock git scan-diff
+case $? in
+  0) ;;                                        # clean, continue
+  1) echo "secret found in this change" >&2; exit 1 ;;
+  2) echo "scan did not complete; not a clean result" >&2; exit 1 ;;
+esac
+```
+
+An empty diff exits `0`. A commit that changes nothing has nothing to leak, so a
+no-op commit does not fail the hook. If the command that produces your diff can
+fail silently, check that separately: an empty diff and a broken `git diff`
+invocation look the same on stdin.
+
+## Deleted files
+
+A whole-file deletion emits a hunk header whose new-side start and count are both
+zero. That is a valid hunk that adds nothing, and it scans clean.
+
+## Output
+
+Results go to stdout. Diagnostics, including errors and verbose suppression
+notes, go to stderr. `--output` writes a SARIF result to a file instead.
+
+| Flag | Purpose |
+|---|---|
+| `--config` | Config file, for `suppress` entries and pattern overrides. |
+| `--json` | Machine-readable findings on stdout. |
+| `--format` | `text`, `json`, or `sarif`. |
+| `-o`, `--output` | Write the report to a file. |
+| `--exclude` | Exclude paths by glob or directory prefix; repeatable. |
+| `--verbose` | Include suppression notes on stderr. |
+
+## Related
+
+- [`pipelock scan`](scan.md) scans files rather than a diff.
+- [`pipelock explain`](explain.md) explains a URL verdict and names the knob that
+  would change it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1590,6 +1590,23 @@ airlock:
     soft_minutes: 5         # soft tier auto-recovers after 5 minutes
     hard_minutes: 15        # hard tier auto-drops to soft after 15 minutes
     drain_minutes: 0        # drain timer disabled
+```
+
+`airlock.triggers` accepts exactly `on_elevated`, `on_high` and `on_critical`.
+Three fields that existed in 3.3.0 are rejected at config load in 3.4.0:
+
+| Removed field | Why |
+|---|---|
+| `on_severity` | Parsed and validated, never read. Setting it changed nothing. |
+| `anomaly_count` | Same. Airlock fires from the three severity triggers. |
+| `anomaly_window_minutes` | Same. |
+
+All three were inert: they passed validation and had no effect on enforcement, so
+a config carrying them described a policy the product was not applying. Loading
+now fails with the replacement named rather than accepting a setting that does
+nothing. Remove the old keys and set the severity triggers instead.
+
+```yaml
     drain_timeout_seconds: 30  # drain deadline for in-flight completion
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1590,6 +1590,7 @@ airlock:
     soft_minutes: 5         # soft tier auto-recovers after 5 minutes
     hard_minutes: 15        # hard tier auto-drops to soft after 15 minutes
     drain_minutes: 0        # drain timer disabled
+    drain_timeout_seconds: 30  # drain deadline for in-flight completion
 ```
 
 `airlock.triggers` accepts exactly `on_elevated`, `on_high` and `on_critical`.
@@ -1605,10 +1606,6 @@ All three were inert: they passed validation and had no effect on enforcement, s
 a config carrying them described a policy the product was not applying. Loading
 now fails with the replacement named rather than accepting a setting that does
 nothing. Remove the old keys and set the severity triggers instead.
-
-```yaml
-    drain_timeout_seconds: 30  # drain deadline for in-flight completion
-```
 
 ## Event Emission
 


### PR DESCRIPTION
## What changed

Authors the 3.4.0 changelog section, bumps the chart, and closes the documentation gaps a sweep of this release turned up.

The chart moves both `version` and `appVersion`. `values.yaml` defaults `image.tag` to `appVersion`, so a chart whose `appVersion` lags deploys the previous image, and the chart publishes to an OCI registry under its own version, so a `version` that does not move overwrites the previously published chart. Both were still 3.3.0.

Three operator-visible behaviors shipped this release without documentation.

`pipelock git scan-diff` gained a three-value exit contract and had no documentation page at all. This adds one. The distinction is the point: `0` is clean, `1` is secrets found, `2` is no verified result, and a caller that reads every non-zero status as "secrets found" reports leaks that were never detected, while one that reads every non-zero status as a failed scan lets real findings through. The page shows how to branch on the three separately.

`pipelock explain` now names every enabled control an allowed verdict did not evaluate. That is worth documenting precisely because the notes follow the loaded configuration rather than printing unconditionally; a note that appeared whether or not the control was enabled would be a disclaimer rather than a disclosure.

Three `airlock.triggers` fields that parsed and validated in 3.3.0 while never being read are now rejected at config load. This is the one item here a reviewer should distrust most, because it stops an upgrade: a config carrying `on_severity`, `anomaly_count` or `anomaly_window_minutes` fails to load until those keys are removed. Refusing rather than warning is deliberate, since a knob that validates and does nothing describes a policy the product is not applying, but it does mean an operator upgrading from 3.3.0 hits it before anything starts. It is covered in the changelog's Breaking Changes section and in the configuration guide with the replacement named.

Everything else in the release was already documented. The sweep checked all sixteen new config fields, the action-divergence warning, the commitment-key content check, release-manifest verification, and guard filesystem enforcement, and found no gaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `pipelock git scan-diff` to scan changes for credentials before commits or merges.
  - Expanded explanations for verdicts and unavailable runtime controls.
  - Documented new guard, containment, keyring, assessment, verification, and deployment capabilities.

- **Breaking Changes**
  - Replaced legacy anomaly trigger settings with supported severity-based triggers.
  - Added configuration validation and migration guidance.

- **Bug Fixes**
  - Improved proxy lifecycle, capacity enforcement, listener binding, scanning coverage, redaction, containment, and release verification.

- **Chores**
  - Updated the Helm chart and application release to version 3.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->