### PR TITLE
fix(proxy): enforce session policy on redirects

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1908,6 +1908,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
+	ctx = context.WithValue(ctx, ctxKeyRedirectSessionRecorder, forwardRec)
 	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), effectiveURLPort(r.URL), result)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client
@@ -2051,6 +2052,13 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if blockedErr, ok := blockedRequestErrorFrom(err); ok {
 			p.logger.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
+			// A redirect-time taint denial supersedes the admission decision.
+			// Preserve whether the matrix blocked outright or requested HITL;
+			// the receipt verdict already records the terminal block outcome.
+			redirectTaint := forwardTaint
+			if blockedErr.taint != nil {
+				redirectTaint = *blockedErr.taint
+			}
 			emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{
 				ActionID:            actionID,
 				Verdict:             config.ActionBlock,
@@ -2061,15 +2069,15 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				Target:              redirectReceiptTarget(blockedErr, targetURL),
 				RequestID:           requestID,
 				Agent:               agent,
-				SessionTaintLevel:   forwardTaint.Risk.Level.String(),
-				SessionContaminated: forwardTaint.Risk.Contaminated,
-				RecentTaintSources:  forwardTaint.Risk.Sources,
-				SessionTaskID:       forwardTaint.Task.CurrentTaskID,
-				SessionTaskLabel:    forwardTaint.Task.CurrentTaskLabel,
-				AuthorityKind:       forwardTaint.Authority.String(),
-				TaintDecision:       forwardTaint.Result.Decision.String(),
-				TaintDecisionReason: forwardTaint.Result.Reason,
-				TaskOverrideApplied: forwardTaint.TaskOverrideApplied,
+				SessionTaintLevel:   redirectTaint.Risk.Level.String(),
+				SessionContaminated: redirectTaint.Risk.Contaminated,
+				RecentTaintSources:  redirectTaint.Risk.Sources,
+				SessionTaskID:       redirectTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    redirectTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       redirectTaint.Authority.String(),
+				TaintDecision:       redirectTaint.Result.Decision.String(),
+				TaintDecisionReason: redirectTaint.Result.Reason,
+				TaskOverrideApplied: redirectTaint.TaskOverrideApplied,
 			}))
 			p.metrics.RecordBlocked(r.URL.Hostname(), blockedErr.layer, time.Since(start), agentLabel)
 			// Open-redirect hint fires on any fail-closed redirect

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -24,7 +24,6 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/decide"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
-	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/mcp"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -1207,22 +1206,8 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case session.PolicyAsk:
 		forwardRequiresReauth = true
-		decision := hitl.DecisionBlock
-		blockReason := forwardTaint.Result.Reason
-		switch {
-		case p.approver == nil:
-			blockReason += " (no HITL approver)"
-		case !p.approver.IsTerminal():
-			blockReason += " (HITL stdin is not a terminal)"
-		default:
-			decision = p.approver.Ask(&hitl.Request{
-				Agent:   agent,
-				URL:     targetURL,
-				Reason:  forwardTaint.Result.Reason,
-				Preview: fmt.Sprintf("%s %s", r.Method, targetURL),
-			})
-		}
-		if decision != hitl.DecisionAllow {
+		approved, blockReason := p.resolveTaintAsk(agent, targetURL, r.Method, forwardTaint.Result.Reason)
+		if !approved {
 			emitForwardReceipt(receipt.EmitOpts{
 				ActionID:            actionID,
 				Verdict:             config.ActionBlock,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -121,6 +121,10 @@ const (
 	// the transport that originated the request rather than the
 	// hardcoded default. See Info 2 on the envelope-signing review.
 	ctxKeyRedirectTransport
+	// ctxKeyRedirectSessionRecorder carries the exact admission-time session
+	// recorder into CheckRedirect so policy is re-evaluated against the same
+	// identity and state on every hop.
+	ctxKeyRedirectSessionRecorder
 
 	// ctxKeySSRFDialScanSnapshot carries the DNS answers from an allowed
 	// scanner SSRF pass into the later dial-time re-resolution. The safe
@@ -179,6 +183,7 @@ type blockedRequestError struct {
 	reason string
 	detail string
 	target string
+	taint  *taintDecision
 }
 
 func (e *blockedRequestError) Error() string {
@@ -221,6 +226,12 @@ func newRedirectBlockedRequest(originLayer, reason string) *blockedRequestError 
 		layer = "redirect"
 	}
 	return newBlockedRequestError(layer, fullReason, fullReason)
+}
+
+func newRedirectTaintBlockedRequest(decision taintDecision, reason string) *blockedRequestError {
+	blockedErr := newRedirectBlockedRequest("taint_policy", reason)
+	blockedErr.taint = &decision
+	return blockedErr
 }
 
 func newEnvelopeBlockedRequest(err error) *blockedRequestError {
@@ -762,6 +773,48 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
 				logger.LogBlocked(actx, "git_protection", "redirect from "+originalURL+" blocked: "+gitPush.Reason)
 				return newRedirectBlockedRequest("git_protection", gitPush.Reason)
+			}
+			redirectRec, _ := req.Context().Value(ctxKeyRedirectSessionRecorder).(session.Recorder)
+			redirectTaint := evaluateHTTPTaint(currentCfg, redirectRec, req.Method, req.URL)
+			if redirectTaint.Result.Decision == session.PolicyAsk || redirectTaint.Result.Decision == session.PolicyBlock {
+				actx := newHTTPAuditContext(logger, req.Method, redirectURL, clientIP, requestID, agentName)
+				logger.LogTaintDecision(actx, audit.TaintDecision{
+					TaintLevel: redirectTaint.Risk.Level.String(), ActionClass: redirectTaint.ActionClass.String(),
+					Sensitivity: redirectTaint.Sensitivity.String(), Authority: redirectTaint.Authority.String(),
+					Decision: redirectTaint.Result.Decision.String(), Reason: redirectTaint.Result.Reason,
+					SourceURL: redirectTaint.Risk.SecurityOriginURL(), SourceKind: redirectTaint.Risk.SecurityOriginKind(),
+				})
+			}
+			switch redirectTaint.Result.Decision {
+			case session.PolicyBlock:
+				return newRedirectTaintBlockedRequest(redirectTaint, redirectTaint.Result.Reason)
+			case session.PolicyAsk:
+				blockReason := redirectTaint.Result.Reason
+				decision := hitl.DecisionBlock
+				switch {
+				case p.approver == nil:
+					blockReason += " (no HITL approver)"
+				case !p.approver.IsTerminal():
+					blockReason += " (HITL stdin is not a terminal)"
+				default:
+					decision = p.approver.Ask(&hitl.Request{
+						Agent:   agentName,
+						URL:     redirectURL,
+						Reason:  redirectTaint.Result.Reason,
+						Preview: fmt.Sprintf("%s %s", req.Method, redirectURL),
+					})
+				}
+				if decision != hitl.DecisionAllow {
+					return newRedirectTaintBlockedRequest(redirectTaint, blockReason)
+				}
+			}
+			if redirectSess, ok := redirectRec.(*SessionState); ok && redirectSess != nil {
+				tier := airlockTierForScope(redirectSess, adaptiveScopeForHost(req.URL.Hostname()))
+				if allowed, reason := ClassifyAction(tier, req.Method, redirectTransport, false); !allowed {
+					logger.LogAirlockDeny(redirectSess.key, tier, redirectTransport, req.Method, clientIP, requestID)
+					p.metrics.RecordAirlockDenial(tier, redirectTransport, req.Method)
+					return newRedirectBlockedRequest("airlock", reason)
+				}
 			}
 
 			// request_policy runs before the contract gate so a contract
@@ -4769,6 +4822,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportFetch)
+	ctx = context.WithValue(ctx, ctxKeyRedirectSessionRecorder, fetchRec)
 	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, parsed.Hostname(), effectiveURLPort(parsed), result)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
 	if err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -789,22 +789,8 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			case session.PolicyBlock:
 				return newRedirectTaintBlockedRequest(redirectTaint, redirectTaint.Result.Reason)
 			case session.PolicyAsk:
-				blockReason := redirectTaint.Result.Reason
-				decision := hitl.DecisionBlock
-				switch {
-				case p.approver == nil:
-					blockReason += " (no HITL approver)"
-				case !p.approver.IsTerminal():
-					blockReason += " (HITL stdin is not a terminal)"
-				default:
-					decision = p.approver.Ask(&hitl.Request{
-						Agent:   agentName,
-						URL:     redirectURL,
-						Reason:  redirectTaint.Result.Reason,
-						Preview: fmt.Sprintf("%s %s", req.Method, redirectURL),
-					})
-				}
-				if decision != hitl.DecisionAllow {
+				approved, blockReason := p.resolveTaintAsk(agentName, redirectURL, req.Method, redirectTaint.Result.Reason)
+				if !approved {
 					return newRedirectTaintBlockedRequest(redirectTaint, blockReason)
 				}
 			}
@@ -4986,6 +4972,10 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 		if blockedErr, ok := blockedRequestErrorFrom(err); ok {
 			log.LogBlocked(actx, blockedErr.layer, blockedErr.detail)
 			p.metrics.RecordBlocked(parsed.Hostname(), blockedErr.layer, time.Since(start), agentLabel)
+			redirectTaint := fetchTaint
+			if blockedErr.taint != nil {
+				redirectTaint = *blockedErr.taint
+			}
 			resp := FetchResponse{
 				URL:         displayURL,
 				Agent:       agent,
@@ -5002,15 +4992,24 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 				resp.Hint = "Request was redirected to a different origin. Cross-origin redirects are blocked to prevent open redirect attacks."
 			}
 			emitFetchReceipt(receipt.EmitOpts{
-				ActionID:  actionID,
-				Verdict:   config.ActionBlock,
-				Layer:     blockedErr.layer,
-				Pattern:   blockedErr.reason,
-				Transport: "fetch",
-				Method:    http.MethodGet,
-				Target:    redirectReceiptTarget(blockedErr, displayURL),
-				RequestID: requestID,
-				Agent:     agent,
+				ActionID:            actionID,
+				Verdict:             config.ActionBlock,
+				Layer:               blockedErr.layer,
+				Pattern:             blockedErr.reason,
+				Transport:           "fetch",
+				Method:              http.MethodGet,
+				Target:              redirectReceiptTarget(blockedErr, displayURL),
+				RequestID:           requestID,
+				Agent:               agent,
+				SessionTaintLevel:   redirectTaint.Risk.Level.String(),
+				SessionContaminated: redirectTaint.Risk.Contaminated,
+				RecentTaintSources:  redirectTaint.Risk.Sources,
+				SessionTaskID:       redirectTaint.Task.CurrentTaskID,
+				SessionTaskLabel:    redirectTaint.Task.CurrentTaskLabel,
+				AuthorityKind:       redirectTaint.Authority.String(),
+				TaintDecision:       redirectTaint.Result.Decision.String(),
+				TaintDecisionReason: redirectTaint.Result.Reason,
+				TaskOverrideApplied: redirectTaint.TaskOverrideApplied,
 			})
 			writeBlockedJSON(w,
 				redirectBlockedInfo(blockedErr),

--- a/internal/proxy/redirect_policy_parity_test.go
+++ b/internal/proxy/redirect_policy_parity_test.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/hitl"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func redirectPolicyTestProxy(t *testing.T, opts ...Option) (*Proxy, *config.Config, *scanner.Scanner) {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SessionProfiling.Enabled = true
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New(), opts...)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(p.Close)
+	return p, cfg, sc
+}
+
+func redirectPolicyRequests(t *testing.T, cfg *config.Config, sc *scanner.Scanner) (*http.Request, *http.Request) {
+	t.Helper()
+	ctx := context.WithValue(t.Context(), ctxKeyClientIP, "127.0.0.1")
+	ctx = context.WithValue(ctx, ctxKeyRequestID, "req-redirect-policy")
+	ctx = context.WithValue(ctx, ctxKeyAgent, agentAnonymous)
+	ctx = context.WithValue(ctx, ctxKeyAgentConfig, cfg)
+	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
+	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
+	redirectReq := httptest.NewRequestWithContext(ctx, http.MethodPost, "https://api.vendor.example/auth/update", nil)
+	originalReq := httptest.NewRequestWithContext(ctx, http.MethodPost, "https://source.vendor.example/start", nil)
+	return redirectReq, originalReq
+}
+
+func TestCheckRedirect_TaintedProtectedActionBlocks(t *testing.T) {
+	p, cfg, sc := redirectPolicyTestProxy(t)
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       taintScopeAction,
+		ActionMatch: "publish:post:https://source.vendor.example/start",
+	}}
+	rec := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	redirectReq, originalReq := redirectPolicyRequests(t, cfg, sc)
+	redirectReq = redirectReq.WithContext(context.WithValue(redirectReq.Context(), ctxKeyRedirectSessionRecorder, rec))
+	originalReq = originalReq.WithContext(context.WithValue(originalReq.Context(), ctxKeyRedirectSessionRecorder, rec))
+	// The recorder is snapshotted at admission, but its live state may change
+	// before a later redirect hop.
+	observeHTTPResponseTaint(rec, cfg, "https://untrusted.vendor.example/page", "text/html", "forward_response", false)
+	if decision := evaluateHTTPTaint(cfg, rec, originalReq.Method, originalReq.URL); decision.Result.Decision.String() != "allow" {
+		t.Fatalf("precondition: action-scoped override did not admit original request: %+v", decision.Result)
+	}
+	if decision := evaluateHTTPTaint(cfg, rec, redirectReq.Method, redirectReq.URL); decision.Result.Decision.String() == "allow" {
+		t.Fatalf("precondition: taint policy unexpectedly allowed protected redirect: %+v", decision.Result)
+	}
+	err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq})
+	blockedErr, ok := blockedRequestErrorFrom(err)
+	if !ok {
+		t.Fatal("taint policy allowed protected redirect")
+	}
+	if blockedErr.layer != "taint_policy" {
+		t.Fatalf("block layer = %q, want taint_policy", blockedErr.layer)
+	}
+	if blockedErr.taint == nil || blockedErr.taint.Result.Decision.String() != "ask" {
+		t.Fatalf("redirect taint decision = %+v, want ask", blockedErr.taint)
+	}
+}
+
+func TestCheckRedirect_TaintedProtectedActionExplicitApprovalAllows(t *testing.T) {
+	approver := hitl.New(5,
+		hitl.WithTerminal(true),
+		hitl.WithInput(strings.NewReader("yes\n")),
+		hitl.WithOutput(io.Discard),
+	)
+	t.Cleanup(approver.Close)
+	p, cfg, sc := redirectPolicyTestProxy(t, WithApprover(approver))
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       taintScopeAction,
+		ActionMatch: "publish:post:https://source.vendor.example/start",
+	}}
+	rec := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	observeHTTPResponseTaint(rec, cfg, "https://untrusted.vendor.example/page", "text/html", "forward_response", false)
+	redirectReq, originalReq := redirectPolicyRequests(t, cfg, sc)
+	redirectReq = redirectReq.WithContext(context.WithValue(redirectReq.Context(), ctxKeyRedirectSessionRecorder, rec))
+	if decision := evaluateHTTPTaint(cfg, rec, originalReq.Method, originalReq.URL); decision.Result.Decision.String() != "allow" {
+		t.Fatalf("precondition: action-scoped override did not admit original request: %+v", decision.Result)
+	}
+	// Pin the arm under test. Without this the test passes whenever the
+	// redirect decision is allow, which proves nothing about the approver:
+	// a matrix change that stopped gating this redirect would leave the
+	// test green while the HITL branch went unexercised.
+	if decision := evaluateHTTPTaint(cfg, rec, redirectReq.Method, redirectReq.URL); decision.Result.Decision.String() != "ask" {
+		t.Fatalf("precondition: redirect decision = %q, want ask", decision.Result.Decision.String())
+	}
+	if err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq}); err != nil {
+		t.Fatalf("explicitly approved redirect blocked: %v", err)
+	}
+}
+
+// TestCheckRedirect_TaintedProtectedActionPolicyBlockIgnoresApprover pins the
+// separation between the PolicyBlock and PolicyAsk arms of the redirect taint
+// switch. PolicyBlock is terminal: a hostile-source session must never be
+// offered an approval prompt, because prompting would let an operator approve
+// away a decision the matrix already refused outright. Nothing else in this
+// file reaches PolicyBlock - the sibling "Blocks" test exercises
+// PolicyAsk-with-no-approver - so collapsing the two arms into one prompt
+// would leave every other redirect test green.
+func TestCheckRedirect_TaintedProtectedActionPolicyBlockIgnoresApprover(t *testing.T) {
+	approver := hitl.New(5,
+		hitl.WithTerminal(true),
+		hitl.WithInput(strings.NewReader("yes\n")),
+		hitl.WithOutput(io.Discard),
+	)
+	t.Cleanup(approver.Close)
+	p, cfg, sc := redirectPolicyTestProxy(t, WithApprover(approver))
+	cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+		Scope:       taintScopeAction,
+		ActionMatch: "publish:post:https://source.vendor.example/start",
+	}}
+	rec := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	// promptHit escalates the source to hostile, which is the level the
+	// matrix answers with block rather than ask.
+	observeHTTPResponseTaint(rec, cfg, "https://untrusted.vendor.example/page", "text/html", "forward_response", true)
+	redirectReq, originalReq := redirectPolicyRequests(t, cfg, sc)
+	redirectReq = redirectReq.WithContext(context.WithValue(redirectReq.Context(), ctxKeyRedirectSessionRecorder, rec))
+	if decision := evaluateHTTPTaint(cfg, rec, originalReq.Method, originalReq.URL); decision.Result.Decision.String() != "allow" {
+		t.Fatalf("precondition: action-scoped override did not admit original request: %+v", decision.Result)
+	}
+	if decision := evaluateHTTPTaint(cfg, rec, redirectReq.Method, redirectReq.URL); decision.Result.Decision.String() != "block" {
+		t.Fatalf("precondition: redirect decision = %q, want block", decision.Result.Decision.String())
+	}
+	err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq})
+	blockedErr, ok := blockedRequestErrorFrom(err)
+	if !ok {
+		t.Fatal("approver allowed a redirect the taint matrix blocked outright")
+	}
+	if blockedErr.layer != "taint_policy" {
+		t.Fatalf("block layer = %q, want taint_policy", blockedErr.layer)
+	}
+	if blockedErr.taint == nil || blockedErr.taint.Result.Decision.String() != "block" {
+		t.Fatalf("redirect taint decision = %+v, want block", blockedErr.taint)
+	}
+}
+
+func TestCheckRedirect_ScopedAirlockBlocks(t *testing.T) {
+	p, cfg, sc := redirectPolicyTestProxy(t)
+	sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	redirectReq, originalReq := redirectPolicyRequests(t, cfg, sc)
+	redirectReq = redirectReq.WithContext(context.WithValue(redirectReq.Context(), ctxKeyRedirectSessionRecorder, sess))
+	originalReq = originalReq.WithContext(context.WithValue(originalReq.Context(), ctxKeyRedirectSessionRecorder, sess))
+	// A scope can enter drain after request admission but before the redirect.
+	if changed, _, _ := sess.AirlockForScope(adaptiveScopeForHost("api.vendor.example")).ForceSetTier(config.AirlockTierDrain); !changed {
+		t.Fatal("precondition: scoped airlock did not enter drain tier")
+	}
+	if allowed, _ := ClassifyAction(config.AirlockTierDrain, redirectReq.Method, TransportForward, false); allowed {
+		t.Fatal("precondition: drain airlock unexpectedly allowed redirected POST")
+	}
+	err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq})
+	blockedErr, ok := blockedRequestErrorFrom(err)
+	if !ok {
+		t.Fatal("scoped airlock allowed redirected action")
+	}
+	if blockedErr.layer != "airlock" {
+		t.Fatalf("block layer = %q, want airlock", blockedErr.layer)
+	}
+}
+
+func TestCheckRedirect_SessionPoliciesAllowHarmlessRedirect(t *testing.T) {
+	p, cfg, sc := redirectPolicyTestProxy(t)
+	redirectReq, originalReq := redirectPolicyRequests(t, cfg, sc)
+	sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	redirectReq = redirectReq.WithContext(context.WithValue(redirectReq.Context(), ctxKeyRedirectSessionRecorder, sess))
+	if err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq}); err != nil {
+		t.Fatalf("clean session redirect blocked: %v", err)
+	}
+
+	redirectReq, originalReq = redirectPolicyRequests(t, cfg, sc)
+	if err := p.client.CheckRedirect(redirectReq, []*http.Request{originalReq}); err != nil {
+		t.Fatalf("redirect without session recorder blocked: %v", err)
+	}
+}
+
+func TestForwardRedirect_SessionPoliciesBlockBeforeRedirectedEgress(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*Proxy)
+	}{
+		{
+			name: "taint reauthorization",
+			setup: func(p *Proxy) {
+				cfg := p.CurrentConfig()
+				sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+				observeHTTPResponseTaint(sess, cfg, "https://untrusted.vendor.example/page", "text/html", "forward_response", false)
+			},
+		},
+		{
+			name: "scoped airlock",
+			setup: func(p *Proxy) {
+				sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+				if changed, _, _ := sess.AirlockForScope(adaptiveScopeForHost("api.vendor.example")).ForceSetTier(config.AirlockTierDrain); !changed {
+					t.Fatal("target scope did not enter drain tier")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var initialHits, redirectedHits atomic.Int32
+			backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Host == "source.vendor.example" {
+					initialHits.Add(1)
+					http.Redirect(w, r, "http://api.vendor.example/auth/update", http.StatusTemporaryRedirect)
+					return
+				}
+				redirectedHits.Add(1)
+				_, _ = io.WriteString(w, "unexpected redirected egress")
+			}))
+			defer backend.Close()
+
+			proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+				cfg.SessionProfiling.Enabled = true
+				cfg.Taint.TrustOverrides = []config.TaintTrustOverride{{
+					Scope:       taintScopeAction,
+					ActionMatch: "publish:post:http://source.vendor.example/start",
+				}}
+			})
+			defer cleanup()
+			tt.setup(p)
+			p.client.Transport = &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					switch addr {
+					case "source.vendor.example:80", "api.vendor.example:80":
+						return (&net.Dialer{}).DialContext(ctx, network, backend.Listener.Addr().String())
+					default:
+						return (&net.Dialer{}).DialContext(ctx, network, addr)
+					}
+				},
+				DisableCompression: true,
+			}
+
+			proxyURL, err := url.Parse("http://" + proxyAddr)
+			if err != nil {
+				t.Fatalf("parse proxy URL: %v", err)
+			}
+			client := &http.Client{
+				Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+				Timeout:   2 * time.Second,
+			}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://source.vendor.example/start", strings.NewReader("payload"))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("forward request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusForbidden {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 403; body=%s", resp.StatusCode, body)
+			}
+			if initialHits.Load() != 1 {
+				t.Fatalf("initial upstream hits = %d, want 1", initialHits.Load())
+			}
+			if redirectedHits.Load() != 0 {
+				t.Fatalf("redirected upstream hits = %d, want 0", redirectedHits.Load())
+			}
+		})
+	}
+}
+
+func TestFetchRedirect_ScopedAirlockBlocksBeforeRedirectedEgress(t *testing.T) {
+	var initialHits, redirectedHits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host == "source.vendor.example" {
+			initialHits.Add(1)
+			http.Redirect(w, r, "http://api.vendor.example/final", http.StatusFound)
+			return
+		}
+		redirectedHits.Add(1)
+		_, _ = io.WriteString(w, "unexpected redirected egress")
+	}))
+	defer backend.Close()
+
+	proxyAddr, p, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.SessionProfiling.Enabled = true
+	})
+	defer cleanup()
+	sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+	if changed, _, _ := sess.AirlockForScope(adaptiveScopeForHost("api.vendor.example")).ForceSetTier(config.AirlockTierDrain); !changed {
+		t.Fatal("target scope did not enter drain tier")
+	}
+	p.client.Transport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			switch addr {
+			case "source.vendor.example:80", "api.vendor.example:80":
+				return (&net.Dialer{}).DialContext(ctx, network, backend.Listener.Addr().String())
+			default:
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			}
+		},
+		DisableCompression: true,
+	}
+
+	requestURL := "http://" + proxyAddr + "/fetch?url=" + url.QueryEscape("http://source.vendor.example/start")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, requestURL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("fetch request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403; body=%s", resp.StatusCode, body)
+	}
+	if initialHits.Load() != 1 {
+		t.Fatalf("initial upstream hits = %d, want 1", initialHits.Load())
+	}
+	if redirectedHits.Load() != 0 {
+		t.Fatalf("redirected upstream hits = %d, want 0", redirectedHits.Load())
+	}
+}

--- a/internal/proxy/redirect_policy_parity_test.go
+++ b/internal/proxy/redirect_policy_parity_test.go
@@ -198,11 +198,12 @@ func TestCheckRedirect_SessionPoliciesAllowHarmlessRedirect(t *testing.T) {
 func TestForwardRedirect_SessionPoliciesBlockBeforeRedirectedEgress(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*Proxy)
+		setup func(*testing.T, *Proxy)
 	}{
 		{
 			name: "taint reauthorization",
-			setup: func(p *Proxy) {
+			setup: func(t *testing.T, p *Proxy) {
+				t.Helper()
 				cfg := p.CurrentConfig()
 				sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
 				observeHTTPResponseTaint(sess, cfg, "https://untrusted.vendor.example/page", "text/html", "forward_response", false)
@@ -210,7 +211,8 @@ func TestForwardRedirect_SessionPoliciesBlockBeforeRedirectedEgress(t *testing.T
 		},
 		{
 			name: "scoped airlock",
-			setup: func(p *Proxy) {
+			setup: func(t *testing.T, p *Proxy) {
+				t.Helper()
 				sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
 				if changed, _, _ := sess.AirlockForScope(adaptiveScopeForHost("api.vendor.example")).ForceSetTier(config.AirlockTierDrain); !changed {
 					t.Fatal("target scope did not enter drain tier")
@@ -241,7 +243,7 @@ func TestForwardRedirect_SessionPoliciesBlockBeforeRedirectedEgress(t *testing.T
 				}}
 			})
 			defer cleanup()
-			tt.setup(p)
+			tt.setup(t, p)
 			p.client.Transport = &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 					switch addr {

--- a/internal/proxy/taint.go
+++ b/internal/proxy/taint.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
@@ -29,6 +30,22 @@ type taintDecision struct {
 	Result              session.PolicyDecisionResult
 	ActionRef           string
 	TaskOverrideApplied bool
+}
+
+func (p *Proxy) resolveTaintAsk(agent, target, method, reason string) (bool, string) {
+	switch {
+	case p.approver == nil:
+		return false, reason + " (no HITL approver)"
+	case !p.approver.IsTerminal():
+		return false, reason + " (HITL stdin is not a terminal)"
+	}
+	decision := p.approver.Ask(&hitl.Request{
+		Agent:   agent,
+		URL:     target,
+		Reason:  reason,
+		Preview: fmt.Sprintf("%s %s", method, target),
+	})
+	return decision == hitl.DecisionAllow, reason
 }
 
 func observeHTTPResponseTaint(rec session.Recorder, cfg *config.Config, rawURL, contentType, kind string, promptHit bool) {


### PR DESCRIPTION
## What changed
Re-evaluate taint policy and scoped airlock state before each fetch or forward redirect, failing closed when the redirected hop is denied. Block receipts preserve the redirect-time decision; distrust any path that reports only the admitted request's state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Redirected requests now re-evaluate taint and access policies at every hop.
  * Protected actions can be blocked, require explicit approval, or be restricted by airlock controls before redirected traffic is sent.
  * Blocked-request records now reflect the taint details from the redirect that triggered the block.

* **Reliability**
  * Session-based policy decisions and approvals are consistently preserved across redirects.
  * Harmless redirects continue without unnecessary interruption across supported request flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->