### PR TITLE
ci: stop passing a stray space to scan-diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,27 +91,27 @@ jobs:
             "${merge_base}" "${HEAD_SHA}" "${diff_file}"
 
           "${RUNNER_TEMP}/pipelock" git scan-diff \
-            --exclude internal/scanner/scanner_test.go \ \
-            --exclude internal/scanner/scan_env_test.go \ \
-            --exclude internal/scanner/text_dlp_test.go \ \
-            --exclude internal/scanner/validate_test.go \ \
-            --exclude internal/proxy/intercept_test.go \ \
-            --exclude internal/proxy/session_api.go \ \
-            --exclude internal/cli/support/bundle_test.go \ \
-            --exclude 'enterprise/licenseservice/*_test.go' \ \
-            --exclude test/secureiqlab/ \ \
-            --exclude README.md \ \
-            --exclude assets/demo.cast \ \
-            --exclude .github/actions/pr-review/pr_review.py \ \
-            --exclude docs/attacks-blocked.md \ \
-            --exclude docs/bypass-resistance.md \ \
-            --exclude docs/configuration.md \ \
-            --exclude docs/scan-api.md \ \
-            --exclude docs/guides/deployment-recipes.md \ \
-            --exclude docs/guides/tls-interception.md \ \
-            --exclude docs/guides/zed.md \ \
-            --exclude examples/demo-readme.sh \ \
-            --exclude sdk/conformance/testdata/aarp-corpus/ \ \
+            --exclude internal/scanner/scanner_test.go \
+            --exclude internal/scanner/scan_env_test.go \
+            --exclude internal/scanner/text_dlp_test.go \
+            --exclude internal/scanner/validate_test.go \
+            --exclude internal/proxy/intercept_test.go \
+            --exclude internal/proxy/session_api.go \
+            --exclude internal/cli/support/bundle_test.go \
+            --exclude 'enterprise/licenseservice/*_test.go' \
+            --exclude test/secureiqlab/ \
+            --exclude README.md \
+            --exclude assets/demo.cast \
+            --exclude .github/actions/pr-review/pr_review.py \
+            --exclude docs/attacks-blocked.md \
+            --exclude docs/bypass-resistance.md \
+            --exclude docs/configuration.md \
+            --exclude docs/scan-api.md \
+            --exclude docs/guides/deployment-recipes.md \
+            --exclude docs/guides/tls-interception.md \
+            --exclude docs/guides/zed.md \
+            --exclude examples/demo-readme.sh \
+            --exclude sdk/conformance/testdata/aarp-corpus/ \
             < "${diff_file}"
 
   test-oss:


### PR DESCRIPTION
## What changed

Every `--exclude` line in the security-scan step ended with a backslash, a space, and another backslash. The first backslash escaped the space, so the shell passed a bare space as a positional argument, twenty-one times over. The line continuations are now a single backslash.

`scan-diff` ignored those arguments, so nothing reported them for as long as they have been there. Rejecting a stray positional argument landed in #1289, and the ignored argument became a hard failure on main.

The test jobs depend on security-scan, so they were skipped and a gate asserting that a skipped result equals success failed as well. One cause, two red checks.

## Verification

The real invocation was extracted from the workflow and run against a built binary rather than reasoning about shell quoting. The form currently on main exits 1 with `unknown command " "`, which reproduces the CI failure exactly. The corrected form scans the diff and exits 0, and all twenty-one excludes are still passed.

The other twelve workflow files were checked for the same shape. Only this one had it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected security scan exclusion arguments to ensure configured paths are properly excluded during scans.
  * Improved the reliability of automated security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->