### PR TITLE
fix(evidence): stream legacy compaction safely

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -657,6 +657,25 @@ pipelock verify-receipt receipt.json --key /etc/pipelock/keys/flight-recorder-si
 The exported file is public key material only. Do not hand verifiers the private
 file named by `flight_recorder.signing_key_path`.
 
+## Offline compaction of legacy evidence
+
+Online evidence views deliberately stop at their documented per-shard read
+limit. If `pipelock evidence doctor` reports an oversized legacy shard, do not
+raise that online limit or manually rewrite the JSONL. Run the stopped-recorder
+offline ceremony instead:
+
+```bash
+pipelock evidence compact --receipt-dir /var/lib/pipelock/recorder --session proxy --key /etc/pipelock/keys/flight-recorder-signing.key.pub
+```
+
+The ceremony is the sanctioned recovery path. It streams input with bounded
+record memory, verifies the recorder hash chain, checkpoint signatures, and
+every signed v1 or v2 receipt chain, then emits normal-sized shards without
+changing any JSONL record bytes. It refuses unknown record types, sidecars, a
+source that changes during the ceremony, and an unverifiable receipt family.
+The original directory is retained as a digest-listed archive only after the
+atomic exchange succeeds.
+
 ## See also
 
 - [Flight recorder guide](flight-recorder.md) for configuring evidence logging

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -223,9 +223,9 @@ sudo pipelock evidence compact \
 sudo systemctl start pipelock.service
 ```
 
-The command refuses to run while a recorder holds the directory lock. It verifies the trusted signed receipt chain before and after compaction, copies each JSONL record line without changing its bytes, and keeps every replacement shard under the 8 MiB read limit. Linux installs the new active directory with one atomic exchange. The original directory moves to a timestamped sibling archive with SHA-256 digests and byte mappings.
+The command refuses to run while a recorder holds the directory lock. It accepts oversized legacy input and streams verification, recovery, and archive creation with bounded record memory. It verifies the trusted recorder hash chain, checkpoint signatures, and every signed v1 or v2 receipt chain before and after compaction, copies each JSONL record line without changing its bytes, and keeps every replacement shard at or below the 8 MiB read limit. Linux installs the new active directory with one atomic exchange; only then does the original directory become a timestamped sibling archive with SHA-256 digests and byte mappings.
 
-This first version accepts one session and no raw-escrow sidecars in the active directory. It refuses mixed directories instead of risking lost evidence. It also refuses malformed chains, duplicate shard starts, symlinks, changing files, more than 4,096 input shards, more than 256 MiB of input, and oversized input shards. A failed check leaves the original directory active.
+This first version accepts exactly one session, up to 4,096 input shards, and no raw-escrow sidecars in the active directory. It refuses mixed directories, malformed or unverifiable chains, unknown record types, duplicate shard starts, symlinks, and sources that change during the ceremony. A failed check leaves the original directory active.
 
 ### Completeness analysis
 
@@ -656,25 +656,6 @@ pipelock verify-receipt receipt.json --key /etc/pipelock/keys/flight-recorder-si
 
 The exported file is public key material only. Do not hand verifiers the private
 file named by `flight_recorder.signing_key_path`.
-
-## Offline compaction of legacy evidence
-
-Online evidence views deliberately stop at their documented per-shard read
-limit. If `pipelock evidence doctor` reports an oversized legacy shard, do not
-raise that online limit or manually rewrite the JSONL. Run the stopped-recorder
-offline ceremony instead:
-
-```bash
-pipelock evidence compact --receipt-dir /var/lib/pipelock/recorder --session proxy --key /etc/pipelock/keys/flight-recorder-signing.key.pub
-```
-
-The ceremony is the sanctioned recovery path. It streams input with bounded
-record memory, verifies the recorder hash chain, checkpoint signatures, and
-every signed v1 or v2 receipt chain, then emits normal-sized shards without
-changing any JSONL record bytes. It refuses unknown record types, sidecars, a
-source that changes during the ceremony, and an unverifiable receipt family.
-The original directory is retained as a digest-listed archive only after the
-atomic exchange succeeds.
 
 ## See also
 

--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -228,6 +228,11 @@ func extractCaptureSummaryWithOptions(entry recorder.Entry, sessionDir string, e
 		return CaptureSummary{}, "", false, fmt.Errorf("parsing capture summary: %w", err)
 	}
 
+	if summary.CaptureSchemaVersion <= 0 {
+		return CaptureSummary{}, "", false,
+			fmt.Errorf("capture schema version must be positive, got %d", summary.CaptureSchemaVersion)
+	}
+
 	if summary.CaptureSchemaVersion != CaptureSchemaV1 {
 		return CaptureSummary{}, "", false,
 			fmt.Errorf("%w: version %d (expected %d)", ErrUnsupportedCaptureSchema,

--- a/internal/capture/loader.go
+++ b/internal/capture/loader.go
@@ -25,6 +25,11 @@ import (
 // sidecars but a sidecar cannot be safely read, decrypted, or verified.
 var ErrSidecarDecrypt = errors.New("capture replay: sidecar decrypt failed")
 
+// ErrUnsupportedCaptureSchema marks a well-formed capture record from a
+// schema this replay binary intentionally does not implement. It is counted as
+// skipped; malformed records are not this error and fail closed.
+var ErrUnsupportedCaptureSchema = errors.New("capture replay: unsupported capture schema")
+
 // ReplayOptions controls optional full-fidelity replay behavior.
 type ReplayOptions struct {
 	// EscrowPrivateKey is the X25519 private key used to decrypt payload
@@ -161,6 +166,14 @@ func LoadAndReplayWithOptions(cfg *config.Config, sessionsDir string, opts Repla
 						sc.Close()
 						return nil, 0, 0, "", err
 					}
+					if errors.Is(err, ErrUnsupportedCaptureSchema) {
+						totalSkipped++
+						continue
+					}
+					if entry.Type == EntryTypeCapture {
+						sc.Close()
+						return nil, 0, 0, "", fmt.Errorf("parse capture evidence for session %s/%s: %w", sessionName, sessionID, err)
+					}
 					totalSkipped++
 					continue
 				}
@@ -201,9 +214,13 @@ func extractCaptureSummaryWithOptions(entry recorder.Entry, sessionDir string, e
 		return CaptureSummary{}, "", false, fmt.Errorf("skipping entry type %q", entry.Type)
 	}
 
-	detailJSON, err := json.Marshal(entry.Detail)
-	if err != nil {
-		return CaptureSummary{}, "", false, fmt.Errorf("marshaling entry detail: %w", err)
+	detailJSON := entry.RawDetail
+	if len(detailJSON) == 0 {
+		var err error
+		detailJSON, err = json.Marshal(entry.Detail)
+		if err != nil {
+			return CaptureSummary{}, "", false, fmt.Errorf("marshaling entry detail: %w", err)
+		}
 	}
 
 	var summary CaptureSummary
@@ -213,7 +230,7 @@ func extractCaptureSummaryWithOptions(entry recorder.Entry, sessionDir string, e
 
 	if summary.CaptureSchemaVersion != CaptureSchemaV1 {
 		return CaptureSummary{}, "", false,
-			fmt.Errorf("unsupported capture schema version %d (expected %d)",
+			fmt.Errorf("%w: version %d (expected %d)", ErrUnsupportedCaptureSchema,
 				summary.CaptureSchemaVersion, CaptureSchemaV1)
 	}
 

--- a/internal/capture/replay_test.go
+++ b/internal/capture/replay_test.go
@@ -802,6 +802,27 @@ func TestLoadAndReplayDistinguishesUnsupportedAndMalformedCaptureEvidence(t *tes
 			t.Fatalf("LoadAndReplay error=%v, want parse failure", err)
 		}
 	})
+
+	for _, tc := range []struct {
+		name   string
+		detail any
+	}{
+		{name: "null detail", detail: nil},
+		{name: "empty object", detail: map[string]any{}},
+		{name: "zero schema version", detail: CaptureSummary{Surface: SurfaceURL, Request: CaptureRequest{URL: "https://safe.example.com"}}},
+	} {
+		t.Run(tc.name+" fails closed", func(t *testing.T) {
+			dir := t.TempDir()
+			writeEntry(t, dir, tc.detail)
+			_, _, _, _, err := LoadAndReplay(cfg, dir)
+			if err == nil || !strings.Contains(err.Error(), "parse capture evidence") {
+				t.Fatalf("LoadAndReplay error=%v, want parse failure", err)
+			}
+			if errors.Is(err, ErrUnsupportedCaptureSchema) {
+				t.Fatalf("LoadAndReplay error=%v, must not classify missing or zero schema as unsupported", err)
+			}
+		})
+	}
 }
 
 func TestExtractCaptureSummaryUsesRawDetailAndFallbacksSafely(t *testing.T) {

--- a/internal/capture/replay_test.go
+++ b/internal/capture/replay_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -759,6 +760,65 @@ func TestLoadAndReplay(t *testing.T) {
 	}
 	if r.Result.CandidateAction != config.ActionBlock {
 		t.Fatalf("expected CandidateAction=%q, got %q", config.ActionBlock, r.Result.CandidateAction)
+	}
+}
+
+func TestLoadAndReplayDistinguishesUnsupportedAndMalformedCaptureEvidence(t *testing.T) {
+	writeEntry := func(t *testing.T, dir string, detail any) {
+		t.Helper()
+		sessionDir := filepath.Join(dir, loadReplaySessionID)
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: sessionDir, MaxEntriesPerFile: 100}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := rec.Record(recorder.Entry{SessionID: loadReplaySessionID, Type: EntryTypeCapture, Summary: "fixture", Detail: detail}); err != nil {
+			t.Fatal(err)
+		}
+		if err := rec.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.DLP.ScanEnv = false
+
+	t.Run("unsupported schema is skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		writeEntry(t, dir, CaptureSummary{CaptureSchemaVersion: CaptureSchemaV1 + 1, Surface: SurfaceURL, Request: CaptureRequest{URL: "https://safe.example.com"}})
+		records, _, skipped, _, err := LoadAndReplay(cfg, dir)
+		if err != nil {
+			t.Fatalf("LoadAndReplay: %v", err)
+		}
+		if len(records) != 0 || skipped != 1 {
+			t.Fatalf("records=%d skipped=%d, want 0 and 1", len(records), skipped)
+		}
+	})
+
+	t.Run("well formed envelope with malformed capture detail fails closed", func(t *testing.T) {
+		dir := t.TempDir()
+		writeEntry(t, dir, []string{"not a capture summary"})
+		_, _, _, _, err := LoadAndReplay(cfg, dir)
+		if err == nil || !strings.Contains(err.Error(), "parse capture evidence") {
+			t.Fatalf("LoadAndReplay error=%v, want parse failure", err)
+		}
+	})
+}
+
+func TestExtractCaptureSummaryUsesRawDetailAndFallbacksSafely(t *testing.T) {
+	valid := []byte(`{"capture_schema_version":1,"surface":"url","request":{"url":"https://raw.example"}}`)
+	summary, input, decrypted, err := extractCaptureSummaryWithOptions(recorder.Entry{Type: EntryTypeCapture, RawDetail: valid, Detail: []string{"would not decode as summary"}}, "", nil)
+	if err != nil {
+		t.Fatalf("raw detail extraction: %v", err)
+	}
+	if summary.Request.URL != "https://raw.example" || input != "https://raw.example" || decrypted {
+		t.Fatalf("raw extraction = %#v input=%q decrypted=%v", summary, input, decrypted)
+	}
+
+	if _, _, _, err := extractCaptureSummaryWithOptions(recorder.Entry{Type: EntryTypeCapture, Detail: math.Inf(1)}, "", nil); err == nil || !strings.Contains(err.Error(), "marshaling entry detail") {
+		t.Fatalf("unmarshalable fallback error=%v", err)
+	}
+	if _, _, _, err := extractCaptureSummaryWithOptions(recorder.Entry{Type: "decision"}, "", nil); err == nil || !strings.Contains(err.Error(), "skipping entry type") {
+		t.Fatalf("non-capture error=%v", err)
 	}
 }
 

--- a/internal/cli/evidence/compact.go
+++ b/internal/cli/evidence/compact.go
@@ -4,22 +4,16 @@
 package evidence
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
-	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
-	"github.com/luckyPipewrench/pipelock/internal/evidencename"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	signing "github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -48,33 +42,17 @@ type compactByteMapping struct {
 	OutputOffset int64  `json:"output_offset"`
 	Bytes        int64  `json:"bytes"`
 }
-type compactShard struct {
-	name       string
-	data       []byte
-	start      uint64
-	sourcePath string
-	sourceInfo os.FileInfo
-	mappings   []compactByteMapping
-}
-
-const (
-	maxCompactInputShards = 4096
-	maxCompactInputBytes  = 256 << 20
-)
 
 var (
 	compactAcquireLock   = recorder.AcquireEvidenceCeremonyLock
-	compactPackRecords   = compactPack
 	compactMakeStage     = os.MkdirTemp
 	compactPrepareStage  = prepareCompactStage
-	compactWriteShards   = writeCompactStage
 	compactSyncPath      = syncCompactDirectory
-	compactExtract       = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
-	compactVerify        = verifyCompactReceipts
-	compactSameChain     = sameReceiptChain
 	compactExchange      = exchangeEvidenceDirectories
 	compactRename        = os.Rename
 	compactWriteManifest = writeCompactManifest
+	compactStreamStage   = streamCompactToStage
+	compactVerifyStream  = streamCompactFiles
 )
 
 func compactCmd() *cobra.Command {
@@ -111,19 +89,9 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 		return fmt.Errorf("lock stopped evidence directory: %w", err)
 	}
 	defer func() { _ = lock.Close() }()
-	original, receipts, err := compactSource(location, opts.sessionID)
+	sourceNames, err := compactStreamNames(location, opts.sessionID)
 	if err != nil {
 		return err
-	}
-	if err := compactVerify(receipts, key); err != nil {
-		return fmt.Errorf("pre-compaction verification: %w", err)
-	}
-	replacement, err := compactPackRecords(opts.sessionID, original)
-	if err != nil {
-		return err
-	}
-	if len(replacement) > recorder.MaxEvidenceReadDirectoryEntries {
-		return fmt.Errorf("compaction produced %d shards, exceeds %d", len(replacement), recorder.MaxEvidenceReadDirectoryEntries)
 	}
 	parent := filepath.Dir(location.Dir)
 	stage, err := compactMakeStage(parent, ".pipelock-evidence-compact-")
@@ -139,8 +107,12 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	if err := compactPrepareStage(location.Dir, stage); err != nil {
 		return fmt.Errorf("preserve active directory metadata on stage: %w", err)
 	}
-	if err := compactWriteShards(stage, replacement); err != nil {
+	writer, original, err := compactStreamStage(location, sourceNames, opts.sessionID, key, stage)
+	if err != nil {
 		return err
+	}
+	if len(writer.files) > recorder.MaxEvidenceReadDirectoryEntries {
+		return fmt.Errorf("compaction produced %d shards, exceeds %d", len(writer.files), recorder.MaxEvidenceReadDirectoryEntries)
 	}
 	if err := compactSyncPath(stage); err != nil {
 		return fmt.Errorf("sync staged evidence directory: %w", err)
@@ -148,31 +120,37 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	if err := compactSyncPath(parent); err != nil {
 		return fmt.Errorf("sync evidence parent before publication: %w", err)
 	}
-	post, err := compactExtract(recorder.EvidenceLocation{Root: stage, Dir: stage}, opts.sessionID)
+	stageLocation := recorder.EvidenceLocation{Root: stage, Dir: stage}
+	stagedNames, err := compactStreamNames(stageLocation, opts.sessionID)
 	if err != nil {
-		return fmt.Errorf("read staged compacted evidence: %w", err)
+		return fmt.Errorf("list staged evidence: %w", err)
 	}
-	if err := compactVerify(post, key); err != nil {
-		return fmt.Errorf("post-compaction verification: %w", err)
-	}
-	if !compactSameChain(receipts, post) {
-		return errors.New("post-compaction receipt chain differs from original")
-	}
-	stagedSource, _, err := compactSource(recorder.EvidenceLocation{Root: stage, Dir: stage}, opts.sessionID)
+	post, err := compactVerifyStream(stageLocation, stagedNames, opts.sessionID, key, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
 	if err != nil {
 		return fmt.Errorf("re-validate staged compacted evidence: %w", err)
 	}
-	if !sameCompactBytes(original, stagedSource) {
-		return errors.New("compaction changed original JSONL record bytes")
+	if !sameCompactProof(original, post) {
+		return errors.New("compaction changed original JSONL bytes or signed receipt proof")
 	}
-	manifest := compactManifest{Version: 1, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), Original: manifestShards(original), Replacement: manifestShards(replacement), Mappings: compactMappings(replacement)}
+	manifest := compactManifest{Version: 1, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), Original: manifestStreamFiles(original.files), Replacement: manifestStreamFiles(writer.files), Mappings: writer.mappings}
 	archive := filepath.Join(parent, ".pipelock-evidence-archive-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
 	stageLock, err := compactAcquireLock(stage)
 	if err != nil {
 		return fmt.Errorf("lock staged evidence directory: %w", err)
 	}
 	defer func() { _ = stageLock.Close() }()
-	if err := verifyCompactSourceUnchanged(location, original); err != nil {
+	recheck, err := compactVerifyStream(location, sourceNames, opts.sessionID, key, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
+	if err != nil || !sameCompactProof(original, recheck) {
+		if err == nil {
+			err = errors.New("source digest changed")
+		}
+		return fmt.Errorf("source changed before publication: %w", err)
+	}
+	currentNames, err := compactStreamNames(location, opts.sessionID)
+	if err != nil || !sameCompactNameSet(sourceNames, currentNames) {
+		if err == nil {
+			err = errors.New("source shard name set changed")
+		}
 		return fmt.Errorf("source changed before publication: %w", err)
 	}
 	if err := compactExchange(location.Dir, stage); err != nil {
@@ -194,228 +172,8 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 		return rollbackCompactExchange(location.Dir, archive, fmt.Errorf("sync evidence parent after archive: %w", err))
 	}
 	committed = true
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "compacted session %q into %d bounded shard(s); original preserved at %s\n", opts.sessionID, len(replacement), archive)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "compacted session %q into %d bounded shard(s); original preserved at %s\n", opts.sessionID, len(writer.files), archive)
 	return nil
-}
-
-func compactSource(location recorder.EvidenceLocation, session string) ([]compactShard, []contractreceipt.EvidenceReceipt, error) {
-	return compactSourceWithLimits(location, session, maxCompactInputShards, maxCompactInputBytes)
-}
-
-func compactSourceWithLimits(location recorder.EvidenceLocation, session string, maxShards int, maxBytes int64) ([]compactShard, []contractreceipt.EvidenceReceipt, error) {
-	entries, truncated, err := recorder.ReadEvidenceLocationEntriesBounded(location, maxShards)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list evidence directory: %w", err)
-	}
-	if truncated {
-		return nil, nil, fmt.Errorf("evidence directory exceeds compaction input limit %d", maxShards)
-	}
-	var names []string
-	for _, entry := range entries {
-		if entry.Type()&os.ModeSymlink != 0 {
-			return nil, nil, fmt.Errorf("refuse symlink in active evidence directory: %s", entry.Name())
-		}
-		if entry.IsDir() {
-			return nil, nil, fmt.Errorf("refuse nested directory %q while compacting session %q", entry.Name(), session)
-		}
-		got, _, ok := recorder.ParseEvidenceFilename(entry.Name())
-		if ok && got == session {
-			names = append(names, entry.Name())
-			continue
-		}
-		// A session compaction must never make unrelated evidence or raw escrow
-		// vanish from the active directory. Support multi-session relocation in a
-		// separate ceremony; this command fails closed until then.
-		return nil, nil, fmt.Errorf("refuse non-selected evidence file %q while compacting session %q", entry.Name(), session)
-	}
-	if len(names) == 0 {
-		return nil, nil, fmt.Errorf("session %q has no evidence shards", session)
-	}
-	type namedStart struct {
-		name  string
-		start uint64
-	}
-	ordered := make([]namedStart, 0, len(names))
-	for _, name := range names {
-		_, start, _ := recorder.ParseEvidenceFilename(name)
-		ordered = append(ordered, namedStart{name: name, start: start})
-	}
-	sort.Slice(ordered, func(i, j int) bool {
-		if ordered[i].start != ordered[j].start {
-			return ordered[i].start < ordered[j].start
-		}
-		return ordered[i].name < ordered[j].name
-	})
-	for i := range ordered {
-		names[i] = ordered[i].name
-	}
-	if err := evidencename.CheckNoDuplicateSeqStart(names); err != nil {
-		return nil, nil, err
-	}
-	source := make([]compactShard, 0, len(names))
-	allEntries := make([]recorder.Entry, 0)
-	var totalBytes int64
-	for _, name := range names {
-		_, start, _ := recorder.ParseEvidenceFilename(name)
-		data, readErr := recorder.ReadEvidenceLocationFileBounded(location, name, recorder.MaxEvidenceReadFileBytes)
-		if readErr != nil {
-			return nil, nil, fmt.Errorf("read %s: %w", name, readErr)
-		}
-		if len(data) == 0 || data[len(data)-1] != '\n' {
-			return nil, nil, fmt.Errorf("%s does not end in newline; refusing cross-file record concatenation", name)
-		}
-		totalBytes += int64(len(data))
-		if totalBytes > maxBytes {
-			return nil, nil, fmt.Errorf("session %q exceeds compaction input byte limit %d", session, maxBytes)
-		}
-		parsed, parseErr := recorder.ReadEntriesFromReader(bytes.NewReader(data))
-		if parseErr != nil {
-			return nil, nil, fmt.Errorf("validate %s: %w", name, parseErr)
-		}
-		for _, entry := range parsed {
-			if entry.SessionID != session {
-				return nil, nil, fmt.Errorf("entry in %s belongs to %q, not %q", name, entry.SessionID, session)
-			}
-			allEntries = append(allEntries, entry)
-		}
-		sourcePath := filepath.Join(location.Dir, name)
-		info, statErr := os.Lstat(sourcePath)
-		if statErr != nil {
-			return nil, nil, fmt.Errorf("stat %s after read: %w", name, statErr)
-		}
-		source = append(source, compactShard{name: name, data: data, start: start, sourcePath: sourcePath, sourceInfo: info})
-	}
-	if err := recorder.VerifyChain(allEntries); err != nil {
-		return nil, nil, fmt.Errorf("verify recorder chain: %w", err)
-	}
-	for i, entry := range allEntries {
-		if entry.Sequence != uint64(i) {
-			return nil, nil, fmt.Errorf("recorder sequence gap or fork: entry %d declares seq %d", i, entry.Sequence)
-		}
-	}
-	receipts, err := contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir(location, session)
-	if err != nil {
-		return nil, nil, fmt.Errorf("extract evidence receipt chain: %w", err)
-	}
-	if len(receipts) == 0 {
-		return nil, nil, errors.New("selected session contains no evidence receipts")
-	}
-	return source, receipts, nil
-}
-
-func verifyCompactSourceUnchanged(location recorder.EvidenceLocation, source []compactShard) error {
-	for _, shard := range source {
-		info, err := os.Lstat(shard.sourcePath)
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", shard.name, err)
-		}
-		if shard.sourceInfo == nil || !os.SameFile(shard.sourceInfo, info) || shard.sourceInfo.Size() != info.Size() || !shard.sourceInfo.ModTime().Equal(info.ModTime()) || shard.sourceInfo.Mode() != info.Mode() {
-			return fmt.Errorf("%s identity or metadata changed", shard.name)
-		}
-		data, err := recorder.ReadEvidenceLocationFileBounded(location, shard.name, recorder.MaxEvidenceReadFileBytes)
-		if err != nil {
-			return fmt.Errorf("re-read %s: %w", shard.name, err)
-		}
-		if !bytes.Equal(data, shard.data) {
-			return fmt.Errorf("%s contents changed", shard.name)
-		}
-	}
-	return nil
-}
-
-func sameCompactBytes(a, b []compactShard) bool {
-	ah, bh := sha256.New(), sha256.New()
-	var aBytes, bBytes int64
-	for _, shard := range a {
-		_, _ = ah.Write(shard.data)
-		aBytes += int64(len(shard.data))
-	}
-	for _, shard := range b {
-		_, _ = bh.Write(shard.data)
-		bBytes += int64(len(shard.data))
-	}
-	return aBytes == bBytes && bytes.Equal(ah.Sum(nil), bh.Sum(nil))
-}
-
-func verifyCompactReceipts(receipts []contractreceipt.EvidenceReceipt, key []byte) error {
-	result := contractreceipt.VerifyChain(receipts, contractreceipt.ChainVerifyOptions{PinnedKey: key})
-	if !result.Valid || !result.SignaturesVerified {
-		return fmt.Errorf("signed receipt chain rejected: %s", result.Error)
-	}
-	return nil
-}
-
-func compactPack(session string, source []compactShard) ([]compactShard, error) {
-	var out []compactShard
-	var current bytes.Buffer
-	var start uint64
-	var mappings []compactByteMapping
-	var currentSourcePath string
-	for _, file := range source {
-		var sourceOffset int64
-		for _, line := range bytes.SplitAfter(file.data, []byte("\n")) {
-			if len(line) == 0 {
-				continue
-			}
-			if int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
-				return nil, errors.New("single JSONL line exceeds evidence shard limit")
-			}
-			if current.Len() > 0 && int64(current.Len()+len(line)) > recorder.MaxEvidenceReadFileBytes {
-				out = append(out, compactShard{name: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), data: append([]byte(nil), current.Bytes()...), start: start, sourcePath: currentSourcePath, mappings: mappings})
-				current.Reset()
-				mappings = nil
-				currentSourcePath = ""
-			}
-			if current.Len() == 0 {
-				var entry recorder.Entry
-				if err := json.Unmarshal(bytes.TrimSpace(line), &entry); err != nil {
-					return nil, fmt.Errorf("parse compacted line: %w", err)
-				}
-				if entry.SessionID != session {
-					return nil, fmt.Errorf("entry session %q does not match selected %q", entry.SessionID, session)
-				}
-				start = entry.Sequence
-				currentSourcePath = file.sourcePath
-			}
-			outOffset := int64(current.Len())
-			_, _ = current.Write(line)
-			mappings = append(mappings, compactByteMapping{Source: file.name, Output: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), SourceOffset: sourceOffset, OutputOffset: outOffset, Bytes: int64(len(line))})
-			sourceOffset += int64(len(line))
-		}
-	}
-	if current.Len() > 0 {
-		out = append(out, compactShard{name: fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(session), start), data: append([]byte(nil), current.Bytes()...), start: start, sourcePath: currentSourcePath, mappings: mappings})
-	}
-	if len(out) == 0 {
-		return nil, errors.New("no compacted evidence bytes produced")
-	}
-	return out, nil
-}
-
-func writeCompactStage(dir string, shards []compactShard) error {
-	for _, shard := range shards {
-		if int64(len(shard.data)) > recorder.MaxEvidenceReadFileBytes {
-			return errors.New("compacted shard exceeds evidence read limit")
-		}
-		if err := os.WriteFile(filepath.Join(dir, shard.name), shard.data, 0o600); err != nil {
-			return fmt.Errorf("write compacted shard %s: %w", shard.name, err)
-		}
-		if err := preserveCompactFileMetadata(shard.sourcePath, filepath.Join(dir, shard.name)); err != nil {
-			return fmt.Errorf("preserve compacted shard metadata: %w", err)
-		}
-		if err := syncCompactFile(filepath.Join(dir, shard.name)); err != nil {
-			return fmt.Errorf("sync compacted shard %s: %w", shard.name, err)
-		}
-	}
-	return nil
-}
-
-func compactMappings(shards []compactShard) []compactByteMapping {
-	var out []compactByteMapping
-	for _, shard := range shards {
-		out = append(out, shard.mappings...)
-	}
-	return out
 }
 
 func rollbackCompactExchange(active, old string, cause error) error {
@@ -441,27 +199,4 @@ func writeCompactManifest(dir string, manifest compactManifest) error {
 		return fmt.Errorf("encode archive manifest: %w", err)
 	}
 	return os.WriteFile(filepath.Join(dir, "compaction-manifest.json"), append(data, '\n'), 0o600)
-}
-
-func manifestShards(shards []compactShard) []compactManifestFile {
-	out := make([]compactManifestFile, 0, len(shards))
-	for _, shard := range shards {
-		sum := sha256.Sum256(shard.data)
-		out = append(out, compactManifestFile{Name: shard.name, SHA256: hex.EncodeToString(sum[:]), Bytes: int64(len(shard.data))})
-	}
-	return out
-}
-
-func sameReceiptChain(a, b []contractreceipt.EvidenceReceipt) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		ah, ae := contractreceipt.ReceiptHash(a[i])
-		bh, be := contractreceipt.ReceiptHash(b[i])
-		if ae != nil || be != nil || ah != bh {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/cli/evidence/compact_stream.go
+++ b/internal/cli/evidence/compact_stream.go
@@ -1,0 +1,387 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+// This file contains the bounded-byte primitives used by the offline
+// compaction ceremony.  Online evidence readers intentionally remain bounded
+// by recorder.MaxEvidenceReadFileBytes; the ceremony is the only consumer that
+// is allowed to walk an old oversized shard, one JSONL record at a time.
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/evidencename"
+	legacyreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+type compactStreamWriter struct {
+	dir, session  string
+	current       *os.File
+	currentName   string
+	currentStart  uint64
+	currentBytes  int64
+	currentSource compactStreamFile
+	files         []compactStreamFile
+	mappings      []compactByteMapping
+	sourceOffsets map[string]int64
+}
+
+// File-operation seams keep the offline ceremony's real error propagation
+// testable without weakening its bounded production path. They are package
+// local and retain the standard library operations by default.
+var (
+	compactStreamSync  = func(f *os.File) error { return f.Sync() }
+	compactStreamClose = func(f *os.File) error { return f.Close() }
+	compactStreamWrite = func(f *os.File, line []byte) (int, error) { return f.Write(line) }
+	compactStreamRead  = os.ReadFile
+)
+
+func compactStreamNames(location recorder.EvidenceLocation, session string) ([]string, error) {
+	entries, truncated, err := recorder.ReadEvidenceLocationEntriesBounded(location, maxCompactInputShards)
+	if err != nil {
+		return nil, fmt.Errorf("list evidence directory: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("evidence directory exceeds compaction input limit %d", maxCompactInputShards)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("refuse symlink in active evidence directory: %s", entry.Name())
+		}
+		if entry.IsDir() {
+			return nil, fmt.Errorf("refuse nested directory %q while compacting session %q", entry.Name(), session)
+		}
+		if strings.HasSuffix(entry.Name(), ".raw.enc") {
+			return nil, fmt.Errorf("refuse raw escrow sidecar %q during compaction; sidecar-preserving compaction is not implemented", entry.Name())
+		}
+		got, _, ok := recorder.ParseEvidenceFilename(entry.Name())
+		if !ok || got != session {
+			return nil, fmt.Errorf("refuse non-selected evidence file %q while compacting session %q", entry.Name(), session)
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("session %q has no evidence shards", session)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		_, a, _ := recorder.ParseEvidenceFilename(names[i])
+		_, b, _ := recorder.ParseEvidenceFilename(names[j])
+		if a != b {
+			return a < b
+		}
+		return names[i] < names[j]
+	})
+	if err := evidencename.CheckNoDuplicateSeqStart(names); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+func streamCompactToStage(location recorder.EvidenceLocation, names []string, session string, key ed25519.PublicKey, stage string) (*compactStreamWriter, compactStreamProof, error) {
+	w := &compactStreamWriter{dir: stage, session: session, sourceOffsets: make(map[string]int64)}
+	proof, err := streamCompactFiles(location, names, session, key, func(source compactStreamFile, line []byte, entry recorder.Entry) error {
+		return w.add(source, line, entry)
+	})
+	if err != nil {
+		_ = w.close()
+		return nil, compactStreamProof{}, err
+	}
+	if err := w.close(); err != nil {
+		return nil, compactStreamProof{}, err
+	}
+	return w, proof, nil
+}
+
+func (w *compactStreamWriter) add(source compactStreamFile, line []byte, entry recorder.Entry) error {
+	if int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
+		return fmt.Errorf("single JSONL line exceeds evidence shard limit")
+	}
+	if w.current == nil || w.currentBytes+int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
+		if err := w.close(); err != nil {
+			return err
+		}
+		if len(w.files) > 0 && source.info.Mode().Perm() != w.files[0].info.Mode().Perm() {
+			return fmt.Errorf("source shard mode differs; compaction cannot preserve per-output provenance")
+		}
+		w.currentStart = entry.Sequence
+		w.currentName = fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(w.session), entry.Sequence)
+		w.currentSource = source
+		f, err := os.OpenFile(filepath.Join(w.dir, w.currentName), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return err
+		}
+		w.current = f
+		w.currentBytes = 0
+	}
+	offset := w.currentBytes
+	sourceOffset := w.sourceOffsets[source.name]
+	written, err := compactStreamWrite(w.current, line)
+	if err != nil {
+		return err
+	}
+	if written != len(line) {
+		return io.ErrShortWrite
+	}
+	w.currentBytes += int64(len(line))
+	n := len(w.mappings)
+	if n > 0 {
+		last := &w.mappings[n-1]
+		if last.Source == source.name && last.Output == w.currentName && last.SourceOffset+last.Bytes == sourceOffset && last.OutputOffset+last.Bytes == offset {
+			last.Bytes += int64(len(line))
+			w.sourceOffsets[source.name] += int64(len(line))
+			return nil
+		}
+	}
+	w.mappings = append(w.mappings, compactByteMapping{Source: source.name, Output: w.currentName, SourceOffset: sourceOffset, OutputOffset: offset, Bytes: int64(len(line))})
+	w.sourceOffsets[source.name] += int64(len(line))
+	return nil
+}
+
+func (w *compactStreamWriter) close() error {
+	if w.current == nil {
+		return nil
+	}
+	if err := compactStreamSync(w.current); err != nil {
+		return err
+	}
+	if err := compactStreamClose(w.current); err != nil {
+		return err
+	}
+	path := filepath.Join(w.dir, w.currentName)
+	if err := preserveCompactFileMetadata(w.currentSource.path, path); err != nil {
+		return err
+	}
+	// #nosec G304 -- path is the bounded staged shard we just created.
+	data, err := compactStreamRead(path)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	w.files = append(w.files, compactStreamFile{name: w.currentName, path: path, info: w.currentSource.info, sum: hex.EncodeToString(sum[:]), bytes: int64(len(data))})
+	w.current = nil
+	return nil
+}
+
+func sameCompactProof(a, b compactStreamProof) bool {
+	return a.bytes == b.bytes && a.sum == b.sum && a.v1Count == b.v1Count && a.v1Head == b.v1Head && a.v2Count == b.v2Count && a.v2Head == b.v2Head
+}
+
+func sameCompactNameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func manifestStreamFiles(files []compactStreamFile) []compactManifestFile {
+	out := make([]compactManifestFile, 0, len(files))
+	for _, f := range files {
+		out = append(out, compactManifestFile{Name: f.name, SHA256: f.sum, Bytes: f.bytes})
+	}
+	return out
+}
+
+// compactStreamFile is deliberately metadata-only. Keeping source content in
+// this structure was the old compactor's 256MiB ceiling and made the live
+// four-gigabyte recorder impossible to repair.
+type compactStreamFile struct {
+	name  string
+	path  string
+	info  os.FileInfo
+	sum   string
+	bytes int64
+}
+
+const maxCompactInputShards = 4096
+
+var compactKnownRecorderTypes = map[string]struct{}{
+	"action_receipt": {}, "evidence_receipt": {}, "checkpoint": {}, "transcript_root": {}, "decision": {}, "capture": {}, "capture_drop": {},
+}
+
+type compactStreamProof struct {
+	files   []compactStreamFile
+	bytes   int64
+	sum     string
+	v1Count uint64
+	v1Head  string
+	v2Count uint64
+	v2Head  string
+}
+
+// compactOuterVerifier checks the recorder envelope while each line is still
+// in its original byte form.  RawDetail is retained by ParseEntryLine, so the
+// compatibility hash covers historical v1 detail bytes rather than a decoded
+// map re-marshaled in a different order.
+type compactOuterVerifier struct {
+	key       ed25519.PublicKey
+	seen      bool
+	previous  string
+	nextSeq   uint64
+	v3Seen    bool
+	v3Session string
+	v3Kind    string
+	v3Writer  string
+}
+
+func (v *compactOuterVerifier) add(e recorder.Entry, session string) error {
+	if e.SessionID != session {
+		return fmt.Errorf("entry seq %d belongs to %q, not %q", e.Sequence, e.SessionID, session)
+	}
+	if err := recorder.ValidateEntrySchema(e); err != nil {
+		return fmt.Errorf("entry seq %d: %w", e.Sequence, err)
+	}
+	if recorder.EntryVersionHasNamespace(e.Version) {
+		if v.seen && !v.v3Seen {
+			return fmt.Errorf("entry seq %d: v3 chain cannot continue legacy recorder namespace", e.Sequence)
+		}
+		if !v.v3Seen {
+			v.v3Seen, v.v3Session, v.v3Kind, v.v3Writer = true, e.SessionID, e.ChainKind, e.WriterInstanceID
+		} else if e.SessionID != v.v3Session || e.ChainKind != v.v3Kind || e.WriterInstanceID != v.v3Writer {
+			return fmt.Errorf("entry seq %d: v3 recorder namespace changed", e.Sequence)
+		}
+	} else if v.v3Seen {
+		return fmt.Errorf("entry seq %d: legacy entry cannot continue v3 recorder namespace", e.Sequence)
+	}
+	if got := recorder.ComputeHash(e); got == "" || got != e.Hash {
+		return fmt.Errorf("entry seq %d: hash mismatch", e.Sequence)
+	}
+	if !v.seen {
+		if e.Sequence != 0 || e.PrevHash != recorder.GenesisHash {
+			return fmt.Errorf("entry seq %d: invalid recorder genesis", e.Sequence)
+		}
+		v.seen = true
+	} else if e.Sequence != v.nextSeq || e.PrevHash != v.previous {
+		return fmt.Errorf("entry seq %d: recorder sequence or hash chain break", e.Sequence)
+	}
+	if e.Type == "checkpoint" && len(v.key) != 0 {
+		if err := recorder.VerifyCheckpoints([]recorder.Entry{e}, v.key); err != nil {
+			return err
+		}
+	}
+	v.previous, v.nextSeq = e.Hash, e.Sequence+1
+	return nil
+}
+
+// streamCompactFiles processes every source shard with a bounded scanner and
+// calls consume once per complete JSONL record.  It never retains a source
+// shard, parsed entry set, or aggregate corpus in memory.
+func streamCompactFiles(location recorder.EvidenceLocation, files []string, session string, key ed25519.PublicKey, consume func(compactStreamFile, []byte, recorder.Entry) error) (compactStreamProof, error) {
+	var proof compactStreamProof
+	h := sha256.New()
+	outer := compactOuterVerifier{key: key}
+	v1, err := legacyreceipt.NewStreamingVerifier(hex.EncodeToString(key))
+	if err != nil {
+		return compactStreamProof{}, fmt.Errorf("initialize v1 receipt verifier: %w", err)
+	}
+	v2, err := contractreceipt.NewPinnedStreamingVerifier(key)
+	if err != nil {
+		return compactStreamProof{}, fmt.Errorf("initialize v2 receipt verifier: %w", err)
+	}
+	for _, name := range files {
+		path := filepath.Join(location.Dir, name)
+		var fileProof compactStreamFile
+		err := recorder.StreamEvidenceLocationFileForOfflineCompaction(location, name, func(r io.Reader, info os.FileInfo) error {
+			fileProof = compactStreamFile{name: name, path: path, info: info}
+			fileHash := sha256.New()
+			s := bufio.NewScanner(r)
+			// A single output record must fit in a normal reader shard.  Scanner's
+			// buffer is therefore bounded to that same operator-visible limit plus
+			// the required newline, instead of accepting an attacker-sized line.
+			s.Buffer(make([]byte, 64<<10), recorder.MaxEntryLineBytes+1)
+			for s.Scan() {
+				line := append(append([]byte(nil), s.Bytes()...), '\n')
+				entry, parseErr := recorder.ParseEntryLine(bytes.TrimSuffix(line, []byte("\n")))
+				if parseErr != nil {
+					return fmt.Errorf("parse %s: %w", name, parseErr)
+				}
+				if err := outer.add(entry, session); err != nil {
+					return err
+				}
+				if _, ok := compactKnownRecorderTypes[entry.Type]; !ok {
+					return fmt.Errorf("unknown recorder entry type %q at seq %d", entry.Type, entry.Sequence)
+				}
+				switch entry.Type {
+				case "action_receipt":
+					if err := v1.Add(entry.RawDetail); err != nil {
+						return fmt.Errorf("verify v1 action_receipt at recorder seq %d: %w", entry.Sequence, err)
+					}
+					proof.v1Count++
+				case contractreceipt.EvidenceEntryType:
+					if err := v2.AddRaw(entry.RawDetail); err != nil {
+						return fmt.Errorf("verify v2 evidence_receipt at recorder seq %d: %w", entry.Sequence, err)
+					}
+					proof.v2Count++
+				}
+				if err := consume(fileProof, line, entry); err != nil {
+					return err
+				}
+				_, _ = h.Write(line)
+				_, _ = fileHash.Write(line)
+				fileProof.bytes += int64(len(line))
+			}
+			if err := s.Err(); err != nil {
+				return fmt.Errorf("read %s: %w", name, err)
+			}
+			if fileProof.bytes == 0 {
+				return fmt.Errorf("%s is empty", name)
+			}
+			// Scanner discards delimiters.  A missing final newline is unsafe:
+			// otherwise the first record of the next shard could be glued to it.
+			if fileProof.bytes != info.Size() {
+				return fmt.Errorf("%s does not end in newline or changed during read", name)
+			}
+			fileProof.sum = hex.EncodeToString(fileHash.Sum(nil))
+			return nil
+		})
+		if err != nil {
+			return compactStreamProof{}, err
+		}
+		// Per-file digest is computed in a second bounded stream during the
+		// source identity recheck.  The first pass only records identity and
+		// byte count, so it cannot accidentally double memory with a 4GiB hash
+		// input buffer.
+		proof.files = append(proof.files, fileProof)
+		proof.bytes += fileProof.bytes
+	}
+	if !outer.seen {
+		return compactStreamProof{}, fmt.Errorf("session %q contains no entries", session)
+	}
+	if proof.v1Count == 0 && proof.v2Count == 0 {
+		return compactStreamProof{}, fmt.Errorf("session %q contains no signed evidence receipts", session)
+	}
+	if proof.v1Count > 0 {
+		result := v1.Finish()
+		if !result.Valid {
+			return compactStreamProof{}, fmt.Errorf("verify v1 receipt chain: %s", result.Error)
+		}
+		proof.v1Head = result.RootHash
+	}
+	if proof.v2Count > 0 {
+		result := v2.Finish()
+		if !result.Valid || !result.SignaturesVerified {
+			return compactStreamProof{}, fmt.Errorf("verify v2 receipt chain: %s", result.Error)
+		}
+		proof.v2Head = result.RootHash
+	}
+	proof.sum = hex.EncodeToString(h.Sum(nil))
+	return proof, nil
+}

--- a/internal/cli/evidence/compact_stream.go
+++ b/internal/cli/evidence/compact_stream.go
@@ -110,12 +110,21 @@ func (w *compactStreamWriter) add(source compactStreamFile, line []byte, entry r
 	if int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
 		return fmt.Errorf("single JSONL line exceeds evidence shard limit")
 	}
+	// Every output shard inherits the metadata of the source that opened it.
+	// Reject a mode change before appending to that shard, even when the line
+	// still fits and therefore would not trigger rotation.
+	if w.current != nil && source.info.Mode().Perm() != w.currentSource.info.Mode().Perm() {
+		return fmt.Errorf("source shard mode differs; compaction cannot preserve per-output provenance")
+	}
 	if w.current == nil || w.currentBytes+int64(len(line)) > recorder.MaxEvidenceReadFileBytes {
 		if err := w.close(); err != nil {
 			return err
 		}
 		if len(w.files) > 0 && source.info.Mode().Perm() != w.files[0].info.Mode().Perm() {
 			return fmt.Errorf("source shard mode differs; compaction cannot preserve per-output provenance")
+		}
+		if len(w.files) >= recorder.MaxEvidenceReadDirectoryEntries {
+			return fmt.Errorf("compaction produced %d shards, exceeds %d", len(w.files)+1, recorder.MaxEvidenceReadDirectoryEntries)
 		}
 		w.currentStart = entry.Sequence
 		w.currentName = fmt.Sprintf("evidence-%s-%d.jsonl", filepath.Base(w.session), entry.Sequence)

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -226,8 +226,8 @@ func TestStreamCompactFilesVerifiesSignedOuterCheckpoint(t *testing.T) {
 	if err := os.WriteFile(path, rewritten.Bytes(), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := streamCompactFiles(location, names, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "checkpoint") {
-		t.Fatalf("tampered signed checkpoint error = %v, want checkpoint verification failure", err)
+	if _, err := streamCompactFiles(location, names, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || err.Error() != "entry seq 1: checkpoint signature verification failed" {
+		t.Fatalf("tampered signed checkpoint error = %v, want exact checkpoint signature verification failure", err)
 	}
 }
 
@@ -246,13 +246,13 @@ func TestRunCompactSupportsOversizeLegacyShardAndResumeAppend(t *testing.T) {
 	}
 	var source bytes.Buffer
 	prevOuter, prevReceipt := recorder.GenesisHash, contractreceipt.GenesisHash
-	for i := range 3 {
+	for i := range 12 {
 		r := compactSignedReceipt(t, priv, uint64(i), prevReceipt)
 		prevReceipt, err = contractreceipt.ReceiptHash(r)
 		if err != nil {
 			t.Fatal(err)
 		}
-		e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision", Transport: "fetch", Summary: strings.Repeat("x", 800<<10), Detail: r, PrevHash: prevOuter}
+		e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision", Transport: "fetch", Summary: strings.Repeat("x", 700<<10), Detail: r, PrevHash: prevOuter}
 		e.Hash = recorder.ComputeHash(e)
 		prevOuter = e.Hash
 		line, marshalErr := json.Marshal(e)
@@ -262,14 +262,41 @@ func TestRunCompactSupportsOversizeLegacyShardAndResumeAppend(t *testing.T) {
 		source.Write(line)
 		source.WriteByte('\n')
 	}
-	if source.Len() <= 1<<20 || source.Len() >= int(recorder.MaxEvidenceReadFileBytes) {
-		t.Fatalf("fixture size = %d, want between 1MiB and 8MiB", source.Len())
+	if source.Len() <= int(recorder.MaxEvidenceReadFileBytes) {
+		t.Fatalf("fixture size = %d, want more than normal evidence shard limit %d", source.Len(), recorder.MaxEvidenceReadFileBytes)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), source.Bytes(), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := runCompact(compactCmd(), compactOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub)}); err != nil {
 		t.Fatalf("compact oversize shard: %v", err)
+	}
+	active, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	var compacted bytes.Buffer
+	for _, shard := range active {
+		info, statErr := shard.Info()
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
+		if info.Size() > recorder.MaxEvidenceReadFileBytes {
+			t.Fatalf("compacted shard %q is %d bytes, exceeds %d", shard.Name(), info.Size(), recorder.MaxEvidenceReadFileBytes)
+		}
+		data, readErr := root.ReadFile(shard.Name())
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		compacted.Write(data)
+	}
+	if !bytes.Equal(compacted.Bytes(), source.Bytes()) {
+		t.Fatal("compaction changed bytes from oversized legacy shard")
 	}
 	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
 	if err != nil {
@@ -427,7 +454,7 @@ func TestCompactStreamWriterPreservesMappingsAndFailsClosed(t *testing.T) {
 		}
 	})
 
-	t.Run("refuses mixed source modes at a new shard", func(t *testing.T) {
+	t.Run("refuses mixed source modes without rotation", func(t *testing.T) {
 		other := filepath.Join(t.TempDir(), "evidence-proxy-1.jsonl")
 		if err := os.WriteFile(other, []byte("other\n"), 0o400); err != nil {
 			t.Fatal(err)
@@ -439,9 +466,37 @@ func TestCompactStreamWriterPreservesMappingsAndFailsClosed(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", files: []compactStreamFile{{info: info}}, sourceOffsets: make(map[string]int64)}
+		w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", sourceOffsets: make(map[string]int64)}
+		if err := w.add(source, []byte("first\n"), recorder.Entry{}); err != nil {
+			t.Fatal(err)
+		}
 		if err := w.add(compactStreamFile{name: filepath.Base(other), path: other, info: otherInfo}, []byte("line\n"), recorder.Entry{}); err == nil || !strings.Contains(err.Error(), "mode differs") {
 			t.Fatalf("add error=%v", err)
+		}
+	})
+
+	t.Run("rejects output shard overflow during rotation", func(t *testing.T) {
+		stage := t.TempDir()
+		f, err := os.CreateTemp(stage, "evidence-proxy-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString("full\n"); err != nil {
+			t.Fatal(err)
+		}
+		files := make([]compactStreamFile, recorder.MaxEvidenceReadDirectoryEntries-1)
+		for i := range files {
+			files[i].info = info
+		}
+		w := &compactStreamWriter{
+			dir: stage, session: "proxy", current: f, currentName: filepath.Base(f.Name()),
+			currentBytes: recorder.MaxEvidenceReadFileBytes, currentSource: source,
+			files: files, sourceOffsets: make(map[string]int64),
+		}
+		err = w.add(source, []byte("next\n"), recorder.Entry{Sequence: 1})
+		want := fmt.Sprintf("compaction produced %d shards, exceeds %d", recorder.MaxEvidenceReadDirectoryEntries+1, recorder.MaxEvidenceReadDirectoryEntries)
+		if err == nil || err.Error() != want {
+			t.Fatalf("rotation overflow error=%v, want %q", err, want)
 		}
 	})
 

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	legacyreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
@@ -128,6 +130,697 @@ func TestRunCompactSignedMultiShardExchange(t *testing.T) {
 	}
 }
 
+// TestRunCompactFrozenV1ActionReceiptFixture is the compatibility proof for
+// the immutable recorder format that the live migration must accept. The
+// fixture predates the v2 evidence receipt and preserves deliberately compact
+// v1 JSON spelling, so a decode/re-marshal verifier would not be an adequate
+// substitute for this test.
+func TestRunCompactFrozenV1ActionReceiptFixture(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	fixture := filepath.Join("..", "..", "..", "sdk", "conformance", "testdata", "frozen", "v1", "action-receipt-v1-chain.jsonl")
+	// #nosec G304 -- fixed repository conformance fixture.
+	data, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("read frozen v1 fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-conformance-session-0.jsonl"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const fixtureKey = "4655a7e605c12ebb00a46037881c33c5bca5eb74b45a02e8e7261a7ff5a21678"
+	if err := runCompact(compactCmd(), compactOptions{receiptDir: dir, sessionID: "conformance-session", publicKey: fixtureKey}); err != nil {
+		t.Fatalf("compact frozen v1 action receipt chain: %v", err)
+	}
+	// #nosec G304 -- test-created compacted shard.
+	active, err := os.ReadFile(filepath.Join(dir, "evidence-conformance-session-0.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(active, data) {
+		t.Fatal("compaction changed immutable frozen v1 JSONL bytes")
+	}
+}
+
+func TestStreamCompactFilesVerifiesSignedOuterCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1, SignCheckpoints: true}, nil, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := compactSignedReceipt(t, priv, 0, contractreceipt.GenesisHash)
+	if err := rec.Record(recorder.Entry{SessionID: "proxy", Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision", Transport: "fetch", Summary: "signed", Detail: r}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
+	names, err := compactStreamNames(location, "proxy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := streamCompactFiles(location, names, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err != nil {
+		t.Fatalf("valid signed checkpoint stream: %v", err)
+	}
+
+	path := filepath.Join(dir, names[0])
+	entries, err := recorder.ReadEntries(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range entries {
+		if entries[i].Type != "checkpoint" {
+			continue
+		}
+		detail := entries[i].Detail.(map[string]any)
+		detail["signature"] = strings.Repeat("00", ed25519.SignatureSize)
+		entries[i].Detail = detail
+		break
+	}
+	for i := range entries {
+		entries[i].RawDetail = nil
+		if i > 0 {
+			entries[i].PrevHash = entries[i-1].Hash
+		}
+		entries[i].Hash = recorder.ComputeHash(entries[i])
+	}
+	var rewritten bytes.Buffer
+	for _, entry := range entries {
+		line, marshalErr := json.Marshal(entry)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		rewritten.Write(line)
+		rewritten.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, rewritten.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := streamCompactFiles(location, names, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "checkpoint") {
+		t.Fatalf("tampered signed checkpoint error = %v, want checkpoint verification failure", err)
+	}
+}
+
+func TestRunCompactSupportsOversizeLegacyShardAndResumeAppend(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var source bytes.Buffer
+	prevOuter, prevReceipt := recorder.GenesisHash, contractreceipt.GenesisHash
+	for i := range 3 {
+		r := compactSignedReceipt(t, priv, uint64(i), prevReceipt)
+		prevReceipt, err = contractreceipt.ReceiptHash(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: contractreceipt.EvidenceEntryType, EventKind: "proxy_decision", Transport: "fetch", Summary: strings.Repeat("x", 800<<10), Detail: r, PrevHash: prevOuter}
+		e.Hash = recorder.ComputeHash(e)
+		prevOuter = e.Hash
+		line, marshalErr := json.Marshal(e)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		source.Write(line)
+		source.WriteByte('\n')
+	}
+	if source.Len() <= 1<<20 || source.Len() >= int(recorder.MaxEvidenceReadFileBytes) {
+		t.Fatalf("fixture size = %d, want between 1MiB and 8MiB", source.Len())
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), source.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runCompact(compactCmd(), compactOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub)}); err != nil {
+		t.Fatalf("compact oversize shard: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("resume compacted recorder: %v", err)
+	}
+	if err := rec.Record(recorder.Entry{SessionID: "proxy", Type: "decision", EventKind: "proxy_decision", Transport: "fetch", Summary: "after compaction"}); err != nil {
+		_ = rec.Close()
+		t.Fatalf("append after compaction: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunCompactSuccessfulRerunPreservesVerifiability(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	opts := newCompactFixture(t)
+	for run := 0; run < 2; run++ {
+		if err := runCompact(compactCmd(), opts); err != nil {
+			t.Fatalf("successful compaction run %d: %v", run+1, err)
+		}
+	}
+	archives, err := filepath.Glob(filepath.Join(filepath.Dir(opts.receiptDir), ".pipelock-evidence-archive-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(archives) != 2 {
+		t.Fatalf("archives after successful rerun = %d, want 2", len(archives))
+	}
+}
+
+func TestCompactStreamNamesRejectsDuplicateShardStarts(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"evidence-proxy-0.jsonl", "evidence-proxy-00.jsonl"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := compactStreamNames(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("duplicate shard starts error = %v", err)
+	}
+}
+
+func TestCompactStreamNamesFailsClosedOnUnsafeDirectoryShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  string
+	}{
+		{name: "missing directory", setup: func(t *testing.T, dir string) { _ = os.Remove(dir) }, want: "list evidence directory"},
+		{name: "nested directory", setup: func(t *testing.T, dir string) {
+			if err := os.Mkdir(filepath.Join(dir, "nested"), 0o750); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "refuse nested directory"},
+		{name: "escrow sidecar", setup: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.raw.enc"), []byte("sealed"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "sidecar-preserving"},
+		{name: "other session shard", setup: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, "evidence-other-0.jsonl"), []byte("line\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "refuse non-selected"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.setup(t, dir)
+			_, err := compactStreamNames(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compactStreamNames error=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompactStreamNamesRejectsDirectoryEntryOverflow(t *testing.T) {
+	dir := t.TempDir()
+	for i := range maxCompactInputShards + 1 {
+		name := fmt.Sprintf("evidence-proxy-%d.jsonl", i)
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := compactStreamNames(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "input limit") {
+		t.Fatalf("compactStreamNames error=%v", err)
+	}
+}
+
+func TestCompactStreamNamesRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(target, []byte("line\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "evidence-proxy-0.jsonl")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, err := compactStreamNames(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "refuse symlink") {
+		t.Fatalf("compactStreamNames error=%v", err)
+	}
+}
+
+func TestCompactStreamWriterPreservesMappingsAndFailsClosed(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "evidence-proxy-0.jsonl")
+	if err := os.WriteFile(sourcePath, []byte("source\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := compactStreamFile{name: filepath.Base(sourcePath), path: sourcePath, info: info}
+
+	t.Run("writes contiguous mapping and output digest", func(t *testing.T) {
+		stage := t.TempDir()
+		w := &compactStreamWriter{dir: stage, session: "proxy", sourceOffsets: make(map[string]int64)}
+		entry := recorder.Entry{Sequence: 7}
+		if err := w.add(source, []byte("one\n"), entry); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.add(source, []byte("two\n"), entry); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.close(); err != nil {
+			t.Fatal(err)
+		}
+		if len(w.files) != 1 || len(w.mappings) != 1 || w.mappings[0].Bytes != int64(len("one\ntwo\n")) {
+			t.Fatalf("files=%d mappings=%#v", len(w.files), w.mappings)
+		}
+		expected := []byte("one\ntwo\n")
+		sum := sha256.Sum256(expected)
+		if w.files[0].bytes != int64(len(expected)) || w.files[0].sum != hex.EncodeToString(sum[:]) {
+			t.Fatalf("staged file metadata=%+v", w.files[0])
+		}
+	})
+
+	t.Run("rejects oversized line before writing", func(t *testing.T) {
+		w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", sourceOffsets: make(map[string]int64)}
+		if err := w.add(source, make([]byte, recorder.MaxEvidenceReadFileBytes+1), recorder.Entry{}); err == nil || !strings.Contains(err.Error(), "single JSONL line") {
+			t.Fatalf("add error=%v", err)
+		}
+	})
+
+	t.Run("refuses an unavailable stage before reading source", func(t *testing.T) {
+		w := &compactStreamWriter{dir: filepath.Join(t.TempDir(), "missing"), session: "proxy", sourceOffsets: make(map[string]int64)}
+		if err := w.add(source, []byte("line\n"), recorder.Entry{}); err == nil {
+			t.Fatal("add accepted missing stage")
+		}
+	})
+
+	t.Run("refuses mixed source modes at a new shard", func(t *testing.T) {
+		other := filepath.Join(t.TempDir(), "evidence-proxy-1.jsonl")
+		if err := os.WriteFile(other, []byte("other\n"), 0o400); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(other, 0o400); err != nil {
+			t.Fatal(err)
+		}
+		otherInfo, err := os.Stat(other)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", files: []compactStreamFile{{info: info}}, sourceOffsets: make(map[string]int64)}
+		if err := w.add(compactStreamFile{name: filepath.Base(other), path: other, info: otherInfo}, []byte("line\n"), recorder.Entry{}); err == nil || !strings.Contains(err.Error(), "mode differs") {
+			t.Fatalf("add error=%v", err)
+		}
+	})
+
+	t.Run("does not publish when source metadata disappears", func(t *testing.T) {
+		stage := t.TempDir()
+		f, err := os.CreateTemp(stage, "evidence-proxy-0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString("line\n"); err != nil {
+			t.Fatal(err)
+		}
+		w := &compactStreamWriter{dir: stage, current: f, currentName: filepath.Base(f.Name()), currentSource: compactStreamFile{path: filepath.Join(t.TempDir(), "gone"), info: info}}
+		if err := w.close(); err == nil {
+			t.Fatal("close accepted missing source metadata")
+		}
+	})
+
+	t.Run("reports sync failure from a closed output", func(t *testing.T) {
+		stage := t.TempDir()
+		f, err := os.CreateTemp(stage, "evidence-proxy-0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		w := &compactStreamWriter{dir: stage, current: f, currentName: filepath.Base(f.Name()), currentSource: source}
+		if err := w.close(); err == nil {
+			t.Fatal("close accepted already-closed output")
+		}
+	})
+
+	t.Run("does not rotate after finalizing current shard fails", func(t *testing.T) {
+		restoreCompactStreamFileHooks(t)
+		stage := t.TempDir()
+		f, err := os.CreateTemp(stage, "evidence-proxy-0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		compactStreamSync = func(*os.File) error { return errors.New("rotate sync") }
+		w := &compactStreamWriter{dir: stage, session: "proxy", current: f, currentName: filepath.Base(f.Name()), currentBytes: recorder.MaxEvidenceReadFileBytes, currentSource: source, sourceOffsets: make(map[string]int64)}
+		if err := w.add(source, []byte("next\n"), recorder.Entry{Sequence: 1}); err == nil || !strings.Contains(err.Error(), "rotate sync") {
+			t.Fatalf("rotate error=%v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		inject func()
+		call   func(*compactStreamWriter) error
+	}{
+		{name: "write", inject: func() {
+			compactStreamWrite = func(*os.File, []byte) (int, error) { return 0, errors.New("injected write") }
+		}, call: func(w *compactStreamWriter) error { return w.add(source, []byte("line\n"), recorder.Entry{}) }},
+		{name: "sync", inject: func() { compactStreamSync = func(*os.File) error { return errors.New("injected sync") } }, call: func(w *compactStreamWriter) error {
+			if err := w.add(source, []byte("line\n"), recorder.Entry{}); err != nil {
+				return err
+			}
+			return w.close()
+		}},
+		{name: "close", inject: func() { compactStreamClose = func(*os.File) error { return errors.New("injected close") } }, call: func(w *compactStreamWriter) error {
+			if err := w.add(source, []byte("line\n"), recorder.Entry{}); err != nil {
+				return err
+			}
+			return w.close()
+		}},
+		{name: "read", inject: func() { compactStreamRead = func(string) ([]byte, error) { return nil, errors.New("injected read") } }, call: func(w *compactStreamWriter) error {
+			if err := w.add(source, []byte("line\n"), recorder.Entry{}); err != nil {
+				return err
+			}
+			return w.close()
+		}},
+	} {
+		t.Run("propagates "+tc.name+" failure", func(t *testing.T) {
+			restoreCompactStreamFileHooks(t)
+			tc.inject()
+			w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", sourceOffsets: make(map[string]int64)}
+			if err := tc.call(w); err == nil || !strings.Contains(err.Error(), "injected "+tc.name) {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+
+	t.Run("rejects short write", func(t *testing.T) {
+		restoreCompactStreamFileHooks(t)
+		compactStreamWrite = func(*os.File, []byte) (int, error) { return 1, nil }
+		w := &compactStreamWriter{dir: t.TempDir(), session: "proxy", sourceOffsets: make(map[string]int64)}
+		if err := w.add(source, []byte("line\n"), recorder.Entry{}); !errors.Is(err, io.ErrShortWrite) {
+			t.Fatalf("error=%v, want io.ErrShortWrite", err)
+		}
+	})
+}
+
+func restoreCompactStreamFileHooks(t *testing.T) {
+	t.Helper()
+	compactStreamSync = func(f *os.File) error { return f.Sync() }
+	compactStreamClose = func(f *os.File) error { return f.Close() }
+	compactStreamWrite = func(f *os.File, line []byte) (int, error) { return f.Write(line) }
+	compactStreamRead = os.ReadFile
+	t.Cleanup(func() {
+		compactStreamSync = func(f *os.File) error { return f.Sync() }
+		compactStreamClose = func(f *os.File) error { return f.Close() }
+		compactStreamWrite = func(f *os.File, line []byte) (int, error) { return f.Write(line) }
+		compactStreamRead = os.ReadFile
+	})
+}
+
+func TestCompactStreamHelpersCompareWholeProofs(t *testing.T) {
+	base := compactStreamProof{bytes: 1, sum: "sum", v1Count: 2, v1Head: "v1", v2Count: 3, v2Head: "v2"}
+	if !sameCompactProof(base, base) {
+		t.Fatal("same proof did not compare equal")
+	}
+	for _, changed := range []compactStreamProof{{bytes: 2}, {sum: "other"}, {v1Count: 4}, {v1Head: "other"}, {v2Count: 4}, {v2Head: "other"}} {
+		candidate := base
+		if changed.bytes != 0 {
+			candidate.bytes = changed.bytes
+		}
+		if changed.sum != "" {
+			candidate.sum = changed.sum
+		}
+		if changed.v1Count != 0 {
+			candidate.v1Count = changed.v1Count
+		}
+		if changed.v1Head != "" {
+			candidate.v1Head = changed.v1Head
+		}
+		if changed.v2Count != 0 {
+			candidate.v2Count = changed.v2Count
+		}
+		if changed.v2Head != "" {
+			candidate.v2Head = changed.v2Head
+		}
+		if sameCompactProof(base, candidate) {
+			t.Fatalf("different proof compared equal: %#v", candidate)
+		}
+	}
+	if sameCompactNameSet([]string{"a"}, []string{"a", "b"}) || sameCompactNameSet([]string{"a"}, []string{"b"}) || !sameCompactNameSet([]string{"a", "b"}, []string{"a", "b"}) {
+		t.Fatal("unexpected compact name-set comparison")
+	}
+}
+
+func TestStreamCompactToStageClosesOnFailureAndPublishesOnSuccess(t *testing.T) {
+	opts := newCompactFixture(t)
+	pub, err := hex.DecodeString(opts.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: opts.receiptDir, Dir: opts.receiptDir}
+	stage := t.TempDir()
+	w, proof, err := streamCompactToStage(location, []string{"evidence-proxy-0.jsonl"}, "proxy", ed25519.PublicKey(pub), stage)
+	if err != nil || len(w.files) != 1 || proof.v2Count != 1 {
+		t.Fatalf("success writer=%#v proof=%#v err=%v", w, proof, err)
+	}
+	if _, _, err := streamCompactToStage(location, []string{"missing.jsonl"}, "proxy", ed25519.PublicKey(pub), t.TempDir()); err == nil {
+		t.Fatal("streamCompactToStage accepted missing source")
+	}
+	restoreCompactStreamFileHooks(t)
+	compactStreamSync = func(*os.File) error { return errors.New("final sync failure") }
+	if _, _, err := streamCompactToStage(location, []string{"evidence-proxy-0.jsonl"}, "proxy", ed25519.PublicKey(pub), t.TempDir()); err == nil || !strings.Contains(err.Error(), "final sync") {
+		t.Fatalf("stream close error=%v", err)
+	}
+}
+
+func TestStreamCompactFilesRejectsMalformedAndIncompleteEvidence(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(t *testing.T, data []byte) recorder.EvidenceLocation {
+		t.Helper()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return recorder.EvidenceLocation{Root: dir, Dir: dir}
+	}
+	run := func(location recorder.EvidenceLocation, consume func(compactStreamFile, []byte, recorder.Entry) error) error {
+		_, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, consume)
+		return err
+	}
+	t.Run("parse failure", func(t *testing.T) {
+		if err := run(write(t, []byte("not-json\n")), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "parse evidence") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+	t.Run("oversized line", func(t *testing.T) {
+		if err := run(write(t, append(make([]byte, recorder.MaxEntryLineBytes+2), '\n')), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "read evidence") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+	t.Run("empty shard", func(t *testing.T) {
+		if err := run(write(t, nil), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "is empty") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+	t.Run("missing trailing newline", func(t *testing.T) {
+		line := compactTestLine(t, 0)
+		if err := run(write(t, bytes.TrimSuffix(line, []byte("\n"))), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "does not end in newline") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+	t.Run("no signed receipt", func(t *testing.T) {
+		if err := run(write(t, compactTestLine(t, 0)), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "no signed evidence receipts") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+	t.Run("consumer failure", func(t *testing.T) {
+		opts := newCompactFixture(t)
+		location := recorder.EvidenceLocation{Root: opts.receiptDir, Dir: opts.receiptDir}
+		fixtureKey, decodeErr := hex.DecodeString(opts.publicKey)
+		if decodeErr != nil {
+			t.Fatal(decodeErr)
+		}
+		_, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", fixtureKey, func(compactStreamFile, []byte, recorder.Entry) error { return errors.New("consumer refused") })
+		if err == nil || !strings.Contains(err.Error(), "consumer refused") {
+			t.Fatalf("stream error=%v", err)
+		}
+	})
+}
+
+func TestCompactOuterVerifierRejectsForeignSession(t *testing.T) {
+	v := compactOuterVerifier{}
+	err := v.add(recorder.Entry{Sequence: 0, SessionID: "other"}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "belongs to") {
+		t.Fatalf("outer verifier error=%v", err)
+	}
+}
+
+func TestCompactOuterVerifierEnforcesChainNamespaceAndOrder(t *testing.T) {
+	entry := func(version int, seq uint64, prev string) recorder.Entry {
+		e := recorder.Entry{Version: version, Sequence: seq, Timestamp: time.Unix(1, 0).UTC(), SessionID: "proxy", Type: "decision", EventKind: "proxy_decision", Transport: "fetch", Summary: "test", Detail: map[string]string{"test": "value"}, PrevHash: prev}
+		if version == 3 {
+			e.ChainKind = recorder.ChainKindRecorder
+			e.WriterInstanceID = "writer-a"
+		}
+		e.Hash = recorder.ComputeHash(e)
+		return e
+	}
+	t.Run("accepts a contiguous legacy chain", func(t *testing.T) {
+		v := compactOuterVerifier{}
+		first := entry(2, 0, recorder.GenesisHash)
+		if err := v.add(first, "proxy"); err != nil {
+			t.Fatal(err)
+		}
+		if err := v.add(entry(2, 1, first.Hash), "proxy"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("rejects namespace transitions", func(t *testing.T) {
+		legacy := entry(2, 0, recorder.GenesisHash)
+		v := compactOuterVerifier{}
+		if err := v.add(legacy, "proxy"); err != nil {
+			t.Fatal(err)
+		}
+		if err := v.add(entry(3, 1, legacy.Hash), "proxy"); err == nil || !strings.Contains(err.Error(), "v3 chain") {
+			t.Fatalf("legacy to v3=%v", err)
+		}
+		v = compactOuterVerifier{}
+		v3 := entry(3, 0, recorder.GenesisHash)
+		if err := v.add(v3, "proxy"); err != nil {
+			t.Fatal(err)
+		}
+		if err := v.add(entry(2, 1, v3.Hash), "proxy"); err == nil || !strings.Contains(err.Error(), "legacy entry") {
+			t.Fatalf("v3 to legacy=%v", err)
+		}
+	})
+	t.Run("rejects namespace, hash, and sequence disagreement", func(t *testing.T) {
+		v := compactOuterVerifier{}
+		first := entry(3, 0, recorder.GenesisHash)
+		if err := v.add(first, "proxy"); err != nil {
+			t.Fatal(err)
+		}
+		other := entry(3, 1, first.Hash)
+		other.WriterInstanceID = "writer-b"
+		other.Hash = recorder.ComputeHash(other)
+		if err := v.add(other, "proxy"); err == nil || !strings.Contains(err.Error(), "namespace changed") {
+			t.Fatalf("namespace=%v", err)
+		}
+		badHash := entry(2, 0, recorder.GenesisHash)
+		badHash.Hash = "not-a-hash"
+		if err := (&compactOuterVerifier{}).add(badHash, "proxy"); err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+			t.Fatalf("hash=%v", err)
+		}
+		badGenesis := entry(2, 1, recorder.GenesisHash)
+		if err := (&compactOuterVerifier{}).add(badGenesis, "proxy"); err == nil || !strings.Contains(err.Error(), "invalid recorder genesis") {
+			t.Fatalf("genesis=%v", err)
+		}
+		v = compactOuterVerifier{}
+		plain := entry(2, 0, recorder.GenesisHash)
+		if err := v.add(plain, "proxy"); err != nil {
+			t.Fatal(err)
+		}
+		if err := v.add(entry(2, 2, plain.Hash), "proxy"); err == nil || !strings.Contains(err.Error(), "sequence or hash chain") {
+			t.Fatalf("sequence=%v", err)
+		}
+	})
+	t.Run("rejects schema-invalid entry before trusting its hash", func(t *testing.T) {
+		invalid := entry(3, 0, recorder.GenesisHash)
+		invalid.WriterInstanceID = ""
+		invalid.Hash = recorder.ComputeHash(invalid)
+		if err := (&compactOuterVerifier{}).add(invalid, "proxy"); err == nil || !strings.Contains(err.Error(), "writer_instance_id") {
+			t.Fatalf("schema error=%v", err)
+		}
+	})
+}
+
+func TestStreamCompactFilesRejectsUnknownRecorderType(t *testing.T) {
+	opts := newCompactFixture(t)
+	path := filepath.Join(opts.receiptDir, "evidence-proxy-0.jsonl")
+	entries, err := recorder.ReadEntries(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknown := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: 1, Timestamp: time.Unix(2, 0).UTC(), SessionID: "proxy", Type: "unrecognized_proof", EventKind: "proxy_decision", Transport: "fetch", Summary: "must not be skipped", Detail: map[string]string{"reason": "test"}, PrevHash: entries[0].Hash}
+	unknown.Hash = recorder.ComputeHash(unknown)
+	line, err := json.Marshal(unknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// #nosec G304 -- test-created evidence shard.
+	if f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0); err != nil {
+		t.Fatal(err)
+	} else {
+		if _, err := f.Write(append(line, '\n')); err != nil {
+			_ = f.Close()
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pub, err := hex.DecodeString(opts.publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: opts.receiptDir, Dir: opts.receiptDir}
+	names, err := compactStreamNames(location, "proxy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := streamCompactFiles(location, names, "proxy", ed25519.PublicKey(pub), func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "unknown recorder entry type") {
+		t.Fatalf("unknown recorder type error = %v", err)
+	}
+}
+
+func TestStreamCompactFilesAcceptsMixedV1AndV2ReceiptFamilies(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1 := receiptForCompactMixedV1(t, priv)
+	v2 := compactSignedReceipt(t, priv, 0, contractreceipt.GenesisHash)
+	outerPrev := recorder.GenesisHash
+	var data bytes.Buffer
+	for i, item := range []struct {
+		typ    string
+		detail any
+	}{{"action_receipt", v1}, {contractreceipt.EvidenceEntryType, v2}} {
+		e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: item.typ, EventKind: "proxy_decision", Transport: "fetch", Summary: item.typ, Detail: item.detail, PrevHash: outerPrev}
+		e.Hash = recorder.ComputeHash(e)
+		outerPrev = e.Hash
+		line, marshalErr := json.Marshal(e)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		data.Write(line)
+		data.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), data.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
+	if _, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err != nil {
+		t.Fatalf("mixed v1/v2 receipt compaction stream: %v", err)
+	}
+}
+
 func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prev string) contractreceipt.EvidenceReceipt {
 	t.Helper()
 	payload, err := json.Marshal(contractreceipt.PayloadShadowDeltaStruct{
@@ -153,133 +846,28 @@ func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, pre
 	return r
 }
 
+func receiptForCompactMixedV1(t *testing.T, priv ed25519.PrivateKey) legacyreceipt.Receipt {
+	t.Helper()
+	r, err := legacyreceipt.Sign(legacyreceipt.ActionRecord{
+		Version:       legacyreceipt.ActionRecordVersion,
+		ActionID:      "compact-mixed-v1",
+		ActionType:    legacyreceipt.ActionRead,
+		Timestamp:     time.Unix(1, 0).UTC(),
+		Target:        "https://api.vendor.example/compact",
+		Verdict:       "allow",
+		Transport:     "fetch",
+		ChainPrevHash: legacyreceipt.GenesisHash,
+		ChainSeq:      0,
+	}, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
 func sha256Bytes(data []byte) []byte {
 	sum := sha256.Sum256(data)
 	return sum[:]
-}
-
-func TestCompactPackPreservesLineBytesAndNamesFirstSequence(t *testing.T) {
-	t.Parallel()
-	first := compactTestLine(t, 4)
-	second := compactTestLine(t, 5)
-	source := []compactShard{{name: "evidence-proxy-4.jsonl", data: append(append([]byte(nil), first...), second...)}}
-	got, err := compactPack("proxy", source)
-	if err != nil {
-		t.Fatalf("compactPack: %v", err)
-	}
-	if len(got) != 1 || got[0].name != "evidence-proxy-4.jsonl" {
-		t.Fatalf("shards = %+v", got)
-	}
-	if !bytes.Equal(got[0].data, source[0].data) {
-		t.Fatalf("compaction altered JSONL bytes\n got %q\nwant %q", got[0].data, source[0].data)
-	}
-}
-
-func TestCompactSourceRefusesNonSelectedEvidence(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	writeDoctorEntries(t, dir, "evidence-proxy-0.jsonl", doctorEntryPlan{{session: "proxy", seq: 0, prev: recorder.GenesisHash}})
-	writeDoctorEntries(t, dir, "evidence-other-0.jsonl", doctorEntryPlan{{session: "other", seq: 0, prev: recorder.GenesisHash}})
-	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-	if err == nil {
-		t.Fatal("compactSource accepted unrelated active evidence")
-	}
-}
-
-func TestCompactSourceRefusesNestedDirectory(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-	if err == nil || !strings.Contains(err.Error(), "refuse nested directory") {
-		t.Fatalf("err = %v", err)
-	}
-}
-
-func TestCompactSourceRefusesShardWithoutTrailingNewline(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	line := compactTestLine(t, 0)
-	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), bytes.TrimSuffix(line, []byte("\n")), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-	if err == nil || !strings.Contains(err.Error(), "does not end in newline") {
-		t.Fatalf("err = %v", err)
-	}
-}
-
-func TestCompactSourceRejectsInputBudgets(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-1.jsonl"), compactTestLine(t, 1), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
-	if _, _, err := compactSourceWithLimits(location, "proxy", 1, maxCompactInputBytes); err == nil || !strings.Contains(err.Error(), "directory exceeds") {
-		t.Fatalf("shard budget err = %v", err)
-	}
-	if _, _, err := compactSourceWithLimits(location, "proxy", maxCompactInputShards, 1); err == nil || !strings.Contains(err.Error(), "input byte limit") {
-		t.Fatalf("byte budget err = %v", err)
-	}
-}
-
-func TestCompactSourceRefusesDuplicateStartSymlinkAndOversize(t *testing.T) {
-	t.Run("duplicate-start", func(t *testing.T) {
-		dir := t.TempDir()
-		line := compactTestLine(t, 0)
-		for _, name := range []string{"evidence-proxy-0.jsonl", "evidence-proxy-000.jsonl"} {
-			if err := os.WriteFile(filepath.Join(dir, name), line, 0o600); err != nil {
-				t.Fatal(err)
-			}
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "ambiguous evidence shard sequence start") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("symlink", func(t *testing.T) {
-		dir := t.TempDir()
-		target := filepath.Join(t.TempDir(), "target.jsonl")
-		if err := os.WriteFile(target, compactTestLine(t, 0), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(target, filepath.Join(dir, "evidence-proxy-0.jsonl")); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "symlink") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("oversize", func(t *testing.T) {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "evidence-proxy-0.jsonl")
-		// #nosec G304 -- path is inside t.TempDir().
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := f.Truncate(recorder.MaxEvidenceReadFileBytes + 1); err != nil {
-			_ = f.Close()
-			t.Fatal(err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err = compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "exceeds") {
-			t.Fatalf("err = %v", err)
-		}
-	})
 }
 
 func TestRunCompactRefusesActiveRecorder(t *testing.T) {
@@ -344,128 +932,6 @@ func TestRunCompactRejectsInvalidInputs(t *testing.T) {
 	}
 }
 
-func TestCompactSourceRejectsMalformedChains(t *testing.T) {
-	t.Parallel()
-	t.Run("empty", func(t *testing.T) {
-		dir := t.TempDir()
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "no evidence shards") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("malformed-json", func(t *testing.T) {
-		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), []byte("{bad}\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "validate") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("wrong-entry-session", func(t *testing.T) {
-		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLineForSession(t, "other", 0), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "belongs to") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("broken-recorder-chain", func(t *testing.T) {
-		dir := t.TempDir()
-		data := append(compactTestLineForSession(t, "proxy", 0), compactTestLineForSession(t, "proxy", 1)...)
-		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), data, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "verify recorder chain") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("no-receipts", func(t *testing.T) {
-		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), compactTestLine(t, 0), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		_, _, err := compactSource(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
-		if err == nil || !strings.Contains(err.Error(), "no evidence receipts") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-}
-
-func compactTestLineForSession(t *testing.T, session string, seq uint64) []byte {
-	t.Helper()
-	e := recorder.Entry{Version: recorder.EntryVersion, Sequence: seq, Timestamp: time.Unix(1, 0).UTC(), SessionID: session, Type: "decision", EventKind: "proxy_decision", Transport: "fetch", Summary: "test", PrevHash: recorder.GenesisHash}
-	e.Hash = recorder.ComputeHash(e)
-	data, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return append(data, '\n')
-}
-
-func TestCompactHelpersRejectInvalidData(t *testing.T) {
-	t.Parallel()
-	t.Run("empty-receipt-chain", func(t *testing.T) {
-		if err := verifyCompactReceipts(nil, make([]byte, ed25519.PublicKeySize)); err == nil {
-			t.Fatal("empty receipt chain verified")
-		}
-	})
-	t.Run("empty-pack", func(t *testing.T) {
-		if _, err := compactPack("proxy", nil); err == nil || !strings.Contains(err.Error(), "no compacted") {
-			t.Fatalf("empty compactPack err = %v", err)
-		}
-	})
-	t.Run("malformed-pack", func(t *testing.T) {
-		if _, err := compactPack("proxy", []compactShard{{data: []byte("{bad}\n")}}); err == nil || !strings.Contains(err.Error(), "parse compacted") {
-			t.Fatalf("malformed compactPack err = %v", err)
-		}
-	})
-	t.Run("wrong-session", func(t *testing.T) {
-		wrong := compactTestLineForSession(t, "other", 0)
-		if _, err := compactPack("proxy", []compactShard{{data: wrong}}); err == nil || !strings.Contains(err.Error(), "does not match") {
-			t.Fatalf("wrong-session compactPack err = %v", err)
-		}
-	})
-	t.Run("oversized-stage", func(t *testing.T) {
-		oversize := compactShard{name: "evidence-proxy-0.jsonl", data: make([]byte, recorder.MaxEvidenceReadFileBytes+1)}
-		if err := writeCompactStage(t.TempDir(), []compactShard{oversize}); err == nil || !strings.Contains(err.Error(), "exceeds") {
-			t.Fatalf("oversize write err = %v", err)
-		}
-	})
-}
-
-func TestCompactManifestMappingsAndReceiptEquality(t *testing.T) {
-	t.Parallel()
-	shards := []compactShard{{name: "one", data: []byte("abc"), mappings: []compactByteMapping{{Source: "old", Output: "one", Bytes: 3}}}}
-	manifest := manifestShards(shards)
-	if len(manifest) != 1 || manifest[0].Name != "one" || manifest[0].Bytes != 3 || manifest[0].SHA256 == "" {
-		t.Fatalf("manifest = %+v", manifest)
-	}
-	if mappings := compactMappings(shards); len(mappings) != 1 || mappings[0].Bytes != 3 {
-		t.Fatalf("mappings = %+v", mappings)
-	}
-	dir := t.TempDir()
-	if err := writeCompactManifest(dir, compactManifest{Version: 1, SessionID: "proxy"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, "compaction-manifest.json")); err != nil {
-		t.Fatal(err)
-	}
-	if !sameReceiptChain(nil, nil) {
-		t.Fatal("equal empty chains differ")
-	}
-	if sameReceiptChain(nil, []contractreceipt.EvidenceReceipt{{}}) {
-		t.Fatal("different-length chains compare equal")
-	}
-	if sameReceiptChain([]contractreceipt.EvidenceReceipt{{}}, []contractreceipt.EvidenceReceipt{{Actor: "different"}}) {
-		t.Fatal("different receipts compare equal")
-	}
-}
-
 func TestRunCompactPropagatesEmptySource(t *testing.T) {
 	t.Parallel()
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
@@ -477,76 +943,6 @@ func TestRunCompactPropagatesEmptySource(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no evidence shards") {
 		t.Fatalf("err = %v", err)
 	}
-}
-
-func TestCompactFileAndRollbackHelpers(t *testing.T) {
-	if !supportsCompactExchangeTest() {
-		t.Skip("atomic evidence directory exchange is unsupported")
-	}
-	t.Run("write-stage", func(t *testing.T) {
-		sourceDir := t.TempDir()
-		stage := t.TempDir()
-		source := filepath.Join(sourceDir, "source.jsonl")
-		if err := os.WriteFile(source, []byte("source\n"), 0o400); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chmod(source, 0o400); err != nil {
-			t.Fatal(err)
-		}
-		shard := compactShard{name: "evidence-proxy-0.jsonl", data: []byte("replacement\n"), sourcePath: source}
-		if err := writeCompactStage(stage, []compactShard{shard}); err != nil {
-			t.Fatal(err)
-		}
-		info, err := os.Stat(filepath.Join(stage, shard.name))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if info.Mode().Perm() != 0o400 {
-			t.Fatalf("mode = %o", info.Mode().Perm())
-		}
-	})
-	t.Run("write-stage-missing-source", func(t *testing.T) {
-		err := writeCompactStage(t.TempDir(), []compactShard{{name: "evidence-proxy-0.jsonl", data: []byte("x\n"), sourcePath: filepath.Join(t.TempDir(), "missing")}})
-		if err == nil || !strings.Contains(err.Error(), "preserve compacted shard metadata") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("write-stage-missing-dir", func(t *testing.T) {
-		err := writeCompactStage(filepath.Join(t.TempDir(), "missing"), []compactShard{{name: "evidence-proxy-0.jsonl", data: []byte("x\n")}})
-		if err == nil || !strings.Contains(err.Error(), "write compacted shard") {
-			t.Fatalf("err = %v", err)
-		}
-	})
-	t.Run("rollback", func(t *testing.T) {
-		parent := t.TempDir()
-		active := filepath.Join(parent, "active")
-		old := filepath.Join(parent, "old")
-		if err := os.Mkdir(active, 0o750); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Mkdir(old, 0o750); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(active, "replacement"), []byte("new"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(old, "original"), []byte("old"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(old, "compaction-manifest.json"), []byte("{}\n"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-		cause := errors.New("publication failed")
-		if err := rollbackCompactExchange(active, old, cause); !errors.Is(err, cause) {
-			t.Fatalf("rollback err = %v", err)
-		}
-		if _, err := os.Stat(filepath.Join(active, "original")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := os.Stat(old); !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("old directory remains: %v", err)
-		}
-	})
 }
 
 func TestCompactLinuxHelpers(t *testing.T) {
@@ -612,16 +1008,6 @@ func TestCompactLinuxHelpers(t *testing.T) {
 	})
 }
 
-func TestCompactPackRejectsOversizedLine(t *testing.T) {
-	t.Parallel()
-	data := make([]byte, recorder.MaxEvidenceReadFileBytes+1)
-	data[len(data)-1] = '\n'
-	_, err := compactPack("proxy", []compactShard{{data: data}})
-	if err == nil || !strings.Contains(err.Error(), "single JSONL line exceeds") {
-		t.Fatalf("err = %v", err)
-	}
-}
-
 func TestWriteCompactManifestRejectsMissingDirectory(t *testing.T) {
 	t.Parallel()
 	err := writeCompactManifest(filepath.Join(t.TempDir(), "missing"), compactManifest{Version: 1})
@@ -638,59 +1024,30 @@ func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
 		name   string
 		inject func()
 	}{
-		{name: "pre-verify", inject: func() {
-			compactVerify = func([]contractreceipt.EvidenceReceipt, []byte) error { return errors.New("injected verify") }
-		}},
-		{name: "pack", inject: func() {
-			compactPackRecords = func(string, []compactShard) ([]compactShard, error) { return nil, errors.New("injected pack") }
+		{name: "stream-source", inject: func() {
+			compactStreamStage = func(recorder.EvidenceLocation, []string, string, ed25519.PublicKey, string) (*compactStreamWriter, compactStreamProof, error) {
+				return nil, compactStreamProof{}, errors.New("injected stream source")
+			}
 		}},
 		{name: "too-many-shards", inject: func() {
-			compactPackRecords = func(string, []compactShard) ([]compactShard, error) {
-				return make([]compactShard, recorder.MaxEvidenceReadDirectoryEntries+1), nil
+			compactStreamStage = func(_ recorder.EvidenceLocation, _ []string, _ string, _ ed25519.PublicKey, dir string) (*compactStreamWriter, compactStreamProof, error) {
+				return &compactStreamWriter{files: make([]compactStreamFile, recorder.MaxEvidenceReadDirectoryEntries+1), dir: dir}, compactStreamProof{}, nil
 			}
 		}},
 		{name: "make-stage", inject: func() {
 			compactMakeStage = func(string, string) (string, error) { return "", errors.New("injected mkdir") }
 		}},
 		{name: "prepare-stage", inject: func() { compactPrepareStage = func(string, string) error { return errors.New("injected prepare") } }},
-		{name: "write-stage", inject: func() {
-			compactWriteShards = func(string, []compactShard) error { return errors.New("injected write") }
-		}},
-		{name: "corrupt-staged-recorder", inject: func() {
-			compactWriteShards = func(dir string, shards []compactShard) error {
-				if err := writeCompactStage(dir, shards); err != nil {
-					return err
-				}
-				var entry recorder.Entry
-				if err := json.Unmarshal(bytes.TrimSpace(shards[0].data), &entry); err != nil {
-					return err
-				}
-				entry.Summary = "changed without updating recorder hash"
-				data, err := json.Marshal(entry)
-				if err != nil {
-					return err
-				}
-				return os.WriteFile(filepath.Join(dir, shards[0].name), append(data, '\n'), 0o600)
-			}
-		}},
 		{name: "sync-stage", inject: func() { compactSyncPath = func(string) error { return errors.New("injected sync") } }},
-		{name: "extract-stage", inject: func() {
-			compactExtract = func(recorder.EvidenceLocation, string) ([]contractreceipt.EvidenceReceipt, error) {
-				return nil, errors.New("injected extract")
-			}
-		}},
-		{name: "post-verify", inject: func() {
+		{name: "post-proof", inject: func() {
 			calls := 0
-			compactVerify = func(receipts []contractreceipt.EvidenceReceipt, key []byte) error {
+			compactVerifyStream = func(location recorder.EvidenceLocation, names []string, session string, key ed25519.PublicKey, consume func(compactStreamFile, []byte, recorder.Entry) error) (compactStreamProof, error) {
 				calls++
-				if calls == 2 {
-					return errors.New("injected post verify")
+				if calls == 1 {
+					return compactStreamProof{}, errors.New("injected post proof")
 				}
-				return verifyCompactReceipts(receipts, key)
+				return streamCompactFiles(location, names, session, key, consume)
 			}
-		}},
-		{name: "chain-mismatch", inject: func() {
-			compactSameChain = func([]contractreceipt.EvidenceReceipt, []contractreceipt.EvidenceReceipt) bool { return false }
 		}},
 		{name: "stage-lock", inject: func() {
 			calls := 0
@@ -737,7 +1094,7 @@ func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
 			if err == nil {
 				t.Fatal("runCompact succeeded across injected ceremony failure")
 			}
-			if tc.name != "too-many-shards" && tc.name != "chain-mismatch" && tc.name != "corrupt-staged-recorder" {
+			if tc.name != "too-many-shards" {
 				if !strings.Contains(err.Error(), "injected") {
 					t.Fatalf("%s failed for the wrong reason: %v", tc.name, err)
 				}
@@ -763,16 +1120,82 @@ func TestRunCompactFailClosedAtCeremonyBoundaries(t *testing.T) {
 	}
 }
 
-func TestSameCompactBytes(t *testing.T) {
-	t.Parallel()
-	a := []compactShard{{data: []byte("one\n")}, {data: []byte("two\n")}}
-	b := []compactShard{{data: []byte("one\ntwo\n")}}
-	if !sameCompactBytes(a, b) {
-		t.Fatal("same byte stream differs across shard boundaries")
+func TestRunCompactRejectsStagingAndSourceIdentityDisagreement(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence compaction requires Linux rename exchange")
 	}
-	b[0].data[0] = 'X'
-	if sameCompactBytes(a, b) {
-		t.Fatal("different byte streams compare equal")
+	for _, tc := range []struct {
+		name   string
+		inject func(t *testing.T, opts compactOptions)
+		want   string
+	}{
+		{
+			name: "stage has no selected shards",
+			inject: func(t *testing.T, _ compactOptions) {
+				compactStreamStage = func(_ recorder.EvidenceLocation, _ []string, _ string, _ ed25519.PublicKey, dir string) (*compactStreamWriter, compactStreamProof, error) {
+					return &compactStreamWriter{dir: dir, files: []compactStreamFile{{name: "expected-output"}}}, compactStreamProof{}, nil
+				}
+			},
+			want: "list staged evidence",
+		},
+		{
+			name: "staged proof differs from source",
+			inject: func(t *testing.T, _ compactOptions) {
+				compactVerifyStream = func(location recorder.EvidenceLocation, names []string, session string, key ed25519.PublicKey, consume func(compactStreamFile, []byte, recorder.Entry) error) (compactStreamProof, error) {
+					proof, err := streamCompactFiles(location, names, session, key, consume)
+					if err == nil {
+						proof.sum = "different"
+					}
+					return proof, err
+				}
+			},
+			want: "changed original JSONL bytes",
+		},
+		{
+			name: "source names change after recheck",
+			inject: func(t *testing.T, opts compactOptions) {
+				calls := 0
+				compactVerifyStream = func(location recorder.EvidenceLocation, names []string, session string, key ed25519.PublicKey, consume func(compactStreamFile, []byte, recorder.Entry) error) (compactStreamProof, error) {
+					proof, err := streamCompactFiles(location, names, session, key, consume)
+					calls++
+					if err == nil && calls == 2 {
+						if writeErr := os.WriteFile(filepath.Join(opts.receiptDir, "evidence-proxy-1.jsonl"), []byte("not read until the next ceremony\n"), 0o600); writeErr != nil {
+							t.Fatal(writeErr)
+						}
+					}
+					return proof, err
+				}
+			},
+			want: "source shard name set changed",
+		},
+		{
+			name: "source proof changes after staging",
+			inject: func(t *testing.T, _ compactOptions) {
+				calls := 0
+				compactVerifyStream = func(location recorder.EvidenceLocation, names []string, session string, key ed25519.PublicKey, consume func(compactStreamFile, []byte, recorder.Entry) error) (compactStreamProof, error) {
+					proof, err := streamCompactFiles(location, names, session, key, consume)
+					calls++
+					if err == nil && calls == 2 {
+						proof.sum = "changed-after-stage"
+					}
+					return proof, err
+				}
+			},
+			want: "source digest changed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreCompactHooks(t)
+			opts := newCompactFixture(t)
+			tc.inject(t, opts)
+			err := runCompact(compactCmd(), opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("runCompact error=%v, want %q", err, tc.want)
+			}
+			if _, statErr := os.Stat(filepath.Join(opts.receiptDir, "evidence-proxy-0.jsonl")); statErr != nil {
+				t.Fatalf("active source was not retained: %v", statErr)
+			}
+		})
 	}
 }
 
@@ -807,30 +1230,24 @@ func TestRunCompactDetectsSourceMutationBeforeExchange(t *testing.T) {
 func restoreCompactHooks(t *testing.T) {
 	t.Helper()
 	compactAcquireLock = recorder.AcquireEvidenceCeremonyLock
-	compactPackRecords = compactPack
 	compactMakeStage = os.MkdirTemp
 	compactPrepareStage = prepareCompactStage
-	compactWriteShards = writeCompactStage
 	compactSyncPath = syncCompactDirectory
-	compactExtract = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
-	compactVerify = verifyCompactReceipts
-	compactSameChain = sameReceiptChain
 	compactExchange = exchangeEvidenceDirectories
 	compactRename = os.Rename
 	compactWriteManifest = writeCompactManifest
+	compactStreamStage = streamCompactToStage
+	compactVerifyStream = streamCompactFiles
 	t.Cleanup(func() {
 		compactAcquireLock = recorder.AcquireEvidenceCeremonyLock
-		compactPackRecords = compactPack
 		compactMakeStage = os.MkdirTemp
 		compactPrepareStage = prepareCompactStage
-		compactWriteShards = writeCompactStage
 		compactSyncPath = syncCompactDirectory
-		compactExtract = contractreceipt.ExtractEvidenceReceiptsFromResolvedSessionDir
-		compactVerify = verifyCompactReceipts
-		compactSameChain = sameReceiptChain
 		compactExchange = exchangeEvidenceDirectories
 		compactRename = os.Rename
 		compactWriteManifest = writeCompactManifest
+		compactStreamStage = streamCompactToStage
+		compactVerifyStream = streamCompactFiles
 	})
 }
 

--- a/internal/contract/inference/compile/compile.go
+++ b/internal/contract/inference/compile/compile.go
@@ -145,6 +145,13 @@ func Compile(in CompileInput, opts CompileOptions) (CompileResult, error) {
 	if fatal != nil {
 		return CompileResult{}, fmt.Errorf("%w: %w", ErrIngestFailed, fatal)
 	}
+	if len(ingErrors) != 0 {
+		// A signed contract must represent the complete supplied evidence
+		// stream. Treating malformed tails as merely diagnostic would sign a
+		// valid-looking prefix after silently dropping the evidence most likely
+		// to change the inferred policy.
+		return CompileResult{}, fmt.Errorf("%w: %w", ErrIngestFailed, ingErrors[0])
+	}
 
 	c, stats, err := inferContract(aggs, in.Config)
 	if err != nil {

--- a/internal/contract/inference/compile/compile_test.go
+++ b/internal/contract/inference/compile/compile_test.go
@@ -102,6 +102,18 @@ func TestCompile_FatalIngestError(t *testing.T) {
 	}
 }
 
+func TestCompileRefusesMalformedTailInsteadOfSigningPrefix(t *testing.T) {
+	t.Parallel()
+	input := fixtureJSONL(t) + "{not-json}\n"
+	_, err := Compile(CompileInput{
+		Stream: strings.NewReader(input),
+		Config: testConfig(),
+	}, CompileOptions{Deterministic: true, Signer: newTestSigner()})
+	if !errors.Is(err, ErrIngestFailed) {
+		t.Fatalf("Compile error = %v, want ErrIngestFailed", err)
+	}
+}
+
 func TestCompile_ObservationWindowRootMarshalError(t *testing.T) {
 	oldMarshal := observationWindowMarshal
 	t.Cleanup(func() { observationWindowMarshal = oldMarshal })

--- a/internal/contract/inference/ingest/ingest.go
+++ b/internal/contract/inference/ingest/ingest.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -156,55 +155,8 @@ func (s streamState) run(input io.Reader, entries chan<- Entry, errs chan<- erro
 	}
 }
 
-type rawRecorderEntry struct {
-	Version          int             `json:"v"`
-	Sequence         uint64          `json:"seq"`
-	Timestamp        time.Time       `json:"ts"`
-	SessionID        string          `json:"session_id"`
-	ChainKind        string          `json:"chain_kind,omitempty"`
-	WriterInstanceID string          `json:"writer_instance_id,omitempty"`
-	TraceID          string          `json:"trace_id,omitempty"`
-	Type             string          `json:"type"`
-	EventKind        string          `json:"event_kind,omitempty"`
-	Transport        string          `json:"transport"`
-	Summary          string          `json:"summary"`
-	Detail           json.RawMessage `json:"detail"`
-	RawRef           string          `json:"raw_ref,omitempty"`
-	PrevHash         string          `json:"prev_hash"`
-	Hash             string          `json:"hash"`
-}
-
 func parseRecorderEntry(line []byte) (recorder.Entry, error) {
-	var raw rawRecorderEntry
-	if err := json.Unmarshal(line, &raw); err != nil {
-		return recorder.Entry{}, err
-	}
-	if err := recorder.ValidateEntryJSONSchema(line, raw.Version); err != nil {
-		return recorder.Entry{}, err
-	}
-
-	detail := json.RawMessage("null")
-	if raw.Detail != nil && string(raw.Detail) != "null" {
-		detail = append(json.RawMessage(nil), raw.Detail...)
-	}
-
-	return recorder.Entry{
-		Version:          raw.Version,
-		Sequence:         raw.Sequence,
-		Timestamp:        raw.Timestamp,
-		SessionID:        raw.SessionID,
-		ChainKind:        raw.ChainKind,
-		WriterInstanceID: raw.WriterInstanceID,
-		TraceID:          raw.TraceID,
-		Type:             raw.Type,
-		EventKind:        raw.EventKind,
-		Transport:        raw.Transport,
-		Summary:          raw.Summary,
-		Detail:           detail,
-		RawRef:           raw.RawRef,
-		PrevHash:         raw.PrevHash,
-		Hash:             raw.Hash,
-	}, nil
+	return recorder.ParseEntryLine(line)
 }
 
 func (s streamState) verifyRecorderEntry(rec recorder.Entry, lineNo int, previousHash string, seenEntry bool) error {
@@ -265,7 +217,7 @@ func typedEntry(rec recorder.Entry) (Entry, error) {
 	}
 
 	var summary capture.CaptureSummary
-	raw, err := asRawMessage(rec.Detail)
+	raw, err := recorderEntryDetailBytes(rec)
 	if err != nil {
 		return Entry{}, fmt.Errorf("marshal capture detail: %w", err)
 	}
@@ -282,6 +234,13 @@ func typedEntry(rec recorder.Entry) (Entry, error) {
 
 	entry.Capture = &summary
 	return entry, nil
+}
+
+func recorderEntryDetailBytes(rec recorder.Entry) (json.RawMessage, error) {
+	if len(rec.RawDetail) > 0 {
+		return append(json.RawMessage(nil), rec.RawDetail...), nil
+	}
+	return asRawMessage(rec.Detail)
 }
 
 func asRawMessage(detail any) (json.RawMessage, error) {

--- a/internal/contract/inference/ingest/ingest_test.go
+++ b/internal/contract/inference/ingest/ingest_test.go
@@ -80,6 +80,33 @@ func TestParseRecorderEntryRejectsExplicitNullV3ProjectedField(t *testing.T) {
 	}
 }
 
+func TestParseRecorderEntrySharesRecorderDuplicateAndRawDetailRules(t *testing.T) {
+	rec := testEntry(t, recorder.EntryVersion, 0, recorder.GenesisHash, "checkpoint", map[string]any{"a": float64(1), "z": float64(2)})
+	rawDetail := json.RawMessage(`{"z":2,"a":1}`)
+	rec.RawDetail = rawDetail
+	rec.Hash = recorder.ComputeHash(rec)
+	wire, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := json.Marshal(rec.Detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire = bytes.Replace(wire, canonical, rawDetail, 1)
+	parsed, err := parseRecorderEntry(wire)
+	if err != nil {
+		t.Fatalf("parse noncanonical detail: %v", err)
+	}
+	if !bytes.Equal(parsed.RawDetail, rawDetail) || recorder.ComputeHash(parsed) != rec.Hash {
+		t.Fatalf("parsed entry lost hash-bound detail bytes: raw=%s hash=%s", parsed.RawDetail, recorder.ComputeHash(parsed))
+	}
+	duplicate := bytes.Replace(wire, []byte(`"transport":"test"`), []byte(`"transport":"test","transport":"evil"`), 1)
+	if _, err := parseRecorderEntry(duplicate); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate-key entry error = %v", err)
+	}
+}
+
 func TestStreamExplicitNullDetailHashesAsNull(t *testing.T) {
 	rec := recorder.Entry{
 		Version:   recorder.EntryVersion,

--- a/internal/contract/receipt/chain.go
+++ b/internal/contract/receipt/chain.go
@@ -235,6 +235,81 @@ func VerifyChain(receipts []EvidenceReceipt, opts ChainVerifyOptions) ChainResul
 	}
 }
 
+// StreamingVerifier verifies the pinned-key compaction profile without
+// retaining all receipts. It intentionally accepts no optional expectation
+// bindings: a maintenance caller must not mistake this narrow API for a full
+// ChainVerifyOptions implementation.
+type StreamingVerifier struct {
+	key      ed25519.PublicKey
+	count    uint64
+	signerID string
+	prevHash string
+	lastSeq  uint64
+	fail     *ChainResult
+}
+
+func NewPinnedStreamingVerifier(key ed25519.PublicKey) (*StreamingVerifier, error) {
+	if len(key) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("pinned streaming verifier requires Ed25519 public key")
+	}
+	return &StreamingVerifier{key: key, prevHash: GenesisHash}, nil
+}
+
+// AddRaw verifies exact v2 wire bytes before advancing the receipt chain.
+func (v *StreamingVerifier) AddRaw(raw []byte) error {
+	if v.fail != nil {
+		return fmt.Errorf("%s", v.fail.Error)
+	}
+	var r EvidenceReceipt
+	if err := jsonscan.RejectDuplicateKeys(raw); err != nil {
+		return v.latch(brokenChain(v.count, "receipt %d duplicate keys: %v", v.count, err))
+	}
+	if err := contract.DecodeStrictJSON(raw, &r); err != nil {
+		return v.latch(brokenChain(v.count, "receipt %d decode: %v", v.count, err))
+	}
+	seq := v.count
+	if err := VerifyWithKey(r, v.key, r.Signature.SignerKeyID); err != nil {
+		res := brokenChain(seq, "receipt %d signature: %v", seq, err)
+		v.fail = &res
+		return fmt.Errorf("%s", res.Error)
+	}
+	if v.count == 0 {
+		v.signerID = r.Signature.SignerKeyID
+	} else if r.Signature.SignerKeyID != v.signerID {
+		res := brokenChain(seq, "receipt %d signer_key_id %q breaks chain signer %q", seq, r.Signature.SignerKeyID, v.signerID)
+		v.fail = &res
+		return fmt.Errorf("%s", res.Error)
+	}
+	if r.ChainSeq != seq || r.ChainPrevHash != v.prevHash {
+		res := brokenChain(seq, "receipt %d chain sequence or previous hash mismatch", seq)
+		v.fail = &res
+		return fmt.Errorf("%s", res.Error)
+	}
+	h, err := ReceiptHash(r)
+	if err != nil {
+		res := brokenChain(seq, "receipt %d hash: %v", seq, err)
+		v.fail = &res
+		return fmt.Errorf("%s", res.Error)
+	}
+	v.prevHash, v.lastSeq, v.count = h, r.ChainSeq, v.count+1
+	return nil
+}
+
+func (v *StreamingVerifier) latch(res ChainResult) error {
+	v.fail = &res
+	return fmt.Errorf("%s", res.Error)
+}
+
+func (v *StreamingVerifier) Finish() ChainResult {
+	if v.fail != nil {
+		return *v.fail
+	}
+	if v.count == 0 {
+		return ChainResult{Valid: false, Error: "empty chain"}
+	}
+	return ChainResult{Valid: true, ReceiptCount: v.count, FinalSeq: v.lastSeq, RootHash: v.prevHash, SignaturesVerified: true, SignerKeyID: v.signerID}
+}
+
 // recorderLine is the minimal recorder Entry shape needed to recover an
 // embedded v2 receipt. Non-evidence entries carry other Detail shapes and
 // are skipped by type.
@@ -338,6 +413,39 @@ func ExtractEvidenceReceiptsFromResolvedSessionDir(location recorder.EvidenceLoc
 		if readErr != nil {
 			return nil, fmt.Errorf("read %s: %w", filepath.Base(file), readErr)
 		}
+	}
+	return out, nil
+}
+
+// ExtractEvidenceReceiptsFromEntries extracts signed receipts from recorder
+// entries that have already passed recorder parsing. It uses RawDetail when
+// present so receipt verification consumes the immutable wire bytes rather
+// than a re-marshaled approximation.
+func ExtractEvidenceReceiptsFromEntries(entries []recorder.Entry) ([]EvidenceReceipt, error) {
+	out := make([]EvidenceReceipt, 0)
+	for i, entry := range entries {
+		if entry.Type != EvidenceEntryType {
+			if knownRecorderEntryType(entry.Type) {
+				continue
+			}
+			return nil, fmt.Errorf("parsed recorder entry %d: unexpected recorder entry type %q", i+1, entry.Type)
+		}
+		detail := entry.RawDetail
+		if len(detail) == 0 {
+			var err error
+			detail, err = json.Marshal(entry.Detail)
+			if err != nil {
+				return nil, fmt.Errorf("parsed recorder entry %d: marshal evidence detail: %w", i+1, err)
+			}
+		}
+		if len(detail) == 0 || string(bytes.TrimSpace(detail)) == "null" {
+			return nil, fmt.Errorf("parsed recorder entry %d: evidence entry has empty detail", i+1)
+		}
+		var receipt EvidenceReceipt
+		if err := contract.DecodeStrictJSON(detail, &receipt); err != nil {
+			return nil, fmt.Errorf("parsed recorder entry %d: decode evidence receipt: %w", i+1, err)
+		}
+		out = append(out, receipt)
 	}
 	return out, nil
 }

--- a/internal/contract/receipt/chain.go
+++ b/internal/contract/receipt/chain.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -269,27 +270,19 @@ func (v *StreamingVerifier) AddRaw(raw []byte) error {
 	}
 	seq := v.count
 	if err := VerifyWithKey(r, v.key, r.Signature.SignerKeyID); err != nil {
-		res := brokenChain(seq, "receipt %d signature: %v", seq, err)
-		v.fail = &res
-		return fmt.Errorf("%s", res.Error)
+		return v.latch(brokenChain(seq, "receipt %d signature: %v", seq, err))
 	}
 	if v.count == 0 {
 		v.signerID = r.Signature.SignerKeyID
 	} else if r.Signature.SignerKeyID != v.signerID {
-		res := brokenChain(seq, "receipt %d signer_key_id %q breaks chain signer %q", seq, r.Signature.SignerKeyID, v.signerID)
-		v.fail = &res
-		return fmt.Errorf("%s", res.Error)
+		return v.latch(brokenChain(seq, "receipt %d signer_key_id %q breaks chain signer %q", seq, r.Signature.SignerKeyID, v.signerID))
 	}
 	if r.ChainSeq != seq || r.ChainPrevHash != v.prevHash {
-		res := brokenChain(seq, "receipt %d chain sequence or previous hash mismatch", seq)
-		v.fail = &res
-		return fmt.Errorf("%s", res.Error)
+		return v.latch(brokenChain(seq, "receipt %d chain sequence or previous hash mismatch", seq))
 	}
 	h, err := ReceiptHash(r)
 	if err != nil {
-		res := brokenChain(seq, "receipt %d hash: %v", seq, err)
-		v.fail = &res
-		return fmt.Errorf("%s", res.Error)
+		return v.latch(brokenChain(seq, "receipt %d hash: %v", seq, err))
 	}
 	v.prevHash, v.lastSeq, v.count = h, r.ChainSeq, v.count+1
 	return nil
@@ -438,12 +431,9 @@ func ExtractEvidenceReceiptsFromEntries(entries []recorder.Entry) ([]EvidenceRec
 				return nil, fmt.Errorf("parsed recorder entry %d: marshal evidence detail: %w", i+1, err)
 			}
 		}
-		if len(detail) == 0 || string(bytes.TrimSpace(detail)) == "null" {
-			return nil, fmt.Errorf("parsed recorder entry %d: evidence entry has empty detail", i+1)
-		}
-		var receipt EvidenceReceipt
-		if err := contract.DecodeStrictJSON(detail, &receipt); err != nil {
-			return nil, fmt.Errorf("parsed recorder entry %d: decode evidence receipt: %w", i+1, err)
+		receipt, err := decodeEvidenceReceiptDetail(detail)
+		if err != nil {
+			return nil, fmt.Errorf("parsed recorder entry %d: %w", i+1, err)
 		}
 		out = append(out, receipt)
 	}
@@ -474,15 +464,9 @@ func extractEvidenceReceiptsFromBytes(data []byte, label string) ([]EvidenceRece
 			}
 			return nil, fmt.Errorf("%s line %d: unexpected recorder entry type %q", label, line, entry.Type)
 		}
-		// json.RawMessage("null") is non-nil and 4 bytes long, so a length
-		// check alone would let a null detail unmarshal to a zero receipt
-		// silently. Reject both empty and literal null.
-		if len(entry.Detail) == 0 || string(bytes.TrimSpace(entry.Detail)) == "null" {
-			return nil, fmt.Errorf("%s line %d: evidence entry has empty detail", label, line)
-		}
-		var r EvidenceReceipt
-		if err := contract.DecodeStrictJSON(entry.Detail, &r); err != nil {
-			return nil, fmt.Errorf("%s line %d: decode evidence receipt: %w", label, line, err)
+		r, err := decodeEvidenceReceiptDetail(entry.Detail)
+		if err != nil {
+			return nil, fmt.Errorf("%s line %d: %w", label, line, err)
 		}
 		out = append(out, r)
 	}
@@ -490,6 +474,20 @@ func extractEvidenceReceiptsFromBytes(data []byte, label string) ([]EvidenceRece
 		return nil, fmt.Errorf("scan evidence file %s: %w", label, err)
 	}
 	return out, nil
+}
+
+// decodeEvidenceReceiptDetail decodes the hash-bound detail value used by
+// both raw JSONL and recorder-parsed extraction. json.RawMessage("null") is
+// non-empty, so explicitly reject it rather than accepting a zero receipt.
+func decodeEvidenceReceiptDetail(detail []byte) (EvidenceReceipt, error) {
+	if len(detail) == 0 || string(bytes.TrimSpace(detail)) == "null" {
+		return EvidenceReceipt{}, errors.New("evidence entry has empty detail")
+	}
+	var receipt EvidenceReceipt
+	if err := contract.DecodeStrictJSON(detail, &receipt); err != nil {
+		return EvidenceReceipt{}, fmt.Errorf("decode evidence receipt: %w", err)
+	}
+	return receipt, nil
 }
 
 // parseEvidenceName splits an evidence shard filename into its session ID and

--- a/internal/contract/receipt/chain_test.go
+++ b/internal/contract/receipt/chain_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
 const (
@@ -98,6 +100,118 @@ func buildChain(t *testing.T, priv ed25519.PrivateKey, n int) []receipt.Evidence
 		prev = h
 	}
 	return chain
+}
+
+func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
+	if _, err := receipt.NewPinnedStreamingVerifier(ed25519.PublicKey{1}); err == nil {
+		t.Fatal("short pinned key accepted")
+	}
+	priv, pub := testKey(t, 9)
+	marshal := func(t *testing.T, r receipt.EvidenceReceipt) []byte {
+		t.Helper()
+		data, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	t.Run("valid chain reaches a signed head", func(t *testing.T) {
+		v, err := receipt.NewPinnedStreamingVerifier(pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		chain := buildChain(t, priv, 2)
+		for _, r := range chain {
+			if err := v.AddRaw(marshal(t, r)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		result := v.Finish()
+		if !result.Valid || !result.SignaturesVerified || result.ReceiptCount != 2 {
+			t.Fatalf("result=%+v", result)
+		}
+	})
+	t.Run("decode failure latches", func(t *testing.T) {
+		v, err := receipt.NewPinnedStreamingVerifier(pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := v.AddRaw([]byte("[]")); err == nil {
+			t.Fatal("malformed receipt accepted")
+		}
+		if err := v.AddRaw([]byte("{}")); err == nil {
+			t.Fatal("latched verifier accepted another receipt")
+		}
+		if v.Finish().Valid {
+			t.Fatal("latched verifier finished valid")
+		}
+	})
+	t.Run("empty verifier is not proof", func(t *testing.T) {
+		v, err := receipt.NewPinnedStreamingVerifier(pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := v.Finish(); got.Valid || got.Error != "empty chain" {
+			t.Fatalf("empty Finish=%+v", got)
+		}
+	})
+	t.Run("signature signer and chain disagreement deny", func(t *testing.T) {
+		v, _ := receipt.NewPinnedStreamingVerifier(pub)
+		badSig := unsignedReceipt(t, testSignerID, 0, receipt.GenesisHash)
+		badSig = signReceipt(t, badSig, priv)
+		badSig.Actor = "tampered"
+		if err := v.AddRaw(marshal(t, badSig)); err == nil || !strings.Contains(err.Error(), "signature") {
+			t.Fatalf("signature error=%v", err)
+		}
+		v, _ = receipt.NewPinnedStreamingVerifier(pub)
+		first := buildChain(t, priv, 1)[0]
+		if err := v.AddRaw(marshal(t, first)); err != nil {
+			t.Fatal(err)
+		}
+		prev, err := receipt.ReceiptHash(first)
+		if err != nil {
+			t.Fatal(err)
+		}
+		other := signReceipt(t, unsignedReceipt(t, "other-signer", 1, prev), priv)
+		if err := v.AddRaw(marshal(t, other)); err == nil || !strings.Contains(err.Error(), "signer_key_id") {
+			t.Fatalf("signer error=%v", err)
+		}
+		v, _ = receipt.NewPinnedStreamingVerifier(pub)
+		wrongSeq := signReceipt(t, unsignedReceipt(t, testSignerID, 1, receipt.GenesisHash), priv)
+		if err := v.AddRaw(marshal(t, wrongSeq)); err == nil || !strings.Contains(err.Error(), "sequence") {
+			t.Fatalf("sequence error=%v", err)
+		}
+	})
+}
+
+func TestExtractEvidenceReceiptsFromEntriesUsesWireDetailAndRejectsUnknown(t *testing.T) {
+	priv, _ := testKey(t, 10)
+	valid := signReceipt(t, unsignedReceipt(t, testSignerID, 0, receipt.GenesisHash), priv)
+	raw, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := []recorder.Entry{
+		{Type: "decision"},
+		{Type: receipt.EvidenceEntryType, RawDetail: raw, Detail: map[string]string{"wrong": "shape"}},
+		{Type: receipt.EvidenceEntryType, Detail: valid},
+	}
+	got, err := receipt.ExtractEvidenceReceiptsFromEntries(entries)
+	if err != nil || len(got) != 2 {
+		t.Fatalf("extract entries=%d err=%v", len(got), err)
+	}
+	if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{{Type: "unknown"}}); err == nil || !strings.Contains(err.Error(), "unexpected recorder entry type") {
+		t.Fatalf("unknown entry error=%v", err)
+	}
+	if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{{Type: receipt.EvidenceEntryType, Detail: math.Inf(1)}}); err == nil || !strings.Contains(err.Error(), "marshal evidence detail") {
+		t.Fatalf("unmarshalable detail error=%v", err)
+	}
+	if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{{Type: receipt.EvidenceEntryType}}); err == nil || !strings.Contains(err.Error(), "empty detail") {
+		t.Fatalf("empty detail error=%v", err)
+	}
+	if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{{Type: receipt.EvidenceEntryType, RawDetail: []byte("[]")}}); err == nil || !strings.Contains(err.Error(), "decode evidence receipt") {
+		t.Fatalf("decode detail error=%v", err)
+	}
 }
 
 func testKey(t *testing.T, seedByte byte) (ed25519.PrivateKey, ed25519.PublicKey) {

--- a/internal/contract/receipt/chain_test.go
+++ b/internal/contract/receipt/chain_test.go
@@ -103,9 +103,6 @@ func buildChain(t *testing.T, priv ed25519.PrivateKey, n int) []receipt.Evidence
 }
 
 func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
-	if _, err := receipt.NewPinnedStreamingVerifier(ed25519.PublicKey{1}); err == nil {
-		t.Fatal("short pinned key accepted")
-	}
 	priv, pub := testKey(t, 9)
 	marshal := func(t *testing.T, r receipt.EvidenceReceipt) []byte {
 		t.Helper()
@@ -115,6 +112,22 @@ func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
 		}
 		return data
 	}
+	t.Run("constructor rejects invalid keys", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			key  ed25519.PublicKey
+		}{
+			{name: "empty"},
+			{name: "short", key: ed25519.PublicKey{1}},
+			{name: "long", key: make(ed25519.PublicKey, ed25519.PublicKeySize+1)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				if _, err := receipt.NewPinnedStreamingVerifier(tc.key); err == nil {
+					t.Fatal("invalid pinned key accepted")
+				}
+			})
+		}
+	})
 	t.Run("valid chain reaches a signed head", func(t *testing.T) {
 		v, err := receipt.NewPinnedStreamingVerifier(pub)
 		if err != nil {
@@ -131,19 +144,36 @@ func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
 			t.Fatalf("result=%+v", result)
 		}
 	})
-	t.Run("decode failure latches", func(t *testing.T) {
-		v, err := receipt.NewPinnedStreamingVerifier(pub)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := v.AddRaw([]byte("[]")); err == nil {
-			t.Fatal("malformed receipt accepted")
-		}
-		if err := v.AddRaw([]byte("{}")); err == nil {
-			t.Fatal("latched verifier accepted another receipt")
-		}
-		if v.Finish().Valid {
-			t.Fatal("latched verifier finished valid")
+	t.Run("invalid input latches independently", func(t *testing.T) {
+		badSignature := unsignedReceipt(t, testSignerID, 0, receipt.GenesisHash)
+		badSignature = signReceipt(t, badSignature, priv)
+		badSignature.Actor = "tampered"
+		valid := buildChain(t, priv, 1)[0]
+		for _, tc := range []struct {
+			name string
+			raw  []byte
+			want string
+		}{
+			{name: "empty", raw: []byte{}, want: "decode"},
+			{name: "malformed", raw: []byte("[]"), want: "decode"},
+			{name: "signature", raw: marshal(t, badSignature), want: "signature"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				v, err := receipt.NewPinnedStreamingVerifier(pub)
+				if err != nil {
+					t.Fatal(err)
+				}
+				firstErr := v.AddRaw(tc.raw)
+				if firstErr == nil || !strings.Contains(firstErr.Error(), tc.want) {
+					t.Fatalf("first AddRaw error = %v, want %q", firstErr, tc.want)
+				}
+				if err := v.AddRaw(marshal(t, valid)); err == nil || err.Error() != firstErr.Error() {
+					t.Fatalf("latched AddRaw error = %v, want original %v", err, firstErr)
+				}
+				if got := v.Finish(); got.Valid || got.Error != firstErr.Error() {
+					t.Fatalf("latched Finish = %+v, want error %q", got, firstErr)
+				}
+			})
 		}
 	})
 	t.Run("empty verifier is not proof", func(t *testing.T) {
@@ -211,6 +241,33 @@ func TestExtractEvidenceReceiptsFromEntriesUsesWireDetailAndRejectsUnknown(t *te
 	}
 	if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{{Type: receipt.EvidenceEntryType, RawDetail: []byte("[]")}}); err == nil || !strings.Contains(err.Error(), "decode evidence receipt") {
 		t.Fatalf("decode detail error=%v", err)
+	}
+}
+
+func TestEvidenceDetailFailuresPreserveExtractorContext(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		detail     string
+		wantDetail string
+	}{
+		{name: "empty", detail: "null", wantDetail: "evidence entry has empty detail"},
+		{name: "malformed", detail: "[]", wantDetail: "decode evidence receipt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := recorder.Entry{Type: receipt.EvidenceEntryType, RawDetail: []byte(tc.detail)}
+			if _, err := receipt.ExtractEvidenceReceiptsFromEntries([]recorder.Entry{entry}); err == nil || !strings.Contains(err.Error(), "parsed recorder entry 1: "+tc.wantDetail) {
+				t.Fatalf("parsed extraction error = %v", err)
+			}
+
+			path := filepath.Join(t.TempDir(), "evidence.jsonl")
+			line := `{"type":"evidence_receipt","detail":` + tc.detail + "}\n"
+			if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+				t.Fatalf("write evidence file: %v", err)
+			}
+			if _, err := receipt.ExtractEvidenceReceipts(path); err == nil || !strings.Contains(err.Error(), path+" line 1: "+tc.wantDetail) {
+				t.Fatalf("raw extraction error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/receipt/chain.go
+++ b/internal/receipt/chain.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 	"time"
@@ -407,33 +408,111 @@ type chainVerifier struct {
 	integrityOnly bool
 }
 
+// StreamingVerifier verifies a v1 receipt chain one receipt at a time.  It is
+// intended for offline maintenance that cannot retain an entire recorder in
+// memory.  It preserves the same lifecycle, rotation, and trusted-key rules as
+// VerifyChain; Finish returns the same ChainResult shape.
+type StreamingVerifier struct {
+	v         *chainVerifier
+	integrity *chainVerifier
+	count     uint64
+	first     *Receipt
+	last      *Receipt
+	fail      *ChainResult
+	lifecycle *ChainResult
+}
+
+// NewStreamingVerifier starts a chain anchored at expectedKeyHex.
+func NewStreamingVerifier(expectedKeyHex string) (*StreamingVerifier, error) {
+	keys, err := normalizeTrustedKeys([]string{expectedKeyHex})
+	if err != nil {
+		return nil, err
+	}
+	newVerifier := func(integrityOnly bool) *chainVerifier {
+		trusted := make(map[string]struct{}, len(keys))
+		for _, key := range keys {
+			trusted[key] = struct{}{}
+		}
+		return &chainVerifier{trusted: trusted, runNonces: make(map[string]string), closedRuns: make(map[string]bool), integrityOnly: integrityOnly}
+	}
+	return &StreamingVerifier{v: newVerifier(false), integrity: newVerifier(true)}, nil
+}
+
+// Add verifies one exact v1 receipt wire representation and advances the
+// chain.  Once an error occurs the verifier remains failed.
+func (s *StreamingVerifier) Add(raw []byte) error {
+	if s.fail != nil {
+		return errors.New(s.fail.Error)
+	}
+	r, err := Unmarshal(raw)
+	if err != nil {
+		return s.latch(ChainResult{Valid: false, Error: err.Error(), FailureKind: ChainFailureIntegrity})
+	}
+	// Unmarshal is strict (duplicate keys, unknown signed fields, trailing
+	// tokens). Each chain walk below verifies the canonical signing projection
+	// with its segment signer, then applies the trusted-key boundary. Do not
+	// pre-verify only against the genesis key here: that would misclassify a
+	// rotated signer as a signature failure instead of the batch verifier's
+	// explicit trust failure.
+	// Keep an integrity-only walk in lockstep. VerifyChain deliberately
+	// downgrades a missing session-open to a lifecycle result only after it
+	// proves the full chain is otherwise intact; a streaming verifier must not
+	// turn that established fallback into an earlier hard failure.
+	if res, ok := s.integrity.add(r, s.count); !ok {
+		return s.latch(res)
+	}
+	if s.lifecycle == nil {
+		if res, ok := s.v.add(r, s.count); !ok {
+			if res.FailureKind != ChainFailureLifecycleOpen {
+				return s.latch(res)
+			}
+			// Preserve the strict failure, but continue the independent
+			// integrity walk. Finish returns the same augmented result as the
+			// batch verifier if every remaining receipt is intact.
+			s.lifecycle = &res
+		}
+	}
+	if s.first == nil {
+		first := r
+		s.first = &first
+	}
+	last := r
+	s.last = &last
+	s.count++
+	return nil
+}
+
+func (s *StreamingVerifier) latch(res ChainResult) error { s.fail = &res; return errors.New(res.Error) }
+
+// Finish completes verification.  Empty chains are rejected because a caller
+// that wants to prove evidence must have observed at least one signed receipt.
+func (s *StreamingVerifier) Finish() ChainResult {
+	if s.fail != nil {
+		return *s.fail
+	}
+	if s.count == 0 || s.first == nil || s.last == nil {
+		return ChainResult{Valid: false, Error: "empty chain"}
+	}
+	s.integrity.closeSegment()
+	if s.lifecycle != nil {
+		res := *s.lifecycle
+		res.IntegrityVerified = true
+		res.ReceiptCount = s.count
+		res.FinalSeq = s.last.ActionRecord.ChainSeq
+		res.RootHash = s.integrity.prevHash
+		res.StartTime = s.first.ActionRecord.Timestamp
+		res.EndTime = s.last.ActionRecord.Timestamp
+		res.SignerKeys = s.integrity.signerKeys
+		res.Segments = s.integrity.segments
+		return res
+	}
+	s.v.closeSegment()
+	return ChainResult{Valid: true, IntegrityVerified: true, ReceiptCount: s.count, FinalSeq: s.last.ActionRecord.ChainSeq, RootHash: s.v.prevHash, StartTime: s.first.ActionRecord.Timestamp, EndTime: s.last.ActionRecord.Timestamp, SignerKeys: s.v.signerKeys, Segments: s.v.segments}
+}
+
 func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 	for i := range receipts {
-		v.index = i
-		r := receipts[i]
-		marker := r.ActionRecord.KeyTransition
-
-		if i == 0 {
-			if res, ok := v.startFirstSegment(r); !ok {
-				return res
-			}
-		} else if marker != nil {
-			if res, ok := v.startRotatedSegment(r, marker); !ok {
-				return res
-			}
-		} else if res, ok := v.checkContinuation(r); !ok {
-			return res
-		}
-
-		if res, ok := v.verifyReceiptIntegrity(r, uint64(i)); !ok {
-			return res
-		}
-		if !v.integrityOnly {
-			if res, ok := v.validateSessionControl(r); !ok {
-				return res
-			}
-		}
-		if res, ok := v.advanceReceiptHash(r); !ok {
+		if res, ok := v.add(receipts[i], uint64(i)); !ok {
 			return res
 		}
 	}
@@ -452,6 +531,34 @@ func (v *chainVerifier) run(receipts []Receipt) ChainResult {
 		SignerKeys:        v.signerKeys,
 		Segments:          v.segments,
 	}
+}
+
+func (v *chainVerifier) add(r Receipt, index uint64) (ChainResult, bool) {
+	if index > uint64(math.MaxInt) {
+		return v.brokenAt(r, "receipt index exceeds verifier capacity"), false
+	}
+	v.index = int(index)
+	marker := r.ActionRecord.KeyTransition
+	if index == 0 {
+		if res, ok := v.startFirstSegment(r); !ok {
+			return res, false
+		}
+	} else if marker != nil {
+		if res, ok := v.startRotatedSegment(r, marker); !ok {
+			return res, false
+		}
+	} else if res, ok := v.checkContinuation(r); !ok {
+		return res, false
+	}
+	if res, ok := v.verifyReceiptIntegrity(r, index); !ok {
+		return res, false
+	}
+	if !v.integrityOnly {
+		if res, ok := v.validateSessionControl(r); !ok {
+			return res, false
+		}
+	}
+	return v.advanceReceiptHash(r)
 }
 
 // startFirstSegment establishes the anchor and key for the genesis segment.

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -143,6 +143,8 @@ func TestStreamingVerifierMatchesBatch(t *testing.T) {
 	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	pub, priv := generateTestKey(t)
 	missingOpen := signRunReceipt(t, priv, 0, GenesisHash, sessionOpenTestRunA, base)
+	later := signRunReceipt(t, priv, 1, mustHash(t, missingOpen), sessionOpenTestRunA, base.Add(time.Second))
+	later.ActionRecord.Target = "https://api.vendor.example/forged-after-missing-open"
 	_, rotatedPriv := generateTestKey(t)
 
 	for _, tc := range []struct {
@@ -152,6 +154,7 @@ func TestStreamingVerifierMatchesBatch(t *testing.T) {
 	}{
 		{name: "ordinary", chain: buildChain(t, priv, 3)},
 		{name: "lifecycle-open-integrity-fallback", chain: []Receipt{missingOpen}},
+		{name: "missing-open-then-later-integrity-failure", chain: []Receipt{missingOpen, later}, wantAddError: true},
 		{name: "key-transition-trust-rejection", chain: buildRotatedChain(t, priv, rotatedPriv, 2, 1), wantAddError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,33 +177,62 @@ func TestStreamingVerifierMatchesBatch(t *testing.T) {
 				t.Fatalf("Add() error = %v, want error=%v", addErr, tc.wantAddError)
 			}
 			got := stream.Finish()
-			if got.Valid != want.Valid || got.FailureKind != want.FailureKind || got.IntegrityVerified != want.IntegrityVerified || got.ReceiptCount != want.ReceiptCount || got.FinalSeq != want.FinalSeq || got.RootHash != want.RootHash {
+			if got.Valid != want.Valid || got.FailureKind != want.FailureKind || got.IntegrityVerified != want.IntegrityVerified || got.ReceiptCount != want.ReceiptCount || got.FinalSeq != want.FinalSeq || got.RootHash != want.RootHash || got.BrokenAtSeq != want.BrokenAtSeq || got.BrokenAtIndex != want.BrokenAtIndex {
 				t.Fatalf("stream result = %+v, batch result = %+v", got, want)
+			}
+			if tc.name == "missing-open-then-later-integrity-failure" && (got.FailureKind != ChainFailureIntegrity || got.BrokenAtSeq != 1 || got.BrokenAtIndex != 1 || got.IntegrityVerified) {
+				t.Fatalf("later integrity failure = %+v, want integrity failure at receipt 1", got)
 			}
 		})
 	}
 }
 
 func TestStreamingVerifierRejectsInvalidKeyEmptyAndMalformedInput(t *testing.T) {
-	if _, err := NewStreamingVerifier(""); err == nil {
-		t.Fatal("invalid trusted key accepted")
-	}
 	pub, _ := generateTestKey(t)
-	stream, err := NewStreamingVerifier(hex.EncodeToString(pub))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := stream.Finish(); got.Valid || got.Error != "empty chain" {
-		t.Fatalf("empty Finish=%+v", got)
-	}
-	if err := stream.Add([]byte("{")); err == nil {
-		t.Fatal("malformed receipt accepted")
-	}
-	if err := stream.Add([]byte("{}")); err == nil {
-		t.Fatal("latched receipt verifier accepted input")
-	}
-	if stream.Finish().Valid {
-		t.Fatal("latched receipt verifier finished valid")
+	for _, tc := range []struct {
+		name          string
+		key           string
+		raw           []byte
+		wantCtorError bool
+		wantEmpty     bool
+		wantAddError  bool
+		checkLatch    bool
+	}{
+		{name: "invalid-key", key: "", wantCtorError: true},
+		{name: "empty", key: hex.EncodeToString(pub), wantEmpty: true},
+		{name: "malformed", key: hex.EncodeToString(pub), raw: []byte("{"), wantAddError: true},
+		{name: "latched", key: hex.EncodeToString(pub), raw: []byte("{"), wantAddError: true, checkLatch: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream, err := NewStreamingVerifier(tc.key)
+			if tc.wantCtorError {
+				if err == nil {
+					t.Fatal("invalid trusted key accepted")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantEmpty {
+				if got := stream.Finish(); got.Valid || got.Error != "empty chain" {
+					t.Fatalf("empty Finish=%+v", got)
+				}
+				return
+			}
+			firstErr := stream.Add(tc.raw)
+			if (firstErr != nil) != tc.wantAddError {
+				t.Fatalf("first Add() error = %v, want error=%t", firstErr, tc.wantAddError)
+			}
+			if tc.checkLatch {
+				if err := stream.Add([]byte("{}")); err == nil || err.Error() != firstErr.Error() {
+					t.Fatalf("latched Add() error = %v, want original %v", err, firstErr)
+				}
+			}
+			if got := stream.Finish(); got.Valid || got.Error != firstErr.Error() {
+				t.Fatalf("failed Finish=%+v, want error %q", got, firstErr)
+			}
+		})
 	}
 }
 

--- a/internal/receipt/chain_test.go
+++ b/internal/receipt/chain_test.go
@@ -134,6 +134,76 @@ func TestVerifyChain_SingleReceipt(t *testing.T) {
 	}
 }
 
+// TestStreamingVerifierMatchesBatch guards the maintenance-only streaming
+// verifier against drifting from the established batch verifier. In
+// particular, lifecycle_missing_open is deliberately a report-only result
+// after the integrity-only fallback succeeds; turning it into an early hard
+// error would change the meaning of historical evidence during compaction.
+func TestStreamingVerifierMatchesBatch(t *testing.T) {
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	pub, priv := generateTestKey(t)
+	missingOpen := signRunReceipt(t, priv, 0, GenesisHash, sessionOpenTestRunA, base)
+	_, rotatedPriv := generateTestKey(t)
+
+	for _, tc := range []struct {
+		name         string
+		chain        []Receipt
+		wantAddError bool
+	}{
+		{name: "ordinary", chain: buildChain(t, priv, 3)},
+		{name: "lifecycle-open-integrity-fallback", chain: []Receipt{missingOpen}},
+		{name: "key-transition-trust-rejection", chain: buildRotatedChain(t, priv, rotatedPriv, 2, 1), wantAddError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			want := VerifyChain(tc.chain, hex.EncodeToString(pub))
+			stream, err := NewStreamingVerifier(hex.EncodeToString(pub))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var addErr error
+			for _, receipt := range tc.chain {
+				raw, marshalErr := Marshal(receipt)
+				if marshalErr != nil {
+					t.Fatal(marshalErr)
+				}
+				if addErr = stream.Add(raw); addErr != nil {
+					break
+				}
+			}
+			if (addErr != nil) != tc.wantAddError {
+				t.Fatalf("Add() error = %v, want error=%v", addErr, tc.wantAddError)
+			}
+			got := stream.Finish()
+			if got.Valid != want.Valid || got.FailureKind != want.FailureKind || got.IntegrityVerified != want.IntegrityVerified || got.ReceiptCount != want.ReceiptCount || got.FinalSeq != want.FinalSeq || got.RootHash != want.RootHash {
+				t.Fatalf("stream result = %+v, batch result = %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestStreamingVerifierRejectsInvalidKeyEmptyAndMalformedInput(t *testing.T) {
+	if _, err := NewStreamingVerifier(""); err == nil {
+		t.Fatal("invalid trusted key accepted")
+	}
+	pub, _ := generateTestKey(t)
+	stream, err := NewStreamingVerifier(hex.EncodeToString(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stream.Finish(); got.Valid || got.Error != "empty chain" {
+		t.Fatalf("empty Finish=%+v", got)
+	}
+	if err := stream.Add([]byte("{")); err == nil {
+		t.Fatal("malformed receipt accepted")
+	}
+	if err := stream.Add([]byte("{}")); err == nil {
+		t.Fatal("latched receipt verifier accepted input")
+	}
+	if stream.Finish().Valid {
+		t.Fatal("latched receipt verifier finished valid")
+	}
+}
+
 func TestVerifyChain_TenReceipts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/receipt/emitter_resume_test.go
+++ b/internal/receipt/emitter_resume_test.go
@@ -245,8 +245,9 @@ func TestResume_LegacyOversizedShardUsesBoundedHeadAndTail(t *testing.T) {
 			Summary:   padding,
 			Detail:    map[string]string{"safe": "value"},
 			PrevHash:  "legacy-prev",
-			Hash:      "legacy-hash",
+			Hash:      "",
 		}
+		entry.Hash = recorder.ComputeHash(entry)
 		if err := encoder.Encode(entry); err != nil {
 			_ = file.Close()
 			t.Fatalf("Encode padding: %v", err)
@@ -284,8 +285,9 @@ func TestResume_LegacyOversizedShardUsesBoundedHeadAndTail(t *testing.T) {
 			Summary:   padding,
 			Detail:    map[string]string{"safe": "value"},
 			PrevHash:  "legacy-prev",
-			Hash:      "legacy-hash",
+			Hash:      "",
 		}
+		entry.Hash = recorder.ComputeHash(entry)
 		if err := encoder.Encode(entry); err != nil {
 			_ = file.Close()
 			t.Fatalf("Encode trailing non-receipt: %v", err)

--- a/internal/recorder/entry.go
+++ b/internal/recorder/entry.go
@@ -242,10 +242,11 @@ func ComputeHash(e Entry) string {
 // Field order: v, seq, ts, session_id, trace_id, type, transport, summary,
 // detail_json, raw_ref, prev_hash. Null byte separators between fields.
 func computeHashV1(e Entry) string {
-	detailJSON, err := json.Marshal(e.Detail)
-	if err != nil {
-		detailJSON = []byte("null")
-	}
+	// A parsed legacy entry must hash the exact detail bytes that its writer
+	// committed. Re-marshaling an object changes key order and can make a valid
+	// v1 chain look corrupt. Fresh in-memory v1 entries have no RawDetail, so
+	// detailJSONForHash retains the original marshal behavior for writers.
+	detailJSON := detailJSONForHash(e)
 
 	h := sha256.New()
 	fields := []string{
@@ -529,71 +530,83 @@ func readEntriesFromReader(r io.Reader, limits entryReadLimits) ([]Entry, bool, 
 			return entries, true, bytesRead, nil
 		}
 
-		// Reject duplicate object keys before json.Unmarshal collapses them
-		// last-wins (a parser-differential smuggling vector); shared with the
-		// receipt verify path via internal/jsonscan.
-		if err := jsonscan.RejectDuplicateKeys([]byte(trimmed)); err != nil {
-			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
+		entry, parseErr := ParseEntryLine([]byte(trimmed))
+		if parseErr != nil {
+			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, parseErr)
 		}
-
-		var raw struct {
-			Version          int             `json:"v"`
-			Sequence         uint64          `json:"seq"`
-			Timestamp        time.Time       `json:"ts"`
-			SessionID        string          `json:"session_id"`
-			ChainKind        string          `json:"chain_kind,omitempty"`
-			WriterInstanceID string          `json:"writer_instance_id,omitempty"`
-			TraceID          string          `json:"trace_id,omitempty"`
-			Type             string          `json:"type"`
-			EventKind        string          `json:"event_kind,omitempty"`
-			Transport        string          `json:"transport"`
-			Summary          string          `json:"summary"`
-			Detail           json.RawMessage `json:"detail"`
-			RawRef           string          `json:"raw_ref,omitempty"`
-			PrevHash         string          `json:"prev_hash"`
-			Hash             string          `json:"hash"`
+		if !acceptedEntryVersions[entry.Version] {
+			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2, 3)", lineNum, entry.Version)
 		}
-		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
-			return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry: %w", lineNum, err)
-		}
-		if err := ValidateEntryJSONSchema([]byte(trimmed), raw.Version); err != nil {
+		if err := ValidateEntrySchema(entry); err != nil {
 			return nil, false, bytesRead, fmt.Errorf("line %d: %w", lineNum, err)
 		}
-		e := Entry{
-			Version:          raw.Version,
-			Sequence:         raw.Sequence,
-			Timestamp:        raw.Timestamp,
-			SessionID:        raw.SessionID,
-			ChainKind:        raw.ChainKind,
-			WriterInstanceID: raw.WriterInstanceID,
-			TraceID:          raw.TraceID,
-			Type:             raw.Type,
-			EventKind:        raw.EventKind,
-			Transport:        raw.Transport,
-			Summary:          raw.Summary,
-			RawRef:           raw.RawRef,
-			PrevHash:         raw.PrevHash,
-			Hash:             raw.Hash,
-		}
-		if raw.Detail != nil {
-			e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
-			var detail any
-			if err := json.Unmarshal(raw.Detail, &detail); err != nil {
-				return nil, false, bytesRead, fmt.Errorf("line %d: parsing entry detail: %w", lineNum, err)
-			}
-			e.Detail = detail
-		}
-		if !acceptedEntryVersions[e.Version] {
-			return nil, false, bytesRead, fmt.Errorf("line %d: unsupported entry version %d (accepted: 1, 2, 3)", lineNum, e.Version)
-		}
-		if err := ValidateEntrySchema(e); err != nil {
-			return nil, false, bytesRead, fmt.Errorf("line %d: %w", lineNum, err)
-		}
-		entries = append(entries, e)
+		entries = append(entries, entry)
 		if errors.Is(err, io.EOF) {
 			return entries, false, bytesRead, nil
 		}
 	}
+}
+
+// ParseEntryLine parses exactly one JSON recorder entry. It preserves the
+// exact detail bytes for hash verification and rejects duplicate JSON keys
+// before decoding could collapse them. Streaming consumers use this same
+// parser so they cannot disagree with recorder verification.
+func ParseEntryLine(line []byte) (Entry, error) {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return Entry{}, errors.New("empty recorder entry")
+	}
+	if err := jsonscan.RejectDuplicateKeys(trimmed); err != nil {
+		return Entry{}, err
+	}
+	var raw struct {
+		Version          int             `json:"v"`
+		Sequence         uint64          `json:"seq"`
+		Timestamp        time.Time       `json:"ts"`
+		SessionID        string          `json:"session_id"`
+		ChainKind        string          `json:"chain_kind,omitempty"`
+		WriterInstanceID string          `json:"writer_instance_id,omitempty"`
+		TraceID          string          `json:"trace_id,omitempty"`
+		Type             string          `json:"type"`
+		EventKind        string          `json:"event_kind,omitempty"`
+		Transport        string          `json:"transport"`
+		Summary          string          `json:"summary"`
+		Detail           json.RawMessage `json:"detail"`
+		RawRef           string          `json:"raw_ref,omitempty"`
+		PrevHash         string          `json:"prev_hash"`
+		Hash             string          `json:"hash"`
+	}
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return Entry{}, err
+	}
+	if err := ValidateEntryJSONSchema(trimmed, raw.Version); err != nil {
+		return Entry{}, err
+	}
+	e := Entry{
+		Version:          raw.Version,
+		Sequence:         raw.Sequence,
+		Timestamp:        raw.Timestamp,
+		SessionID:        raw.SessionID,
+		ChainKind:        raw.ChainKind,
+		WriterInstanceID: raw.WriterInstanceID,
+		TraceID:          raw.TraceID,
+		Type:             raw.Type,
+		EventKind:        raw.EventKind,
+		Transport:        raw.Transport,
+		Summary:          raw.Summary,
+		RawRef:           raw.RawRef,
+		PrevHash:         raw.PrevHash,
+		Hash:             raw.Hash,
+	}
+	if raw.Detail != nil {
+		e.RawDetail = append(json.RawMessage(nil), raw.Detail...)
+		var detail any
+		if err := json.Unmarshal(raw.Detail, &detail); err != nil {
+			return Entry{}, fmt.Errorf("parsing entry detail: %w", err)
+		}
+		e.Detail = detail
+	}
+	return e, nil
 }
 
 func readLimitExceededError(path string, limits entryReadLimits, bytesRead int64) error {

--- a/internal/recorder/entry_test.go
+++ b/internal/recorder/entry_test.go
@@ -4,6 +4,7 @@
 package recorder_test
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -224,18 +225,12 @@ func TestReadEntries_PreservesRawDetailAndBindsV2Hash(t *testing.T) {
 
 			got[0].RawDetail = json.RawMessage(`{"different":true}`)
 			afterHash := recorder.ComputeHash(got[0])
-			if version == 1 {
-				if afterHash != beforeHash {
-					t.Fatalf("v1 ComputeHash changed after RawDetail mutation: got %s want %s", afterHash, beforeHash)
-				}
-			} else if afterHash == beforeHash {
-				t.Fatalf("v2 ComputeHash did not bind RawDetail mutation: got %s", afterHash)
+			if afterHash == beforeHash {
+				t.Fatalf("v%d ComputeHash did not bind RawDetail mutation: got %s", version, afterHash)
 			}
-			if version != 1 {
-				got[0].RawDetail = json.RawMessage(`{"z":2,"a":{"b":1}}`)
-				if err := recorder.VerifyChain(got); err == nil {
-					t.Fatal("v2 VerifyChain accepted semantically equivalent but byte-different RawDetail")
-				}
+			got[0].RawDetail = json.RawMessage(`{"z":2,"a":{"b":1}}`)
+			if err := recorder.VerifyChain(got); err == nil {
+				t.Fatalf("v%d VerifyChain accepted semantically equivalent but byte-different RawDetail", version)
 			}
 			got[0].RawDetail = rawWire.Detail
 			if hashRestored := recorder.ComputeHash(got[0]); hashRestored != beforeHash {
@@ -255,6 +250,43 @@ func TestReadEntries_PreservesRawDetailAndBindsV2Hash(t *testing.T) {
 				t.Fatalf("RawDetail leaked into reread serialized entry: %s", rewire)
 			}
 		})
+	}
+}
+
+func TestReadEntries_V1HashUsesStoredNoncanonicalDetailBytes(t *testing.T) {
+	t.Parallel()
+	detail := map[string]any{"a": float64(1), "z": float64(2)}
+	rawDetail := json.RawMessage(`{"z":2,"a":1}`)
+	e := recorder.Entry{
+		Version: 1, Sequence: 0, Timestamp: time.Unix(1, 0).UTC(),
+		SessionID: "legacy", Type: testType, Transport: testTransport,
+		Summary: "legacy raw bytes", Detail: detail, RawDetail: rawDetail,
+		PrevHash: recorder.GenesisHash,
+	}
+	const wantHash = "0b397097e21d632c4d2eeb21b2b6a9436e604bbda3ea27eddb65a948488fe8c8"
+	if got := recorder.ComputeHash(e); got != wantHash {
+		t.Fatalf("frozen v1 noncanonical hash = %s", got)
+	}
+	e.Hash = wantHash
+	wire, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalDetail, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire = bytes.Replace(wire, canonicalDetail, rawDetail, 1)
+	got, err := recorder.ReadEntriesFromReader(bytes.NewReader(append(wire, '\n')))
+	if err != nil {
+		t.Fatalf("read noncanonical v1 entry: %v", err)
+	}
+	if err := recorder.VerifyChain(got); err != nil {
+		t.Fatalf("VerifyChain(valid noncanonical v1): %v", err)
+	}
+	got[0].RawDetail = json.RawMessage(`{"a":1,"z":2}`)
+	if err := recorder.VerifyChain(got); err == nil {
+		t.Fatal("VerifyChain accepted v1 detail byte-order tampering")
 	}
 }
 

--- a/internal/recorder/evidence_location_read.go
+++ b/internal/recorder/evidence_location_read.go
@@ -124,6 +124,48 @@ func ReadEvidenceLocationFileBounded(location EvidenceLocation, name string, max
 	return raw, nil
 }
 
+// ReadEvidenceLocationFileForOfflineCompaction reads one immutable source
+// shard for a stopped, operator-invoked compaction ceremony. Callers must pass
+// their remaining aggregate budget. Online query, view, serve, and doctor
+// paths must continue to use ReadEvidenceLocationFileBounded with their normal
+// 8 MiB ceiling.
+func ReadEvidenceLocationFileForOfflineCompaction(location EvidenceLocation, name string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("offline compaction byte limit must be positive")
+	}
+	return ReadEvidenceLocationFileBounded(location, name, maxBytes)
+}
+
+// StreamEvidenceLocationFileForOfflineCompaction streams one immutable source
+// shard for an explicitly offline compaction ceremony.  It deliberately does
+// not impose the online whole-file ceiling: callers must process the stream
+// with their own bounded buffers.  The callback is invoked while the no-follow
+// descriptor is open and the file is re-statted afterwards, so a replacement,
+// resize, or timestamp change fails the ceremony rather than producing a
+// partially trusted rewrite.  Do not use this API for query, view, serve, or
+// doctor paths.
+func StreamEvidenceLocationFileForOfflineCompaction(location EvidenceLocation, name string, consume func(io.Reader, os.FileInfo) error) error {
+	if consume == nil {
+		return errors.New("offline compaction stream consumer is required")
+	}
+	file, before, err := openEvidenceLocationFile(location, name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if err := consume(file, before); err != nil {
+		return err
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(before, after) || before.Size() != after.Size() || before.ModTime() != after.ModTime() || before.Mode() != after.Mode() {
+		return errors.New("evidence file changed during offline compaction read")
+	}
+	return nil
+}
+
 // ReadEvidenceLocationFileTail reads at most maxBytes from the end of one
 // regular evidence file. The boolean reports that older bytes were omitted.
 func ReadEvidenceLocationFileTail(location EvidenceLocation, name string, maxBytes int64) ([]byte, bool, error) {

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -492,6 +492,10 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 	}
 
 	e.Version = CurrentWriteEntryVersion
+	// RawDetail is parser provenance for an entry read from disk. A caller must
+	// never be able to smuggle stale or unredacted provenance bytes into a new
+	// write: escrow, redaction, and hashing below all derive from Detail.
+	e.RawDetail = nil
 	// Namespace fields are authenticated only by the v3 projection. Strip any
 	// caller-supplied values while this binary emits v2 so unhashed metadata
 	// cannot leak into the evidence file or an enterprise audit envelope.
@@ -953,18 +957,12 @@ func (r *Recorder) resumeSessionLocked(sessionID string) error {
 		// older sequence and fork the chain.
 		last := entries[0]
 
-		// NOTE: We do NOT recompute and verify the tail hash here because
-		// ComputeHash is not round-trip stable for entries whose Detail was
-		// stored as json.RawMessage (e.g., receipt entries). ReadEntries
-		// deserializes Detail into map[string]interface{}, which re-marshals
-		// with alphabetically sorted keys, producing a different hash than
-		// the original struct-ordered JSON. Full chain verification (which
-		// has the same limitation) is done by verify-receipt / VerifyChain.
-		// The chain linkage (prevHash threading) is still enforced on each
-		// new Record call.
 		if last.Hash == "" {
 			return fmt.Errorf("evidence file %s: tail entry seq %d has empty hash",
 				candidate.base, last.Sequence)
+		}
+		if computed := ComputeHash(last); computed != last.Hash {
+			return fmt.Errorf("evidence file %s: tail entry seq %d hash mismatch: computed %s, stored %s", candidate.base, last.Sequence, computed, last.Hash)
 		}
 
 		// Filtering candidates by parsed filename settles which shard to read,

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -1182,8 +1182,8 @@ func TestRecorder_ResumeAcceptsOverCapLegacyTailRead(t *testing.T) {
 			Summary:   strings.Repeat("x", 512<<10),
 			Detail:    map[string]string{"safe": "value"},
 			PrevHash:  recorder.GenesisHash,
-			Hash:      "non-empty-tail-hash",
 		}
+		entry.Hash = recorder.ComputeHash(entry)
 		line, err := json.Marshal(entry)
 		if err != nil {
 			t.Fatalf("Marshal entry: %v", err)
@@ -1218,6 +1218,30 @@ func TestRecorder_ResumeAcceptsOverCapLegacyTailRead(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Record after over-cap legacy shard: %v", err)
+	}
+}
+
+func TestRecordClearsCallerRawDetailBeforeHashing(t *testing.T) {
+	dir := t.TempDir()
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 100}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Record(recorder.Entry{SessionID: "raw-clear", Type: testType, Transport: testTransport, Summary: "fresh", Detail: map[string]string{"fresh": "value"}, RawDetail: json.RawMessage(`{"stale":true}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := recorder.ReadEntries(filepath.Join(dir, "evidence-raw-clear-0.jsonl"))
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("ReadEntries = %d, %v", len(entries), err)
+	}
+	if string(entries[0].RawDetail) != `{"fresh":"value"}` {
+		t.Fatalf("stored raw detail = %s, want fresh caller Detail", entries[0].RawDetail)
+	}
+	if err := recorder.VerifyChain(entries); err != nil {
+		t.Fatalf("VerifyChain: %v", err)
 	}
 }
 

--- a/internal/recorder/resume_availability_test.go
+++ b/internal/recorder/resume_availability_test.go
@@ -41,8 +41,8 @@ func writeResumeShard(t *testing.T, dir, session string, seqStart uint64, empty 
 		Summary:   "resume fixture",
 		Detail:    map[string]string{"safe": "value"},
 		PrevHash:  recorder.GenesisHash,
-		Hash:      fmt.Sprintf("tail-hash-%d", seqStart),
 	}
+	entry.Hash = recorder.ComputeHash(entry)
 	line, err := json.Marshal(entry)
 	if err != nil {
 		t.Fatalf("Marshal entry: %v", err)
@@ -120,8 +120,8 @@ func TestRecorder_ResumeSucceedsFromLegacyShardAboveReadCap(t *testing.T) {
 			Summary:   "legacy oversized shard fixture",
 			Detail:    detail,
 			PrevHash:  fmt.Sprintf("prev-%d", seq),
-			Hash:      fmt.Sprintf("hash-%d", seq),
 		}
+		entry.Hash = recorder.ComputeHash(entry)
 		if err := encoder.Encode(entry); err != nil {
 			_ = file.Close()
 			t.Fatalf("Encode seq %d: %v", seq, err)


### PR DESCRIPTION
## What changed
- Verify historical recorder entries from their exact stored detail bytes, then stream offline compaction without a whole-session memory ceiling while keeping normal evidence reads bounded.
- Verify recorder checkpoints and both receipt generations before and after staging, and fail closed on malformed input, unknown record types, source changes, or chain disagreement. Reviewers should distrust any path that can publish staged shards without proving byte-for-byte source equivalence and signed-chain parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer offline evidence compaction with bounded streaming, shard limits, integrity verification, and atomic archival.
  * Added support for verifying legacy and current receipt formats before and after compaction.
  * Improved handling of large shards while preserving metadata and verification details.

* **Bug Fixes**
  * Malformed records can no longer produce signed contracts.
  * Resume operations now detect tampered or inconsistent evidence.
  * Raw evidence details are preserved consistently for hash verification.

* **Documentation**
  * Documented offline legacy-evidence compaction and recovery procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->