### PR TITLE
Give the release preflight gate the keyring secret it checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Release-readiness gate
+        # The gate asserts the release keyring secret is present BEFORE any build runs, so
+        # it has to receive that secret. Without this mapping the check reads an empty value
+        # and fails every release, which is how it behaved when it was introduced.
+        env:
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
         run: scripts/check-release-ready.sh "$GITHUB_REF_NAME"
 
   release-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   over a list. Known environment and file secrets written as hex are matched through the
   same set, where a separate smaller list had been maintained alongside it.
 - A credential spread across more than four query values is assembled before matching.
+- The kill switch denies proxied requests whatever destination path they carry. Its
+  endpoint exemptions keep Pipelock's own operational endpoints answering while traffic is
+  denied, but they compared the request path without first establishing that the request
+  was addressed to Pipelock, and a forward-proxy request carries the destination's path.
+  Exemptions now sit behind a single check consulted ahead of all of them, so one added
+  later inherits it. The IP allowlist still applies to proxied traffic, because it keys on
+  the client address rather than a path the client chooses. Upgrade if you treat the kill
+  switch as an absolute stop.
+- URL DLP joins the path and the query when matching credential patterns. Targets were
+  built from each side of the separator with nothing joining them, so a credential divided
+  across that boundary matched no target: neither half satisfies a pattern alone, and the
+  whole-URL view cannot bridge the separator because it falls outside every credential
+  pattern's character class. The seam is now its own target, in the shared helper both the
+  configured scanner and the core floor use, so the core copy cannot shadow the fix. The
+  path side is decoded to a fixpoint first, because `url.Parse` decodes a path once while
+  the query values were already decoded repeatedly, and a multi-escaped prefix survived
+  that asymmetry.
 - The provider-opaque request-body carve-out requires the body to measure as ciphertext.
   A long opaque field previously qualified on length alone, so padded content skipped
   inspection.


### PR DESCRIPTION
## What changed

The release preflight gate now receives the release keyring secret it checks. It asserts that secret is present before any build runs, but the job never received it, so it read an empty value and failed every release at the first step. The secret was only mapped into the later release job. The check and this gap arrived together and were never exercised end to end, because a local GoReleaser dry run supplies its own environment and never runs this job.

Reviewers should distrust the failure direction here. The gate is meant to stop a release that would embed an empty keyring and could never verify a signed update, so the fix must not make the check quieter: with the secret absent it still fails, and only a genuinely populated secret passes.

Also records the kill-switch and URL DLP fixes in the 3.4.0 changelog. Both merged without an entry, and an operator reading the release notes needs the kill-switch behaviour to judge upgrade urgency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kill-switch endpoint exemptions so they apply only to requests addressed to Pipelock.
  * Fixed URL data-loss prevention matching across path and query boundaries.
  * Improved detection for URLs that use repeated path encoding.

* **Release Improvements**
  * Strengthened release validation to support more reliable metadata checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->