### PR TITLE
test(e2e): pin HOME across the cline install and remove pair

### DIFF
--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -150,7 +150,7 @@ assert_no_discovery_warning() {
   # Anchored whole-line matches against the two documented outcomes. A
   # substring match would accept the phrase inside unrelated output, and
   # matching only a line prefix would accept a truncated or malformed line.
-  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, ' "$stderr_file" || true)
+  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, .*to enable scanning\.$' "$stderr_file" || true)
   discovered=$(grep -c '^Using config .* for the wrapped MCP proxy\.$' "$stderr_file" || true)
   # Exactly one outcome is the only readable result. Both means the run
   # contradicted itself and neither means the command said something we do not

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -91,6 +91,12 @@ trap cleanup EXIT
 
 CONFIG="$WORKDIR/cline_mcp_settings.json"
 SEED="$WORKDIR/cline_mcp_settings.seed.json"
+# Every invocation that writes or reads a header sidecar must resolve the same
+# HOME, because the sidecar directory is derived from it. Pinning HOME on
+# install but not on remove makes remove look in the operator's real home,
+# reject the recorded path as escaping the sidecar directory, and silently
+# leave the entry wrapped with its credential file still on disk.
+E2E_HOME="$WORKDIR/empty-home"
 
 if [[ -n "${PIPELOCK_BIN:-}" ]]; then
   PIPELOCK="$PIPELOCK_BIN"
@@ -102,7 +108,9 @@ fi
 
 PASS=0
 FAIL=0
+SKIP=0
 FAILED_TESTS=()
+SKIPPED_TESTS=()
 
 # assert <description> <command>: runs the command, records pass/fail.
 assert() {
@@ -117,6 +125,20 @@ assert() {
     echo "  FAIL  $desc"
   fi
 }
+
+# skip <description> <reason>: records an assertion this host cannot run. The
+# reason is printed and summarized so a skipped check never reads as coverage.
+skip() {
+  SKIP=$((SKIP + 1))
+  SKIPPED_TESTS+=("$1 ($2)")
+  echo "  SKIP  $1 ($2)"
+}
+
+# SYSTEM_CONFIG is the last candidate pipelock's config discovery consults, and
+# no environment variable can suppress it. A host that has one cannot exercise
+# the nothing-discoverable branch, so that single assertion is skipped there
+# rather than reported as a failure of the code under test.
+SYSTEM_CONFIG="/etc/pipelock/pipelock.yaml"
 
 json_value_equals() {
   local file="$1"
@@ -206,12 +228,17 @@ echo "[1] install"
 # Suppress pipelock config auto-discovery so this script remains hermetic and
 # does not pick up the operator's $HOME pipelock.yaml. Operators get
 # auto-discovery; the test asserts the no-discovery warning instead.
-PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$WORKDIR/empty-home" \
+PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$E2E_HOME" \
   "$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install.stdout" 2>"$WORKDIR/install.stderr"
 assert "install exit 0" test -s "$WORKDIR/install.stdout"
 assert "install stdout reports 2 wrapped" grep -q "Wrapped 2 server(s)" "$WORKDIR/install.stdout"
-assert "install stderr warns when no pipelock config is discoverable" \
-  grep -q "no pipelock config found" "$WORKDIR/install.stderr"
+if [[ -e "$SYSTEM_CONFIG" ]]; then
+  skip "install stderr warns when no pipelock config is discoverable" \
+    "$SYSTEM_CONFIG exists on this host"
+else
+  assert "install stderr warns when no pipelock config is discoverable" \
+    grep -q "no pipelock config found" "$WORKDIR/install.stderr"
+fi
 
 # Second install pass exercises the auto-discovery branch against a seeded
 # user config in a controlled HOME. The wrapped argv must carry --config.
@@ -322,7 +349,7 @@ assert "wrapped argv parses without cobra error" \
 echo ""
 echo "[4] remove and restore"
 
-"$PIPELOCK" cline remove --path "$CONFIG" >"$WORKDIR/remove.stdout" 2>"$WORKDIR/remove.stderr"
+HOME="$E2E_HOME" "$PIPELOCK" cline remove --path "$CONFIG" >"$WORKDIR/remove.stdout" 2>"$WORKDIR/remove.stderr"
 assert "remove exit 0" test -s "$WORKDIR/remove.stdout"
 assert "remove stdout reports 2 unwrapped" grep -q "Unwrapped 2 server(s)" "$WORKDIR/remove.stdout"
 
@@ -353,14 +380,23 @@ echo "[5] idempotence: re-run install on already-installed config (no double-wra
 
 # Re-run install on the (restored) config; should wrap both servers exactly
 # once. Then re-run on the wrapped config; should skip both.
-"$PIPELOCK" cline install --path "$CONFIG" >/dev/null 2>&1
-"$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install2.stdout" 2>&1
+HOME="$E2E_HOME" "$PIPELOCK" cline install --path "$CONFIG" >/dev/null 2>&1
+HOME="$E2E_HOME" "$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install2.stdout" 2>&1
 assert "second install skipped both servers" grep -q "Wrapped 0 server(s).*(2 already wrapped)" "$WORKDIR/install2.stdout"
 
 echo ""
 echo "=== Summary ==="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"
+echo "SKIP: $SKIP"
+
+if [[ $SKIP -gt 0 ]]; then
+  echo ""
+  echo "Skipped assertions (not covered on this host):"
+  for t in "${SKIPPED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+fi
 
 if [[ $FAIL -gt 0 ]]; then
   echo ""

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -146,12 +146,24 @@ skip() {
 assert_no_discovery_warning() {
   local stderr_file="$1"
   local desc="install stderr warns when no pipelock config is discoverable"
-  if grep -q "no pipelock config found" "$stderr_file"; then
+  local warned discovered config
+  # Anchored whole-line matches against the two documented outcomes. A
+  # substring match would accept the phrase inside unrelated output, and
+  # matching only a line prefix would accept a truncated or malformed line.
+  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, ' "$stderr_file" || true)
+  discovered=$(grep -c '^Using config .* for the wrapped MCP proxy\.$' "$stderr_file" || true)
+  # Exactly one outcome is the only readable result. Both means the run
+  # contradicted itself and neither means the command said something we do not
+  # recognise; either way the outcome is unknown, and an unknown outcome fails
+  # rather than skipping, because a skip would record it as deliberately
+  # uncovered when in fact it was not understood.
+  if [ "$warned" -eq 1 ] && [ "$discovered" -eq 0 ]; then
     assert "$desc" true
-  elif grep -q "^Using config " "$stderr_file"; then
-    skip "$desc" \
-      "$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file" | head -1) was discoverable on this host"
+  elif [ "$discovered" -eq 1 ] && [ "$warned" -eq 0 ]; then
+    config=$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file")
+    skip "$desc" "$config was discoverable on this host"
   else
+    echo "    unreadable discovery outcome: warned=$warned discovered=$discovered" >&2
     assert "$desc" false
   fi
 }

--- a/scripts/e2e/cline-install.sh
+++ b/scripts/e2e/cline-install.sh
@@ -134,11 +134,27 @@ skip() {
   echo "  SKIP  $1 ($2)"
 }
 
-# SYSTEM_CONFIG is the last candidate pipelock's config discovery consults, and
-# no environment variable can suppress it. A host that has one cannot exercise
-# the nothing-discoverable branch, so that single assertion is skipped there
-# rather than reported as a failure of the code under test.
-SYSTEM_CONFIG="/etc/pipelock/pipelock.yaml"
+# Config discovery ends at a compiled-in system path that no environment
+# variable can suppress, so a host carrying a usable config there cannot
+# exercise the nothing-discoverable branch. Decide that from what the
+# invocation actually did rather than by probing the host: a separate probe
+# races the invocation, and reproducing discovery's regular-file and
+# permission predicate in shell would be a second copy of a security check
+# that is free to drift from the real one. The command reports exactly one of
+# the two outcomes on stderr, so the outcome itself says whether the branch
+# ran.
+assert_no_discovery_warning() {
+  local stderr_file="$1"
+  local desc="install stderr warns when no pipelock config is discoverable"
+  if grep -q "no pipelock config found" "$stderr_file"; then
+    assert "$desc" true
+  elif grep -q "^Using config " "$stderr_file"; then
+    skip "$desc" \
+      "$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file" | head -1) was discoverable on this host"
+  else
+    assert "$desc" false
+  fi
+}
 
 json_value_equals() {
   local file="$1"
@@ -232,13 +248,7 @@ PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$E2E_HOME" \
   "$PIPELOCK" cline install --path "$CONFIG" >"$WORKDIR/install.stdout" 2>"$WORKDIR/install.stderr"
 assert "install exit 0" test -s "$WORKDIR/install.stdout"
 assert "install stdout reports 2 wrapped" grep -q "Wrapped 2 server(s)" "$WORKDIR/install.stdout"
-if [[ -e "$SYSTEM_CONFIG" ]]; then
-  skip "install stderr warns when no pipelock config is discoverable" \
-    "$SYSTEM_CONFIG exists on this host"
-else
-  assert "install stderr warns when no pipelock config is discoverable" \
-    grep -q "no pipelock config found" "$WORKDIR/install.stderr"
-fi
+assert_no_discovery_warning "$WORKDIR/install.stderr"
 
 # Second install pass exercises the auto-discovery branch against a seeded
 # user config in a controlled HOME. The wrapped argv must carry --config.

--- a/scripts/e2e/opencode-install.sh
+++ b/scripts/e2e/opencode-install.sh
@@ -102,12 +102,6 @@ skip() {
   echo "  SKIP  $1 ($2)"
 }
 
-# SYSTEM_CONFIG is the last candidate pipelock's config discovery consults, and
-# no environment variable can suppress it. A host that has one cannot exercise
-# the nothing-discoverable branch, so that single assertion is skipped there
-# rather than reported as a failure of the code under test.
-SYSTEM_CONFIG="/etc/pipelock/pipelock.yaml"
-
 assert() {
   local desc="$1"
   shift
@@ -118,6 +112,28 @@ assert() {
     FAIL=$((FAIL + 1))
     FAILED_TESTS+=("$desc")
     echo "  FAIL  $desc"
+  fi
+}
+
+# Config discovery ends at a compiled-in system path that no environment
+# variable can suppress, so a host carrying a usable config there cannot
+# exercise the nothing-discoverable branch. Decide that from what the
+# invocation actually did rather than by probing the host: a separate probe
+# races the invocation, and reproducing discovery's regular-file and
+# permission predicate in shell would be a second copy of a security check
+# that is free to drift from the real one. The command reports exactly one of
+# the two outcomes on stderr, so the outcome itself says whether the branch
+# ran.
+assert_no_discovery_warning() {
+  local stderr_file="$1"
+  local desc="install stderr warns when no pipelock config is discoverable"
+  if grep -q "no pipelock config found" "$stderr_file"; then
+    assert "$desc" true
+  elif grep -q "^Using config " "$stderr_file"; then
+    skip "$desc" \
+      "$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file" | head -1) was discoverable on this host"
+  else
+    assert "$desc" false
   fi
 }
 
@@ -201,13 +217,7 @@ PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$E2E_HOME" \
   "$PIPELOCK" opencode install --path "$CONFIG" >"$WORKDIR/install.stdout" 2>"$WORKDIR/install.stderr"
 assert "install exit 0" test -s "$WORKDIR/install.stdout"
 assert "install stdout reports 2 wrapped" grep -q "Wrapped 2 server(s)" "$WORKDIR/install.stdout"
-if [[ -e "$SYSTEM_CONFIG" ]]; then
-  skip "install stderr warns when no pipelock config is discoverable" \
-    "$SYSTEM_CONFIG exists on this host"
-else
-  assert "install stderr warns when no pipelock config is discoverable" \
-    grep -q "no pipelock config found" "$WORKDIR/install.stderr"
-fi
+assert_no_discovery_warning "$WORKDIR/install.stderr"
 
 echo ""
 echo "[1b] install honors auto-discovery"

--- a/scripts/e2e/opencode-install.sh
+++ b/scripts/e2e/opencode-install.sh
@@ -90,7 +90,23 @@ fi
 
 PASS=0
 FAIL=0
+SKIP=0
 FAILED_TESTS=()
+SKIPPED_TESTS=()
+
+# skip <description> <reason>: records an assertion this host cannot run. The
+# reason is printed and summarized so a skipped check never reads as coverage.
+skip() {
+  SKIP=$((SKIP + 1))
+  SKIPPED_TESTS+=("$1 ($2)")
+  echo "  SKIP  $1 ($2)"
+}
+
+# SYSTEM_CONFIG is the last candidate pipelock's config discovery consults, and
+# no environment variable can suppress it. A host that has one cannot exercise
+# the nothing-discoverable branch, so that single assertion is skipped there
+# rather than reported as a failure of the code under test.
+SYSTEM_CONFIG="/etc/pipelock/pipelock.yaml"
 
 assert() {
   local desc="$1"
@@ -185,8 +201,13 @@ PIPELOCK_CONFIG="" XDG_CONFIG_HOME="$WORKDIR/empty-xdg" HOME="$E2E_HOME" \
   "$PIPELOCK" opencode install --path "$CONFIG" >"$WORKDIR/install.stdout" 2>"$WORKDIR/install.stderr"
 assert "install exit 0" test -s "$WORKDIR/install.stdout"
 assert "install stdout reports 2 wrapped" grep -q "Wrapped 2 server(s)" "$WORKDIR/install.stdout"
-assert "install stderr warns when no pipelock config is discoverable" \
-  grep -q "no pipelock config found" "$WORKDIR/install.stderr"
+if [[ -e "$SYSTEM_CONFIG" ]]; then
+  skip "install stderr warns when no pipelock config is discoverable" \
+    "$SYSTEM_CONFIG exists on this host"
+else
+  assert "install stderr warns when no pipelock config is discoverable" \
+    grep -q "no pipelock config found" "$WORKDIR/install.stderr"
+fi
 
 echo ""
 echo "[1b] install honors auto-discovery"
@@ -304,6 +325,15 @@ echo ""
 echo "=== Summary ==="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"
+echo "SKIP: $SKIP"
+
+if [[ $SKIP -gt 0 ]]; then
+  echo ""
+  echo "Skipped assertions (not covered on this host):"
+  for t in "${SKIPPED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+fi
 
 if [[ $FAIL -gt 0 ]]; then
   echo ""

--- a/scripts/e2e/opencode-install.sh
+++ b/scripts/e2e/opencode-install.sh
@@ -127,12 +127,24 @@ assert() {
 assert_no_discovery_warning() {
   local stderr_file="$1"
   local desc="install stderr warns when no pipelock config is discoverable"
-  if grep -q "no pipelock config found" "$stderr_file"; then
+  local warned discovered config
+  # Anchored whole-line matches against the two documented outcomes. A
+  # substring match would accept the phrase inside unrelated output, and
+  # matching only a line prefix would accept a truncated or malformed line.
+  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, ' "$stderr_file" || true)
+  discovered=$(grep -c '^Using config .* for the wrapped MCP proxy\.$' "$stderr_file" || true)
+  # Exactly one outcome is the only readable result. Both means the run
+  # contradicted itself and neither means the command said something we do not
+  # recognise; either way the outcome is unknown, and an unknown outcome fails
+  # rather than skipping, because a skip would record it as deliberately
+  # uncovered when in fact it was not understood.
+  if [ "$warned" -eq 1 ] && [ "$discovered" -eq 0 ]; then
     assert "$desc" true
-  elif grep -q "^Using config " "$stderr_file"; then
-    skip "$desc" \
-      "$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file" | head -1) was discoverable on this host"
+  elif [ "$discovered" -eq 1 ] && [ "$warned" -eq 0 ]; then
+    config=$(sed -n 's/^Using config \(.*\) for the wrapped MCP proxy\.$/\1/p' "$stderr_file")
+    skip "$desc" "$config was discoverable on this host"
   else
+    echo "    unreadable discovery outcome: warned=$warned discovered=$discovered" >&2
     assert "$desc" false
   fi
 }

--- a/scripts/e2e/opencode-install.sh
+++ b/scripts/e2e/opencode-install.sh
@@ -131,7 +131,7 @@ assert_no_discovery_warning() {
   # Anchored whole-line matches against the two documented outcomes. A
   # substring match would accept the phrase inside unrelated output, and
   # matching only a line prefix would accept a truncated or malformed line.
-  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, ' "$stderr_file" || true)
+  warned=$(grep -c '^warning: no pipelock config found at PIPELOCK_CONFIG, .*to enable scanning\.$' "$stderr_file" || true)
   discovered=$(grep -c '^Using config .* for the wrapped MCP proxy\.$' "$stderr_file" || true)
   # Exactly one outcome is the only readable result. Both means the run
   # contradicted itself and neither means the command said something we do not


### PR DESCRIPTION
## What changed

The cline end-to-end script pinned a fixture HOME on install but not on remove. The header sidecar directory is derived from HOME, so remove looked in the operator's real home, rejected the recorded path as escaping the sidecar directory, and left the HTTP entry wrapped with its credential file still on disk. The HTTP removal path therefore had no working coverage on any host whose real home differs from the fixture. Remove and the idempotence re-installs now share the same pinned home, which the opencode sibling script already did.

Both scripts also gain a skip path for the one assertion that requires no discoverable pipelock config. Config discovery ends at a compiled-in system path that no environment variable can suppress, so a host carrying that file cannot exercise the branch. Skips are counted and listed in the summary so a check that did not run never reads as one that passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end installation checks for more consistent behavior across environments.
  - Installation, removal, and repeat-run checks now use a controlled home directory where applicable.
  - Added clearer handling for environments with existing system configuration.
  - Skipped assertions are now tracked separately and included in final test summaries with reasons.
  - Configuration checks now distinguish between absent, discovered, contradictory, and unrecognized outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->