### PR TITLE
fix(taint): preserve sticky risk source attribution

### DIFF
--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -659,8 +659,8 @@ func ForwardScannedInput(
 					Authority:   decision.Authority.String(),
 					Decision:    decision.Result.Decision.String(),
 					Reason:      decision.Result.Reason,
-					SourceURL:   decision.Risk.LastExternalURL,
-					SourceKind:  decision.Risk.LastExternalKind,
+					SourceURL:   decision.Risk.SecurityOriginURL(),
+					SourceKind:  decision.Risk.SecurityOriginKind(),
 				},
 			)
 		}

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -428,8 +428,8 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				Authority:   decision.Authority.String(),
 				Decision:    decision.Result.Decision.String(),
 				Reason:      decision.Result.Reason,
-				SourceURL:   decision.Risk.LastExternalURL,
-				SourceKind:  decision.Risk.LastExternalKind,
+				SourceURL:   decision.Risk.SecurityOriginURL(),
+				SourceKind:  decision.Risk.SecurityOriginKind(),
 			},
 		)
 	}

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -275,7 +275,7 @@ func allTaintActionRefsMatch(actionRefs []string, pattern string) bool {
 }
 
 func taintRiskSourceMatches(risk session.SessionRisk, pattern string) bool {
-	return taintWildcardMatch(risk.LastExternalURL, pattern)
+	return taintWildcardMatch(risk.SecurityOriginURL(), pattern)
 }
 
 func taintWildcardMatch(value, pattern string) bool {

--- a/internal/mcp/taint_test.go
+++ b/internal/mcp/taint_test.go
@@ -275,6 +275,13 @@ func TestScanHTTPInput_TaintProtectedWriteRequiresApproval(t *testing.T) {
 			Level: session.TaintExternalUntrusted,
 		},
 	})
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://docs.vendor.example/copilot",
+			Kind:  "http_response",
+			Level: session.TaintAllowlistedReference,
+		},
+	})
 	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write_file","arguments":{"path":"/repo/auth/middleware.go","content":"x"}}}`)
 
 	blocked := scanHTTPInput(msg, &bytes.Buffer{}, "sess", "sess", MCPProxyOpts{
@@ -419,6 +426,12 @@ func TestScanHTTPInputDecision_ApprovedTaintAskEmitsAudit(t *testing.T) {
 		}
 		if ev.Fields["authority_kind"] != session.AuthorityUserBroad.String() {
 			t.Fatalf("authority_kind = %v, want %q", ev.Fields["authority_kind"], session.AuthorityUserBroad.String())
+		}
+		if ev.Fields["source_url"] != "https://evil.example/issue/123" {
+			t.Fatalf("source_url = %v, want sticky taint origin", ev.Fields["source_url"])
+		}
+		if ev.Fields["source_kind"] != "http_response" {
+			t.Fatalf("source_kind = %v, want http_response", ev.Fields["source_kind"])
 		}
 		return
 	}
@@ -608,7 +621,12 @@ func TestMCPReportedActionRef(t *testing.T) {
 	}
 }
 
-func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
+// A benign allowlisted source observed AFTER a hostile one must not be able to
+// satisfy a source-scoped trust override: the session's sticky taint still comes
+// from the hostile source. The benign observation has to come last, or the test
+// passes on unpatched code too - a latest-source-wins origin and a
+// highest-source-wins origin agree whenever the hostile source is the latest.
+func TestEvaluateMCPTaint_TrustOverrideUsesStickyTaintOrigin(t *testing.T) {
 	t.Parallel()
 
 	sc := testScannerWithAction(t, config.ActionWarn)
@@ -616,10 +634,143 @@ func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 	rec := &taintRecorder{}
 	rec.ObserveRisk(session.RiskObservation{
 		Source: session.TaintSourceRef{
-			URL:   "https://docs.github.com/copilot",
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://docs.vendor.example/copilot",
 			Kind:  "http_response",
 			Level: session.TaintAllowlistedReference,
 		},
+	})
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       "source",
+		SourceMatch: "https://docs.vendor.example/*",
+		ExpiresAt:   nowPlusHour(t),
+	}}
+
+	decision := evaluateMCPTaint(MCPProxyOpts{
+		Scanner:  sc,
+		Rec:      rec,
+		TaintCfg: &cfg.Taint,
+	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyAsk {
+		t.Fatalf("decision = %v, want ask when only a later benign source matches", decision.Result.Decision)
+	}
+}
+
+// The MCP ingest path taints with a Kind and no URL
+// (ClassifyMCPResponseObservation sets no URL), so an origin can legitimately
+// have an empty URL. A later benign HTTP fetch in the same session then supplies
+// the only non-empty LastExternalURL. Keying "was an origin recorded" on the
+// origin URL alone treats that origin as absent and falls back to the benign
+// URL, which a source-scoped override matches - the exact substitution the
+// sticky origin exists to prevent, on the most common mixed MCP+proxy session.
+func TestEvaluateMCPTaint_TrustOverrideIgnoresURLLessOrigin(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.ClassifyMCPResponseObservation(mcpTaintSourceKind, true, false))
+	if got := rec.RiskSnapshot().Level; got != session.TaintExternalUntrusted {
+		t.Fatalf("setup: level = %v, want untrusted", got)
+	}
+	if got := rec.RiskSnapshot().SecurityOriginURL(); got != "" {
+		t.Fatalf("setup: security origin URL = %q, want empty for URL-less MCP origin", got)
+	}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://docs.vendor.example/copilot",
+			Kind:  "http_response",
+			Level: session.TaintAllowlistedReference,
+		},
+	})
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       "source",
+		SourceMatch: "https://docs.vendor.example/*",
+		ExpiresAt:   nowPlusHour(t),
+	}}
+
+	decision := evaluateMCPTaint(MCPProxyOpts{
+		Scanner:  sc,
+		Rec:      rec,
+		TaintCfg: &cfg.Taint,
+	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyAsk {
+		t.Fatalf("decision = %v, want ask when the origin is the URL-less MCP source", decision.Result.Decision)
+	}
+}
+
+// Being more severe does not make a source the origin. A docs page an operator
+// trusts enough to have written a source-scoped override for can still be
+// escalated to hostile by the documented false-positive class - security prose
+// that trips the injection patterns. If that escalation hands it the origin,
+// the override matches and clears a protected write that the earlier untrusted
+// page still justifies blocking. Worse, the decision gets more permissive as
+// the session gets strictly more dangerous: without the override the hostile
+// level is a block, not an ask, so the laundering converts a block into an
+// allow.
+func TestEvaluateMCPTaint_TrustOverrideIgnoresMoreSevereBenignSource(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://evil.example/issue/123",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+	})
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://docs.vendor.example/copilot",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+		PromptHit: true,
+	})
+	if got := rec.RiskSnapshot().Level; got != session.TaintExternalHostile {
+		t.Fatalf("setup: level = %v, want hostile", got)
+	}
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       "source",
+		SourceMatch: "https://docs.vendor.example/*",
+		ExpiresAt:   nowPlusHour(t),
+	}}
+
+	decision := evaluateMCPTaint(MCPProxyOpts{
+		Scanner:  sc,
+		Rec:      rec,
+		TaintCfg: &cfg.Taint,
+	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyBlock {
+		t.Fatalf("decision = %v, want block when a second source still contaminates", decision.Result.Decision)
+	}
+}
+
+// The reverse ordering of the same laundering: the untrusted page arrives after
+// the hostile one, so it is strictly less severe than the recorded origin. It
+// still contaminates independently, so an override naming the hostile origin
+// must not clear the action either.
+func TestEvaluateMCPTaint_TrustOverrideIgnoresOriginOutrankingALaterSource(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	rec.ObserveRisk(session.RiskObservation{
+		Source: session.TaintSourceRef{
+			URL:   "https://docs.vendor.example/copilot",
+			Kind:  "http_response",
+			Level: session.TaintExternalUntrusted,
+		},
+		PromptHit: true,
 	})
 	rec.ObserveRisk(session.RiskObservation{
 		Source: session.TaintSourceRef{
@@ -630,7 +781,7 @@ func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 	})
 	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
 		Scope:       "source",
-		SourceMatch: "https://docs.github.com/*",
+		SourceMatch: "https://docs.vendor.example/*",
 		ExpiresAt:   nowPlusHour(t),
 	}}
 
@@ -639,8 +790,40 @@ func TestEvaluateMCPTaint_TrustOverrideUsesActiveSourceOnly(t *testing.T) {
 		Rec:      rec,
 		TaintCfg: &cfg.Taint,
 	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
-	if decision.Result.Decision != session.PolicyAsk {
-		t.Fatalf("decision = %v, want ask when only a historical source matches", decision.Result.Decision)
+	if decision.Result.Decision != session.PolicyBlock {
+		t.Fatalf("decision = %v, want block when a later source still contaminates", decision.Result.Decision)
+	}
+}
+
+// A single hostile source must stay nameable. This is the availability half of
+// the ambiguity rule: if escalation alone erased attribution, the operator's
+// narrowest remedy would never work and the override knob would be dead.
+func TestEvaluateMCPTaint_TrustOverrideStillMatchesSingleEscalatingSource(t *testing.T) {
+	t.Parallel()
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	cfg := config.Defaults()
+	rec := &taintRecorder{}
+	source := session.TaintSourceRef{
+		URL:   "https://docs.vendor.example/copilot",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	rec.ObserveRisk(session.RiskObservation{Source: source})
+	rec.ObserveRisk(session.RiskObservation{Source: source, PromptHit: true})
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       "source",
+		SourceMatch: "https://docs.vendor.example/*",
+		ExpiresAt:   nowPlusHour(t),
+	}}
+
+	decision := evaluateMCPTaint(MCPProxyOpts{
+		Scanner:  sc,
+		Rec:      rec,
+		TaintCfg: &cfg.Taint,
+	}, "write_file", `{"path":"/repo/auth/middleware.go","content":"x"}`)
+	if decision.Result.Decision != session.PolicyAllow {
+		t.Fatalf("decision = %v, want allow for the one source the override names", decision.Result.Decision)
 	}
 }
 

--- a/internal/proxy/cross_agent_test.go
+++ b/internal/proxy/cross_agent_test.go
@@ -114,8 +114,8 @@ func TestCrossAgentContaminationSurvivesReset(t *testing.T) {
 }
 
 // Cross-agent evidence resets LastExternalKind to "cross_agent" but preserves
-// LastExternalURL. Source-scoped trust overrides match on URL only, so the
-// boundary ref must not break an operator's source-match override.
+// LastExternalURL. The sticky security origin remains the original source, so
+// the synthesized boundary ref cannot replace it in source-scoped trust checks.
 func TestCrossAgentContaminationPreservesSourceTrustOverride(t *testing.T) {
 	sess := &SessionState{}
 	contaminateSession(sess, session.TaintExternalUntrusted, false)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1162,8 +1162,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				Authority:   forwardTaint.Authority.String(),
 				Decision:    forwardTaint.Result.Decision.String(),
 				Reason:      forwardTaint.Result.Reason,
-				SourceURL:   forwardTaint.Risk.LastExternalURL,
-				SourceKind:  forwardTaint.Risk.LastExternalKind,
+				SourceURL:   forwardTaint.Risk.SecurityOriginURL(),
+				SourceKind:  forwardTaint.Risk.SecurityOriginKind(),
 			},
 		)
 	}

--- a/internal/proxy/taint.go
+++ b/internal/proxy/taint.go
@@ -167,7 +167,7 @@ func runtimeTrustOverrideApplies(overrides []session.TrustOverride, task session
 }
 
 func riskSourceMatches(risk session.SessionRisk, pattern string) bool {
-	return wildcardMatch(risk.LastExternalURL, pattern)
+	return wildcardMatch(risk.SecurityOriginURL(), pattern)
 }
 
 func wildcardMatch(value, pattern string) bool {

--- a/internal/session/cross_agent.go
+++ b/internal/session/cross_agent.go
@@ -48,9 +48,17 @@ func ClassifyCrossAgentObservation(current SessionRisk, boundary CrossAgentBound
 	if level < TaintExternalUntrusted {
 		level = TaintExternalUntrusted
 	}
+	url := current.SecurityOriginURL()
+	if url == "" {
+		// Ambiguous and URL-less origins cannot name one source, but the
+		// cross-agent ref must not erase the latest external audit context.
+		// updateTaintOrigin never adopts a synthesized cross-agent ref, so this
+		// fallback cannot rename the security origin.
+		url = current.LastExternalURL
+	}
 	return RiskObservation{
 		Source: TaintSourceRef{
-			URL:         current.LastExternalURL,
+			URL:         url,
 			Kind:        TaintSourceKindCrossAgent,
 			Level:       level,
 			MatchReason: crossAgentMatchReason(boundary),

--- a/internal/session/risk.go
+++ b/internal/session/risk.go
@@ -89,10 +89,20 @@ type SessionRisk struct {
 	LastExternalAt   time.Time        `json:"last_external_at,omitempty"`
 	LastExternalURL  string           `json:"last_external_url,omitempty"`
 	LastExternalKind string           `json:"last_external_kind,omitempty"`
+	TaintOriginAt    time.Time        `json:"taint_origin_at,omitempty"`
+	TaintOriginURL   string           `json:"taint_origin_url,omitempty"`
+	TaintOriginKind  string           `json:"taint_origin_kind,omitempty"`
 	PromptHit        bool             `json:"prompt_hit"`
 	MediaSeen        bool             `json:"media_seen"`
 	ApprovedUntil    time.Time        `json:"approved_until,omitempty"`
 	Sources          []TaintSourceRef `json:"sources,omitempty"`
+
+	// TaintOriginAmbiguous records that more than one distinct source is
+	// responsible for the session's escalating taint, so no single source may
+	// be named as the origin. It is a security marker rather than a display
+	// field: it is what keeps a cleared origin identity from reading as "no
+	// origin was ever resolved" and falling back to the latest source.
+	TaintOriginAmbiguous bool `json:"taint_origin_ambiguous,omitempty"`
 }
 
 // Snapshot returns a copy that is safe to hand to callers.
@@ -121,6 +131,24 @@ func (sr *SessionRisk) Observe(observation RiskObservation) {
 		}
 	}
 
+	previousLevel := sr.Level
+	if !sr.hasTaintOrigin() && previousLevel >= TaintAllowlistedReference {
+		// Snapshot written before taint origins were tracked separately: the
+		// level-establishing source survives only in LastExternal*, which the
+		// update below is about to overwrite with this (possibly lower-risk)
+		// source. Recover it before that happens.
+		sr.TaintOriginAt = sr.LastExternalAt
+		sr.TaintOriginURL = sr.LastExternalURL
+		sr.TaintOriginKind = sr.LastExternalKind
+		if !sr.hasTaintOrigin() {
+			// Nothing recoverable. Record the origin as resolved but
+			// unnameable, which is the same thing an ambiguous origin means to
+			// every consumer: SecurityOrigin* report nothing, no source-scoped
+			// override can match, and a repeat of this recovery on a later
+			// call cannot adopt a benign later source instead.
+			sr.markOriginAmbiguous()
+		}
+	}
 	sr.Level = maxTaintLevel(sr.Level, source.Level)
 	sr.PromptHit = sr.PromptHit || observation.PromptHit
 	sr.MediaSeen = sr.MediaSeen || observation.MediaSeen
@@ -138,6 +166,7 @@ func (sr *SessionRisk) Observe(observation RiskObservation) {
 		sr.LastExternalURL = source.URL
 		sr.LastExternalKind = source.Kind
 	}
+	sr.updateTaintOrigin(source, previousLevel)
 
 	if source.URL != "" || source.Kind != "" || source.Level != TaintTrusted {
 		limit := observation.MaxSources
@@ -146,6 +175,136 @@ func (sr *SessionRisk) Observe(observation RiskObservation) {
 		}
 		sr.Sources = appendBoundedSource(sr.Sources, source, limit)
 	}
+}
+
+// updateTaintOrigin maintains the sticky source attribution consumed by trust
+// decisions. The origin names the source responsible for the session's current
+// taint, and it is deliberately not the latest source: that stickiness is what
+// stops a later benign source from standing in for the one that actually
+// tainted the session.
+//
+// Relative severity does not decide the origin once the escalation floor is in
+// play. A source at or above that floor justifies escalation on its own for the
+// rest of the session, so it is never retired by a later source - not by a more
+// severe one, not by an equal one, and not by a weaker one. All three orderings
+// fail open if severity is allowed to decide:
+//
+//   - Higher wins: a trusted docs page whose security prose trips the injection
+//     patterns escalates the session from untrusted to hostile. If it takes the
+//     origin, a source-scoped override naming that docs page clears an action
+//     the earlier untrusted page still justifies blocking - and does so at a
+//     strictly higher risk level, turning a block into an allow.
+//   - Equal wins: there is no safe winner. First-to-arrive fails open when the
+//     operator-trusted source arrives first; newest fails open in the other
+//     order.
+//   - Weaker loses: an untrusted page fetched after a hostile one still
+//     contaminates independently, so leaving the hostile origin named lets an
+//     override for it clear an action the untrusted page justifies blocking.
+//
+// So any second, distinct source at or above the floor marks the origin
+// ambiguous: SecurityOrigin* then report nothing, no single-source override can
+// match, and the full source list still carries every ref as evidence. A
+// distinct source below the floor cannot escalate anything by itself, so it
+// neither displaces an escalating origin nor creates ambiguity with one.
+func (sr *SessionRisk) updateTaintOrigin(source TaintSourceRef, previousLevel TaintLevel) {
+	if source.Level < TaintAllowlistedReference {
+		return
+	}
+	if source.Kind == TaintSourceKindCrossAgent {
+		// Synthesized from the current origin rather than ingested, so it is
+		// never a second source and never names or unnames one. It must still
+		// leave an origin resolved if it raised the level, or the legacy
+		// recovery in Observe would adopt a later benign source on the next
+		// observation. Unreachable from the only production caller, which
+		// propagates an already contaminated session's own level.
+		if source.Level > previousLevel {
+			sr.markOriginAmbiguous()
+		}
+		return
+	}
+	if !sr.TaintOriginAmbiguous && source.URL == sr.TaintOriginURL && source.Kind == sr.TaintOriginKind {
+		// The same source again, possibly at a higher level than before. Not a
+		// second source, so the identity stands.
+		if source.Level > previousLevel {
+			sr.TaintOriginAt = source.Timestamp.UTC()
+		}
+		return
+	}
+	// Distinct from the recorded origin from here on.
+	if taintLevelEscalates(previousLevel) {
+		// The established origin escalates on its own and cannot be retired. A
+		// second escalating source makes attribution ambiguous; a weaker one
+		// changes nothing.
+		if taintLevelEscalates(source.Level) {
+			sr.markOriginAmbiguous()
+		}
+		return
+	}
+	if source.Level > previousLevel {
+		sr.TaintOriginAt = source.Timestamp.UTC()
+		sr.TaintOriginURL = source.URL
+		sr.TaintOriginKind = source.Kind
+		// Any earlier ambiguity was between sources below the escalation floor,
+		// none of which an override needs to cover. Clearing it here is what
+		// keeps two harmless reference fetches from making the session
+		// permanently override-proof.
+		sr.TaintOriginAmbiguous = false
+		return
+	}
+	sr.markOriginAmbiguous()
+}
+
+// markOriginAmbiguous records that no single source may be named as the origin.
+//
+// Clearing the identity fields alone is not sufficient. hasTaintOrigin also
+// consults TaintOriginAt, and an origin recovered from a legacy snapshot can
+// carry an empty LastExternalAt alongside a URL. Clearing URL and Kind against
+// a zero timestamp would make hasTaintOrigin report "no origin at all", and
+// SecurityOrigin* would fall back to LastExternal* - which Observe has just
+// overwritten with the newest source. The explicit flag is what keeps the
+// ambiguous state from silently becoming unambiguous again.
+func (sr *SessionRisk) markOriginAmbiguous() {
+	sr.TaintOriginAmbiguous = true
+	sr.TaintOriginURL = ""
+	sr.TaintOriginKind = ""
+}
+
+// taintLevelEscalates reports whether a level can, on its own, drive a policy
+// escalation. Shared by the policy matrix and the taint-origin ambiguity rule
+// so the level at which an origin becomes irreplaceable cannot drift away from
+// the level at which the matrix starts escalating.
+func taintLevelEscalates(level TaintLevel) bool {
+	return level >= TaintExternalUntrusted
+}
+
+// hasTaintOrigin reports whether a taint origin has been resolved for the
+// current sticky level. Any one field is sufficient, and all of them must be
+// consulted. An MCP tool result taints with a Kind and no URL, so keying on
+// TaintOriginURL alone would treat a real origin as absent and fall back to the
+// latest source - reintroducing exactly the substitution the origin exists to
+// prevent. An ambiguous origin has no URL and no Kind by construction, so it
+// depends on the flag for the same reason.
+func (sr SessionRisk) hasTaintOrigin() bool {
+	return sr.TaintOriginAmbiguous || !sr.TaintOriginAt.IsZero() ||
+		sr.TaintOriginURL != "" || sr.TaintOriginKind != ""
+}
+
+// SecurityOriginURL returns the source that established the current taint
+// level. The fallback preserves snapshots written before taint origins were
+// tracked separately, and applies only when no origin was resolved at all.
+func (sr SessionRisk) SecurityOriginURL() string {
+	if sr.hasTaintOrigin() {
+		return sr.TaintOriginURL
+	}
+	return sr.LastExternalURL
+}
+
+// SecurityOriginKind returns the kind paired with SecurityOriginURL.
+func (sr SessionRisk) SecurityOriginKind() string {
+	if sr.hasTaintOrigin() {
+		return sr.TaintOriginKind
+	}
+	return sr.LastExternalKind
 }
 
 // RiskObservation describes a single taint observation flowing into a session.
@@ -308,7 +467,7 @@ func (pm PolicyMatrix) EvaluateWithOptions(
 		return PolicyDecisionResult{Decision: PolicyAllow, Reason: "taint_safe_read_only_action"}
 	}
 
-	if taint < TaintExternalUntrusted {
+	if !taintLevelEscalates(taint) {
 		return PolicyDecisionResult{Decision: PolicyAllow, Reason: "trusted_or_allowlisted_context"}
 	}
 

--- a/internal/session/risk_test.go
+++ b/internal/session/risk_test.go
@@ -4,6 +4,7 @@
 package session_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -76,6 +77,421 @@ func TestSessionRiskSnapshotCopiesSources(t *testing.T) {
 
 	if risk.Sources[0].URL != "https://example.com" {
 		t.Fatal("snapshot should deep-copy sources")
+	}
+}
+
+func TestSessionRiskTrustedSourceDoesNotEstablishOrigin(t *testing.T) {
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL: "https://trusted.example/page", Kind: "http_response", Level: session.TaintTrusted,
+	}})
+
+	if risk.Level != session.TaintTrusted {
+		t.Fatalf("level = %v, want trusted", risk.Level)
+	}
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want empty", got)
+	}
+}
+
+func TestSessionRiskHigherCrossAgentLevelStaysUnnameable(t *testing.T) {
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		Kind: session.TaintSourceKindCrossAgent, Level: session.TaintExternalHostile,
+	}})
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL: testGitHubCopilotDocs, Kind: "http_response", Level: session.TaintAllowlistedReference,
+	}})
+
+	if !risk.TaintOriginAmbiguous {
+		t.Fatal("higher cross-agent level must leave the origin unnameable")
+	}
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want empty after later benign source", got)
+	}
+}
+
+func TestSessionRiskCrossAgentKeepsLatestURLForAmbiguousOrigin(t *testing.T) {
+	risk := session.SessionRisk{
+		Level:                session.TaintExternalUntrusted,
+		Contaminated:         true,
+		LastExternalURL:      testGitHubCopilotDocs,
+		TaintOriginAmbiguous: true,
+	}
+	risk.Observe(session.ClassifyCrossAgentObservation(
+		risk.Snapshot(), session.CrossAgentBoundaryA2ARequest,
+	))
+
+	if risk.LastExternalURL != testGitHubCopilotDocs {
+		t.Fatalf("last external URL = %q, want latest audit context preserved", risk.LastExternalURL)
+	}
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want ambiguous origin to stay empty", got)
+	}
+}
+
+func TestSessionRiskAmbiguityMarkerSurvivesJSONRoundTrip(t *testing.T) {
+	risk := session.SessionRisk{
+		Level:                session.TaintExternalUntrusted,
+		Contaminated:         true,
+		LastExternalURL:      testGitHubCopilotDocs,
+		LastExternalKind:     "http_response",
+		TaintOriginAmbiguous: true,
+	}
+	raw, err := json.Marshal(risk)
+	if err != nil {
+		t.Fatalf("marshal risk: %v", err)
+	}
+	var decoded session.SessionRisk
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal risk: %v", err)
+	}
+	if got := decoded.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL after round trip = %q, want empty", got)
+	}
+}
+
+func TestSessionRiskLegacyKindFallback(t *testing.T) {
+	risk := session.SessionRisk{LastExternalKind: "legacy_response"}
+	if got := risk.SecurityOriginKind(); got != "legacy_response" {
+		t.Fatalf("security origin kind = %q, want legacy_response", got)
+	}
+}
+
+func TestSessionRiskTaintOriginSurvivesLaterSources(t *testing.T) {
+	var risk session.SessionRisk
+	hostileAt := time.Date(2026, time.August, 23, 1, 0, 0, 0, time.UTC)
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:       "https://evil.example/issue/123",
+		Kind:      "http_response",
+		Level:     session.TaintExternalUntrusted,
+		Timestamp: hostileAt,
+	}})
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:       testGitHubCopilotDocs,
+		Kind:      "http_response",
+		Level:     session.TaintAllowlistedReference,
+		Timestamp: hostileAt.Add(time.Minute),
+	}})
+
+	if risk.LastExternalURL != testGitHubCopilotDocs {
+		t.Fatalf("last external URL = %q, want latest source", risk.LastExternalURL)
+	}
+	if got := risk.SecurityOriginURL(); got != "https://evil.example/issue/123" {
+		t.Fatalf("security origin URL = %q, want hostile source", got)
+	}
+	if got := risk.SecurityOriginKind(); got != "http_response" {
+		t.Fatalf("security origin kind = %q, want http_response", got)
+	}
+	if !risk.TaintOriginAt.Equal(hostileAt) {
+		t.Fatalf("taint origin time = %v, want %v", risk.TaintOriginAt, hostileAt)
+	}
+}
+
+func TestSessionRiskTaintOriginMigratesLegacySnapshot(t *testing.T) {
+	legacyAt := time.Date(2026, time.August, 23, 1, 0, 0, 0, time.UTC)
+	risk := session.SessionRisk{
+		Level:            session.TaintExternalUntrusted,
+		Contaminated:     true,
+		LastExternalAt:   legacyAt,
+		LastExternalURL:  "https://evil.example/legacy",
+		LastExternalKind: "http_response",
+	}
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:       testGitHubCopilotDocs,
+		Kind:      "http_response",
+		Level:     session.TaintAllowlistedReference,
+		Timestamp: legacyAt.Add(time.Minute),
+	}})
+
+	if got := risk.SecurityOriginURL(); got != "https://evil.example/legacy" {
+		t.Fatalf("migrated security origin URL = %q, want legacy source", got)
+	}
+	if risk.LastExternalURL != testGitHubCopilotDocs {
+		t.Fatalf("last external URL = %q, want latest source", risk.LastExternalURL)
+	}
+}
+
+// The MCP ingest path records a Kind and no URL, so an origin with an empty URL
+// is a resolved origin, not a missing one. Falling back to LastExternalURL here
+// hands a source-scoped trust override the later benign URL to match.
+func TestSessionRiskURLLessOriginDoesNotFallBackToLatest(t *testing.T) {
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		Kind:  "mcp_response",
+		Level: session.TaintExternalUntrusted,
+	}})
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:   testGitHubCopilotDocs,
+		Kind:  "http_response",
+		Level: session.TaintAllowlistedReference,
+	}})
+
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want empty for the URL-less MCP origin", got)
+	}
+	if got := risk.SecurityOriginKind(); got != "mcp_response" {
+		t.Fatalf("security origin kind = %q, want mcp_response", got)
+	}
+	if risk.LastExternalURL != testGitHubCopilotDocs {
+		t.Fatalf("last external URL = %q, want latest source", risk.LastExternalURL)
+	}
+}
+
+// Two distinct sources at the session maximum make the origin ambiguous, so no
+// single-source trust override may match. Naming a winner fails open in one
+// ordering or the other: first-wins clears the action when the operator-trusted
+// source arrives first, newest-wins clears it when the trusted source arrives
+// last. Both orderings are asserted here.
+func TestSessionRiskDistinctEqualLevelSourcesClearOriginIdentity(t *testing.T) {
+	trustedURL := session.TaintSourceRef{
+		URL:   "https://internal.corp.example/wiki",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	hostileURL := session.TaintSourceRef{
+		URL:   "https://evil.example/inject",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	sameURLDifferentKind := trustedURL
+	sameURLDifferentKind.Kind = "mcp_tool_result"
+
+	for _, tc := range []struct {
+		name  string
+		first session.TaintSourceRef
+		last  session.TaintSourceRef
+	}{
+		{"trusted source first", trustedURL, hostileURL},
+		{"trusted source last", hostileURL, trustedURL},
+		{"same URL different kind first", trustedURL, sameURLDifferentKind},
+		{"same URL different kind last", sameURLDifferentKind, trustedURL},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var risk session.SessionRisk
+			risk.Observe(session.RiskObservation{Source: tc.first})
+			risk.Observe(session.RiskObservation{Source: tc.last})
+
+			if got := risk.SecurityOriginURL(); got != "" {
+				t.Fatalf("security origin URL = %q, want empty once two sources share the maximum", got)
+			}
+			if got := risk.SecurityOriginKind(); got != "" {
+				t.Fatalf("security origin kind = %q, want empty once two sources share the maximum", got)
+			}
+			if risk.Level != session.TaintExternalUntrusted {
+				t.Fatalf("level = %v, want untrusted preserved", risk.Level)
+			}
+		})
+	}
+}
+
+// Re-observing the same source at the maximum is not a second source and must
+// leave the origin intact, or a chatty poll of one hostile page would erase its
+// own attribution.
+func TestSessionRiskRepeatedSameSourceKeepsOrigin(t *testing.T) {
+	source := session.TaintSourceRef{
+		URL:   "https://evil.example/inject",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: source})
+	risk.Observe(session.RiskObservation{Source: source})
+
+	if got := risk.SecurityOriginURL(); got != source.URL {
+		t.Fatalf("security origin URL = %q, want %q", got, source.URL)
+	}
+}
+
+// A cross-agent ref is synthesized from the current origin and re-asserts the
+// existing level. Adopting it as the origin would overwrite the real origin's
+// attribution with a self-reference.
+func TestSessionRiskCrossAgentRefDoesNotReplaceOrigin(t *testing.T) {
+	origin := "https://attacker.example/inject"
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:   origin,
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}})
+	risk.Observe(session.ClassifyCrossAgentObservation(risk.Snapshot(), session.CrossAgentBoundaryA2ARequest))
+
+	if got := risk.SecurityOriginURL(); got != origin {
+		t.Fatalf("security origin URL = %q, want %q", got, origin)
+	}
+	if got := risk.SecurityOriginKind(); got != "http_response" {
+		t.Fatalf("security origin kind = %q, want the ingest kind, not cross_agent", got)
+	}
+}
+
+// A legacy snapshot carrying a level but no recoverable LastExternal* must not
+// let a later, lower-risk source become the origin on a subsequent observation.
+func TestSessionRiskUnrecoverableLegacyOriginStaysEmpty(t *testing.T) {
+	risk := session.SessionRisk{Level: session.TaintExternalUntrusted, Contaminated: true}
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:   testGitHubCopilotDocs,
+		Kind:  "http_response",
+		Level: session.TaintAllowlistedReference,
+	}})
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:   "https://another.example/page",
+		Kind:  "http_response",
+		Level: session.TaintAllowlistedReference,
+	}})
+
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want empty for an unrecoverable legacy origin", got)
+	}
+}
+
+// Relative severity must not decide the origin once a source has reached the
+// escalation floor. All three orderings are asserted because each one fails
+// open on its own if severity is allowed to pick a winner, and each reaches a
+// different branch. The escalating source here is a page an operator would
+// plausibly trust, escalated to hostile because its security prose trips the
+// injection patterns - the documented false-positive class, not a contrivance.
+func TestSessionRiskEscalatingOriginIsNeverRetiredByASecondSource(t *testing.T) {
+	untrusted := session.TaintSourceRef{
+		URL:   "https://evil.example/inject",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	docs := session.TaintSourceRef{
+		URL:   testGitHubCopilotDocs,
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+
+	for _, tc := range []struct {
+		name             string
+		first, second    session.RiskObservation
+		wantLevel        session.TaintLevel
+		wantOriginBefore string
+	}{
+		{
+			name:             "more severe source arrives second",
+			first:            session.RiskObservation{Source: untrusted},
+			second:           session.RiskObservation{Source: docs, PromptHit: true},
+			wantLevel:        session.TaintExternalHostile,
+			wantOriginBefore: untrusted.URL,
+		},
+		{
+			name:             "less severe source arrives second",
+			first:            session.RiskObservation{Source: docs, PromptHit: true},
+			second:           session.RiskObservation{Source: untrusted},
+			wantLevel:        session.TaintExternalHostile,
+			wantOriginBefore: docs.URL,
+		},
+		{
+			name:             "equally severe source arrives second",
+			first:            session.RiskObservation{Source: untrusted},
+			second:           session.RiskObservation{Source: docs},
+			wantLevel:        session.TaintExternalUntrusted,
+			wantOriginBefore: untrusted.URL,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var risk session.SessionRisk
+			risk.Observe(tc.first)
+			if got := risk.SecurityOriginURL(); got != tc.wantOriginBefore {
+				t.Fatalf("setup: security origin URL = %q, want %q", got, tc.wantOriginBefore)
+			}
+
+			risk.Observe(tc.second)
+
+			if risk.Level != tc.wantLevel {
+				t.Fatalf("level = %v, want %v", risk.Level, tc.wantLevel)
+			}
+			if got := risk.SecurityOriginURL(); got != "" {
+				t.Fatalf("security origin URL = %q, want empty once a second escalating source is present", got)
+			}
+			if got := risk.SecurityOriginKind(); got != "" {
+				t.Fatalf("security origin kind = %q, want empty once a second escalating source is present", got)
+			}
+		})
+	}
+}
+
+// The same source escalating itself is not a second source. Losing the origin
+// here would be an availability bug: the single page an operator needs to
+// exempt would stop being nameable the moment its own content tripped a
+// pattern.
+func TestSessionRiskSameSourceEscalatingKeepsOrigin(t *testing.T) {
+	source := session.TaintSourceRef{
+		URL:   "https://evil.example/inject",
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: source})
+	risk.Observe(session.RiskObservation{Source: source, PromptHit: true})
+
+	if risk.Level != session.TaintExternalHostile {
+		t.Fatalf("level = %v, want hostile", risk.Level)
+	}
+	if got := risk.SecurityOriginURL(); got != source.URL {
+		t.Fatalf("security origin URL = %q, want %q", got, source.URL)
+	}
+	if got := risk.SecurityOriginKind(); got != source.Kind {
+		t.Fatalf("security origin kind = %q, want %q", got, source.Kind)
+	}
+}
+
+// Sources below the escalation floor cannot escalate anything by themselves, so
+// they must not make the session permanently unnameable. Two distinct reference
+// fetches followed by the first real untrusted source must still name that
+// source, or ordinary browsing would disable source-scoped overrides for the
+// rest of the session.
+func TestSessionRiskSubEscalationSourcesDoNotBlockOriginNaming(t *testing.T) {
+	var risk session.SessionRisk
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL: testGitHubCopilotDocs, Kind: "http_response", Level: session.TaintAllowlistedReference,
+	}})
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL: "https://docs.vendor.example/guide", Kind: "http_response", Level: session.TaintAllowlistedReference,
+	}})
+	if risk.Level != session.TaintAllowlistedReference {
+		t.Fatalf("setup: level = %v, want allowlisted reference", risk.Level)
+	}
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL: "https://evil.example/inject", Kind: "http_response", Level: session.TaintExternalUntrusted,
+	}})
+
+	if got := risk.SecurityOriginURL(); got != "https://evil.example/inject" {
+		t.Fatalf("security origin URL = %q, want the first escalating source", got)
+	}
+	if got := risk.SecurityOriginKind(); got != "http_response" {
+		t.Fatalf("security origin kind = %q, want http_response", got)
+	}
+}
+
+// An ambiguous origin must stay ambiguous. A legacy snapshot can carry a
+// LastExternalURL with a zero LastExternalAt, so recovery resolves an origin
+// whose only non-zero field is the URL. Clearing that URL for ambiguity leaves
+// every other origin field zero, and if "was an origin resolved" is inferred
+// from those fields alone it now reads as "no origin at all" - falling back to
+// LastExternal*, which Observe has just overwritten with the newest source.
+func TestSessionRiskAmbiguousOriginNeverFallsBackToLatestSource(t *testing.T) {
+	risk := session.SessionRisk{
+		Level:            session.TaintExternalUntrusted,
+		Contaminated:     true,
+		LastExternalURL:  "https://evil.example/legacy",
+		LastExternalKind: "http_response",
+	}
+	risk.Observe(session.RiskObservation{Source: session.TaintSourceRef{
+		URL:   testGitHubCopilotDocs,
+		Kind:  "http_response",
+		Level: session.TaintExternalUntrusted,
+	}})
+
+	if got := risk.SecurityOriginURL(); got != "" {
+		t.Fatalf("security origin URL = %q, want empty once the origin is ambiguous", got)
+	}
+	if got := risk.SecurityOriginKind(); got != "" {
+		t.Fatalf("security origin kind = %q, want empty once the origin is ambiguous", got)
+	}
+	if risk.LastExternalURL != testGitHubCopilotDocs {
+		t.Fatalf("last external URL = %q, want latest source", risk.LastExternalURL)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Keep security source attribution tied to the sources that established escalating session taint instead of the most recently observed external source.
- Treat multiple distinct escalating sources as ambiguous, so a source-scoped trust override can't clear risk created by another source. Latest-source fields remain available for audit context, and existing session state migrates without adopting a later source.

The change fails closed when no single source can explain the risk. Reviewers should distrust the ambiguity transition and the fallback used for session state created before origin tracking existed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added authority verification for inbound MCP, HTTP, CONNECT, and forwarded requests.
  * Requests that fail authorization are now blocked with mismatch details.
  * Authority information is preserved when requests are deferred and rechecked before forwarding.
  * Duplicate authority metadata is rejected without altering the original payload.

* **Bug Fixes**
  * Improved taint tracking and security-origin attribution across multiple sources.
  * Prevented ambiguous or unrelated sources from incorrectly overriding trusted origin information.
  * Preserved accurate origin details across deferred processing and restored session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->