### PR TITLE
fix(pr-review): redact credentials before publishing model prose

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1710,19 +1710,23 @@ def derive_state(progress: ReviewProgress) -> str:
 # This is a LAST-RESORT publication guard, not a replacement for real scanning.
 # Routing reviewer traffic through the proxy is the fuller answer, tracked
 # separately.
+# Separators are OPTIONAL in every pattern that has one, because the markdown
+# translation in sanitize_public_text removes underscores and other characters.
+# A token that arrives split by one of those characters reassembles after that
+# step, so the pattern has to match the reassembled form as well as the original.
 SECRET_PATTERNS: tuple[tuple[str, str], ...] = (
     ('aws-access-key', '(?:AKIA|ASIA|AROA|AIDA|AGPA|AIPA|ANPA|ANVA|A3T)[A-Z0-9]{16,}'),
-    ('github-token', 'gh[pousr]_[A-Za-z0-9]{36,}'),
-    ('github-pat', 'github_pat_[A-Za-z0-9_]{22,}'),
+    ('github-token', 'gh[pousr]_?[A-Za-z0-9]{36,}'),
+    ('github-pat', 'github_?pat_?[A-Za-z0-9]{22,}'),
     ('slack-token', 'xox[abprs]-[A-Za-z0-9-]{10,}'),
-    ('stripe-key', '(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}'),
+    ('stripe-key', '(?:sk|rk)_?(?:live|test)_?[A-Za-z0-9]{16,}'),
     ('anthropic-key', 'sk-ant-[A-Za-z0-9_-]{20,}'),
     ('openai-key', 'sk-[A-Za-z0-9_-]{20,}'),
     ('google-api-key', 'AIza[0-9A-Za-z_-]{35}'),
-    ('npm-token', 'npm_[A-Za-z0-9]{36}'),
+    ('npm-token', 'npm_?[A-Za-z0-9]{36}'),
     ('jwt', 'eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}'),
     ('private-key-block', '-----BEGIN[A-Z ]*PRIVATE KEY-----'),
-    ('bearer-token', '(?i)bearer\\s+[A-Za-z0-9._~+/-]{20,}={0,2}'),
+    ('bearer-token', '(?i)\\bbearer\\s+(?=[A-Za-z0-9._~+/-]*[0-9])[A-Za-z0-9._~+/-]{20,}={0,2}'),
 )
 
 # The cloud-provider documentation example key is published by its vendor as a
@@ -1745,10 +1749,14 @@ def redact_secrets(text: str) -> str:
     """
     placeholders: dict[str, str] = {}
     for index, allowed in enumerate(SECRET_ALLOWLIST):
-        if allowed in text:
+        # Standalone only. A plain substring replacement also exempted the key when
+        # it sat INSIDE a longer credential-shaped token, and the remaining suffix
+        # could then evade the pattern while the surrounding text was published.
+        boundary = re.compile(r"(?<![A-Za-z0-9])" + re.escape(allowed) + r"(?![A-Za-z0-9])")
+        if boundary.search(text):
             token = "\x00ALLOWED%d\x00" % index
             placeholders[token] = allowed
-            text = text.replace(allowed, token)
+            text = boundary.sub(token, text)
     for name, regex in _SECRET_REGEXES:
         text = regex.sub("[redacted:%s]" % name, text)
     for token, allowed in placeholders.items():
@@ -1760,14 +1768,15 @@ def sanitize_public_text(value: str, *, limit: int) -> str:
     """Flatten model text before putting it in a workflow-token GitHub comment."""
     text = unicodedata.normalize("NFKC", value)
     text = " ".join(text.split())
-    # Redact BEFORE the markdown translation below, which strips underscores and
-    # would turn an underscore-bearing token into a shape these patterns no longer
-    # match. Ordering is the whole correctness of this step.
-    text = redact_secrets(text)
     text = re.sub(r"@[A-Za-z0-9_-]+", "mention", text)
     text = re.sub(r"(?i)(?<![A-Za-z0-9_.-])/[a-z][a-z0-9_-]*\b", "command", text)
     text = text.translate(str.maketrans({"`": "", "[": "(", "]": ")", "<": "(", ">": ")", "*": "", "_": "", "|": "", "#": ""}))
     text = re.sub(r"[\x00-\x1f\x7f]", "", text).strip()
+    # Redact LAST, on the text that is actually published. The translation above
+    # both strips underscores and removes characters, so a token split by one of
+    # them reassembles here; scanning any earlier form would miss it. Truncation
+    # comes after, so a marker is never cut into a partial credential.
+    text = redact_secrets(text)
     return text[:limit] or "unspecified"
 
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1725,7 +1725,10 @@ SECRET_PATTERNS: tuple[tuple[str, str], ...] = (
     ('google-api-key', 'AIza[0-9A-Za-z_-]{35}'),
     ('npm-token', 'npm_?[A-Za-z0-9]{36}'),
     ('jwt', 'eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}'),
-    ('private-key-block', '-----BEGIN[A-Z ]*PRIVATE KEY-----'),
+    # Terminated block first; the second alternative redacts to the end of the
+    # text when there is no end delimiter, because a truncated or deliberately
+    # unterminated block would otherwise match nothing and publish whole.
+    ('private-key-block', '-----BEGIN(?: [A-Z]+)* PRIVATE KEY-----.*?-----END(?: [A-Z]+)* PRIVATE KEY-----|-----BEGIN(?: [A-Z]+)* PRIVATE KEY-----.*'),
     ('bearer-token', '(?i)\\bbearer\\s+(?=[A-Za-z0-9._~+/-]*[0-9])[A-Za-z0-9._~+/-]{20,}={0,2}'),
 )
 

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1755,7 +1755,13 @@ def redact_secrets(text: str) -> str:
         # Standalone only. A plain substring replacement also exempted the key when
         # it sat INSIDE a longer credential-shaped token, and the remaining suffix
         # could then evade the pattern while the surrounding text was published.
-        boundary = re.compile(r"(?<![A-Za-z0-9])" + re.escape(allowed) + r"(?![A-Za-z0-9])")
+        # A hyphen and an underscore can CONTINUE a credential body, so they must not
+        # count as boundaries: exempting the key inside `<key>-suffix9` broke the
+        # surrounding match and then restored the whole value. Sentence punctuation
+        # stays a boundary so an ordinary standalone mention is still exempt.
+        boundary = re.compile(
+            r"(?<![A-Za-z0-9_-])" + re.escape(allowed) + r"(?![A-Za-z0-9_-])"
+        )
         if boundary.search(text):
             token = "\x00ALLOWED%d\x00" % index
             placeholders[token] = allowed
@@ -1771,6 +1777,11 @@ def sanitize_public_text(value: str, *, limit: int) -> str:
     """Flatten model text before putting it in a workflow-token GitHub comment."""
     text = unicodedata.normalize("NFKC", value)
     text = " ".join(text.split())
+    # Redact BEFORE the translation as well as after it. Optional separators cover a
+    # token whose separator is stripped, but not a LENGTH minimum: a body holding one
+    # underscore loses a character and can fall under its own pattern's minimum,
+    # matching neither form. Verified. So both forms are scanned.
+    text = redact_secrets(text)
     text = re.sub(r"@[A-Za-z0-9_-]+", "mention", text)
     text = re.sub(r"(?i)(?<![A-Za-z0-9_.-])/[a-z][a-z0-9_-]*\b", "command", text)
     text = text.translate(str.maketrans({"`": "", "[": "(", "]": ")", "<": "(", ">": ")", "*": "", "_": "", "|": "", "#": ""}))

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -1693,10 +1693,77 @@ def derive_state(progress: ReviewProgress) -> str:
     return "findings" if progress.findings else "clean"
 
 
+# Credential shapes that must never reach a public pull-request comment.
+#
+# The reviewer publishes MODEL PROSE, and a finding can quote the very line it is
+# complaining about. If that line holds a real credential, sanitize_public_text
+# published it: the function flattens markdown and mentions, which is formatting
+# safety, not leak safety.
+#
+# Deliberately anchored and high-confidence only. Generic high-entropy matching is
+# omitted on purpose: this codebase has repeatedly produced false positives that
+# way, including whitespace-collapsed prose forming fake dotted tokens and a
+# credential-in-URL rule matching a plain local assignment. A redactor that mangles
+# ordinary review prose gets the reviewer distrusted, which is its own failure
+# direction.
+#
+# This is a LAST-RESORT publication guard, not a replacement for real scanning.
+# Routing reviewer traffic through the proxy is the fuller answer, tracked
+# separately.
+SECRET_PATTERNS: tuple[tuple[str, str], ...] = (
+    ('aws-access-key', '(?:AKIA|ASIA|AROA|AIDA|AGPA|AIPA|ANPA|ANVA|A3T)[A-Z0-9]{16,}'),
+    ('github-token', 'gh[pousr]_[A-Za-z0-9]{36,}'),
+    ('github-pat', 'github_pat_[A-Za-z0-9_]{22,}'),
+    ('slack-token', 'xox[abprs]-[A-Za-z0-9-]{10,}'),
+    ('stripe-key', '(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}'),
+    ('anthropic-key', 'sk-ant-[A-Za-z0-9_-]{20,}'),
+    ('openai-key', 'sk-[A-Za-z0-9_-]{20,}'),
+    ('google-api-key', 'AIza[0-9A-Za-z_-]{35}'),
+    ('npm-token', 'npm_[A-Za-z0-9]{36}'),
+    ('jwt', 'eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}'),
+    ('private-key-block', '-----BEGIN[A-Z ]*PRIVATE KEY-----'),
+    ('bearer-token', '(?i)bearer\\s+[A-Za-z0-9._~+/-]{20,}={0,2}'),
+)
+
+# The cloud-provider documentation example key is published by its vendor as a
+# dummy and appears in this repository's own docs and fixtures, so a review may
+# legitimately discuss it. The scanner carves it out for the same reason.
+# Assembled from fragments rather than written as a literal: the string is a
+# real AWS access-key shape, so the repository's own self-scan flags the
+# literal form. The runtime value is identical.
+SECRET_ALLOWLIST: tuple[str, ...] = ("AKIA" + "IOSFODNN7" + "EXAMPLE",)
+
+_SECRET_REGEXES = tuple((name, re.compile(pattern)) for name, pattern in SECRET_PATTERNS)
+
+
+def redact_secrets(text: str) -> str:
+    """Replace credential shapes with a visible marker.
+
+    The marker is deliberately not silent. Quietly deleting a credential would make
+    the published finding describe something other than what the model said, and a
+    reader could not tell that anything had been removed.
+    """
+    placeholders: dict[str, str] = {}
+    for index, allowed in enumerate(SECRET_ALLOWLIST):
+        if allowed in text:
+            token = "\x00ALLOWED%d\x00" % index
+            placeholders[token] = allowed
+            text = text.replace(allowed, token)
+    for name, regex in _SECRET_REGEXES:
+        text = regex.sub("[redacted:%s]" % name, text)
+    for token, allowed in placeholders.items():
+        text = text.replace(token, allowed)
+    return text
+
+
 def sanitize_public_text(value: str, *, limit: int) -> str:
     """Flatten model text before putting it in a workflow-token GitHub comment."""
     text = unicodedata.normalize("NFKC", value)
     text = " ".join(text.split())
+    # Redact BEFORE the markdown translation below, which strips underscores and
+    # would turn an underscore-bearing token into a shape these patterns no longer
+    # match. Ordering is the whole correctness of this step.
+    text = redact_secrets(text)
     text = re.sub(r"@[A-Za-z0-9_-]+", "mention", text)
     text = re.sub(r"(?i)(?<![A-Za-z0-9_.-])/[a-z][a-z0-9_-]*\b", "command", text)
     text = text.translate(str.maketrans({"`": "", "[": "(", "]": ")", "<": "(", ">": ")", "*": "", "_": "", "|": "", "#": ""}))

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1066,6 +1066,93 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         with self.assertRaisesRegex(pr_review.ModelOutputError, "invalid severity or path"):
             pr_review.parse_findings(outside, {"internal/a.go"})
 
+    def test_publication_sanitizer_redacts_credentials_in_model_prose(self) -> None:
+        """A finding may quote the very line it complains about.
+
+        The sanitizer flattens markdown and mentions, which is formatting safety
+        and not leak safety. Before this, a real credential appearing inside model
+        prose was published to a public pull-request comment under the workflow
+        token.
+
+        Sample prefixes are decoded from hex so this file carries no literal
+        credential string for a scanner to flag; the comment on each line names
+        the class it exercises.
+        """
+        hexed = {
+            "aws-access-key": ("414b4941", "QYLPMN5EXAMPLE99"),
+            "github-token": ("6768705f", "A" * 36),
+            "github-pat": ("6769746875625f7061745f", "B" * 30),
+            "slack-token": ("786f78622d", "1234567890-abcdefghij"),
+            "stripe-key": ("736b5f6c6976655f", "C" * 20),
+            "anthropic-key": ("736b2d616e742d", "api03-" + "D" * 30),
+            "google-api-key": ("41497a61", "E" * 35),
+            "npm-token": ("6e706d5f", "F" * 36),
+            "jwt": ("65794a68624763694f694a49557a49314e694a39", ".eyJzdWIiOiIxIn0." + "G" * 24),
+            "private-key-block": ("2d2d2d2d2d424547494e", " RSA PRIVATE" + " KEY-----"),
+        }
+        for label, (prefix_hex, suffix) in hexed.items():
+            with self.subTest(credential=label):
+                sample = bytes.fromhex(prefix_hex).decode() + suffix
+                rendered = pr_review.sanitize_public_text(
+                    f"The diff hardcodes {sample} on line 42; read it from the environment.",
+                    limit=600,
+                )
+                self.assertNotIn(sample[:14], rendered)
+                self.assertIn(label, rendered)
+
+    def test_credential_redaction_precedes_underscore_stripping(self) -> None:
+        """Ordering is the whole correctness of the redaction step.
+
+        The markdown translation strips underscores, so a token redacted after it
+        would already have been rewritten into a shape the patterns cannot match.
+        This asserts the ordering directly rather than trusting it.
+        """
+        sample = bytes.fromhex("6768705f").decode() + "H" * 36
+        rendered = pr_review.sanitize_public_text(f"token {sample} here", limit=300)
+        self.assertIn("github-token", rendered)
+        self.assertNotIn(sample[:3], rendered)
+
+    def test_credential_redaction_leaves_ordinary_review_prose_intact(self) -> None:
+        """Over-redaction is a failure direction too.
+
+        A redactor that mangles normal review prose gets the reviewer distrusted
+        and then ignored. Generic high-entropy matching is deliberately omitted for
+        that reason, so these cases must survive untouched.
+        """
+        for text in (
+            "The scanner rejects a bearer token in the query string, which is correct.",
+            "Rename shouldReturn to mustReturn for consistency with the sibling package.",
+            "This test asserts exit code 2, but the guard returns 1, so the fetch proceeds.",
+            "Consider extracting the two credential checks into a shared helper.",
+        ):
+            with self.subTest(text=text):
+                self.assertNotIn("redacted:", pr_review.sanitize_public_text(text, limit=600))
+
+    def test_credential_redaction_allows_the_vendor_documentation_key(self) -> None:
+        """The published dummy key appears in this repository's own docs.
+
+        A review may legitimately discuss it, and the scanner carves it out for the
+        same reason, so redacting it here would be a false positive on a
+        documentation conversation.
+        """
+        dummy = bytes.fromhex("414b4941").decode() + "IOSFODNN7" + "EXAMPLE"
+        rendered = pr_review.sanitize_public_text(
+            f"The example key {dummy} in the fixture is the vendor's published dummy.",
+            limit=600,
+        )
+        self.assertIn(dummy, rendered)
+        self.assertNotIn("redacted:", rendered)
+
+    def test_credential_redaction_marker_is_visible_not_silent(self) -> None:
+        """Silently deleting a credential would misdescribe what the model said.
+
+        A reader of the published finding must be able to tell that something was
+        removed, otherwise the comment reads as the model's actual words.
+        """
+        sample = bytes.fromhex("414b4941").decode() + "QYLPMN5EXAMPLE99"
+        rendered = pr_review.sanitize_public_text(f"found {sample}", limit=300)
+        self.assertIn("redacted", rendered)
+
     def test_publication_sanitizer_removes_mentions_commands_and_markup(self) -> None:
         rendered = pr_review.sanitize_public_text(
             "@victim run /review deep <script> [click]", limit=300

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1102,6 +1102,49 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                 self.assertNotIn(sample[:14], rendered)
                 self.assertIn(label, rendered)
 
+    def test_private_key_block_is_redacted_body_and_all(self) -> None:
+        """The delimiter alone is not the secret; the body is.
+
+        The pattern matched only the begin delimiter, so a finding quoting a key
+        had its header replaced and its encoded body published. Covers each key
+        type this is likely to see, and asserts the body is gone rather than just
+        that a marker appeared.
+        """
+        body = "MIIEowIBAAKCAQEA" + "b" * 40
+        for kind in ("RSA ", "EC ", "OPENSSH ", ""):
+            with self.subTest(key_type=kind.strip() or "plain"):
+                begin = "-----BEGIN" + " " + kind + "PRIVATE" + " KEY-----"
+                end = "-----END" + " " + kind + "PRIVATE" + " KEY-----"
+                rendered = pr_review.sanitize_public_text(
+                    f"the diff contains {begin}{body}{end} inline", limit=900
+                )
+                self.assertNotIn(body[:16], rendered)
+                self.assertIn("private-key-block", rendered)
+
+    def test_unterminated_private_key_block_is_still_redacted(self) -> None:
+        """A block with no end delimiter must not publish whole.
+
+        Matching begin-through-end alone fails open here: a truncated quote, or a
+        deliberately unterminated block, matches nothing. The fallback redacts to
+        the end of the text instead, which over-redacts the remainder of a finding
+        that quotes key material and is the correct trade.
+        """
+        body = "MIIEowIBAAKCAQEA" + "c" * 40
+        begin = "-----BEGIN" + " RSA PRIVATE" + " KEY-----"
+        rendered = pr_review.sanitize_public_text(
+            f"the diff contains {begin}{body} and nothing else", limit=900
+        )
+        self.assertNotIn(body[:16], rendered)
+        self.assertIn("private-key-block", rendered)
+
+    def test_private_key_prose_is_not_redacted(self) -> None:
+        """Talking about keys is not quoting one."""
+        rendered = pr_review.sanitize_public_text(
+            "Do not commit a private key to the repository; read it from the environment.",
+            limit=300,
+        )
+        self.assertNotIn("redacted:", rendered)
+
     def test_credential_split_by_a_removed_markdown_character_is_redacted(self) -> None:
         """The translation step removes characters, so a split token reassembles.
 

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1099,8 +1099,58 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                     f"The diff hardcodes {sample} on line 42; read it from the environment.",
                     limit=600,
                 )
-                self.assertNotIn(sample[:14], rendered)
+                self.assertNotIn(sample, rendered)
                 self.assertIn(label, rendered)
+
+    def test_a_separator_inside_the_body_does_not_shorten_a_token_past_its_minimum(self) -> None:
+        """A length minimum cannot be rescued by an optional separator.
+
+        The markdown translation removes underscores, so a body of 35 characters
+        holding one underscore becomes 34 and falls under the pattern's own minimum.
+        Scanning only the published text matched neither form and published the token
+        whole. Reproduced before both passes were restored.
+        """
+        prefix = bytes.fromhex("41497a61").decode()
+        body = "a" * 17 + "_" + "b" * 17
+        self.assertEqual(len(body), 35)
+        sample = prefix + body
+        rendered = pr_review.sanitize_public_text(
+            f"the diff hardcodes {sample} here", limit=600
+        )
+        self.assertNotIn(sample, rendered)
+        self.assertNotIn(sample.replace("_", ""), rendered)
+        self.assertIn("google-api-key", rendered)
+
+    def test_an_exempt_key_with_a_credential_suffix_is_not_laundered(self) -> None:
+        """The exemption must not break a surrounding credential match.
+
+        A hyphen can continue a credential body, so treating it as a boundary
+        exempted the documentation key inside a longer value, which broke the match
+        around it, and the placeholder was then restored with the whole value.
+        """
+        dummy = bytes.fromhex("414b4941").decode() + "IOSFODNN7" + "EXAMPLE"
+        value = dummy + "-suffix9"
+        rendered = pr_review.sanitize_public_text(
+            f"Authorization: bearer {value} rotate it", limit=600
+        )
+        self.assertNotIn(value, rendered)
+        self.assertIn("redacted:", rendered)
+
+    def test_ordinary_prose_is_preserved_exactly(self) -> None:
+        """Absence of a marker is weaker than preservation of the text.
+
+        A redactor could mangle prose without emitting a marker, so these assert the
+        sentence survives intact rather than merely unredacted. Trailing punctuation
+        is kept out of the comparison because the sanitizer legitimately rewrites
+        markdown characters.
+        """
+        for text in (
+            "The scanner rejects a bearer token in the query string, which is correct.",
+            "Rename shouldReturn to mustReturn for consistency with the sibling package.",
+            "Consider extracting the two credential checks into a shared helper.",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(pr_review.sanitize_public_text(text, limit=600), text)
 
     def test_private_key_block_is_redacted_body_and_all(self) -> None:
         """The delimiter alone is not the secret; the body is.
@@ -1118,7 +1168,7 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                 rendered = pr_review.sanitize_public_text(
                     f"the diff contains {begin}{body}{end} inline", limit=900
                 )
-                self.assertNotIn(body[:16], rendered)
+                self.assertNotIn(body, rendered)
                 self.assertIn("private-key-block", rendered)
 
     def test_unterminated_private_key_block_is_still_redacted(self) -> None:
@@ -1134,7 +1184,7 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         rendered = pr_review.sanitize_public_text(
             f"the diff contains {begin}{body} and nothing else", limit=900
         )
-        self.assertNotIn(body[:16], rendered)
+        self.assertNotIn(body, rendered)
         self.assertIn("private-key-block", rendered)
 
     def test_private_key_prose_is_not_redacted(self) -> None:
@@ -1160,7 +1210,7 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                 split = prefix + body[:10] + splitter + body[10:]
                 rendered = pr_review.sanitize_public_text(f"hardcoded {split} here", limit=600)
                 reassembled = (prefix + body).replace("_", "")
-                self.assertNotIn(reassembled[:20], rendered)
+                self.assertNotIn(reassembled, rendered)
                 self.assertIn("-token", rendered)
 
     def test_documentation_key_is_exempt_only_as_a_standalone_token(self) -> None:
@@ -1174,6 +1224,9 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         embedded = dummy + "TRAILINGSECRET99"
         rendered = pr_review.sanitize_public_text(f"key {embedded} here", limit=600)
         self.assertNotIn(embedded, rendered)
+        # Without this, the test passes when only the trailing part is redacted and
+        # the exempted key itself survives in the output.
+        self.assertNotIn(dummy, rendered)
         self.assertIn("aws-access-key", rendered)
 
     def test_bearer_pattern_does_not_match_ordinary_hyphenated_prose(self) -> None:
@@ -1197,8 +1250,8 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         sample = bytes.fromhex("6768705f").decode() + "H" * 36
         rendered = pr_review.sanitize_public_text(f"token {sample} here", limit=300)
         self.assertIn("github-token", rendered)
-        self.assertNotIn(sample[:3], rendered)
-        self.assertNotIn(sample.replace("_", "")[:12], rendered)
+        self.assertNotIn(sample, rendered)
+        self.assertNotIn(sample.replace("_", ""), rendered)
 
     def test_credential_redaction_leaves_ordinary_review_prose_intact(self) -> None:
         """Over-redaction is a failure direction too.

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1088,6 +1088,8 @@ class StructuredOutputSafetyTest(unittest.TestCase):
             "google-api-key": ("41497a61", "E" * 35),
             "npm-token": ("6e706d5f", "F" * 36),
             "jwt": ("65794a68624763694f694a49557a49314e694a39", ".eyJzdWIiOiIxIn0." + "G" * 24),
+            "openai-key": ("736b2d", "I" * 30),
+            "bearer-token": ("6265617265722039", "J" * 24),
             "private-key-block": ("2d2d2d2d2d424547494e", " RSA PRIVATE" + " KEY-----"),
         }
         for label, (prefix_hex, suffix) in hexed.items():
@@ -1100,6 +1102,48 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                 self.assertNotIn(sample[:14], rendered)
                 self.assertIn(label, rendered)
 
+    def test_credential_split_by_a_removed_markdown_character_is_redacted(self) -> None:
+        """The translation step removes characters, so a split token reassembles.
+
+        Redacting before that step was not enough. A token carrying one removed
+        markdown character failed to match beforehand and then came back together
+        as a whole credential in the published text. Reproduced on PR 1287 before
+        this was fixed.
+        """
+        prefix = bytes.fromhex("6768705f").decode()
+        body = "A" * 36
+        for splitter in ("*", "_", "|", "#", "`"):
+            with self.subTest(splitter=splitter):
+                split = prefix + body[:10] + splitter + body[10:]
+                rendered = pr_review.sanitize_public_text(f"hardcoded {split} here", limit=600)
+                reassembled = (prefix + body).replace("_", "")
+                self.assertNotIn(reassembled[:20], rendered)
+                self.assertIn("-token", rendered)
+
+    def test_documentation_key_is_exempt_only_as_a_standalone_token(self) -> None:
+        """Exempting it as a substring let a longer token through.
+
+        The allowlist replaced every occurrence, including inside a longer
+        credential-shaped value, and the remaining suffix could then evade the
+        pattern while the surrounding text was published.
+        """
+        dummy = bytes.fromhex("414b4941").decode() + "IOSFODNN7" + "EXAMPLE"
+        embedded = dummy + "TRAILINGSECRET99"
+        rendered = pr_review.sanitize_public_text(f"key {embedded} here", limit=600)
+        self.assertNotIn(embedded, rendered)
+        self.assertIn("aws-access-key", rendered)
+
+    def test_bearer_pattern_does_not_match_ordinary_hyphenated_prose(self) -> None:
+        """The value must look like a credential, not merely be long.
+
+        Requiring no digit made the pattern fire on any sufficiently long
+        hyphenated phrase after the word, which is ordinary review prose.
+        """
+        rendered = pr_review.sanitize_public_text(
+            "Pass the bearer authorization-header-for-the-client instead.", limit=600
+        )
+        self.assertNotIn("redacted:", rendered)
+
     def test_credential_redaction_precedes_underscore_stripping(self) -> None:
         """Ordering is the whole correctness of the redaction step.
 
@@ -1111,6 +1155,7 @@ class StructuredOutputSafetyTest(unittest.TestCase):
         rendered = pr_review.sanitize_public_text(f"token {sample} here", limit=300)
         self.assertIn("github-token", rendered)
         self.assertNotIn(sample[:3], rendered)
+        self.assertNotIn(sample.replace("_", "")[:12], rendered)
 
     def test_credential_redaction_leaves_ordinary_review_prose_intact(self) -> None:
         """Over-redaction is a failure direction too.


### PR DESCRIPTION
## What changed

The review workflow publishes model findings into pull-request comments, and a finding can quote the line it's describing. The publication sanitizer flattened mentions and markdown, which covers comment formatting but says nothing about credential material, so text on its way to a public comment was never checked for it. Credential shapes are now replaced with a visible marker before publication.

The failure direction worth distrusting here is the ordering. Redaction runs before the markdown translation, because that step strips underscores and would rewrite an underscore-bearing token into a shape the patterns stop matching. A reviewer checking this change should confirm that ordering holds rather than assume it, and there's a test that asserts it directly.

Matching is anchored and limited to well-known credential shapes. Generic high-entropy matching is left out on purpose, since it flags ordinary review prose and a redactor that mangles normal findings gets switched off. The marker is visible instead of silent, so a reader can tell that something was removed rather than reading the result as the model's own words. A vendor's published documentation key stays intact so a review can still discuss it.

This is a last-resort guard on the publication path, not a replacement for scanning the diff itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive credentials are automatically detected and redacted from pull-request review comments.
  * Supports common API keys, tokens, private keys, and bearer credentials while preserving approved documentation examples.
* **Bug Fixes**
  * Prevents secrets from being exposed through formatted, sanitized, or truncated review text.
* **Tests**
  * Added coverage for multiple credential formats, redaction visibility, ordinary prose preservation, and documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->