### PR TITLE
ci: separate release build from protected promotion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,9 +172,19 @@ jobs:
       - name: Install and verify customer receipt verifiers
         run: scripts/release-verifier-install-gate.sh --tag "$GITHUB_REF_NAME"
 
-  release:
+  release-build:
     needs: [release-tests, release-verifier-install]
     runs-on: ubuntu-latest
+    outputs:
+      pipelock_index: ${{ steps.platform-digests.outputs.pipelock_index }}
+      pipelock_init_index: ${{ steps.platform-digests.outputs.pipelock_init_index }}
+      license_service_index: ${{ steps.platform-digests.outputs.license_service_index }}
+      pipelock_amd64: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
+      pipelock_arm64: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
+      pipelock_init_amd64: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
+      pipelock_init_arm64: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
+      license_service_amd64: ${{ steps.platform-digests.outputs.license_service_amd64 }}
+      license_service_arm64: ${{ steps.platform-digests.outputs.license_service_arm64 }}
     permissions:
       contents: write
       packages: write
@@ -369,7 +379,6 @@ jobs:
         run: goreleaser release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GOVERSION: ${{ env.GOVERSION }}
           LICENSE_PUBLIC_KEY: ${{ secrets.LICENSE_PUBLIC_KEY }}
           RULES_KEYRING_HEX: ${{ secrets.RULES_KEYRING_HEX }}
@@ -732,12 +741,8 @@ jobs:
         with:
           version: v3.21.3
 
-      # A retry after publishing the chart must not fail halfway through the
-      # release. Compare a pre-existing chart with this run's packaged chart and
-      # skip its immutable upload only when their contents are identical.
-      - name: Package and verify Helm chart version
+      - name: Package Helm chart
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -747,118 +752,7 @@ jobs:
             echo "::error::could not read chart version from charts/pipelock/Chart.yaml"
             exit 1
           }
-          echo "CHART_VERSION=$chart_version" >> "$GITHUB_ENV"
           helm package charts/pipelock --app-version "$app_version" --destination dist-chart
-          helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
-          trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
-          existing_dir="$RUNNER_TEMP/published-chart-${chart_version}"
-          candidate_dir="$RUNNER_TEMP/candidate-chart-${chart_version}"
-          mkdir -p "$existing_dir"
-          if chart_lookup_output="$(helm pull "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" --destination "$existing_dir" 2>&1)"; then
-            mkdir -p "$candidate_dir"
-            tar -xzf "dist-chart/pipelock-${chart_version}.tgz" -C "$candidate_dir"
-            tar -xzf "$existing_dir/pipelock-${chart_version}.tgz" -C "$existing_dir"
-            diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock" || {
-              echo "::error::published chart ${chart_version} differs from this release; refusing to overwrite it"
-              exit 1
-            }
-            echo "CHART_ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
-            echo "Chart ${chart_version} already matches this release; skipping its immutable upload"
-          elif ! printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
-            echo "::error::could not determine whether chart ${chart_version} already exists; refusing image promotion"
-            exit 1
-          else
-            echo "CHART_ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
-          fi
-
-      # GoReleaser writes only staging tags, so an attestation failure leaves
-      # no consumer version or latest image manifest. Promote the verified index
-      # by digest. Version tags never overwrite an existing different digest;
-      # latest advances only for a newer stable release, never for a prerelease
-      # or an older-line backport.
-      - name: Promote verified image manifests
-        env:
-          TAG: ${{ github.ref_name }}
-          PIPELOCK_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_index }}
-          PIPELOCK_INIT_INDEX_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_index }}
-          LICENSE_SERVICE_INDEX_DIGEST: ${{ steps.platform-digests.outputs.license_service_index }}
-          PIPELOCK_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_amd64 }}
-          PIPELOCK_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_arm64 }}
-          PIPELOCK_INIT_AMD64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_amd64 }}
-          PIPELOCK_INIT_ARM64_DIGEST: ${{ steps.platform-digests.outputs.pipelock_init_arm64 }}
-          LICENSE_SERVICE_AMD64_DIGEST: ${{ steps.platform-digests.outputs.license_service_amd64 }}
-          LICENSE_SERVICE_ARM64_DIGEST: ${{ steps.platform-digests.outputs.license_service_arm64 }}
-        run: |
-          set -euo pipefail
-          promote_image() {
-            local repository="$1"
-            local index_digest="$2"
-            local version="${TAG#v}"
-            local tags existing latest_digest newest_stable
-
-            tags="$(crane ls "$repository")" || {
-              echo "::error::could not list tags for ${repository}; refusing image promotion"
-              exit 1
-            }
-            if grep -Fxq "$version" <<<"$tags"; then
-              existing="$(crane digest "${repository}:${version}")" || {
-                echo "::error::could not resolve existing ${repository}:${version}"
-                exit 1
-              }
-              test "$existing" = "$index_digest" || {
-                echo "::error::${repository}:${version} already resolves to a different digest"
-                exit 1
-              }
-            else
-              crane copy --no-clobber "${repository}@${index_digest}" "${repository}:${version}"
-            fi
-
-            if [[ "$version" != *-* ]]; then
-              newest_stable="$(printf '%s\n%s\n' "$tags" "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)"
-              if [[ "$newest_stable" = "$version" ]]; then
-                latest_digest="$(crane digest "${repository}:latest" 2>/dev/null || true)"
-                if [[ "$latest_digest" != "$index_digest" ]]; then
-                  crane copy "${repository}@${index_digest}" "${repository}:latest"
-                fi
-                test "$(crane digest "${repository}:latest")" = "$index_digest"
-              else
-                echo "Not moving ${repository}:latest for non-newer or prerelease version ${version}"
-              fi
-            else
-              echo "Not moving ${repository}:latest for prerelease version ${version}"
-            fi
-
-            test "$(crane digest "${repository}:${version}")" = "$index_digest"
-          }
-
-          promote_platform_image() {
-            local repository="$1"
-            local digest="$2"
-            local arch="$3"
-            local version="${TAG#v}"
-            local target="${repository}:${version}-${arch}"
-            local existing
-
-            if existing="$(crane digest "$target" 2>/dev/null)"; then
-              test "$existing" = "$digest" || {
-                echo "::error::${target} already resolves to a different digest"
-                exit 1
-              }
-            else
-              crane copy --no-clobber "${repository}@${digest}" "$target"
-            fi
-            test "$(crane digest "$target")" = "$digest"
-          }
-
-          promote_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_INDEX_DIGEST"
-          promote_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_INDEX_DIGEST"
-          promote_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_INDEX_DIGEST"
-          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_AMD64_DIGEST" amd64
-          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_ARM64_DIGEST" arm64
-          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_AMD64_DIGEST" amd64
-          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_ARM64_DIGEST" arm64
-          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_AMD64_DIGEST" amd64
-          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_ARM64_DIGEST" arm64
 
       # Build the operator-facing bundle only after every child image has its
       # own SBOM and provenance proof. The bundle contains index digests because
@@ -896,6 +790,229 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" dist/release-images.json --clobber
 
+      # upload-artifact's if-no-files-found only fires when NOTHING matches, so a
+      # bundle missing just the formula, or just the chart, uploads and passes.
+      # The promotion job would then fail partway through, with images already
+      # promoted. Assert each input separately here, in the job that produced it.
+      - name: Verify promotion inputs are complete
+        run: |
+          set -euo pipefail
+          test -s dist/release-images.json || {
+            echo "::error::dist/release-images.json was not generated"
+            exit 1
+          }
+          test -n "$(find dist-chart -maxdepth 1 -name 'pipelock-*.tgz' -print -quit)" || {
+            echo "::error::helm package produced no chart archive in dist-chart"
+            exit 1
+          }
+          test -s dist/homebrew/Formula/pipelock.rb || {
+            echo "::error::GoReleaser did not write dist/homebrew/Formula/pipelock.rb (found: $(find dist -name '*.rb' -print 2>/dev/null | tr '\n' ' '))"
+            exit 1
+          }
+
+      # overwrite so re-running the whole workflow works. Artifacts are immutable
+      # per run, and a re-run is a new attempt of the SAME run, so a second
+      # upload under this name is rejected without it: the rebuild would redo
+      # every image push and then fail on its last step.
+      - name: Save promotion inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-promotion-inputs
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+          path: |
+            dist/homebrew/Formula/pipelock.rb
+            dist-chart/pipelock-*.tgz
+            dist/release-images.json
+
+  release-promote:
+    needs: [release-build]
+    runs-on: ubuntu-latest
+    # Approval wait does not count against this; it bounds the promotion itself
+    # so a hung registry call cannot hold the release-publication concurrency
+    # group, and every later release with it, for the six-hour default.
+    timeout-minutes: 30
+    environment: release-promotion
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25.12'
+          check-latest: true
+
+      - name: Verify Go version
+        run: test "$(go env GOVERSION)" = "go1.25.12"
+
+      - name: Download promotion inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-promotion-inputs
+
+      - name: Install verified crane
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CRANE_VERSION: v0.21.9
+          CRANE_LINUX_AMD64_SHA256: 5c16d8ddb971cb1d5e6ed8b1e743da8224414eeba2c2762d8f1a61b2f095699e
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/crane-${CRANE_VERSION}"
+          archive="go-containerregistry_Linux_x86_64.tar.gz"
+          mkdir -p "$tool_dir"
+          gh release download "$CRANE_VERSION" --repo google/go-containerregistry --pattern "$archive" --dir "$tool_dir"
+          printf '%s  %s\n' "$CRANE_LINUX_AMD64_SHA256" "$tool_dir/$archive" | sha256sum --check
+          tar -xzf "$tool_dir/$archive" -C "$tool_dir" crane
+          test "$("$tool_dir/crane" version)" = "${CRANE_VERSION#v}"
+          echo "$tool_dir" >> "$GITHUB_PATH"
+
+      - name: Set up Helm
+        uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.21.3
+
+      - name: Verify release manifest signature before promotion
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
+        run: |
+          set -euo pipefail
+          verify_dir="$RUNNER_TEMP/release-manifest-verify"
+          mkdir -p "$verify_dir"
+          if ! gh release download "$GITHUB_REF_NAME" --pattern release.json --pattern release.json.sig --dir "$verify_dir" --clobber; then
+            echo "::error::release.json.sig is not attached to ${GITHUB_REF_NAME}; refusing promotion"
+            exit 1
+          fi
+          go run ./cmd/pipelock-release-manifest --verify --manifest "$verify_dir/release.json"
+          # A good signature proves only that someone we trust signed SOME
+          # manifest. Signing is offline and manual, so the reachable mistake is
+          # uploading a correctly signed manifest belonging to a different
+          # release, which would publish the previous release's asset digests as
+          # this tag's self-update evidence. Bind the verified manifest to the
+          # tag and commit being promoted, exactly as the image bundle is bound
+          # below.
+          manifest_tag="$(jq -r .tag "$verify_dir/release.json")"
+          manifest_commit="$(jq -r .commit "$verify_dir/release.json")"
+          test "$manifest_tag" = "$GITHUB_REF_NAME" || {
+            echo "::error::signed release manifest is for ${manifest_tag}, not ${GITHUB_REF_NAME}"
+            exit 1
+          }
+          test "$manifest_commit" = "$(git rev-parse "${GITHUB_REF_NAME}^{}")" || {
+            echo "::error::signed release manifest names commit ${manifest_commit}, which is not the commit ${GITHUB_REF_NAME} points at"
+            exit 1
+          }
+
+      # Every promotion input is checked here, before the first consumer-facing
+      # write below. A presence check that lives in the step that consumes the
+      # file fails after images are already promoted, which leaves a release
+      # half-published and needing a re-run.
+      - name: Verify promotion image inputs
+        env:
+          PIPELOCK_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_index }}
+          PIPELOCK_INIT_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_init_index }}
+          LICENSE_SERVICE_INDEX_DIGEST: ${{ needs.release-build.outputs.license_service_index }}
+        run: |
+          set -euo pipefail
+          test -s dist/homebrew/Formula/pipelock.rb || {
+            echo "::error::promotion bundle has no Homebrew formula"
+            exit 1
+          }
+          test -n "$(find dist-chart -maxdepth 1 -name 'pipelock-*.tgz' -print -quit)" || {
+            echo "::error::promotion bundle has no Helm chart"
+            exit 1
+          }
+          test "$(jq -r .schema dist/release-images.json)" = "pipelock-release-images-v1"
+          test "$(jq -r .tag dist/release-images.json)" = "$GITHUB_REF_NAME"
+          test "$(jq -r .commit dist/release-images.json)" = "$(git rev-parse "${GITHUB_REF_NAME}^{}")"
+          test "$(jq -er '.images[] | select(.name == "pipelock") | .digest' dist/release-images.json)" = "$PIPELOCK_INDEX_DIGEST"
+          test "$(jq -er '.images[] | select(.name == "pipelock-init") | .digest' dist/release-images.json)" = "$PIPELOCK_INIT_INDEX_DIGEST"
+          test "$(jq -er '.images[] | select(.name == "pipelock-license-service") | .digest' dist/release-images.json)" = "$LICENSE_SERVICE_INDEX_DIGEST"
+          test "$(jq '.images | length' dist/release-images.json)" -eq 3
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+
+          manifest = json.loads(
+              pathlib.Path(os.environ["RUNNER_TEMP"], "release-manifest-verify", "release.json").read_text()
+          )
+          assets = {asset["name"]: asset["sha256"] for asset in manifest["assets"]}
+          formula = pathlib.Path("dist/homebrew/Formula/pipelock.rb").read_text()
+          pairs = re.findall(
+              r'/download/[^/]+/([^"/]+)"\s+sha256 "([0-9a-f]{64})"',
+              formula,
+          )
+          if len(pairs) != 4:
+              raise SystemExit(f"expected 4 Homebrew archive checksums, found {len(pairs)}")
+          for name, digest in pairs:
+              if assets.get(name) != digest:
+                  raise SystemExit(f"Homebrew checksum for {name} does not match signed release.json")
+          PY
+
+      - name: Promote verified image manifests
+        env:
+          TAG: ${{ github.ref_name }}
+          PIPELOCK_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_index }}
+          PIPELOCK_INIT_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_init_index }}
+          LICENSE_SERVICE_INDEX_DIGEST: ${{ needs.release-build.outputs.license_service_index }}
+          PIPELOCK_AMD64_DIGEST: ${{ needs.release-build.outputs.pipelock_amd64 }}
+          PIPELOCK_ARM64_DIGEST: ${{ needs.release-build.outputs.pipelock_arm64 }}
+          PIPELOCK_INIT_AMD64_DIGEST: ${{ needs.release-build.outputs.pipelock_init_amd64 }}
+          PIPELOCK_INIT_ARM64_DIGEST: ${{ needs.release-build.outputs.pipelock_init_arm64 }}
+          LICENSE_SERVICE_AMD64_DIGEST: ${{ needs.release-build.outputs.license_service_amd64 }}
+          LICENSE_SERVICE_ARM64_DIGEST: ${{ needs.release-build.outputs.license_service_arm64 }}
+        run: |
+          set -euo pipefail
+          remote_stable_tags="$(git ls-remote --tags --refs origin 'refs/tags/v*')"
+          newest_stable="$(printf '%s\n' "$remote_stable_tags" | awk '{sub("refs/tags/v", "", $2); print $2}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)"
+          test -n "$newest_stable" || { echo "::error::could not determine newest stable release tag"; exit 1; }
+          promote_image() {
+            local repository="$1" index_digest="$2" version="${TAG#v}"
+            local tags existing latest_digest
+            tags="$(crane ls "$repository")" || { echo "::error::could not list tags for ${repository}"; exit 1; }
+            if grep -Fxq "$version" <<<"$tags"; then
+              existing="$(crane digest "${repository}:${version}")"
+              test "$existing" = "$index_digest" || { echo "::error::${repository}:${version} has a different digest"; exit 1; }
+            else
+              crane copy --no-clobber "${repository}@${index_digest}" "${repository}:${version}"
+            fi
+            if [[ "$version" != *-* ]]; then
+              if [[ "$newest_stable" = "$version" ]]; then
+                latest_digest="$(crane digest "${repository}:latest" 2>/dev/null || true)"
+                if [[ "$latest_digest" != "$index_digest" ]]; then
+                  crane copy "${repository}@${index_digest}" "${repository}:latest"
+                fi
+                test "$(crane digest "${repository}:latest")" = "$index_digest"
+              fi
+            fi
+            test "$(crane digest "${repository}:${version}")" = "$index_digest"
+          }
+          promote_platform_image() {
+            local repository="$1" digest="$2" arch="$3" version="${TAG#v}"
+            local target="${repository}:${version}-${arch}" existing
+            if existing="$(crane digest "$target" 2>/dev/null)"; then
+              test "$existing" = "$digest" || { echo "::error::${target} has a different digest"; exit 1; }
+            else
+              crane copy --no-clobber "${repository}@${digest}" "$target"
+            fi
+            test "$(crane digest "$target")" = "$digest"
+          }
+          promote_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_INDEX_DIGEST"
+          promote_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_INDEX_DIGEST"
+          promote_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_INDEX_DIGEST"
+          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock "$PIPELOCK_ARM64_DIGEST" arm64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-init "$PIPELOCK_INIT_ARM64_DIGEST" arm64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_AMD64_DIGEST" amd64
+          promote_platform_image ghcr.io/luckypipewrench/pipelock-license-service "$LICENSE_SERVICE_ARM64_DIGEST" arm64
+
       # Deliberately placed after the attestation gate. The chart is the least
       # critical artifact in the release, and an earlier position would let a
       # registry hiccup on the chart abort the job with binaries and images
@@ -925,16 +1042,36 @@ jobs:
         run: |
           set -euo pipefail
           app_version="${TAG_NAME#v}"
-          chart_version="$CHART_VERSION"
-          test -n "$chart_version" || {
-            echo "::error::chart version was not established before publication"
+          chart_archive="$(find dist-chart -maxdepth 1 -name 'pipelock-*.tgz' -print -quit)"
+          test -n "$chart_archive" || {
+            echo "::error::promotion bundle has no Helm chart"
+            exit 1
+          }
+          chart_version="$(helm show chart "$chart_archive" | awk '$1 == "version:" { print $2 }')"
+          chart_app_version="$(helm show chart "$chart_archive" | awk '$1 == "appVersion:" { gsub(/\"/, "", $2); print $2 }')"
+          test -n "$chart_version"
+          test "$chart_archive" = "dist-chart/pipelock-${chart_version}.tgz"
+          test "$chart_app_version" = "$app_version" || {
+            echo "::error::chart appVersion ${chart_app_version} does not match ${app_version}"
             exit 1
           }
           helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin <<<"$GITHUB_TOKEN"
           trap 'helm registry logout ghcr.io >/dev/null 2>&1 || true' EXIT
-
-          if [[ "$CHART_ALREADY_PUBLISHED" != true ]]; then
-            helm push "dist-chart/pipelock-${chart_version}.tgz" oci://ghcr.io/luckypipewrench/charts
+          existing_dir="$RUNNER_TEMP/published-chart-${chart_version}"
+          candidate_dir="$RUNNER_TEMP/candidate-chart-${chart_version}"
+          mkdir -p "$existing_dir" "$candidate_dir"
+          if chart_lookup_output="$(helm pull "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" --destination "$existing_dir" 2>&1)"; then
+            tar -xzf "$chart_archive" -C "$candidate_dir"
+            tar -xzf "$existing_dir/pipelock-${chart_version}.tgz" -C "$existing_dir"
+            diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock" || {
+              echo "::error::published chart ${chart_version} differs from the signed release input"
+              exit 1
+            }
+          elif printf '%s\n' "$chart_lookup_output" | grep -qE ': not found$'; then
+            helm push "$chart_archive" oci://ghcr.io/luckypipewrench/charts
+          else
+            echo "::error::could not determine whether chart ${chart_version} exists"
+            exit 1
           fi
 
           # A brand-new GHCR package is private, and the install command in the
@@ -954,6 +1091,36 @@ jobs:
             echo "everyone until it is made public once under Package settings."
           } >>"$GITHUB_STEP_SUMMARY"
 
+      - name: Publish Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          formula="dist/homebrew/Formula/pipelock.rb"
+          test -s "$formula" || { echo "::error::promotion bundle has no Homebrew formula"; exit 1; }
+          path="Formula/pipelock.rb"
+          encoded="$(base64 -w0 "$formula")"
+          existing_json="$RUNNER_TEMP/homebrew-existing.json"
+          if gh api "repos/luckyPipewrench/homebrew-tap/contents/${path}?ref=main" >"$existing_json" 2>"$RUNNER_TEMP/homebrew-read.err"; then
+            existing_sha="$(jq -r .sha "$existing_json")"
+            jq -r .content "$existing_json" | tr -d '\n' | base64 -d >"$RUNNER_TEMP/homebrew-existing.rb"
+            if cmp -s "$formula" "$RUNNER_TEMP/homebrew-existing.rb"; then
+              echo "Homebrew formula already matches ${TAG_NAME}"
+              exit 0
+            fi
+            gh api --method PUT "repos/luckyPipewrench/homebrew-tap/contents/${path}" \
+              -f message="Update Pipelock to ${TAG_NAME}" -f branch=main \
+              -f content="$encoded" -f sha="$existing_sha" >/dev/null
+          elif grep -q 'HTTP 404' "$RUNNER_TEMP/homebrew-read.err"; then
+            gh api --method PUT "repos/luckyPipewrench/homebrew-tap/contents/${path}" \
+              -f message="Add Pipelock ${TAG_NAME}" -f branch=main -f content="$encoded" >/dev/null
+          else
+            cat "$RUNNER_TEMP/homebrew-read.err" >&2
+            echo "::error::could not read the existing Homebrew formula"
+            exit 1
+          fi
+
       # Promote only after the proof gate, Kubernetes digest bundle, and chart
       # have all succeeded. The draft kept GitHub Release assets private while
       # those checks ran. Container images and Homebrew remain separate
@@ -972,7 +1139,7 @@ jobs:
       # allows. It does not make the pair atomic, which GitHub does not offer, so
       # the digests that were verified are recorded in the job log as the record
       # of what the decision was made against.
-      - name: Verify the release manifest signature and publish
+      - name: Reverify the release manifest signature and publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_KEYRING_HEX: ${{ secrets.RELEASE_KEYRING_HEX }}
@@ -988,6 +1155,16 @@ jobs:
             exit 1
           fi
           go run ./cmd/pipelock-release-manifest --verify --manifest "$verify_dir/release.json"
+          manifest_tag="$(jq -r .tag "$verify_dir/release.json")"
+          manifest_commit="$(jq -r .commit "$verify_dir/release.json")"
+          test "$manifest_tag" = "$GITHUB_REF_NAME" || {
+            echo "::error::signed release manifest is for ${manifest_tag}, not ${GITHUB_REF_NAME}"
+            exit 1
+          }
+          test "$manifest_commit" = "$(git rev-parse "${GITHUB_REF_NAME}^{}")" || {
+            echo "::error::signed release manifest names commit ${manifest_commit}, which is not the commit ${GITHUB_REF_NAME} points at"
+            exit 1
+          }
           echo "verified asset digests:"
           sha256sum "$verify_dir/release.json" "$verify_dir/release.json.sig"
           gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -871,6 +871,13 @@ jobs:
           test "$("$tool_dir/crane" version)" = "${CRANE_VERSION#v}"
           echo "$tool_dir" >> "$GITHUB_PATH"
 
+      - name: Login to GHCR for promotion
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Helm
         uses: Azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -923,6 +923,12 @@ jobs:
           PIPELOCK_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_index }}
           PIPELOCK_INIT_INDEX_DIGEST: ${{ needs.release-build.outputs.pipelock_init_index }}
           LICENSE_SERVICE_INDEX_DIGEST: ${{ needs.release-build.outputs.license_service_index }}
+          PIPELOCK_AMD64_DIGEST: ${{ needs.release-build.outputs.pipelock_amd64 }}
+          PIPELOCK_ARM64_DIGEST: ${{ needs.release-build.outputs.pipelock_arm64 }}
+          PIPELOCK_INIT_AMD64_DIGEST: ${{ needs.release-build.outputs.pipelock_init_amd64 }}
+          PIPELOCK_INIT_ARM64_DIGEST: ${{ needs.release-build.outputs.pipelock_init_arm64 }}
+          LICENSE_SERVICE_AMD64_DIGEST: ${{ needs.release-build.outputs.license_service_amd64 }}
+          LICENSE_SERVICE_ARM64_DIGEST: ${{ needs.release-build.outputs.license_service_arm64 }}
         run: |
           set -euo pipefail
           test -s dist/homebrew/Formula/pipelock.rb || {
@@ -940,6 +946,17 @@ jobs:
           test "$(jq -er '.images[] | select(.name == "pipelock-init") | .digest' dist/release-images.json)" = "$PIPELOCK_INIT_INDEX_DIGEST"
           test "$(jq -er '.images[] | select(.name == "pipelock-license-service") | .digest' dist/release-images.json)" = "$LICENSE_SERVICE_INDEX_DIGEST"
           test "$(jq '.images | length' dist/release-images.json)" -eq 3
+          for digest_name in \
+            PIPELOCK_INDEX_DIGEST PIPELOCK_INIT_INDEX_DIGEST LICENSE_SERVICE_INDEX_DIGEST \
+            PIPELOCK_AMD64_DIGEST PIPELOCK_ARM64_DIGEST \
+            PIPELOCK_INIT_AMD64_DIGEST PIPELOCK_INIT_ARM64_DIGEST \
+            LICENSE_SERVICE_AMD64_DIGEST LICENSE_SERVICE_ARM64_DIGEST; do
+            digest="${!digest_name}"
+            [[ "$digest" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+              echo "::error::${digest_name} is missing or is not a lowercase sha256 digest"
+              exit 1
+            }
+          done
           python3 - <<'PY'
           import json
           import os
@@ -1068,6 +1085,10 @@ jobs:
           candidate_dir="$RUNNER_TEMP/candidate-chart-${chart_version}"
           mkdir -p "$existing_dir" "$candidate_dir"
           if chart_lookup_output="$(helm pull "oci://ghcr.io/luckypipewrench/charts/pipelock" --version "$chart_version" --destination "$existing_dir" 2>&1)"; then
+            cmp -s "$chart_archive" "$existing_dir/pipelock-${chart_version}.tgz" || {
+              echo "::error::published chart archive ${chart_version} differs from the staged release archive"
+              exit 1
+            }
             tar -xzf "$chart_archive" -C "$candidate_dir"
             tar -xzf "$existing_dir/pipelock-${chart_version}.tgz" -C "$existing_dir"
             diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock" || {
@@ -1104,6 +1125,14 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          version="${TAG_NAME#v}"
+          remote_stable_tags="$(git ls-remote --tags --refs origin 'refs/tags/v*')"
+          newest_stable="$(printf '%s\n' "$remote_stable_tags" | awk '{sub("refs/tags/v", "", $2); print $2}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)"
+          test -n "$newest_stable" || { echo "::error::could not determine newest stable release tag"; exit 1; }
+          if [[ "$version" != "$newest_stable" ]]; then
+            echo "Not updating Homebrew for ${TAG_NAME}; newest stable release is v${newest_stable}"
+            exit 0
+          fi
           formula="dist/homebrew/Formula/pipelock.rb"
           test -s "$formula" || { echo "::error::promotion bundle has no Homebrew formula"; exit 1; }
           path="Formula/pipelock.rb"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,6 +167,10 @@ release:
 
 brews:
   - ids: [pipelock]
+    # Generate the exact formula into dist/homebrew/Formula/pipelock.rb, but do
+    # not publish it during the build job. The protected promotion job commits
+    # this file only after the offline release-manifest signature verifies.
+    skip_upload: true
     repository:
       owner: luckyPipewrench
       name: homebrew-tap

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -477,17 +477,25 @@ class TestReleaseArtifacts(unittest.TestCase):
             promote_step_names.index("Verify promotion image inputs"),
             promote_step_names.index("Promote verified image manifests"),
         )
-        for output in (
-            "pipelock_index",
-            "pipelock_init_index",
-            "license_service_index",
-            "pipelock_amd64",
-            "pipelock_arm64",
-            "pipelock_init_amd64",
-            "pipelock_init_arm64",
-            "license_service_amd64",
-            "license_service_arm64",
-        ):
+        expected_outputs = {
+            "pipelock_index": "pipelock_index",
+            "pipelock_init_index": "pipelock_init_index",
+            "license_service_index": "license_service_index",
+            "pipelock_amd64": "pipelock_amd64",
+            "pipelock_arm64": "pipelock_arm64",
+            "pipelock_init_amd64": "pipelock_init_amd64",
+            "pipelock_init_arm64": "pipelock_init_arm64",
+            "license_service_amd64": "license_service_amd64",
+            "license_service_arm64": "license_service_arm64",
+        }
+        self.assertEqual(
+            build["outputs"],
+            {
+                output: f"${{{{ steps.platform-digests.outputs.{step_output} }}}}"
+                for output, step_output in expected_outputs.items()
+            },
+        )
+        for output in expected_outputs:
             self.assertIn(f"needs.release-build.outputs.{output}", self.workflow)
         for digest_name in (
             "PIPELOCK_AMD64_DIGEST",

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -119,7 +119,7 @@ class TestReleaseArtifacts(unittest.TestCase):
         config = yaml.safe_load(self.goreleaser)
         brews = config.get("brews", [])
         self.assertEqual(len(brews), 1)
-        self.assertIs(brews[0].get("skip_upload"), True)
+        self.assertTrue(brews[0].get("skip_upload") is True)
         self.assertEqual(brews[0].get("directory"), "Formula")
 
     def test_tap_token_reaches_only_the_protected_publish_step(self) -> None:
@@ -373,7 +373,7 @@ class TestReleaseArtifacts(unittest.TestCase):
             lines.append(line)
         return lines
 
-    def test_promotion_is_separate_protected_and_signature_gated(self) -> None:
+    def test_promotion_is_separate_protected_and_signature_gated(self) -> None:  # noqa: PLR0915
         parsed = yaml.safe_load(WORKFLOW.read_text())
         build = parsed["jobs"]["release-build"]
         promote = parsed["jobs"]["release-promote"]
@@ -396,6 +396,7 @@ class TestReleaseArtifacts(unittest.TestCase):
 
         names = [name for name, _ in promote_runs]
         verify = names.index("Verify release manifest signature before promotion")
+        inputs_verified = names.index("Verify promotion image inputs")
         for public_write in (
             "Promote verified image manifests",
             "Publish Helm chart",
@@ -404,6 +405,7 @@ class TestReleaseArtifacts(unittest.TestCase):
             "Update floating major tag for GitHub Action",
         ):
             self.assertLess(verify, names.index(public_write))
+            self.assertLess(inputs_verified, names.index(public_write))
 
         self.assertIn("actions/upload-artifact@043fb46d", self.workflow)
         self.assertIn("actions/download-artifact@3e5f45b", self.workflow)
@@ -416,7 +418,7 @@ class TestReleaseArtifacts(unittest.TestCase):
         save = build["steps"][build_step_names.index("Save promotion inputs")]
         self.assertEqual(save["with"]["retention-days"], 7)
         self.assertEqual(save["with"]["if-no-files-found"], "error")
-        self.assertIs(save["with"]["overwrite"], True)
+        self.assertTrue(save["with"]["overwrite"] is True)
         self.assertEqual(
             [line.strip() for line in save["with"]["path"].split("\n") if line.strip()],
             [
@@ -438,6 +440,14 @@ class TestReleaseArtifacts(unittest.TestCase):
             self.assertIn(required, completeness)
 
         promote_step_names = [step.get("name", "") for step in promote["steps"]]
+        login = promote_step_names.index("Login to GHCR for promotion")
+        self.assertLess(login, promote_step_names.index("Promote verified image manifests"))
+        login_step = promote["steps"][login]
+        self.assertEqual(
+            login_step["uses"],
+            "docker/login-action@dbcb813823bdd20940b903addbd779551569679f",
+        )
+        self.assertEqual(login_step["with"]["registry"], "ghcr.io")
         download = promote_step_names.index("Download promotion inputs")
         for consumer in (
             "Verify release manifest signature before promotion",

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -115,10 +115,39 @@ class TestReleaseArtifacts(unittest.TestCase):
             self.assertNotIn(f'name_template: "{repository}:{{{{ .Version }}}}"', self.goreleaser)
             self.assertNotIn(f'name_template: "{repository}:latest"', self.goreleaser)
 
+    def test_homebrew_formula_is_generated_without_build_time_publication(self) -> None:
+        config = yaml.safe_load(self.goreleaser)
+        brews = config.get("brews", [])
+        self.assertEqual(len(brews), 1)
+        self.assertIs(brews[0].get("skip_upload"), True)
+        self.assertEqual(brews[0].get("directory"), "Formula")
+
+    def test_tap_token_reaches_only_the_protected_publish_step(self) -> None:
+        """The tap credential is what makes "generates but does not publish" real.
+
+        `skip_upload` is a GoReleaser setting, so on its own it is a promise in a
+        config file. Withholding the tap token from the build job is the part
+        that cannot be undone by a config edit, and it is worth asserting
+        separately because a token quietly restored to the GoReleaser step would
+        make the separation cosmetic while every other check here still passed.
+        """
+        parsed = yaml.safe_load(WORKFLOW.read_text())
+        holders = []
+        for job_name, job in parsed["jobs"].items():
+            for step in job.get("steps", []):
+                blocks = (step.get("env") or {}, step.get("with") or {})
+                if any(
+                    "HOMEBREW_TAP_TOKEN" in str(value)
+                    for block in blocks
+                    for value in block.values()
+                ):
+                    holders.append((job_name, step.get("name", "")))
+        self.assertEqual(holders, [("release-promote", "Publish Homebrew formula")])
+
     def test_release_waits_for_customer_verifier_install_gate(self) -> None:
         gate = self.workflow.index("  release-verifier-install:")
-        release = self.workflow.index("\n  release:\n", gate)
-        gate_block = self.workflow[gate:release]
+        release_build = self.workflow.index("\n  release-build:\n", gate)
+        gate_block = self.workflow[gate:release_build]
 
         self.assertIn("needs: [release-tests]", gate_block)
         self.assertIn("fetch-depth: 0", gate_block)
@@ -126,7 +155,10 @@ class TestReleaseArtifacts(unittest.TestCase):
             'scripts/release-verifier-install-gate.sh --tag "$GITHUB_REF_NAME"',
             gate_block,
         )
-        self.assertIn("needs: [release-tests, release-verifier-install]", self.workflow[release:])
+        self.assertIn(
+            "needs: [release-tests, release-verifier-install]",
+            self.workflow[release_build:],
+        )
 
     def test_other_release_tools_are_exactly_pinned_and_verified(self) -> None:
         expected_tools = (
@@ -246,17 +278,16 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn(expected_condition, normalized_gate)
         self.assertNotIn("== 'failure'", normalized_gate)
 
-    def test_verified_staging_indexes_promote_after_the_proof_gate(self) -> None:
+    def test_verified_staging_indexes_promote_only_in_protected_job(self) -> None:
         resolution = self.workflow.index("- name: Resolve release image platform digests")
         proof_gate = self.workflow.index("- name: Verify attestation")
-        chart_preflight = self.workflow.index("- name: Package and verify Helm chart version")
-        promotion = self.workflow.index("- name: Promote verified image manifests")
+        chart_preflight = self.workflow.index("- name: Package Helm chart")
         bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
+        promotion = self.workflow.index("- name: Promote verified image manifests")
         self.assertLess(resolution, proof_gate)
         self.assertLess(proof_gate, chart_preflight)
-        self.assertLess(chart_preflight, promotion)
-        self.assertLess(proof_gate, promotion)
-        self.assertLess(promotion, bundle)
+        self.assertLess(chart_preflight, bundle)
+        self.assertLess(bundle, promotion)
         self.assertIn('crane copy --no-clobber "${repository}@${index_digest}"', self.workflow)
         self.assertIn('crane copy --no-clobber "${repository}@${digest}" "$target"', self.workflow)
         self.assertIn('"${repository}:latest"', self.workflow)
@@ -264,7 +295,10 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertIn("grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+$'", self.workflow)
         self.assertIn('if [[ "$newest_stable" = "$version" ]]; then', self.workflow)
         self.assertIn('if [[ "$latest_digest" != "$index_digest" ]]; then', self.workflow)
-        runs = self._release_job_runs()
+        runs = self._job_runs("release-promote")
+        image_promotion = dict(runs)["Promote verified image manifests"]
+        self.assertIn("git ls-remote --tags --refs origin 'refs/tags/v*'", image_promotion)
+        self.assertNotIn("printf '%s\\n%s\\n' \"$tags\" \"$version\"", image_promotion)
         floating_steps = [script for name, script in runs if name == "Update floating major tag for GitHub Action"]
         self.assertEqual(len(floating_steps), 1, "expected exactly one floating-tag step")
         floating_lines = self._executable_lines(floating_steps[0])
@@ -309,15 +343,15 @@ class TestReleaseArtifacts(unittest.TestCase):
                     self.workflow,
                 )
 
-    def _release_job_runs(self) -> list[tuple[str, str]]:
-        """Return (step name, run script) for every step of the release job.
+    def _job_runs(self, job_name: str) -> list[tuple[str, str]]:
+        """Return (step name, run script) for every step of one workflow job.
 
         Reading the parsed workflow rather than its text is the point. A string
         search is satisfied by a comment or an echo that merely mentions a
         command, and it cannot tell which step a command belongs to.
         """
         parsed = yaml.safe_load(WORKFLOW.read_text())
-        steps = parsed["jobs"]["release"]["steps"]
+        steps = parsed["jobs"][job_name]["steps"]
         return [
             (step.get("name", ""), step["run"])
             for step in steps
@@ -339,36 +373,113 @@ class TestReleaseArtifacts(unittest.TestCase):
             lines.append(line)
         return lines
 
-    def test_github_release_promotion_follows_proof_bundle_and_chart(self) -> None:
-        goreleaser = self.workflow.index("- name: Run GoReleaser")
-        proof_gate = self.workflow.index("- name: Verify attestation")
-        bundle = self.workflow.index("- name: Build Kubernetes image digest bundle")
-        bundle_attestation = self.workflow.index("- name: Attest Kubernetes image digest bundle")
-        bundle_gate = self.workflow.index("- name: Verify Kubernetes image digest bundle attestation")
-        upload = self.workflow.index("- name: Upload Kubernetes image digest bundle")
-        chart = self.workflow.index("- name: Publish Helm chart")
-        promotion = self.workflow.index("- name: Verify the release manifest signature and publish")
-        self.assertIn('gh release edit "$GITHUB_REF_NAME" --draft=false', self.workflow)
+    def test_promotion_is_separate_protected_and_signature_gated(self) -> None:
+        parsed = yaml.safe_load(WORKFLOW.read_text())
+        build = parsed["jobs"]["release-build"]
+        promote = parsed["jobs"]["release-promote"]
+        self.assertEqual(promote["needs"], ["release-build"])
+        self.assertEqual(promote["environment"], "release-promotion")
+        self.assertEqual(promote["permissions"], {"contents": "write", "packages": "write"})
 
-        # Release assets stay mutable while the release is a draft, and the job
-        # holds contents: write, so verifying and then promoting in one step
-        # NARROWS the window in which a verified manifest could be replaced. It
-        # does not close it. Preventing the substitution outright needs an
-        # immutable or pinned publication mechanism, which GitHub releases do not
-        # provide.
-        #
-        # Both commands must live inside the promotion step for even that
-        # narrowing to hold, so the ordering is asserted within the step's own
-        # text. Searching the whole workflow would pass while the two sat in
-        # different steps, which is the arrangement this is meant to rule out.
+        build_runs = self._job_runs("release-build")
+        promote_runs = self._job_runs("release-promote")
+        build_script = "\n".join(script for _, script in build_runs)
+        for forbidden in (
+            "helm push ",
+            "gh release edit ",
+            "git push origin ",
+            "repos/luckyPipewrench/homebrew-tap/contents/",
+            '"${repository}:${version}"',
+            '"${repository}:latest"',
+        ):
+            self.assertNotIn(forbidden, build_script)
+
+        names = [name for name, _ in promote_runs]
+        verify = names.index("Verify release manifest signature before promotion")
+        for public_write in (
+            "Promote verified image manifests",
+            "Publish Helm chart",
+            "Publish Homebrew formula",
+            "Reverify the release manifest signature and publish",
+            "Update floating major tag for GitHub Action",
+        ):
+            self.assertLess(verify, names.index(public_write))
+
+        self.assertIn("actions/upload-artifact@043fb46d", self.workflow)
+        self.assertIn("actions/download-artifact@3e5f45b", self.workflow)
+
+        # These two were positional (`build["steps"][-1]`, `promote["steps"][3]`).
+        # A positional index starts passing for the wrong reason the moment a
+        # step is inserted ahead of it, and it never expressed the property that
+        # matters. Look the steps up by name and assert the ordering instead.
+        build_step_names = [step.get("name", "") for step in build["steps"]]
+        save = build["steps"][build_step_names.index("Save promotion inputs")]
+        self.assertEqual(save["with"]["retention-days"], 7)
+        self.assertEqual(save["with"]["if-no-files-found"], "error")
+        self.assertIs(save["with"]["overwrite"], True)
+        self.assertEqual(
+            [line.strip() for line in save["with"]["path"].split("\n") if line.strip()],
+            [
+                "dist/homebrew/Formula/pipelock.rb",
+                "dist-chart/pipelock-*.tgz",
+                "dist/release-images.json",
+            ],
+        )
+        self.assertLess(
+            build_step_names.index("Verify promotion inputs are complete"),
+            build_step_names.index("Save promotion inputs"),
+        )
+        completeness = dict(build_runs)["Verify promotion inputs are complete"]
+        for required in (
+            "dist/release-images.json",
+            "dist-chart -maxdepth 1 -name 'pipelock-*.tgz'",
+            "dist/homebrew/Formula/pipelock.rb",
+        ):
+            self.assertIn(required, completeness)
+
+        promote_step_names = [step.get("name", "") for step in promote["steps"]]
+        download = promote_step_names.index("Download promotion inputs")
+        for consumer in (
+            "Verify release manifest signature before promotion",
+            "Verify promotion image inputs",
+            "Promote verified image manifests",
+            "Publish Helm chart",
+            "Publish Homebrew formula",
+        ):
+            self.assertLess(download, promote_step_names.index(consumer))
+
+        self.assertIn(
+            'test "$("$tool_dir/crane" version)" = "${CRANE_VERSION#v}"',
+            self.workflow,
+        )
+        input_checks = dict(promote_runs)["Verify promotion image inputs"]
+        self.assertIn("pipelock-release-images-v1", input_checks)
+        self.assertIn('git rev-parse "${GITHUB_REF_NAME}^{}"', input_checks)
+        self.assertIn("expected 4 Homebrew archive checksums", input_checks)
+        self.assertIn("does not match signed release.json", input_checks)
+
+        # Every promotion input is proven present before the first public write,
+        # not when the step that consumes it finally runs. A presence check that
+        # lives in the consuming step fails with images already promoted.
+        self.assertIn("dist/homebrew/Formula/pipelock.rb", input_checks)
+        self.assertIn("dist-chart -maxdepth 1 -name 'pipelock-*.tgz'", input_checks)
+        self.assertLess(
+            promote_step_names.index("Verify promotion image inputs"),
+            promote_step_names.index("Promote verified image manifests"),
+        )
+        for output in (
+            "pipelock_index",
+            "pipelock_init_index",
+            "license_service_index",
+        ):
+            self.assertIn(f"needs.release-build.outputs.{output}", self.workflow)
+
         undraft_cmd = 'gh release edit "$GITHUB_REF_NAME" --draft=false'
         verify_cmd = "go run ./cmd/pipelock-release-manifest --verify --manifest"
-
-        runs = self._release_job_runs()
         promotion_steps = [
             script
-            for name, script in runs
-            if name == "Verify the release manifest signature and publish"
+            for name, script in promote_runs
+            if name == "Reverify the release manifest signature and publish"
         ]
         self.assertEqual(len(promotion_steps), 1, "expected exactly one promotion step")
         promotion_lines = self._executable_lines(promotion_steps[0])
@@ -377,12 +488,12 @@ class TestReleaseArtifacts(unittest.TestCase):
         # else could publish before verification while a check scoped to this
         # step still passed.
         undrafting_steps = [
-            name for name, script in runs
+            name for name, script in promote_runs
             if any(undraft_cmd in line for line in self._executable_lines(script))
         ]
         self.assertEqual(
             undrafting_steps,
-            ["Verify the release manifest signature and publish"],
+            ["Reverify the release manifest signature and publish"],
             f"draft removal must happen only in the promotion step, found {undrafting_steps}",
         )
 
@@ -407,21 +518,58 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertLess(verify_at[0], undraft_at[0])
         self.assertNotIn("- name: Publish GitHub release", self.workflow)
 
-        self.assertLess(goreleaser, proof_gate)
-        self.assertLess(proof_gate, bundle)
-        self.assertLess(bundle, bundle_attestation)
-        self.assertLess(bundle_attestation, bundle_gate)
-        self.assertLess(bundle_gate, upload)
-        self.assertLess(upload, chart)
-        self.assertLess(chart, promotion)
+        # The same fail-closed treatment for the PRE-promotion gate. Only the
+        # publish step was checked this way, so `--verify ... || true` in the
+        # first gate would have passed every assertion in this file while
+        # letting an unverifiable manifest reach the image promotion below it.
+        prepromotion_steps = [
+            script
+            for name, script in promote_runs
+            if name == "Verify release manifest signature before promotion"
+        ]
+        self.assertEqual(len(prepromotion_steps), 1, "expected one pre-promotion gate")
+        prepromotion_lines = self._executable_lines(prepromotion_steps[0])
+        pre_verify_at = [
+            i for i, line in enumerate(prepromotion_lines) if canonical_verify in line
+        ]
+        self.assertEqual(
+            len(pre_verify_at), 1, "pre-promotion gate must run the verifier exactly once"
+        )
+        self.assertEqual(prepromotion_lines[pre_verify_at[0]], canonical_verify)
+
+        # A good signature over the WRONG release still verifies: the verifier
+        # checks the signature and the keyring, never which release the manifest
+        # describes. Signing is offline and manual, so both gates must bind the
+        # verified manifest to the tag and commit being promoted.
+        tag_bind = 'test "$manifest_tag" = "$GITHUB_REF_NAME" || {'
+        commit_bind = (
+            'test "$manifest_commit" = "$(git rev-parse "${GITHUB_REF_NAME}^{}")" || {'
+        )
+        for gate in (
+            "Verify release manifest signature before promotion",
+            "Reverify the release manifest signature and publish",
+        ):
+            lines = self._executable_lines(dict(promote_runs)[gate])
+            self.assertIn('manifest_tag="$(jq -r .tag "$verify_dir/release.json")"', lines)
+            self.assertIn(
+                'manifest_commit="$(jq -r .commit "$verify_dir/release.json")"', lines
+            )
+            self.assertIn(tag_bind, lines)
+            self.assertIn(commit_bind, lines)
+
+        # In the publish step the binding has to sit between the verification and
+        # the undraft, or the release goes public before anything checked that
+        # the signed manifest belongs to this tag.
+        tag_bind_at = [i for i, line in enumerate(promotion_lines) if line == tag_bind]
+        self.assertEqual(len(tag_bind_at), 1)
+        self.assertLess(verify_at[0], tag_bind_at[0])
+        self.assertLess(tag_bind_at[0], undraft_at[0])
 
         self.assertIn('release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{}")"', self.workflow)
         self.assertNotIn('-commit "$GITHUB_SHA"', self.workflow)
         self.assertIn('steps.attest-release-images.outcome != \'success\'', self.workflow)
-        self.assertIn('if [[ "$CHART_ALREADY_PUBLISHED" != true ]]; then', self.workflow)
         self.assertIn('diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock"', self.workflow)
-        self.assertIn('echo "CHART_VERSION=$chart_version" >> "$GITHUB_ENV"', self.workflow)
-        self.assertIn('chart_version="$CHART_VERSION"', self.workflow)
+        self.assertIn('test "$chart_app_version" = "$app_version"', self.workflow)
         digest_vars = {
             "pipelock": "PIPELOCK_INDEX_DIGEST",
             "pipelock_init": "PIPELOCK_INIT_INDEX_DIGEST",

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -481,8 +481,24 @@ class TestReleaseArtifacts(unittest.TestCase):
             "pipelock_index",
             "pipelock_init_index",
             "license_service_index",
+            "pipelock_amd64",
+            "pipelock_arm64",
+            "pipelock_init_amd64",
+            "pipelock_init_arm64",
+            "license_service_amd64",
+            "license_service_arm64",
         ):
             self.assertIn(f"needs.release-build.outputs.{output}", self.workflow)
+        for digest_name in (
+            "PIPELOCK_AMD64_DIGEST",
+            "PIPELOCK_ARM64_DIGEST",
+            "PIPELOCK_INIT_AMD64_DIGEST",
+            "PIPELOCK_INIT_ARM64_DIGEST",
+            "LICENSE_SERVICE_AMD64_DIGEST",
+            "LICENSE_SERVICE_ARM64_DIGEST",
+        ):
+            self.assertIn(digest_name, input_checks)
+        self.assertIn("^sha256:[a-f0-9]{64}$", input_checks)
 
         undraft_cmd = 'gh release edit "$GITHUB_REF_NAME" --draft=false'
         verify_cmd = "go run ./cmd/pipelock-release-manifest --verify --manifest"
@@ -579,7 +595,18 @@ class TestReleaseArtifacts(unittest.TestCase):
         self.assertNotIn('-commit "$GITHUB_SHA"', self.workflow)
         self.assertIn('steps.attest-release-images.outcome != \'success\'', self.workflow)
         self.assertIn('diff -ru "$candidate_dir/pipelock" "$existing_dir/pipelock"', self.workflow)
+        self.assertIn(
+            'cmp -s "$chart_archive" "$existing_dir/pipelock-${chart_version}.tgz"',
+            self.workflow,
+        )
         self.assertIn('test "$chart_app_version" = "$app_version"', self.workflow)
+        homebrew = dict(promote_runs)["Publish Homebrew formula"]
+        self.assertIn("git ls-remote --tags --refs origin 'refs/tags/v*'", homebrew)
+        self.assertIn('if [[ "$version" != "$newest_stable" ]]; then', homebrew)
+        self.assertLess(
+            homebrew.index('if [[ "$version" != "$newest_stable" ]]; then'),
+            homebrew.index("gh api --method PUT"),
+        )
         digest_vars = {
             "pipelock": "PIPELOCK_INDEX_DIGEST",
             "pipelock_init": "PIPELOCK_INIT_INDEX_DIGEST",


### PR DESCRIPTION
## What changed
- Build and attest release artifacts once, then carry the exact image, Helm, and Homebrew inputs into an environment-protected promotion job.
- Bind the signed manifest to the release tag and commit before publishing any consumer surface, and fail closed when saved inputs or existing immutable outputs disagree.

Reviewers should distrust any path that can publish images, packages, the GitHub release, or the floating action tag before signature and input verification complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Separated release builds from protected promotion.
  * Added signed-manifest and release tag/commit validation before publication.
  * Added integrity checks for container images, Helm charts, and Homebrew formulas.
  * Staged all release artifacts before publishing them.
  * Helm charts, Homebrew formulas, and GitHub releases are published only after verification.

* **Quality Assurance**
  * Expanded automated coverage for artifact validation, permissions, signatures, workflow ordering, and promotion safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->