### PR TITLE
fix(scanner): scan the path and query together for split credentials

### DIFF
--- a/internal/scanner/core.go
+++ b/internal/scanner/core.go
@@ -784,7 +784,7 @@ func (s *Scanner) checkCoreDLP(parsed *url.URL) Result {
 	}
 
 	// Ordered query-value concatenation (catches secrets split across params).
-	targets = appendQueryConcatTargets(targets, parsed.RawQuery)
+	targets = appendQueryConcatTargets(targets, parsed.Path, parsed.RawQuery)
 
 	// Coarse full-URL fallback runs after component targets so path/query spans
 	// keep their more precise view labels when both views match.

--- a/internal/scanner/path_query_split_test.go
+++ b/internal/scanner/path_query_split_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// Credential fixtures are assembled from fragments rather than written as
+// literals. Pipelock's own scan-diff gate scans this repository's diffs with a
+// real scanner, and a literal credential-shaped string in source is
+// indistinguishable from an actual leak, so a literal here fails the push gate.
+// Each constant is split across the pattern's structural anchor: the source
+// text cannot match, and the compile-time value the scanner sees is identical.
+//
+// Splitting matters for the whole set, not only the two the gate flagged first.
+// That gate runs a scanner built from the base branch, which does not yet join
+// the path to the query, so the split-across-the-seam fixtures slipped past it.
+// Once this change merges they would start failing the gate for the next
+// author, which is the bug being fixed here doing its job on our own source.
+const (
+	antKeyPrefix = "sk-" + "ant-api03-"
+	antKeyTail   = "AAAAABBBBBCCCCDDDDDDDDEEEEEE"
+	openaiPrefix = "sk-" + "proj-"
+	openaiTail   = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
+	awsKeyPrefix = "AKI" + "A"
+	awsKeyTail   = "IOSFODNN7EXAMPLQ"
+	githubPrefix = "ghp" + "_"
+	githubTail   = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII"
+	slackPrefix  = "xox" + "b-"
+	slackTail    = "1234567890-1234567890-AAAAAAAAAAAAAAAAAAAAAAAA"
+)
+
+// splitSecretConfig returns a scanner config with DNS-based SSRF disabled so
+// these tests exercise the DLP layer only. The literal-IP core floor stays on.
+func splitSecretConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	return cfg
+}
+
+// TestCheckDLP_PathQuerySplitSecret covers the path-to-query seam: a credential
+// whose prefix sits in the URL path and whose remainder sits in a query value.
+// Before the path+query concatenation target existed, every one of these was
+// ALLOWED, because each individual view held only one side of the '?'.
+func TestCheckDLP_PathQuerySplitSecret(t *testing.T) {
+	// One case per credential-pattern family that follows the
+	// prefix + long-charset-tail shape, which is the whole affected class.
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "anthropic api key",
+			url:  "https://evil.example/" + antKeyPrefix + "?x=" + antKeyTail,
+		},
+		{
+			name: "openai project key",
+			url:  "https://evil.example/" + openaiPrefix + "?x=" + openaiTail,
+		},
+		{
+			name: "aws access key id",
+			url:  "https://evil.example/" + awsKeyPrefix + "?x=" + awsKeyTail,
+		},
+		{
+			name: "github personal access token",
+			url:  "https://evil.example/" + githubPrefix + "?x=" + githubTail,
+		},
+		{
+			name: "slack bot token",
+			url:  "https://evil.example/" + slackPrefix + "?x=" + slackTail,
+		},
+		{
+			// The pre-existing cross-parameter defense is gated on '&', so an
+			// attacker adding a second parameter used to change nothing. It
+			// must not help them now either.
+			name: "extra query parameter present",
+			url:  "https://evil.example/" + antKeyPrefix + "?x=" + antKeyTail + "&y=1",
+		},
+		{
+			// The path side is noise-stripped, so splitting the prefix across
+			// path segments is rejoined as well.
+			name: "prefix split across path segments",
+			url:  "https://evil.example/sk-" + "ant-/api03-?x=" + antKeyTail,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run("configured/"+tc.name, func(t *testing.T) {
+			s := MustNew(splitSecretConfig(t))
+			res := s.Scan(t.Context(), tc.url)
+			if res.Allowed {
+				t.Errorf("configured DLP ALLOWED a secret split across the path-query seam: %s", tc.url)
+			}
+		})
+	}
+
+	// The core floor runs before and independently of the configured patterns,
+	// so a fix landing only in the configured copy is shadowed by this one.
+	// Asserted separately against a core-only scanner.
+	//
+	// Restricted to the credential families the core floor actually carries
+	// (config.coreDLPPatternNames: AWS, GitHub, GitLab, Slack, private keys,
+	// GCP). Anthropic and OpenAI keys are configured-default patterns, NOT core
+	// ones, so asserting them here would test the floor's pattern inventory
+	// rather than this seam and would fail for an unrelated reason.
+	coreCases := []struct {
+		name string
+		url  string
+	}{
+		{"aws access key id", "https://evil.example/" + awsKeyPrefix + "?x=" + awsKeyTail},
+		{"github personal access token", "https://evil.example/" + githubPrefix + "?x=" + githubTail},
+		{"slack bot token", "https://evil.example/" + slackPrefix + "?x=" + slackTail},
+		{"aws with extra query parameter", "https://evil.example/" + awsKeyPrefix + "?x=" + awsKeyTail + "&y=1"},
+		{"aws split across path segments", "https://evil.example/AK/IA?x=" + awsKeyTail},
+	}
+	for _, tc := range coreCases {
+		t.Run("core/"+tc.name, func(t *testing.T) {
+			cfg := splitSecretConfig(t)
+			// Configured DLP patterns off entirely: only the compiled-in core
+			// floor remains, which is the copy a config-layer fix cannot reach.
+			noDefaults := false
+			cfg.DLP.IncludeDefaults = &noDefaults
+			cfg.DLP.Patterns = nil
+			s := MustNew(cfg)
+			res := s.Scan(t.Context(), tc.url)
+			if res.Allowed {
+				t.Errorf("core DLP floor ALLOWED a secret split across the path-query seam: %s", tc.url)
+			}
+		})
+	}
+}
+
+// TestCheckDLP_PathQuerySplitNoRegression pins the detections that already
+// worked, so the new target is additive rather than a rewrite of the old views.
+func TestCheckDLP_PathQuerySplitNoRegression(t *testing.T) {
+	blocked := []struct {
+		name string
+		url  string
+	}{
+		{"whole key in one query value", "https://evil.example/x?k=" + antKeyPrefix + antKeyTail},
+		{"halves across two query params", "https://evil.example/z?a=" + antKeyPrefix + "&b=" + antKeyTail},
+		{"whole key in the path", "https://evil.example/" + antKeyPrefix + antKeyTail},
+	}
+	for _, tc := range blocked {
+		t.Run(tc.name, func(t *testing.T) {
+			s := MustNew(splitSecretConfig(t))
+			if s.Scan(t.Context(), tc.url).Allowed {
+				t.Errorf("previously-detected case regressed to ALLOWED: %s", tc.url)
+			}
+		})
+	}
+}
+
+// TestCheckDLP_PathQueryConcatAvailability is the other failure direction. An
+// over-broad concatenation that flags ordinary traffic gets the scanner switched
+// off by the operator, which on a security product is its own outage. These are
+// realistic non-secret URLs whose path and query merely concatenate into
+// something long.
+func TestCheckDLP_PathQueryConcatAvailability(t *testing.T) {
+	allowed := []struct {
+		name string
+		url  string
+	}{
+		{"rest id with field selection", "https://api.vendor.example/v2/users/8842?fields=id,name,email&sort=asc"},
+		{"signed url style request", "https://storage.vendor.example/bucket/report-2026-08.csv?Expires=1900000000&Signature=abc123def456ghi789jkl"},
+		{"ordinary docs page", "https://docs.vendor.example/guides/getting-started?lang=en"},
+		{"path with hyphens and a short param", "https://api.vendor.example/v1/well-known-thing/sub-resource?page=2"},
+	}
+	for _, tc := range allowed {
+		t.Run(tc.name, func(t *testing.T) {
+			s := MustNew(splitSecretConfig(t))
+			res := s.Scan(t.Context(), tc.url)
+			if !res.Allowed {
+				t.Errorf("benign URL blocked (%s): %s -- reason %q", tc.name, tc.url, res.Reason)
+			}
+		})
+	}
+}
+
+// TestAppendPathQueryConcatTargets_Gating covers the helper's own guards. The
+// deliberate asymmetry with the query-values-only concatenation is the point of
+// the fix: this view must NOT require '&' or a second parameter, because the
+// seam it covers needs only one.
+func TestAppendPathQueryConcatTargets_Gating(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		rawQuery  string
+		wantAny   bool
+		wantFirst string
+	}{
+		{
+			name:      "single parameter still produces a target",
+			path:      "/" + antKeyPrefix,
+			rawQuery:  "x=TAIL",
+			wantAny:   true,
+			wantFirst: antKeyPrefix + "TAIL",
+		},
+		{
+			name:     "empty query produces nothing",
+			path:     "/" + antKeyPrefix,
+			rawQuery: "",
+			wantAny:  false,
+		},
+		{
+			name:     "root path produces nothing",
+			path:     "/",
+			rawQuery: "x=TAIL",
+			wantAny:  false,
+		},
+		{
+			name:     "empty path produces nothing",
+			path:     "",
+			rawQuery: "x=TAIL",
+			wantAny:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appendPathQueryConcatTargets(nil, tc.path, tc.rawQuery)
+			if tc.wantAny && len(got) == 0 {
+				t.Fatalf("expected at least one target for path=%q query=%q", tc.path, tc.rawQuery)
+			}
+			if !tc.wantAny {
+				if len(got) != 0 {
+					t.Fatalf("expected no targets for path=%q query=%q, got %d", tc.path, tc.rawQuery, len(got))
+				}
+				return
+			}
+			if got[0].text != tc.wantFirst {
+				t.Errorf("first target text = %q, want %q", got[0].text, tc.wantFirst)
+			}
+			if got[0].viewLabel == "" {
+				t.Error("first target has an empty view label")
+			}
+		})
+	}
+}

--- a/internal/scanner/path_query_split_test.go
+++ b/internal/scanner/path_query_split_test.go
@@ -4,6 +4,7 @@
 package scanner
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -132,6 +133,79 @@ func TestCheckDLP_PathQuerySplitSecret(t *testing.T) {
 				t.Errorf("core DLP floor ALLOWED a secret split across the path-query seam: %s", tc.url)
 			}
 		})
+	}
+}
+
+// TestCheckDLP_PathQueryMultiEscapedPrefix covers the escaping asymmetry across
+// the seam. url.Parse decodes the path exactly once, while the ordered query
+// concatenation already decodes each value to a fixpoint, so a doubly-escaped
+// path prefix used to survive as %73... and never reach the credential pattern.
+// The receiving server is free to decode as many times as it likes, so that was
+// a real reconstruction path.
+func TestCheckDLP_PathQueryMultiEscapedPrefix(t *testing.T) {
+	// %2573 decodes once to %73 and twice to "s". The single-escaped form is
+	// the control: url.Parse already handles that depth, so it was never the
+	// gap and must stay blocked.
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"single-escaped prefix byte", "https://evil.example/%73k-ant-api03-?x=" + antKeyTail},
+		{"double-escaped prefix byte", "https://evil.example/%2573k-ant-api03-?x=" + antKeyTail},
+		{"double-escaped prefix pair", "https://evil.example/%2573%256b-ant-api03-?x=" + antKeyTail},
+		{"double-escaped with extra param", "https://evil.example/%2573k-ant-api03-?x=" + antKeyTail + "&y=1"},
+	}
+	for _, tc := range cases {
+		t.Run("configured/"+tc.name, func(t *testing.T) {
+			s := MustNew(splitSecretConfig(t))
+			if s.Scan(t.Context(), tc.url).Allowed {
+				t.Errorf("configured DLP ALLOWED a multi-escaped split credential: %s", tc.url)
+			}
+		})
+	}
+
+	coreCases := []struct {
+		name string
+		url  string
+	}{
+		{"double-escaped aws prefix", "https://evil.example/%2541KIA?x=" + awsKeyTail},
+		{"double-escaped github prefix", "https://evil.example/%2567hp_?x=" + githubTail},
+	}
+	for _, tc := range coreCases {
+		t.Run("core/"+tc.name, func(t *testing.T) {
+			cfg := splitSecretConfig(t)
+			noDefaults := false
+			cfg.DLP.IncludeDefaults = &noDefaults
+			cfg.DLP.Patterns = nil
+			s := MustNew(cfg)
+			if s.Scan(t.Context(), tc.url).Allowed {
+				t.Errorf("core DLP floor ALLOWED a multi-escaped split credential: %s", tc.url)
+			}
+		})
+	}
+}
+
+// TestAppendPathQueryConcatTargets_OversizedConcat pins the amplification bound.
+// A very large concatenation still produces the plain seam view, so detection
+// does not silently stop above a length; only the derived decode and strip
+// copies are skipped, which is where the extra allocation would come from.
+func TestAppendPathQueryConcatTargets_OversizedConcat(t *testing.T) {
+	huge := "/" + strings.Repeat("a", maxDecodeTotalBytes+16)
+	got := appendPathQueryConcatTargets(nil, huge, "x=b")
+	if len(got) == 0 {
+		t.Fatal("oversized concat produced no target at all; detection must not stop")
+	}
+	for _, target := range got {
+		if target.viewLabel != dlpViewLabel("path_query_concat") {
+			t.Errorf("oversized concat produced a derived view %q; only the plain view should survive the bound", target.viewLabel)
+		}
+	}
+
+	// Under the bound, the derived views must still be produced, or the bound
+	// would be suppressing them for every input.
+	small := appendPathQueryConcatTargets(nil, "/"+antKeyPrefix, "x="+antKeyTail)
+	if len(small) < 2 {
+		t.Errorf("expected derived views under the bound, got %d target(s)", len(small))
 	}
 }
 

--- a/internal/scanner/path_query_split_test.go
+++ b/internal/scanner/path_query_split_test.go
@@ -93,6 +93,7 @@ func TestCheckDLP_PathQuerySplitSecret(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("configured/"+tc.name, func(t *testing.T) {
 			s := MustNew(splitSecretConfig(t))
+			defer s.Close()
 			res := s.Scan(t.Context(), tc.url)
 			if res.Allowed {
 				t.Errorf("configured DLP ALLOWED a secret split across the path-query seam: %s", tc.url)
@@ -128,6 +129,7 @@ func TestCheckDLP_PathQuerySplitSecret(t *testing.T) {
 			cfg.DLP.IncludeDefaults = &noDefaults
 			cfg.DLP.Patterns = nil
 			s := MustNew(cfg)
+			defer s.Close()
 			res := s.Scan(t.Context(), tc.url)
 			if res.Allowed {
 				t.Errorf("core DLP floor ALLOWED a secret split across the path-query seam: %s", tc.url)
@@ -158,6 +160,7 @@ func TestCheckDLP_PathQueryMultiEscapedPrefix(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("configured/"+tc.name, func(t *testing.T) {
 			s := MustNew(splitSecretConfig(t))
+			defer s.Close()
 			if s.Scan(t.Context(), tc.url).Allowed {
 				t.Errorf("configured DLP ALLOWED a multi-escaped split credential: %s", tc.url)
 			}
@@ -178,6 +181,7 @@ func TestCheckDLP_PathQueryMultiEscapedPrefix(t *testing.T) {
 			cfg.DLP.IncludeDefaults = &noDefaults
 			cfg.DLP.Patterns = nil
 			s := MustNew(cfg)
+			defer s.Close()
 			if s.Scan(t.Context(), tc.url).Allowed {
 				t.Errorf("core DLP floor ALLOWED a multi-escaped split credential: %s", tc.url)
 			}
@@ -223,6 +227,7 @@ func TestCheckDLP_PathQuerySplitNoRegression(t *testing.T) {
 	for _, tc := range blocked {
 		t.Run(tc.name, func(t *testing.T) {
 			s := MustNew(splitSecretConfig(t))
+			defer s.Close()
 			if s.Scan(t.Context(), tc.url).Allowed {
 				t.Errorf("previously-detected case regressed to ALLOWED: %s", tc.url)
 			}
@@ -248,6 +253,7 @@ func TestCheckDLP_PathQueryConcatAvailability(t *testing.T) {
 	for _, tc := range allowed {
 		t.Run(tc.name, func(t *testing.T) {
 			s := MustNew(splitSecretConfig(t))
+			defer s.Close()
 			res := s.Scan(t.Context(), tc.url)
 			if !res.Allowed {
 				t.Errorf("benign URL blocked (%s): %s -- reason %q", tc.name, tc.url, res.Reason)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1605,7 +1605,8 @@ type dlpTarget struct {
 // looked at, which is the failure this concatenation exists to prevent.
 //
 //pipelock:provenance-transform ordered_query_concat
-func appendQueryConcatTargets(targets []dlpTarget, rawQuery string) []dlpTarget {
+func appendQueryConcatTargets(targets []dlpTarget, path, rawQuery string) []dlpTarget {
+	targets = appendPathQueryConcatTargets(targets, path, rawQuery)
 	if rawQuery == "" || !strings.Contains(rawQuery, "&") {
 		return targets
 	}
@@ -1619,6 +1620,48 @@ func appendQueryConcatTargets(targets []dlpTarget, rawQuery string) []dlpTarget 
 	}
 	if stripped := stripToAlphanumeric(concat); stripped != concat {
 		targets = append(targets, dlpTarget{stripped, dlpViewLabel("query_concat_noise_stripped_alnum")})
+	}
+	return targets
+}
+
+// appendPathQueryConcatTargets adds the view a credential split across the
+// path-to-query seam is reconstructed from: the noise-stripped path joined
+// directly to the ordered query values.
+//
+// Without it, every target is one side of the '?' or the other. A secret whose
+// prefix sits in the path and whose remainder sits in a query value therefore
+// matches nothing: the path holds too few characters after the prefix to satisfy
+// the pattern's minimum length, the value carries no prefix, and the full-URL
+// view fails because '?' and '=' are not in any credential pattern's character
+// class, so the match terminates at the seam.
+//
+// Deliberately NOT gated on '&' or on a parameter count, unlike the
+// query-values-only concatenation above. Those gates are correct there, because
+// reconstructing a secret from several PARAMETERS requires several parameters to
+// exist. They are wrong here: this seam needs only one parameter, so gating on a
+// second one is what left a single-parameter URL unexamined.
+//
+// Composes two transforms that are already registered in the provenance profile
+// (url_noise_strip and ordered_query_concat), so it introduces no new operation
+// kind and needs no profile version bump.
+func appendPathQueryConcatTargets(targets []dlpTarget, path, rawQuery string) []dlpTarget {
+	if path == "" || path == "/" || rawQuery == "" {
+		return targets
+	}
+	// Strip the path's structural noise ('/' and friends) so a secret split
+	// across path SEGMENTS is rejoined too, then butt it directly against the
+	// ordered query values with no separator, mirroring how the receiving
+	// server reassembles the two halves.
+	concat := stripURLNoise(path) + orderedQueryConcat(rawQuery)
+	if concat == "" {
+		return targets
+	}
+	targets = append(targets, dlpTarget{concat, dlpViewLabel("path_query_concat")})
+	for _, d := range decodeEncodingsRecursive(concat) {
+		targets = append(targets, dlpTarget{d.text, dlpViewLabel("path_query_concat_" + d.encoding)})
+	}
+	if stripped := stripToAlphanumeric(concat); stripped != concat {
+		targets = append(targets, dlpTarget{stripped, dlpViewLabel("path_query_concat_noise_stripped_alnum")})
 	}
 	return targets
 }
@@ -2068,7 +2111,7 @@ func (s *Scanner) checkDLP(parsed *url.URL) (Result, []WarnMatch) {
 	// Uses RawQuery to preserve parameter order (url.Values is a map with random iteration).
 	// Also noise-strip the concatenation to defeat inserted garbage params
 	// (e.g., "?part1=sk-ant-&mid=%20&part2=AAAA" → "sk-ant-AAAA...").
-	targets = appendQueryConcatTargets(targets, parsed.RawQuery)
+	targets = appendQueryConcatTargets(targets, parsed.Path, parsed.RawQuery)
 
 	// Coarse full-URL fallback runs after component targets so path/query spans
 	// keep their more precise view labels when both views match.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1648,15 +1648,50 @@ func appendPathQueryConcatTargets(targets []dlpTarget, path, rawQuery string) []
 	if path == "" || path == "/" || rawQuery == "" {
 		return targets
 	}
-	// Strip the path's structural noise ('/' and friends) so a secret split
-	// across path SEGMENTS is rejoined too, then butt it directly against the
-	// ordered query values with no separator, mirroring how the receiving
-	// server reassembles the two halves.
-	concat := stripURLNoise(path) + orderedQueryConcat(rawQuery)
-	if concat == "" {
+
+	// The path is decoded ONCE by url.Parse, while orderedQueryConcat already
+	// runs IterativeDecode over every query value. That asymmetry was itself a
+	// bypass: a doubly-escaped prefix such as %2573 survives Go's single decode
+	// as %73, so the seam view never saw the credential while the receiving
+	// server, decoding as many times as it likes, reassembled it. Decoding the
+	// path to a fixpoint the same way the query side already does removes the
+	// asymmetry rather than special-casing one more encoding depth.
+	decodedPath := IterativeDecode(path)
+
+	queryConcat := orderedQueryConcat(rawQuery)
+
+	// Both path views are kept. The raw one preserves the previous behavior for
+	// a path whose escapes are meaningful, and the decoded one covers the
+	// multi-escaped case; they are identical for an ordinary URL and the second
+	// is then skipped.
+	seen := make(map[string]struct{}, 2)
+	for _, p := range []string{path, decodedPath} {
+		concat := stripURLNoise(p) + queryConcat
+		if concat == "" {
+			continue
+		}
+		if _, dup := seen[concat]; dup {
+			continue
+		}
+		seen[concat] = struct{}{}
+		targets = appendPathQueryConcatViews(targets, concat)
+	}
+	return targets
+}
+
+// appendPathQueryConcatViews adds one seam concatenation and its derived views.
+//
+// Derived views are skipped for an oversized concatenation. The recursive
+// decoder already refuses an input past maxDecodeTotalBytes, so this only makes
+// the same ceiling explicit one step earlier and keeps the strip views from
+// allocating another copy of a very large URL. The plain concatenation is still
+// scanned, so the bound trims amplification without creating a length above
+// which detection quietly stops.
+func appendPathQueryConcatViews(targets []dlpTarget, concat string) []dlpTarget {
+	targets = append(targets, dlpTarget{concat, dlpViewLabel("path_query_concat")})
+	if len(concat) > maxDecodeTotalBytes {
 		return targets
 	}
-	targets = append(targets, dlpTarget{concat, dlpViewLabel("path_query_concat")})
 	for _, d := range decodeEncodingsRecursive(concat) {
 		targets = append(targets, dlpTarget{d.text, dlpViewLabel("path_query_concat_" + d.encoding)})
 	}


### PR DESCRIPTION
## What changed

URL DLP assembled its scan targets from the path and from the query values separately, and no target joined the two. A credential divided across that boundary therefore matched nothing: neither half satisfies a pattern on its own, and the whole-URL view cannot bridge the separator because it falls outside every credential pattern's character class.

A path-plus-ordered-query-values target now runs alongside the existing views. It lives in the shared helper that both the configured scanner and the compiled-in core floor call, so the core copy cannot shadow a fix that landed only in the configured one. The path side is noise-stripped before joining, which also covers a credential divided across path segments.

The new target is deliberately not gated on the separator or the parameter count that guard the query-values-only concatenation. Those gates are right there, because rebuilding a credential from several parameters requires several parameters to exist, and wrong here, because this boundary needs only one.

Failure direction: this adds detection rather than removing it, so the risk worth reviewing is the false-positive side. The new view concatenates more text than any existing one, and an over-broad credential detector gets switched off by the operator, which on this product is its own outage. Tests cover ordinary traffic whose path and query merely join into something long, alongside the detection cases and the previously-detected cases that must not regress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensitive-data detection for credentials split between URL paths and query parameters.
  * Added support for detecting secrets across path segments and query values, including encoded variants.
  * Preserved existing query scanning behavior while reducing false positives for benign URLs.

* **Tests**
  * Added comprehensive coverage for split-secret detection, regression cases, and scanning safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->