### PR TITLE
fix(mcp): refuse tool arguments redaction cannot mask

### DIFF
--- a/docs/guides/redaction.md
+++ b/docs/guides/redaction.md
@@ -71,6 +71,7 @@ Use a narrow `code` profile for developer traffic and add broader `business` pro
 - Non-JSON HTTP bodies and complete non-JSON WebSocket messages are blocked unless the destination host is on `allowlist_unparseable` or the request matches `allowlist_unparseable_routes`.
 - Outbound WebSocket fragments are blocked while redaction is enabled because partial JSON messages cannot be rewritten safely.
 - Malformed JSON, numeric scalars containing secrets, key-collision rewrites, or redaction limits being exceeded all block the request instead of forwarding partially transformed data.
+- An MCP `tools/call` whose `params.arguments` is a string, array, number, or boolean is blocked. The redactor walks object members, so it cannot mask a secret carried directly in that value. Absent and `null` arguments are forwarded unchanged, because they carry no content to rewrite.
 
 `allowlist_unparseable` accepts bare lowercase hostnames only. Do not include schemes, paths, or ports. Use it sparingly for trusted endpoints that legitimately require non-JSON request formats.
 

--- a/internal/mcp/redaction.go
+++ b/internal/mcp/redaction.go
@@ -81,7 +81,7 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	}
 
 	if IsA2AMethod(method) {
-		rewrittenParams, report, _, err := rewriteRedactableJSON(paramsRaw, cfg, "A2A params", false)
+		rewrittenParams, report, err := rewriteRedactableJSON(paramsRaw, cfg, "A2A params")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -124,12 +124,9 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 		return line, nil, nil
 	}
 
-	rewrittenArgs, report, didRewrite, err := rewriteRedactableJSON(argsRaw, cfg, "tools/call arguments", true)
+	rewrittenArgs, report, err := rewriteRedactableJSON(argsRaw, cfg, "tools/call arguments")
 	if err != nil {
 		return nil, nil, err
-	}
-	if !didRewrite {
-		return line, nil, nil
 	}
 	params["arguments"] = rewrittenArgs
 
@@ -161,24 +158,27 @@ func applyMCPToolCallRedactionWithConfig(line []byte, cfg MCPRedactionConfig) ([
 	return rewritten.Bytes(), report, nil
 }
 
-func rewriteRedactableJSON(raw json.RawMessage, cfg MCPRedactionConfig, objectKind string, skipOnNonObject bool) ([]byte, *redact.Report, bool, error) {
+func rewriteRedactableJSON(raw json.RawMessage, cfg MCPRedactionConfig, objectKind string) ([]byte, *redact.Report, error) {
 	if err := redact.NoDuplicateJSONKeys(raw); err != nil && redact.IsDuplicateKeyBlock(err) {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
+	// A non-object value fails closed for every callable kind. The redaction
+	// engine walks object members, so it cannot mask a secret carried directly
+	// in a string, array, or number: returning the original bytes forwarded an
+	// unredacted credential while reporting success. A tools/call whose
+	// arguments are absent or null is handled by the caller and never reaches
+	// here, so refusing this shape costs no legitimate traffic.
 	if !redact.IsJSONObject(raw) {
-		if skipOnNonObject {
-			return raw, nil, false, nil
-		}
-		return nil, nil, false, &redact.BlockError{
+		return nil, nil, &redact.BlockError{
 			Reason: redact.ReasonBodyUnparseable,
 			Detail: fmt.Sprintf("invalid %s object: expected JSON object", objectKind),
 		}
 	}
 	rewritten, report, err := redact.RewriteJSON(raw, cfg.Matcher, redact.NewRedactor(), cfg.Limits)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
-	return rewritten, report, true, nil
+	return rewritten, report, nil
 }
 
 func marshalMCPMessage(v any) ([]byte, error) {

--- a/internal/mcp/redaction_test.go
+++ b/internal/mcp/redaction_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -215,41 +216,140 @@ func TestApplyMCPToolCallRedaction_NoArgumentsBypasses(t *testing.T) {
 	}
 }
 
-func TestApplyMCPToolCallRedaction_InvalidArgumentsBypass(t *testing.T) {
+// TestApplyMCPToolCallRedaction_NullArgumentsBypasses keeps the one non-object
+// shape that is a legitimate no-op. Absent or null arguments carry no content,
+// so there is nothing to mask and passing the line through unchanged forwards no
+// secret. This is the availability half of the fail-closed rule below: refusing
+// it would break every tool that takes no arguments.
+func TestApplyMCPToolCallRedaction_NullArgumentsBypasses(t *testing.T) {
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":null}}`)
+
+	rewritten, report, err := applyMCPToolCallRedaction(line, MCPProxyOpts{
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  redact.DefaultLimits().ToLimits(),
+	})
+	if err != nil {
+		t.Fatalf("applyMCPToolCallRedaction: %v", err)
+	}
+	if !bytes.Equal(rewritten, line) {
+		t.Fatalf("null arguments should pass through unchanged\ngot:  %s\nwant: %s", rewritten, line)
+	}
+	if report != nil {
+		t.Fatalf("report should be nil for null arguments, got %+v", report)
+	}
+}
+
+// TestApplyMCPToolCallRedaction_NonObjectArgumentsFailClosed pins the direction
+// for arguments that carry content the redaction engine cannot walk. The engine
+// masks object members, so a credential placed directly in a string or an array
+// was previously forwarded verbatim while the call reported success: enabling
+// redaction masked an object-shaped secret and silently passed the same secret
+// one shape over. A2A params at the sibling call site already failed closed here.
+func TestApplyMCPToolCallRedaction_NonObjectArgumentsFailClosed(t *testing.T) {
+	secret := mcpRedactionSecret()
 	tests := []struct {
 		name string
 		line []byte
 	}{
 		{
-			name: "null",
-			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":null}}`),
+			name: "string carrying a credential",
+			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":"` + secret + `"}}`),
 		},
 		{
-			name: "string",
-			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":"oops"}}`),
+			name: "array carrying a credential",
+			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":["` + secret + `"]}}`),
 		},
 		{
-			name: "array",
+			name: "empty array",
 			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":[]}}`),
+		},
+		{
+			name: "number",
+			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":7}}`),
+		},
+		{
+			name: "boolean",
+			line: []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":true}}`),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rewritten, report, err := applyMCPToolCallRedaction(tt.line, MCPProxyOpts{
+			rewritten, _, err := applyMCPToolCallRedaction(tt.line, MCPProxyOpts{
 				RedactMatcher: testRedactionMatcher(),
 				RedactLimits:  redact.DefaultLimits().ToLimits(),
 			})
-			if err != nil {
-				t.Fatalf("applyMCPToolCallRedaction: %v", err)
+			if err == nil {
+				t.Fatalf("non-object arguments should block, got %s", rewritten)
 			}
-			if !bytes.Equal(rewritten, tt.line) {
-				t.Fatalf("invalid arguments should pass through unchanged\ngot:  %s\nwant: %s", rewritten, tt.line)
+			var blockErr *redact.BlockError
+			if !errors.As(err, &blockErr) {
+				t.Fatalf("expected BlockError, got %T: %v", err, err)
 			}
-			if report != nil {
-				t.Fatalf("report should be nil for invalid arguments, got %+v", report)
+			if blockErr.Reason != redact.ReasonBodyUnparseable {
+				t.Fatalf("reason = %q, want %q", blockErr.Reason, redact.ReasonBodyUnparseable)
+			}
+			if bytes.Contains(rewritten, []byte(secret)) {
+				t.Fatalf("blocked call still returned the secret: %s", rewritten)
 			}
 		})
+	}
+}
+
+// TestApplyMCPToolCallRedaction_OversizeArgumentsFailClosed covers the engine's
+// own refusal reaching the caller. An operator can lower max_body_bytes, and
+// arguments above that bound cannot be walked, so the call must block rather
+// than forward the bytes the engine declined to inspect.
+func TestApplyMCPToolCallRedaction_OversizeArgumentsFailClosed(t *testing.T) {
+	secret := mcpRedactionSecret()
+	line := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"note":"` + secret + `"}}}`)
+
+	limits := redact.DefaultLimits()
+	// Below the arguments object, so the engine refuses to walk it.
+	limits.MaxBodyBytes = 8
+
+	rewritten, _, err := applyMCPToolCallRedaction(line, MCPProxyOpts{
+		RedactMatcher: testRedactionMatcher(),
+		RedactLimits:  limits.ToLimits(),
+	})
+	if err == nil {
+		t.Fatalf("oversize arguments should block, got %s", rewritten)
+	}
+	var blockErr *redact.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %T: %v", err, err)
+	}
+	if blockErr.Reason != redact.ReasonBodyTooLarge {
+		t.Fatalf("reason = %q, want %q", blockErr.Reason, redact.ReasonBodyTooLarge)
+	}
+	if bytes.Contains(rewritten, []byte(secret)) {
+		t.Fatalf("blocked call still returned the secret: %s", rewritten)
+	}
+}
+
+// TestRewriteRedactableJSON_DuplicateKeysFailClosed exercises the helper
+// directly, because the duplicate-key guard inside it is defence in depth that
+// the current callers cannot reach: applyMCPToolCallRedaction already screens
+// the whole envelope, and that walk recurses, so a duplicate nested inside
+// params or arguments is caught before the helper runs. The guard is kept for
+// the next call site, which may not screen its input first, and this test is
+// what keeps it honest rather than dead.
+func TestRewriteRedactableJSON_DuplicateKeysFailClosed(t *testing.T) {
+	cfg := MCPRedactionConfig{
+		Matcher: testRedactionMatcher(),
+		Limits:  redact.DefaultLimits().ToLimits(),
+	}
+	raw := json.RawMessage(`{"note":"safe","note":"` + mcpRedactionSecret() + `"}`)
+
+	rewritten, _, err := rewriteRedactableJSON(raw, cfg, "tools/call arguments")
+	if err == nil {
+		t.Fatalf("duplicate keys should block, got %s", rewritten)
+	}
+	if !redact.IsDuplicateKeyBlock(err) {
+		t.Fatalf("expected duplicate-key block, got %T: %v", err, err)
+	}
+	if rewritten != nil {
+		t.Fatalf("blocked call should return no bytes, got %s", rewritten)
 	}
 }
 


### PR DESCRIPTION
## What changed
- Block MCP `tools/call` requests whose argument value can't be safely rewritten while redaction is enabled, instead of forwarding the original value without a redaction report.
- Keep absent and `null` arguments working for no-argument tools. The failure direction is deny for other non-object values; the compatibility boundary to distrust is servers that emit those values outside the MCP object-shaped argument contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MCP tool requests with scalar or array arguments are now blocked instead of potentially bypassing redaction.
  - Oversized or duplicate-key arguments are rejected safely.
  - Absent or `null` arguments continue to be forwarded unchanged.

- **Documentation**
  - Documented fail-closed behavior for unsupported MCP tool argument formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->