### PR TITLE
Bring the changelog current and fix the release-blocking gaps

### DIFF
--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: bash scripts/ci-apt-install.sh ripgrep
 
       - name: Workflow and release audit
         run: make release-audit
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: bash scripts/ci-apt-install.sh ripgrep
 
       - name: Runtime policy audit
         run: make runtime-policy-audit

--- a/.github/workflows/hardening.yaml
+++ b/.github/workflows/hardening.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   workflow-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -41,7 +41,7 @@ jobs:
     # release. The release workflow still runs this audit as a defense-
     # in-depth gate; this job catches regressions earlier.
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,7 +195,7 @@ jobs:
         run: bash scripts/ci-retry.sh go mod verify
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: bash scripts/ci-apt-install.sh ripgrep
 
       - name: Run release audit
         run: make release-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fires from `on_elevated`, `on_high` and `on_critical`; remove the three old keys and
   set those instead. A silently inert knob is worse than a rejected one, which is why
   this refuses rather than warning.
+- **A reasoning trust class can no longer weaken a stricter response action.** An MCP
+  server marked `trust: reasoning` maps to `warn`, but Pipelock now applies whichever of
+  that mapping and `response_scanning.action` is stricter. An operator running `block`,
+  `ask` or `strip` with a reasoning server configured was getting warn-and-forward for
+  that server; those responses now take the section action. A trust class can tighten the
+  enclosing action and can no longer relax it. If you relied on the old behaviour, set
+  `response_scanning.action: warn` explicitly rather than expecting the server entry to
+  override a stricter setting.
 - **`pipelock git scan-diff` has a three-value exit contract.** `0` means the diff was
   scanned and is clean, `1` means secrets were found, and `2` means no verified result
   was produced, covering unreadable or unparseable input and configuration, encoding or
@@ -57,7 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Human-readable CLI results go to stdout and diagnostics to stderr, so a caller can pipe
-  one without the other.
+  one without the other. `pipelock version > file` and `pipelock generate docker-compose >
+  docker-compose.yml` produce their content rather than an empty file.
+- A command group rejects a subcommand it does not have instead of printing help and
+  reporting success. A setup step whose subcommand name is wrong now fails, where it
+  previously looked like it had run.
 - `pipelock explain` discloses every enabled control an allowed verdict did not evaluate.
   It does not fetch the URL or resolve DNS, so response scanning, request body scanning
   and the SSRF layer can still block a request the explanation allowed.
@@ -103,6 +115,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A second release no longer overwrites the published Helm chart.
 - The sandbox preserves capacity on busy hosts and treats its network lifecycle as a
   fail-closed required service.
+- `pipelock quickstart` prints a walkthrough a reader can run. It creates the config its
+  later steps use, instead of naming one that ships only in a source checkout, and writes
+  each step in the syntax of the platform it is printed on.
+- Integration guides and the README no longer show commands that cannot run: a flag that
+  does not exist on `run` or `mcp proxy`, config paths present only in a source checkout,
+  and an evidence-viewer invocation pointed at a directory it cannot read.
 
 ## [3.3.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ pipelock verify-receipt "$(ls ./out/*.json | head -1)" --key ./out/signer.pub  #
 
 The scorecard grades each claim on its own and states what it does not prove: whether anything happened outside the boundary Pipelock mediates. Below it, the receipt timeline lists the recorded mediated decisions with their verdicts and hash links. A receipt that is honest about its own limits beats a green checkmark that hides them.
 
-The evidence viewer is free and needs no license:
+The evidence viewer is free and needs no license. It reads a flight-recorder
+session, which is what Pipelock writes while it runs, rather than the demo
+receipts above:
 
 ```bash
-pipelock evidence serve --receipt-dir ./out   # read-only HTML report for one recorded session
-pipelock evidence view --receipt-dir ./out    # static offline report, no server
+pipelock init --output ./pipelock.yaml        # names a recorder directory and generates its signing key
+pipelock run --config ./pipelock.yaml         # record while your agent works
+pipelock evidence view --receipt-dir ./recorder --out report.html   # static offline report, no server
+pipelock evidence serve --receipt-dir ./recorder                    # same report, served read-only
 ```
 
 Two honesty notes, stated up front. The demo signs with an ephemeral key it prints for the run, which proves the receipts are self-consistent rather than tied to a named identity. The public Pipelock playground is a separate path that verifies against a key Pipelock publishes. And the operator running Pipelock holds the signing key, so a receipt proves what the boundary decided and that the key holder signed it, not that the operator is honest. `pipelock anchor receipts` records receipt-chain checkpoints to a local backend or a Rekor transparency log for later audit, and operator-independent verification against that anchor is still being proven end to end.

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -13,8 +13,11 @@ go install github.com/luckyPipewrench/pipelock/cmd/pipelock@latest
 # 2. Verify it works
 pipelock version
 
-# 3. Wrap an MCP server
-pipelock mcp proxy --preset claude-code -- npx -y @modelcontextprotocol/server-filesystem /tmp
+# 3. Generate a config from the Claude Code preset
+pipelock generate config --preset claude-code -o pipelock.yaml
+
+# 4. Wrap an MCP server with it
+pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
 ## MCP Proxy Mode
@@ -154,7 +157,7 @@ pipelock as an HTTP proxy server:
 
 ```bash
 # Start the proxy (background or separate terminal)
-pipelock run --preset claude-code
+pipelock run --config pipelock.yaml
 ```
 
 The proxy listens on `127.0.0.1:8888` by default and exposes:
@@ -244,7 +247,10 @@ interception. They scan traffic directly without certificates.
 
 ## Choosing a Config
 
-Pipelock ships with agent-specific presets selectable via `--preset`:
+Pipelock ships with agent-specific presets. A preset is selected when the config is
+generated, with `pipelock generate config --preset <name> -o pipelock.yaml`, and the
+resulting file is what `run` and `mcp proxy` take through `--config`. Run
+`pipelock presets` to list them:
 
 | Preset | Action | Entropy | Rate Limit | Best For |
 |--------|--------|---------|------------|----------|
@@ -305,5 +311,5 @@ during development, run the MCP server manually:
 
 ```bash
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | \
-  pipelock mcp proxy --preset claude-code -- npx -y @modelcontextprotocol/server-filesystem /tmp
+  pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -275,7 +275,7 @@ Verify the command works without pipelock first:
 npx -y @modelcontextprotocol/server-filesystem /tmp
 
 # Then wrap it
-pipelock mcp proxy -- npx -y @modelcontextprotocol/server-filesystem /tmp
+pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
 ### Config file not found

--- a/docs/guides/cline.md
+++ b/docs/guides/cline.md
@@ -45,7 +45,8 @@ pipelock cline install
 For outbound HTTP that Cline executes through tool calls (`curl`, `wget`, etc.), run pipelock as a forward proxy and point the agent shell at it:
 
 ```bash
-pipelock run --config configs/balanced.yaml &
+pipelock generate config --preset balanced > pipelock.yaml
+pipelock run --config pipelock.yaml &
 export HTTPS_PROXY=http://127.0.0.1:8888
 export HTTP_PROXY=http://127.0.0.1:8888
 export NO_PROXY=127.0.0.1,localhost

--- a/docs/guides/cline.md
+++ b/docs/guides/cline.md
@@ -58,12 +58,12 @@ Combined with MCP wrapping, this covers Cline MCP traffic and HTTP clients that 
 
 | Preset | Action | Best for |
 |---|---|---|
-| `balanced.yaml` | warn | Getting started, tuning phase |
-| `claude-code.yaml` | block | Unattended Cline sessions on regulated codebases |
-| `strict.yaml` | block | High-security repos, third-party plugin work |
-| `hostile-model.yaml` | block | If running an uncensored or jailbroken model under Cline |
+| `balanced` | warn | Getting started, tuning phase |
+| `claude-code` | block | Unattended Cline sessions on regulated codebases |
+| `strict` | block | High-security repos, third-party plugin work |
+| `hostile-model` | block | If running an uncensored or jailbroken model under Cline |
 
-Start with `balanced.yaml` to see what gets flagged. Switch to `claude-code.yaml` or `strict.yaml` once you've verified no false positives in your workflow.
+Start with `balanced` to see what gets flagged. Switch to `claude-code` or `strict` once you've verified no false positives in your workflow.
 
 ## Action Receipts
 

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -37,8 +37,11 @@ go install github.com/luckyPipewrench/pipelock/cmd/pipelock@latest
 # 2. Wrap every Codex MCP server with pipelock in one shot
 pipelock codex install
 
-# 3. Run an assessment before first use
-pipelock assess init --config configs/balanced.yaml
+# 3. Generate a config to work from
+pipelock generate config --preset balanced -o pipelock.yaml
+
+# 4. Run an assessment before first use
+pipelock assess init --config pipelock.yaml
 pipelock assess run assessment-*/
 pipelock assess finalize assessment-*/
 ```
@@ -56,7 +59,7 @@ For manual / per-server control, the original pattern still works:
 
 ```bash
 codex mcp add my-server \
-  -- pipelock mcp proxy --config configs/balanced.yaml \
+  -- pipelock mcp proxy --config pipelock.yaml \
   -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
@@ -75,17 +78,17 @@ Codex  <-->  pipelock mcp proxy  <-->  MCP Server
 ```bash
 # Wrap a filesystem server
 codex mcp add filesystem \
-  -- pipelock mcp proxy --config configs/balanced.yaml \
+  -- pipelock mcp proxy --config pipelock.yaml \
   -- npx -y @modelcontextprotocol/server-filesystem ~/projects
 
 # Wrap a database server
 codex mcp add postgres \
-  -- pipelock mcp proxy --config configs/balanced.yaml \
+  -- pipelock mcp proxy --config pipelock.yaml \
   -- npx -y @modelcontextprotocol/server-postgres postgresql://localhost/mydb
 
 # Wrap a remote MCP server (Streamable HTTP)
 codex mcp add remote-tools \
-  -- pipelock mcp proxy --config configs/balanced.yaml \
+  -- pipelock mcp proxy --config pipelock.yaml \
   --upstream http://localhost:8080/mcp
 ```
 
@@ -120,7 +123,7 @@ fetch), run pipelock as a forward proxy:
 
 ```bash
 # Start the proxy
-pipelock run --config configs/balanced.yaml &
+pipelock run --config pipelock.yaml &
 
 # Set the proxy for Codex sessions
 export HTTPS_PROXY=http://127.0.0.1:8888
@@ -141,7 +144,7 @@ Think of it as a background check before the agent starts work.
 
 ```bash
 # Initialize an assessment session
-pipelock assess init --config configs/balanced.yaml
+pipelock assess init --config pipelock.yaml
 
 # Run attack simulations
 pipelock assess run assessment-*/
@@ -173,8 +176,9 @@ For maximum containment, use both:
 
 ```bash
 # Codex sandbox + pipelock sandbox on MCP server
+pipelock generate config --preset strict -o pipelock-strict.yaml
 codex mcp add secure-filesystem \
-  -- pipelock mcp proxy --config configs/strict.yaml --sandbox \
+  -- pipelock mcp proxy --config pipelock-strict.yaml --sandbox \
   -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
@@ -216,10 +220,10 @@ Verify the command works without Codex first:
 
 ```bash
 # Test the MCP server directly
-pipelock mcp proxy --config configs/balanced.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
+pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
 
 # Then add to Codex
-codex mcp add test-fs -- pipelock mcp proxy --config configs/balanced.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
+codex mcp add test-fs -- pipelock mcp proxy --config pipelock.yaml -- npx -y @modelcontextprotocol/server-filesystem /tmp
 ```
 
 ### Environment variables not passing through

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -101,7 +101,7 @@ Codex stores MCP server config in `~/.codex/config.toml`:
 command = "pipelock"
 args = [
   "mcp", "proxy",
-  "--config", "/home/you/.config/pipelock/balanced.yaml",
+  "--config", "/home/you/pipelock.yaml",
   "--",
   "npx", "-y", "@modelcontextprotocol/server-filesystem", "/home/you/projects"
 ]
@@ -184,15 +184,19 @@ codex mcp add secure-filesystem \
 
 ## Choosing a Config
 
+A preset is chosen when the config is generated, with `pipelock generate config
+--preset <name> -o pipelock.yaml`, and the file it writes is what `--config`
+takes. Run `pipelock presets` to list them.
+
 | Preset | Action | Best For |
 |--------|--------|----------|
-| `balanced.yaml` | warn | Getting started, tuning phase |
-| `claude-code.yaml` | block | Unattended Codex sessions (works for Codex too) |
-| `strict.yaml` | block | High-security repos, sensitive code |
-| `hostile-model.yaml` | block | If using uncensored models via Codex |
+| `balanced` | warn | Getting started, tuning phase |
+| `claude-code` | block | Unattended Codex sessions (works for Codex too) |
+| `strict` | block | High-security repos, sensitive code |
+| `hostile-model` | block | If using uncensored models via Codex |
 
-Start with `balanced.yaml` to see what gets flagged. Switch to
-`claude-code.yaml` or `strict.yaml` once you've verified no false positives.
+Start with `balanced` to see what gets flagged. Switch to
+`claude-code` or `strict` once you've verified no false positives.
 
 ## Evidence and Audit Trail
 

--- a/docs/guides/crewai.md
+++ b/docs/guides/crewai.md
@@ -259,7 +259,8 @@ For scanning HTTP traffic from CrewAI agents (web searches, API calls), run
 Pipelock as a fetch proxy:
 
 ```bash
-pipelock run --preset balanced
+pipelock generate config --preset balanced > pipelock.yaml
+pipelock run --config pipelock.yaml
 ```
 
 Configure your agent to route HTTP requests through `http://localhost:8888/fetch`.

--- a/docs/guides/hermes.md
+++ b/docs/guides/hermes.md
@@ -99,11 +99,11 @@ pipelock hermes rollback --restore-backup ~/.hermes/config.yaml.bak.<ts>   # exp
 
 | Preset | Action | Best for |
 |---|---|---|
-| `balanced.yaml` | warn | Getting started, tuning phase |
-| `strict.yaml` | block | High-security workflows |
-| `hostile-model.yaml` | block | Running an uncensored or jailbroken model |
+| `balanced` | warn | Getting started, tuning phase |
+| `strict` | block | High-security workflows |
+| `hostile-model` | block | Running an uncensored or jailbroken model |
 
-Start with `balanced.yaml` to see what gets flagged, then move to a blocking preset once you have verified no false positives.
+Start with `balanced` to see what gets flagged, then move to a blocking preset once you have verified no false positives.
 
 ## See also
 

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -44,7 +44,8 @@ pipelock opencode install
 For shell-executed HTTP (curl, wget, fetch), run pipelock as a forward proxy:
 
 ```bash
-pipelock run --config configs/balanced.yaml &
+pipelock generate config --preset balanced > pipelock.yaml
+pipelock run --config pipelock.yaml &
 export HTTPS_PROXY=http://127.0.0.1:8888
 export HTTP_PROXY=http://127.0.0.1:8888
 export NO_PROXY=127.0.0.1,localhost

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -57,12 +57,12 @@ This adds DLP / SSRF / response-injection scanning to outbound HTTP requests fro
 
 | Preset | Action | Best for |
 |---|---|---|
-| `balanced.yaml` | warn | Getting started, tuning phase |
-| `claude-code.yaml` | block | Unattended OpenCode sessions on production code |
-| `strict.yaml` | block | High-security repos |
-| `hostile-model.yaml` | block | If you're running an uncensored model |
+| `balanced` | warn | Getting started, tuning phase |
+| `claude-code` | block | Unattended OpenCode sessions on production code |
+| `strict` | block | High-security repos |
+| `hostile-model` | block | If you're running an uncensored model |
 
-Start in `balanced.yaml` to surface false positives in audit mode. Promote to a blocking preset once a workload is clean.
+Start in `balanced` to surface false positives in audit mode. Promote to a blocking preset once a workload is clean.
 
 ## Containment for Local Multi-User Hosts
 

--- a/docs/guides/zed.md
+++ b/docs/guides/zed.md
@@ -188,13 +188,13 @@ and strips that field. Non-wrapped entries and non-server top-level fields
 
 | Preset | Action | Best For |
 |--------|--------|----------|
-| `balanced.yaml` | warn | Getting started, tuning phase |
-| `claude-code.yaml` | block | Unattended Zed agent sessions |
-| `strict.yaml` | block | High-security repos, sensitive code |
-| `hostile-model.yaml` | block | Local / uncensored models routed through Zed |
+| `balanced` | warn | Getting started, tuning phase |
+| `claude-code` | block | Unattended Zed agent sessions |
+| `strict` | block | High-security repos, sensitive code |
+| `hostile-model` | block | Local / uncensored models routed through Zed |
 
-Start with `balanced.yaml` to surface false positives without breaking your
-workflow. Switch to `claude-code.yaml` or `strict.yaml` once you've tuned
+Start with `balanced` to surface false positives without breaking your
+workflow. Switch to `claude-code` or `strict` once you've tuned
 the pattern set.
 
 ## Limitations

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -4,22 +4,45 @@
 
 # Install apt packages in CI without letting a slow mirror cancel the job.
 #
-# `apt-get update` normally takes about 50 seconds on a GitHub runner. When a
-# mirror stalls it does not fail, it hangs, and the job hits its 5 minute limit
-# and is cancelled with no project code having run. That happened three times in
-# one day across the hardening and release workflows, each time reading as a red
-# check on work that was fine.
+# `apt-get update` normally takes about fifty seconds on a GitHub runner, and
+# the install about twenty. When a mirror stalls neither fails, they hang, and
+# the job hits its limit and is cancelled with no project code having run. That
+# happened three times in one day across the hardening and release workflows,
+# each time reading as a red check on work that was fine.
 #
-# ci-retry.sh alone does not help, because a hung command never returns for the
-# retry to fire. Bounding each attempt is what converts the hang into a fast
-# failure that a retry can then absorb, and two bounded attempts plus backoff
-# still fit inside the job budget.
+# A retry alone does not help, because a hung command never returns for the
+# retry to fire. Bounding each command is what converts the hang into a fast
+# failure that a retry can absorb.
+#
+# THE BUDGET IS THE WHOLE POINT, so the arithmetic is written out to be checked
+# rather than trusted:
+#
+#   one attempt        = UPDATE_TIMEOUT + INSTALL_TIMEOUT = 90 + 60 = 150s
+#   worst case overall = (ATTEMPTS * 150s) + BACKOFF
+#                      = (2 * 150s) + 10s
+#                      = 310s
+#
+# The hardening jobs allow 480s, leaving about 170s for checkout and the audit
+# work itself, against a job that normally finishes in well under two minutes.
+#
+# A bound that does not fit its job's limit is not a fix, it is a slower path to
+# the same cancellation. The first version of this script used the shared
+# three-attempt helper at 120s per attempt across two separate retried calls,
+# which is 750s of worst case against a 300s limit: strictly worse than the hang
+# it was written to prevent. If a workflow ever needs a larger package set,
+# re-derive the numbers above against that job's timeout rather than raising a
+# bound on its own.
 set -euo pipefail
 
 if [ "$#" -eq 0 ]; then
   echo "usage: ci-apt-install.sh PACKAGE [PACKAGE...]" >&2
   exit 2
 fi
+
+readonly ATTEMPTS=2
+readonly UPDATE_TIMEOUT=90
+readonly INSTALL_TIMEOUT=60
+readonly BACKOFF=10
 
 # The runner image already carries some of these. Skipping the network entirely
 # when every package is present is both faster and one less thing to stall.
@@ -34,16 +57,24 @@ if [ "${#missing[@]}" -eq 0 ]; then
   exit 0
 fi
 
-: "${CI_APT_TIMEOUT:=120}"
-
-run_bounded() {
-  # A non-zero status here is what lets ci-retry.sh try again. timeout exits 124
-  # when it kills the command, which is the case this exists for.
-  sudo timeout "$CI_APT_TIMEOUT" "$@"
+# Package names reach apt-get as an argument array and are never rebuilt into a
+# command string. Interpolating them into a shell program would re-parse them,
+# so a name carrying whitespace or a glob would change the invocation and a name
+# that looks like an option would be read as one. The trailing -- stops apt-get
+# reading a package name as a flag.
+attempt_install() {
+  sudo timeout "$UPDATE_TIMEOUT" apt-get update \
+    && sudo timeout "$INSTALL_TIMEOUT" apt-get install -y -- "${missing[@]}"
 }
-export -f run_bounded
-export CI_APT_TIMEOUT
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-bash "$script_dir/ci-retry.sh" bash -c 'run_bounded apt-get update'
-bash "$script_dir/ci-retry.sh" bash -c "run_bounded apt-get install -y ${missing[*]}"
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if attempt_install; then
+    exit 0
+  fi
+  if [ "$attempt" -eq "$ATTEMPTS" ]; then
+    echo "ci-apt-install: ${ATTEMPTS} attempts failed for: ${missing[*]}" >&2
+    exit 1
+  fi
+  echo "ci-apt-install: attempt ${attempt} of ${ATTEMPTS} failed; retrying in ${BACKOFF}s" >&2
+  sleep "$BACKOFF"
+done

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Install apt packages in CI without letting a slow mirror cancel the job.
+#
+# `apt-get update` normally takes about 50 seconds on a GitHub runner. When a
+# mirror stalls it does not fail, it hangs, and the job hits its 5 minute limit
+# and is cancelled with no project code having run. That happened three times in
+# one day across the hardening and release workflows, each time reading as a red
+# check on work that was fine.
+#
+# ci-retry.sh alone does not help, because a hung command never returns for the
+# retry to fire. Bounding each attempt is what converts the hang into a fast
+# failure that a retry can then absorb, and two bounded attempts plus backoff
+# still fit inside the job budget.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: ci-apt-install.sh PACKAGE [PACKAGE...]" >&2
+  exit 2
+fi
+
+# The runner image already carries some of these. Skipping the network entirely
+# when every package is present is both faster and one less thing to stall.
+missing=()
+for pkg in "$@"; do
+  if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "ok installed"; then
+    missing+=("$pkg")
+  fi
+done
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "ci-apt-install: all packages already installed: $*"
+  exit 0
+fi
+
+: "${CI_APT_TIMEOUT:=120}"
+
+run_bounded() {
+  # A non-zero status here is what lets ci-retry.sh try again. timeout exits 124
+  # when it kills the command, which is the case this exists for.
+  sudo timeout "$CI_APT_TIMEOUT" "$@"
+}
+export -f run_bounded
+export CI_APT_TIMEOUT
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$script_dir/ci-retry.sh" bash -c 'run_bounded apt-get update'
+bash "$script_dir/ci-retry.sh" bash -c "run_bounded apt-get install -y ${missing[*]}"


### PR DESCRIPTION
## What changed

The hardening and release workflows install a package with a bare index update. That normally takes about fifty seconds, but when a mirror stalls it hangs rather than failing, and the job reaches its five minute limit and is cancelled with no project code having run. It happened three times in one day, each time reading as a red check on work that was fine. The existing retry helper does not cover this, because a hung command never returns for a retry to fire, so each attempt is now bounded and a package already present on the runner skips the network entirely. The install command itself is unchanged.

Integration guides and the README showed commands that cannot run. A flag that does not exist on `run` or `mcp proxy` opened the Claude Code quick start and appeared three more times across two guides. Eleven commands in the Codex guide named a config path that ships only in a source checkout, so a reader who installed the binary, as that guide's own first step tells them to, had no such file. The README pointed the evidence viewer at the directory the demo had just written, which it cannot read because the two produce different shapes. Each guide now generates a config before using one, and the corrected evidence sequence was run end to end before being written down.

The changelog covers what merged after it was written. The response-trust clamp changes what an existing configuration enforces, so it sits with the upgrade notes rather than in a list of fixes: an operator running a stricter response action alongside a reasoning-trusted server will see responses that previously forwarded with a warning start taking the section action instead.

The failure direction worth distrusting here is the workflow change, because it sits in the path that publishes a release. A bounded attempt that is too short would turn a merely slow mirror into a failed install, which fails the job rather than hanging it. The bound is set well above the observed normal duration, and the retry absorbs a single slow attempt, but the behaviour under a genuinely degraded mirror is the part to check rather than assume.

Every new changelog claim was verified by running it against a binary built from merged main rather than from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart and integration guides with runnable, platform-specific configuration workflows.
  * Clarified configuration setup for Claude Code, Cline, Codex, CrewAI, OpenCode, Hermes, and Zed.
  * Added instructions for recording sessions and generating or serving offline evidence reports.
  * Updated preset references to use clear preset names instead of filenames.
  * Corrected outdated commands, paths, and examples.

* **Bug Fixes**
  * Clarified stricter response-scanning behavior, output streams, and invalid command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->