### PR TITLE
fix(filesentry): return fatal watcher errors

### DIFF
--- a/internal/cli/runtime/filesentry_runtime_test.go
+++ b/internal/cli/runtime/filesentry_runtime_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/filesentry"
+)
+
+// fileSentryCloseBackstop converts a deadlocked stop path into a fast, clear
+// failure instead of letting it ride out the whole-package deadline. Close
+// ends Start in microseconds on a healthy run; this ceiling is generous so
+// heavy -race load never trips it.
+const fileSentryCloseBackstop = 10 * time.Second
+
+// TestFileSentryWatcherCloseUnblocksStartWithLiveContext pins the one
+// production assumption the gated fake below encodes but cannot validate: that
+// Close alone ends Start, and ends it CLEANLY.
+//
+// Both stop paths depend on it against a live, never-cancelled context.
+// `pipelock mcp proxy` calls stop after the wrapped child exits on its own, and
+// `pipelock run` calls stop after the proxy returns from Server.Shutdown. In
+// neither case has anything cancelled the watcher context, so the fsnotify
+// backend closing its Events/Errors channels is the only thing that returns
+// Start.
+//
+// Both failure directions are load-bearing and both are silent in a fake:
+// a Start that does not return deadlocks every clean shutdown, and a Start that
+// returns non-nil makes every clean run record a file-sentry runtime failure and
+// exit nonzero, which is the availability direction that gets a security control
+// switched off. The fake decides its own answer here by construction, so this
+// case is driven against the real watcher.
+func TestFileSentryWatcherCloseUnblocksStartWithLiveContext(t *testing.T) {
+	scanContent := false
+	cfg := &config.FileSentry{
+		Enabled:     true,
+		WatchPaths:  []config.WatchPath{{Path: t.TempDir()}},
+		ScanContent: &scanContent,
+	}
+	watcher, err := filesentry.NewWatcher(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	if armErr := watcher.Arm(); armErr != nil {
+		t.Fatalf("Arm: %v", armErr)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- watcher.Start(ctx) }()
+
+	if closeErr := watcher.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	select {
+	case startErr := <-done:
+		if startErr != nil {
+			t.Fatalf("Start after Close on a live context = %v, want nil; a non-nil return here reports a file sentry runtime failure on every clean shutdown", startErr)
+		}
+	case <-time.After(fileSentryCloseBackstop):
+		t.Fatalf("Start did not return within %s of Close on a live context; the stop path deadlocks on every clean shutdown", fileSentryCloseBackstop)
+	}
+}
+
+// gatedFileSentryWatcher lets runtime tests release a backend failure only
+// after the production path has started the watcher. It avoids timing-based
+// tests while still exercising the asynchronous lifecycle boundary.
+type gatedFileSentryWatcher struct {
+	err     error
+	started chan struct{}
+	release chan struct{}
+	stopped chan struct{}
+
+	findings  chan filesentry.Finding
+	overflow  chan filesentry.Finding
+	closeOnce sync.Once
+}
+
+func newGatedFileSentryWatcher(err error) *gatedFileSentryWatcher {
+	return &gatedFileSentryWatcher{
+		err:      err,
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		stopped:  make(chan struct{}),
+		findings: make(chan filesentry.Finding),
+		overflow: make(chan filesentry.Finding),
+	}
+}
+
+func (w *gatedFileSentryWatcher) Arm() error { return nil }
+
+func (w *gatedFileSentryWatcher) Start(ctx context.Context) error {
+	close(w.started)
+	select {
+	case <-w.release:
+		return w.err
+	case <-w.stopped:
+		return nil
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+func (w *gatedFileSentryWatcher) Findings() <-chan filesentry.Finding { return w.findings }
+
+func (w *gatedFileSentryWatcher) OverflowFindings() <-chan filesentry.Finding { return w.overflow }
+
+func (w *gatedFileSentryWatcher) DegradedPaths() []filesentry.DegradedPath { return nil }
+
+func (w *gatedFileSentryWatcher) DegradedPathCount() int { return 0 }
+
+func (w *gatedFileSentryWatcher) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.stopped)
+		close(w.findings)
+		close(w.overflow)
+	})
+	return nil
+}
+
+func installGatedFileSentryWatcher(t *testing.T, watcher *gatedFileSentryWatcher) {
+	t.Helper()
+	old := newFileSentryWatcher
+	newFileSentryWatcher = func(*config.FileSentry, filesentry.DLPScanner, filesentry.Lineage, func(error)) (filesentry.Watcher, error) {
+		return watcher, nil
+	}
+	t.Cleanup(func() { newFileSentryWatcher = old })
+}

--- a/internal/cli/runtime/filesentry_runtime_test.go
+++ b/internal/cli/runtime/filesentry_runtime_test.go
@@ -5,6 +5,8 @@ package runtime
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +20,31 @@ import (
 // ends Start in microseconds on a healthy run; this ceiling is generous so
 // heavy -race load never trips it.
 const fileSentryCloseBackstop = 10 * time.Second
+
+func TestPreferFileSentryRuntimeError(t *testing.T) {
+	startupErr := errors.New("bind failed")
+	fileSentryErr := errors.New("watch backend failed")
+
+	tests := []struct {
+		name     string
+		startErr error
+		wantErr  error
+	}{
+		{name: "nil early return", wantErr: fileSentryErr},
+		{name: "direct cancellation", startErr: context.Canceled, wantErr: fileSentryErr},
+		{name: "wrapped cancellation", startErr: fmt.Errorf("listener startup: %w", context.Canceled), wantErr: fileSentryErr},
+		{name: "unrelated startup failure", startErr: startupErr, wantErr: startupErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preferFileSentryRuntimeError(tt.startErr, fileSentryErr)
+			if !errors.Is(got, tt.wantErr) {
+				t.Fatalf("preferFileSentryRuntimeError() = %v, want %v", got, tt.wantErr)
+			}
+		})
+	}
+}
 
 // TestFileSentryWatcherCloseUnblocksStartWithLiveContext pins the one
 // production assumption the gated fake below encodes but cannot validate: that

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1706,6 +1706,7 @@ Key-free evidence capture:
 			// to prevent early writes from being missed.
 			var lin filesentry.Lineage
 			var onChildReady func()
+			stopFileSentry := func() error { return nil }
 			if cfg.FileSentry.Enabled {
 				lin = filesentry.NewLineage()
 				// Error handler for non-fatal runtime errors (e.g. failing to watch new dirs).
@@ -1746,24 +1747,40 @@ Key-free evidence capture:
 						OnFinding: findingHook,
 						Cancel:    cancel,
 					})
-					// Single defer: close watcher (flushes + closes channel),
-					// then wait for consumer to finish processing.
-					defer func() {
-						_ = watcher.Close()
-						waitConsumer()
-					}()
+					var failure fileSentryRuntimeFailure
+					var watcherWG sync.WaitGroup
+					var watcherStartOnce sync.Once
+					var stopOnce sync.Once
+					var stopErr error
+					stopFileSentry = func() error {
+						stopOnce.Do(func() {
+							_ = watcher.Close()
+							watcherWG.Wait()
+							waitConsumer()
+							if err := failure.get(); err != nil {
+								stopErr = fmt.Errorf("file sentry runtime failed: %w", err)
+							}
+						})
+						return stopErr
+					}
+					defer func() { _ = stopFileSentry() }()
 					reportFileSentryCoverage(logW, len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action, watcher.DegradedPathCount())
 
 					// onChildReady: called by RunProxy after cmd.Start() + TrackPID.
 					// Starts the file sentry event loop AFTER the child PID is registered,
 					// so attribution is ready before classifying any writes.
 					onChildReady = func() {
-						go func() {
-							if startErr := watcher.Start(ctx); startErr != nil {
-								_, _ = fmt.Fprintf(logW, "pipelock: file sentry fatal: %v — cancelling proxy\n", startErr)
-								cancel()
-							}
-						}()
+						watcherStartOnce.Do(func() {
+							watcherWG.Add(1)
+							go func() {
+								defer watcherWG.Done()
+								if startErr := watcher.Start(ctx); startErr != nil {
+									_, _ = fmt.Fprintf(logW, "pipelock: file sentry fatal: %v — cancelling proxy\n", startErr)
+									failure.set(startErr)
+									cancel()
+								}
+							}()
+						})
 					}
 				} // watcher != nil
 			}
@@ -1807,10 +1824,23 @@ Key-free evidence capture:
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "pipelock: proxying MCP server %v (response=%s, trust=%s, server=%s, input=%s, tools=%s, policy=%s)\n",
 				serverCmd, respAction, respTrust, respServer, inputCfg.Action, toolAction, policyAction)
 			if err := mcp.RunProxy(ctx, cmd.InOrStdin(), cmd.OutOrStdout(), logW, serverCmd, proxyOpts, extraEnv...); err != nil {
+				if fileSentryErr := stopFileSentry(); fileSentryErr != nil {
+					return fileSentryErr
+				}
 				if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
 					return heartbeatErr
 				}
+				// signal.NotifyContext terminates the wrapped child during an
+				// ordinary parent cancellation. That resulting process status is
+				// teardown noise, not a proxy failure. File-sentry and required
+				// heartbeat failures are checked above so they still fail closed.
+				if ctx.Err() != nil {
+					return nil
+				}
 				return handleProxyError(err, logW, sentryClient)
+			}
+			if fileSentryErr := stopFileSentry(); fileSentryErr != nil {
+				return fileSentryErr
 			}
 			if heartbeatErr := requiredHeartbeatErr(); heartbeatErr != nil {
 				return heartbeatErr

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -139,6 +139,111 @@ func TestMcpProxyCmd_FileSentryBestEffortRejectsInitializationFailure(t *testing
 	}
 }
 
+func TestMcpProxyCmd_ReturnsFileSentryRuntimeFailure(t *testing.T) {
+	wantErr := errors.New("watch backend failed")
+	watcher := newGatedFileSentryWatcher(wantErr)
+	installGatedFileSentryWatcher(t, watcher)
+	configPath := writeMCPFileSentryConfig(t, false, t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	inputR, inputW := io.Pipe()
+	defer func() { _ = inputR.Close() }()
+	defer func() { _ = inputW.Close() }()
+	cmd := McpCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetContext(ctx)
+	cmd.SetIn(inputR)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"proxy",
+		"--config", configPath,
+		"--env", "PIPELOCK_TEST_MCP_HELPER=1",
+		"--",
+		os.Args[0],
+		"-test.run=TestMCPRuntimeHelperProcess$",
+	})
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute() }()
+
+	select {
+	case <-watcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file sentry watcher did not start after MCP child launch")
+	}
+	close(watcher.release)
+	if err := inputW.Close(); err != nil {
+		t.Fatalf("close MCP input: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("mcp proxy error = %v, want file sentry runtime failure wrapping %v\nstderr:\n%s", err, wantErr, stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mcp proxy did not return after file sentry runtime failure")
+	}
+}
+
+func TestMcpProxyCmd_KeepsCleanCancellationNilWithFileSentry(t *testing.T) {
+	watcher := newGatedFileSentryWatcher(errors.New("must not be returned after clean cancellation"))
+	installGatedFileSentryWatcher(t, watcher)
+	configPath := writeMCPFileSentryConfig(t, false, t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	inputR, inputW := io.Pipe()
+	defer func() { _ = inputR.Close() }()
+	defer func() { _ = inputW.Close() }()
+	cmd := McpCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetContext(ctx)
+	cmd.SetIn(inputR)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"proxy",
+		"--config", configPath,
+		"--env", "PIPELOCK_TEST_MCP_HELPER=1",
+		"--",
+		os.Args[0],
+		"-test.run=TestMCPRuntimeHelperProcess$",
+	})
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute() }()
+
+	select {
+	case <-watcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file sentry watcher did not start after MCP child launch")
+	}
+	cancel()
+	if err := inputW.Close(); err != nil {
+		t.Fatalf("close MCP input: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("mcp proxy error after clean cancellation = %v, want nil\nstderr:\n%s", err, stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mcp proxy did not return after clean cancellation")
+	}
+}
+
+func TestMcpProxyCmd_KeepsNaturalChildExitNilWithFileSentry(t *testing.T) {
+	watcher := newGatedFileSentryWatcher(errors.New("must not be returned after natural child exit"))
+	installGatedFileSentryWatcher(t, watcher)
+	configPath := writeMCPFileSentryConfig(t, false, t.TempDir())
+
+	_, stderr, err := runMCPProxyCommand(t, configPath)
+	if err != nil {
+		t.Fatalf("mcp proxy error after natural child exit = %v, want nil\nstderr:\n%s", err, stderr)
+	}
+}
+
 func TestMcpProxyCmd_FileSentryKeepsRunningWhenOnePathArms(t *testing.T) {
 	watchDir := t.TempDir()
 	missing := filepath.Join(t.TempDir(), "nonexistent-mixed-coverage")

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -284,7 +284,7 @@ func killSwitchAPITokenConfigured(cfg *config.Config) bool {
 // proxy. Start blocks until ctx is cancelled or the proxy returns an
 // error, then drains listener error channels, closes owned resources, and
 // returns.
-func (s *Server) Start(ctx context.Context) error {
+func (s *Server) Start(ctx context.Context) (startErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancelMu.Lock()
 	s.internalCancel = cancel
@@ -426,7 +426,9 @@ func (s *Server) Start(ctx context.Context) error {
 	if fsErr != nil {
 		return fsErr
 	}
-	defer func() { _ = stopFileSentry() }()
+	defer func() {
+		startErr = preferFileSentryRuntimeError(startErr, stopFileSentry())
+	}()
 
 	// Pre-bind the fetch listener so the startup summary reports the real
 	// OS-chosen address when the configured port is ephemeral (":0"), instead
@@ -1260,6 +1262,13 @@ func (s *Server) Start(ctx context.Context) error {
 	s.logger.LogShutdown("signal received")
 	_, _ = fmt.Fprintln(s.opts.Stderr, "\nPipelock stopped.")
 	return nil
+}
+
+func preferFileSentryRuntimeError(startErr, fileSentryErr error) error {
+	if fileSentryErr != nil && (startErr == nil || errors.Is(startErr, context.Canceled)) {
+		return fileSentryErr
+	}
+	return startErr
 }
 
 // mcpAirlockConfigFor returns the live airlock configuration the MCP listener

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -34,9 +34,35 @@ import (
 
 var newFileSentryWatcher = filesentry.NewWatcher
 
-func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel context.CancelFunc) (func(), error) {
+// fileSentryRuntimeFailure preserves the first asynchronous watcher failure
+// until its owner has completed graceful shutdown. A file sentry backend error
+// is a fail-closed runtime failure; cancellation is only the mechanism used to
+// drain listeners and child processes safely.
+type fileSentryRuntimeFailure struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (f *fileSentryRuntimeFailure) set(err error) {
+	if err == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err == nil {
+		f.err = err
+	}
+}
+
+func (f *fileSentryRuntimeFailure) get() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.err
+}
+
+func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel context.CancelFunc) (func() error, error) {
 	if cfg == nil || !cfg.FileSentry.Enabled {
-		return func() {}, nil
+		return func() error { return nil }, nil
 	}
 
 	onErr := func(err error) {
@@ -58,7 +84,7 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		_ = watcher.Close()
 		if cfg.FileSentry.BestEffort && !fileSentryArmErrorMustFailClosed(err) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry failed to arm watches (best_effort: continuing without file monitoring): %v\n", err)
-			return func() {}, nil
+			return func() error { return nil }, nil
 		}
 		return nil, fmt.Errorf("file sentry failed to arm watches (feature is enabled): %w", err)
 	}
@@ -75,9 +101,13 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 		Cancel:    cancel,
 	})
 
+	var failure fileSentryRuntimeFailure
+	watcherDone := make(chan struct{})
 	go func() {
+		defer close(watcherDone)
 		if err := watcher.Start(ctx); err != nil {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry fatal: %v — cancelling runtime\n", err)
+			failure.set(err)
 			cancel()
 		}
 	}()
@@ -87,9 +117,18 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 	// roots would invent an inaccurate count.
 	reportFileSentryCoverage(s.opts.Stderr, len(cfg.FileSentry.WatchPaths), cfg.FileSentry.Action, watcher.DegradedPathCount())
 
-	return func() {
-		_ = watcher.Close()
-		waitConsumer()
+	var stopOnce sync.Once
+	var stopErr error
+	return func() error {
+		stopOnce.Do(func() {
+			_ = watcher.Close()
+			<-watcherDone
+			waitConsumer()
+			if err := failure.get(); err != nil {
+				stopErr = fmt.Errorf("file sentry runtime failed: %w", err)
+			}
+		})
+		return stopErr
 	}, nil
 }
 
@@ -387,7 +426,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if fsErr != nil {
 		return fsErr
 	}
-	defer stopFileSentry()
+	defer func() { _ = stopFileSentry() }()
 
 	// Pre-bind the fetch listener so the startup summary reports the real
 	// OS-chosen address when the configured port is ephemeral (":0"), instead
@@ -1208,6 +1247,10 @@ func (s *Server) Start(ctx context.Context) error {
 		if rpErr := <-reverseProxyErr; rpErr != nil {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: reverse proxy listener error: %v\n", rpErr)
 		}
+	}
+
+	if err := stopFileSentry(); err != nil {
+		return err
 	}
 
 	if heartbeatErr := getRequiredHeartbeatErr(); heartbeatErr != nil {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
+	"github.com/luckyPipewrench/pipelock/internal/filesentry"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
@@ -1302,6 +1303,123 @@ func TestServer_StartArmsFileSentry(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Start did not return within 5s of Shutdown")
+	}
+}
+
+func TestServer_StartReturnsFileSentryRuntimeFailure(t *testing.T) {
+	wantErr := errors.New("watch backend failed")
+	watcher := newGatedFileSentryWatcher(wantErr)
+	installGatedFileSentryWatcher(t, watcher)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(t.TempDir()),
+		"",
+	}, "\n"))
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.Start(context.Background()) }()
+	select {
+	case <-watcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file sentry watcher did not start")
+	}
+	waitForServerOutput(t, buf, "  Health:")
+	close(watcher.release)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Start error = %v, want file sentry runtime failure wrapping %v", err, wantErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after file sentry runtime failure")
+	}
+}
+
+func TestServer_StartKeepsCleanCancellationNilWithFileSentry(t *testing.T) {
+	watcher := newGatedFileSentryWatcher(errors.New("must not be returned after clean cancellation"))
+	installGatedFileSentryWatcher(t, watcher)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  watch_paths:",
+		"    - " + strconv.Quote(t.TempDir()),
+		"",
+	}, "\n"))
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.Start(context.Background()) }()
+	select {
+	case <-watcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file sentry watcher did not start")
+	}
+	waitForServerOutput(t, buf, "  Health:")
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start error after clean Shutdown = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Shutdown")
+	}
+}
+
+func TestServer_StartKeepsFileSentryBlockCancellationNil(t *testing.T) {
+	watcher := newGatedFileSentryWatcher(errors.New("must not be returned after a file sentry block"))
+	installGatedFileSentryWatcher(t, watcher)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"file_sentry:",
+		"  enabled: true",
+		"  action: block",
+		"  watch_paths:",
+		"    - " + strconv.Quote(t.TempDir()),
+		"",
+	}, "\n"))
+	s, buf := newTestServer(t, func(o *ServerOpts) {
+		o.ConfigFile = cfgPath
+		o.Listen = serverTestEphemeralListen
+		o.ListenChanged = true
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.Start(context.Background()) }()
+	select {
+	case <-watcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("file sentry watcher did not start")
+	}
+	waitForServerOutput(t, buf, "  Health:")
+	watcher.findings <- filesentry.Finding{Path: "agent-output", PatternName: "test", Severity: "high", IsAgent: true}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start error after file sentry block cancellation = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after file sentry block cancellation")
 	}
 }
 

--- a/internal/filesentry/watcher.go
+++ b/internal/filesentry/watcher.go
@@ -31,7 +31,9 @@ type Watcher interface {
 	// continues with accessible paths but reports every skipped subtree;
 	// strict mode, required paths, and zero armed paths return an error.
 	Arm() error
-	// Start processes filesystem events. Blocks until ctx is cancelled.
+	// Start processes filesystem events. Blocks until ctx is cancelled or Close
+	// stops the backend. A backend failure already queued when cancellation is
+	// observed is returned instead of being hidden by clean-shutdown handling.
 	// Call Arm() first to install watches.
 	Start(ctx context.Context) error
 	// Findings returns a channel that receives DLP findings as they are detected.

--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -302,6 +302,12 @@ func (w *fsWatcher) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			// Cancellation and a backend failure can become ready together.
+			// Prefer the queued failure so lost coverage cannot be reported as
+			// a clean shutdown merely because select chose ctx first.
+			if err := readyBackendError(w.watcher.Errors); err != nil {
+				return fmt.Errorf("fsnotify backend error: %w", err)
+			}
 			return nil
 		case ev, ok := <-w.watcher.Events:
 			if !ok {
@@ -319,6 +325,17 @@ func (w *fsWatcher) Start(ctx context.Context) error {
 			return fmt.Errorf("fsnotify backend error: %w", err)
 		}
 	}
+}
+
+func readyBackendError(errors <-chan error) error {
+	select {
+	case err, ok := <-errors:
+		if ok {
+			return err
+		}
+	default:
+	}
+	return nil
 }
 
 // Findings returns the channel that receives DLP findings.

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -30,6 +30,45 @@ const (
 	filesentrySubdirectoryRetryTick = 200 * time.Millisecond
 )
 
+func TestReadyBackendErrorPrefersQueuedFailure(t *testing.T) {
+	wantErr := errors.New("inotify queue overflow")
+	errorsCh := make(chan error, 1)
+	errorsCh <- wantErr
+
+	if got := readyBackendError(errorsCh); !errors.Is(got, wantErr) {
+		t.Fatalf("readyBackendError() = %v, want %v", got, wantErr)
+	}
+
+	if got := readyBackendError(errorsCh); got != nil {
+		t.Fatalf("readyBackendError() after drain = %v, want nil", got)
+	}
+
+	close(errorsCh)
+	if got := readyBackendError(errorsCh); got != nil {
+		t.Fatalf("readyBackendError() on closed channel = %v, want nil", got)
+	}
+}
+
+func TestStartPrefersQueuedBackendFailureOverCancellation(t *testing.T) {
+	backend, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("fsnotify.NewWatcher: %v", err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+
+	wantErr := errors.New("inotify queue overflow")
+	backend.Errors = make(chan error, 1)
+	backend.Errors <- wantErr
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	watcher := &fsWatcher{watcher: backend}
+	if got := watcher.Start(ctx); !errors.Is(got, wantErr) {
+		t.Fatalf("Start() = %v, want queued backend failure %v", got, wantErr)
+	}
+}
+
 // armAndStart arms the watcher synchronously, then starts the event loop
 // in a goroutine. Returns after watches are installed.
 // Start errors are captured via channel and checked in t.Cleanup to avoid


### PR DESCRIPTION
## What changed

- Return fatal file-sentry backend failures from the server and MCP runtimes after orderly teardown, so service managers can restart instead of treating lost monitoring as a clean exit.
- Prefer queued backend errors over concurrent cancellation while keeping clean shutdown, block enforcement, and natural child exit successful. Reviewers should distrust any path where cancellation can erase a stored watcher failure or turn expected shutdown into an availability failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-watching failures are now reported reliably instead of being hidden during shutdown or cancellation.
  * Runtime errors from file monitoring now propagate correctly when starting or stopping services.
  * Improved shutdown handling prevents hangs and ensures monitoring stops cleanly.
  * Normal cancellation and successful process completion continue to finish without unnecessary errors.

* **Documentation**
  * Clarified file-watcher behavior when cancellation and backend failures occur at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->