### PR TITLE
feat(evidence): add offline recorder compaction

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -225,7 +225,7 @@ sudo systemctl start pipelock.service
 
 The command refuses to run while a recorder holds the directory lock. It verifies the trusted signed receipt chain before and after compaction, copies each JSONL record line without changing its bytes, and keeps every replacement shard under the 8 MiB read limit. Linux installs the new active directory with one atomic exchange. The original directory moves to a timestamped sibling archive with SHA-256 digests and byte mappings.
 
-This first version accepts one session and no raw-escrow sidecars in the active directory. It refuses mixed directories instead of risking lost evidence. It also refuses malformed chains, duplicate shard starts, symlinks, changing files, and oversized input shards. A failed check leaves the original directory active.
+This first version accepts one session and no raw-escrow sidecars in the active directory. It refuses mixed directories instead of risking lost evidence. It also refuses malformed chains, duplicate shard starts, symlinks, changing files, more than 4,096 input shards, more than 256 MiB of input, and oversized input shards. A failed check leaves the original directory active.
 
 ### Completeness analysis
 

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -210,6 +210,23 @@ match their recorded hash. Those symptoms narrow the cause but do not by
 themselves establish it: a fork and a crafted edit can present the same
 structure.
 
+### Compacting an over-cap recorder directory
+
+Evidence readers refuse a session with more than 256 JSONL shards. Use the offline compaction ceremony only after `pipelock evidence doctor` confirms that the recorder and receipt chains are intact.
+
+```bash
+sudo systemctl stop pipelock.service
+sudo pipelock evidence compact \
+  --receipt-dir /var/lib/pipelock/recorder \
+  --session proxy \
+  --key /etc/pipelock/keys/flight-recorder-signing.key.pub
+sudo systemctl start pipelock.service
+```
+
+The command refuses to run while a recorder holds the directory lock. It verifies the trusted signed receipt chain before and after compaction, copies each JSONL record line without changing its bytes, and keeps every replacement shard under the 8 MiB read limit. Linux installs the new active directory with one atomic exchange. The original directory moves to a timestamped sibling archive with SHA-256 digests and byte mappings.
+
+This first version accepts one session and no raw-escrow sidecars in the active directory. It refuses mixed directories instead of risking lost evidence. It also refuses malformed chains, duplicate shard starts, symlinks, changing files, and oversized input shards. A failed check leaves the original directory active.
+
 ### Completeness analysis
 
 `pipelock-verifier completeness` analyzes the signed session lifecycle evidence

--- a/internal/cli/evidence/compact.go
+++ b/internal/cli/evidence/compact.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	signing "github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+type (
+	compactOptions  struct{ receiptDir, locationID, sessionID, publicKey string }
+	compactManifest struct {
+		Version     int                   `json:"version"`
+		SessionID   string                `json:"session_id"`
+		CreatedAt   time.Time             `json:"created_at"`
+		Original    []compactManifestFile `json:"original"`
+		Replacement []compactManifestFile `json:"replacement"`
+		Mappings    []compactByteMapping  `json:"mappings"`
+	}
+)
+
+type compactManifestFile struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+	Bytes  int64  `json:"bytes"`
+}
+type compactByteMapping struct {
+	Source       string `json:"source"`
+	Output       string `json:"output"`
+	SourceOffset int64  `json:"source_offset"`
+	OutputOffset int64  `json:"output_offset"`
+	Bytes        int64  `json:"bytes"`
+}
+type compactShard struct {
+	name       string
+	data       []byte
+	start      uint64
+	sourcePath string
+	mappings   []compactByteMapping
+}
+
+var (
+	compactAcquireLock   = recorder.AcquireEvidenceCeremonyLock
+	compactPackRecords   = compactPack
+	compactMakeStage     = os.MkdirTemp
+	compactPrepareStage  = prepareCompactStage
+	compactWriteShards   = writeCompactStage
+	compactSyncPath      = syncCompactDirectory
+	compactExtract       = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
+	compactVerify        = verifyCompactReceipts
+	compactSameChain     = sameReceiptChain
+	compactExchange      = exchangeEvidenceDirectories
+	compactRename        = os.Rename
+	compactWriteManifest = writeCompactManifest
+)
+
+func compactCmd() *cobra.Command {
+	opts := compactOptions{}
+	cmd := &cobra.Command{Use: "compact", Short: "Offline-compact one stopped flight-recorder session", Long: `Compact one stopped flight-recorder session into bounded JSONL shards. It requires a trusted public key, verifies before and after the rewrite, atomically exchanges the active directory on Linux, and retains the original as a digest-listed archive.`, Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error { return runCompact(cmd, opts) }}
+	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "", "flight-recorder evidence directory")
+	cmd.Flags().StringVar(&opts.locationID, "location", "", "location path relative to the evidence directory")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "", "session ID to compact")
+	cmd.Flags().StringVar(&opts.publicKey, "key", "", "trusted receipt signing public key (inline or file)")
+	_ = cmd.MarkFlagRequired("receipt-dir")
+	_ = cmd.MarkFlagRequired("session")
+	_ = cmd.MarkFlagRequired("key")
+	return cmd
+}
+
+func runCompact(cmd *cobra.Command, opts compactOptions) error {
+	if strings.TrimSpace(opts.sessionID) == "" {
+		return errors.New("--session is required")
+	}
+	root, err := validateReceiptDir(opts.receiptDir)
+	if err != nil {
+		return err
+	}
+	location, err := recorder.ResolveEvidenceLocation(root, opts.locationID)
+	if err != nil {
+		return fmt.Errorf("resolve evidence location: %w", err)
+	}
+	key, err := signing.LoadPublicKey(strings.TrimSpace(opts.publicKey))
+	if err != nil {
+		return fmt.Errorf("load --key: %w", err)
+	}
+	lock, err := compactAcquireLock(location.Dir)
+	if err != nil {
+		return fmt.Errorf("lock stopped evidence directory: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+	original, receipts, err := compactSource(location, opts.sessionID)
+	if err != nil {
+		return err
+	}
+	if err := compactVerify(receipts, key); err != nil {
+		return fmt.Errorf("pre-compaction verification: %w", err)
+	}
+	replacement, err := compactPackRecords(opts.sessionID, original)
+	if err != nil {
+		return err
+	}
+	if len(replacement) > recorder.MaxEvidenceReadDirectoryEntries {
+		return fmt.Errorf("compaction produced %d shards, exceeds %d", len(replacement), recorder.MaxEvidenceReadDirectoryEntries)
+	}
+	parent := filepath.Dir(location.Dir)
+	stage, err := compactMakeStage(parent, ".pipelock-evidence-compact-")
+	if err != nil {
+		return fmt.Errorf("create compaction stage: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+	if err := compactPrepareStage(location.Dir, stage); err != nil {
+		return fmt.Errorf("preserve active directory metadata on stage: %w", err)
+	}
+	if err := compactWriteShards(stage, replacement); err != nil {
+		return err
+	}
+	if err := compactSyncPath(stage); err != nil {
+		return fmt.Errorf("sync staged evidence directory: %w", err)
+	}
+	if err := compactSyncPath(parent); err != nil {
+		return fmt.Errorf("sync evidence parent before publication: %w", err)
+	}
+	post, err := compactExtract(recorder.EvidenceLocation{Root: stage, Dir: stage}, opts.sessionID)
+	if err != nil {
+		return fmt.Errorf("read staged compacted evidence: %w", err)
+	}
+	if err := compactVerify(post, key); err != nil {
+		return fmt.Errorf("post-compaction verification: %w", err)
+	}
+	if !compactSameChain(receipts, post) {
+		return errors.New("post-compaction receipt chain differs from original")
+	}
+	manifest := compactManifest{Version: 1, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), Original: manifestShards(original), Replacement: manifestShards(replacement), Mappings: compactMappings(replacement)}
+	archive := filepath.Join(parent, ".pipelock-evidence-archive-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	stageLock, err := compactAcquireLock(stage)
+	if err != nil {
+		return fmt.Errorf("lock staged evidence directory: %w", err)
+	}
+	defer func() { _ = stageLock.Close() }()
+	if err := compactExchange(location.Dir, stage); err != nil {
+		return fmt.Errorf("atomically exchange active evidence directory: %w", err)
+	}
+	if err := compactRename(stage, archive); err != nil {
+		return rollbackCompactExchange(location.Dir, stage, fmt.Errorf("preserve original evidence archive at %s: %w", stage, err))
+	}
+	// The manifest belongs beside the archived inputs. Writing it only after
+	// the exchange keeps the active directory to evidence shards alone and
+	// leaves every original JSONL byte unchanged.
+	if err := compactWriteManifest(archive, manifest); err != nil {
+		return rollbackCompactExchange(location.Dir, archive, fmt.Errorf("write archive digest manifest: %w", err))
+	}
+	if err := compactSyncPath(archive); err != nil {
+		return rollbackCompactExchange(location.Dir, archive, fmt.Errorf("sync archive manifest: %w", err))
+	}
+	if err := compactSyncPath(parent); err != nil {
+		return rollbackCompactExchange(location.Dir, archive, fmt.Errorf("sync evidence parent after archive: %w", err))
+	}
+	committed = true
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "compacted session %q into %d bounded shard(s); original preserved at %s\n", opts.sessionID, len(replacement), archive)
+	return nil
+}
+
+func compactSource(location recorder.EvidenceLocation, session string) ([]compactShard, []contractreceipt.EvidenceReceipt, error) {
+	entries, err := recorder.ReadEvidenceLocationEntries(location)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list evidence directory: %w", err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil, nil, fmt.Errorf("refuse symlink in active evidence directory: %s", entry.Name())
+		}
+		if entry.IsDir() {
+			return nil, nil, fmt.Errorf("refuse nested directory %q while compacting session %q", entry.Name(), session)
+		}
+		got, _, ok := recorder.ParseEvidenceFilename(entry.Name())
+		if ok && got == session {
+			names = append(names, entry.Name())
+			continue
+		}
+		// A session compaction must never make unrelated evidence or raw escrow
+		// vanish from the active directory. Support multi-session relocation in a
+		// separate ceremony; this command fails closed until then.
+		return nil, nil, fmt.Errorf("refuse non-selected evidence file %q while compacting session %q", entry.Name(), session)
+	}
+	if len(names) == 0 {
+		return nil, nil, fmt.Errorf("session %q has no evidence shards", session)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		_, a, _ := recorder.ParseEvidenceFilename(names[i])
+		_, b, _ := recorder.ParseEvidenceFilename(names[j])
+		if a != b {
+			return a < b
+		}
+		return names[i] < names[j]
+	})
+	starts := map[uint64]struct{}{}
+	source := make([]compactShard, 0, len(names))
+	allEntries := make([]recorder.Entry, 0)
+	for _, name := range names {
+		_, start, _ := recorder.ParseEvidenceFilename(name)
+		if _, dup := starts[start]; dup {
+			return nil, nil, fmt.Errorf("duplicate shard sequence start %d", start)
+		}
+		starts[start] = struct{}{}
+		data, readErr := recorder.ReadEvidenceLocationFileBounded(location, name, recorder.MaxEvidenceReadFileBytes)
+		if readErr != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", name, readErr)
+		}
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			return nil, nil, fmt.Errorf("%s does not end in newline; refusing cross-file record concatenation", name)
+		}
+		parsed, parseErr := recorder.ReadEntriesFromReader(bytes.NewReader(data))
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("validate %s: %w", name, parseErr)
+		}
+		for _, entry := range parsed {
+			if entry.SessionID != session {
+				return nil, nil, fmt.Errorf("entry in %s belongs to %q, not %q", name, entry.SessionID, session)
+			}
+			allEntries = append(allEntries, entry)
+		}
+		source = append(source, compactShard{name: name, data: data, start: start, sourcePath: filepath.Join(location.Dir, name)})
+	}
+	if err := recorder.VerifyChain(allEntries); err != nil {
+		return nil, nil, fmt.Errorf("verify recorder chain: %w", err)
+	}
+	for i, entry := range allEntries {
+		if entry.Sequence != uint64(i) {
+			return nil, nil, fmt.Errorf("recorder sequence gap or fork: entry %d declares seq %d", i, entry.Sequence)
+		}
+	}
+	receipts, err := contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir(location, session)
+	if err != nil {
+		return nil, nil, fmt.Errorf("extract evidence receipt chain: %w", err)
+	}
+	if len(receipts) == 0 {
+		return nil, nil, errors.New("selected session contains no evidence receipts")
+	}
+	return source, receipts, nil
+}
+
+func verifyCompactReceipts(receipts []contractreceipt.EvidenceReceipt, key []byte) error {
+	result := contractreceipt.VerifyChain(receipts, contractreceipt.ChainVerifyOptions{PinnedKey: key})
+	if !result.Valid || !result.SignaturesVerified {
+		return fmt.Errorf("signed receipt chain rejected: %s", result.Error)
+	}
+	return nil
+}
+
+func compactPack(session string, source []compactShard) ([]compactShard, error) {
+	var out []compactShard
+	var current bytes.Buffer
+	var start uint64
+	var mappings []compactByteMapping
+	var currentSourcePath string
+	for _, file := range source {
+		var sourceOffset int64
+		for _, line := range bytes.SplitAfter(file.data, []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
+			if int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
+				return nil, errors.New("single JSONL line exceeds evidence shard limit")
+			}
+			if current.Len() > 0 && int64(current.Len()+len(line)) > recorder.MaxEvidenceReadFileBytes {
+				out = append(out, compactShard{name: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), data: append([]byte(nil), current.Bytes()...), start: start, sourcePath: currentSourcePath, mappings: mappings})
+				current.Reset()
+				mappings = nil
+				currentSourcePath = ""
+			}
+			if current.Len() == 0 {
+				var entry recorder.Entry
+				if err := json.Unmarshal(bytes.TrimSpace(line), &entry); err != nil {
+					return nil, fmt.Errorf("parse compacted line: %w", err)
+				}
+				if entry.SessionID != session {
+					return nil, fmt.Errorf("entry session %q does not match selected %q", entry.SessionID, session)
+				}
+				start = entry.Sequence
+				currentSourcePath = file.sourcePath
+			}
+			outOffset := int64(current.Len())
+			_, _ = current.Write(line)
+			mappings = append(mappings, compactByteMapping{Source: file.name, Output: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), SourceOffset: sourceOffset, OutputOffset: outOffset, Bytes: int64(len(line))})
+			sourceOffset += int64(len(line))
+		}
+	}
+	if current.Len() > 0 {
+		out = append(out, compactShard{name: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), data: append([]byte(nil), current.Bytes()...), start: start, sourcePath: currentSourcePath, mappings: mappings})
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no compacted evidence bytes produced")
+	}
+	return out, nil
+}
+
+func writeCompactStage(dir string, shards []compactShard) error {
+	for _, shard := range shards {
+		if int64(len(shard.data)) > recorder.MaxEvidenceReadFileBytes {
+			return errors.New("compacted shard exceeds evidence read limit")
+		}
+		if err := os.WriteFile(filepath.Join(dir, shard.name), shard.data, 0o600); err != nil {
+			return fmt.Errorf("write compacted shard %s: %w", shard.name, err)
+		}
+		if err := preserveCompactFileMetadata(shard.sourcePath, filepath.Join(dir, shard.name)); err != nil {
+			return fmt.Errorf("preserve compacted shard metadata: %w", err)
+		}
+		if err := syncCompactFile(filepath.Join(dir, shard.name)); err != nil {
+			return fmt.Errorf("sync compacted shard %s: %w", shard.name, err)
+		}
+	}
+	return nil
+}
+
+func compactMappings(shards []compactShard) []compactByteMapping {
+	var out []compactByteMapping
+	for _, shard := range shards {
+		out = append(out, shard.mappings...)
+	}
+	return out
+}
+
+func rollbackCompactExchange(active, old string, cause error) error {
+	manifestPath := filepath.Join(old, "compaction-manifest.json")
+	if err := os.Remove(manifestPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.Join(cause, fmt.Errorf("CRITICAL rollback could not remove archive manifest before restoring original: %w", err))
+	}
+	if err := syncCompactDirectory(old); err != nil {
+		return errors.Join(cause, fmt.Errorf("CRITICAL rollback could not sync original archive before restoring it: %w", err))
+	}
+	if err := exchangeEvidenceDirectories(active, old); err != nil {
+		return errors.Join(cause, fmt.Errorf("CRITICAL rollback exchange failed: %w", err))
+	}
+	if err := os.RemoveAll(old); err != nil {
+		return errors.Join(cause, fmt.Errorf("rollback restored active but could not remove compacted directory %s: %w", old, err))
+	}
+	return cause
+}
+
+func writeCompactManifest(dir string, manifest compactManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode archive manifest: %w", err)
+	}
+	return os.WriteFile(filepath.Join(dir, "compaction-manifest.json"), append(data, '\n'), 0o600)
+}
+
+func manifestShards(shards []compactShard) []compactManifestFile {
+	out := make([]compactManifestFile, 0, len(shards))
+	for _, shard := range shards {
+		sum := sha256.Sum256(shard.data)
+		out = append(out, compactManifestFile{Name: shard.name, SHA256: hex.EncodeToString(sum[:]), Bytes: int64(len(shard.data))})
+	}
+	return out
+}
+
+func sameReceiptChain(a, b []contractreceipt.EvidenceReceipt) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		ah, ae := contractreceipt.ReceiptHash(a[i])
+		bh, be := contractreceipt.ReceiptHash(b[i])
+		if ae != nil || be != nil || ah != bh {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/evidence/compact.go
+++ b/internal/cli/evidence/compact.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/evidencename"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	signing "github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -52,8 +53,14 @@ type compactShard struct {
 	data       []byte
 	start      uint64
 	sourcePath string
+	sourceInfo os.FileInfo
 	mappings   []compactByteMapping
 }
+
+const (
+	maxCompactInputShards = 4096
+	maxCompactInputBytes  = 256 << 20
+)
 
 var (
 	compactAcquireLock   = recorder.AcquireEvidenceCeremonyLock
@@ -151,6 +158,13 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	if !compactSameChain(receipts, post) {
 		return errors.New("post-compaction receipt chain differs from original")
 	}
+	stagedSource, _, err := compactSource(recorder.EvidenceLocation{Root: stage, Dir: stage}, opts.sessionID)
+	if err != nil {
+		return fmt.Errorf("re-validate staged compacted evidence: %w", err)
+	}
+	if !sameCompactBytes(original, stagedSource) {
+		return errors.New("compaction changed original JSONL record bytes")
+	}
 	manifest := compactManifest{Version: 1, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), Original: manifestShards(original), Replacement: manifestShards(replacement), Mappings: compactMappings(replacement)}
 	archive := filepath.Join(parent, ".pipelock-evidence-archive-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
 	stageLock, err := compactAcquireLock(stage)
@@ -158,6 +172,9 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 		return fmt.Errorf("lock staged evidence directory: %w", err)
 	}
 	defer func() { _ = stageLock.Close() }()
+	if err := verifyCompactSourceUnchanged(location, original); err != nil {
+		return fmt.Errorf("source changed before publication: %w", err)
+	}
 	if err := compactExchange(location.Dir, stage); err != nil {
 		return fmt.Errorf("atomically exchange active evidence directory: %w", err)
 	}
@@ -182,9 +199,16 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 }
 
 func compactSource(location recorder.EvidenceLocation, session string) ([]compactShard, []contractreceipt.EvidenceReceipt, error) {
-	entries, err := recorder.ReadEvidenceLocationEntries(location)
+	return compactSourceWithLimits(location, session, maxCompactInputShards, maxCompactInputBytes)
+}
+
+func compactSourceWithLimits(location recorder.EvidenceLocation, session string, maxShards int, maxBytes int64) ([]compactShard, []contractreceipt.EvidenceReceipt, error) {
+	entries, truncated, err := recorder.ReadEvidenceLocationEntriesBounded(location, maxShards)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list evidence directory: %w", err)
+	}
+	if truncated {
+		return nil, nil, fmt.Errorf("evidence directory exceeds compaction input limit %d", maxShards)
 	}
 	var names []string
 	for _, entry := range entries {
@@ -207,29 +231,42 @@ func compactSource(location recorder.EvidenceLocation, session string) ([]compac
 	if len(names) == 0 {
 		return nil, nil, fmt.Errorf("session %q has no evidence shards", session)
 	}
-	sort.Slice(names, func(i, j int) bool {
-		_, a, _ := recorder.ParseEvidenceFilename(names[i])
-		_, b, _ := recorder.ParseEvidenceFilename(names[j])
-		if a != b {
-			return a < b
-		}
-		return names[i] < names[j]
-	})
-	starts := map[uint64]struct{}{}
-	source := make([]compactShard, 0, len(names))
-	allEntries := make([]recorder.Entry, 0)
+	type namedStart struct {
+		name  string
+		start uint64
+	}
+	ordered := make([]namedStart, 0, len(names))
 	for _, name := range names {
 		_, start, _ := recorder.ParseEvidenceFilename(name)
-		if _, dup := starts[start]; dup {
-			return nil, nil, fmt.Errorf("duplicate shard sequence start %d", start)
+		ordered = append(ordered, namedStart{name: name, start: start})
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].start != ordered[j].start {
+			return ordered[i].start < ordered[j].start
 		}
-		starts[start] = struct{}{}
+		return ordered[i].name < ordered[j].name
+	})
+	for i := range ordered {
+		names[i] = ordered[i].name
+	}
+	if err := evidencename.CheckNoDuplicateSeqStart(names); err != nil {
+		return nil, nil, err
+	}
+	source := make([]compactShard, 0, len(names))
+	allEntries := make([]recorder.Entry, 0)
+	var totalBytes int64
+	for _, name := range names {
+		_, start, _ := recorder.ParseEvidenceFilename(name)
 		data, readErr := recorder.ReadEvidenceLocationFileBounded(location, name, recorder.MaxEvidenceReadFileBytes)
 		if readErr != nil {
 			return nil, nil, fmt.Errorf("read %s: %w", name, readErr)
 		}
 		if len(data) == 0 || data[len(data)-1] != '\n' {
 			return nil, nil, fmt.Errorf("%s does not end in newline; refusing cross-file record concatenation", name)
+		}
+		totalBytes += int64(len(data))
+		if totalBytes > maxBytes {
+			return nil, nil, fmt.Errorf("session %q exceeds compaction input byte limit %d", session, maxBytes)
 		}
 		parsed, parseErr := recorder.ReadEntriesFromReader(bytes.NewReader(data))
 		if parseErr != nil {
@@ -241,7 +278,12 @@ func compactSource(location recorder.EvidenceLocation, session string) ([]compac
 			}
 			allEntries = append(allEntries, entry)
 		}
-		source = append(source, compactShard{name: name, data: data, start: start, sourcePath: filepath.Join(location.Dir, name)})
+		sourcePath := filepath.Join(location.Dir, name)
+		info, statErr := os.Lstat(sourcePath)
+		if statErr != nil {
+			return nil, nil, fmt.Errorf("stat %s after read: %w", name, statErr)
+		}
+		source = append(source, compactShard{name: name, data: data, start: start, sourcePath: sourcePath, sourceInfo: info})
 	}
 	if err := recorder.VerifyChain(allEntries); err != nil {
 		return nil, nil, fmt.Errorf("verify recorder chain: %w", err)
@@ -259,6 +301,40 @@ func compactSource(location recorder.EvidenceLocation, session string) ([]compac
 		return nil, nil, errors.New("selected session contains no evidence receipts")
 	}
 	return source, receipts, nil
+}
+
+func verifyCompactSourceUnchanged(location recorder.EvidenceLocation, source []compactShard) error {
+	for _, shard := range source {
+		info, err := os.Lstat(shard.sourcePath)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", shard.name, err)
+		}
+		if shard.sourceInfo == nil || !os.SameFile(shard.sourceInfo, info) || shard.sourceInfo.Size() != info.Size() || !shard.sourceInfo.ModTime().Equal(info.ModTime()) || shard.sourceInfo.Mode() != info.Mode() {
+			return fmt.Errorf("%s identity or metadata changed", shard.name)
+		}
+		data, err := recorder.ReadEvidenceLocationFileBounded(location, shard.name, recorder.MaxEvidenceReadFileBytes)
+		if err != nil {
+			return fmt.Errorf("re-read %s: %w", shard.name, err)
+		}
+		if !bytes.Equal(data, shard.data) {
+			return fmt.Errorf("%s contents changed", shard.name)
+		}
+	}
+	return nil
+}
+
+func sameCompactBytes(a, b []compactShard) bool {
+	ah, bh := sha256.New(), sha256.New()
+	var aBytes, bBytes int64
+	for _, shard := range a {
+		_, _ = ah.Write(shard.data)
+		aBytes += int64(len(shard.data))
+	}
+	for _, shard := range b {
+		_, _ = bh.Write(shard.data)
+		bBytes += int64(len(shard.data))
+	}
+	return aBytes == bBytes && bytes.Equal(ah.Sum(nil), bh.Sum(nil))
 }
 
 func verifyCompactReceipts(receipts []contractreceipt.EvidenceReceipt, key []byte) error {

--- a/internal/cli/evidence/compact_linux.go
+++ b/internal/cli/evidence/compact_linux.go
@@ -19,37 +19,38 @@ func exchangeEvidenceDirectories(active, stage string) error {
 	if filepath.Dir(active) != filepath.Dir(stage) {
 		return fmt.Errorf("active and staged evidence directories must share a parent")
 	}
-	return unix.Renameat2(unix.AT_FDCWD, stage, unix.AT_FDCWD, active, unix.RENAME_EXCHANGE)
+	err := unix.Renameat2(unix.AT_FDCWD, stage, unix.AT_FDCWD, active, unix.RENAME_EXCHANGE)
+	return compactExchangeError(err)
 }
 
-func prepareCompactStage(active, stage string) error {
-	info, err := os.Stat(active)
-	if err != nil {
-		return err
+func compactExchangeError(err error) error {
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.ENOTSUP) {
+		return fmt.Errorf("atomic directory exchange is unavailable on this kernel or filesystem: %w", err)
 	}
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Errorf("stat active evidence directory has no unix ownership")
-	}
-	if err := os.Chmod(stage, info.Mode().Perm()); err != nil {
-		return err
-	}
-	return os.Chown(stage, int(st.Uid), int(st.Gid))
+	return err
 }
 
-func preserveCompactFileMetadata(source, target string) error {
+func copyCompactOwnershipAndMode(source, target, what string) error {
 	info, err := os.Stat(source)
 	if err != nil {
 		return err
 	}
 	st, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("stat source evidence file has no unix ownership")
+		return fmt.Errorf("stat %s has no unix ownership", what)
 	}
 	if err := os.Chmod(target, info.Mode().Perm()); err != nil {
 		return err
 	}
 	return os.Chown(target, int(st.Uid), int(st.Gid))
+}
+
+func prepareCompactStage(active, stage string) error {
+	return copyCompactOwnershipAndMode(active, stage, "active evidence directory")
+}
+
+func preserveCompactFileMetadata(source, target string) error {
+	return copyCompactOwnershipAndMode(source, target, "source evidence file")
 }
 
 func syncCompactFile(path string) error {

--- a/internal/cli/evidence/compact_linux.go
+++ b/internal/cli/evidence/compact_linux.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package evidence
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func exchangeEvidenceDirectories(active, stage string) error {
+	if filepath.Dir(active) != filepath.Dir(stage) {
+		return fmt.Errorf("active and staged evidence directories must share a parent")
+	}
+	return unix.Renameat2(unix.AT_FDCWD, stage, unix.AT_FDCWD, active, unix.RENAME_EXCHANGE)
+}
+
+func prepareCompactStage(active, stage string) error {
+	info, err := os.Stat(active)
+	if err != nil {
+		return err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("stat active evidence directory has no unix ownership")
+	}
+	if err := os.Chmod(stage, info.Mode().Perm()); err != nil {
+		return err
+	}
+	return os.Chown(stage, int(st.Uid), int(st.Gid))
+}
+
+func preserveCompactFileMetadata(source, target string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("stat source evidence file has no unix ownership")
+	}
+	if err := os.Chmod(target, info.Mode().Perm()); err != nil {
+		return err
+	}
+	return os.Chown(target, int(st.Uid), int(st.Gid))
+}
+
+func syncCompactFile(path string) error {
+	// #nosec G304 -- path names a staged shard created by this ceremony.
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	return errors.Join(syncErr, f.Close())
+}
+
+func syncCompactDirectory(path string) error {
+	// #nosec G304 -- path is the validated evidence directory or its parent.
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	return errors.Join(syncErr, f.Close())
+}

--- a/internal/cli/evidence/compact_linux_test.go
+++ b/internal/cli/evidence/compact_linux_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package evidence
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCompactExchangeErrorReportsUnsupportedFilesystem(t *testing.T) {
+	t.Parallel()
+	for _, errno := range []error{unix.EINVAL, unix.ENOSYS, unix.ENOTSUP} {
+		err := compactExchangeError(errno)
+		if !errors.Is(err, errno) || !strings.Contains(err.Error(), "atomic directory exchange is unavailable") {
+			t.Fatalf("compactExchangeError(%v) = %v", errno, err)
+		}
+	}
+	other := errors.New("other")
+	if err := compactExchangeError(other); !errors.Is(err, other) || strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("other error changed: %v", err)
+	}
+}

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -214,6 +214,24 @@ func TestCompactSourceRefusesShardWithoutTrailingNewline(t *testing.T) {
 	}
 }
 
+func TestCompactSourceRejectsInputBudgets(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-1.jsonl"), compactTestLine(t, 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
+	if _, _, err := compactSourceWithLimits(location, "proxy", 1, maxCompactInputBytes); err == nil || !strings.Contains(err.Error(), "directory exceeds") {
+		t.Fatalf("shard budget err = %v", err)
+	}
+	if _, _, err := compactSourceWithLimits(location, "proxy", maxCompactInputShards, 1); err == nil || !strings.Contains(err.Error(), "input byte limit") {
+		t.Fatalf("byte budget err = %v", err)
+	}
+}
+
 func TestCompactSourceRefusesDuplicateStartSymlinkAndOversize(t *testing.T) {
 	t.Run("duplicate-start", func(t *testing.T) {
 		dir := t.TempDir()
@@ -224,7 +242,7 @@ func TestCompactSourceRefusesDuplicateStartSymlinkAndOversize(t *testing.T) {
 			}
 		}
 		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "duplicate shard sequence start") {
+		if err == nil || !strings.Contains(err.Error(), "ambiguous evidence shard sequence start") {
 			t.Fatalf("err = %v", err)
 		}
 	})
@@ -391,23 +409,33 @@ func compactTestLineForSession(t *testing.T, session string, seq uint64) []byte 
 
 func TestCompactHelpersRejectInvalidData(t *testing.T) {
 	t.Parallel()
-	if err := verifyCompactReceipts(nil, make([]byte, ed25519.PublicKeySize)); err == nil {
-		t.Fatal("empty receipt chain verified")
-	}
-	if _, err := compactPack("proxy", nil); err == nil || !strings.Contains(err.Error(), "no compacted") {
-		t.Fatalf("empty compactPack err = %v", err)
-	}
-	if _, err := compactPack("proxy", []compactShard{{data: []byte("{bad}\n")}}); err == nil || !strings.Contains(err.Error(), "parse compacted") {
-		t.Fatalf("malformed compactPack err = %v", err)
-	}
-	wrong := compactTestLineForSession(t, "other", 0)
-	if _, err := compactPack("proxy", []compactShard{{data: wrong}}); err == nil || !strings.Contains(err.Error(), "does not match") {
-		t.Fatalf("wrong-session compactPack err = %v", err)
-	}
-	oversize := compactShard{name: "evidence-proxy-0.jsonl", data: make([]byte, recorder.MaxEvidenceReadFileBytes+1)}
-	if err := writeCompactStage(t.TempDir(), []compactShard{oversize}); err == nil || !strings.Contains(err.Error(), "exceeds") {
-		t.Fatalf("oversize write err = %v", err)
-	}
+	t.Run("empty-receipt-chain", func(t *testing.T) {
+		if err := verifyCompactReceipts(nil, make([]byte, ed25519.PublicKeySize)); err == nil {
+			t.Fatal("empty receipt chain verified")
+		}
+	})
+	t.Run("empty-pack", func(t *testing.T) {
+		if _, err := compactPack("proxy", nil); err == nil || !strings.Contains(err.Error(), "no compacted") {
+			t.Fatalf("empty compactPack err = %v", err)
+		}
+	})
+	t.Run("malformed-pack", func(t *testing.T) {
+		if _, err := compactPack("proxy", []compactShard{{data: []byte("{bad}\n")}}); err == nil || !strings.Contains(err.Error(), "parse compacted") {
+			t.Fatalf("malformed compactPack err = %v", err)
+		}
+	})
+	t.Run("wrong-session", func(t *testing.T) {
+		wrong := compactTestLineForSession(t, "other", 0)
+		if _, err := compactPack("proxy", []compactShard{{data: wrong}}); err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("wrong-session compactPack err = %v", err)
+		}
+	})
+	t.Run("oversized-stage", func(t *testing.T) {
+		oversize := compactShard{name: "evidence-proxy-0.jsonl", data: make([]byte, recorder.MaxEvidenceReadFileBytes+1)}
+		if err := writeCompactStage(t.TempDir(), []compactShard{oversize}); err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Fatalf("oversize write err = %v", err)
+		}
+	})
 }
 
 func TestCompactManifestMappingsAndReceiptEquality(t *testing.T) {
@@ -525,43 +553,63 @@ func TestCompactLinuxHelpers(t *testing.T) {
 	if !supportsCompactExchangeTest() {
 		t.Skip("linux helpers are unsupported")
 	}
-	active := t.TempDir()
-	stage := t.TempDir()
-	if err := prepareCompactStage(active, stage); err != nil {
-		t.Fatal(err)
-	}
-	if err := prepareCompactStage(filepath.Join(t.TempDir(), "missing"), stage); err == nil {
-		t.Fatal("prepareCompactStage accepted missing source")
-	}
-	source := filepath.Join(t.TempDir(), "source")
-	target := filepath.Join(t.TempDir(), "target")
-	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := preserveCompactFileMetadata(source, target); err != nil {
-		t.Fatal(err)
-	}
-	if err := preserveCompactFileMetadata(filepath.Join(t.TempDir(), "missing"), target); err == nil {
-		t.Fatal("preserveCompactFileMetadata accepted missing source")
-	}
-	if err := syncCompactFile(target); err != nil {
-		t.Fatal(err)
-	}
-	if err := syncCompactFile(filepath.Join(t.TempDir(), "missing")); err == nil {
-		t.Fatal("syncCompactFile accepted missing file")
-	}
-	if err := syncCompactDirectory(active); err != nil {
-		t.Fatal(err)
-	}
-	if err := syncCompactDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
-		t.Fatal("syncCompactDirectory accepted missing directory")
-	}
-	if err := exchangeEvidenceDirectories(filepath.Join(active, "missing-a"), filepath.Join(active, "missing-b")); err == nil {
-		t.Fatal("exchangeEvidenceDirectories accepted missing directories")
-	}
+	t.Run("prepare-success", func(t *testing.T) {
+		if err := prepareCompactStage(t.TempDir(), t.TempDir()); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("prepare-missing", func(t *testing.T) {
+		if err := prepareCompactStage(filepath.Join(t.TempDir(), "missing"), t.TempDir()); err == nil {
+			t.Fatal("prepareCompactStage accepted missing source")
+		}
+	})
+	t.Run("metadata-success", func(t *testing.T) {
+		source, target := filepath.Join(t.TempDir(), "source"), filepath.Join(t.TempDir(), "target")
+		if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := preserveCompactFileMetadata(source, target); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("metadata-missing", func(t *testing.T) {
+		if err := preserveCompactFileMetadata(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "target")); err == nil {
+			t.Fatal("preserveCompactFileMetadata accepted missing source")
+		}
+	})
+	t.Run("sync-file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "file")
+		if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := syncCompactFile(path); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("sync-file-missing", func(t *testing.T) {
+		if err := syncCompactFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+			t.Fatal("syncCompactFile accepted missing file")
+		}
+	})
+	t.Run("sync-directory", func(t *testing.T) {
+		if err := syncCompactDirectory(t.TempDir()); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("sync-directory-missing", func(t *testing.T) {
+		if err := syncCompactDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
+			t.Fatal("syncCompactDirectory accepted missing directory")
+		}
+	})
+	t.Run("exchange-missing", func(t *testing.T) {
+		parent := t.TempDir()
+		if err := exchangeEvidenceDirectories(filepath.Join(parent, "missing-a"), filepath.Join(parent, "missing-b")); err == nil {
+			t.Fatal("exchangeEvidenceDirectories accepted missing directories")
+		}
+	})
 }
 
 func TestCompactPackRejectsOversizedLine(t *testing.T) {
@@ -604,6 +652,23 @@ func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
 		{name: "prepare-stage", inject: func() { compactPrepareStage = func(string, string) error { return errors.New("injected prepare") } }},
 		{name: "write-stage", inject: func() {
 			compactWriteShards = func(string, []compactShard) error { return errors.New("injected write") }
+		}},
+		{name: "corrupt-staged-recorder", inject: func() {
+			compactWriteShards = func(dir string, shards []compactShard) error {
+				if err := writeCompactStage(dir, shards); err != nil {
+					return err
+				}
+				var entry recorder.Entry
+				if err := json.Unmarshal(bytes.TrimSpace(shards[0].data), &entry); err != nil {
+					return err
+				}
+				entry.Summary = "changed without updating recorder hash"
+				data, err := json.Marshal(entry)
+				if err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dir, shards[0].name), append(data, '\n'), 0o600)
+			}
 		}},
 		{name: "sync-stage", inject: func() { compactSyncPath = func(string) error { return errors.New("injected sync") } }},
 		{name: "extract-stage", inject: func() {
@@ -665,10 +730,71 @@ func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
 			restoreCompactHooks(t)
 			opts := newCompactFixture(t)
 			tc.inject()
-			if err := runCompact(compactCmd(), opts); err == nil {
+			err := runCompact(compactCmd(), opts)
+			if err == nil {
 				t.Fatal("runCompact succeeded across injected ceremony failure")
 			}
+			if tc.name != "too-many-shards" && tc.name != "chain-mismatch" && tc.name != "corrupt-staged-recorder" {
+				if !strings.Contains(err.Error(), "injected") {
+					t.Fatalf("%s failed for the wrong reason: %v", tc.name, err)
+				}
+			}
+			if _, statErr := os.Stat(filepath.Join(opts.receiptDir, "evidence-proxy-0.jsonl")); statErr != nil {
+				t.Fatalf("original shard not restored after %s: %v (run error: %v)", tc.name, statErr, err)
+			}
+			parent := filepath.Dir(opts.receiptDir)
+			for _, pattern := range []string{".pipelock-evidence-compact-*", ".pipelock-evidence-archive-*"} {
+				leftover, globErr := filepath.Glob(filepath.Join(parent, pattern))
+				if globErr != nil {
+					t.Fatal(globErr)
+				}
+				if len(leftover) != 0 {
+					t.Fatalf("%s left ceremony directories %v (run error: %v)", tc.name, leftover, err)
+				}
+			}
+			restoreCompactHooks(t)
+			if retryErr := runCompact(compactCmd(), opts); retryErr != nil {
+				t.Fatalf("%s left ceremony non-retryable: %v (original error: %v)", tc.name, retryErr, err)
+			}
 		})
+	}
+}
+
+func TestSameCompactBytes(t *testing.T) {
+	t.Parallel()
+	a := []compactShard{{data: []byte("one\n")}, {data: []byte("two\n")}}
+	b := []compactShard{{data: []byte("one\ntwo\n")}}
+	if !sameCompactBytes(a, b) {
+		t.Fatal("same byte stream differs across shard boundaries")
+	}
+	b[0].data[0] = 'X'
+	if sameCompactBytes(a, b) {
+		t.Fatal("different byte streams compare equal")
+	}
+}
+
+func TestRunCompactDetectsSourceMutationBeforeExchange(t *testing.T) {
+	restoreCompactHooks(t)
+	opts := newCompactFixture(t)
+	calls := 0
+	compactAcquireLock = func(dir string) (*recorder.EvidenceCeremonyLock, error) {
+		lock, err := recorder.AcquireEvidenceCeremonyLock(dir)
+		if err != nil {
+			return nil, err
+		}
+		calls++
+		if calls == 2 {
+			path := filepath.Join(opts.receiptDir, "evidence-proxy-0.jsonl")
+			if writeErr := os.WriteFile(path, append(compactTestLine(t, 0), []byte("changed\n")...), 0o600); writeErr != nil {
+				_ = lock.Close()
+				return nil, writeErr
+			}
+		}
+		return lock, nil
+	}
+	err := runCompact(compactCmd(), opts)
+	if err == nil || !strings.Contains(err.Error(), "source changed before publication") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -1,0 +1,726 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func supportsCompactExchangeTest() bool { return runtime.GOOS == "linux" }
+
+func TestRunCompactSignedMultiShardExchange(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalBytes := make([]byte, 0)
+	receiptPrev := contractreceipt.GenesisHash
+	recorderPrev := recorder.GenesisHash
+	sourceShards := recorder.MaxEvidenceReadDirectoryEntries + 1
+	for i := range sourceShards {
+		r := compactSignedReceipt(t, priv, uint64(i), receiptPrev)
+		receiptPrev, err = contractreceipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		e := recorder.Entry{
+			Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i),
+			Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy",
+			Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision",
+			Transport: "fetch", Summary: strings.Repeat("x", 40_000), Detail: r, PrevHash: recorderPrev,
+		}
+		e.Hash = recorder.ComputeHash(e)
+		recorderPrev = e.Hash
+		line, marshalErr := json.Marshal(e)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		line = append(line, '\n')
+		originalBytes = append(originalBytes, line...)
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("evidence-proxy-%d.jsonl", i)), line, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := compactCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("compact command: %v", err)
+	}
+	active, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 2 {
+		t.Fatalf("active entries = %d, want 2 compacted shards", len(active))
+	}
+	sort.Slice(active, func(i, j int) bool {
+		_, a, _ := recorder.ParseEvidenceFilename(active[i].Name())
+		_, b, _ := recorder.ParseEvidenceFilename(active[j].Name())
+		return a < b
+	})
+	var compacted []byte
+	for _, entry := range active {
+		// #nosec G304 -- entry comes from the freshly compacted test directory.
+		part, readErr := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		compacted = append(compacted, part...)
+	}
+	if !bytes.Equal(compacted, originalBytes) {
+		t.Fatal("active compaction changed original JSONL line bytes")
+	}
+	archives, err := filepath.Glob(filepath.Join(parent, ".pipelock-evidence-archive-*"))
+	if err != nil || len(archives) != 1 {
+		t.Fatalf("archives = %v, err = %v", archives, err)
+	}
+	var manifest compactManifest
+	manifestBytes, err := os.ReadFile(filepath.Join(archives[0], "compaction-manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Original) != sourceShards || len(manifest.Replacement) != 2 || len(manifest.Mappings) != sourceShards {
+		t.Fatalf("manifest counts = original %d replacement %d mappings %d", len(manifest.Original), len(manifest.Replacement), len(manifest.Mappings))
+	}
+	for i := range sourceShards {
+		archived, readErr := os.ReadFile(filepath.Join(archives[0], fmt.Sprintf("evidence-proxy-%d.jsonl", i)))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if got := hex.EncodeToString(sha256Bytes(archived)); got != manifest.Original[i].SHA256 {
+			t.Fatalf("archive digest %d = %s, manifest %s", i, got, manifest.Original[i].SHA256)
+		}
+	}
+	if !strings.Contains(out.String(), "original preserved at") {
+		t.Fatalf("command output = %q", out.String())
+	}
+}
+
+func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prev string) contractreceipt.EvidenceReceipt {
+	t.Helper()
+	payload, err := json.Marshal(contractreceipt.PayloadShadowDeltaStruct{
+		ContractHash: "sha256:test-contract", RuleID: "rule-1", OriginalVerdict: "allow", CandidateVerdict: "block",
+		Aggregation: contractreceipt.ShadowDeltaAggregation{WindowStart: "2026-08-23T00:00:00Z", WindowEnd: "2026-08-23T00:01:00Z", LosslessCount: 1, DeltaSampleCount: 1, ExemplarIDs: []string{"sha256:example"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := contractreceipt.EvidenceReceipt{
+		RecordType: contractreceipt.RecordTypeEvidenceV2, ReceiptVersion: 2,
+		PayloadKind: contractreceipt.PayloadShadowDelta, Canonicalization: contractreceipt.DefaultCanonicalizationProfile(),
+		Crit:    contractreceipt.CritForPayloadKind(contractreceipt.PayloadShadowDelta),
+		EventID: fmt.Sprintf("01900000-0000-7000-8000-%012d", seq), Timestamp: time.Unix(1, 0).UTC(), Actor: "test",
+		ChainSeq: seq, ChainPrevHash: prev, ContractHash: "sha256:test-contract", ActiveManifestHash: "sha256:test-manifest", Payload: payload,
+		Signature: contractreceipt.SignatureProof{SignerKeyID: "test-key", KeyPurpose: "receipt-signing", Algorithm: "ed25519"},
+	}
+	preimage, err := r.SignablePreimage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Signature.Signature = "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage))
+	return r
+}
+
+func sha256Bytes(data []byte) []byte {
+	sum := sha256.Sum256(data)
+	return sum[:]
+}
+
+func TestCompactPackPreservesLineBytesAndNamesFirstSequence(t *testing.T) {
+	t.Parallel()
+	first := compactTestLine(t, 4)
+	second := compactTestLine(t, 5)
+	source := []compactShard{{name: "evidence-proxy-4.jsonl", data: append(append([]byte(nil), first...), second...)}}
+	got, err := compactPack("proxy", source)
+	if err != nil {
+		t.Fatalf("compactPack: %v", err)
+	}
+	if len(got) != 1 || got[0].name != "evidence-proxy-4.jsonl" {
+		t.Fatalf("shards = %+v", got)
+	}
+	if !bytes.Equal(got[0].data, source[0].data) {
+		t.Fatalf("compaction altered JSONL bytes\n got %q\nwant %q", got[0].data, source[0].data)
+	}
+}
+
+func TestCompactSourceRefusesNonSelectedEvidence(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDoctorEntries(t, dir, "evidence-proxy-0.jsonl", doctorEntryPlan{{session: "proxy", seq: 0, prev: recorder.GenesisHash}})
+	writeDoctorEntries(t, dir, "evidence-other-0.jsonl", doctorEntryPlan{{session: "other", seq: 0, prev: recorder.GenesisHash}})
+	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil {
+		t.Fatal("compactSource accepted unrelated active evidence")
+	}
+}
+
+func TestCompactSourceRefusesNestedDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "refuse nested directory") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCompactSourceRefusesShardWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	line := compactTestLine(t, 0)
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), bytes.TrimSuffix(line, []byte("\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "does not end in newline") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCompactSourceRefusesDuplicateStartSymlinkAndOversize(t *testing.T) {
+	t.Run("duplicate-start", func(t *testing.T) {
+		dir := t.TempDir()
+		line := compactTestLine(t, 0)
+		for _, name := range []string{"evidence-proxy-0.jsonl", "evidence-proxy-000.jsonl"} {
+			if err := os.WriteFile(filepath.Join(dir, name), line, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "duplicate shard sequence start") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(t.TempDir(), "target.jsonl")
+		if err := os.WriteFile(target, compactTestLine(t, 0), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(dir, "evidence-proxy-0.jsonl")); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("oversize", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+		// #nosec G304 -- path is inside t.TempDir().
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Truncate(recorder.MaxEvidenceReadFileBytes + 1); err != nil {
+			_ = f.Close()
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func TestRunCompactRefusesActiveRecorder(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("ceremony locking is unsupported")
+	}
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rec.Close() }()
+	cmd := compactCmd()
+	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub)})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires a stopped recorder") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func compactTestLine(t *testing.T, seq uint64) []byte {
+	t.Helper()
+	e := recorder.Entry{Version: recorder.EntryVersion, Sequence: seq, Timestamp: time.Unix(1, 0).UTC(), SessionID: "proxy", Type: "decision", EventKind: "proxy_decision", Transport: "fetch", Summary: "test", Detail: map[string]string{"test": "value"}, PrevHash: recorder.GenesisHash}
+	e.Hash = recorder.ComputeHash(e)
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return append(data, '\n')
+}
+
+func TestExchangeEvidenceDirectoriesRejectsSeparateParents(t *testing.T) {
+	t.Parallel()
+	err := exchangeEvidenceDirectories(filepath.Join(t.TempDir(), "active"), filepath.Join(t.TempDir(), "stage"))
+	if err == nil {
+		t.Fatal("exchangeEvidenceDirectories accepted separate parents")
+	}
+}
+
+func TestRunCompactRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		opts compactOptions
+		want string
+	}{
+		{name: "blank-session", opts: compactOptions{}, want: "--session is required"},
+		{name: "bad-directory", opts: compactOptions{sessionID: "proxy", receiptDir: filepath.Join(t.TempDir(), "missing")}, want: "no such file"},
+		{name: "bad-location", opts: compactOptions{sessionID: "proxy", receiptDir: t.TempDir(), locationID: "../escape", publicKey: "bad"}, want: "resolve evidence location"},
+		{name: "bad-key", opts: compactOptions{sessionID: "proxy", receiptDir: t.TempDir(), publicKey: "bad"}, want: "load --key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runCompact(compactCmd(), tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompactSourceRejectsMalformedChains(t *testing.T) {
+	t.Parallel()
+	t.Run("empty", func(t *testing.T) {
+		dir := t.TempDir()
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "no evidence shards") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("malformed-json", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), []byte("{bad}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "validate") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("wrong-entry-session", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLineForSession(t, "other", 0), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "belongs to") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("broken-recorder-chain", func(t *testing.T) {
+		dir := t.TempDir()
+		data := append(compactTestLineForSession(t, "proxy", 0), compactTestLineForSession(t, "proxy", 1)...)
+		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "verify recorder chain") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("no-receipts", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "no evidence receipts") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+func compactTestLineForSession(t *testing.T, session string, seq uint64) []byte {
+	t.Helper()
+	e := recorder.Entry{Version: recorder.EntryVersion, Sequence: seq, Timestamp: time.Unix(1, 0).UTC(), SessionID: session, Type: "decision", EventKind: "proxy_decision", Transport: "fetch", Summary: "test", PrevHash: recorder.GenesisHash}
+	e.Hash = recorder.ComputeHash(e)
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(data, '\n')
+}
+
+func TestCompactHelpersRejectInvalidData(t *testing.T) {
+	t.Parallel()
+	if err := verifyCompactReceipts(nil, make([]byte, ed25519.PublicKeySize)); err == nil {
+		t.Fatal("empty receipt chain verified")
+	}
+	if _, err := compactPack("proxy", nil); err == nil || !strings.Contains(err.Error(), "no compacted") {
+		t.Fatalf("empty compactPack err = %v", err)
+	}
+	if _, err := compactPack("proxy", []compactShard{{data: []byte("{bad}\n")}}); err == nil || !strings.Contains(err.Error(), "parse compacted") {
+		t.Fatalf("malformed compactPack err = %v", err)
+	}
+	wrong := compactTestLineForSession(t, "other", 0)
+	if _, err := compactPack("proxy", []compactShard{{data: wrong}}); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("wrong-session compactPack err = %v", err)
+	}
+	oversize := compactShard{name: "evidence-proxy-0.jsonl", data: make([]byte, recorder.MaxEvidenceReadFileBytes+1)}
+	if err := writeCompactStage(t.TempDir(), []compactShard{oversize}); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversize write err = %v", err)
+	}
+}
+
+func TestCompactManifestMappingsAndReceiptEquality(t *testing.T) {
+	t.Parallel()
+	shards := []compactShard{{name: "one", data: []byte("abc"), mappings: []compactByteMapping{{Source: "old", Output: "one", Bytes: 3}}}}
+	manifest := manifestShards(shards)
+	if len(manifest) != 1 || manifest[0].Name != "one" || manifest[0].Bytes != 3 || manifest[0].SHA256 == "" {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+	if mappings := compactMappings(shards); len(mappings) != 1 || mappings[0].Bytes != 3 {
+		t.Fatalf("mappings = %+v", mappings)
+	}
+	dir := t.TempDir()
+	if err := writeCompactManifest(dir, compactManifest{Version: 1, SessionID: "proxy"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "compaction-manifest.json")); err != nil {
+		t.Fatal(err)
+	}
+	if !sameReceiptChain(nil, nil) {
+		t.Fatal("equal empty chains differ")
+	}
+	if sameReceiptChain(nil, []contractreceipt.EvidenceReceipt{{}}) {
+		t.Fatal("different-length chains compare equal")
+	}
+	if sameReceiptChain([]contractreceipt.EvidenceReceipt{{}}, []contractreceipt.EvidenceReceipt{{Actor: "different"}}) {
+		t.Fatal("different receipts compare equal")
+	}
+}
+
+func TestRunCompactPropagatesEmptySource(t *testing.T) {
+	t.Parallel()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	err = runCompact(compactCmd(), compactOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub)})
+	if err == nil || !strings.Contains(err.Error(), "no evidence shards") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCompactFileAndRollbackHelpers(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	t.Run("write-stage", func(t *testing.T) {
+		sourceDir := t.TempDir()
+		stage := t.TempDir()
+		source := filepath.Join(sourceDir, "source.jsonl")
+		if err := os.WriteFile(source, []byte("source\n"), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(source, 0o400); err != nil {
+			t.Fatal(err)
+		}
+		shard := compactShard{name: "evidence-proxy-0.jsonl", data: []byte("replacement\n"), sourcePath: source}
+		if err := writeCompactStage(stage, []compactShard{shard}); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(filepath.Join(stage, shard.name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o400 {
+			t.Fatalf("mode = %o", info.Mode().Perm())
+		}
+	})
+	t.Run("write-stage-missing-source", func(t *testing.T) {
+		err := writeCompactStage(t.TempDir(), []compactShard{{name: "evidence-proxy-0.jsonl", data: []byte("x\n"), sourcePath: filepath.Join(t.TempDir(), "missing")}})
+		if err == nil || !strings.Contains(err.Error(), "preserve compacted shard metadata") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("write-stage-missing-dir", func(t *testing.T) {
+		err := writeCompactStage(filepath.Join(t.TempDir(), "missing"), []compactShard{{name: "evidence-proxy-0.jsonl", data: []byte("x\n")}})
+		if err == nil || !strings.Contains(err.Error(), "write compacted shard") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+	t.Run("rollback", func(t *testing.T) {
+		parent := t.TempDir()
+		active := filepath.Join(parent, "active")
+		old := filepath.Join(parent, "old")
+		if err := os.Mkdir(active, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(old, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(active, "replacement"), []byte("new"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(old, "original"), []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(old, "compaction-manifest.json"), []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cause := errors.New("publication failed")
+		if err := rollbackCompactExchange(active, old, cause); !errors.Is(err, cause) {
+			t.Fatalf("rollback err = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(active, "original")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(old); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("old directory remains: %v", err)
+		}
+	})
+}
+
+func TestCompactLinuxHelpers(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("linux helpers are unsupported")
+	}
+	active := t.TempDir()
+	stage := t.TempDir()
+	if err := prepareCompactStage(active, stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareCompactStage(filepath.Join(t.TempDir(), "missing"), stage); err == nil {
+		t.Fatal("prepareCompactStage accepted missing source")
+	}
+	source := filepath.Join(t.TempDir(), "source")
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := preserveCompactFileMetadata(source, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := preserveCompactFileMetadata(filepath.Join(t.TempDir(), "missing"), target); err == nil {
+		t.Fatal("preserveCompactFileMetadata accepted missing source")
+	}
+	if err := syncCompactFile(target); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncCompactFile(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("syncCompactFile accepted missing file")
+	}
+	if err := syncCompactDirectory(active); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncCompactDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("syncCompactDirectory accepted missing directory")
+	}
+	if err := exchangeEvidenceDirectories(filepath.Join(active, "missing-a"), filepath.Join(active, "missing-b")); err == nil {
+		t.Fatal("exchangeEvidenceDirectories accepted missing directories")
+	}
+}
+
+func TestCompactPackRejectsOversizedLine(t *testing.T) {
+	t.Parallel()
+	data := make([]byte, recorder.MaxEvidenceReadFileBytes+1)
+	data[len(data)-1] = '\n'
+	_, err := compactPack("proxy", []compactShard{{data: data}})
+	if err == nil || !strings.Contains(err.Error(), "single JSONL line exceeds") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestWriteCompactManifestRejectsMissingDirectory(t *testing.T) {
+	t.Parallel()
+	err := writeCompactManifest(filepath.Join(t.TempDir(), "missing"), compactManifest{Version: 1})
+	if err == nil {
+		t.Fatal("writeCompactManifest accepted missing directory")
+	}
+}
+
+func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
+	tests := []struct {
+		name   string
+		inject func()
+	}{
+		{name: "pre-verify", inject: func() {
+			compactVerify = func([]contractreceipt.EvidenceReceipt, []byte) error { return errors.New("injected verify") }
+		}},
+		{name: "pack", inject: func() {
+			compactPackRecords = func(string, []compactShard) ([]compactShard, error) { return nil, errors.New("injected pack") }
+		}},
+		{name: "too-many-shards", inject: func() {
+			compactPackRecords = func(string, []compactShard) ([]compactShard, error) {
+				return make([]compactShard, recorder.MaxEvidenceReadDirectoryEntries+1), nil
+			}
+		}},
+		{name: "make-stage", inject: func() {
+			compactMakeStage = func(string, string) (string, error) { return "", errors.New("injected mkdir") }
+		}},
+		{name: "prepare-stage", inject: func() { compactPrepareStage = func(string, string) error { return errors.New("injected prepare") } }},
+		{name: "write-stage", inject: func() {
+			compactWriteShards = func(string, []compactShard) error { return errors.New("injected write") }
+		}},
+		{name: "sync-stage", inject: func() { compactSyncPath = func(string) error { return errors.New("injected sync") } }},
+		{name: "extract-stage", inject: func() {
+			compactExtract = func(recorder.EvidenceLocation, string) ([]contractreceipt.EvidenceReceipt, error) {
+				return nil, errors.New("injected extract")
+			}
+		}},
+		{name: "post-verify", inject: func() {
+			calls := 0
+			compactVerify = func(receipts []contractreceipt.EvidenceReceipt, key []byte) error {
+				calls++
+				if calls == 2 {
+					return errors.New("injected post verify")
+				}
+				return verifyCompactReceipts(receipts, key)
+			}
+		}},
+		{name: "chain-mismatch", inject: func() {
+			compactSameChain = func([]contractreceipt.EvidenceReceipt, []contractreceipt.EvidenceReceipt) bool { return false }
+		}},
+		{name: "stage-lock", inject: func() {
+			calls := 0
+			compactAcquireLock = func(dir string) (*recorder.EvidenceCeremonyLock, error) {
+				calls++
+				if calls == 2 {
+					return nil, errors.New("injected stage lock")
+				}
+				return recorder.AcquireEvidenceCeremonyLock(dir)
+			}
+		}},
+		{name: "exchange", inject: func() { compactExchange = func(string, string) error { return errors.New("injected exchange") } }},
+		{name: "rename", inject: func() { compactRename = func(string, string) error { return errors.New("injected rename") } }},
+		{name: "manifest", inject: func() {
+			compactWriteManifest = func(string, compactManifest) error { return errors.New("injected manifest") }
+		}},
+		{name: "archive-sync", inject: func() {
+			calls := 0
+			compactSyncPath = func(path string) error {
+				calls++
+				if calls == 3 {
+					return errors.New("injected archive sync")
+				}
+				return syncCompactDirectory(path)
+			}
+		}},
+		{name: "final-parent-sync", inject: func() {
+			calls := 0
+			compactSyncPath = func(path string) error {
+				calls++
+				if calls == 4 {
+					return errors.New("injected final sync")
+				}
+				return syncCompactDirectory(path)
+			}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreCompactHooks(t)
+			opts := newCompactFixture(t)
+			tc.inject()
+			if err := runCompact(compactCmd(), opts); err == nil {
+				t.Fatal("runCompact succeeded across injected ceremony failure")
+			}
+		})
+	}
+}
+
+func restoreCompactHooks(t *testing.T) {
+	t.Helper()
+	compactAcquireLock = recorder.AcquireEvidenceCeremonyLock
+	compactPackRecords = compactPack
+	compactMakeStage = os.MkdirTemp
+	compactPrepareStage = prepareCompactStage
+	compactWriteShards = writeCompactStage
+	compactSyncPath = syncCompactDirectory
+	compactExtract = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
+	compactVerify = verifyCompactReceipts
+	compactSameChain = sameReceiptChain
+	compactExchange = exchangeEvidenceDirectories
+	compactRename = os.Rename
+	compactWriteManifest = writeCompactManifest
+	t.Cleanup(func() {
+		compactAcquireLock = recorder.AcquireEvidenceCeremonyLock
+		compactPackRecords = compactPack
+		compactMakeStage = os.MkdirTemp
+		compactPrepareStage = prepareCompactStage
+		compactWriteShards = writeCompactStage
+		compactSyncPath = syncCompactDirectory
+		compactExtract = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
+		compactVerify = verifyCompactReceipts
+		compactSameChain = sameReceiptChain
+		compactExchange = exchangeEvidenceDirectories
+		compactRename = os.Rename
+		compactWriteManifest = writeCompactManifest
+	})
+}
+
+func newCompactFixture(t *testing.T) compactOptions {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := compactSignedReceipt(t, priv, 0, contractreceipt.GenesisHash)
+	e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: 0, Timestamp: time.Unix(1, 0).UTC(), SessionID: "proxy", Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision", Transport: "fetch", Summary: "test", Detail: r, PrevHash: recorder.GenesisHash}
+	e.Hash = recorder.ComputeHash(e)
+	line, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), append(line, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return compactOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub)}
+}

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -631,6 +631,9 @@ func TestWriteCompactManifestRejectsMissingDirectory(t *testing.T) {
 }
 
 func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence compaction requires Linux rename exchange")
+	}
 	tests := []struct {
 		name   string
 		inject func()
@@ -774,6 +777,9 @@ func TestSameCompactBytes(t *testing.T) {
 }
 
 func TestRunCompactDetectsSourceMutationBeforeExchange(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence compaction requires Linux rename exchange")
+	}
 	restoreCompactHooks(t)
 	opts := newCompactFixture(t)
 	calls := 0

--- a/internal/cli/evidence/compact_unsupported.go
+++ b/internal/cli/evidence/compact_unsupported.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package evidence
+
+import "errors"
+
+func exchangeEvidenceDirectories(_, _ string) error {
+	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+}
+
+func prepareCompactStage(_, _ string) error {
+	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+}
+
+func preserveCompactFileMetadata(_, _ string) error {
+	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+}
+
+func syncCompactFile(_ string) error {
+	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+}
+
+func syncCompactDirectory(_ string) error {
+	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+}

--- a/internal/cli/evidence/compact_unsupported.go
+++ b/internal/cli/evidence/compact_unsupported.go
@@ -7,22 +7,24 @@ package evidence
 
 import "errors"
 
+var errCompactUnsupported = errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+
 func exchangeEvidenceDirectories(_, _ string) error {
-	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+	return errCompactUnsupported
 }
 
 func prepareCompactStage(_, _ string) error {
-	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+	return errCompactUnsupported
 }
 
 func preserveCompactFileMetadata(_, _ string) error {
-	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+	return errCompactUnsupported
 }
 
 func syncCompactFile(_ string) error {
-	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+	return errCompactUnsupported
 }
 
 func syncCompactDirectory(_ string) error {
-	return errors.New("offline evidence compaction requires Linux RENAME_EXCHANGE")
+	return errCompactUnsupported
 }

--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -38,6 +38,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(viewCmd())
 	cmd.AddCommand(serveCmd())
 	cmd.AddCommand(expireCmd())
+	cmd.AddCommand(compactCmd())
 	cmd.AddCommand(doctorCmd())
 	cmd.AddCommand(verifyCertCmd())
 	return cmd

--- a/internal/recorder/discovery.go
+++ b/internal/recorder/discovery.go
@@ -71,6 +71,9 @@ func discoverEvidenceLocations(root string, afterRootOpen func()) ([]EvidenceLoc
 		if walkErr != nil {
 			return fmt.Errorf("read evidence path %q: %w", relPath, walkErr)
 		}
+		if entry.IsDir() && relPath != "." && isReservedEvidenceCeremonyDir(entry.Name()) {
+			return fs.SkipDir
+		}
 		entryInfo, infoErr := entry.Info()
 		if infoErr != nil {
 			return fmt.Errorf("stat evidence path %q: %w", relPath, infoErr)
@@ -105,6 +108,11 @@ func discoverEvidenceLocations(root string, afterRootOpen func()) ([]EvidenceLoc
 	}
 	sort.Slice(locations, func(i, j int) bool { return locations[i].ID < locations[j].ID })
 	return locations, nil
+}
+
+func isReservedEvidenceCeremonyDir(name string) bool {
+	return strings.HasPrefix(name, ".pipelock-evidence-compact-") ||
+		strings.HasPrefix(name, ".pipelock-evidence-archive-")
 }
 
 // validateEvidenceRootComponents checks from the filesystem root down so a

--- a/internal/recorder/discovery.go
+++ b/internal/recorder/discovery.go
@@ -10,8 +10,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
+)
+
+var (
+	compactStageDirPattern   = regexp.MustCompile(`^\.pipelock-evidence-compact-[[:alnum:]]{6,12}$`)
+	compactArchiveDirPattern = regexp.MustCompile(`^\.pipelock-evidence-archive-[0-9]{8}T[0-9]{6}\.[0-9]{9}Z$`)
 )
 
 // EvidenceLocation identifies an evidence-file directory below an
@@ -111,8 +117,7 @@ func discoverEvidenceLocations(root string, afterRootOpen func()) ([]EvidenceLoc
 }
 
 func isReservedEvidenceCeremonyDir(name string) bool {
-	return strings.HasPrefix(name, ".pipelock-evidence-compact-") ||
-		strings.HasPrefix(name, ".pipelock-evidence-archive-")
+	return compactStageDirPattern.MatchString(name) || compactArchiveDirPattern.MatchString(name)
 }
 
 // validateEvidenceRootComponents checks from the filesystem root down so a

--- a/internal/recorder/discovery_test.go
+++ b/internal/recorder/discovery_test.go
@@ -37,6 +37,16 @@ func TestDiscoverEvidenceLocations(t *testing.T) {
 			wantIDs: []string{"recorder-a/run-a", "recorder-b/run-b"},
 		},
 		{
+			name: "offline compaction stage and archive are not active locations",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				writeDiscoveryShard(t, filepath.Join(root, "active"))
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-compact-test"))
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-archive-test"))
+			},
+			wantIDs: []string{"active"},
+		},
+		{
 			name: "unexpected deeply nested location is found",
 			setup: func(t *testing.T, root string) {
 				t.Helper()

--- a/internal/recorder/discovery_test.go
+++ b/internal/recorder/discovery_test.go
@@ -41,10 +41,22 @@ func TestDiscoverEvidenceLocations(t *testing.T) {
 			setup: func(t *testing.T, root string) {
 				t.Helper()
 				writeDiscoveryShard(t, filepath.Join(root, "active"))
-				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-compact-test"))
-				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-archive-test"))
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-compact-123456789"))
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-archive-20260823T120000.000000000Z"))
+				writeDiscoveryShard(t, filepath.Join(root, "nested"))
+				writeDiscoveryShard(t, filepath.Join(root, "nested", ".pipelock-evidence-compact-987654321"))
+				writeDiscoveryShard(t, filepath.Join(root, "nested", ".pipelock-evidence-archive-20260823T120001.000000000Z"))
 			},
-			wantIDs: []string{"active"},
+			wantIDs: []string{"active", "nested"},
+		},
+		{
+			name: "unrelated prefixed directories remain visible",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-compact-user-data"))
+				writeDiscoveryShard(t, filepath.Join(root, ".pipelock-evidence-archive-old"))
+			},
+			wantIDs: []string{".pipelock-evidence-archive-old", ".pipelock-evidence-compact-user-data"},
 		},
 		{
 			name: "unexpected deeply nested location is found",

--- a/internal/recorder/evidence_location_read.go
+++ b/internal/recorder/evidence_location_read.go
@@ -67,6 +67,12 @@ func ReadEvidenceLocationEntries(location EvidenceLocation) ([]os.DirEntry, erro
 	return entries, err
 }
 
+// ReadEvidenceLocationEntriesBounded lists at most maxEntries and reports
+// whether another entry exists without retaining an unbounded directory.
+func ReadEvidenceLocationEntriesBounded(location EvidenceLocation, maxEntries int) ([]os.DirEntry, bool, error) {
+	return readEvidenceLocationDirectoryEntries(location, maxEntries)
+}
+
 func readEntriesAtEvidenceLocation(location EvidenceLocation, name string, limits entryReadLimits) ([]Entry, bool, int64, error) {
 	file, before, err := openEvidenceLocationFile(location, name)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Add a Linux-only offline ceremony that compacts a stopped single-session recorder directory into bounded shards while preserving the original JSONL record bytes.
- Verify the recorder and pinned signed-receipt chains before and after publication, then retain the original directory with SHA-256 digests and byte mappings.

The command fails closed on active writers, damaged or changing evidence, mixed layouts, unsupported platforms, and publication errors. Reviewers should distrust the directory-exchange rollback and the source-to-output byte mappings because either can undermine evidence preservation if implemented incorrectly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline evidence compaction for stopped recording sessions.
  * Compaction verifies signed chains, preserves record bytes and metadata, creates bounded shards, and archives originals.
  * Added atomic replacement, rollback protection, manifests, and receipt-chain validation.
  * Added guidance for safely compacting oversized evidence directories.

* **Bug Fixes**
  * Evidence discovery now ignores temporary compaction and archive directories.
  * Unsupported platforms clearly report that compaction requires Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->