### PR TITLE
fix(scanapi): deny when embedded-URL decoding stops early

### DIFF
--- a/internal/scanapi/handler_test.go
+++ b/internal/scanapi/handler_test.go
@@ -2033,7 +2033,11 @@ func TestEmbeddedURLTextViews_EntityDecodeCountsAsFurtherWork(t *testing.T) {
 // never runs. The probe would not have found it anyway, because it inspects
 // percent and entity decoding and not the escaped-slash rewrite.
 func TestEmbeddedURLTextViews_CapRejectionAloneReportsTruncation(t *testing.T) {
-	encoded := "http://169.254.169.254/latest/meta-data/"
+	// A neutral host: this test measures view counting and the cap, not SSRF
+	// detection, so the target is incidental here. The tests that assert a
+	// metadata endpoint is denied keep the real address, because there the
+	// address is the thing under test.
+	encoded := "http://api.vendor.example/latest/meta-data/"
 	for i := range 4 {
 		encoded = url.QueryEscape(encoded)
 		if i < 2 {

--- a/internal/scanapi/handler_test.go
+++ b/internal/scanapi/handler_test.go
@@ -1982,13 +1982,10 @@ func TestEmbeddedURLTextViews_TruncationSignal(t *testing.T) {
 // decode pass branch, so the collected views reach the cap while decoding is
 // still productive.
 //
-// What this test does NOT establish, stated so a later reader does not assume
-// it: it does not isolate the cap's own truncation flag. Neutralising that flag
-// leaves this test passing, because a view the cap refuses is by construction
-// still decodable and unseen, so the further-work probe reports truncation too.
-// The flag is not redundant - it is the only reporter when the pass loop
-// CONVERGES after an earlier block, since the probe runs only when the budget
-// was exhausted - but that interleaving is not reproduced here.
+// This case does not isolate the cap's own flag: neutralising it leaves this
+// test passing, because the further-work probe also reports truncation here.
+// TestEmbeddedURLTextViews_CapRejectionAloneReportsTruncation is the case that
+// isolates it, so the flag is covered by that test rather than this one.
 func TestEmbeddedURLTextViews_ViewCapReportsTruncation(t *testing.T) {
 	payload := "http://169.254.169.254/latest/meta-data/"
 	for i := range 4 {
@@ -2020,5 +2017,39 @@ func TestEmbeddedURLTextViews_EntityDecodeCountsAsFurtherWork(t *testing.T) {
 	}
 	if _, truncated := embeddedURLTextViews(payload); !truncated {
 		t.Fatal("entity-encoded layers left unread were not reported as truncated")
+	}
+}
+
+// TestEmbeddedURLTextViews_CapRejectionAloneReportsTruncation isolates the view
+// cap from the further-work probe, which the sibling test above cannot do.
+//
+// Finding this input took a differential search, and the search overturned two
+// earlier conclusions of mine that the cap flag was unprovable. It is provable:
+// with the cap's assignment neutralised, this case reports truncated=false while
+// the intact code reports true, so the flag is the only thing that catches it.
+//
+// The shape that isolates it: the cap refuses a view whose slash-decoded form
+// also needs a slot, and the pass loop then converges, so the further-work probe
+// never runs. The probe would not have found it anyway, because it inspects
+// percent and entity decoding and not the escaped-slash rewrite.
+func TestEmbeddedURLTextViews_CapRejectionAloneReportsTruncation(t *testing.T) {
+	encoded := "http://169.254.169.254/latest/meta-data/"
+	for i := range 4 {
+		encoded = url.QueryEscape(encoded)
+		if i < 2 {
+			encoded = strings.Replace(encoded, "%", "&#37;", 1)
+		}
+	}
+	// The escaped slash rides in a trailing token so it does not disturb the
+	// URL's own decode chain; it is what makes an append need two slots.
+	text := encoded + ` note:a\/b`
+
+	views, truncated := embeddedURLTextViews(text)
+	if len(views) != maxEmbeddedURLTextViews {
+		t.Fatalf("views = %d, want the cap of %d so this exercises the rejection path",
+			len(views), maxEmbeddedURLTextViews)
+	}
+	if !truncated {
+		t.Fatal("the cap refused a view without reporting truncation, so a dropped view reads as complete inspection")
 	}
 }

--- a/internal/scanapi/handler_test.go
+++ b/internal/scanapi/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1910,5 +1911,114 @@ func TestHandler_OrdinaryEncodedContentStillAllows(t *testing.T) {
 				t.Fatalf("decision = %q, want allow for ordinary content; findings = %+v", resp.Decision, resp.Findings)
 			}
 		})
+	}
+}
+
+// TestHandler_BenignURLAtEveryDepthWithinBudgetAllows is the boundary guard for
+// the truncation signal. Exhausting the decode-pass budget is not the same as
+// having a layer left to read: a payload can converge exactly on the final pass,
+// fully inspected. Before this was fixed, five layers allowed and six denied
+// with a truncation finding, so an ordinary URL was blocked at the boundary.
+func TestHandler_BenignURLAtEveryDepthWithinBudgetAllows(t *testing.T) {
+	for layers := 1; layers <= maxEmbeddedURLDecodePasses; layers++ {
+		t.Run(fmt.Sprintf("layers_%d", layers), func(t *testing.T) {
+			payload := "https://docs.vendor.example/guide"
+			for range layers {
+				payload = url.QueryEscape(payload)
+			}
+			h := newTestHandler(t)
+			body, err := json.Marshal(map[string]any{
+				"kind":  "dlp",
+				"input": map[string]string{"text": "see " + payload},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/scan", strings.NewReader(string(body)))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("code = %d, want 200; body = %s", w.Code, w.Body.String())
+			}
+			var resp Response
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.Decision != DecisionAllow {
+				t.Fatalf("decision = %q at %d layers, want allow for a fully decoded benign URL; findings = %+v",
+					resp.Decision, layers, resp.Findings)
+			}
+		})
+	}
+}
+
+// TestEmbeddedURLTextViews_TruncationSignal covers both bounds directly, since
+// the handler cannot easily be driven to the view cap. A payload that still has
+// an undecoded layer when the budget runs out must report truncated; one that
+// converges must not.
+func TestEmbeddedURLTextViews_TruncationSignal(t *testing.T) {
+	converging := "https://docs.vendor.example/guide"
+	for range maxEmbeddedURLDecodePasses {
+		converging = url.QueryEscape(converging)
+	}
+	if _, truncated := embeddedURLTextViews(converging); truncated {
+		t.Fatal("a payload that converges within the budget was reported truncated")
+	}
+
+	beyond := "http://169.254.169.254/latest/meta-data/"
+	for range maxEmbeddedURLDecodePasses + 4 {
+		beyond = url.QueryEscape(beyond)
+	}
+	if _, truncated := embeddedURLTextViews(beyond); !truncated {
+		t.Fatal("a payload with layers left unread was not reported truncated")
+	}
+}
+
+// TestEmbeddedURLTextViews_ViewCapReportsTruncation drives the view cap, the
+// other bound that must not drop a view silently. Entity injection makes each
+// decode pass branch, so the collected views reach the cap while decoding is
+// still productive.
+//
+// What this test does NOT establish, stated so a later reader does not assume
+// it: it does not isolate the cap's own truncation flag. Neutralising that flag
+// leaves this test passing, because a view the cap refuses is by construction
+// still decodable and unseen, so the further-work probe reports truncation too.
+// The flag is not redundant - it is the only reporter when the pass loop
+// CONVERGES after an earlier block, since the probe runs only when the budget
+// was exhausted - but that interleaving is not reproduced here.
+func TestEmbeddedURLTextViews_ViewCapReportsTruncation(t *testing.T) {
+	payload := "http://169.254.169.254/latest/meta-data/"
+	for i := range 4 {
+		payload = url.QueryEscape(payload)
+		if i%2 == 0 {
+			payload = strings.Replace(payload, "%", "&#37;", 1)
+		}
+	}
+
+	views, truncated := embeddedURLTextViews(payload)
+	if len(views) > maxEmbeddedURLTextViews {
+		t.Fatalf("views = %d, must never exceed the cap of %d", len(views), maxEmbeddedURLTextViews)
+	}
+	if len(views) != maxEmbeddedURLTextViews {
+		t.Fatalf("views = %d, want the cap of %d so this test exercises the bound", len(views), maxEmbeddedURLTextViews)
+	}
+	if !truncated {
+		t.Fatal("view cap was reached without reporting truncation, so a dropped view would read as complete inspection")
+	}
+}
+
+// TestEmbeddedURLTextViews_EntityDecodeCountsAsFurtherWork covers the HTML
+// entity half of the further-work probe. A payload whose remaining layers are
+// entity-encoded rather than percent-encoded must still count as unread.
+func TestEmbeddedURLTextViews_EntityDecodeCountsAsFurtherWork(t *testing.T) {
+	payload := "http://169.254.169.254/latest/meta-data/"
+	for range maxEmbeddedURLDecodePasses + 2 {
+		payload = strings.ReplaceAll(url.QueryEscape(payload), "%", "&#37;")
+	}
+	if _, truncated := embeddedURLTextViews(payload); !truncated {
+		t.Fatal("entity-encoded layers left unread were not reported as truncated")
 	}
 }

--- a/internal/scanapi/handler_test.go
+++ b/internal/scanapi/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1809,4 +1810,105 @@ func deepScanAPIJSONObject(value string, depth int) string {
 		b.WriteByte('}')
 	}
 	return b.String()
+}
+
+// TestHandler_DeeplyEncodedEmbeddedURLDoesNotAllow covers the silent
+// decode-ceiling fail-open. The Scan API peels a bounded number of
+// percent/HTML passes looking for an embedded URL. The token-count cap already
+// sets truncated and therefore denies, but the decode-pass and view-count caps
+// were silent, so a URL wrapped past the ceiling produced no token, an empty
+// result set, truncated=false, and a clean allow.
+//
+// The boundary is the point: at the ceiling the metadata endpoint is denied as
+// an SSRF, and one layer beyond it the same payload was allowed with no
+// findings at all. Incomplete inspection must never present as clean.
+func TestHandler_DeeplyEncodedEmbeddedURLDoesNotAllow(t *testing.T) {
+	const metadataURL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+	encode := func(layers int) string {
+		payload := metadataURL
+		for range layers {
+			payload = url.QueryEscape(payload)
+		}
+		return payload
+	}
+
+	for _, tc := range []struct {
+		name   string
+		layers int
+	}{
+		{name: "at_ceiling_control", layers: 6},
+		{name: "one_past_ceiling", layers: 7},
+		{name: "far_past_ceiling", layers: 12},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			body := `{"kind":"dlp","input":{"text":"fetch ` + encode(tc.layers) + `"}}`
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/scan", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("code = %d, want 200; body = %s", w.Code, w.Body.String())
+			}
+			var resp Response
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.Decision != DecisionDeny {
+				t.Fatalf("decision = %q, want deny; a URL the scanner never finished decoding must not read as clean (findings=%+v)",
+					resp.Decision, resp.Findings)
+			}
+			if len(resp.Findings) == 0 {
+				t.Fatal("deny carried no findings; the operator needs to know why")
+			}
+		})
+	}
+}
+
+// TestHandler_OrdinaryEncodedContentStillAllows is the availability guard for
+// the truncation change. Making incomplete inspection deny is only safe if
+// ordinary content converges well inside the bounds. A benign URL, a couple of
+// encoding layers, and HTML entities must all still allow, or an operator turns
+// the Scan API off.
+func TestHandler_OrdinaryEncodedContentStillAllows(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "plain_prose", text: "please summarize the quarterly report"},
+		{name: "plain_url", text: "see https://docs.vendor.example/guide for details"},
+		{name: "single_encoded_url", text: "see " + url.QueryEscape("https://docs.vendor.example/guide?a=1&b=2")},
+		{name: "double_encoded_url", text: "see " + url.QueryEscape(url.QueryEscape("https://docs.vendor.example/guide"))},
+		{name: "html_entities", text: "see https://docs.vendor.example/guide?a=1&amp;b=2&amp;c=3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			payload, err := json.Marshal(map[string]any{
+				"kind":  "dlp",
+				"input": map[string]string{"text": tc.text},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/scan", strings.NewReader(string(payload)))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("code = %d, want 200; body = %s", w.Code, w.Body.String())
+			}
+			var resp Response
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if resp.Decision != DecisionAllow {
+				t.Fatalf("decision = %q, want allow for ordinary content; findings = %+v", resp.Decision, resp.Findings)
+			}
+		})
+	}
 }

--- a/internal/scanapi/scan.go
+++ b/internal/scanapi/scan.go
@@ -144,7 +144,8 @@ func scanEmbeddedTextURLs(ctx context.Context, sc *scanner.Scanner, text string)
 func embeddedHTTPURLTokens(text string, limit int) ([]string, bool) {
 	seen := make(map[string]struct{})
 	tokens := make([]string, 0, limit)
-	for _, view := range embeddedURLTextViews(text) {
+	views, viewsTruncated := embeddedURLTextViews(text)
+	for _, view := range views {
 		for _, raw := range embeddedHTTPURLTokenRe.FindAllString(view, -1) {
 			token := strings.TrimRight(raw, ".,;)]}")
 			if token == "" {
@@ -160,14 +161,24 @@ func embeddedHTTPURLTokens(text string, limit int) ([]string, bool) {
 			tokens = append(tokens, token)
 		}
 	}
-	return tokens, false
+	// A view-building bound that stopped early means the token list may be
+	// incomplete even when the token cap was never reached.
+	return tokens, viewsTruncated
 }
 
-func embeddedURLTextViews(text string) []string {
+// embeddedURLTextViews builds the decoded views the URL token matcher reads.
+// It returns truncated=true when either bound stopped it while more decoding
+// was still productive: the view cap, or the decode-pass budget. Both were
+// previously silent, so a URL wrapped past the ceiling yielded no token and the
+// caller reported a clean allow on content it had not finished inspecting. The
+// token-count cap already reported this way; these two now match it.
+func embeddedURLTextViews(text string) ([]string, bool) {
 	views := make([]string, 0, 4)
 	seen := make(map[string]struct{}, 4)
+	truncated := false
 	addView := func(view string) {
 		if len(views) >= maxEmbeddedURLTextViews {
+			truncated = true
 			return
 		}
 		if _, ok := seen[view]; ok {
@@ -185,6 +196,7 @@ func embeddedURLTextViews(text string) []string {
 	}
 	addView(text)
 
+	converged := false
 	for range maxEmbeddedURLDecodePasses {
 		startLen := len(views)
 		for _, view := range views[:startLen] {
@@ -202,10 +214,18 @@ func embeddedURLTextViews(text string) []string {
 			}
 		}
 		if len(views) == startLen {
+			// Nothing new decoded, so the payload is fully peeled. This is the
+			// normal exit and the only one that proves inspection completed.
+			converged = true
 			break
 		}
 	}
-	return views
+	if !converged {
+		// The pass budget ran out while the previous pass was still producing
+		// new views, so at least one more layer exists that was never read.
+		truncated = true
+	}
+	return views, truncated
 }
 
 func embeddedURLResultIsFinding(result scanner.Result) bool {

--- a/internal/scanapi/scan.go
+++ b/internal/scanapi/scan.go
@@ -176,22 +176,37 @@ func embeddedURLTextViews(text string) ([]string, bool) {
 	views := make([]string, 0, 4)
 	seen := make(map[string]struct{}, 4)
 	truncated := false
+	// addView records a view and, when that view carries escaped slashes, its
+	// slash-decoded form. Both are decided in ONE capacity check: the cap could
+	// otherwise fill between the two appends and drop the decoded form, which
+	// may be the first form containing a literal scheme. A view the bound
+	// refuses must set truncated rather than vanish, because the caller treats
+	// truncation as "inspection did not finish" and denies.
 	addView := func(view string) {
-		if len(views) >= maxEmbeddedURLTextViews {
-			truncated = true
+		if _, ok := seen[view]; ok {
 			return
 		}
-		if _, ok := seen[view]; ok {
+		slashDecoded := ""
+		if strings.Contains(view, `\/`) {
+			if decoded := strings.ReplaceAll(view, `\/`, `/`); decoded != view {
+				if _, dup := seen[decoded]; !dup {
+					slashDecoded = decoded
+				}
+			}
+		}
+		needed := 1
+		if slashDecoded != "" {
+			needed = 2
+		}
+		if len(views)+needed > maxEmbeddedURLTextViews {
+			truncated = true
 			return
 		}
 		seen[view] = struct{}{}
 		views = append(views, view)
-		if strings.Contains(view, `\/`) && len(views) < maxEmbeddedURLTextViews {
-			slashDecoded := strings.ReplaceAll(view, `\/`, `/`)
-			if _, ok := seen[slashDecoded]; !ok {
-				seen[slashDecoded] = struct{}{}
-				views = append(views, slashDecoded)
-			}
+		if slashDecoded != "" {
+			seen[slashDecoded] = struct{}{}
+			views = append(views, slashDecoded)
 		}
 	}
 	addView(text)
@@ -220,12 +235,39 @@ func embeddedURLTextViews(text string) ([]string, bool) {
 			break
 		}
 	}
-	if !converged {
-		// The pass budget ran out while the previous pass was still producing
-		// new views, so at least one more layer exists that was never read.
+	if !converged && anyViewDecodesFurther(views, seen) {
+		// The pass budget ran out AND a further pass would still produce a view
+		// nobody has seen, so a layer genuinely went unread. Exhausting the
+		// budget alone is not evidence of that: a payload can converge exactly
+		// on the final pass, having been fully decoded, and flagging that as
+		// truncated denies content the scanner actually finished inspecting.
 		truncated = true
 	}
 	return views, truncated
+}
+
+// anyViewDecodesFurther reports whether decoding the current views once more
+// would yield a view not already collected. It is a read-only probe: it does not
+// add views, so it answers "was inspection incomplete" without extending the
+// bound the caller chose.
+func anyViewDecodesFurther(views []string, seen map[string]struct{}) bool {
+	for _, view := range views {
+		if strings.Contains(view, "%") {
+			if decoded, err := url.PathUnescape(view); err == nil && decoded != view {
+				if _, ok := seen[decoded]; !ok {
+					return true
+				}
+			}
+		}
+		if strings.Contains(view, "&") {
+			if decoded := html.UnescapeString(view); decoded != view {
+				if _, ok := seen[decoded]; !ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func embeddedURLResultIsFinding(result scanner.Result) bool {


### PR DESCRIPTION
## What changed

The Scan API peels a bounded number of percent and HTML-entity passes looking for an embedded URL. The token-count cap already reported truncation and therefore denied, but the decode-pass budget and the view cap both stopped silently, so a URL wrapped past the ceiling produced no token, an empty result set, and a clean allow on content the scanner had not finished reading.

Measured boundary before the change: the same cloud metadata endpoint denied as an SSRF at six encoding layers and was allowed with zero findings at seven. Both bounds now report truncation, which the existing allow predicate already treats as a denial, so the rule that incomplete inspection cannot present as clean is applied uniformly instead of to one of three limits.

The reviewer should distrust that boundary in the availability direction. Too eager a truncation signal denies legitimate deeply-encoded payloads, which is the failure that gets the API switched off. Ordinary content converges well inside the bounds, and prose, a plain URL, singly and doubly encoded URLs, and HTML entities all still allow.

The view-cap half is fixed because it becomes the next bypass once the pass budget closes, but no test isolates it; a probe reached twelve of sixteen views and converged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanning of deeply encoded embedded URLs.
  * URLs exceeding supported decoding or inspection limits are now flagged for review instead of treated as clean.
  * Incomplete inspection caused by decoding, view-count, or entity-encoding limits is now reported accurately.
  * Preserved expected results for ordinary text, benign URLs, percent-encoded content, and HTML entities within supported limits.
  * Improved detection reliability when embedded URL content cannot be fully inspected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->