### PR TITLE
fix(killswitch): scope endpoint exemptions to pipelock's own requests

### DIFF
--- a/internal/killswitch/forward_exemption_test.go
+++ b/internal/killswitch/forward_exemption_test.go
@@ -71,9 +71,9 @@ func TestIsActiveHTTP_ForwardProxyGetsNoEndpointExemption(t *testing.T) {
 		for _, method := range methods {
 			t.Run(method+" "+path, func(t *testing.T) {
 				c := activeController(t)
-				req := absProxyRequest(t, method, "http://attacker.example"+path)
+				req := absProxyRequest(t, method, "http://proxy-target.vendor.example"+path)
 				if d := c.IsActiveHTTP(req); !d.Active {
-					t.Errorf("forward-proxy %s http://attacker.example%s was EXEMPTED under an active kill switch; egress bypass", method, path)
+					t.Errorf("forward-proxy %s http://proxy-target.vendor.example%s was EXEMPTED under an active kill switch; egress bypass", method, path)
 				}
 			})
 		}
@@ -81,7 +81,7 @@ func TestIsActiveHTTP_ForwardProxyGetsNoEndpointExemption(t *testing.T) {
 
 	t.Run("query string does not change the verdict", func(t *testing.T) {
 		c := activeController(t)
-		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health?exfil=secret")
+		req := absProxyRequest(t, http.MethodGet, "http://proxy-target.vendor.example/health?exfil=secret")
 		if d := c.IsActiveHTTP(req); !d.Active {
 			t.Error("forward-proxy request with exempt path plus query was exempted")
 		}
@@ -90,8 +90,8 @@ func TestIsActiveHTTP_ForwardProxyGetsNoEndpointExemption(t *testing.T) {
 	t.Run("CONNECT is denied", func(t *testing.T) {
 		c := activeController(t)
 		r := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "/", nil)
-		r.URL = &url.URL{Host: "attacker.example:443"}
-		r.RequestURI = "attacker.example:443"
+		r.URL = &url.URL{Host: "proxy-target.vendor.example:443"}
+		r.RequestURI = "proxy-target.vendor.example:443"
 		if d := c.IsActiveHTTP(r); !d.Active {
 			t.Error("CONNECT was exempted under an active kill switch")
 		}
@@ -126,7 +126,7 @@ func TestIsActiveHTTP_OwnEndpointExemptionsStillWork(t *testing.T) {
 
 	t.Run("non-exempt own path is still denied", func(t *testing.T) {
 		c := activeController(t)
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fetch?url=http://example.com", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fetch?url=http://api.vendor.example", nil)
 		if d := c.IsActiveHTTP(req); !d.Active {
 			t.Error("/fetch was exempted under an active kill switch")
 		}
@@ -159,7 +159,7 @@ func TestIsActiveHTTP_AllowlistStillAppliesToProxiedTraffic(t *testing.T) {
 	}
 
 	t.Run("allowlisted client is exempt", func(t *testing.T) {
-		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health")
+		req := absProxyRequest(t, http.MethodGet, "http://proxy-target.vendor.example/health")
 		req.RemoteAddr = "10.9.9.5:5555"
 		if d := c.IsActiveHTTP(req); d.Active {
 			t.Error("allowlisted client IP should stay exempt for proxied traffic")
@@ -167,12 +167,91 @@ func TestIsActiveHTTP_AllowlistStillAppliesToProxiedTraffic(t *testing.T) {
 	})
 
 	t.Run("non-allowlisted client is denied", func(t *testing.T) {
-		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health")
+		req := absProxyRequest(t, http.MethodGet, "http://proxy-target.vendor.example/health")
 		req.RemoteAddr = "203.0.113.7:5555"
 		if d := c.IsActiveHTTP(req); !d.Active {
 			t.Error("non-allowlisted client was exempted via the destination path")
 		}
 	})
+}
+
+// TestAllowlistExempt_MalformedClientAddress covers the two error paths in
+// allowlistExempt, both of which decide whether traffic is exempt and so must
+// fail in the safe direction.
+//
+// RemoteAddr is normally host:port, but it is not guaranteed to be: a Unix
+// socket or a synthetic request can carry a bare address. SplitHostPort fails
+// there, and the fallback treats the whole string as the host so a legitimate
+// allowlisted operator is not locked out. An address that is neither parses to
+// a nil IP, and that must NOT be treated as allowlisted, because a client
+// choosing an unparseable address would otherwise select its own exemption.
+func TestAllowlistExempt_MalformedClientAddress(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		wantActive bool // true = denied, false = exempt
+	}{
+		{
+			name:       "bare allowlisted ip without a port stays exempt",
+			remoteAddr: "10.9.9.5",
+			wantActive: false,
+		},
+		{
+			name:       "bare non-allowlisted ip is denied",
+			remoteAddr: "203.0.113.7",
+			wantActive: true,
+		},
+		{
+			name:       "unparseable address is denied",
+			remoteAddr: "not-an-ip-address",
+			wantActive: true,
+		},
+		{
+			name:       "empty address is denied",
+			remoteAddr: "",
+			wantActive: true,
+		},
+		{
+			name:       "host:port with a non-ip host is denied",
+			remoteAddr: "some-hostname:5555",
+			wantActive: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.KillSwitch.AllowlistIPs = []string{"10.9.9.0/24"}
+			c := New(cfg)
+			if !c.ToggleSignal() {
+				t.Fatal("ToggleSignal should report the switch now active")
+			}
+
+			req := absProxyRequest(t, http.MethodGet, "http://proxy-target.vendor.example/health")
+			req.RemoteAddr = tc.remoteAddr
+
+			got := c.IsActiveHTTP(req).Active
+			if got != tc.wantActive {
+				verb := "denied"
+				if !tc.wantActive {
+					verb = "exempt"
+				}
+				t.Errorf("RemoteAddr %q: Active = %v, want %v (expected %s)",
+					tc.remoteAddr, got, tc.wantActive, verb)
+			}
+		})
+	}
+}
+
+// TestAllowlistExempt_NoAllowlistConfigured pins the common case: with no
+// allowlist set, no client address can produce an exemption.
+func TestAllowlistExempt_NoAllowlistConfigured(t *testing.T) {
+	c := activeController(t)
+	req := absProxyRequest(t, http.MethodGet, "http://proxy-target.vendor.example/health")
+	req.RemoteAddr = "10.9.9.5:5555"
+	if d := c.IsActiveHTTP(req); !d.Active {
+		t.Error("an unconfigured allowlist exempted a client")
+	}
 }
 
 // TestIsProxiedRequest covers the helper directly, including the nil-URL case a
@@ -184,8 +263,8 @@ func TestIsProxiedRequest(t *testing.T) {
 		u      *url.URL
 		want   bool
 	}{
-		{"absolute uri", http.MethodGet, &url.URL{Scheme: "http", Host: "h.example", Path: "/health"}, true},
-		{"connect authority form", http.MethodConnect, &url.URL{Host: "h.example:443"}, true},
+		{"absolute uri", http.MethodGet, &url.URL{Scheme: "http", Host: "api.vendor.example", Path: "/health"}, true},
+		{"connect authority form", http.MethodConnect, &url.URL{Host: "api.vendor.example:443"}, true},
 		{"connect with nil url", http.MethodConnect, nil, true},
 		{"origin form", http.MethodGet, &url.URL{Path: "/health"}, false},
 		{"scheme without host", http.MethodGet, &url.URL{Scheme: "http", Path: "/health"}, false},

--- a/internal/killswitch/forward_exemption_test.go
+++ b/internal/killswitch/forward_exemption_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package killswitch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// absProxyRequest builds a forward-proxy request the way net/http parses one off
+// the wire: an absolute-URI request-target, so r.URL carries the DESTINATION
+// host and path. This is the shape every pre-existing test in this package
+// omitted, which is why the exemption bypass survived.
+func absProxyRequest(t *testing.T, method, rawURL string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		t.Fatalf("test bug: %q is not an absolute URI", rawURL)
+	}
+	r := httptest.NewRequestWithContext(context.Background(), method, rawURL, nil)
+	r.URL = u
+	r.RequestURI = rawURL
+	return r
+}
+
+// activeController returns a controller with the kill switch active via the
+// signal source, matching the SIGUSR1 activation an operator actually uses.
+func activeController(t *testing.T) *Controller {
+	t.Helper()
+	c := New(testConfig())
+	if !c.ToggleSignal() {
+		t.Fatal("ToggleSignal should report the switch now active")
+	}
+	if !c.IsActive() {
+		t.Fatal("precondition: kill switch should be active")
+	}
+	return c
+}
+
+// TestIsActiveHTTP_ForwardProxyGetsNoEndpointExemption is the regression test
+// for the kill-switch bypass: with the switch active, a forward-proxy request
+// for an arbitrary host must be denied even when the DESTINATION path happens to
+// equal one of pipelock's own exempt endpoint paths.
+func TestIsActiveHTTP_ForwardProxyGetsNoEndpointExemption(t *testing.T) {
+	// Every path that IsActiveHTTP exempts on pipelock's own listener. Each is
+	// attacker-chosen on a forward-proxy request, so each must NOT exempt.
+	exemptPaths := []string{
+		"/health",
+		"/metrics",
+		"/api/v1/killswitch",
+		"/api/v1/killswitch/status",
+		"/api/v1/sessions",
+		"/api/v1/sessions/abc123",
+		"/api/v1/sessions/abc123/reset",
+		"/api/v1/sessions/abc123/airlock",
+		"/api/v1/sessions/abc123/task",
+		"/api/v1/sessions/abc123/trust",
+		"/api/v1/sessions/abc123/explain",
+		"/api/v1/sessions/abc123/terminate",
+	}
+	methods := []string{http.MethodGet, http.MethodPost}
+
+	for _, path := range exemptPaths {
+		for _, method := range methods {
+			t.Run(method+" "+path, func(t *testing.T) {
+				c := activeController(t)
+				req := absProxyRequest(t, method, "http://attacker.example"+path)
+				if d := c.IsActiveHTTP(req); !d.Active {
+					t.Errorf("forward-proxy %s http://attacker.example%s was EXEMPTED under an active kill switch; egress bypass", method, path)
+				}
+			})
+		}
+	}
+
+	t.Run("query string does not change the verdict", func(t *testing.T) {
+		c := activeController(t)
+		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health?exfil=secret")
+		if d := c.IsActiveHTTP(req); !d.Active {
+			t.Error("forward-proxy request with exempt path plus query was exempted")
+		}
+	})
+
+	t.Run("CONNECT is denied", func(t *testing.T) {
+		c := activeController(t)
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodConnect, "/", nil)
+		r.URL = &url.URL{Host: "attacker.example:443"}
+		r.RequestURI = "attacker.example:443"
+		if d := c.IsActiveHTTP(r); !d.Active {
+			t.Error("CONNECT was exempted under an active kill switch")
+		}
+	})
+}
+
+// TestIsActiveHTTP_OwnEndpointExemptionsStillWork guards the availability
+// direction. An over-strict fix that also denies pipelock's own /health would
+// break liveness probes under lockdown, which gets the control switched off.
+func TestIsActiveHTTP_OwnEndpointExemptionsStillWork(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"health probe", "/health"},
+		{"metrics scrape", "/metrics"},
+		{"killswitch api", "/api/v1/killswitch"},
+		{"killswitch status", "/api/v1/killswitch/status"},
+		{"sessions list", "/api/v1/sessions"},
+		{"session terminate", "/api/v1/sessions/abc123/terminate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := activeController(t)
+			// Origin-form request-target, i.e. a request to pipelock itself.
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
+			if d := c.IsActiveHTTP(req); d.Active {
+				t.Errorf("pipelock's own %s was DENIED under lockdown; probes and the deactivation API must survive", tc.path)
+			}
+		})
+	}
+
+	t.Run("non-exempt own path is still denied", func(t *testing.T) {
+		c := activeController(t)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/fetch?url=http://example.com", nil)
+		if d := c.IsActiveHTTP(req); !d.Active {
+			t.Error("/fetch was exempted under an active kill switch")
+		}
+	})
+}
+
+// TestIsActiveHTTP_ExemptionMatchesRouterEncoding pins the exemption to the same
+// path encoding the session API router uses. Matching the decoded path made the
+// exemption broader than the routes it covers.
+func TestIsActiveHTTP_ExemptionMatchesRouterEncoding(t *testing.T) {
+	c := activeController(t)
+	// %74 decodes to 't', so the decoded path reads as .../terminate while the
+	// router, which routes on EscapedPath, would 404 it. It must not be exempt.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/sessions/abc123/%74erminate", nil)
+	if d := c.IsActiveHTTP(req); !d.Active {
+		t.Error("percent-encoded non-route was exempted; exemption is broader than the router")
+	}
+}
+
+// TestIsActiveHTTP_AllowlistStillAppliesToProxiedTraffic documents the one
+// exemption that is deliberately preserved for proxied requests. The IP
+// allowlist keys on the client address, which the client cannot choose the way
+// it chooses a request path, so an operator's break-glass host keeps working.
+func TestIsActiveHTTP_AllowlistStillAppliesToProxiedTraffic(t *testing.T) {
+	cfg := testConfig()
+	cfg.KillSwitch.AllowlistIPs = []string{"10.9.9.0/24"}
+	c := New(cfg)
+	if !c.ToggleSignal() {
+		t.Fatal("ToggleSignal should report the switch now active")
+	}
+
+	t.Run("allowlisted client is exempt", func(t *testing.T) {
+		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health")
+		req.RemoteAddr = "10.9.9.5:5555"
+		if d := c.IsActiveHTTP(req); d.Active {
+			t.Error("allowlisted client IP should stay exempt for proxied traffic")
+		}
+	})
+
+	t.Run("non-allowlisted client is denied", func(t *testing.T) {
+		req := absProxyRequest(t, http.MethodGet, "http://attacker.example/health")
+		req.RemoteAddr = "203.0.113.7:5555"
+		if d := c.IsActiveHTTP(req); !d.Active {
+			t.Error("non-allowlisted client was exempted via the destination path")
+		}
+	})
+}
+
+// TestIsProxiedRequest covers the helper directly, including the nil-URL case a
+// hand-built request can present.
+func TestIsProxiedRequest(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		u      *url.URL
+		want   bool
+	}{
+		{"absolute uri", http.MethodGet, &url.URL{Scheme: "http", Host: "h.example", Path: "/health"}, true},
+		{"connect authority form", http.MethodConnect, &url.URL{Host: "h.example:443"}, true},
+		{"connect with nil url", http.MethodConnect, nil, true},
+		{"origin form", http.MethodGet, &url.URL{Path: "/health"}, false},
+		{"scheme without host", http.MethodGet, &url.URL{Scheme: "http", Path: "/health"}, false},
+		{"nil url", http.MethodGet, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{Method: tc.method, URL: tc.u}
+			if got := isProxiedRequest(r); got != tc.want {
+				t.Errorf("isProxiedRequest = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/killswitch/killswitch.go
+++ b/internal/killswitch/killswitch.go
@@ -136,11 +136,45 @@ func (c *Controller) IsActiveForIP(clientIP string) Decision {
 // IsActiveHTTP checks whether the kill switch should deny an HTTP request.
 // Checks exemptions (health/metrics/API endpoints, allowlisted IPs) before
 // computing the active state from all sources.
+// isProxiedRequest reports whether r is a request to be PROXIED somewhere else
+// rather than a request against pipelock's own endpoints. A forward-proxy
+// request carries an absolute-URI request-target and CONNECT carries an
+// authority-form one, so in neither case does the request path name a pipelock
+// endpoint - it names a path on the DESTINATION host.
+//
+// Every endpoint exemption below must be gated on this, because those
+// exemptions compare the request path against pipelock's own endpoint paths.
+// Without the gate, a request for http://any-host/health takes the health
+// exemption and is forwarded while the kill switch is active, which defeats the
+// emergency control entirely. The gate lives in one helper consulted ahead of
+// all exemptions so that any exemption added later inherits it by construction
+// rather than by the next author remembering this.
+func isProxiedRequest(r *http.Request) bool {
+	if r.Method == http.MethodConnect {
+		return true
+	}
+	return r.URL != nil && r.URL.IsAbs() && r.URL.Host != ""
+}
+
 func (c *Controller) IsActiveHTTP(r *http.Request) Decision {
 	rt := c.cfg.Load()
 
-	// Check endpoint exemptions first.
-	path := r.URL.Path
+	// Proxied traffic gets no endpoint exemption: the request path belongs to
+	// the destination, not to pipelock. The IP allowlist is deliberately still
+	// honoured here, because it keys on the CLIENT address rather than on a
+	// path the client chooses.
+	if isProxiedRequest(r) {
+		if d := c.allowlistExempt(rt, r); d != nil {
+			return *d
+		}
+		return c.computeDecision(rt)
+	}
+
+	// Check endpoint exemptions first. Compare on EscapedPath so an exemption
+	// cannot be broader than the routes it is meant to cover: sessionAPIRouter
+	// routes on EscapedPath, so matching the decoded path here would exempt
+	// e.g. /api/v1/sessions/x/%74erminate, which the router then 404s.
+	path := r.URL.EscapedPath()
 	if rt.healthExempt && path == "/health" {
 		return Decision{}
 	}
@@ -149,18 +183,8 @@ func (c *Controller) IsActiveHTTP(r *http.Request) Decision {
 	}
 
 	// Check IP allowlist.
-	if len(rt.allowlistNets) > 0 {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			host = r.RemoteAddr
-		}
-		if clientIP := net.ParseIP(host); clientIP != nil {
-			for _, ipNet := range rt.allowlistNets {
-				if ipNet.Contains(clientIP) {
-					return Decision{}
-				}
-			}
-		}
+	if d := c.allowlistExempt(rt, r); d != nil {
+		return *d
 	}
 
 	// Check API exemption. When the API runs on a separate port
@@ -180,6 +204,30 @@ func (c *Controller) IsActiveHTTP(r *http.Request) Decision {
 	}
 
 	return c.computeDecision(rt)
+}
+
+// allowlistExempt returns a non-nil zero Decision when the request's client IP
+// is allowlisted, and nil when it is not. Keyed on the client address, so it is
+// safe to honour for proxied traffic: a client cannot choose its own source IP
+// the way it chooses a request path.
+func (c *Controller) allowlistExempt(rt *runtime, r *http.Request) *Decision {
+	if len(rt.allowlistNets) == 0 {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	clientIP := net.ParseIP(host)
+	if clientIP == nil {
+		return nil
+	}
+	for _, ipNet := range rt.allowlistNets {
+		if ipNet.Contains(clientIP) {
+			return &Decision{}
+		}
+	}
+	return nil
 }
 
 // IsActiveMCP checks whether the kill switch should deny an MCP message.


### PR DESCRIPTION
## What changed

The kill switch exempts a small set of pipelock's own endpoints so health probes, metrics scrapes, and the deactivation API keep working while traffic is denied. Those exemptions compared the request path without first establishing that the request was addressed to pipelock at all, and a proxied request carries the destination's path rather than a local one.

Exemptions are now gated on a single check consulted ahead of all of them, so an exemption added later inherits the guard instead of depending on the next author knowing this. The IP allowlist still applies to proxied traffic, since it keys on the client address rather than on a path the client chooses. Exemption matching also moved onto the same path encoding the session API router uses, so an exemption can no longer be broader than the routes it covers.

Failure direction: this closes a fail-open. Traffic that should have been refused under an active kill switch was being allowed. The thing to distrust in review is the exemption list itself, because every entry there is a path comparison and a path comparison is only meaningful once the request is known to be addressed to pipelock.

Reviewers should confirm the availability side by hand as well as the denial side: with the switch active, pipelock's own health and metrics endpoints must still answer, or liveness probes fail during a lockdown and an operator turns the control off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kill-switch handling for forward-proxy requests.
  * Prevented destination paths from bypassing an active kill switch.
  * Preserved exemptions for Pipelock endpoints and configured IP allowlists.
  * Improved handling of encoded router paths, CONNECT requests, and missing URLs.
  * Added safeguards for malformed client addresses and cases where no allowlist is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->