### PR TITLE
fix(proxy): preserve WebSocket response taint

### DIFF
--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1052,7 +1052,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		DeferClean: true,
 	})
 
-	forwardSessionKey := ceeSessionKey(agent, clientIP, id.Auth)
+	forwardSessionKey := responseTaintSessionKey(agent, clientIP, id.Auth)
 	var forwardRec session.Recorder
 	if sm := p.sessionMgrPtr.Load(); sm != nil {
 		forwardRec = sm.GetOrCreate(forwardSessionKey)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4187,7 +4187,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// RecordClean at the end when no finding was detected.
 	var fetchRec session.Recorder
 	if sm := p.sessionMgrPtr.Load(); sm != nil {
-		fetchRec = sm.GetOrCreate(sessionKeyFor(agent, clientIP))
+		fetchRec = sm.GetOrCreate(responseTaintSessionKey(agent, clientIP, id.Auth))
 	}
 	fetchTaint := evaluateHTTPTaint(cfg, fetchRec, http.MethodGet, parsed)
 

--- a/internal/proxy/taint.go
+++ b/internal/proxy/taint.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/hitl"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
@@ -30,6 +31,10 @@ type taintDecision struct {
 	Result              session.PolicyDecisionResult
 	ActionRef           string
 	TaskOverrideApplied bool
+}
+
+func responseTaintSessionKey(agent, clientIP string, auth envelope.ActorAuth) string {
+	return ceeSessionKey(agent, clientIP, auth)
 }
 
 func (p *Proxy) resolveTaintAsk(agent, target, method, reason string) (bool, string) {

--- a/internal/proxy/taint_helpers_test.go
+++ b/internal/proxy/taint_helpers_test.go
@@ -10,8 +10,19 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
+
+func TestResponseTaintSessionKey_UsesAuthenticatedIdentityBoundary(t *testing.T) {
+	const clientIP = "203.0.113.10"
+	if first, second := responseTaintSessionKey("rotated-a", clientIP, envelope.ActorAuthSelfDeclared), responseTaintSessionKey("rotated-b", clientIP, envelope.ActorAuthSelfDeclared); first != second {
+		t.Fatalf("self-declared agent rotation split taint state: %q != %q", first, second)
+	}
+	if first, second := responseTaintSessionKey("bound-a", clientIP, envelope.ActorAuthBound), responseTaintSessionKey("bound-b", clientIP, envelope.ActorAuthBound); first == second {
+		t.Fatalf("bound identities shared taint state: %q", first)
+	}
+}
 
 func TestEvaluateHTTPTaintDisabledAndNil(t *testing.T) {
 	t.Parallel()

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -2440,14 +2440,12 @@ func (r *wsRelay) observeUpstreamResponseTaint(promptHit bool) {
 	}
 	rec := sm.GetOrCreate(r.taintSessionKey)
 	risk := rec.RiskSnapshot()
-	if promptHit && risk.PromptHit {
-		return
-	}
-	if !promptHit {
-		for _, source := range risk.Sources {
-			if source.URL == r.targetURL && source.Kind == "websocket_response" {
-				return
-			}
+	for _, source := range risk.Sources {
+		if source.URL != r.targetURL || source.Kind != "websocket_response" {
+			continue
+		}
+		if !promptHit || source.MatchReason == "prompt_injection_pattern" {
+			return
 		}
 	}
 	observeHTTPResponseTaint(rec, r.cfg, r.targetURL, "application/websocket", "websocket_response", promptHit)

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -79,6 +79,7 @@ type wsRelay struct {
 	reqPolicyPath    string
 	redactionLog     *redact.Report
 	rec              session.Recorder // live escalation level for UpgradeAction; nil when profiling disabled
+	taintSessionKey  string           // rotation-safe key re-resolved for every response observation
 	terminalOnce     sync.Once        // ensures only one terminal receipt (kill_switch/session_deny) is emitted across concurrent relay goroutines
 
 	// lastActivity is the shared idle clock, updated by BOTH relay directions
@@ -979,24 +980,25 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	relay := &wsRelay{
-		clientConn:   clientConn,
-		upstreamConn: upstreamConn,
-		scanner:      sc,
-		proxy:        p,
-		cfg:          cfg,
-		redaction:    p.currentRedactionRuntimeFor(cfg),
-		agent:        agent,
-		metricAgent:  id.Profile,
-		actorAuth:    id.Auth,
-		clientIP:     clientIP,
-		requestID:    requestID,
-		targetURL:    targetURL,
-		hostname:     strings.ToLower(parsed.Hostname()),
-		path:         parsed.Path,
-		maxMsg:       cfg.WebSocketProxy.MaxMessageBytes,
-		scanText:     scanTextFrames,
-		allowBinary:  cfg.WebSocketProxy.AllowBinaryFrames,
-		rec:          wsRec,
+		clientConn:      clientConn,
+		upstreamConn:    upstreamConn,
+		scanner:         sc,
+		proxy:           p,
+		cfg:             cfg,
+		redaction:       p.currentRedactionRuntimeFor(cfg),
+		agent:           agent,
+		metricAgent:     id.Profile,
+		actorAuth:       id.Auth,
+		clientIP:        clientIP,
+		requestID:       requestID,
+		targetURL:       targetURL,
+		hostname:        strings.ToLower(parsed.Hostname()),
+		path:            parsed.Path,
+		maxMsg:          cfg.WebSocketProxy.MaxMessageBytes,
+		scanText:        scanTextFrames,
+		allowBinary:     cfg.WebSocketProxy.AllowBinaryFrames,
+		rec:             wsRec,
+		taintSessionKey: responseTaintSessionKey(agent, clientIP, id.Auth),
 	}
 	// Per-frame request_policy reuses the handshake route inputs: the escaped
 	// path the handshake gate matched on and a clone of the upgrade headers (for
@@ -2342,7 +2344,11 @@ func (r *wsRelay) clientToUpstream(ctx context.Context, cancel context.CancelFun
 func (r *wsRelay) enforceUpstreamTextPayload(ctx context.Context, log *audit.Logger, msg []byte, allowTransform bool) ([]byte, bool) {
 	const responseScanLayer = "response_scan"
 
-	if len(msg) == 0 || !r.scanText || !r.scanner.ResponseScanningEnabled() {
+	if len(msg) == 0 {
+		return msg, false
+	}
+	if !r.scanText || !r.scanner.ResponseScanningEnabled() {
+		r.observeUpstreamResponseTaint(false)
 		return msg, false
 	}
 
@@ -2350,6 +2356,7 @@ func (r *wsRelay) enforceUpstreamTextPayload(ctx context.Context, log *audit.Log
 	// to warn with no adaptive scoring or action upgrade.
 	wsRespExempt := isResponseScanExempt(r.hostname, r.cfg.ResponseScanning.ExemptDomains)
 	scanResult := r.scanner.ScanResponseWithSuppress(ctx, string(msg), r.targetURL, r.cfg.Suppress)
+	r.observeUpstreamResponseTaint(!scanResult.Clean)
 	recordSuppressedResponseScanExempts(r.proxy.metrics, scanResult.SuppressedMatches, TransportWS)
 	if scanResult.Clean {
 		return msg, false
@@ -2421,6 +2428,29 @@ func (r *wsRelay) enforceUpstreamTextPayload(ctx context.Context, log *audit.Log
 		log.LogWSScan(audit.WSScanEvent{Target: r.targetURL, Direction: audit.DirectionServerToClient, ClientIP: r.clientIP, RequestID: r.requestID, Agent: r.agent, Action: wsAction, MatchCount: len(scanResult.Matches), PatternNames: patternNames, BundleRules: respBundleRules})
 	}
 	return msg, false
+}
+
+func (r *wsRelay) observeUpstreamResponseTaint(promptHit bool) {
+	if r.cfg == nil || !r.cfg.Taint.Enabled {
+		return
+	}
+	sm := r.proxy.sessionMgrPtr.Load()
+	if sm == nil || r.taintSessionKey == "" {
+		return
+	}
+	rec := sm.GetOrCreate(r.taintSessionKey)
+	risk := rec.RiskSnapshot()
+	if promptHit && risk.PromptHit {
+		return
+	}
+	if !promptHit {
+		for _, source := range risk.Sources {
+			if source.URL == r.targetURL && source.Kind == "websocket_response" {
+				return
+			}
+		}
+	}
+	observeHTTPResponseTaint(rec, r.cfg, r.targetURL, "application/websocket", "websocket_response", promptHit)
 }
 
 // upstreamToClient reads frames from upstream, injection-scans text, writes to client.
@@ -2636,6 +2666,7 @@ func (r *wsRelay) upstreamToClient(ctx context.Context, cancel context.CancelFun
 
 		// Complete message. Count and scan.
 		if opCode == ws.OpBinary {
+			r.observeUpstreamResponseTaint(false)
 			actx := newHTTPAuditContext(log, "WS", r.targetURL, r.clientIP, r.requestID, r.agent)
 			mediaVerdict := applyMediaPolicy(r.cfg, "", msg)
 			logMediaExposureIfPresent(log, actx, mediaVerdict, TransportWS)

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/capture"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
@@ -501,7 +502,7 @@ func TestWSProxyEcho(t *testing.T) {
 	defer proxyCleanup()
 
 	conn := dialWS(t, proxyAddr, backendAddr)
-	defer conn.Close() //nolint:errcheck // test
+	defer func() { _ = conn.Close() }()
 
 	// Send a text message.
 	msg := []byte("hello websocket proxy")
@@ -1642,6 +1643,145 @@ func TestWSProxyInjectionWarn(t *testing.T) {
 	}
 	if !strings.Contains(string(reply), "ignore") {
 		t.Errorf("expected injection payload to be forwarded in warn mode, got %q", reply)
+	}
+}
+
+func TestWSProxyInjectionWarn_ContaminatesSessionBeforeSensitiveAction(t *testing.T) {
+	backendAddr, backendCleanup := wsInjectionServer(t)
+	defer backendCleanup()
+
+	proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.ResponseScanning.Enabled = true
+		cfg.ResponseScanning.Action = config.ActionWarn
+		cfg.SessionProfiling.Enabled = true
+	})
+	defer proxyCleanup()
+
+	const agent = "named-agent"
+	conn, err := dialWSConnWithHeader(proxyAddr, backendAddr, http.Header{"X-Pipelock-Agent": {agent}})
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // test
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(testWSHello)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := wsutil.ReadServerData(conn); err != nil {
+		t.Fatalf("read warn-mode injection: %v", err)
+	}
+	reloaded := p.CurrentConfig().Clone()
+	reloaded.KillSwitch.Message = "unrelated reload"
+	if !p.Reload(reloaded, scanner.MustNew(reloaded)) {
+		t.Fatal("unrelated reload failed")
+	}
+
+	sm := p.sessionMgrPtr.Load()
+	if sm == nil {
+		t.Fatal("session manager not initialized")
+	}
+	sess := sm.GetOrCreate(ceeSessionKey(agent, "127.0.0.1", envelope.ActorAuthSelfDeclared))
+	if risk := sess.RiskSnapshot(); !risk.Contaminated {
+		t.Fatal("WebSocket injection finding left the session falsely clean")
+	}
+	target, err := url.Parse("https://api.vendor.example/auth/update")
+	if err != nil {
+		t.Fatalf("parse sensitive target: %v", err)
+	}
+	decision := evaluateHTTPTaint(p.CurrentConfig(), sess, http.MethodPost, target)
+	if decision.Result.Decision != session.PolicyBlock {
+		t.Fatalf("sensitive follow-up decision = %v, want block", decision.Result.Decision)
+	}
+}
+
+// TestWSProxyResponseTaintControls covers the observation controls. Read the
+// "clean trusted response" case narrowly: the backend is 127.0.0.1, which
+// ClassifyURLSource pins to TaintTrusted via isTrustedLocalhost before the
+// allowlist is ever consulted, so wantTainted=false there follows from the
+// target being localhost and NOT from the payload being clean. A clean frame
+// from a non-allowlisted host classifies TaintExternalUntrusted and does set
+// Contaminated; only PromptHit distinguishes clean from injected content here.
+func TestWSProxyResponseTaintControls(t *testing.T) {
+	tests := []struct {
+		name          string
+		injection     bool
+		responseScan  bool
+		taintEnabled  bool
+		wantTainted   bool
+		wantPromptHit bool
+	}{
+		{name: "clean trusted response", responseScan: true, taintEnabled: true},
+		{name: "injection response", injection: true, responseScan: true, taintEnabled: true, wantTainted: true, wantPromptHit: true},
+		{name: "taint disabled", injection: true, responseScan: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var backendAddr string
+			var backendCleanup func()
+			if tt.injection {
+				backendAddr, backendCleanup = wsInjectionServer(t)
+			} else {
+				backendAddr, backendCleanup = wsEchoServer(t)
+			}
+			defer backendCleanup()
+
+			proxyAddr, p, proxyCleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+				cfg.ResponseScanning.Enabled = tt.responseScan
+				cfg.ResponseScanning.Action = config.ActionWarn
+				cfg.SessionProfiling.Enabled = true
+				cfg.Taint.Enabled = tt.taintEnabled
+			})
+			defer proxyCleanup()
+
+			conn := dialWS(t, proxyAddr, backendAddr)
+			defer func() { _ = conn.Close() }()
+			if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(testWSHello)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if _, _, err := wsutil.ReadServerData(conn); err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+
+			sess := p.sessionMgrPtr.Load().GetOrCreate(sessionKeyFor(agentAnonymous, "127.0.0.1"))
+			risk := sess.RiskSnapshot()
+			if risk.Contaminated != tt.wantTainted {
+				t.Fatalf("contaminated = %v, want %v", risk.Contaminated, tt.wantTainted)
+			}
+			if risk.PromptHit != tt.wantPromptHit {
+				t.Fatalf("prompt hit = %v, want %v", risk.PromptHit, tt.wantPromptHit)
+			}
+		})
+	}
+}
+
+func TestWSRelayResponseTaint_ReResolvesEvictedSession(t *testing.T) {
+	_, p, cleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.SessionProfiling.Enabled = true
+		cfg.SessionProfiling.MaxSessions = 1
+	})
+	defer cleanup()
+
+	key := ceeSessionKey("named-agent", "127.0.0.1", envelope.ActorAuthSelfDeclared)
+	relay := &wsRelay{
+		proxy:           p,
+		cfg:             p.CurrentConfig(),
+		targetURL:       "wss://socket.vendor.example/events",
+		taintSessionKey: key,
+	}
+	relay.observeUpstreamResponseTaint(false)
+	sm := p.sessionMgrPtr.Load()
+	original := sm.GetOrCreate(key)
+	if !original.RiskSnapshot().Contaminated {
+		t.Fatal("first external WebSocket response did not contaminate session")
+	}
+	sm.GetOrCreate("evict-response-taint-session")
+
+	relay.observeUpstreamResponseTaint(true)
+	current := sm.GetOrCreate(key)
+	if current == original {
+		t.Fatal("test did not evict the original session")
+	}
+	if risk := current.RiskSnapshot(); !risk.PromptHit || risk.Level != session.TaintExternalHostile {
+		t.Fatalf("recreated session risk = %+v, want hostile prompt hit", risk)
 	}
 }
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -1785,6 +1785,43 @@ func TestWSRelayResponseTaint_ReResolvesEvictedSession(t *testing.T) {
 	}
 }
 
+func TestWSRelayResponseTaint_DeduplicatesBySourceAndPromptState(t *testing.T) {
+	_, p, cleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+		cfg.SessionProfiling.Enabled = true
+		cfg.Taint.RecentSources = 10
+	})
+	defer cleanup()
+
+	const key = "websocket-response-dedup"
+	relay := &wsRelay{
+		proxy:           p,
+		cfg:             p.CurrentConfig(),
+		targetURL:       "wss://first.vendor.example/events",
+		taintSessionKey: key,
+	}
+	relay.observeUpstreamResponseTaint(false)
+	relay.observeUpstreamResponseTaint(false)
+	relay.observeUpstreamResponseTaint(true)
+	relay.observeUpstreamResponseTaint(true)
+
+	relay.targetURL = "wss://second.vendor.example/events"
+	relay.observeUpstreamResponseTaint(true)
+	relay.observeUpstreamResponseTaint(true)
+
+	risk := p.sessionMgrPtr.Load().GetOrCreate(key).RiskSnapshot()
+	if len(risk.Sources) != 3 {
+		t.Fatalf("response sources = %+v, want one clean and two prompt observations", risk.Sources)
+	}
+	if risk.Sources[0].URL != "wss://first.vendor.example/events" || risk.Sources[0].MatchReason != "" {
+		t.Fatalf("first source = %+v, want clean observation", risk.Sources[0])
+	}
+	for i, source := range risk.Sources[1:] {
+		if source.MatchReason != "prompt_injection_pattern" {
+			t.Fatalf("prompt source %d = %+v, want prompt match reason", i, source)
+		}
+	}
+}
+
 func TestWSProxyInjection_ExemptDomain(t *testing.T) {
 	backendAddr, backendCleanup := wsInjectionServer(t)
 	defer backendCleanup()


### PR DESCRIPTION
## What changed
- Record upstream WebSocket text and binary response provenance in the same identity-bound taint session used by HTTP traffic, including after reload or session eviction.
- Keep repeated frames from flooding the source history without suppressing a later prompt-injection finding.

The failure direction is false-clean state. The identity-key boundary and deduplication check are the parts most likely to hide a later finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response-taint tracking across HTTP and WebSocket interactions.
  * Separated taint state by authenticated identity, including during identity rotation.
  * WebSocket prompt-injection warnings can now influence subsequent sensitive-action controls.
  * Improved handling of binary responses, disabled scanning, clean responses, and refreshed session state.
  * Prevented duplicate taint observations from the same source and prompt state.
* **Tests**
  * Added coverage for taint isolation, identity changes, prompt-injection warnings, and sensitive-action blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->