### PR TITLE
chore(release): fix the 3.4.0 date and verifier availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.4.0] - 2026-08-19
+## [3.4.0] - 2026-08-20
 
 ### Breaking Changes / Upgrade Notes
 

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -174,7 +174,7 @@ The published Python verifier includes a directory-fetch helper:
 ```python
 from pipelock_verify import fetch_directory, verify
 
-directory = fetch_directory("https://pipelock.example.com")
+directory = fetch_directory("pipelock.example.com")
 result = verify(receipt, public_key_hex=directory.public_key_hex())
 if not result.valid:
     raise SystemExit(f"verification failed: {result.error}")

--- a/docs/guides/federation.md
+++ b/docs/guides/federation.md
@@ -167,9 +167,9 @@ External verifiers fetch this endpoint on a configurable interval and use it as 
 
 The directory is served on the same listener as the proxy. There is no auth on the endpoint; the keys are public verification keys, not secrets. If you do not want this endpoint exposed publicly, gate it at your ingress layer.
 
-### Prepared `pipelock-verify-python` 0.2.0 example
+### `pipelock-verify-python` directory-fetch example
 
-The prepared Python verifier update includes a directory-fetch helper:
+The published Python verifier includes a directory-fetch helper:
 
 ```python
 from pipelock_verify import fetch_directory, verify
@@ -180,7 +180,7 @@ if not result.valid:
     raise SystemExit(f"verification failed: {result.error}")
 ```
 
-The 0.1.x example pinned a SHA hex out of band; the prepared 0.2.0 update uses well-known fetch to resolve the public key for individual receipt verification once published. See [`receipt-transports.md`](receipt-transports.md) and the Python verifier's README.
+The 0.1.x example pinned a SHA hex out of band; current releases use well-known fetch to resolve the public key for individual receipt verification. See [`receipt-transports.md`](receipt-transports.md) and the Python verifier's README.
 
 ## Authenticated agent identity
 
@@ -220,7 +220,7 @@ Different deployments (region A, region B) sign their own envelopes. A central a
 
 ### External auditor
 
-The auditor doesn't run Pipelock at all. They can use the standalone Go `pipelock-verifier` today, or `pipelock-verify-python` after the prepared 0.2.0 update is published, against the Pipelock deployment's well-known directory. The auditor verifies individual receipts the deployment emits without ever needing the deployment's blessing — the public verification keys are public, the directory endpoint is open.
+The auditor doesn't run Pipelock at all. They can use the standalone Go `pipelock-verifier` today, or `pipelock-verify-python`, against the Pipelock deployment's well-known directory. The auditor verifies individual receipts the deployment emits without ever needing the deployment's blessing — the public verification keys are public, the directory endpoint is open.
 
 ## Receipt verification
 
@@ -229,7 +229,7 @@ A request that traverses two mediated Pipelocks accumulates two layers of signed
 1. The originating Pipelock signs an outbound envelope.
 2. The receiving Pipelock verifies the inbound envelope and emits its own outbound envelope on the next hop (or on the response). The `EvidenceReceipt v2` schema reserves `proxy_decision.policy_sources` for runtime contract-aware decision evidence as that emit path is wired progressively.
 
-External auditors verify both envelopes independently using the standalone Go `pipelock-verifier` today, or `pipelock-verify-python` after the prepared 0.2.0 update is published, against the corresponding deployments' well-known directories.
+External auditors verify both envelopes independently using the standalone Go `pipelock-verifier` today, or `pipelock-verify-python`, against the corresponding deployments' well-known directories.
 
 ## Failure modes
 
@@ -272,4 +272,4 @@ deployment, enabling it before clients sign envelopes will fail closed with
 - [`receipt-transports.md`](receipt-transports.md) — receipt verification recipe.
 - [`mediation-envelope.md`](mediation-envelope.md) — outbound envelope format and signing.
 - [`learn-and-lock.md`](learn-and-lock.md) — `EvidenceReceipt v2` envelope (independent of mediation-envelope verification).
-- [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) — external Python verifier; prepared v0.2.0 update uses well-known fetch for individual receipt verification once published.
+- [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) — external Python verifier; uses well-known fetch for individual receipt verification.

--- a/docs/guides/learn-and-lock.md
+++ b/docs/guides/learn-and-lock.md
@@ -187,7 +187,7 @@ The v2.4 receipt schema defines an `EvidenceReceipt v2` envelope for contract-aw
 
 v2 envelopes are distinguished from legacy v1 by the top-level `record_type` field. v1 verifiers reject v2 with `unsupported version 2 (expected 1)`; the existing audit pipeline keeps working unchanged for non-contract-aware deployments.
 
-External verification for individual EvidenceReceipt v2 envelopes and v2 receipt chains is supported by the standalone Go `pipelock-verifier` today. Use `pipelock-verifier receipt --key <receipt-signing.pub> ...` for a single envelope, or `pipelock-verifier chain --key <receipt-signing.pub> ...` / `pipelock-verifier evidence ...` for a recorder JSONL chain. Without `--key`, v2 chain verification reports self-consistency only; provenance requires a pinned public key. A prepared `pipelock-verify-python` 0.2.0 update adds individual v2-envelope verification once published; v2 chain verification is not part of that Python update. See [`docs/guides/receipt-verification.md`](receipt-verification.md) for the full `pipelock-verifier` recipe covering v2 envelopes and chains.
+External verification for individual EvidenceReceipt v2 envelopes and v2 receipt chains is supported by the standalone Go `pipelock-verifier` today. Use `pipelock-verifier receipt --key <receipt-signing.pub> ...` for a single envelope, or `pipelock-verifier chain --key <receipt-signing.pub> ...` / `pipelock-verifier evidence ...` for a recorder JSONL chain. Without `--key`, v2 chain verification reports self-consistency only; provenance requires a pinned public key. `pipelock-verify-python` verifies individual v2 envelopes; v2 chain verification is not part of the Python verifier. See [`docs/guides/receipt-verification.md`](receipt-verification.md) for the full `pipelock-verifier` recipe covering v2 envelopes and chains.
 
 ## Signing keys
 
@@ -344,4 +344,4 @@ The runtime watches the active-manifest store via fsnotify with a 100ms debounce
 - [`docs/configuration.md`](../configuration.md#learn-and-lock) — `learn` configuration reference.
 - [`docs/guides/receipt-transports.md`](receipt-transports.md) — verifying receipts externally.
 - [`docs/guides/federation.md`](federation.md) — cross-org envelope verification (independent of contracts).
-- [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) — external Python verifier; prepared v0.2.0 update adds individual EvidenceReceipt v2 envelope verification once published.
+- [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) — external Python verifier; verifies individual EvidenceReceipt v2 envelopes.

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -549,7 +549,7 @@ surface that fits your downstream audit pipeline:
 | Go (in-tree reference) | `sdk/audit-packet/` and `cmd/pipelock-verifier/` | Server-side audit pipelines, CI workflows, EvidenceReceipt v2 receipt/chain verification |
 | TypeScript | [`sdk/verifiers/ts/`](../../sdk/verifiers/ts/) | Node-based audit / SIEM, browser-side evidence inspection |
 | Rust | [`sdk/verifiers/rust/`](../../sdk/verifiers/rust/) | Embedded use, audit-platform sidecars, no-runtime environments |
-| Python (companion) | [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) | Python-based audit pipelines and Jupyter analysis. v1 chains today; EvidenceReceipt v2 envelopes after the prepared 0.2.0 release. |
+| Python (companion) | [`pipelock-verify-python`](https://github.com/luckyPipewrench/pipelock-verify-python) | Python-based audit pipelines and Jupyter analysis. Verifies ActionReceipt v1 chains and individual EvidenceReceipt v2 envelopes; install from PyPI as `pipelock-verify`. |
 | Browser wasm (Go implementation) | `cmd/pipelock-verifier-wasm/` | In-browser receipt and chain verification without treating wasm as an independent fifth implementation |
 
 The TypeScript and Rust verifiers ship with their own test suites that


### PR DESCRIPTION
## What changed

The 3.4.0 heading carried the date the release was expected rather than the date it is being cut, so the changelog would have stated a release date that never happened.

Three guides also described individual EvidenceReceipt v2 envelope verification as arriving with a prepared Python verifier release that had not shipped yet. That release shipped some time ago, and the published package states that it verifies ActionReceipt v1 chains and individual EvidenceReceipt v2 envelopes, so a reader following those guides was told to wait for something already available to them.

The distinction the Python verifier still does not cover, v2 chain verification as opposed to individual v2 envelopes, is preserved rather than flattened. The historical changelog entry naming the version that shipped is left alone, because it accurately records what shipped when.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated federation and receipt-verification guides to reflect currently available Python verifier capabilities.
  * Clarified support for verifying individual EvidenceReceipt v2 envelopes and ActionReceipt v1 chains.
  * Removed references to unpublished or planned releases.
  * Updated the 3.4.0 changelog release date to August 20, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->