### PR TITLE
fix(setup): verify MCP wrapping by invocation, not marker

### DIFF
--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -175,6 +175,7 @@ func runClineInstall(cmd *cobra.Command, override string, dryRun bool, configFil
 			skipped++
 			continue
 		}
+		warnForeignWrapper(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, plan, err := wrapClineServer(server, exe, configFile, targetPath, name)
 		if err != nil {

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -268,6 +268,7 @@ func runClineRemove(cmd *cobra.Command, override string, dryRun bool) error {
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
 		if !isRestorableWrapper(server) {
+			warnUnrestorableWrapper(cmd.ErrOrStderr(), name, server)
 			continue
 		}
 

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -171,7 +171,7 @@ func runClineInstall(cmd *cobra.Command, override string, dryRun bool, configFil
 	skipped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if isVscodeWrapped(server) {
+		if isWrappedBySelf(server) {
 			skipped++
 			continue
 		}
@@ -267,7 +267,7 @@ func runClineRemove(cmd *cobra.Command, override string, dryRun bool) error {
 	unwrapped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if !isVscodeWrapped(server) {
+		if !isRestorableWrapper(server) {
 			continue
 		}
 

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -395,9 +395,10 @@ func unwrapCodexArgs(args []string) (origCmd string, origArgs []string, origURL 
 // codexInstallPlan is the precomputed action list for a server (preview-able
 // before any shell-out). One per input server.
 type codexInstallPlan struct {
-	Server   string
-	Action   string // codexActionWrapStdio, codexActionWrapURL, codexActionSkipWrapped, codexActionSkipUnsupported
-	Reason   string // human-readable detail; empty when not skipped
+	Server string
+	Action string // codexActionWrapStdio, codexActionWrapURL, codexActionSkipWrapped, codexActionSkipUnsupported
+	Reason string // human-readable detail; set when skipped, or when a wrap
+	// replaces a wrapper this binary cannot confirm
 	NewCmd   string
 	NewArgs  []string
 	Env      map[string]string
@@ -427,6 +428,7 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 			plans = append(plans, codexInstallPlan{
 				Server:   s.Name,
 				Action:   codexActionWrapStdio,
+				Reason:   foreignCodexWrapperReason(s),
 				NewCmd:   pipelockBin,
 				NewArgs:  wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile),
 				Env:      copyStringMap(s.Transport.Env),
@@ -436,6 +438,7 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 			plans = append(plans, codexInstallPlan{
 				Server:   s.Name,
 				Action:   codexActionWrapURL,
+				Reason:   foreignCodexWrapperReason(s),
 				NewCmd:   pipelockBin,
 				NewArgs:  wrapCodexURL(s.Transport.URL, configFile),
 				Original: s.Transport,
@@ -541,6 +544,9 @@ func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverr
 	for _, p := range plans {
 		switch p.Action {
 		case codexActionWrapStdio, codexActionWrapURL:
+			if p.Reason != "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: server %q %s\n", p.Server, p.Reason)
+			}
 			if dryRun {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 					"would wrap %s (%s): codex mcp add %s%s -- %s %s\n",
@@ -766,4 +772,17 @@ func joinArgs(args []string) string {
 		out += strconv.Quote(a)
 	}
 	return out
+}
+
+// foreignCodexWrapperReason describes an entry that runs proxy arguments through a
+// binary this one cannot confirm. Wrapping proceeds, so the result IS mediated;
+// the note exists so a false mediation claim is visible rather than silently
+// corrected, matching the warning the map-based installers emit.
+func foreignCodexWrapperReason(server codexMCPServer) string {
+	if classifyCodexWrapper(server) != stateForeignWrapper {
+		return ""
+	}
+	return fmt.Sprintf(
+		"runs %q with proxy arguments but that is not this pipelock binary; wrapping it, and remove-then-install for a single clean wrap",
+		server.Transport.Command)
 }

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -207,41 +207,46 @@ func parseCodexMCPList(data []byte) ([]codexMCPServer, error) {
 	return servers, nil
 }
 
-// isCodexWrapped reports whether a server's transport is already wrapped by
-// pipelock. Detection keys on the args prefix ["mcp", "proxy"] AND a binary
-// basename of "pipelock" (with optional suffix like "pipelock-dev"). This
-// matches both the current pipelock binary and any prior pipelock binary at
-// a different path - important so a rebuild at a new location does not
-// double-wrap servers on the next install.
+// classifyCodexWrapper answers the same question for a Codex transport that
+// classifyWrapper answers for the map-shaped configs, using the same file-identity
+// test so the two cannot drift apart.
 //
-// The basename check guards against the unlikely case of a non-pipelock tool
-// that also uses `mcp proxy` as its leading args. Operators who want to point
-// the wrap at an alternate binary should `pipelock codex remove` first and
-// then `pipelock codex install` from the new binary.
-func isCodexWrapped(server codexMCPServer, _ string) bool {
+// The previous form keyed on the args prefix AND a binary BASENAME of "pipelock".
+// That basename check is a fail-open, and its own comment described it as guarding
+// only the "unlikely case of a non-pipelock tool" while the real case is
+// deliberate: a config naming an attacker binary "pipelock" with leading
+// "mcp proxy" arguments was treated as already wrapped and skipped, so that binary
+// ran with nothing in front of it.
+func classifyCodexWrapper(server codexMCPServer) wrapperState {
 	if server.Transport.Type != codexTransportStdio {
-		return false
+		return stateNotWrapper
 	}
-	if !looksLikePipelockBinary(server.Transport.Command) {
-		return false
+	if len(server.Transport.Args) < 2 ||
+		server.Transport.Args[0] != codexMCP || server.Transport.Args[1] != codexMCPProxy {
+		return stateNotWrapper
 	}
-	if len(server.Transport.Args) < 2 {
-		return false
+	if isThisExecutable(server.Transport.Command) {
+		return stateSelf
 	}
-	return server.Transport.Args[0] == codexMCP && server.Transport.Args[1] == codexMCPProxy
+	return stateForeignWrapper
+}
+
+// isCodexWrappedBySelf reports a transport already mediated by this binary, the
+// only state an installer may skip.
+func isCodexWrappedBySelf(server codexMCPServer) bool {
+	return classifyCodexWrapper(server) == stateSelf
+}
+
+// isCodexRestorableWrapper reports a transport remove should unwrap. It accepts a
+// wrapper written by a pipelock at another path, so upgrading the binary does not
+// strand entries as permanently un-removable.
+func isCodexRestorableWrapper(server codexMCPServer) bool {
+	return classifyCodexWrapper(server) != stateNotWrapper
 }
 
 // looksLikePipelockBinary reports whether the command path is plausibly a
 // pipelock binary. Matches "pipelock", "pipelock.exe", and dev variants like
 // "pipelock-dev". Path is matched on basename so it is location-independent.
-func looksLikePipelockBinary(command string) bool {
-	if command == "" {
-		return false
-	}
-	base := filepath.Base(command)
-	base = strings.TrimSuffix(base, ".exe")
-	return base == pipelockBinaryName || strings.HasPrefix(base, pipelockBinaryName+"-")
-}
 
 func serverEnabled(server codexMCPServer) bool {
 	return server.Enabled == nil || *server.Enabled
@@ -407,7 +412,7 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 	for _, s := range servers {
 		unsupportedReason := unsupportedCodexInstallReason(s)
 		switch {
-		case isCodexWrapped(s, pipelockBin):
+		case isCodexWrappedBySelf(s):
 			plans = append(plans, codexInstallPlan{
 				Server: s.Name,
 				Action: codexActionSkipWrapped,
@@ -463,7 +468,7 @@ type codexRemovePlan struct {
 func planCodexRemove(servers []codexMCPServer, pipelockBin string) ([]codexRemovePlan, error) {
 	plans := make([]codexRemovePlan, 0, len(servers))
 	for _, s := range servers {
-		if !isCodexWrapped(s, pipelockBin) {
+		if !isCodexRestorableWrapper(s) {
 			plans = append(plans, codexRemovePlan{
 				Server: s.Name,
 				Action: codexActionSkipNotWrapped,

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -221,8 +221,7 @@ func classifyCodexWrapper(server codexMCPServer) wrapperState {
 	if server.Transport.Type != codexTransportStdio {
 		return stateNotWrapper
 	}
-	if len(server.Transport.Args) < 2 ||
-		server.Transport.Args[0] != codexMCP || server.Transport.Args[1] != codexMCPProxy {
+	if !argsBeginMCPProxy(server.Transport.Args) {
 		return stateNotWrapper
 	}
 	if isThisExecutable(server.Transport.Command) {
@@ -465,7 +464,7 @@ type codexRemovePlan struct {
 }
 
 // planCodexRemove computes the unwrap plan for each server. Pure function.
-func planCodexRemove(servers []codexMCPServer, pipelockBin string) ([]codexRemovePlan, error) {
+func planCodexRemove(servers []codexMCPServer) ([]codexRemovePlan, error) {
 	plans := make([]codexRemovePlan, 0, len(servers))
 	for _, s := range servers {
 		if !isCodexRestorableWrapper(s) {
@@ -579,16 +578,15 @@ func runCodexRemove(cmd *cobra.Command, dryRun bool, codexPathOverride string) e
 	if err != nil {
 		return err
 	}
-	pipelockBin, err := resolvePipelockBinary()
-	if err != nil {
-		return err
-	}
-
+	// Remove no longer resolves the pipelock binary. Identity now comes from
+	// os.Executable() inside the classifier, and requiring a PATH lookup here
+	// made remove fail for an operator whose pipelock had been moved, which is
+	// exactly when they most need to unwrap their editors.
 	servers, err := codexMCPList(cmd.Context(), codexBin)
 	if err != nil {
 		return err
 	}
-	plans, err := planCodexRemove(servers, pipelockBin)
+	plans, err := planCodexRemove(servers)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -154,7 +153,7 @@ func TestClassifyCodexWrapper(t *testing.T) {
 			want: stateNotWrapper,
 		},
 		{
-			name: "a path containing pipelock as a substring is not a wrapper",
+			name: "a path containing pipelock as a substring is a foreign wrapper",
 			server: codexMCPServer{Transport: codexMCPTransport{
 				Type: "stdio", Command: "/some/path/with-pipelock-in-name/run.sh",
 				Args: []string{"mcp", "proxy"},
@@ -576,7 +575,7 @@ func TestPlanCodexRemove(t *testing.T) {
 			},
 		},
 	}
-	plans, err := planCodexRemove(servers, pipelockBin)
+	plans, err := planCodexRemove(servers)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -617,7 +616,7 @@ func TestPlanCodexRemove_MalformedWrapErrors(t *testing.T) {
 			Args:    []string{"mcp", "proxy", "--config"}, // trailing flag
 		},
 	}}
-	_, err := planCodexRemove(servers, pipelockBin)
+	_, err := planCodexRemove(servers)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -684,7 +683,7 @@ func TestPlanCodexRemove_UnsupportedCodexStateErrors(t *testing.T) {
 				StartupTimeoutSec: tt.startupRaw,
 				ToolTimeoutSec:    tt.toolRaw,
 			}}
-			_, err := planCodexRemove(servers, pipelockBin)
+			_, err := planCodexRemove(servers)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -708,7 +707,7 @@ func TestPlanCodexRemove_DisabledServerErrors(t *testing.T) {
 			Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
 		},
 	}}
-	_, err := planCodexRemove(servers, pipelockBin)
+	_, err := planCodexRemove(servers)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -911,7 +910,7 @@ func TestRunCodexInstall_AlreadyWrappedSkipped(t *testing.T) {
 		"enabled": true,
 		"transport": {
 			"type": "stdio",
-			"command": ` + strconv.Quote(testSelfExe(t)) + `,
+			"command": ` + selfCommandJSON(t) + `,
 			"args": ["mcp", "proxy", "--", "node", "x.js"]
 		}
 	}]`
@@ -1528,4 +1527,16 @@ func testSelfExe(t *testing.T) string {
 		t.Fatalf("os.Executable: %v", err)
 	}
 	return self
+}
+
+// selfCommandJSON encodes this test binary's path as a JSON string. Go's quoting
+// and JSON's diverge on non-ASCII and non-printable bytes, so a JSON fixture uses
+// the JSON encoder even where a temp path happens to be plain ASCII.
+func selfCommandJSON(t *testing.T) string {
+	t.Helper()
+	encoded, err := json.Marshal(testSelfExe(t))
+	if err != nil {
+		t.Fatalf("marshal exe path: %v", err)
+	}
+	return string(encoded)
 }

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -106,89 +107,86 @@ func TestParseCodexMCPList(t *testing.T) {
 	}
 }
 
-func TestIsCodexWrapped(t *testing.T) {
-	tests := []struct {
-		name        string
-		server      codexMCPServer
-		pipelockBin string
-		want        bool
+func TestClassifyCodexWrapper(t *testing.T) {
+	// The binary that is genuinely mediating is the one running this test, since
+	// that is what an install writes into the config. A path merely NAMED pipelock
+	// is not: that basename check was the bypass this replaced.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		server codexMCPServer
+		want   wrapperState
 	}{
 		{
-			name: "stdio with pipelock + mcp proxy prefix is wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type:    "stdio",
-					Command: pipelockBin,
-					Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        true,
+			name: "this binary with the proxy subcommand is mediated",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: self,
+				Args: []string{"mcp", "proxy", "--", "node", "x.js"},
+			}},
+			want: stateSelf,
 		},
 		{
-			name: "stdio with pipelock but wrong subcommand is NOT wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type:    "stdio",
-					Command: pipelockBin,
-					Args:    []string{"run", "--config", "x.yaml"},
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        false,
+			name: "a binary merely named pipelock is a foreign wrapper, never mediated",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: "/usr/local/bin/pipelock",
+				Args: []string{"mcp", "proxy", "--", "node", "x.js"},
+			}},
+			want: stateForeignWrapper,
 		},
 		{
-			name: "stdio with different binary is NOT wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type:    "stdio",
-					Command: "/usr/bin/node",
-					Args:    []string{"mcp", "proxy"},
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        false,
+			name: "an attacker binary named pipelock in the project is a foreign wrapper",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: "./tools/pipelock",
+				Args: []string{"mcp", "proxy", "--", "whoami"},
+			}},
+			want: stateForeignWrapper,
 		},
 		{
-			name: "stdio command containing 'pipelock' substring is NOT wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type:    "stdio",
-					Command: "/some/path/with-pipelock-in-name/run.sh",
-					Args:    []string{"mcp", "proxy"},
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        false,
+			name: "this binary with the wrong subcommand is not a wrapper",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: self,
+				Args: []string{"run", "--config", "x.yaml"},
+			}},
+			want: stateNotWrapper,
 		},
 		{
-			name: "URL transport is NOT wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type: "streamable_http",
-					URL:  "https://api.example.com/mcp",
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        false,
+			name: "a path containing pipelock as a substring is not a wrapper",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: "/some/path/with-pipelock-in-name/run.sh",
+				Args: []string{"mcp", "proxy"},
+			}},
+			want: stateForeignWrapper,
 		},
 		{
-			name: "stdio with too-short args is NOT wrapped",
-			server: codexMCPServer{
-				Transport: codexMCPTransport{
-					Type:    "stdio",
-					Command: pipelockBin,
-					Args:    []string{"mcp"},
-				},
-			},
-			pipelockBin: pipelockBin,
-			want:        false,
+			name: "a URL transport is not a wrapper",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "streamable_http", URL: "https://api.vendor.example/mcp",
+			}},
+			want: stateNotWrapper,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isCodexWrapped(tt.server, tt.pipelockBin); got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
+		{
+			name: "too-short args are not a wrapper",
+			server: codexMCPServer{Transport: codexMCPTransport{
+				Type: "stdio", Command: self, Args: []string{"mcp"},
+			}},
+			want: stateNotWrapper,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyCodexWrapper(tc.server); got != tc.want {
+				t.Fatalf("classifyCodexWrapper = %v, want %v", got, tc.want)
+			}
+			// Only this binary may be skipped by an installer; a foreign wrapper
+			// must still be restorable so an upgrade can remove it.
+			if got := isCodexWrappedBySelf(tc.server); got != (tc.want == stateSelf) {
+				t.Fatalf("isCodexWrappedBySelf = %v, want %v", got, tc.want == stateSelf)
+			}
+			if got := isCodexRestorableWrapper(tc.server); got != (tc.want != stateNotWrapper) {
+				t.Fatalf("isCodexRestorableWrapper = %v, want %v", got, tc.want != stateNotWrapper)
 			}
 		})
 	}
@@ -377,7 +375,7 @@ func TestPlanCodexInstall(t *testing.T) {
 			Name: "already-wrapped",
 			Transport: codexMCPTransport{
 				Type:    "stdio",
-				Command: pipelockBin,
+				Command: testSelfExe(t),
 				Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
 			},
 		},
@@ -440,13 +438,20 @@ func TestPlanCodexInstall(t *testing.T) {
 	}
 }
 
-func TestPlanCodexInstall_DifferentPipelockBinIsSkipped(t *testing.T) {
-	// Server is wrapped with an OLDER pipelock binary path (e.g.,
-	// /tmp/pipelock-dev or a previous install location). A fresh install from
-	// a different pipelock binary must NOT re-wrap it - that would produce
-	// nested `pipelock proxy -- pipelock proxy -- node x.js` and break unwrap.
-	// Detection keys on basename "pipelock" + canonical args prefix, not on
-	// exact-match against the running pipelock path.
+func TestPlanCodexInstall_DifferentPipelockBinIsWrapped(t *testing.T) {
+	// A server wrapped by a pipelock at ANOTHER path is wrapped again rather than
+	// skipped, and that inverts what this test used to assert.
+	//
+	// The old behaviour keyed on a "pipelock" basename plus the canonical argument
+	// prefix, so it was location-independent and idempotent across paths. That is a
+	// fail-open: any config can name an attacker binary "pipelock" and be skipped,
+	// leaving it unmediated. Identity cannot be forged by naming, and the installer
+	// cannot prove that some other file called pipelock is pipelock.
+	//
+	// The cost is the nesting this test's original comment worried about. It is
+	// accepted deliberately: the result is still mediated by this binary, the
+	// installer warns, and the operator can remove-then-install for a single clean
+	// wrap. Normalising the nested invocation instead is tracked separately.
 	servers := []codexMCPServer{{
 		Name: "old-wrap",
 		Transport: codexMCPTransport{
@@ -459,8 +464,8 @@ func TestPlanCodexInstall_DifferentPipelockBinIsSkipped(t *testing.T) {
 	if len(plans) != 1 {
 		t.Fatalf("expected 1 plan, got %d", len(plans))
 	}
-	if plans[0].Action != codexActionSkipWrapped {
-		t.Errorf("expected skip-already-wrapped (idempotent across pipelock paths), got %q", plans[0].Action)
+	if plans[0].Action == codexActionSkipWrapped {
+		t.Errorf("a pipelock at another path was skipped; it cannot be proven to be pipelock, so it must be wrapped")
 	}
 }
 
@@ -540,30 +545,6 @@ func TestPlanCodexInstall_SkipsUnsupportedCodexState(t *testing.T) {
 		if plan.Reason == "" {
 			t.Errorf("%s missing skip reason", plan.Server)
 		}
-	}
-}
-
-func TestLooksLikePipelockBinary(t *testing.T) {
-	tests := []struct {
-		command string
-		want    bool
-	}{
-		{"/usr/local/bin/pipelock", true},
-		{"/tmp/pipelock-dev", true},
-		{"/opt/build/pipelock-rc1", true},
-		{"./pipelock.exe", true},
-		{"pipelock", true},
-		{"/usr/bin/node", false},
-		{"/some/path/with-pipelock-in-name/run.sh", false},
-		{"", false},
-		{"/usr/bin/pipelocker", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.command, func(t *testing.T) {
-			if got := looksLikePipelockBinary(tt.command); got != tt.want {
-				t.Errorf("looksLikePipelockBinary(%q) = %v, want %v", tt.command, got, tt.want)
-			}
-		})
 	}
 }
 
@@ -921,15 +902,16 @@ func TestRunCodexInstall_RealInstall(t *testing.T) {
 }
 
 func TestRunCodexInstall_AlreadyWrappedSkipped(t *testing.T) {
-	// Wrapped server's command is a "pipelock" basename at any path -
-	// detection is location-independent so a server wrapped by an earlier
-	// pipelock binary at a different path is still treated as already-wrapped.
+	// An already-wrapped server is one this binary actually mediates, so the
+	// fixture names the running executable. Detection is no longer
+	// location-independent: a "pipelock" basename at any path was forgeable, and a
+	// config naming an attacker binary that way was skipped and left unmediated.
 	listJSON := `[{
 		"name": "preWrapped",
 		"enabled": true,
 		"transport": {
 			"type": "stdio",
-			"command": "/some/prior/install/pipelock",
+			"command": ` + strconv.Quote(testSelfExe(t)) + `,
 			"args": ["mcp", "proxy", "--", "node", "x.js"]
 		}
 	}]`
@@ -1534,4 +1516,16 @@ func newCodexTestRoot() *cobra.Command {
 	root := &cobra.Command{Use: "pipelock"}
 	root.AddCommand(CodexCmd())
 	return root
+}
+
+// testSelfExe is the binary running the test, which is what an install writes into
+// a config. A fixture that means "already mediated" must name this, because a path
+// merely NAMED pipelock is a foreign wrapper and gets wrapped rather than skipped.
+func testSelfExe(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	return self
 }

--- a/internal/cli/setup/jetbrains.go
+++ b/internal/cli/setup/jetbrains.go
@@ -159,11 +159,11 @@ func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, confi
 	wrapped := 0
 	skipped := 0
 	for name, server := range cfg.Servers {
-		if isWrapped(server) {
+		if isWrappedBySelf(server) {
 			skipped++
 			continue
 		}
-		warnUnmediatedMarker(cmd.ErrOrStderr(), name, server)
+		warnForeignWrapper(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, err := wrapMCPServer(server, exe, resolvedConfig.Path, sandbox, workspace)
 		if err != nil {
@@ -239,7 +239,7 @@ func runJetbrainsRemove(cmd *cobra.Command, global, project, dryRun bool) error 
 
 	unwrapped := 0
 	for name, server := range cfg.Servers {
-		if !isWrapped(server) {
+		if !isRestorableWrapper(server) {
 			continue
 		}
 

--- a/internal/cli/setup/jetbrains.go
+++ b/internal/cli/setup/jetbrains.go
@@ -163,6 +163,7 @@ func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, confi
 			skipped++
 			continue
 		}
+		warnUnmediatedMarker(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, err := wrapMCPServer(server, exe, resolvedConfig.Path, sandbox, workspace)
 		if err != nil {

--- a/internal/cli/setup/jetbrains.go
+++ b/internal/cli/setup/jetbrains.go
@@ -240,6 +240,7 @@ func runJetbrainsRemove(cmd *cobra.Command, global, project, dryRun bool) error 
 	unwrapped := 0
 	for name, server := range cfg.Servers {
 		if !isRestorableWrapper(server) {
+			warnUnrestorableWrapper(cmd.ErrOrStderr(), name, server)
 			continue
 		}
 

--- a/internal/cli/setup/jetbrains_test.go
+++ b/internal/cli/setup/jetbrains_test.go
@@ -20,7 +20,6 @@ const (
 	testPipelockConf = "/etc/pipelock.yaml"
 	testSandboxFlag  = "--sandbox"
 	testEchoCmd      = "echo"
-	testWrappedJSON  = `{"mcpServers": {"srv": {"type": "stdio", "command": "pipelock", "args": ["mcp", "proxy", "--", "echo"], "_pipelock": {"original_type": "stdio", "original_command": "echo"}}}}`
 )
 
 func TestJetbrainsInstall_StdioServer(t *testing.T) {
@@ -173,8 +172,11 @@ func TestJetbrainsRemove_Unwrap(t *testing.T) {
 	}
 
 	for name, server := range mcpCfg.Servers {
-		if !isWrapped(server) {
-			t.Fatal("expected server to be wrapped")
+		// The remove path asks whether SOME pipelock wrapper is present, not
+		// whether this binary wrote it, so an entry from another install is still
+		// restorable.
+		if !isRestorableWrapper(server) {
+			t.Fatal("expected server to be a restorable wrapper")
 		}
 		restored, err := unwrapMCPServer(server)
 		if err != nil {
@@ -330,7 +332,7 @@ func TestRunJetbrainsRemove_DryRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wrapped := testWrappedJSON
+	wrapped := wrappedByThisBinaryJSON(t)
 	cfgPath := filepath.Join(junieDir, testMCPFilename)
 	if err := os.WriteFile(cfgPath, []byte(wrapped), 0o600); err != nil {
 		t.Fatal(err)
@@ -428,7 +430,7 @@ func TestRunJetbrainsInstall_AlreadyWrapped(t *testing.T) {
 	}
 
 	// Pre-wrapped config.
-	wrapped := testWrappedJSON
+	wrapped := wrappedByThisBinaryJSON(t)
 	cfgPath := filepath.Join(junieDir, testMCPFilename)
 	if err := os.WriteFile(cfgPath, []byte(wrapped), 0o600); err != nil {
 		t.Fatal(err)
@@ -459,7 +461,7 @@ func TestRunJetbrainsRemove_WritesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wrapped := testWrappedJSON
+	wrapped := wrappedByThisBinaryJSON(t)
 	cfgPath := filepath.Join(junieDir, testMCPFilename)
 	if err := os.WriteFile(cfgPath, []byte(wrapped), 0o600); err != nil {
 		t.Fatal(err)
@@ -831,21 +833,28 @@ func TestIsWrapped(t *testing.T) {
 	// beside a raw command, and treating it as proof made the installer skip the
 	// entry and leave its traffic unmediated.
 	markerOnly := map[string]interface{}{mcpFieldPipelock: map[string]interface{}{}}
-	if isWrapped(markerOnly) {
+	if isWrappedBySelf(markerOnly) {
 		t.Error("a bare _pipelock marker must not count as wrapped")
 	}
 
+	// The binary that genuinely mediates is the one running this test, because
+	// that is what an install writes into the config. A path merely NAMED pipelock
+	// is a foreign wrapper and must not be skipped.
+	self, selfErr := os.Executable()
+	if selfErr != nil {
+		t.Fatalf("os.Executable: %v", selfErr)
+	}
 	wrapped := map[string]interface{}{
-		mcpFieldCommand:  testPipelockExe,
+		mcpFieldCommand:  self,
 		mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", testEchoCmd},
 		mcpFieldPipelock: map[string]interface{}{},
 	}
-	if !isWrapped(wrapped) {
+	if !isWrappedBySelf(wrapped) {
 		t.Error("an entry invoking the pipelock MCP proxy must count as wrapped")
 	}
 
 	notWrapped := map[string]interface{}{mcpFieldCommand: testEchoCmd}
-	if isWrapped(notWrapped) {
+	if isWrappedBySelf(notWrapped) {
 		t.Error("expected not wrapped")
 	}
 }
@@ -962,7 +971,25 @@ func TestJetbrainsInstall_WarnsOnFalseCoverageClaim(t *testing.T) {
 		t.Fatalf("unmarshal result: %v", err)
 	}
 	server := result["mcpServers"]["forged"]
-	if !isWrapped(server) {
+	if !isWrappedBySelf(server) {
 		t.Fatalf("the forged entry was not wrapped, so its traffic stays unmediated: %+v", server)
 	}
+}
+
+// wrappedByThisBinaryJSON is a config whose server is genuinely mediated by the
+// binary running the test, which is what an install writes. The previous fixture
+// hardcoded a bare "pipelock" command; that is a FOREIGN wrapper under identity
+// checking, so an installer wraps it rather than skipping it.
+func wrappedByThisBinaryJSON(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	encoded, err := json.Marshal(self)
+	if err != nil {
+		t.Fatalf("marshal exe path: %v", err)
+	}
+	return `{"mcpServers": {"srv": {"type": "stdio", "command": ` + string(encoded) +
+		`, "args": ["mcp", "proxy", "--", "echo"], "_pipelock": {"original_type": "stdio", "original_command": "echo"}}}}`
 }

--- a/internal/cli/setup/jetbrains_test.go
+++ b/internal/cli/setup/jetbrains_test.go
@@ -826,9 +826,22 @@ func TestWrapMCPServer_SandboxSkippedForHTTP(t *testing.T) {
 }
 
 func TestIsWrapped(t *testing.T) {
-	wrapped := map[string]interface{}{mcpFieldPipelock: map[string]interface{}{}}
+	// A bare marker used to count as wrapped. It must not: the marker is a value
+	// this tool writes, so an attacker-authored project config can carry one
+	// beside a raw command, and treating it as proof made the installer skip the
+	// entry and leave its traffic unmediated.
+	markerOnly := map[string]interface{}{mcpFieldPipelock: map[string]interface{}{}}
+	if isWrapped(markerOnly) {
+		t.Error("a bare _pipelock marker must not count as wrapped")
+	}
+
+	wrapped := map[string]interface{}{
+		mcpFieldCommand:  testPipelockExe,
+		mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", testEchoCmd},
+		mcpFieldPipelock: map[string]interface{}{},
+	}
 	if !isWrapped(wrapped) {
-		t.Error("expected wrapped")
+		t.Error("an entry invoking the pipelock MCP proxy must count as wrapped")
 	}
 
 	notWrapped := map[string]interface{}{mcpFieldCommand: testEchoCmd}
@@ -892,4 +905,64 @@ func chdirTemp(t *testing.T, dir string) {
 			t.Errorf("failed to restore working directory: %v", err)
 		}
 	})
+}
+
+// TestJetbrainsInstall_WarnsOnFalseCoverageClaim drives a real install against an
+// entry that claims pipelock coverage it does not have: a _pipelock marker beside
+// a raw command. Deciding from the marker used to make the installer skip that
+// entry and leave its traffic unmediated, which is the bypass this predicate
+// closes. The entry must now be wrapped, so it ends up mediated, and the operator
+// must be told the claim was false rather than having it silently corrected.
+func TestJetbrainsInstall_WarnsOnFalseCoverageClaim(t *testing.T) {
+	dir := t.TempDir()
+	junieDir := filepath.Join(dir, ".junie", "mcp")
+	if err := os.MkdirAll(junieDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"forged": map[string]interface{}{
+				"command":   testEchoCmd,
+				"args":      []interface{}{"--serve"},
+				"_pipelock": map[string]interface{}{"original_type": "stdio"},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(junieDir, testMCPFilename), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+	t.Chdir(dir)
+
+	cmd := jetbrainsInstallCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--project"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install: %v\nstdout: %s\nstderr: %s", err, out.String(), errOut.String())
+	}
+
+	if !strings.Contains(errOut.String(), "carries pipelock metadata but does not run through the proxy") {
+		t.Fatalf("install did not warn about the false coverage claim; stderr = %q", errOut.String())
+	}
+
+	written, err := os.ReadFile(filepath.Clean(filepath.Join(junieDir, testMCPFilename)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]map[string]map[string]interface{}
+	if err := json.Unmarshal(written, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	server := result["mcpServers"]["forged"]
+	if !isWrapped(server) {
+		t.Fatalf("the forged entry was not wrapped, so its traffic stays unmediated: %+v", server)
+	}
 }

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -284,18 +284,46 @@ func isWrappedBySelf(server map[string]interface{}) bool {
 	return classifyWrapper(server) == stateSelf
 }
 
-// isRestorableWrapper reports whether an entry looks like a pipelock wrapper that
-// remove should unwrap. It deliberately accepts a FOREIGN wrapper as well as this
+// isRestorableWrapper reports whether an entry is a pipelock wrapper that remove
+// can actually put back. It deliberately accepts a FOREIGN wrapper as well as this
 // binary, because requiring identity here would strand every entry wrapped by an
 // earlier pipelock installed at a different path: an operator who upgrades could
 // never remove them.
 //
-// That looseness is safe for choosing WHICH entries to restore and is not safe for
-// everything the restore then does. In particular a metadata-supplied deletion
-// target must never be honoured; see the header-sidecar note in the VS Code
-// removal path.
+// It does REQUIRE the restoration metadata, because restoration is driven entirely
+// by that metadata. Accepting a proxy-shaped entry without it produced a false
+// success: unwrapMCPServer returns such an entry unchanged, so remove counted it,
+// rewrote the config and the backup, and reported an unwrap that never happened
+// while the server stayed routed through someone else's proxy. On a security tool
+// a wrong success report is worse than a refusal, so this refuses and the caller
+// says why.
+//
+// The looseness that remains is safe for choosing WHICH entries to restore and is
+// not safe for everything the restore then does. In particular a metadata-supplied
+// deletion target must never be honoured; see the header-sidecar note in the VS
+// Code removal path.
 func isRestorableWrapper(server map[string]interface{}) bool {
+	if _, ok := server[mcpFieldPipelock]; !ok {
+		return false
+	}
 	return classifyWrapper(server) != stateNotWrapper
+}
+
+// warnUnrestorableWrapper tells the operator about an entry that runs through a
+// proxy but carries no record of what it replaced. Remove skips it, and staying
+// silent would read as nothing having been wrapped, when the truth is that the
+// entry is wrapped and cannot be put back.
+func warnUnrestorableWrapper(w io.Writer, name string, server map[string]interface{}) {
+	if _, ok := server[mcpFieldPipelock]; ok {
+		return
+	}
+	if classifyWrapper(server) == stateNotWrapper {
+		return
+	}
+	binary, _ := serverInvocation(server)
+	_, _ = fmt.Fprintf(w,
+		"warning: server %q runs %q with proxy arguments but carries no pipelock metadata, so the original command is unknown; leaving it unchanged, restore it by hand\n",
+		name, binary)
 }
 
 // isThisExecutable reports whether a command names the binary running right now,
@@ -378,25 +406,3 @@ func commandArgStrings(v interface{}) []string {
 		return interfaceSliceToStrings(v)
 	}
 }
-
-// looksLikeWrapperBinary reports whether a command is a pipelock binary that
-// could be mediating this entry. It accepts the pipelock basename, matching
-// isCodexWrapped so a rebuild at a different path does not cause double
-// wrapping, and it also accepts the currently running executable by path.
-//
-// The second case matters because the wrapper writes os.Executable() into the
-// config, and that binary is not always named "pipelock": it is the test binary
-// under test, and it can be a renamed build in the field. An entry invoking THIS
-// executable with the proxy subcommand is mediated by definition, so accepting it
-// adds no trust that basename matching did not already grant.
-
-// warnUnmediatedMarker tells the operator that an entry claimed pipelock coverage
-// it does not have. The entry is still wrapped by the caller, so it ends up
-// mediated; the warning exists so a false claim is visible rather than silently
-// corrected. Shared by every installer so the wording cannot drift.
-
-// hasUnmediatedPipelockMarker reports an entry that claims to be wrapped but is
-// not: a _pipelock marker beside an invocation that does not go through the
-// proxy. The installer wraps such an entry rather than skipping it, so the
-// server ends up mediated, and warns so the operator sees that the claim was
-// false rather than having it silently corrected.

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -233,48 +233,136 @@ func unwrapMCPServer(server map[string]interface{}) (map[string]interface{}, err
 	return result, nil
 }
 
-// isWrapped reports whether a server entry is actually mediated by the pipelock
-// MCP proxy.
+// wrapperState is how an MCP server entry relates to this pipelock binary. A
+// single boolean cannot serve both callers: install asks whether THIS executable
+// will mediate the traffic, and remove asks whether some pipelock wrapper can be
+// migrated away. Answering both with one predicate is what allowed a forged entry
+// to be skipped, or would strand an older wrapper permanently.
+type wrapperState int
+
+const (
+	// stateNotWrapper is an entry that does not invoke the MCP proxy at all.
+	stateNotWrapper wrapperState = iota
+	// stateSelf invokes the proxy with the binary running right now, so its
+	// traffic is mediated by this executable. Only this state may be skipped.
+	stateSelf
+	// stateForeignWrapper is shaped like a proxy invocation run by some other
+	// binary. That may be a pipelock built at a different path, or an
+	// attacker-authored config naming its own binary "pipelock". The installer
+	// cannot tell those apart and must not skip either.
+	stateForeignWrapper
+)
+
+// classifyWrapper decides which state an entry is in from its own invocation.
 //
-// It deliberately does NOT decide this from the presence of the _pipelock
-// marker. That marker is a value this tool writes, so an attacker-authored
-// project config can carry one beside a raw command; treating it as proof made
-// the installer report "already wrapped", skip the entry, and leave its traffic
-// unmediated, which is the outcome wrapping exists to prevent.
-//
-// The invocation is the evidence instead, and the shape of that evidence is
-// already established for the Codex integration by isCodexWrapped: the command
-// must look like a pipelock binary AND its arguments must begin "mcp proxy".
-// Arguments alone are not proof, because an attacker can put those arguments in
-// front of their own binary.
-//
-// The marker is also not REQUIRED here, on purpose. An entry whose invocation
-// already goes through the proxy must keep reporting as wrapped even if its
-// marker was removed, because re-wrapping it would nest one proxy inside
-// another.
-func isWrapped(server map[string]interface{}) bool {
-	return invokesMCPProxy(server)
+// The binary is compared by FILE IDENTITY, not by name. A basename check was the
+// original form and is a fail-open: any project config can name an
+// attacker-controlled binary "pipelock", add leading "mcp proxy" arguments, and be
+// skipped by the installer, leaving that binary running with nothing in front of
+// it. Reproduced before this changed, for both a relative ./tools/pipelock and a
+// bare PATH-resolved pipelock.
+func classifyWrapper(server map[string]interface{}) wrapperState {
+	binary, args := serverInvocation(server)
+	if binary == "" || !argsBeginMCPProxy(args) {
+		return stateNotWrapper
+	}
+	if isThisExecutable(binary) {
+		return stateSelf
+	}
+	return stateForeignWrapper
 }
 
-// invokesMCPProxy reports whether a server entry's own invocation runs the
-// pipelock MCP proxy. Two config shapes exist and both are handled: a command
-// string with a separate args array, and OpenCode's single command array where
-// the binary is element zero.
-func invokesMCPProxy(server map[string]interface{}) bool {
+// isWrappedBySelf reports whether an entry is already mediated by this binary. It
+// is the ONLY condition under which an installer may skip an entry, because it is
+// the only one that establishes the traffic is actually mediated.
+//
+// The _pipelock marker is deliberately not consulted. It is a value this tool
+// writes, so treating its presence as proof let a forged config be skipped. The
+// marker is also not REQUIRED: an entry already invoking this binary through the
+// proxy stays skipped with its marker removed, rather than being wrapped twice.
+func isWrappedBySelf(server map[string]interface{}) bool {
+	return classifyWrapper(server) == stateSelf
+}
+
+// isRestorableWrapper reports whether an entry looks like a pipelock wrapper that
+// remove should unwrap. It deliberately accepts a FOREIGN wrapper as well as this
+// binary, because requiring identity here would strand every entry wrapped by an
+// earlier pipelock installed at a different path: an operator who upgrades could
+// never remove them.
+//
+// That looseness is safe for choosing WHICH entries to restore and is not safe for
+// everything the restore then does. In particular a metadata-supplied deletion
+// target must never be honoured; see the header-sidecar note in the VS Code
+// removal path.
+func isRestorableWrapper(server map[string]interface{}) bool {
+	return classifyWrapper(server) != stateNotWrapper
+}
+
+// isThisExecutable reports whether a command names the binary running right now,
+// compared by file identity rather than by name. A bare command that does not
+// resolve to a file is refused, which is correct: the installer cannot prove what
+// a PATH lookup will find when the editor launches.
+//
+// This establishes filesystem identity and nothing more. It does not prove binary
+// provenance or contents, and it cannot prevent the file changing between this
+// check and the editor's launch.
+func isThisExecutable(command string) bool {
+	if command == "" {
+		return false
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	selfInfo, err := os.Stat(self)
+	if err != nil {
+		return false
+	}
+	commandInfo, err := os.Stat(command)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(selfInfo, commandInfo)
+}
+
+// serverInvocation reads the binary and its arguments out of either config shape:
+// a command string with a separate args array, or OpenCode's single command array
+// where the binary is element zero.
+func serverInvocation(server map[string]interface{}) (binary string, args []string) {
 	if command, ok := server[mcpFieldCommand].(string); ok {
-		return looksLikeWrapperBinary(command) &&
-			argsBeginMCPProxy(commandArgStrings(server[mcpFieldArgs]))
+		return command, commandArgStrings(server[mcpFieldArgs])
 	}
 	if command := commandArgStrings(server[mcpFieldCommand]); len(command) > 0 {
-		return looksLikeWrapperBinary(command[0]) && argsBeginMCPProxy(command[1:])
+		return command[0], command[1:]
 	}
-	return false
+	return "", nil
 }
 
 // argsBeginMCPProxy reports whether an argument list starts the MCP proxy
 // subcommand.
 func argsBeginMCPProxy(args []string) bool {
 	return len(args) >= 2 && args[0] == mcpSubcommand && args[1] == proxySubcommand
+}
+
+// warnForeignWrapper tells the operator that an entry claimed mediation this
+// binary cannot confirm. The caller wraps it regardless, so the result IS
+// mediated; the warning exists so a false claim is visible rather than silently
+// corrected, and so an operator who upgraded pipelock knows why an entry is being
+// wrapped again.
+func warnForeignWrapper(w io.Writer, name string, server map[string]interface{}) {
+	switch classifyWrapper(server) {
+	case stateForeignWrapper:
+		binary, _ := serverInvocation(server)
+		_, _ = fmt.Fprintf(w,
+			"warning: server %q runs %q with proxy arguments but that is not this pipelock binary; wrapping it, and remove-then-install for a single clean wrap\n",
+			name, binary)
+	case stateNotWrapper:
+		if _, marked := server[mcpFieldPipelock]; marked {
+			_, _ = fmt.Fprintf(w,
+				"warning: server %q carries pipelock metadata but does not run through the proxy; wrapping it\n", name)
+		}
+	case stateSelf:
+	}
 }
 
 // commandArgStrings reads an argument list that may be either shape. A config
@@ -301,47 +389,14 @@ func commandArgStrings(v interface{}) []string {
 // under test, and it can be a renamed build in the field. An entry invoking THIS
 // executable with the proxy subcommand is mediated by definition, so accepting it
 // adds no trust that basename matching did not already grant.
-func looksLikeWrapperBinary(command string) bool {
-	if command == "" {
-		return false
-	}
-	if looksLikePipelockBinary(command) {
-		return true
-	}
-	self, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	if resolved, linkErr := filepath.EvalSymlinks(self); linkErr == nil {
-		self = resolved
-	}
-	if command == self {
-		return true
-	}
-	resolvedCommand, err := filepath.EvalSymlinks(command)
-	return err == nil && resolvedCommand == self
-}
 
 // warnUnmediatedMarker tells the operator that an entry claimed pipelock coverage
 // it does not have. The entry is still wrapped by the caller, so it ends up
 // mediated; the warning exists so a false claim is visible rather than silently
 // corrected. Shared by every installer so the wording cannot drift.
-func warnUnmediatedMarker(w io.Writer, name string, server map[string]interface{}) {
-	if !hasUnmediatedPipelockMarker(server) {
-		return
-	}
-	_, _ = fmt.Fprintf(w,
-		"warning: server %q carries pipelock metadata but does not run through the proxy; wrapping it\n", name)
-}
 
 // hasUnmediatedPipelockMarker reports an entry that claims to be wrapped but is
 // not: a _pipelock marker beside an invocation that does not go through the
 // proxy. The installer wraps such an entry rather than skipping it, so the
 // server ends up mediated, and warns so the operator sees that the claim was
 // false rather than having it silently corrected.
-func hasUnmediatedPipelockMarker(server map[string]interface{}) bool {
-	if _, ok := server[mcpFieldPipelock]; !ok {
-		return false
-	}
-	return !invokesMCPProxy(server)
-}

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -14,6 +15,8 @@ import (
 const (
 	mcpFieldCommand  = "command"
 	mcpFieldArgs     = "args"
+	mcpSubcommand    = "mcp"
+	proxySubcommand  = "proxy"
 	mcpFieldURL      = "url"
 	mcpFieldHeaders  = "headers"
 	mcpFieldType     = "type"
@@ -230,8 +233,115 @@ func unwrapMCPServer(server map[string]interface{}) (map[string]interface{}, err
 	return result, nil
 }
 
-// isWrapped returns true if a server entry has pipelock metadata.
+// isWrapped reports whether a server entry is actually mediated by the pipelock
+// MCP proxy.
+//
+// It deliberately does NOT decide this from the presence of the _pipelock
+// marker. That marker is a value this tool writes, so an attacker-authored
+// project config can carry one beside a raw command; treating it as proof made
+// the installer report "already wrapped", skip the entry, and leave its traffic
+// unmediated, which is the outcome wrapping exists to prevent.
+//
+// The invocation is the evidence instead, and the shape of that evidence is
+// already established for the Codex integration by isCodexWrapped: the command
+// must look like a pipelock binary AND its arguments must begin "mcp proxy".
+// Arguments alone are not proof, because an attacker can put those arguments in
+// front of their own binary.
+//
+// The marker is also not REQUIRED here, on purpose. An entry whose invocation
+// already goes through the proxy must keep reporting as wrapped even if its
+// marker was removed, because re-wrapping it would nest one proxy inside
+// another.
 func isWrapped(server map[string]interface{}) bool {
-	_, ok := server[mcpFieldPipelock]
-	return ok
+	return invokesMCPProxy(server)
+}
+
+// invokesMCPProxy reports whether a server entry's own invocation runs the
+// pipelock MCP proxy. Two config shapes exist and both are handled: a command
+// string with a separate args array, and OpenCode's single command array where
+// the binary is element zero.
+func invokesMCPProxy(server map[string]interface{}) bool {
+	if command, ok := server[mcpFieldCommand].(string); ok {
+		return looksLikeWrapperBinary(command) &&
+			argsBeginMCPProxy(commandArgStrings(server[mcpFieldArgs]))
+	}
+	if command := commandArgStrings(server[mcpFieldCommand]); len(command) > 0 {
+		return looksLikeWrapperBinary(command[0]) && argsBeginMCPProxy(command[1:])
+	}
+	return false
+}
+
+// argsBeginMCPProxy reports whether an argument list starts the MCP proxy
+// subcommand.
+func argsBeginMCPProxy(args []string) bool {
+	return len(args) >= 2 && args[0] == mcpSubcommand && args[1] == proxySubcommand
+}
+
+// commandArgStrings reads an argument list that may be either shape. A config
+// decoded from JSON yields []interface{}, while an entry produced in-process by
+// wrapMCPServer holds []string. Reading only the first shape made a freshly
+// wrapped entry look unwrapped to any in-process caller, which would double-wrap
+// it on the next pass.
+func commandArgStrings(v interface{}) []string {
+	switch typed := v.(type) {
+	case []string:
+		return typed
+	default:
+		return interfaceSliceToStrings(v)
+	}
+}
+
+// looksLikeWrapperBinary reports whether a command is a pipelock binary that
+// could be mediating this entry. It accepts the pipelock basename, matching
+// isCodexWrapped so a rebuild at a different path does not cause double
+// wrapping, and it also accepts the currently running executable by path.
+//
+// The second case matters because the wrapper writes os.Executable() into the
+// config, and that binary is not always named "pipelock": it is the test binary
+// under test, and it can be a renamed build in the field. An entry invoking THIS
+// executable with the proxy subcommand is mediated by definition, so accepting it
+// adds no trust that basename matching did not already grant.
+func looksLikeWrapperBinary(command string) bool {
+	if command == "" {
+		return false
+	}
+	if looksLikePipelockBinary(command) {
+		return true
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	if resolved, linkErr := filepath.EvalSymlinks(self); linkErr == nil {
+		self = resolved
+	}
+	if command == self {
+		return true
+	}
+	resolvedCommand, err := filepath.EvalSymlinks(command)
+	return err == nil && resolvedCommand == self
+}
+
+// warnUnmediatedMarker tells the operator that an entry claimed pipelock coverage
+// it does not have. The entry is still wrapped by the caller, so it ends up
+// mediated; the warning exists so a false claim is visible rather than silently
+// corrected. Shared by every installer so the wording cannot drift.
+func warnUnmediatedMarker(w io.Writer, name string, server map[string]interface{}) {
+	if !hasUnmediatedPipelockMarker(server) {
+		return
+	}
+	_, _ = fmt.Fprintf(w,
+		"warning: server %q carries pipelock metadata but does not run through the proxy; wrapping it\n", name)
+}
+
+// hasUnmediatedPipelockMarker reports an entry that claims to be wrapped but is
+// not: a _pipelock marker beside an invocation that does not go through the
+// proxy. The installer wraps such an entry rather than skipping it, so the
+// server ends up mediated, and warns so the operator sees that the claim was
+// false rather than having it silently corrected.
+func hasUnmediatedPipelockMarker(server map[string]interface{}) bool {
+	if _, ok := server[mcpFieldPipelock]; !ok {
+		return false
+	}
+	return !invokesMCPProxy(server)
 }

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -309,21 +309,35 @@ func isRestorableWrapper(server map[string]interface{}) bool {
 	return classifyWrapper(server) != stateNotWrapper
 }
 
-// warnUnrestorableWrapper tells the operator about an entry that runs through a
-// proxy but carries no record of what it replaced. Remove skips it, and staying
-// silent would read as nothing having been wrapped, when the truth is that the
-// entry is wrapped and cannot be put back.
+// warnUnrestorableWrapper explains why remove is leaving an entry alone. There
+// are two distinct causes and both were silent, which reads to the operator as
+// nothing having been wrapped:
+//
+//   - proxy-shaped with no metadata: the entry IS mediated but nothing records
+//     what it replaced, so it cannot be put back automatically.
+//   - metadata on an entry that is not proxy-shaped: the marker is false. The
+//     entry is not mediated, so remove has nothing to undo, and the operator
+//     should learn the claim was bogus rather than trusting it.
+//
+// The second case is the same forged-marker shape this change stopped trusting on
+// the install path. Suppressing its warning here reintroduced a silent wrong
+// answer on the removal path, which is why the causes are separated rather than
+// sharing one condition.
 func warnUnrestorableWrapper(w io.Writer, name string, server map[string]interface{}) {
-	if _, ok := server[mcpFieldPipelock]; ok {
-		return
-	}
-	if classifyWrapper(server) == stateNotWrapper {
-		return
-	}
+	_, marked := server[mcpFieldPipelock]
+	proxyShaped := classifyWrapper(server) != stateNotWrapper
 	binary, _ := serverInvocation(server)
-	_, _ = fmt.Fprintf(w,
-		"warning: server %q runs %q with proxy arguments but carries no pipelock metadata, so the original command is unknown; leaving it unchanged, restore it by hand\n",
-		name, binary)
+
+	switch {
+	case proxyShaped && !marked:
+		_, _ = fmt.Fprintf(w,
+			"warning: server %q runs %q with proxy arguments but carries no pipelock metadata, so the original command is unknown; leaving it unchanged, restore it by hand\n",
+			name, binary)
+	case marked && !proxyShaped:
+		_, _ = fmt.Fprintf(w,
+			"warning: server %q carries pipelock metadata but runs %q without the proxy, so the metadata is not describing a real wrap; leaving it unchanged, and nothing needs removing\n",
+			name, binary)
+	}
 }
 
 // isThisExecutable reports whether a command names the binary running right now,

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -222,3 +222,87 @@ func TestWarnForeignWrapper(t *testing.T) {
 		})
 	}
 }
+
+// TestIsRestorableWrapper_RefusesEntryWithoutRestorationMetadata pins the pairing
+// between the predicate that SELECTS entries for removal and the function that
+// restores them. Restoration is driven entirely by the _pipelock metadata, so a
+// proxy-shaped entry without it cannot be put back.
+//
+// Selecting one anyway produced a false success rather than a visible failure:
+// unwrapMCPServer returns such an entry unchanged, so remove incremented its
+// count, rewrote the config and the backup, and told the operator it had
+// unwrapped a server that was still routed through someone else's proxy. The
+// assertion is on the PAIRING, not on either half, because each half is correct
+// alone and only the combination lies.
+func TestIsRestorableWrapper_RefusesEntryWithoutRestorationMetadata(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		command string
+	}{
+		{name: "wrapped by this binary", command: self},
+		{name: "wrapped by a pipelock at another path", command: "/other/bin/pipelock"},
+		{name: "wrapped by an attacker binary in the project", command: "./tools/pipelock"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := map[string]interface{}{
+				mcpFieldCommand: tc.command,
+				mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "node", "x.js"},
+			}
+			if classifyWrapper(server) == stateNotWrapper {
+				t.Fatalf("fixture is not proxy-shaped, so it does not exercise the case")
+			}
+			if isRestorableWrapper(server) {
+				t.Fatalf("selected for restore with no metadata to restore from")
+			}
+
+			// The other half of the pairing: had it been selected, the restore
+			// would have been a no-op reported as a success.
+			restored, err := unwrapMCPServer(server)
+			if err != nil {
+				t.Fatalf("unwrapMCPServer: %v", err)
+			}
+			if restored[mcpFieldCommand] != tc.command {
+				t.Fatalf("unwrapMCPServer restored something; this test no longer describes the code")
+			}
+		})
+	}
+}
+
+// TestWarnUnrestorableWrapper_TellsOperatorWhyNothingHappened covers the
+// availability direction of the refusal above. Refusing silently would read as
+// "nothing was wrapped" when the truth is "this is wrapped and I cannot put it
+// back", which leaves the operator with no way to act.
+func TestWarnUnrestorableWrapper_TellsOperatorWhyNothingHappened(t *testing.T) {
+	var buf bytes.Buffer
+	warnUnrestorableWrapper(&buf, "orphaned", map[string]interface{}{
+		mcpFieldCommand: "/other/bin/pipelock",
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "node", "x.js"},
+	})
+	got := buf.String()
+	for _, want := range []string{"orphaned", "/other/bin/pipelock", "no pipelock metadata", "by hand"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning omitted %q: %s", want, got)
+		}
+	}
+
+	// A genuine wrapper and an ordinary server both stay silent, so the warning
+	// does not become noise on every remove.
+	buf.Reset()
+	warnUnrestorableWrapper(&buf, "genuine", map[string]interface{}{
+		mcpFieldCommand:  "/other/bin/pipelock",
+		mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", "node", "x.js"},
+		mcpFieldPipelock: map[string]interface{}{"original_type": "stdio", "original_command": "node"},
+	})
+	warnUnrestorableWrapper(&buf, "ordinary", map[string]interface{}{
+		mcpFieldCommand: "node",
+		mcpFieldArgs:    []interface{}{"x.js"},
+	})
+	if buf.Len() != 0 {
+		t.Fatalf("warned about an entry that needs no warning: %s", buf.String())
+	}
+}

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -304,5 +305,78 @@ func TestWarnUnrestorableWrapper_TellsOperatorWhyNothingHappened(t *testing.T) {
 	})
 	if buf.Len() != 0 {
 		t.Fatalf("warned about an entry that needs no warning: %s", buf.String())
+	}
+}
+
+// TestInstallersWarnOnForeignWrapper_AllSurfaces pins the warning to every
+// installer rather than to the shared helper. The helper being correct is not the
+// property that matters; every install path CALLING it is, and the original marker
+// bypass survived in five integrations at once precisely because each surface was
+// wired separately. A structural check is used because a behavioural test per
+// installer would still silently pass for a surface nobody thought to add.
+func TestInstallersWarnOnForeignWrapper_AllSurfaces(t *testing.T) {
+	// Every map-based installer skips with isWrappedBySelf and must warn.
+	for _, fn := range []string{"cline.go", "jetbrains.go", "opencode.go", "vscode.go", "zed.go"} {
+		src, err := os.ReadFile(filepath.Clean(fn))
+		if err != nil {
+			t.Fatalf("reading %s: %v", fn, err)
+		}
+		text := string(src)
+		if !strings.Contains(text, "isWrappedBySelf(server)") {
+			t.Fatalf("%s no longer gates install on isWrappedBySelf; this test needs updating", fn)
+		}
+		if !strings.Contains(text, "warnForeignWrapper(cmd.ErrOrStderr()") {
+			t.Fatalf("%s skips a foreign wrapper without warning, so a false mediation claim is invisible there", fn)
+		}
+		if !strings.Contains(text, "warnUnrestorableWrapper(cmd.ErrOrStderr()") {
+			t.Fatalf("%s removes without reporting an entry it cannot restore", fn)
+		}
+	}
+
+	// Codex builds a plan rather than writing directly, so it carries the note on
+	// the plan and prints it in the execution loop.
+	src, err := os.ReadFile(filepath.Clean("codex.go"))
+	if err != nil {
+		t.Fatalf("reading codex.go: %v", err)
+	}
+	if !strings.Contains(string(src), "foreignCodexWrapperReason(s)") {
+		t.Fatalf("codex install no longer records the foreign-wrapper note")
+	}
+}
+
+// TestForeignCodexWrapperReason covers the note itself in both directions: it
+// fires for a wrapper this binary cannot confirm and stays quiet otherwise, so it
+// does not become noise on every codex install.
+func TestForeignCodexWrapperReason(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	foreign := codexMCPServer{Transport: codexMCPTransport{
+		Type: "stdio", Command: "/other/bin/pipelock",
+		Args: []string{"mcp", "proxy", "--", "node", "x.js"},
+	}}
+	reason := foreignCodexWrapperReason(foreign)
+	if !strings.Contains(reason, "/other/bin/pipelock") || !strings.Contains(reason, "not this pipelock binary") {
+		t.Fatalf("note does not name the binary or the problem: %q", reason)
+	}
+
+	for _, quiet := range []struct {
+		name   string
+		server codexMCPServer
+	}{
+		{name: "mediated by this binary", server: codexMCPServer{Transport: codexMCPTransport{
+			Type: "stdio", Command: self, Args: []string{"mcp", "proxy", "--", "node", "x.js"},
+		}}},
+		{name: "an ordinary server", server: codexMCPServer{Transport: codexMCPTransport{
+			Type: "stdio", Command: "node", Args: []string{"x.js"},
+		}}},
+	} {
+		t.Run(quiet.name, func(t *testing.T) {
+			if got := foreignCodexWrapperReason(quiet.server); got != "" {
+				t.Fatalf("warned where nothing is wrong: %q", got)
+			}
+		})
 	}
 }

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -291,6 +291,24 @@ func TestWarnUnrestorableWrapper_TellsOperatorWhyNothingHappened(t *testing.T) {
 		}
 	}
 
+	// A forged marker on a command that never reaches the proxy is the OTHER
+	// unrestorable cause, and it was silent: it shares "cannot restore" with the
+	// case above but for the opposite reason, so one condition could not cover
+	// both. Staying quiet here reintroduced on the removal path exactly the
+	// forged-marker trust this change removed from the install path.
+	buf.Reset()
+	warnUnrestorableWrapper(&buf, "forged", map[string]interface{}{
+		mcpFieldCommand:  "node",
+		mcpFieldArgs:     []interface{}{"x.js"},
+		mcpFieldPipelock: map[string]interface{}{"original_type": "stdio", "original_command": "node"},
+	})
+	got = buf.String()
+	for _, want := range []string{"forged", "without the proxy", "nothing needs removing"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("forged-marker warning omitted %q: %s", want, got)
+		}
+	}
+
 	// A genuine wrapper and an ordinary server both stay silent, so the warning
 	// does not become noise on every remove.
 	buf.Reset()

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -4,6 +4,9 @@
 package setup
 
 import (
+	"bytes"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -18,9 +21,13 @@ import (
 // isWrapped must answer is whether the invocation actually goes through the
 // pipelock proxy.
 func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 	genuine, _, err := wrapMCPServer(map[string]interface{}{
 		mcpFieldCommand: testEchoCmd,
-	}, testPipelockExe, "", false, "")
+	}, self, "", false, "")
 	if err != nil {
 		t.Fatalf("wrapMCPServer: %v", err)
 	}
@@ -61,6 +68,14 @@ func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
 			// the proxy subcommand in front of their OWN binary, so the
 			// invocation reads as mediated while nothing is mediated. This is
 			// why the command must be checked as well as the arguments.
+			name: "binary_merely_named_pipelock_is_not_mediated",
+			server: map[string]interface{}{
+				mcpFieldCommand: "/usr/local/bin/pipelock",
+				mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "echo"},
+			},
+			want: false,
+		},
+		{
 			name: "attacker_binary_with_proxy_args",
 			server: map[string]interface{}{
 				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
@@ -84,7 +99,7 @@ func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
 			// rerun would wrap the wrapper.
 			name: "genuine_wrap_array_form",
 			server: map[string]interface{}{
-				mcpFieldCommand: []interface{}{testPipelockExe, "mcp", "proxy", "--", "echo"},
+				mcpFieldCommand: []interface{}{self, "mcp", "proxy", "--", "echo"},
 			},
 			want: true,
 		},
@@ -92,7 +107,7 @@ func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
 			name: "marker_beside_unrelated_args",
 			server: map[string]interface{}{
 				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
-				mcpFieldCommand:  testPipelockExe,
+				mcpFieldCommand:  self,
 				mcpFieldArgs:     []interface{}{"serve", "--port", "9999"},
 			},
 			want: false,
@@ -116,7 +131,7 @@ func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isWrapped(tc.server); got != tc.want {
+			if got := isWrappedBySelf(tc.server); got != tc.want {
 				t.Fatalf("isWrapped = %v, want %v (server=%+v)", got, tc.want, tc.server)
 			}
 		})
@@ -127,67 +142,82 @@ func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
 // A real wrap must keep reporting as wrapped so a rerun skips it instead of
 // wrapping the wrapper, which would nest one proxy inside another.
 func TestIsWrapped_GenuineWrapStaysIdempotent(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 	for _, server := range []map[string]interface{}{
 		{mcpFieldCommand: testEchoCmd},
 		{mcpFieldType: "http", mcpFieldURL: "https://mcp.vendor.example/sse"},
 	} {
-		wrapped, meta, err := wrapMCPServer(server, testPipelockExe, "", false, "")
-		if err != nil {
-			t.Fatalf("wrapMCPServer(%+v): %v", server, err)
+		wrapped, meta, wrapErr := wrapMCPServer(server, self, "", false, "")
+		if wrapErr != nil {
+			t.Fatalf("wrapMCPServer(%+v): %v", server, wrapErr)
 		}
 		wrapped[mcpFieldPipelock] = map[string]interface{}{"original_type": meta.OriginalType}
-		if !isWrapped(wrapped) {
+		if !isWrappedBySelf(wrapped) {
 			t.Fatalf("genuine wrap reported unwrapped, a rerun would double-wrap it: %+v", wrapped)
 		}
 	}
 }
 
-// TestHasUnmediatedPipelockMarker covers the case the installer warns about: an
-// entry that claims pipelock coverage while its invocation does not go through
-// the proxy. It is wrapped rather than refused, so the server ends up mediated,
-// and the operator is told the claim was false instead of having it silently
+// TestWarnForeignWrapper covers what the installer tells the operator. Both cases
+// are wrapped regardless, so the traffic ends up mediated; the warning exists so a
+// claim of coverage this binary cannot confirm is visible rather than silently
 // corrected.
-func TestHasUnmediatedPipelockMarker(t *testing.T) {
+func TestWarnForeignWrapper(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
 	for _, tc := range []struct {
 		name   string
 		server map[string]interface{}
-		want   bool
+		want   string
 	}{
 		{
-			name: "false_claim",
+			name: "foreign binary running proxy arguments",
 			server: map[string]interface{}{
-				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
-				mcpFieldCommand:  "/usr/bin/attacker-server",
+				mcpFieldCommand: "/usr/bin/attacker-server",
+				mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", testEchoCmd},
 			},
-			want: true,
+			want: "is not this pipelock binary",
 		},
 		{
-			name: "false_claim_with_proxy_args_on_other_binary",
+			name: "marker beside a command that does not run the proxy",
 			server: map[string]interface{}{
 				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
-				mcpFieldCommand:  "/usr/bin/attacker-server",
-				mcpFieldArgs:     []interface{}{"mcp", "proxy"},
+				mcpFieldCommand:  testEchoCmd,
 			},
-			want: true,
+			want: "carries pipelock metadata but does not run through the proxy",
 		},
 		{
-			name: "genuine_wrap_makes_no_false_claim",
+			name: "genuinely mediated entry says nothing",
 			server: map[string]interface{}{
-				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
-				mcpFieldCommand:  testPipelockExe,
-				mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", testEchoCmd},
+				mcpFieldCommand: self,
+				mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", testEchoCmd},
 			},
-			want: false,
+			want: "",
 		},
 		{
-			name:   "no_marker_makes_no_claim",
+			name:   "ordinary unwrapped entry says nothing",
 			server: map[string]interface{}{mcpFieldCommand: testEchoCmd},
-			want:   false,
+			want:   "",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := hasUnmediatedPipelockMarker(tc.server); got != tc.want {
-				t.Fatalf("hasUnmediatedPipelockMarker = %v, want %v", got, tc.want)
+			var buf bytes.Buffer
+			warnForeignWrapper(&buf, "srv", tc.server)
+			got := buf.String()
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("expected silence, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("warning = %q, want it to mention %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"testing"
+)
+
+// TestIsWrapped_ForgedMarkerIsNotTrusted covers the forged-marker mediation
+// bypass. isWrapped decided "already wrapped" from the mere presence of the
+// _pipelock key, so an attacker-authored project config could carry a bare
+// marker beside a raw stdio command. The installer then reported the server as
+// already wrapped and skipped it, leaving its traffic unmediated: the exact
+// outcome wrapping exists to prevent.
+//
+// The marker is something we write, so it cannot be the evidence. The question
+// isWrapped must answer is whether the invocation actually goes through the
+// pipelock proxy.
+func TestIsWrapped_ForgedMarkerIsNotTrusted(t *testing.T) {
+	genuine, _, err := wrapMCPServer(map[string]interface{}{
+		mcpFieldCommand: testEchoCmd,
+	}, testPipelockExe, "", false, "")
+	if err != nil {
+		t.Fatalf("wrapMCPServer: %v", err)
+	}
+	genuine[mcpFieldPipelock] = map[string]interface{}{"original_type": "stdio"}
+
+	for _, tc := range []struct {
+		name   string
+		server map[string]interface{}
+		want   bool
+	}{
+		{
+			name:   "genuine_wrap",
+			server: genuine,
+			want:   true,
+		},
+		{
+			name: "bare_forged_marker",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{},
+				mcpFieldCommand:  "/usr/bin/attacker-server",
+			},
+			want: false,
+		},
+		{
+			name: "forged_marker_with_plausible_metadata",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{
+					"original_type":    "stdio",
+					"original_command": "echo",
+				},
+				mcpFieldCommand: "/usr/bin/attacker-server",
+				mcpFieldArgs:    []interface{}{"--serve"},
+			},
+			want: false,
+		},
+		{
+			// The bypass that args-only checking allows: the attacker supplies
+			// the proxy subcommand in front of their OWN binary, so the
+			// invocation reads as mediated while nothing is mediated. This is
+			// why the command must be checked as well as the arguments.
+			name: "attacker_binary_with_proxy_args",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  "/usr/bin/attacker-server",
+				mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", "echo"},
+			},
+			want: false,
+		},
+		{
+			// Same shape in OpenCode's single command array, where the binary is
+			// element zero rather than a separate field.
+			name: "attacker_binary_with_proxy_args_array_form",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  []interface{}{"/usr/bin/attacker-server", "mcp", "proxy", "--", "echo"},
+			},
+			want: false,
+		},
+		{
+			// The array form of a genuine wrap must still be recognised, or a
+			// rerun would wrap the wrapper.
+			name: "genuine_wrap_array_form",
+			server: map[string]interface{}{
+				mcpFieldCommand: []interface{}{testPipelockExe, "mcp", "proxy", "--", "echo"},
+			},
+			want: true,
+		},
+		{
+			name: "marker_beside_unrelated_args",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  testPipelockExe,
+				mcpFieldArgs:     []interface{}{"serve", "--port", "9999"},
+			},
+			want: false,
+		},
+		{
+			// An entry with a marker and no command at all makes a claim it cannot
+			// back. It must not read as wrapped, or the installer would skip an
+			// entry it never examined.
+			name: "marker_with_empty_command",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  "",
+				mcpFieldArgs:     []interface{}{"mcp", "proxy"},
+			},
+			want: false,
+		},
+		{
+			name:   "no_marker_at_all",
+			server: map[string]interface{}{mcpFieldCommand: testEchoCmd},
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWrapped(tc.server); got != tc.want {
+				t.Fatalf("isWrapped = %v, want %v (server=%+v)", got, tc.want, tc.server)
+			}
+		})
+	}
+}
+
+// TestIsWrapped_GenuineWrapStaysIdempotent guards the availability direction.
+// A real wrap must keep reporting as wrapped so a rerun skips it instead of
+// wrapping the wrapper, which would nest one proxy inside another.
+func TestIsWrapped_GenuineWrapStaysIdempotent(t *testing.T) {
+	for _, server := range []map[string]interface{}{
+		{mcpFieldCommand: testEchoCmd},
+		{mcpFieldType: "http", mcpFieldURL: "https://mcp.vendor.example/sse"},
+	} {
+		wrapped, meta, err := wrapMCPServer(server, testPipelockExe, "", false, "")
+		if err != nil {
+			t.Fatalf("wrapMCPServer(%+v): %v", server, err)
+		}
+		wrapped[mcpFieldPipelock] = map[string]interface{}{"original_type": meta.OriginalType}
+		if !isWrapped(wrapped) {
+			t.Fatalf("genuine wrap reported unwrapped, a rerun would double-wrap it: %+v", wrapped)
+		}
+	}
+}
+
+// TestHasUnmediatedPipelockMarker covers the case the installer warns about: an
+// entry that claims pipelock coverage while its invocation does not go through
+// the proxy. It is wrapped rather than refused, so the server ends up mediated,
+// and the operator is told the claim was false instead of having it silently
+// corrected.
+func TestHasUnmediatedPipelockMarker(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		server map[string]interface{}
+		want   bool
+	}{
+		{
+			name: "false_claim",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  "/usr/bin/attacker-server",
+			},
+			want: true,
+		},
+		{
+			name: "false_claim_with_proxy_args_on_other_binary",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  "/usr/bin/attacker-server",
+				mcpFieldArgs:     []interface{}{"mcp", "proxy"},
+			},
+			want: true,
+		},
+		{
+			name: "genuine_wrap_makes_no_false_claim",
+			server: map[string]interface{}{
+				mcpFieldPipelock: map[string]interface{}{"original_type": "stdio"},
+				mcpFieldCommand:  testPipelockExe,
+				mcpFieldArgs:     []interface{}{"mcp", "proxy", "--", testEchoCmd},
+			},
+			want: false,
+		},
+		{
+			name:   "no_marker_makes_no_claim",
+			server: map[string]interface{}{mcpFieldCommand: testEchoCmd},
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasUnmediatedPipelockMarker(tc.server); got != tc.want {
+				t.Fatalf("hasUnmediatedPipelockMarker = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/setup/opencode.go
+++ b/internal/cli/setup/opencode.go
@@ -178,7 +178,7 @@ func runOpenCodeInstall(cmd *cobra.Command, override string, dryRun bool, config
 	skipped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if isVscodeWrapped(server) {
+		if isWrappedBySelf(server) {
 			skipped++
 			continue
 		}
@@ -265,7 +265,7 @@ func runOpenCodeRemove(cmd *cobra.Command, override string, dryRun bool) error {
 	unwrapped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if !isVscodeWrapped(server) {
+		if !isRestorableWrapper(server) {
 			continue
 		}
 

--- a/internal/cli/setup/opencode.go
+++ b/internal/cli/setup/opencode.go
@@ -182,6 +182,7 @@ func runOpenCodeInstall(cmd *cobra.Command, override string, dryRun bool, config
 			skipped++
 			continue
 		}
+		warnForeignWrapper(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, plan, err := wrapOpenCodeServer(server, exe, configFile, targetPath, name)
 		if err != nil {

--- a/internal/cli/setup/opencode.go
+++ b/internal/cli/setup/opencode.go
@@ -266,6 +266,7 @@ func runOpenCodeRemove(cmd *cobra.Command, override string, dryRun bool) error {
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
 		if !isRestorableWrapper(server) {
+			warnUnrestorableWrapper(cmd.ErrOrStderr(), name, server)
 			continue
 		}
 

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -306,7 +306,7 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 	skipped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if isVscodeWrapped(server) {
+		if isWrappedBySelf(server) {
 			skipped++
 			continue
 		}
@@ -414,7 +414,7 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 	unwrapped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
-		if !isVscodeWrapped(server) {
+		if !isRestorableWrapper(server) {
 			continue
 		}
 
@@ -486,9 +486,6 @@ func isVscodeHTTPType(t string) bool { return t != vsTypeStdio && t != "" }
 // presence of the _pipelock marker, and it covers more surface: VS Code, Cline
 // and OpenCode all route through it. Both share one invocation check now, so the
 // two predicates cannot drift apart again.
-func isVscodeWrapped(server map[string]interface{}) bool {
-	return invokesMCPProxy(server)
-}
 
 // wrapVscodeServer wraps a single VS Code MCP server through pipelock mcp proxy.
 // wrapVscodeServer wraps a single MCP server entry through pipelock mcp proxy.

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -481,10 +481,13 @@ const (
 // (anything that is not stdio).
 func isVscodeHTTPType(t string) bool { return t != vsTypeStdio && t != "" }
 
-// isVscodeWrapped returns true if a server entry has pipelock metadata.
+// isVscodeWrapped reports whether a VS Code family entry is actually mediated by
+// the pipelock MCP proxy. It had the same defect as isWrapped, deciding from the
+// presence of the _pipelock marker, and it covers more surface: VS Code, Cline
+// and OpenCode all route through it. Both share one invocation check now, so the
+// two predicates cannot drift apart again.
 func isVscodeWrapped(server map[string]interface{}) bool {
-	_, ok := server["_pipelock"]
-	return ok
+	return invokesMCPProxy(server)
 }
 
 // wrapVscodeServer wraps a single VS Code MCP server through pipelock mcp proxy.

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -310,6 +310,7 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 			skipped++
 			continue
 		}
+		warnForeignWrapper(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, plan, err := wrapVscodeServer(server, exe, configFile, targetPath, name)
 		if err != nil {

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -415,6 +415,7 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 	var sidecarOps []sidecarOp
 	for name, server := range mcpCfg.Servers {
 		if !isRestorableWrapper(server) {
+			warnUnrestorableWrapper(cmd.ErrOrStderr(), name, server)
 			continue
 		}
 
@@ -481,14 +482,7 @@ const (
 // (anything that is not stdio).
 func isVscodeHTTPType(t string) bool { return t != vsTypeStdio && t != "" }
 
-// isVscodeWrapped reports whether a VS Code family entry is actually mediated by
-// the pipelock MCP proxy. It had the same defect as isWrapped, deciding from the
-// presence of the _pipelock marker, and it covers more surface: VS Code, Cline
-// and OpenCode all route through it. Both share one invocation check now, so the
-// two predicates cannot drift apart again.
-
-// wrapVscodeServer wraps a single VS Code MCP server through pipelock mcp proxy.
-// wrapVscodeServer wraps a single MCP server entry through pipelock mcp proxy.
+// wrapVscodeServer wraps a single VS Code family MCP server through pipelock mcp proxy.
 // targetConfigPath + serverName are used to derive the per-server 0o600 header
 // sidecar file when the entry carries an HTTP `headers` block; the wrapped
 // argv references it via --header-file so credential header values never

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -336,11 +336,11 @@ func installZedPath(cmd *cobra.Command, targetPath, exe, configFile string, dryR
 	skipped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range cfg.Servers {
-		if isWrapped(server) {
+		if isWrappedBySelf(server) {
 			skipped++
 			continue
 		}
-		warnUnmediatedMarker(cmd.ErrOrStderr(), name, server)
+		warnForeignWrapper(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, plan, wrapErr := wrapClineServer(server, exe, configFile, targetPath, name)
 		if wrapErr != nil {
@@ -443,7 +443,7 @@ func removeZedPath(cmd *cobra.Command, targetPath string, dryRun bool) error {
 	unwrapped := 0
 	var sidecarOps []sidecarOp
 	for name, server := range cfg.Servers {
-		if !isWrapped(server) {
+		if !isRestorableWrapper(server) {
 			continue
 		}
 

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -340,6 +340,7 @@ func installZedPath(cmd *cobra.Command, targetPath, exe, configFile string, dryR
 			skipped++
 			continue
 		}
+		warnUnmediatedMarker(cmd.ErrOrStderr(), name, server)
 
 		newServer, meta, plan, wrapErr := wrapClineServer(server, exe, configFile, targetPath, name)
 		if wrapErr != nil {

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -444,6 +444,7 @@ func removeZedPath(cmd *cobra.Command, targetPath string, dryRun bool) error {
 	var sidecarOps []sidecarOp
 	for name, server := range cfg.Servers {
 		if !isRestorableWrapper(server) {
+			warnUnrestorableWrapper(cmd.ErrOrStderr(), name, server)
 			continue
 		}
 

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -892,7 +892,7 @@ func TestZedInstall_DefaultScansBothPathsWhenBothExist(t *testing.T) {
 		}
 		wrapCount := 0
 		for _, server := range cfg.Servers {
-			if isWrapped(server) {
+			if isWrappedBySelf(server) {
 				wrapCount++
 			}
 		}
@@ -1035,7 +1035,7 @@ func TestZedInstall_DefaultWrapsZedPreviewChannel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isWrapped(cfg.Servers["my-server"]) {
+	if !isWrappedBySelf(cfg.Servers["my-server"]) {
 		t.Error("Zed Preview channel settings.json should have been wrapped")
 	}
 }
@@ -1064,7 +1064,7 @@ func TestZedInstall_DefaultWrapsFlatpakStable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isWrapped(cfg.Servers["my-server"]) {
+	if !isWrappedBySelf(cfg.Servers["my-server"]) {
 		t.Error("Flatpak Zed stable settings.json should have been wrapped")
 	}
 }
@@ -1092,7 +1092,7 @@ func TestZedInstall_DefaultWrapsFlatpakPreview(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isWrapped(cfg.Servers["my-server"]) {
+	if !isWrappedBySelf(cfg.Servers["my-server"]) {
 		t.Error("Flatpak Zed Preview settings.json should have been wrapped")
 	}
 }
@@ -1200,7 +1200,7 @@ func TestZedInstall_DefaultUserOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isWrapped(cfg.Servers["my-server"]) {
+	if !isWrappedBySelf(cfg.Servers["my-server"]) {
 		t.Error("user-level server should be wrapped")
 	}
 }
@@ -1225,7 +1225,7 @@ func TestZedInstall_DefaultProjectOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isWrapped(cfg.Servers["my-server"]) {
+	if !isWrappedBySelf(cfg.Servers["my-server"]) {
 		t.Error("project-level server should be wrapped")
 	}
 }

--- a/internal/cli/setup/zed_test.go
+++ b/internal/cli/setup/zed_test.go
@@ -1448,3 +1448,38 @@ func TestWrapClineServer_ZedConfigShape_Stdio(t *testing.T) {
 		t.Errorf("wrapped result should declare type=stdio for Zed launch, got %v", result[mcpFieldType])
 	}
 }
+
+// TestZedInstall_WarnsOnForgedMarker covers the Zed call site for the false-claim
+// warning. The warning helper is shared with the other installers, but the Zed
+// wiring is its own line, and leaving a sibling call site untested is how the
+// original defect survived in five integrations at once.
+func TestZedInstall_WarnsOnForgedMarker(t *testing.T) {
+	home := isolateHome(t)
+	chdirIsolated(t)
+
+	userPath := filepath.Join(home, ".config", zedUserConfigSubdir, zedConfigFilename)
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	forged := `{"context_servers": {"forged": {"command": "echo", "args": ["--serve"], ` +
+		`"_pipelock": {"original_type": "stdio", "original_command": "echo"}}}}`
+	if err := os.WriteFile(userPath, []byte(forged), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := runZedCmdOutput(t, "install")
+	if err != nil {
+		t.Fatalf("install: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stderr, "carries pipelock metadata but does not run through the proxy") {
+		t.Fatalf("Zed install did not warn about the false coverage claim; stderr = %q", stderr)
+	}
+
+	cfg, _, err := readMCPConfig(userPath, zedServersKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isWrappedBySelf(cfg.Servers["forged"]) {
+		t.Fatalf("the forged entry was not wrapped, so its traffic stays unmediated: %+v", cfg.Servers["forged"])
+	}
+}


### PR DESCRIPTION
## What changed

`isWrapped` and `isVscodeWrapped` decided that an MCP server entry was already wrapped from the presence of the `_pipelock` marker. That marker is a value this tool writes, so an attacker-authored project config could carry one beside a raw stdio command: the installer reported the server as already wrapped, skipped it, and left its traffic unmediated, which is the outcome wrapping exists to prevent. The same marker also drove restoration on remove, so a forged one chose the command an entry became.

Both predicates now share one invocation check, following the shape `isCodexWrapped` already used for the Codex integration: the command must look like a pipelock binary AND its arguments must begin with the proxy subcommand. Arguments alone are not proof, because those arguments can be placed in front of any binary. The marker is deliberately not required, so an entry already running through the proxy still reports as wrapped when its marker is missing rather than being wrapped a second time.

This covered five editor integrations rather than the one originally reported: JetBrains and Zed through `isWrapped`, and VS Code, Cline and OpenCode through `isVscodeWrapped`. Both config shapes are handled, a command string with separate arguments and OpenCode's single command array. An entry that claims coverage it does not have is wrapped rather than refused, so it ends up mediated, and the installer warns rather than silently correcting the false claim.

The reviewer should distrust the binary-identity half rather than the argument half. It accepts the pipelock basename, matching the existing Codex behaviour so a rebuild at a new path does not double-wrap, and it also accepts the currently running executable by resolved path, because the wrapper writes `os.Executable()` into the config and that binary is not always named `pipelock`. Too strict and a genuine wrap reads as unwrapped and gets nested inside another proxy; too loose and the check stops being evidence. A pre-existing test asserted that a bare marker counts as wrapped, which asserted the vulnerability, and it was corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved server protection by verifying that entries actually invoke the Pipelock MCP proxy before considering them wrapped.
  - Prevented forged metadata or unrelated executables from bypassing protection or causing incorrect wrapping decisions.
- **User Experience**
  - Added warnings when server metadata claims mediation but the server remains unmediated.
  - Installation now warns before wrapping unprotected or externally wrapped servers.
- **Bug Fixes**
  - Prevented unnecessary nested wrapping for already-mediated servers.
  - Improved removal to restore only validated, restorable Pipelock wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->