### PR TITLE
fix(setup): derive the sidecar delete target, never trust metadata

### DIFF
--- a/internal/cli/hermes/rollback.go
+++ b/internal/cli/hermes/rollback.go
@@ -161,7 +161,7 @@ func unwrapHermesMCPServers(cmd *cobra.Command, cfg *hermesConfig) (int, []mcpwr
 		if !ok || !mcpwrap.IsWrapped(server) {
 			continue
 		}
-		restored, op, err := mcpwrap.UnwrapServer(server)
+		restored, op, err := mcpwrap.UnwrapServer(server, cfg.path, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap mcp server %q: %v\n", name, err)
 			continue

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -273,7 +273,7 @@ func runClineRemove(cmd *cobra.Command, override string, dryRun bool) error {
 			continue
 		}
 
-		restored, plan, err := unwrapVscodeServer(server)
+		restored, plan, err := unwrapVscodeServer(server, targetPath, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q: %v\n", name, err)
 			continue

--- a/internal/cli/setup/opencode.go
+++ b/internal/cli/setup/opencode.go
@@ -271,7 +271,7 @@ func runOpenCodeRemove(cmd *cobra.Command, override string, dryRun bool) error {
 			continue
 		}
 
-		restored, plan, err := unwrapOpenCodeServer(server)
+		restored, plan, err := unwrapOpenCodeServer(server, targetPath, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q: %v\n", name, err)
 			continue
@@ -434,7 +434,14 @@ func wrapOpenCodeServer(server map[string]interface{}, exe, configFile, targetCo
 	}
 }
 
-func unwrapOpenCodeServer(server map[string]interface{}) (map[string]interface{}, *sidecarOp, error) {
+// unwrapOpenCodeServer restores a server from its pipelock metadata. The
+// delete target is DERIVED from targetConfigPath and serverName rather than
+// read from the metadata: the marker lives in an operator-editable config, and
+// every server's sidecar shares one directory, so a metadata-supplied path
+// would let one server's config nominate another server's credential file for
+// deletion. The metadata path is still shape-checked so a tampered marker
+// fails closed, but it never selects the file removed.
+func unwrapOpenCodeServer(server map[string]interface{}, targetConfigPath, serverName string) (map[string]interface{}, *sidecarOp, error) {
 	metaRaw, ok := server[mcpFieldPipelock]
 	if !ok {
 		return server, nil, nil
@@ -451,7 +458,10 @@ func unwrapOpenCodeServer(server map[string]interface{}) (map[string]interface{}
 
 	var plan *sidecarOp
 	if meta.HeaderSidecarPath != "" {
-		path, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath)
+		if _, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath); err != nil {
+			return nil, nil, err
+		}
+		path, err := headerSidecarPath(targetConfigPath, serverName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cli/setup/opencode_test.go
+++ b/internal/cli/setup/opencode_test.go
@@ -1104,7 +1104,7 @@ func TestUnwrapOpenCodeServer_InvalidMetadata(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := map[string]interface{}{mcpFieldPipelock: tt.meta}
-			if _, _, err := unwrapOpenCodeServer(server); err == nil {
+			if _, _, err := unwrapOpenCodeServer(server, "opencode.json", "remote"); err == nil {
 				t.Error("unwrap should reject invalid metadata")
 			}
 		})
@@ -1114,7 +1114,7 @@ func TestUnwrapOpenCodeServer_InvalidMetadata(t *testing.T) {
 func TestUnwrapOpenCodeServer_NoMeta(t *testing.T) {
 	server := map[string]interface{}{"name": "plain"}
 
-	result, plan, err := unwrapOpenCodeServer(server)
+	result, plan, err := unwrapOpenCodeServer(server, "opencode.json", "remote")
 	if err != nil {
 		t.Fatalf("unwrap no meta: %v", err)
 	}
@@ -1144,7 +1144,7 @@ func TestUnwrapOpenCodeServer_MetadataDecodeErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := map[string]interface{}{mcpFieldPipelock: tt.meta}
-			if _, _, err := unwrapOpenCodeServer(server); err == nil {
+			if _, _, err := unwrapOpenCodeServer(server, "opencode.json", "remote"); err == nil {
 				t.Error("expected unwrap to fail")
 			}
 		})

--- a/internal/cli/setup/sidecar_delete_binding_test.go
+++ b/internal/cli/setup/sidecar_delete_binding_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Pipelab
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// victimSidecar creates a sidecar belonging to a DIFFERENT (config, server)
+// pair than the one the hostile config under test will unwrap, and returns its
+// absolute path plus the body it must still hold afterwards.
+func victimSidecar(t *testing.T) (string, []byte) {
+	t.Helper()
+	victimConfig := filepath.Join(t.TempDir(), "global", "mcp.json")
+	path, err := headerSidecarPath(victimConfig, "victim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("Authorization: Bearer victim-credential\n")
+	if err := commitHeaderSidecar(path, body); err != nil {
+		t.Fatal(err)
+	}
+	return path, body
+}
+
+// TestVscodeRemove_HostileMetadataCannotDeleteAnotherServersSidecar is the
+// AF-383 regression. A project-local config controls its own _pipelock marker,
+// and remove used to honour that marker's header_sidecar_path as a DELETE
+// target. Containment to the sidecar directory is not enough: every other
+// server's credential file lives in that same directory, so a config for
+// "evil" could nominate an unrelated server's sidecar and remove would destroy
+// it. The delete target must be DERIVED from the config path and server name,
+// never accepted from metadata.
+func TestVscodeRemove_HostileMetadataCannotDeleteAnotherServersSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	victimPath, victimBody := victimSidecar(t)
+
+	project := t.TempDir()
+	chdirTemp(t, project)
+	vsDir := filepath.Join(project, ".vscode")
+	if err := os.MkdirAll(vsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(vsDir, "mcp.json")
+	metaPath := strings.ReplaceAll(victimPath, `\`, `\\`)
+	hostile := []byte(`{"servers":{"evil":{"type":"stdio","command":"/usr/bin/pipelock","args":["mcp","proxy"],` +
+		`"_pipelock":{"original_type":"http","original_url":"https://api.vendor.example/mcp",` +
+		`"header_sidecar_path":"` + metaPath + `"}}}}`)
+	if err := os.WriteFile(target, hostile, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := VscodeCmd()
+	cmd.SetArgs([]string{"remove", "--project"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	assertFileBytes(t, victimPath, victimBody)
+}
+
+// TestUnwrapServers_DeleteTargetIsDerivedNotMetadata covers the same defect at
+// the unit level for every unwrap path that shares this metadata shape. The
+// hostile marker names a valid, contained sidecar belonging to another server;
+// the returned delete op must name the caller's own derived path instead.
+func TestUnwrapServers_DeleteTargetIsDerivedNotMetadata(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	victimPath, _ := victimSidecar(t)
+
+	const configPath = "/configs/mcp.json"
+	const serverName = "evil"
+	want, err := headerSidecarPath(configPath, serverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want == victimPath {
+		t.Fatal("test setup is vacuous: derived path equals the victim path")
+	}
+
+	hostileMeta := map[string]interface{}{
+		"original_type":       "http",
+		"original_url":        "https://api.vendor.example/mcp",
+		"header_sidecar_path": victimPath,
+	}
+
+	t.Run("vscode family", func(t *testing.T) {
+		server := map[string]interface{}{"_pipelock": hostileMeta}
+		_, plan, err := unwrapVscodeServer(server, configPath, serverName)
+		if err != nil {
+			t.Fatalf("unwrap: %v", err)
+		}
+		assertDerivedDelete(t, plan, want)
+	})
+
+	t.Run("opencode", func(t *testing.T) {
+		server := map[string]interface{}{
+			mcpFieldPipelock: map[string]interface{}{
+				"original_type":       opencodeTypeRemote,
+				"original_url":        "https://api.vendor.example/mcp",
+				"header_sidecar_path": victimPath,
+			},
+		}
+		_, plan, err := unwrapOpenCodeServer(server, configPath, serverName)
+		if err != nil {
+			t.Fatalf("unwrap: %v", err)
+		}
+		assertDerivedDelete(t, plan, want)
+	})
+}
+
+func assertDerivedDelete(t *testing.T, plan *sidecarOp, want string) {
+	t.Helper()
+	if plan == nil {
+		t.Fatal("expected a sidecar delete plan")
+	}
+	if plan.kind != sidecarOpDelete {
+		t.Fatalf("plan.kind = %q, want %q", plan.kind, sidecarOpDelete)
+	}
+	if plan.path != want {
+		t.Errorf("plan.path = %q, want the derived path %q", plan.path, want)
+	}
+}

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -420,7 +420,7 @@ func runVscodeRemove(cmd *cobra.Command, global, project, dryRun bool) error {
 			continue
 		}
 
-		restored, plan, err := unwrapVscodeServer(server)
+		restored, plan, err := unwrapVscodeServer(server, targetPath, name)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q: %v\n", name, err)
 			continue
@@ -608,7 +608,15 @@ func wrapVscodeServer(server map[string]interface{}, exe, configFile, targetConf
 // disk; otherwise a marshal / atomic-write failure later in the remove path
 // would leave the still-wrapped config on disk while the credential carrier
 // it references is gone.
-func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, *sidecarOp, error) {
+//
+// The delete target is DERIVED from targetConfigPath and serverName, never
+// taken from the metadata. A project-local config controls its own _pipelock
+// marker, so a metadata-supplied path is attacker-controlled input: since
+// every server's sidecar shares one directory, containment checks alone still
+// let a config for one server nominate an unrelated server's credential file
+// for deletion. The metadata path is still shape-checked so obviously tampered
+// markers fail closed and stay visible, but it never selects the file removed.
+func unwrapVscodeServer(server map[string]interface{}, targetConfigPath, serverName string) (map[string]interface{}, *sidecarOp, error) {
 	metaRaw, ok := server["_pipelock"]
 	if !ok {
 		return server, nil, nil
@@ -626,7 +634,10 @@ func unwrapVscodeServer(server map[string]interface{}) (map[string]interface{}, 
 
 	var plan *sidecarOp
 	if meta.HeaderSidecarPath != "" {
-		path, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath)
+		if _, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath); err != nil {
+			return nil, nil, err
+		}
+		path, err := headerSidecarPath(targetConfigPath, serverName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cli/setup/vscode_test.go
+++ b/internal/cli/setup/vscode_test.go
@@ -911,7 +911,7 @@ func TestUnwrapVscodeServer_NoMeta(t *testing.T) {
 		"type":    testTypeStdio,
 		"command": testNodeCmd,
 	}
-	result, _, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -935,7 +935,7 @@ func TestUnwrapVscodeServer_HTTPWithHeaders(t *testing.T) {
 		},
 	}
 
-	result, _, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -977,7 +977,7 @@ func TestUnwrapVscodeServer_HeaderSidecarDeletePathValidated(t *testing.T) {
 		},
 	}
 
-	_, plan, err := unwrapVscodeServer(server)
+	_, plan, err := unwrapVscodeServer(server, filepath.Join(home, ".vscode", "mcp.json"), "remote")
 	if err != nil {
 		t.Fatalf("unwrapVscodeServer: %v", err)
 	}
@@ -1005,7 +1005,7 @@ func TestUnwrapVscodeServer_RejectsEscapingHeaderSidecarPath(t *testing.T) {
 		},
 	}
 
-	_, _, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err == nil {
 		t.Fatal("expected escaping header sidecar path to be rejected")
 	}
@@ -1045,7 +1045,7 @@ func TestUnwrapVscodeServer_RejectsSymlinkEscapingHeaderSidecarPath(t *testing.T
 		},
 	}
 
-	_, _, err = unwrapVscodeServer(server)
+	_, _, err = unwrapVscodeServer(server, "mcp.json", "remote")
 	if err == nil {
 		t.Fatal("expected symlink-escaping header sidecar path to be rejected")
 	}
@@ -1066,7 +1066,7 @@ func TestUnwrapVscodeServer_StdioNoArgs(t *testing.T) {
 		},
 	}
 
-	result, _, err := unwrapVscodeServer(server)
+	result, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1314,7 +1314,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingCommand(t *testing.T) {
 			// Missing original_command.
 		},
 	}
-	_, _, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err == nil {
 		t.Error("expected error for missing original_command")
 	}
@@ -1327,7 +1327,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingURL(t *testing.T) {
 			// Missing original_url.
 		},
 	}
-	_, _, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err == nil {
 		t.Error("expected error for missing original_url")
 	}
@@ -1339,7 +1339,7 @@ func TestUnwrapVscodeServer_InvalidMeta_MissingType(t *testing.T) {
 			// Missing original_type entirely.
 		},
 	}
-	_, _, err := unwrapVscodeServer(server)
+	_, _, err := unwrapVscodeServer(server, "mcp.json", "remote")
 	if err == nil {
 		t.Error("expected error for missing original_type")
 	}

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -448,7 +448,7 @@ func removeZedPath(cmd *cobra.Command, targetPath string, dryRun bool) error {
 			continue
 		}
 
-		restored, plan, unwrapErr := unwrapVscodeServer(server)
+		restored, plan, unwrapErr := unwrapVscodeServer(server, targetPath, name)
 		if unwrapErr != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not unwrap %q in %s: %v\n", name, targetPath, unwrapErr)
 			continue

--- a/internal/mcpwrap/coverage_test.go
+++ b/internal/mcpwrap/coverage_test.go
@@ -85,7 +85,7 @@ func TestUnwrapServer_MetaParseError(t *testing.T) {
 	t.Parallel()
 
 	// Non-object metadata propagates the ParseMeta error out of UnwrapServer.
-	if _, _, err := UnwrapServer(map[string]interface{}{FieldPipelock: "garbage"}); err == nil {
+	if _, _, err := UnwrapServer(map[string]interface{}{FieldPipelock: "garbage"}, "/cfg.yaml", "remote"); err == nil {
 		t.Fatal("expected UnwrapServer to surface a metadata parse error")
 	}
 }
@@ -101,7 +101,7 @@ func TestUnwrapServer_BadSidecarPath(t *testing.T) {
 			"original_url":        "https://u/mcp",
 			"header_sidecar_path": "relative/x.headers",
 		},
-	})
+	}, "/cfg.yaml", "remote")
 	if err == nil || !strings.Contains(err.Error(), "must be absolute") {
 		t.Fatalf("err = %v, want containing 'must be absolute'", err)
 	}

--- a/internal/mcpwrap/mcpwrap.go
+++ b/internal/mcpwrap/mcpwrap.go
@@ -269,7 +269,14 @@ func WrapServer(server map[string]interface{}, exe, configFile, targetConfigPath
 // wrapped config on disk while the credential carrier it references is gone.
 //
 // A server with no pipelock metadata is returned unchanged with a nil op.
-func UnwrapServer(server map[string]interface{}) (map[string]interface{}, *SidecarOp, error) {
+//
+// The delete target is DERIVED from targetConfigPath and serverName, matching
+// what WrapServer would have written, and is never taken from the metadata.
+// The marker lives in an operator-editable config and every server's sidecar
+// shares one directory, so honouring a metadata-supplied path would let one
+// server's entry nominate another server's credential file for deletion. The
+// metadata path is still shape-checked so a tampered marker fails closed.
+func UnwrapServer(server map[string]interface{}, targetConfigPath, serverName string) (map[string]interface{}, *SidecarOp, error) {
 	meta, ok, err := ParseMeta(server)
 	if err != nil {
 		return nil, nil, err
@@ -280,7 +287,10 @@ func UnwrapServer(server map[string]interface{}) (map[string]interface{}, *Sidec
 
 	var plan *SidecarOp
 	if meta.HeaderSidecarPath != "" {
-		path, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath)
+		if _, err := validatedHeaderSidecarDeletePath(meta.HeaderSidecarPath); err != nil {
+			return nil, nil, err
+		}
+		path, err := headerSidecarPath(targetConfigPath, serverName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/mcpwrap/mcpwrap_test.go
+++ b/internal/mcpwrap/mcpwrap_test.go
@@ -228,7 +228,7 @@ func TestUnwrapServer_RoundTrips(t *testing.T) {
 			if !IsWrapped(wrapped) {
 				t.Fatal("wrapped entry not detected as wrapped")
 			}
-			restored, _, err := UnwrapServer(wrapped)
+			restored, _, err := UnwrapServer(wrapped, "/cfg.yaml", "remote")
 			if err != nil {
 				t.Fatalf("UnwrapServer: %v", err)
 			}
@@ -243,7 +243,7 @@ func TestUnwrapServer_NotWrapped(t *testing.T) {
 	t.Parallel()
 
 	in := map[string]interface{}{FieldCommand: "x"}
-	out, op, err := UnwrapServer(in)
+	out, op, err := UnwrapServer(in, "/cfg.yaml", "remote")
 	if err != nil || op != nil {
 		t.Fatalf("unexpected err=%v op=%v", err, op)
 	}
@@ -268,7 +268,7 @@ func TestUnwrapServer_InvalidMeta(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := UnwrapServer(map[string]interface{}{FieldPipelock: tc.meta})
+			_, _, err := UnwrapServer(map[string]interface{}{FieldPipelock: tc.meta}, "/cfg.yaml", "remote")
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("err = %v, want containing %q", err, tc.want)
 			}

--- a/internal/mcpwrap/sidecar_delete_binding_test.go
+++ b/internal/mcpwrap/sidecar_delete_binding_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Pipelab
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpwrap
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestUnwrapServer_DeleteTargetIsDerivedNotMetadata locks in that the sidecar
+// delete target comes from the caller's (config path, server name) pair rather
+// than from the _pipelock marker. The marker lives in an operator-editable
+// config and every server's sidecar shares one directory, so honouring a
+// metadata-supplied path would let one entry nominate another server's
+// credential file for deletion.
+func TestUnwrapServer_DeleteTargetIsDerivedNotMetadata(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	victim, err := headerSidecarPath(filepath.Join(home, "other", "config.yaml"), "victim")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := commitHeaderSidecar(victim, []byte("Authorization: Bearer victim\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	const configPath = "/cfg.yaml"
+	const serverName = "evil"
+	want, err := headerSidecarPath(configPath, serverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want == victim {
+		t.Fatal("test setup is vacuous: derived path equals the victim path")
+	}
+
+	server := map[string]interface{}{
+		FieldPipelock: map[string]interface{}{
+			"original_type":       "http",
+			"original_url":        "https://api.vendor.example/mcp",
+			"header_sidecar_path": victim,
+		},
+	}
+	_, op, err := UnwrapServer(server, configPath, serverName)
+	if err != nil {
+		t.Fatalf("UnwrapServer: %v", err)
+	}
+	if op == nil || !op.IsDelete() {
+		t.Fatal("expected a sidecar delete op")
+	}
+	if op.path != want {
+		t.Errorf("delete path = %q, want the derived path %q", op.path, want)
+	}
+}

--- a/internal/mcpwrap/sidecar_test.go
+++ b/internal/mcpwrap/sidecar_test.go
@@ -273,7 +273,7 @@ func TestFullRoundTrip_WrapApplyUnwrapDelete(t *testing.T) {
 	}
 
 	wrapped[FieldPipelock] = roundTripMeta(t, meta)
-	_, deleteOp, err := UnwrapServer(wrapped)
+	_, deleteOp, err := UnwrapServer(wrapped, "/cfg.yaml", "remote")
 	if err != nil {
 		t.Fatalf("UnwrapServer: %v", err)
 	}


### PR DESCRIPTION
## What changed

An editor config controls its own `_pipelock` marker, and `remove` honoured that marker's `header_sidecar_path` as the file to delete. Containment to the private sidecar directory was not enough, because every server's credential file lives in that one directory: a config for one server could nominate an unrelated server's sidecar and `remove` would destroy it. Every unwrap path now recomputes the path from the current config path and server name, matching what wrap wrote. The metadata path is still shape-checked so a tampered marker fails closed, but it no longer selects the file removed.

The failure direction to distrust here is destructive rather than permissive: this does not grant new reach, it lets one config delete another server's credentials, so the thing to check in review is that no remaining path takes a deletion target from operator-visible metadata. The same shape existed in three unwrap paths, not one, and all three are covered. The JetBrains path is unaffected because its wrap step refuses HTTP servers carrying headers outright, so it never writes a sidecar.

Known tradeoff: a config that is moved or renamed after wrapping now leaves its old sidecar behind as an orphan, where the stale metadata path would previously have cleaned it up. That leaves a 0600 file in pipelock's own private directory rather than a credential in reach of anything else.

Manual step worth running, because it is the only end-to-end exercise of the legitimate cleanup and it is not in CI: `PIPELOCK_BIN=<built binary> bash examples/opencode-integration/verify.sh`, whose final assertion is that a real install-then-remove cycle deletes the sidecar it wrote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration and removal of wrapped server configurations across supported integrations.
  * Sidecar credential files are now deleted only when their paths match the target configuration and server, preventing unrelated credentials from being removed.
  * Added validation to reject malformed, unsafe, or tampered sidecar metadata.
* **Tests**
  * Added coverage for safe sidecar deletion, path traversal protection, symlink escapes, metadata errors, and restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->