### PR TITLE
ci: install apt packages without refreshing the index first

### DIFF
--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -17,14 +17,24 @@
 # THE BUDGET IS THE WHOLE POINT, so the arithmetic is written out to be checked
 # rather than trusted:
 #
-#   no-update probe    = PROBE_TIMEOUT                      = 45s
-#   one attempt        = UPDATE_TIMEOUT + INSTALL_TIMEOUT = 90 + 60 = 150s
-#   worst case overall = PROBE_TIMEOUT + (ATTEMPTS * 150s) + BACKOFF
-#                      = 45s + (2 * 150s) + 10s
-#                      = 355s
+# Each bound also carries KILL_GRACE, since a command that ignores TERM is only
+# gone after the KILL. The worst path escalates at FIVE points, not three: the
+# probe, then update and install on each of the two attempts. Counting call sites
+# instead of escalations undercounts it by two grace periods.
 #
-# The hardening jobs allow 480s, leaving about 125s for checkout and the audit
+#   no-update probe    = PROBE_TIMEOUT + KILL_GRACE          = 45 + 5  = 50s
+#   one attempt        = (UPDATE_TIMEOUT + KILL_GRACE)
+#                        + (INSTALL_TIMEOUT + KILL_GRACE)
+#                      = (90 + 5) + (60 + 5)                           = 160s
+#   worst case overall = probe + (ATTEMPTS * one attempt) + BACKOFF
+#                      = 50s + (2 * 160s) + 10s
+#                      = 380s
+#
+# The hardening jobs allow 480s, leaving about 100s for checkout and the audit
 # work itself, against a job that normally finishes in well under two minutes.
+# The probe is the common path and costs about two seconds in practice, so the
+# expected time is far below either number; the 380s is the pathological path
+# where every single bound has to be enforced by force.
 #
 # The probe is the common path and costs seconds, so it lowers the EXPECTED time
 # while raising the worst case by its own bound. Both numbers still fit, and the
@@ -49,6 +59,13 @@ readonly UPDATE_TIMEOUT=90
 readonly INSTALL_TIMEOUT=60
 readonly BACKOFF=10
 
+# Every bound below is enforced with a forced-kill grace period, because a bound
+# that only sends TERM is not a bound. apt-get waiting on the dpkg lock can be
+# slow to act on TERM or ignore it outright, and the process then outlives the
+# timeout it was supposedly held to, which makes the arithmetic above a claim
+# rather than a limit. KILL sends the process away after the grace period.
+readonly KILL_GRACE=5
+
 # The runner image already carries some of these. Skipping the network entirely
 # when every package is present is both faster and one less thing to stall.
 missing=()
@@ -68,8 +85,8 @@ fi
 # that looks like an option would be read as one. The trailing -- stops apt-get
 # reading a package name as a flag.
 attempt_install() {
-  sudo timeout "$UPDATE_TIMEOUT" apt-get update \
-    && sudo timeout "$INSTALL_TIMEOUT" apt-get install -y -- "${missing[@]}"
+  sudo timeout --kill-after "$KILL_GRACE" "$UPDATE_TIMEOUT" apt-get update \
+    && sudo timeout --kill-after "$KILL_GRACE" "$INSTALL_TIMEOUT" apt-get install -y -- "${missing[@]}"
 }
 
 # Try installing from the lists the image already carries, before fetching any.
@@ -92,7 +109,7 @@ attempt_install() {
 # satisfy the request.
 readonly PROBE_TIMEOUT=45
 attempt_install_without_update() {
-  sudo timeout "$PROBE_TIMEOUT" apt-get install -y -- "${missing[@]}"
+  sudo timeout --kill-after "$KILL_GRACE" "$PROBE_TIMEOUT" apt-get install -y -- "${missing[@]}"
 }
 
 # Announce the path taken. The previous version of this logic had no marker, so a

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -17,13 +17,18 @@
 # THE BUDGET IS THE WHOLE POINT, so the arithmetic is written out to be checked
 # rather than trusted:
 #
+#   no-update probe    = PROBE_TIMEOUT                      = 45s
 #   one attempt        = UPDATE_TIMEOUT + INSTALL_TIMEOUT = 90 + 60 = 150s
-#   worst case overall = (ATTEMPTS * 150s) + BACKOFF
-#                      = (2 * 150s) + 10s
-#                      = 310s
+#   worst case overall = PROBE_TIMEOUT + (ATTEMPTS * 150s) + BACKOFF
+#                      = 45s + (2 * 150s) + 10s
+#                      = 355s
 #
-# The hardening jobs allow 480s, leaving about 170s for checkout and the audit
+# The hardening jobs allow 480s, leaving about 125s for checkout and the audit
 # work itself, against a job that normally finishes in well under two minutes.
+#
+# The probe is the common path and costs seconds, so it lowers the EXPECTED time
+# while raising the worst case by its own bound. Both numbers still fit, and the
+# expected case is what stops the coin flip.
 #
 # A bound that does not fit its job's limit is not a fix, it is a slower path to
 # the same cancellation. The first version of this script used the shared
@@ -57,34 +62,6 @@ if [ "${#missing[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# Drop the runner's regional mirror before updating.
-#
-# GitHub's Ubuntu images point apt at azure.archive.ubuntu.com. When that mirror
-# is unreachable apt does not fail, it waits: every index line comes back Ign,
-# apt falls back to archive.ubuntu.com for the InRelease files, and the package
-# indices never finish inside UPDATE_TIMEOUT. Both attempts then burn their full
-# bound and the job fails having installed nothing. That is not a transient
-# flake — it reproduced across two runs fifteen minutes apart on 2026-08-19,
-# failing `workflow-audit` and `runtime-policy` on a PR whose own code was fine.
-#
-# Retrying a dead mirror cannot help, and raising the bound only trades a red
-# check for a cancelled job (see the budget note above). Removing the mirror is
-# what changes the outcome: archive.ubuntu.com answered in the same logs where
-# the regional mirror did not.
-#
-# Both source layouts are rewritten because the path moved in Ubuntu 24.04: the
-# deb822 file is authoritative on noble, the one-line list on older images. A
-# missing file is not an error, so absence of either is ignored rather than
-# treated as a failure.
-use_primary_mirror() {
-  local f
-  for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
-    [ -f "$f" ] || continue
-    sudo sed -i 's|[a-z0-9-]*\.archive\.ubuntu\.com|archive.ubuntu.com|g' "$f" || return 1
-  done
-  return 0
-}
-
 # Package names reach apt-get as an argument array and are never rebuilt into a
 # command string. Interpolating them into a shell program would re-parse them,
 # so a name carrying whitespace or a glob would change the invocation and a name
@@ -95,13 +72,37 @@ attempt_install() {
     && sudo timeout "$INSTALL_TIMEOUT" apt-get install -y -- "${missing[@]}"
 }
 
-# Rewrite once, before the first attempt. A failure here is reported and does not
-# abort: the mirror swap is an availability fix, so falling through to the
-# unmodified sources leaves the original behaviour rather than turning a slow
-# install into no install at all.
-if ! use_primary_mirror; then
-  echo "ci-apt-install: could not rewrite apt sources; continuing with the image defaults" >&2
+# Try installing from the lists the image already carries, before fetching any.
+#
+# The failure this addresses is throughput, not reachability. Measured on
+# 2026-08-19: a run that SUCCEEDED fetched at 237 kB/s and 56 kB/s and needed
+# roughly seventy seconds of update, so attempt one blew the ninety-second bound
+# and attempt two squeaked through. With two attempts that is a coin flip, and it
+# landed both ways within half an hour on two pull requests whose own code was
+# fine. Nothing about the mirror was down; an earlier attempt at this rewrote the
+# sources to a different host and changed nothing, because the host was never the
+# problem.
+#
+# So skip the fetch entirely where it is not needed. The runner image ships
+# package lists, and a package already present in them installs in seconds with
+# no index download at all. This lowers the EXPECTED time to seconds and raises
+# the worst case by the probe's own bound, from 310s to 355s; the header
+# arithmetic carries both numbers and both still fit the job's 480s. The update
+# path below is unchanged for the case where the lists really are too old to
+# satisfy the request.
+readonly PROBE_TIMEOUT=45
+attempt_install_without_update() {
+  sudo timeout "$PROBE_TIMEOUT" apt-get install -y -- "${missing[@]}"
+}
+
+# Announce the path taken. The previous version of this logic had no marker, so a
+# log could not answer whether it had run, and confirming that took three reads
+# of three different job logs. A step that changes behaviour says so.
+if attempt_install_without_update; then
+  echo "ci-apt-install: installed from the image's existing lists: ${missing[*]}"
+  exit 0
 fi
+echo "ci-apt-install: existing lists could not satisfy ${missing[*]}; refreshing" >&2
 
 for attempt in $(seq 1 "$ATTEMPTS"); do
   if attempt_install; then

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -66,6 +66,16 @@ readonly BACKOFF=10
 # rather than a limit. KILL sends the process away after the grace period.
 readonly KILL_GRACE=5
 
+# Wait for the dpkg lock instead of failing on it.
+#
+# timeout signals only its direct child, which is apt-get. apt-get spawns dpkg,
+# and a dpkg that outlives a killed apt-get keeps the lock, so the retry would
+# otherwise collide with the corpse of the attempt it is retrying and fail on a
+# lock rather than on the condition it was retrying. Waiting is bounded twice
+# over: by this value and by the enclosing install timeout. Only the install
+# paths need it, since apt-get update never invokes dpkg.
+readonly LOCK_WAIT=30
+
 # The runner image already carries some of these. Skipping the network entirely
 # when every package is present is both faster and one less thing to stall.
 missing=()
@@ -86,7 +96,8 @@ fi
 # reading a package name as a flag.
 attempt_install() {
   sudo timeout --kill-after "$KILL_GRACE" "$UPDATE_TIMEOUT" apt-get update \
-    && sudo timeout --kill-after "$KILL_GRACE" "$INSTALL_TIMEOUT" apt-get install -y -- "${missing[@]}"
+    && sudo timeout --kill-after "$KILL_GRACE" "$INSTALL_TIMEOUT" \
+      apt-get -o "DPkg::Lock::Timeout=$LOCK_WAIT" install -y -- "${missing[@]}"
 }
 
 # Try installing from the lists the image already carries, before fetching any.
@@ -109,7 +120,8 @@ attempt_install() {
 # satisfy the request.
 readonly PROBE_TIMEOUT=45
 attempt_install_without_update() {
-  sudo timeout --kill-after "$KILL_GRACE" "$PROBE_TIMEOUT" apt-get install -y -- "${missing[@]}"
+  sudo timeout --kill-after "$KILL_GRACE" "$PROBE_TIMEOUT" \
+    apt-get -o "DPkg::Lock::Timeout=$LOCK_WAIT" install -y -- "${missing[@]}"
 }
 
 # Announce the path taken. The previous version of this logic had no marker, so a


### PR DESCRIPTION
## What changed

The apt failure reporting red on unrelated pull requests is throughput, not reachability. A run that succeeded fetched at 237 kB/s and needed roughly seventy seconds of index refresh against a ninety-second bound, so its first attempt expired and its second finished with little margin. Two attempts against that timing is close to a coin flip, and it landed both ways within half an hour across three pull requests whose own code was fine.

The install now tries the package lists the runner image already carries before refreshing anything, which needs no index download and completes in seconds. The refresh path is unchanged for the case where those lists genuinely cannot satisfy the request. The header arithmetic carries both the new expected case and the new worst case, and both still fit the job's own timeout.

A previous attempt at this rewrote apt's mirror host. That change was inert, because the passing runs contacted the original host as often as the failing ones, so the host was never the problem. It is removed here rather than left in place, and the remaining path announces which branch it took so a log can answer that question directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by trying available package lists before refreshing them.
  * Added clearer installation result logging and fallback behavior when the initial attempt fails.
  * Updated timeout handling to account for installation checks, lock waiting, and forced-termination grace periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->