### PR TITLE
fix(scanner): decode canary views recursively

### DIFF
--- a/internal/scanner/canary.go
+++ b/internal/scanner/canary.go
@@ -66,7 +66,14 @@ func (s *Scanner) scanCanaryText(text string) []TextDLPMatch {
 		matches = append(matches, s.matchCanaryTokens(cleaned, "split", true, ViewDLPNormalized)...)
 	}
 
-	for _, d := range decodeEncodings(cleaned) {
+	// Walk the bounded recursive decode fixpoint, not a single pass. Ordinary
+	// text DLP and the core response scanner already use this decoder in the
+	// same shape; a canary matcher that stopped at one layer meant a single
+	// extra wrapper hid the one token whose whole purpose is to prove an
+	// exfiltration path. The fixpoint's candidate and byte bounds terminate it,
+	// and the candidates are already generated for DLP, so this adds substring
+	// checks rather than decode work.
+	for _, d := range decodeEncodingsRecursiveWithURL(cleaned) {
 		matches = append(matches, s.matchCanaryTokens(d.text, d.encoding, false, spanViewLabel(d.encoding+"_decoded", ViewDLPNormalized))...)
 	}
 
@@ -76,7 +83,10 @@ func (s *Scanner) scanCanaryText(text string) []TextDLPMatch {
 			if len(seg) < 8 {
 				continue
 			}
-			for _, d := range decodeEncodings(seg) {
+			// Same recursion for the per-segment view: the whole-text and
+			// segment loops are separate call sites, so leaving this one
+			// single-pass would keep a query-value bypass open.
+			for _, d := range decodeEncodingsRecursiveWithURL(seg) {
 				matches = append(matches, s.matchCanaryTokens(d.text, d.encoding, false, spanViewLabel(d.encoding+"_decoded", view.viewLabel))...)
 			}
 			if collapsed := canonicalizeCanaryText(seg); collapsed != "" && collapsed != seg {

--- a/internal/scanner/canary_test.go
+++ b/internal/scanner/canary_test.go
@@ -176,3 +176,85 @@ func TestScanTextForDLP_CanaryDisabled(t *testing.T) {
 		}
 	}
 }
+
+// TestCanary_NestedEncodingIsDetected covers the recursive-decode gap. Ordinary
+// DLP walks the bounded recursive decode fixpoint, but the canary matcher used
+// the single-pass decoder, so one extra encoding layer hid the token entirely.
+// A canary exists precisely to prove an exfiltration path, so a single wrapper
+// defeating it is the worst place for this asymmetry.
+func TestCanary_NestedEncodingIsDetected(t *testing.T) {
+	s := testCanaryScanner()
+	defer s.Close()
+
+	canary := testCanaryValue()
+	once := base64.StdEncoding.EncodeToString([]byte(canary))
+	twice := base64.StdEncoding.EncodeToString([]byte(once))
+	thrice := base64.StdEncoding.EncodeToString([]byte(twice))
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "single_layer_control", text: once},
+		{name: "double_layer", text: twice},
+		{name: "triple_layer", text: thrice},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := s.scanCanaryText(tc.text)
+			if len(matches) == 0 {
+				t.Fatalf("no canary match for %s; a wrapped canary must still be detected", tc.name)
+			}
+		})
+	}
+}
+
+// TestCanary_NestedEncodingInQuerySegment covers the per-segment path. The
+// whole-text and segment loops are separate call sites, so fixing only the
+// first leaves a query-value bypass open.
+func TestCanary_NestedEncodingInQuerySegment(t *testing.T) {
+	s := testCanaryScanner()
+	defer s.Close()
+
+	once := base64.StdEncoding.EncodeToString([]byte(testCanaryValue()))
+	twice := base64.StdEncoding.EncodeToString([]byte(once))
+
+	matches := s.scanCanaryText("GET /upload?blob=" + twice + "&mode=sync")
+	if len(matches) == 0 {
+		t.Fatal("no canary match for a doubly-encoded query value")
+	}
+}
+
+// BenchmarkScanCanaryText_Clean measures the canary path on ordinary text with
+// canary tokens configured. benchConfig deliberately has none, so the existing
+// text-DLP benchmarks never enter this code.
+func BenchmarkScanCanaryText_Clean(b *testing.B) {
+	cfg := testConfig()
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{{Name: "bench_canary", Value: testCanaryValue()}}
+	s := MustNew(cfg)
+	b.Cleanup(s.Close)
+
+	const text = "GET /v1/models?stream=true HTTP/1.1 host api.vendor.example accept application/json"
+	b.ResetTimer()
+	for b.Loop() {
+		s.scanCanaryText(text)
+	}
+}
+
+// BenchmarkScanCanaryText_NestedEncoded measures the worst realistic case for
+// the recursive decode: a payload that genuinely decodes several layers deep.
+func BenchmarkScanCanaryText_NestedEncoded(b *testing.B) {
+	cfg := testConfig()
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{{Name: "bench_canary", Value: testCanaryValue()}}
+	s := MustNew(cfg)
+	b.Cleanup(s.Close)
+
+	text := base64.StdEncoding.EncodeToString([]byte(
+		base64.StdEncoding.EncodeToString([]byte(
+			base64.StdEncoding.EncodeToString([]byte(testCanaryValue()))))))
+	b.ResetTimer()
+	for b.Loop() {
+		s.scanCanaryText(text)
+	}
+}


### PR DESCRIPTION
## What changed

The canary matcher walked a single decode pass while ordinary text DLP and the core response scanner both walk the bounded recursive fixpoint. One extra encoding wrapper therefore hid a canary token entirely, which is the worst place for that asymmetry: a canary exists to prove an exfiltration path, so defeating it with one wrapper removes the proof.

Both call sites move to the recursive decoder, the whole-text view and the per-segment view, because delimiter splitting means each can see a payload the other does not. The fixpoint's existing candidate and byte bounds terminate it.

The reviewer should distrust the per-segment call site rather than the whole-text one. Only the segment change has a reproduction that fails without it; the whole-text change is parity with the two sibling scanners, and no test isolates it, because nested base64 output is alphanumeric and the delimiter split rarely cuts through a payload.

A canary benchmark is added because the existing text-DLP benchmarks configure no canary tokens and never entered this code, so a before-and-after comparison on them measured nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved canary detection for tokens hidden behind multiple layers of encoding.
  - Added support for detecting encoded canaries in query segments.

- **Tests**
  - Added coverage for one-, two-, and three-layer encoded canaries.
  - Added performance benchmarks for clean and deeply encoded scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->