### PR TITLE
fix(proxy): count hidden response-scan blocks in stats

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5156,6 +5156,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			// Exempt domains: scan for visibility but pin to warn, no adaptive scoring.
 			blocked, _, found := p.filterAndActOnResponseScan(w, rawResult, content, displayURL, agent, clientIP, requestID, actionID, sc, cfg, log, recEscalationLevel(fetchRec), responseScanExempt)
 			if blocked {
+				p.metrics.RecordBlocked(parsed.Hostname(), "response_scan", time.Since(start), agentLabel)
 				outcomeStatus = strconv.Itoa(http.StatusForbidden)
 				outcomeBytes = int64(len(body))
 				outcomeReason = "response_scan"

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4259,7 +4259,8 @@ func TestFetchEndpoint_ResponseScan_RawHTML(t *testing.T) {
 
 			logger := audit.NewNop()
 			sc := scanner.MustNew(cfg)
-			p, err := New(cfg, logger, sc, metrics.New())
+			m := metrics.New()
+			p, err := New(cfg, logger, sc, m)
 			if err != nil {
 				t.Fatalf("proxy.New: %v", err)
 			}
@@ -4281,6 +4282,30 @@ func TestFetchEndpoint_ResponseScan_RawHTML(t *testing.T) {
 			}
 			if !resp.Blocked {
 				t.Errorf("expected blocked=true for %s", tt.name)
+			}
+
+			statsRecorder := httptest.NewRecorder()
+			m.StatsHandler().ServeHTTP(
+				statsRecorder,
+				httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/stats", nil),
+			)
+			var stats struct {
+				Requests struct {
+					Blocked int `json:"blocked"`
+				} `json:"requests"`
+				TopScanners []struct {
+					Name  string `json:"name"`
+					Count int    `json:"count"`
+				} `json:"top_scanners"`
+			}
+			if err := json.Unmarshal(statsRecorder.Body.Bytes(), &stats); err != nil {
+				t.Fatalf("stats JSON parse: %v", err)
+			}
+			if stats.Requests.Blocked != 1 {
+				t.Errorf("blocked request count = %d, want 1", stats.Requests.Blocked)
+			}
+			if len(stats.TopScanners) != 1 || stats.TopScanners[0].Name != "response_scan" || stats.TopScanners[0].Count != 1 {
+				t.Errorf("top scanners = %+v, want one response_scan block", stats.TopScanners)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

A hidden-content response scan that blocks a fetch returned HTTP 403 and wrote an audit event, but never incremented the blocked-request counters, so the block was invisible in `/stats` and in the top-scanners breakdown. Enforcement was correct and the record of it was not, which is the worse direction for an operator reading those numbers to decide whether a control is doing anything.

The failure was asymmetric rather than total. The neighbouring fail-closed path, which blocks when hidden injection is found and readability cannot strip it, already recorded. Only the direct-block path did not, so the counter undercounted by an amount that depended on which of the two branches fired.

The fetch handler has four response-scan block sites and every one of them returns before reaching the next, so this records once rather than twice. Removing the added call makes four hidden-HTML cases fail with a blocked count of zero and an empty scanner breakdown.

Reviewers reading this as a metrics change should check the direction: a counter that starts counting something it previously missed changes what `/stats` reports for anyone already reading it, and the thing to distrust is whether any path can now record the same block twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring for blocked responses detected during hidden-content scanning.
  * Blocked requests now appear in metrics with a `response_scan` classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->