### PR TITLE
ci: pin the promoted AEB 3.4.0 corpus

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  AEB_REF: 53c95da15268447709914834a716516fd682bf1d
+  AEB_REF: 1627e1abd016ae33907a20b53dacef632e4b846e
 
 jobs:
   candidate:

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -12,7 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
-EXPECTED_AEB_REF = "53c95da15268447709914834a716516fd682bf1d"
+EXPECTED_AEB_REF = "1627e1abd016ae33907a20b53dacef632e4b846e"
 EVIDENCE_FILES = (
     "continuous-gauntlet-pipelock.json",
     "promotion-decision.json",


### PR DESCRIPTION
## What changed

Pin the read-only Gauntlet candidate workflow to the reviewed Agent Egress Bench commit containing the Pipelock 3.4.0 baseline and canonical-history fix. The workflow still fails closed if its checkout differs from the exact pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled and manual Pipelock Gauntlet workflow to use a newer Agent Egress Bench revision.
  * Updated validation checks to match the revised benchmark version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->