### PR TITLE
fix(mcp): verify wrapper executable identity

### DIFF
--- a/internal/cli/diag/discover_test.go
+++ b/internal/cli/diag/discover_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,7 +166,7 @@ func TestDiscoverCmd_HumanAndGenerateRedactSensitiveValues(t *testing.T) {
 
 func TestDiscoverCmd_HumanOutput(t *testing.T) {
 	home := t.TempDir()
-	content := `{"mcpServers":{"brain":{"command":"pipelock","args":["mcp","proxy","--","node","brain.js"]}}}`
+	content := protectedDiscoveryConfig(t)
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +191,7 @@ func TestDiscoverCmd_HumanOutput(t *testing.T) {
 
 func TestDiscoverCmd_ExitCodeZeroAllProtected(t *testing.T) {
 	home := t.TempDir()
-	content := `{"mcpServers":{"brain":{"command":"pipelock","args":["mcp","proxy","--","node","brain.js"]}}}`
+	content := protectedDiscoveryConfig(t)
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -204,6 +205,15 @@ func TestDiscoverCmd_ExitCodeZeroAllProtected(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error (exit 0), got %v", err)
 	}
+}
+
+func protectedDiscoveryConfig(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve current executable: %v", err)
+	}
+	return fmt.Sprintf(`{"mcpServers":{"brain":{"command":%q,"args":["mcp","proxy","--","node","brain.js"]}}}`, self)
 }
 
 func TestDiscoverCmd_ExitCodeOneUnprotected(t *testing.T) {

--- a/internal/cli/generate/coverage_boost_test.go
+++ b/internal/cli/generate/coverage_boost_test.go
@@ -6,6 +6,7 @@ package generate
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,15 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/presets"
 )
+
+func TestExecutableOrName(t *testing.T) {
+	if got := executableOrName("/opt/pipelock", nil); got != "/opt/pipelock" {
+		t.Fatalf("executableOrName success = %q", got)
+	}
+	if got := executableOrName("", errors.New("unsupported")); got != mcporterBinaryName {
+		t.Fatalf("executableOrName fallback = %q, want %q", got, mcporterBinaryName)
+	}
+}
 
 // ---------- generateConfigCmd error paths ----------
 
@@ -180,16 +190,16 @@ func TestIsAlreadyWrapped(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "wrapped stdio",
-			command: "pipelock",
+			name:    "wrapped by current executable",
+			command: currentPipelockExecutable(),
 			args:    []string{"mcp", "proxy", "--config", "p.yaml", "--", "node", "server.js"},
 			want:    true,
 		},
 		{
-			name:    "wrapped with path",
+			name:    "foreign binary merely named pipelock",
 			command: "/usr/bin/pipelock",
 			args:    []string{"mcp", "proxy", "--upstream", "http://example.com"},
-			want:    true,
+			want:    false,
 		},
 		{
 			name:    "not wrapped",
@@ -215,10 +225,16 @@ func TestIsAlreadyWrapped(t *testing.T) {
 			args:    []string{"proxy", "mcp"},
 			want:    false,
 		},
+		{
+			name:    "mcp and proxy later in arguments",
+			command: currentPipelockExecutable(),
+			args:    []string{"--config", "x", "mcp", "proxy", "--", "server"},
+			want:    false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isAlreadyWrapped(tc.command, tc.args)
+			got := isAlreadyWrapped(tc.command, tc.args, currentPipelockExecutable())
 			if got != tc.want {
 				t.Errorf("isAlreadyWrapped(%q, %v) = %v, want %v", tc.command, tc.args, got, tc.want)
 			}
@@ -325,7 +341,7 @@ func TestAtomicWriteFile(t *testing.T) {
 func TestWrapServerEntry_URLBased(t *testing.T) {
 	raw := json.RawMessage(`{"url": "http://localhost:8090/sse"}`)
 
-	entry, err := wrapServerEntry(raw, "pipelock", "pipelock.yaml")
+	entry, err := wrapServerEntry(raw, currentPipelockExecutable(), "pipelock.yaml")
 	if err != nil {
 		t.Fatalf("wrapServerEntry: %v", err)
 	}
@@ -334,7 +350,7 @@ func TestWrapServerEntry_URLBased(t *testing.T) {
 	}
 
 	m := entry.value.(map[string]interface{})
-	if m["command"] != mcporterBinaryName {
+	if m["command"] != currentPipelockExecutable() {
 		t.Errorf("command = %v, want pipelock", m["command"])
 	}
 	args := m["args"].([]string)
@@ -458,7 +474,7 @@ func TestGenerateMcporterCmd_InPlace(t *testing.T) {
 	}
 	servers := result["mcpServers"].(map[string]interface{})
 	test := servers["test"].(map[string]interface{})
-	if test["command"] != mcporterBinaryName {
+	if test["command"] != currentPipelockExecutable() {
 		t.Error("in-place modification should wrap the server")
 	}
 }

--- a/internal/cli/generate/coverage_boost_test.go
+++ b/internal/cli/generate/coverage_boost_test.go
@@ -6,7 +6,6 @@ package generate
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,15 +15,6 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cli/presets"
 )
-
-func TestExecutableOrName(t *testing.T) {
-	if got := executableOrName("/opt/pipelock", nil); got != "/opt/pipelock" {
-		t.Fatalf("executableOrName success = %q", got)
-	}
-	if got := executableOrName("", errors.New("unsupported")); got != mcporterBinaryName {
-		t.Fatalf("executableOrName fallback = %q, want %q", got, mcporterBinaryName)
-	}
-}
 
 // ---------- generateConfigCmd error paths ----------
 

--- a/internal/cli/generate/generate_mcporter.go
+++ b/internal/cli/generate/generate_mcporter.go
@@ -17,8 +17,13 @@ import (
 )
 
 func generateMcporterCmd() *cobra.Command {
+	return generateMcporterCmdWithExecutable(os.Executable)
+}
+
+func generateMcporterCmdWithExecutable(executable func() (string, error)) *cobra.Command {
 	var inputFile, outputFile, pipelockBin, configPath string
 	var inPlace, backup bool
+	defaultPipelockBin, executableErr := executable()
 
 	cmd := &cobra.Command{
 		Use:   "mcporter",
@@ -41,6 +46,9 @@ Examples:
   pipelock generate mcporter -i servers.json --in-place --backup`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if executableErr != nil && !cmd.Flags().Changed("pipelock-bin") {
+				return fmt.Errorf("resolving current pipelock executable: %w", executableErr)
+			}
 			if inPlace && outputFile != "" {
 				return fmt.Errorf("--in-place and --output are mutually exclusive")
 			}
@@ -119,7 +127,7 @@ Examples:
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "output file path (default: stdout)")
 	cmd.Flags().BoolVar(&inPlace, "in-place", false, "modify input file in-place (atomic write)")
 	cmd.Flags().BoolVar(&backup, "backup", false, "create .bak before in-place modification")
-	cmd.Flags().StringVar(&pipelockBin, "pipelock-bin", currentPipelockExecutable(), "path to pipelock binary in output")
+	cmd.Flags().StringVar(&pipelockBin, "pipelock-bin", defaultPipelockBin, "path to pipelock binary in output")
 	cmd.Flags().StringVarP(&configPath, "config", "c", "pipelock.yaml", "path to pipelock config in output")
 	return cmd
 }
@@ -267,17 +275,8 @@ func copyExtraFields(dst, src map[string]interface{}, managed ...string) {
 	}
 }
 
-const mcporterBinaryName = "pipelock"
-
 func currentPipelockExecutable() string {
-	self, err := os.Executable()
-	return executableOrName(self, err)
-}
-
-func executableOrName(self string, err error) string {
-	if err != nil {
-		return mcporterBinaryName
-	}
+	self, _ := os.Executable()
 	return self
 }
 

--- a/internal/cli/generate/generate_mcporter.go
+++ b/internal/cli/generate/generate_mcporter.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
 	"github.com/spf13/cobra"
 )
 
@@ -118,7 +119,7 @@ Examples:
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "output file path (default: stdout)")
 	cmd.Flags().BoolVar(&inPlace, "in-place", false, "modify input file in-place (atomic write)")
 	cmd.Flags().BoolVar(&backup, "backup", false, "create .bak before in-place modification")
-	cmd.Flags().StringVar(&pipelockBin, "pipelock-bin", "pipelock", "path to pipelock binary in output")
+	cmd.Flags().StringVar(&pipelockBin, "pipelock-bin", currentPipelockExecutable(), "path to pipelock binary in output")
 	cmd.Flags().StringVarP(&configPath, "config", "c", "pipelock.yaml", "path to pipelock config in output")
 	return cmd
 }
@@ -148,7 +149,7 @@ func wrapServerEntry(raw json.RawMessage, pipelockBin, configPath string) (wrapp
 			if argsErr != nil {
 				return wrappedEntry{}, fmt.Errorf("url server args: %w", argsErr)
 			}
-			if isAlreadyWrapped(cmdStr, args) {
+			if isAlreadyWrapped(cmdStr, args, pipelockBin) {
 				return wrappedEntry{value: entry, skipped: true}, nil
 			}
 		}
@@ -174,7 +175,7 @@ func wrapServerEntry(raw json.RawMessage, pipelockBin, configPath string) (wrapp
 		return wrappedEntry{}, fmt.Errorf("args: %w", argsErr)
 	}
 
-	if isAlreadyWrapped(cmdStr, args) {
+	if isAlreadyWrapped(cmdStr, args, pipelockBin) {
 		return wrappedEntry{value: entry, skipped: true}, nil
 	}
 
@@ -266,30 +267,22 @@ func copyExtraFields(dst, src map[string]interface{}, managed ...string) {
 	}
 }
 
-const (
-	mcporterBinaryName = "pipelock"
-	mcporterSubMCP     = "mcp"
-	mcporterSubProxy   = "proxy"
-)
+const mcporterBinaryName = "pipelock"
 
-func isAlreadyWrapped(command string, args []string) bool {
-	if filepath.Base(command) != mcporterBinaryName {
-		return false
+func currentPipelockExecutable() string {
+	self, err := os.Executable()
+	return executableOrName(self, err)
+}
+
+func executableOrName(self string, err error) string {
+	if err != nil {
+		return mcporterBinaryName
 	}
-	foundMCP := false
-	for _, a := range args {
-		if a == "--" {
-			break
-		}
-		if !foundMCP && a == mcporterSubMCP {
-			foundMCP = true
-			continue
-		}
-		if foundMCP && a == mcporterSubProxy {
-			return true
-		}
-	}
-	return false
+	return self
+}
+
+func isAlreadyWrapped(command string, args []string, pipelockBin string) bool {
+	return mcpwrap.ClassifyInvocationAgainst(command, args, pipelockBin) == mcpwrap.WrapperSelf
 }
 
 func toStringSlice(raw []interface{}) ([]string, error) {

--- a/internal/cli/generate/generate_mcporter_test.go
+++ b/internal/cli/generate/generate_mcporter_test.go
@@ -151,7 +151,11 @@ func TestGenerateMcporter_ExplicitTargetRerunIsIdempotent(t *testing.T) {
 }
 
 func TestGenerateMcporter_ForeignPipelockNameIsWrapped(t *testing.T) {
-	input := `{"mcpServers":{"forged":{"command":"/tmp/attacker/pipelock","args":["mcp","proxy","--","server"]}}}`
+	input := `{"mcpServers":{
+		"forged":{"command":"/tmp/attacker/pipelock","args":["mcp","proxy","--","server"]},
+		"forged-http":{"url":"https://api.vendor.example/mcp","command":"/tmp/attacker/pipelock","args":["mcp","proxy"]},
+		"forged-ws":{"url":"wss://api.vendor.example/mcp","command":"/tmp/attacker/pipelock","args":["mcp","proxy"]}
+	}}`
 	var out, stderr bytes.Buffer
 	cmd := testRootCmd()
 	cmd.SetOut(&out)
@@ -179,6 +183,37 @@ func TestGenerateMcporter_ForeignPipelockNameIsWrapped(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "already wrapped") {
 		t.Fatalf("foreign command was reported protected: %q", stderr.String())
+	}
+	for _, name := range []string{"forged-http", "forged-ws"} {
+		remote := result["mcpServers"].(map[string]interface{})[name].(map[string]interface{})
+		if remote["command"] != currentPipelockExecutable() {
+			t.Fatalf("%s foreign command was trusted instead of wrapped: %#v", name, remote)
+		}
+		remoteArgs := remote["args"].([]interface{})
+		if len(remoteArgs) < 2 || remoteArgs[0] != "mcp" || remoteArgs[1] != "proxy" {
+			t.Fatalf("%s wrapper args missing strict prefix: %v", name, remoteArgs)
+		}
+	}
+}
+
+func TestGenerateMcporter_ExecutableResolutionFailure(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "mcporter.json")
+	if err := os.WriteFile(input, []byte(testMCPInput), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolver := func() (string, error) { return "/untrusted/partial/path", fmt.Errorf("unsupported") }
+
+	cmd := generateMcporterCmdWithExecutable(resolver)
+	cmd.SetArgs([]string{"--input", input})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "resolving current pipelock executable") {
+		t.Fatalf("default executable resolution error = %v", err)
+	}
+
+	cmd = generateMcporterCmdWithExecutable(resolver)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--input", input, "--pipelock-bin", "/opt/pipelock"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("explicit executable should bypass current-path resolution: %v", err)
 	}
 }
 

--- a/internal/cli/generate/generate_mcporter_test.go
+++ b/internal/cli/generate/generate_mcporter_test.go
@@ -6,6 +6,7 @@ package generate
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +53,7 @@ func TestGenerateMcporter_BasicWrap(t *testing.T) {
 	servers := result["mcpServers"].(map[string]interface{})
 	fs := servers["filesystem"].(map[string]interface{})
 
-	if fs["command"] != mcporterBinaryName {
+	if fs["command"] != currentPipelockExecutable() {
 		t.Fatalf("command should be pipelock, got %v", fs["command"])
 	}
 
@@ -77,14 +78,14 @@ func TestGenerateMcporter_BasicWrap(t *testing.T) {
 }
 
 func TestGenerateMcporter_AlreadyWrapped(t *testing.T) {
-	input := `{
+	input := fmt.Sprintf(`{
 		"mcpServers": {
 			"filesystem": {
-				"command": "pipelock",
+				"command": %q,
 				"args": ["mcp", "proxy", "--", "npx", "server"]
 			}
 		}
-	}`
+	}`, currentPipelockExecutable())
 
 	var buf bytes.Buffer
 	cmd := testRootCmd()
@@ -108,13 +109,76 @@ func TestGenerateMcporter_AlreadyWrapped(t *testing.T) {
 
 	servers := result["mcpServers"].(map[string]interface{})
 	fs := servers["filesystem"].(map[string]interface{})
-	if fs["command"] != mcporterBinaryName {
+	if fs["command"] != currentPipelockExecutable() {
 		t.Fatal("already-wrapped server should remain unchanged")
 	}
 	// Verify args are unchanged (not double-wrapped).
 	args := fs["args"].([]interface{})
 	if len(args) != 5 || args[0] != "mcp" || args[1] != "proxy" {
 		t.Fatalf("args should be unchanged, got %v", args)
+	}
+}
+
+func TestGenerateMcporter_ExplicitTargetRerunIsIdempotent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "pipelock")
+	if err := os.WriteFile(target, []byte("target binary fixture"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	input := fmt.Sprintf(`{"mcpServers":{"server":{"command":%q,"args":["mcp","proxy","--","node","server.js"]}}}`, target)
+	tmpFile := filepath.Join(t.TempDir(), "mcporter.json")
+	if err := os.WriteFile(tmpFile, []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, stderr bytes.Buffer
+	cmd := testRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"generate", "mcporter", "-i", tmpFile, "--pipelock-bin", target})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "already wrapped") {
+		t.Fatalf("explicit target rerun was not skipped: %q", stderr.String())
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	server := result["mcpServers"].(map[string]interface{})["server"].(map[string]interface{})
+	if server["command"] != target || len(server["args"].([]interface{})) != 5 {
+		t.Fatalf("explicit target rerun changed wrapper: %#v", server)
+	}
+}
+
+func TestGenerateMcporter_ForeignPipelockNameIsWrapped(t *testing.T) {
+	input := `{"mcpServers":{"forged":{"command":"/tmp/attacker/pipelock","args":["mcp","proxy","--","server"]}}}`
+	var out, stderr bytes.Buffer
+	cmd := testRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	tmpFile := filepath.Join(t.TempDir(), "mcporter.json")
+	if err := os.WriteFile(tmpFile, []byte(input), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd.SetArgs([]string{"generate", "mcporter", "-i", tmpFile})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
+	server := result["mcpServers"].(map[string]interface{})["forged"].(map[string]interface{})
+	if server["command"] != currentPipelockExecutable() {
+		t.Fatalf("foreign command was trusted instead of wrapped: %#v", server)
+	}
+	args := server["args"].([]interface{})
+	if len(args) < 2 || args[0] != "mcp" || args[1] != "proxy" {
+		t.Fatalf("new wrapper args missing strict prefix: %v", args)
+	}
+	if strings.Contains(stderr.String(), "already wrapped") {
+		t.Fatalf("foreign command was reported protected: %q", stderr.String())
 	}
 }
 
@@ -149,7 +213,7 @@ func TestGenerateMcporter_HTTPUpstream(t *testing.T) {
 
 	servers := result["mcpServers"].(map[string]interface{})
 	remote := servers["remote"].(map[string]interface{})
-	if remote["command"] != mcporterBinaryName {
+	if remote["command"] != currentPipelockExecutable() {
 		t.Fatal("expected pipelock wrapper")
 	}
 	args := remote["args"].([]interface{})
@@ -195,7 +259,7 @@ func TestGenerateMcporter_WSUpstream(t *testing.T) {
 
 	servers := result["mcpServers"].(map[string]interface{})
 	ws := servers["ws-server"].(map[string]interface{})
-	if ws["command"] != mcporterBinaryName {
+	if ws["command"] != currentPipelockExecutable() {
 		t.Fatal("expected pipelock wrapper")
 	}
 	args := ws["args"].([]interface{})
@@ -315,7 +379,7 @@ func TestGenerateMcporter_InPlace(t *testing.T) {
 
 	servers := result["mcpServers"].(map[string]interface{})
 	test := servers["test"].(map[string]interface{})
-	if test["command"] != mcporterBinaryName {
+	if test["command"] != currentPipelockExecutable() {
 		t.Fatal("in-place write should have wrapped the server")
 	}
 }
@@ -391,7 +455,7 @@ func TestGenerateMcporter_CustomBinAndConfig(t *testing.T) {
 }
 
 func TestGenerateMcporter_MultipleServers(t *testing.T) {
-	input := `{
+	input := fmt.Sprintf(`{
 		"mcpServers": {
 			"stdio-server": {
 				"command": "node",
@@ -401,11 +465,11 @@ func TestGenerateMcporter_MultipleServers(t *testing.T) {
 				"url": "http://localhost:3000/mcp"
 			},
 			"wrapped": {
-				"command": "pipelock",
+				"command": %q,
 				"args": ["mcp", "proxy", "--", "python", "server.py"]
 			}
 		}
-	}`
+	}`, currentPipelockExecutable())
 
 	var buf, stderr bytes.Buffer
 	cmd := testRootCmd()
@@ -431,19 +495,19 @@ func TestGenerateMcporter_MultipleServers(t *testing.T) {
 
 	// stdio-server should be wrapped.
 	stdio := servers["stdio-server"].(map[string]interface{})
-	if stdio["command"] != mcporterBinaryName {
+	if stdio["command"] != currentPipelockExecutable() {
 		t.Fatal("stdio-server should be wrapped")
 	}
 
 	// http-server should be wrapped with --upstream.
 	http := servers["http-server"].(map[string]interface{})
-	if http["command"] != mcporterBinaryName {
+	if http["command"] != currentPipelockExecutable() {
 		t.Fatal("http-server should be wrapped")
 	}
 
 	// wrapped should remain unchanged.
 	w := servers["wrapped"].(map[string]interface{})
-	if w["command"] != mcporterBinaryName {
+	if w["command"] != currentPipelockExecutable() {
 		t.Fatal("wrapped should remain pipelock")
 	}
 	wArgs := w["args"].([]interface{})
@@ -684,7 +748,7 @@ func TestGenerateMcporter_OutputFile(t *testing.T) {
 	}
 	servers := result["mcpServers"].(map[string]interface{})
 	test := servers["test"].(map[string]interface{})
-	if test["command"] != mcporterBinaryName {
+	if test["command"] != currentPipelockExecutable() {
 		t.Fatal("output file should contain wrapped server")
 	}
 }
@@ -786,15 +850,15 @@ func TestGenerateMcporter_OutputFileError(t *testing.T) {
 
 func TestGenerateMcporter_URLEntryAlreadyWrapped(t *testing.T) {
 	// URL entry that also has command/args indicating pipelock wrapping.
-	input := `{
+	input := fmt.Sprintf(`{
 		"mcpServers": {
 			"gateway": {
 				"url": "ws://localhost:3000/mcp",
-				"command": "pipelock",
+				"command": %q,
 				"args": ["mcp", "proxy", "--upstream", "ws://localhost:3000/mcp"]
 			}
 		}
-	}`
+	}`, currentPipelockExecutable())
 
 	var buf bytes.Buffer
 	cmd := testRootCmd()
@@ -819,14 +883,15 @@ func TestGenerateMcporter_URLEntryAlreadyWrapped(t *testing.T) {
 	servers := result["mcpServers"].(map[string]interface{})
 	gw := servers["gateway"].(map[string]interface{})
 	// Should be skipped (already wrapped).
-	if gw["command"] != mcporterBinaryName {
+	if gw["command"] != currentPipelockExecutable() {
 		t.Fatal("already-wrapped URL entry should remain unchanged")
 	}
 }
 
 func TestGenerateMcporter_IsAlreadyWrapped_DashDashBeforeProxy(t *testing.T) {
 	// Args with -- before "proxy" should not be considered wrapped.
-	if isAlreadyWrapped(mcporterBinaryName, []string{"mcp", "--", "proxy"}) {
+	self := currentPipelockExecutable()
+	if isAlreadyWrapped(self, []string{"mcp", "--", "proxy"}, self) {
 		t.Fatal("should not detect as wrapped when -- appears before proxy")
 	}
 }
@@ -934,7 +999,7 @@ func TestGenerateMcporter_PreservesPerServerExtraFields(t *testing.T) {
 
 	// stdio-server should be wrapped AND preserve extra fields.
 	stdio := servers["stdio-server"].(map[string]interface{})
-	if stdio["command"] != mcporterBinaryName {
+	if stdio["command"] != currentPipelockExecutable() {
 		t.Fatal("stdio-server should be wrapped")
 	}
 	if stdio["disabled"] != false {
@@ -951,7 +1016,7 @@ func TestGenerateMcporter_PreservesPerServerExtraFields(t *testing.T) {
 
 	// url-server should be wrapped AND preserve extra fields (except url).
 	urlSrv := servers["url-server"].(map[string]interface{})
-	if urlSrv["command"] != mcporterBinaryName {
+	if urlSrv["command"] != currentPipelockExecutable() {
 		t.Fatal("url-server should be wrapped")
 	}
 	if urlSrv["disabled"] != true {

--- a/internal/cli/hermes/hermesconfig.go
+++ b/internal/cli/hermes/hermesconfig.go
@@ -376,7 +376,7 @@ func (c *hermesConfig) enabledPlugins(plugins map[string]interface{}) ([]string,
 func (c *hermesConfig) wrappedMCPServerCount() int {
 	n := 0
 	for _, raw := range c.mcpServers() {
-		if s, ok := raw.(map[string]interface{}); ok && mcpwrap.IsWrapped(s) {
+		if s, ok := raw.(map[string]interface{}); ok && mcpwrap.IsWrappedBySelf(s) {
 			n++
 		}
 	}

--- a/internal/cli/hermes/install.go
+++ b/internal/cli/hermes/install.go
@@ -225,7 +225,7 @@ func installMCPOnly(cmd *cobra.Command, opts *installOptions) error {
 			failed++
 			continue
 		}
-		if mcpwrap.IsWrapped(server) {
+		if mcpwrap.IsWrappedBySelf(server) {
 			skipped++
 			continue
 		}

--- a/internal/cli/hermes/install_test.go
+++ b/internal/cli/hermes/install_test.go
@@ -68,6 +68,47 @@ func TestInstallCmd_FlagsAndUsage(t *testing.T) {
 	}
 }
 
+func TestRunInstall_MCPOnlyDoesNotTrustForgedMarker(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	opts := fullOpts(tmp)
+	opts.Mode = ModeMCPOnly
+	seed := "mcp_servers:\n" +
+		"  forged:\n" +
+		"    command: /tmp/attacker/pipelock\n" +
+		"    args: [mcp, proxy, --, attacker-server]\n" +
+		"    _pipelock: {original_type: stdio}\n"
+	if err := os.WriteFile(opts.HermesConfig, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cmd := installCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runInstall(cmd, opts); err != nil {
+		t.Fatalf("mcp-only install: %v", err)
+	}
+	cfg, err := loadHermesConfig(opts.HermesConfig)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	server := cfg.mcpServers()["forged"].(map[string]interface{})
+	if !mcpwrap.IsWrappedBySelf(server) {
+		t.Fatalf("forged marker was skipped instead of wrapped: %#v", server)
+	}
+	args := mcpwrap.InterfaceSliceToStrings(server["args"])
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if len(args) < 3 || args[0] != "mcp" || args[1] != "proxy" || separator < 0 || separator+1 >= len(args) || args[separator+1] != "/tmp/attacker/pipelock" {
+		t.Fatalf("foreign invocation was not preserved behind the new wrapper: %v", args)
+	}
+}
+
 func TestCmd_RegistersAllSubcommands(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/hermes/install_test.go
+++ b/internal/cli/hermes/install_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -104,7 +105,8 @@ func TestRunInstall_MCPOnlyDoesNotTrustForgedMarker(t *testing.T) {
 			break
 		}
 	}
-	if len(args) < 3 || args[0] != "mcp" || args[1] != "proxy" || separator < 0 || separator+1 >= len(args) || args[separator+1] != "/tmp/attacker/pipelock" {
+	wantSuffix := []string{"/tmp/attacker/pipelock", "mcp", "proxy", "--", "attacker-server"}
+	if len(args) < 3 || args[0] != "mcp" || args[1] != "proxy" || separator < 0 || !slices.Equal(args[separator+1:], wantSuffix) {
 		t.Fatalf("foreign invocation was not preserved behind the new wrapper: %v", args)
 	}
 }

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -243,10 +243,6 @@ func isCodexRestorableWrapper(server codexMCPServer) bool {
 	return classifyCodexWrapper(server) != stateNotWrapper
 }
 
-// looksLikePipelockBinary reports whether the command path is plausibly a
-// pipelock binary. Matches "pipelock", "pipelock.exe", and dev variants like
-// "pipelock-dev". Path is matched on basename so it is location-independent.
-
 func serverEnabled(server codexMCPServer) bool {
 	return server.Enabled == nil || *server.Enabled
 }

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -321,7 +321,7 @@ func isRestorableWrapper(server map[string]interface{}) bool {
 func warnUnrestorableWrapper(w io.Writer, name string, server map[string]interface{}) {
 	_, marked := server[mcpFieldPipelock]
 	proxyShaped := classifyWrapper(server) != stateNotWrapper
-	binary, _ := serverInvocation(server)
+	binary := serverCommand(server)
 
 	switch {
 	case proxyShaped && !marked:
@@ -347,17 +347,16 @@ func isThisExecutable(command string) bool {
 	return mcpwrap.ClassifyInvocation(command, []string{mcpSubcommand, proxySubcommand}) == mcpwrap.WrapperSelf
 }
 
-// serverInvocation reads the binary and its arguments out of either config shape:
-// a command string with a separate args array, or OpenCode's single command array
-// where the binary is element zero.
-func serverInvocation(server map[string]interface{}) (binary string, args []string) {
+// serverCommand reads the binary out of either config shape: a command string,
+// or OpenCode's single command array where the binary is element zero.
+func serverCommand(server map[string]interface{}) string {
 	if command, ok := server[mcpFieldCommand].(string); ok {
-		return command, commandArgStrings(server[mcpFieldArgs])
+		return command
 	}
 	if command := commandArgStrings(server[mcpFieldCommand]); len(command) > 0 {
-		return command[0], command[1:]
+		return command[0]
 	}
-	return "", nil
+	return ""
 }
 
 // argsBeginMCPProxy reports whether an argument list starts the MCP proxy
@@ -374,7 +373,7 @@ func argsBeginMCPProxy(args []string) bool {
 func warnForeignWrapper(w io.Writer, name string, server map[string]interface{}) {
 	switch classifyWrapper(server) {
 	case stateForeignWrapper:
-		binary, _ := serverInvocation(server)
+		binary := serverCommand(server)
 		_, _ = fmt.Fprintf(w,
 			"warning: server %q runs %q with proxy arguments but that is not this pipelock binary; wrapping it, and remove-then-install for a single clean wrap\n",
 			name, binary)

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
 )
 
 // MCP server JSON field keys used across wrap/unwrap operations.
@@ -238,19 +240,19 @@ func unwrapMCPServer(server map[string]interface{}) (map[string]interface{}, err
 // will mediate the traffic, and remove asks whether some pipelock wrapper can be
 // migrated away. Answering both with one predicate is what allowed a forged entry
 // to be skipped, or would strand an older wrapper permanently.
-type wrapperState int
+type wrapperState = mcpwrap.WrapperState
 
 const (
 	// stateNotWrapper is an entry that does not invoke the MCP proxy at all.
-	stateNotWrapper wrapperState = iota
+	stateNotWrapper = mcpwrap.WrapperNone
 	// stateSelf invokes the proxy with the binary running right now, so its
 	// traffic is mediated by this executable. Only this state may be skipped.
-	stateSelf
+	stateSelf = mcpwrap.WrapperSelf
 	// stateForeignWrapper is shaped like a proxy invocation run by some other
 	// binary. That may be a pipelock built at a different path, or an
 	// attacker-authored config naming its own binary "pipelock". The installer
 	// cannot tell those apart and must not skip either.
-	stateForeignWrapper
+	stateForeignWrapper = mcpwrap.WrapperForeign
 )
 
 // classifyWrapper decides which state an entry is in from its own invocation.
@@ -262,14 +264,7 @@ const (
 // it. Reproduced before this changed, for both a relative ./tools/pipelock and a
 // bare PATH-resolved pipelock.
 func classifyWrapper(server map[string]interface{}) wrapperState {
-	binary, args := serverInvocation(server)
-	if binary == "" || !argsBeginMCPProxy(args) {
-		return stateNotWrapper
-	}
-	if isThisExecutable(binary) {
-		return stateSelf
-	}
-	return stateForeignWrapper
+	return mcpwrap.ClassifyServer(server)
 }
 
 // isWrappedBySelf reports whether an entry is already mediated by this binary. It
@@ -349,22 +344,7 @@ func warnUnrestorableWrapper(w io.Writer, name string, server map[string]interfa
 // provenance or contents, and it cannot prevent the file changing between this
 // check and the editor's launch.
 func isThisExecutable(command string) bool {
-	if command == "" {
-		return false
-	}
-	self, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	selfInfo, err := os.Stat(self)
-	if err != nil {
-		return false
-	}
-	commandInfo, err := os.Stat(command)
-	if err != nil {
-		return false
-	}
-	return os.SameFile(selfInfo, commandInfo)
+	return mcpwrap.ClassifyInvocation(command, []string{mcpSubcommand, proxySubcommand}) == mcpwrap.WrapperSelf
 }
 
 // serverInvocation reads the binary and its arguments out of either config shape:

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -5,6 +5,7 @@ package discover
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -155,12 +156,16 @@ func TestConfigPathsVSCodeUsesServersKey(t *testing.T) {
 
 func TestDiscoverWithTestFixtures(t *testing.T) {
 	home := t.TempDir()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 
 	// Create a Claude Code config with one wrapped and one bare server
-	content := `{"mcpServers":{
-		"brain":{"command":"pipelock","args":["mcp","proxy","--","node","brain.js"]},
+	content := fmt.Sprintf(`{"mcpServers":{
+		"brain":{"command":%q,"args":["mcp","proxy","--","node","brain.js"]},
 		"raw":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}
-	}}`
+	}}`, self)
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -295,12 +300,15 @@ func TestDiscoverFindsZedAllChannels(t *testing.T) {
 // TestDiscoverZedWrappedShowsProtected covers the case where Zed's
 // settings.json carries a pipelock-wrapped context_server entry: discover
 // must classify it as ProtectedPipelock, matching what it does for other
-// IDEs that share the same wrap shape (command=pipelock, args contain mcp
-// and proxy).
+// IDEs that share the same wrap shape and current-executable identity check.
 func TestDiscoverZedWrappedShowsProtected(t *testing.T) {
 	home := t.TempDir()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 
-	wrapped := `{"context_servers":{"filesystem":{"type":"stdio","command":"pipelock","args":["mcp","proxy","--config","/etc/pipelock/pipelock.yaml","--","npx","-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}`
+	wrapped := fmt.Sprintf(`{"context_servers":{"filesystem":{"type":"stdio","command":%q,"args":["mcp","proxy","--config","/etc/pipelock/pipelock.yaml","--","npx","-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}`, self)
 	zedPath := filepath.Join(home, ".config", clientZed, "settings.json")
 	if err := os.MkdirAll(filepath.Dir(zedPath), 0o750); err != nil {
 		t.Fatal(err)
@@ -606,13 +614,17 @@ func TestBuildSummaryAllStates(t *testing.T) {
 
 func TestDiscoverSortRiskThenName(t *testing.T) {
 	home := t.TempDir()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 
-	content := `{"mcpServers":{
+	content := fmt.Sprintf(`{"mcpServers":{
 		"memory":{"command":"npx","args":["-y","@modelcontextprotocol/server-memory"]},
 		"zz-database":{"command":"npx","args":["-y","@modelcontextprotocol/server-postgres"]},
 		"aa-filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem"]},
-		"wrapped":{"command":"pipelock","args":["mcp","proxy","--","node","s.js"]}
-	}}`
+		"wrapped":{"command":%q,"args":["mcp","proxy","--","node","s.js"]}
+	}}`, self)
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/discover/generate.go
+++ b/internal/discover/generate.go
@@ -5,13 +5,22 @@ package discover
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
 
 // GenerateWrapper returns a human-readable wrapper suggestion for an unprotected server.
 func GenerateWrapper(s MCPServer) string {
+	self, _ := os.Executable()
+	return generateWrapper(s, self)
+}
+
+func generateWrapper(s MCPServer, pipelockBin string) string {
 	var b strings.Builder
+	if pipelockBin == "" {
+		return "  (cannot suggest a verified wrapper because the current pipelock executable path is unavailable)"
+	}
 
 	if s.Transport == TransportStdio && s.Command != "" {
 		_, _ = fmt.Fprintf(&b, "  Replace in your %s config:\n\n", s.Client)
@@ -23,7 +32,7 @@ func GenerateWrapper(s MCPServer) string {
 
 		// After: include --env flags for each env var so they are passed through
 		_, _ = fmt.Fprintf(&b, "  After:\n")
-		_, _ = fmt.Fprintf(&b, "    \"command\": \"pipelock\",\n")
+		_, _ = fmt.Fprintf(&b, "    \"command\": %q,\n", pipelockBin)
 
 		afterArgs := []string{wrapperArgMCP, wrapperArgProxy, flagConfig, "~/.config/pipelock/local.yaml"}
 		for _, k := range sortedEnvKeys(s.Env) {
@@ -43,7 +52,7 @@ func GenerateWrapper(s MCPServer) string {
 		_, _ = fmt.Fprintf(&b, "    \"url\": %q\n\n", s.URL)
 
 		_, _ = fmt.Fprintf(&b, "  After:\n")
-		_, _ = fmt.Fprintf(&b, "    \"command\": \"pipelock\",\n")
+		_, _ = fmt.Fprintf(&b, "    \"command\": %q,\n", pipelockBin)
 		_, _ = fmt.Fprintf(&b, "    \"args\": [\"mcp\", \"proxy\", \"--config\", \"~/.config/pipelock/local.yaml\", \"--upstream\", %q]\n", s.URL)
 
 		return b.String()

--- a/internal/discover/generate.go
+++ b/internal/discover/generate.go
@@ -12,7 +12,14 @@ import (
 
 // GenerateWrapper returns a human-readable wrapper suggestion for an unprotected server.
 func GenerateWrapper(s MCPServer) string {
-	self, _ := os.Executable()
+	return generateWrapperForCurrent(s, os.Executable)
+}
+
+func generateWrapperForCurrent(s MCPServer, executable func() (string, error)) string {
+	self, err := executable()
+	if err != nil {
+		self = ""
+	}
 	return generateWrapper(s, self)
 }
 

--- a/internal/discover/generate_test.go
+++ b/internal/discover/generate_test.go
@@ -4,6 +4,7 @@
 package discover
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -118,5 +119,9 @@ func TestGenerateWrapperNoArgs(t *testing.T) {
 func TestGenerateWrapperUnavailableExecutable(t *testing.T) {
 	if got := generateWrapper(MCPServer{Transport: TransportStdio, Command: "server"}, ""); !strings.Contains(got, "path is unavailable") {
 		t.Fatalf("generateWrapper unavailable executable = %q", got)
+	}
+	resolver := func() (string, error) { return "/untrusted/partial/path", errors.New("unsupported") }
+	if got := generateWrapperForCurrent(MCPServer{Transport: TransportStdio, Command: "server"}, resolver); !strings.Contains(got, "path is unavailable") {
+		t.Fatalf("generateWrapper resolver error = %q", got)
 	}
 }

--- a/internal/discover/generate_test.go
+++ b/internal/discover/generate_test.go
@@ -18,7 +18,7 @@ func TestGenerateWrapperStdio(t *testing.T) {
 		Protection: Unprotected,
 	}
 
-	suggestion := GenerateWrapper(server)
+	suggestion := generateWrapper(server, "/opt/pipelock")
 	if suggestion == "" {
 		t.Fatal("expected non-empty suggestion")
 	}
@@ -45,7 +45,7 @@ func TestGenerateWrapperHTTP(t *testing.T) {
 		Protection: Unprotected,
 	}
 
-	suggestion := GenerateWrapper(server)
+	suggestion := generateWrapper(server, "/opt/pipelock")
 	if !strings.Contains(suggestion, "--upstream") {
 		t.Error("HTTP suggestion should contain --upstream")
 	}
@@ -61,7 +61,7 @@ func TestGenerateWrapperUnknown(t *testing.T) {
 		Protection: Unprotected,
 	}
 
-	suggestion := GenerateWrapper(server)
+	suggestion := generateWrapper(server, "/opt/pipelock")
 	if !strings.Contains(suggestion, "no suggestion") {
 		t.Error("should indicate no suggestion available")
 	}
@@ -78,7 +78,7 @@ func TestGenerateWrapperStdioWithEnv(t *testing.T) {
 		Protection: Unprotected,
 	}
 
-	suggestion := GenerateWrapper(server)
+	suggestion := generateWrapper(server, "/opt/pipelock")
 	if !strings.Contains(suggestion, `"--env"`) {
 		t.Error("suggestion should contain --env flags for env vars")
 	}
@@ -106,11 +106,17 @@ func TestGenerateWrapperNoArgs(t *testing.T) {
 		Protection: Unprotected,
 	}
 
-	suggestion := GenerateWrapper(server)
+	suggestion := generateWrapper(server, "/opt/pipelock")
 	if !strings.Contains(suggestion, wrapperCommand) {
 		t.Error("suggestion should contain pipelock")
 	}
 	if !strings.Contains(suggestion, "myserver") {
 		t.Error("suggestion should contain original command")
+	}
+}
+
+func TestGenerateWrapperUnavailableExecutable(t *testing.T) {
+	if got := generateWrapper(MCPServer{Transport: TransportStdio, Command: "server"}, ""); !strings.Contains(got, "path is unavailable") {
+		t.Fatalf("generateWrapper unavailable executable = %q", got)
 	}
 }

--- a/internal/discover/protection.go
+++ b/internal/discover/protection.go
@@ -3,10 +3,7 @@
 
 package discover
 
-import (
-	"path/filepath"
-	"strings"
-)
+import "github.com/luckyPipewrench/pipelock/internal/mcpwrap"
 
 // classifyProtection determines if a server is wrapped by a security proxy.
 func classifyProtection(s MCPServer) ProtectionStatus {
@@ -23,53 +20,26 @@ func classifyProtection(s MCPServer) ProtectionStatus {
 	return Unprotected
 }
 
-// isPipelockWrapped checks if the server command is pipelock with mcp proxy args.
-// Handles Windows paths (pipelock.exe) and avoids false positives on names
-// like "pipelock-helper" by stripping the extension and comparing exactly.
+// isPipelockWrapped checks that the server invokes this executable with the
+// exact MCP proxy subcommand prefix. A basename or config-authored marker is not
+// evidence that Pipelock will mediate the traffic.
 func isPipelockWrapped(s MCPServer) bool {
-	base := commandBase(s.Command)
-	name := strings.TrimSuffix(base, filepath.Ext(base))
-	if !strings.EqualFold(name, wrapperCommand) {
-		return false
-	}
-
-	hasMCP := false
-	hasProxy := false
-	for _, arg := range s.Args {
-		switch arg {
-		case wrapperArgMCP:
-			hasMCP = true
-		case wrapperArgProxy:
-			hasProxy = true
-		}
-	}
-	return hasMCP && hasProxy
-}
-
-// commandBase extracts the final path component from a command string,
-// handling both forward slashes and backslashes. This is needed because
-// JSON configs may contain Windows paths (e.g., C:\Program Files\pipelock.exe)
-// that are read on Linux where filepath.Base only splits on forward slashes.
-func commandBase(cmd string) string {
-	// Use filepath.Base for the native separator, then also check for
-	// the non-native separator in case the path uses the other convention.
-	base := filepath.Base(cmd)
-	if i := strings.LastIndexByte(base, '\\'); i >= 0 {
-		base = base[i+1:]
-	}
-	return base
+	return mcpwrap.ClassifyInvocation(s.Command, s.Args) == mcpwrap.WrapperSelf
 }
 
 // protectionEvidence returns a human-readable explanation for a protection classification.
 func protectionEvidence(s MCPServer) string {
 	switch s.Protection {
 	case ProtectedPipelock:
-		return "command=pipelock, args contain mcp+proxy"
+		return "command is this pipelock executable and args begin mcp proxy"
 	case ProtectedOther:
 		return "wrapped by recognized security proxy"
 	case Unknown:
 		return "no command or url configured"
 	default:
+		if mcpwrap.ClassifyInvocation(s.Command, s.Args) == mcpwrap.WrapperForeign {
+			return "mcp proxy wrapper found, but its executable identity is unconfirmed"
+		}
 		return evidenceNoProxy
 	}
 }

--- a/internal/discover/protection_test.go
+++ b/internal/discover/protection_test.go
@@ -3,28 +3,35 @@
 
 package discover
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestClassifyProtection(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
 	tests := []struct {
 		name   string
 		server MCPServer
 		want   ProtectionStatus
 	}{
 		{
-			name:   "pipelock wrapped stdio with full path",
-			server: MCPServer{Command: "/home/user/.local/bin/pipelock", Args: []string{wrapperArgMCP, wrapperArgProxy, flagConfig, "local.yaml", "--", testCmdNode, testServerJS}},
+			name:   "current executable wrapped stdio",
+			server: MCPServer{Command: self, Args: []string{wrapperArgMCP, wrapperArgProxy, flagConfig, "local.yaml", "--", testCmdNode, testServerJS}},
 			want:   ProtectedPipelock,
 		},
 		{
-			name:   "pipelock bare command",
+			name:   "bare name is not identity proof",
 			server: MCPServer{Command: wrapperCommand, Args: []string{wrapperArgMCP, wrapperArgProxy, "--", "uvx", "some-server"}},
-			want:   ProtectedPipelock,
+			want:   Unprotected,
 		},
 		{
-			name:   "pipelock with tilde path",
+			name:   "unexpanded path is not identity proof",
 			server: MCPServer{Command: "~/.local/bin/pipelock", Args: []string{wrapperArgMCP, wrapperArgProxy, "--", testCmdNode, "s.js"}},
-			want:   ProtectedPipelock,
+			want:   Unprotected,
 		},
 		{
 			name:   "pipelock command but no mcp arg",
@@ -57,9 +64,9 @@ func TestClassifyProtection(t *testing.T) {
 			want:   Unprotected,
 		},
 		{
-			name:   "windows exe path",
+			name:   "foreign windows path is not identity proof",
 			server: MCPServer{Command: `C:\Program Files\pipelock.exe`, Args: []string{wrapperArgMCP, wrapperArgProxy, "--", testCmdNode, "s.js"}},
-			want:   ProtectedPipelock,
+			want:   Unprotected,
 		},
 		{
 			name:   "false positive pipelock-helper",
@@ -79,18 +86,18 @@ func TestClassifyProtection(t *testing.T) {
 
 func TestProtectionEvidence(t *testing.T) {
 	tests := []struct {
-		status ProtectionStatus
+		server MCPServer
 		want   string
 	}{
-		{ProtectedPipelock, "command=pipelock, args contain mcp+proxy"},
-		{ProtectedOther, "wrapped by recognized security proxy"},
-		{Unknown, "no command or url configured"},
-		{Unprotected, "no proxy wrapper detected"},
+		{MCPServer{Protection: ProtectedPipelock}, "command is this pipelock executable and args begin mcp proxy"},
+		{MCPServer{Protection: ProtectedOther}, "wrapped by recognized security proxy"},
+		{MCPServer{Protection: Unknown}, "no command or url configured"},
+		{MCPServer{Protection: Unprotected}, "no proxy wrapper detected"},
+		{MCPServer{Protection: Unprotected, Command: "/opt/other/pipelock", Args: []string{"mcp", "proxy"}}, "mcp proxy wrapper found, but its executable identity is unconfirmed"},
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.status), func(t *testing.T) {
-			s := MCPServer{Protection: tt.status}
-			got := protectionEvidence(s)
+		t.Run(tt.want, func(t *testing.T) {
+			got := protectionEvidence(tt.server)
 			if got != tt.want {
 				t.Errorf("protectionEvidence() = %q, want %q", got, tt.want)
 			}

--- a/internal/mcpwrap/mcpwrap.go
+++ b/internal/mcpwrap/mcpwrap.go
@@ -39,9 +39,80 @@ package mcpwrap
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
+
+// WrapperState describes whether an MCP server invocation actually runs this
+// executable's proxy. Only WrapperSelf proves that this process mediates the
+// server's traffic.
+type WrapperState int
+
+const (
+	WrapperNone WrapperState = iota
+	WrapperSelf
+	WrapperForeign
+)
+
+// ClassifyInvocation classifies a command by proxy shape and file identity.
+// Names and metadata are not proof: both can be supplied by the config being
+// inspected.
+func ClassifyInvocation(command string, args []string) WrapperState {
+	if command == "" || len(args) < 2 || args[0] != "mcp" || args[1] != "proxy" {
+		return WrapperNone
+	}
+	self, err := os.Executable()
+	return classifyExecutable(command, self, err)
+}
+
+// ClassifyInvocationAgainst classifies a proxy invocation against an explicit
+// executable selected by the caller. This is for generators that intentionally
+// target a different installed Pipelock path than the binary generating the
+// config.
+func ClassifyInvocationAgainst(command string, args []string, expected string) WrapperState {
+	if command == "" || expected == "" || len(args) < 2 || args[0] != "mcp" || args[1] != "proxy" {
+		return WrapperNone
+	}
+	return classifyExecutable(command, expected, nil)
+}
+
+func classifyExecutable(command, self string, executableErr error) WrapperState {
+	if executableErr != nil {
+		return WrapperForeign
+	}
+	selfInfo, err := os.Stat(self)
+	if err != nil {
+		return WrapperForeign
+	}
+	commandInfo, err := os.Stat(command)
+	if err != nil || !os.SameFile(selfInfo, commandInfo) {
+		return WrapperForeign
+	}
+	return WrapperSelf
+}
+
+// ClassifyServer applies ClassifyInvocation to either the conventional
+// command-plus-args shape or OpenCode's single command-array shape.
+func ClassifyServer(server map[string]interface{}) WrapperState {
+	if command, ok := server[FieldCommand].(string); ok {
+		args, err := stringArgs(server[FieldArgs])
+		if err != nil {
+			return WrapperNone
+		}
+		return ClassifyInvocation(command, args)
+	}
+	command, err := stringArgs(server[FieldCommand])
+	if err != nil || len(command) == 0 {
+		return WrapperNone
+	}
+	return ClassifyInvocation(command[0], command[1:])
+}
+
+// IsWrappedBySelf reports whether the current executable mediates this entry.
+func IsWrappedBySelf(server map[string]interface{}) bool {
+	return ClassifyServer(server) == WrapperSelf
+}
 
 // MCP server entry field keys, shared across wrap/unwrap operations.
 const (

--- a/internal/mcpwrap/mcpwrap_test.go
+++ b/internal/mcpwrap/mcpwrap_test.go
@@ -5,12 +5,129 @@ package mcpwrap
 
 import (
 	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 )
 
 const fakeExe = "/usr/bin/pipelock"
+
+func TestClassifyInvocationRequiresCurrentExecutableIdentity(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		args    []string
+		want    WrapperState
+	}{
+		{"current executable", self, []string{"mcp", "proxy", "--", "server"}, WrapperSelf},
+		{"foreign name", "/tmp/attacker/pipelock", []string{"mcp", "proxy", "--", "server"}, WrapperForeign},
+		{"bare name", "pipelock", []string{"mcp", "proxy", "--", "server"}, WrapperForeign},
+		{"arguments out of order", self, []string{"--config", "x", "mcp", "proxy"}, WrapperNone},
+		{"not proxy", self, []string{"mcp", "scan"}, WrapperNone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyInvocation(tc.command, tc.args); got != tc.want {
+				t.Fatalf("ClassifyInvocation() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyServerCurrentExecutableArrayForm(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	server := map[string]interface{}{
+		FieldCommand: []interface{}{self, "mcp", "proxy", "--", "server"},
+	}
+	if got := ClassifyServer(server); got != WrapperSelf {
+		t.Fatalf("ClassifyServer() = %v, want WrapperSelf", got)
+	}
+}
+
+func TestClassifyExecutableErrorsFailClosed(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := filepath.Join(t.TempDir(), "pipelock")
+	if err := os.WriteFile(foreign, []byte("not this executable"), 0o600); err != nil {
+		t.Fatalf("write foreign executable: %v", err)
+	}
+	for _, tc := range []struct {
+		name       string
+		command    string
+		self       string
+		executable error
+	}{
+		{"executable lookup error", self, self, errors.New("lookup failed")},
+		{"current executable stat error", self, filepath.Join(t.TempDir(), "missing"), nil},
+		{"command stat error", filepath.Join(t.TempDir(), "missing"), self, nil},
+		{"different existing file", foreign, self, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyExecutable(tc.command, tc.self, tc.executable); got != WrapperForeign {
+				t.Fatalf("classifyExecutable() = %v, want WrapperForeign", got)
+			}
+		})
+	}
+}
+
+func TestClassifyServerConventionalAndEmptyShapes(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if got := ClassifyServer(map[string]interface{}{
+		FieldCommand: self,
+		FieldArgs:    []string{"mcp", "proxy"},
+	}); got != WrapperSelf {
+		t.Fatalf("conventional ClassifyServer() = %v, want WrapperSelf", got)
+	}
+	if got := ClassifyServer(map[string]interface{}{}); got != WrapperNone {
+		t.Fatalf("empty ClassifyServer() = %v, want WrapperNone", got)
+	}
+	if IsWrappedBySelf(map[string]interface{}{FieldCommand: "server"}) {
+		t.Fatal("non-proxy server reported wrapped by self")
+	}
+	if got := ClassifyServer(map[string]interface{}{
+		FieldCommand: self,
+		FieldArgs:    []interface{}{"mcp", 1, "proxy"},
+	}); got != WrapperNone {
+		t.Fatalf("non-string args ClassifyServer() = %v, want WrapperNone", got)
+	}
+	if got := ClassifyServer(map[string]interface{}{
+		FieldCommand: []interface{}{self, "mcp", 1, "proxy"},
+	}); got != WrapperNone {
+		t.Fatalf("non-string array command ClassifyServer() = %v, want WrapperNone", got)
+	}
+}
+
+func TestClassifyInvocationAgainstExplicitTarget(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "pipelock")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	args := []string{"mcp", "proxy", "--", "server"}
+	if got := ClassifyInvocationAgainst(target, args, target); got != WrapperSelf {
+		t.Fatalf("matching target = %v, want WrapperSelf", got)
+	}
+	if got := ClassifyInvocationAgainst(target, args, ""); got != WrapperNone {
+		t.Fatalf("empty target = %v, want WrapperNone", got)
+	}
+	if got := ClassifyInvocationAgainst(target, []string{"mcp", "scan"}, target); got != WrapperNone {
+		t.Fatalf("wrong args = %v, want WrapperNone", got)
+	}
+}
 
 // argsOf returns the wrapped server's args as []string. WrapServer builds args
 // as a []string, so a direct assertion is sufficient in unit tests (no YAML/JSON


### PR DESCRIPTION
## What changed

- Verify MCP proxy wrappers by strict argument shape and executable file identity before installers skip them or discovery reports protection.
- Keep mcporter reruns idempotent for the executable selected by the operator, and emit discovery suggestions that the same identity check can verify.

Installers wrap unconfirmed wrappers again, and discovery reports them as unprotected with explicit evidence. Reviewers should distrust path-stability and mixed-version rerun behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of MCP proxy wrappers using verified executable identity.
  * Prevented foreign or forged commands from being mistaken for trusted wrappers.
  * Ensured repeated wrapping operations remain idempotent.
  * Generated configurations now use the active executable path and report unavailable paths clearly.
* **Refactor**
  * Standardized wrapper detection across setup, discovery, installation, and configuration generation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->