### PR TITLE
fix(proxy): enforce Git push allowlist on redirects

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1118,7 +1118,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if gitPush := evaluateGitPushAllowlist(cfg.GitProtection, r.URL); gitPush.Block {
+	if gitPush := evaluateGitPushAllowlist(cfg.GitProtection, r.Method, r.URL); gitPush.Block {
 		p.logger.LogBlocked(actx, "git_protection", gitPush.Reason)
 		emitForwardReceipt(receipt.EmitOpts{
 			ActionID:  actionID,

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2962,6 +2962,7 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var finalRequestHits atomic.Int32
 			var finalMethod, finalBody string
+			finalCaptured := make(chan struct{}, 1)
 			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == tt.requestPath && r.URL.RawQuery == "" {
 					http.Redirect(w, r, "http://git.vendor.example"+tt.redirectPath, tt.redirectStatus)
@@ -2974,6 +2975,7 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 					t.Errorf("read redirected body: %v", err)
 				}
 				finalBody = string(body)
+				finalCaptured <- struct{}{}
 				_, _ = fmt.Fprint(w, "final")
 			}))
 			defer backend.Close()
@@ -3016,6 +3018,7 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 			if tt.wantFinalRequestHits == 0 {
 				return
 			}
+			<-finalCaptured
 			if finalMethod != tt.wantFinalMethod {
 				t.Errorf("final method = %q, want %q", finalMethod, tt.wantFinalMethod)
 			}

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2915,6 +2915,117 @@ func TestForwardHTTPBlocksNonAllowlistedGitPush(t *testing.T) {
 	}
 }
 
+func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		requestPath          string
+		redirectPath         string
+		redirectStatus       int
+		wantStatus           int
+		wantFinalMethod      string
+		wantFinalBody        string
+		wantFinalRequestHits int32
+	}{
+		{
+			name:                 "307 blocks redirected non-allowlisted push",
+			requestPath:          "/acme/private.git/git-receive-pack",
+			redirectPath:         "/acme/public.git/git-receive-pack",
+			redirectStatus:       http.StatusTemporaryRedirect,
+			wantStatus:           http.StatusForbidden,
+			wantFinalRequestHits: 0,
+		},
+		{
+			name:                 "308 allows redirected allowlisted push",
+			requestPath:          "/acme/private.git/git-receive-pack",
+			redirectPath:         "/acme/private.git/git-receive-pack?redirected=1",
+			redirectStatus:       http.StatusPermanentRedirect,
+			wantStatus:           http.StatusOK,
+			wantFinalMethod:      http.MethodPost,
+			wantFinalBody:        "0000",
+			wantFinalRequestHits: 1,
+		},
+		{
+			name:                 "303 non-push redirect remains method changing",
+			requestPath:          "/non-push-start",
+			redirectPath:         "/non-push-final",
+			redirectStatus:       http.StatusSeeOther,
+			wantStatus:           http.StatusOK,
+			wantFinalMethod:      http.MethodGet,
+			wantFinalBody:        "",
+			wantFinalRequestHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var finalRequestHits atomic.Int32
+			var finalMethod, finalBody string
+			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == tt.requestPath && r.URL.RawQuery == "" {
+					http.Redirect(w, r, "http://github.com"+tt.redirectPath, tt.redirectStatus)
+					return
+				}
+				finalRequestHits.Add(1)
+				finalMethod = r.Method
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read redirected body: %v", err)
+				}
+				finalBody = string(body)
+				_, _ = fmt.Fprint(w, "final")
+			}))
+			defer backend.Close()
+
+			proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+				cfg.GitProtection.Enabled = true
+				cfg.GitProtection.AllowedPushRepos = []string{"github.com/acme/private"}
+			})
+			defer cleanup()
+			p.client.Transport = &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					if addr == "github.com:80" {
+						return (&net.Dialer{}).DialContext(ctx, network, backend.Listener.Addr().String())
+					}
+					return (&net.Dialer{}).DialContext(ctx, network, addr)
+				},
+				DisableCompression: true,
+			}
+
+			proxyURL, err := url.Parse("http://" + proxyAddr)
+			if err != nil {
+				t.Fatalf("parse proxy URL: %v", err)
+			}
+			client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}, Timeout: 2 * time.Second}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://github.com"+tt.requestPath, strings.NewReader("0000"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("forward redirected request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if got := finalRequestHits.Load(); got != tt.wantFinalRequestHits {
+				t.Fatalf("final request hits = %d, want %d", got, tt.wantFinalRequestHits)
+			}
+			if tt.wantFinalRequestHits == 0 {
+				return
+			}
+			if finalMethod != tt.wantFinalMethod {
+				t.Errorf("final method = %q, want %q", finalMethod, tt.wantFinalMethod)
+			}
+			if finalBody != tt.wantFinalBody {
+				t.Errorf("final body = %q, want %q", finalBody, tt.wantFinalBody)
+			}
+		})
+	}
+}
+
 // TestForwardHTTPBlocksEncodedSubdomainExfil proves transport parity for the
 // absolute-URI forward path: an encoded-subdomain exfil target is blocked at
 // the scan (pre-dial), matching the fetch and CONNECT paths.

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2960,11 +2960,13 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var initialRequestHits atomic.Int32
 			var finalRequestHits atomic.Int32
 			var finalMethod, finalBody string
 			finalCaptured := make(chan struct{}, 1)
 			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == tt.requestPath && r.URL.RawQuery == "" {
+					initialRequestHits.Add(1)
 					http.Redirect(w, r, "http://git.vendor.example"+tt.redirectPath, tt.redirectStatus)
 					return
 				}
@@ -3011,6 +3013,9 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 			defer func() { _ = resp.Body.Close() }()
 			if resp.StatusCode != tt.wantStatus {
 				t.Fatalf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if got := initialRequestHits.Load(); got != 1 {
+				t.Fatalf("initial request hits = %d, want 1", got)
 			}
 			if got := finalRequestHits.Load(); got != tt.wantFinalRequestHits {
 				t.Fatalf("final request hits = %d, want %d", got, tt.wantFinalRequestHits)

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -2947,9 +2947,9 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 			wantFinalRequestHits: 1,
 		},
 		{
-			name:                 "303 non-push redirect remains method changing",
-			requestPath:          "/non-push-start",
-			redirectPath:         "/non-push-final",
+			name:                 "303 excluded push path becomes GET",
+			requestPath:          "/acme/private.git/git-receive-pack",
+			redirectPath:         "/acme/public.git/git-receive-pack",
 			redirectStatus:       http.StatusSeeOther,
 			wantStatus:           http.StatusOK,
 			wantFinalMethod:      http.MethodGet,
@@ -2964,7 +2964,7 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 			var finalMethod, finalBody string
 			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == tt.requestPath && r.URL.RawQuery == "" {
-					http.Redirect(w, r, "http://github.com"+tt.redirectPath, tt.redirectStatus)
+					http.Redirect(w, r, "http://git.vendor.example"+tt.redirectPath, tt.redirectStatus)
 					return
 				}
 				finalRequestHits.Add(1)
@@ -2980,12 +2980,12 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 
 			proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
 				cfg.GitProtection.Enabled = true
-				cfg.GitProtection.AllowedPushRepos = []string{"github.com/acme/private"}
+				cfg.GitProtection.AllowedPushRepos = []string{"git.vendor.example/acme/private"}
 			})
 			defer cleanup()
 			p.client.Transport = &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-					if addr == "github.com:80" {
+					if addr == "git.vendor.example:80" {
 						return (&net.Dialer{}).DialContext(ctx, network, backend.Listener.Addr().String())
 					}
 					return (&net.Dialer{}).DialContext(ctx, network, addr)
@@ -2998,7 +2998,7 @@ func TestForwardHTTPGitPushRedirectAllowlist(t *testing.T) {
 				t.Fatalf("parse proxy URL: %v", err)
 			}
 			client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}, Timeout: 2 * time.Second}
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://github.com"+tt.requestPath, strings.NewReader("0000"))
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://git.vendor.example"+tt.requestPath, strings.NewReader("0000"))
 			if err != nil {
 				t.Fatalf("new request: %v", err)
 			}

--- a/internal/proxy/git_push_guard.go
+++ b/internal/proxy/git_push_guard.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,10 @@ type gitPushDecision struct {
 	Reason string
 }
 
-func evaluateGitPushAllowlist(cfg config.GitProtection, u *url.URL) gitPushDecision {
+func evaluateGitPushAllowlist(cfg config.GitProtection, method string, u *url.URL) gitPushDecision {
+	if method != http.MethodPost {
+		return gitPushDecision{}
+	}
 	if !cfg.Enabled || u == nil {
 		return gitPushDecision{}
 	}

--- a/internal/proxy/git_push_guard_edges_test.go
+++ b/internal/proxy/git_push_guard_edges_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestEvaluateGitPushAllowlistNilAndUnparseable(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.GitProtection{Enabled: true, AllowedPushRepos: []string{"git.vendor.example/acme/private"}}
-	if got := evaluateGitPushAllowlist(cfg, nil); got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, nil); got.Block {
 		t.Fatalf("nil URL blocked: %+v", got)
 	}
 
@@ -22,7 +23,7 @@ func TestEvaluateGitPushAllowlistNilAndUnparseable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse empty host: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, emptyHost); got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, emptyHost); got.Block {
 		t.Fatalf("empty host treated as a push: %+v", got)
 	}
 

--- a/internal/proxy/git_push_guard_test.go
+++ b/internal/proxy/git_push_guard_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -63,28 +64,28 @@ func TestEvaluateGitPushAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse blocked URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, blockedURL); !got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, blockedURL); !got.Block {
 		t.Fatalf("expected non-allowlisted push to block, got %+v", got)
 	}
 	allowedURL, err := url.Parse("https://github.com/acme/private.git/git-receive-pack")
 	if err != nil {
 		t.Fatalf("parse allowed URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, allowedURL); got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, allowedURL); got.Block {
 		t.Fatalf("expected allowlisted push to pass, got %+v", got)
 	}
 	hostWideURL, err := url.Parse("https://example.com/acme/project.git/git-receive-pack")
 	if err != nil {
 		t.Fatalf("parse host-wide URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, hostWideURL); got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, hostWideURL); got.Block {
 		t.Fatalf("expected host-wide allowlisted push to pass, got %+v", got)
 	}
 	nestedGroupURL, err := url.Parse("https://gitlab.com/group/subgroup/project.git/git-receive-pack")
 	if err != nil {
 		t.Fatalf("parse nested group URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, nestedGroupURL); !got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, nestedGroupURL); !got.Block {
 		t.Fatalf("owner-level allowlist must not match nested group path, got %+v", got)
 	}
 	// host/* must match on a path-segment boundary, never a host-prefix
@@ -94,12 +95,12 @@ func TestEvaluateGitPushAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse look-alike host URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, lookalikeHostURL); !got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, lookalikeHostURL); !got.Block {
 		t.Fatalf("host/* must not match a look-alike host prefix, got %+v", got)
 	}
 	disabled := cfg
 	disabled.Enabled = false
-	if got := evaluateGitPushAllowlist(disabled, blockedURL); got.Block {
+	if got := evaluateGitPushAllowlist(disabled, http.MethodPost, blockedURL); got.Block {
 		t.Fatalf("disabled git protection blocked: %+v", got)
 	}
 }
@@ -110,7 +111,7 @@ func TestEvaluateGitPushAllowlistBlocksEmptyAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, u); !got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, u); !got.Block {
 		t.Fatalf("enabled git push protection with empty allowlist must block, got %+v", got)
 	}
 }
@@ -124,7 +125,7 @@ func TestEvaluateGitPushAllowlistDoesNotMatchHostlessRepoPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse URL: %v", err)
 	}
-	if got := evaluateGitPushAllowlist(cfg, u); !got.Block {
+	if got := evaluateGitPushAllowlist(cfg, http.MethodPost, u); !got.Block {
 		t.Fatalf("hostless allowlist entry must not allow arbitrary host path, got %+v", got)
 	}
 }

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -810,7 +810,7 @@ func newInterceptHandler(
 			ic.Logger.LogAnomaly(actx, urlResult.Scanner, urlResult.Reason, urlResult.Score)
 		}
 
-		if gitPush := evaluateGitPushAllowlist(ic.Config.GitProtection, r.URL); gitPush.Block {
+		if gitPush := evaluateGitPushAllowlist(ic.Config.GitProtection, r.Method, r.URL); gitPush.Block {
 			ic.Logger.LogBlocked(actx, "git_protection", gitPush.Reason)
 			ic.Metrics.RecordTLSRequestBlocked("git_protection")
 			_ = interceptEmitReceipt(ic, receipt.EmitOpts{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -730,7 +730,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			// git-receive-pack POST therefore remains a push on the redirected
 			// target, which must satisfy the same repository allowlist as the
 			// admitted request.
-			if gitPush := evaluateGitPushAllowlist(currentCfg.GitProtection, req.URL); gitPush.Block {
+			if gitPush := evaluateGitPushAllowlist(currentCfg.GitProtection, req.Method, req.URL); gitPush.Block {
 				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
 				logger.LogBlocked(actx, "git_protection", "redirect from "+originalURL+" blocked: "+gitPush.Reason)
 				return newRedirectBlockedRequest("git_protection", gitPush.Reason)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -726,6 +726,16 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			}
 			scannerMatched := !result.Allowed
 
+			// A 307/308 redirect preserves the original method and body. A
+			// git-receive-pack POST therefore remains a push on the redirected
+			// target, which must satisfy the same repository allowlist as the
+			// admitted request.
+			if gitPush := evaluateGitPushAllowlist(currentCfg.GitProtection, req.URL); gitPush.Block {
+				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
+				logger.LogBlocked(actx, "git_protection", "redirect from "+originalURL+" blocked: "+gitPush.Reason)
+				return newRedirectBlockedRequest("git_protection", gitPush.Reason)
+			}
+
 			// request_policy runs before the contract gate so a contract
 			// allow can never suppress an operation-policy block.
 			if rpRes := p.applyRequestPolicy(requestPolicyInput{


### PR DESCRIPTION
## What changed

Reapply `git_protection.allowed_push_repos` to every redirect hop that still carries a visible Git push, blocking the hop before an excluded repository receives the request.

This fails closed for method-preserving redirects while leaving allowed push destinations and non-push redirect behavior unchanged. Reviewers should distrust any redirect path that can preserve `git-receive-pack` without rerunning repository policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened Git push protection across HTTP redirects.
  - Blocked redirected pushes to repositories outside the configured allowlist before they reach their destination.
  - Preserved valid redirects, including those retaining the original method and request body.
  - Ensured redirects that change a push into a retrieval request are handled safely.
  - Continued standard redirect behavior for non-push requests.
  - Added audit logging for blocked redirected Git push attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->