### PR TITLE
fix(evidence): preserve degraded receipt integrity

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -212,7 +212,7 @@ structure.
 
 ### Compacting an over-cap recorder directory
 
-Evidence readers refuse a session with more than 256 JSONL shards. Use the offline compaction ceremony only after `pipelock evidence doctor` confirms that the recorder and receipt chains are intact.
+Evidence readers refuse a session with more than 256 JSONL shards or an individual shard above 8 MiB. Stop the recorder before running the offline compaction ceremony. The compactor has its own bounded reader for legacy oversized shards, so a normal `pipelock evidence doctor` run isn't a prerequisite.
 
 ```bash
 sudo systemctl stop pipelock.service
@@ -223,9 +223,11 @@ sudo pipelock evidence compact \
 sudo systemctl start pipelock.service
 ```
 
-The command refuses to run while a recorder holds the directory lock. It accepts oversized legacy input and streams verification, recovery, and archive creation with bounded record memory. It verifies the trusted recorder hash chain, checkpoint signatures, and every signed v1 or v2 receipt chain before and after compaction, copies each JSONL record line without changing its bytes, and keeps every replacement shard at or below the 8 MiB read limit. Linux installs the new active directory with one atomic exchange; only then does the original directory become a timestamped sibling archive with SHA-256 digests and byte mappings.
+The command refuses to run while a recorder holds the directory lock. It accepts oversized legacy input and uses bounded record memory. It verifies the trusted recorder hash chain, checkpoint signatures, and signed v1 or v2 receipts before and after compaction. It copies each JSONL record line without changing its bytes and keeps every replacement shard at or below the 8 MiB read limit. Linux installs the new active directory with one atomic exchange. The original directory then becomes a timestamped sibling archive with SHA-256 digests and byte mappings.
 
-This first version accepts exactly one session, up to 4,096 input shards, and no raw-escrow sidecars in the active directory. It refuses mixed directories, malformed or unverifiable chains, unknown record types, duplicate shard starts, symlinks, and sources that change during the ceremony. A failed check leaves the original directory active.
+Earlier recorder output may contain an entire signed v1 receipt replaced by a redaction tombstone. That receipt and its chain position can't be recovered. The compactor accepts known middle-of-chain tombstones and reports `receipt proof: DEGRADED`; a tombstone at the first or last v1 receipt is refused because the published directory would not be safe to resume. The command exits non-zero and reports the observed middle-gap count; after inspection, rerun with `--allow-degraded-receipts=N` to acknowledge exactly that count. After each gap, it verifies the remaining signed receipts as a contiguous suffix; the first predecessor remains untrusted, while deletion, reordering, or splicing later in that suffix still fails. The version 2 archive manifest records every tombstone, whether a later signed recorder checkpoint covers it, and each verified suffix boundary. It doesn't publish a complete v1 chain head for a degraded chain. Any other malformed receipt still stops compaction.
+
+This version accepts exactly one session, up to 4,096 input shards, and no raw-escrow sidecars in the active directory. It refuses mixed directories, unknown record types, duplicate shard starts, symlinks, and sources that change during the ceremony. A failed check leaves the original directory active. Restart the recorder after either success or failure. Retain the archive until bounded reads and fresh emission succeed; general receipt verification correctly remains non-green for a degraded historical chain.
 
 ### Completeness analysis
 

--- a/internal/cli/evidence/compact.go
+++ b/internal/cli/evidence/compact.go
@@ -19,16 +19,30 @@ import (
 )
 
 type (
-	compactOptions  struct{ receiptDir, locationID, sessionID, publicKey string }
+	compactOptions struct {
+		receiptDir, locationID, sessionID, publicKey string
+		allowDegradedReceipts                        int
+	}
 	compactManifest struct {
-		Version     int                   `json:"version"`
-		SessionID   string                `json:"session_id"`
-		CreatedAt   time.Time             `json:"created_at"`
-		Original    []compactManifestFile `json:"original"`
-		Replacement []compactManifestFile `json:"replacement"`
-		Mappings    []compactByteMapping  `json:"mappings"`
+		Version             int                                `json:"version"`
+		SessionID           string                             `json:"session_id"`
+		CreatedAt           time.Time                          `json:"created_at"`
+		ReceiptVerification compactManifestReceiptVerification `json:"receipt_verification"`
+		Original            []compactManifestFile              `json:"original"`
+		Replacement         []compactManifestFile              `json:"replacement"`
+		Mappings            []compactByteMapping               `json:"mappings"`
 	}
 )
+
+type compactManifestReceiptVerification struct {
+	Status       string                      `json:"status"`
+	V1Count      uint64                      `json:"v1_signed_receipts"`
+	V1ChainHead  string                      `json:"v1_chain_head,omitempty"`
+	V2Count      uint64                      `json:"v2_signed_receipts"`
+	V2ChainHead  string                      `json:"v2_chain_head,omitempty"`
+	Degradations []compactReceiptDegradation `json:"degradations,omitempty"`
+	V1Suffixes   []compactReceiptSuffix      `json:"v1_verified_suffixes,omitempty"`
+}
 
 type compactManifestFile struct {
 	Name   string `json:"name"`
@@ -62,6 +76,7 @@ func compactCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.locationID, "location", "", "location path relative to the evidence directory")
 	cmd.Flags().StringVar(&opts.sessionID, "session", "", "session ID to compact")
 	cmd.Flags().StringVar(&opts.publicKey, "key", "", "trusted receipt signing public key (inline or file)")
+	cmd.Flags().IntVar(&opts.allowDegradedReceipts, "allow-degraded-receipts", 0, "acknowledge exactly N recognized irrecoverable receipt gaps")
 	_ = cmd.MarkFlagRequired("receipt-dir")
 	_ = cmd.MarkFlagRequired("session")
 	_ = cmd.MarkFlagRequired("key")
@@ -111,6 +126,12 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	if err != nil {
 		return err
 	}
+	if original.v1FirstGap || original.v1TailGap {
+		return errors.New("degraded v1 receipt gap is at the first or last action_receipt; refusing to publish an evidence directory that receipt resume cannot load")
+	}
+	if original.v1Degraded && opts.allowDegradedReceipts != len(original.degradations) {
+		return fmt.Errorf("receipt proof is DEGRADED by %d recognized whole-receipt tombstone(s); inspect the source and rerun with --allow-degraded-receipts=%d to acknowledge exactly these gaps", len(original.degradations), len(original.degradations))
+	}
 	if len(writer.files) > recorder.MaxEvidenceReadDirectoryEntries {
 		return fmt.Errorf("compaction produced %d shards, exceeds %d", len(writer.files), recorder.MaxEvidenceReadDirectoryEntries)
 	}
@@ -132,7 +153,7 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	if !sameCompactProof(original, post) {
 		return errors.New("compaction changed original JSONL bytes or signed receipt proof")
 	}
-	manifest := compactManifest{Version: 1, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), Original: manifestStreamFiles(original.files), Replacement: manifestStreamFiles(writer.files), Mappings: writer.mappings}
+	manifest := compactManifest{Version: 2, SessionID: opts.sessionID, CreatedAt: time.Now().UTC(), ReceiptVerification: manifestReceiptVerification(original), Original: manifestStreamFiles(original.files), Replacement: manifestStreamFiles(writer.files), Mappings: writer.mappings}
 	archive := filepath.Join(parent, ".pipelock-evidence-archive-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
 	stageLock, err := compactAcquireLock(stage)
 	if err != nil {
@@ -173,7 +194,20 @@ func runCompact(cmd *cobra.Command, opts compactOptions) error {
 	}
 	committed = true
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "compacted session %q into %d bounded shard(s); original preserved at %s\n", opts.sessionID, len(writer.files), archive)
+	if original.v1Degraded {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "receipt proof: DEGRADED; preserved %d known whole-receipt redaction tombstone(s); see archive manifest\n", len(original.degradations))
+	} else {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "receipt proof: VERIFIED")
+	}
 	return nil
+}
+
+func manifestReceiptVerification(proof compactStreamProof) compactManifestReceiptVerification {
+	status := "verified"
+	if proof.v1Degraded {
+		status = "degraded"
+	}
+	return compactManifestReceiptVerification{Status: status, V1Count: proof.v1Count, V1ChainHead: proof.v1Head, V2Count: proof.v2Count, V2ChainHead: proof.v2Head, Degradations: append([]compactReceiptDegradation(nil), proof.degradations...), V1Suffixes: append([]compactReceiptSuffix(nil), proof.v1Suffixes...)}
 }
 
 func rollbackCompactExchange(active, old string, cause error) error {

--- a/internal/cli/evidence/compact_stream.go
+++ b/internal/cli/evidence/compact_stream.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -194,7 +195,13 @@ func sameCompactProof(a, b compactStreamProof) bool {
 		return false
 	}
 	for i := range a.degradations {
-		if a.degradations[i] != b.degradations[i] {
+		// Compaction can coalesce several source shards into one output shard,
+		// so the same recorder entry can legitimately acquire a different file
+		// name. The signed recorder sequence and tombstone metadata identify the
+		// degradation; File remains provenance for the corresponding manifest.
+		aGap, bGap := a.degradations[i], b.degradations[i]
+		aGap.File, bGap.File = "", ""
+		if aGap != bGap {
 			return false
 		}
 	}
@@ -204,6 +211,13 @@ func sameCompactProof(a, b compactStreamProof) bool {
 		}
 	}
 	return true
+}
+
+func advanceCompactSuffixOrigin(current, delta uint64) (uint64, error) {
+	if current > math.MaxUint64-delta {
+		return 0, fmt.Errorf("v1 receipt suffix origin overflows after chain_seq %d", current)
+	}
+	return current + delta, nil
 }
 
 func sameCompactNameSet(a, b []string) bool {
@@ -428,10 +442,11 @@ func streamCompactFiles(location recorder.EvidenceLocation, files []string, sess
 					if tombstone {
 						if !proof.v1Degraded && proof.v1Count > 0 {
 							result := v1.Finish()
-							if !result.Valid {
-								return fmt.Errorf("verify v1 receipt prefix before redaction tombstone: %s", result.Error)
+							proof.v1Suffixes = append(proof.v1Suffixes, compactReceiptSuffix{Count: result.ReceiptCount, OriginSeq: 0, OriginPrevHash: legacyreceipt.GenesisHash, FinalSeq: result.FinalSeq, Head: result.RootHash})
+							next, nextErr := advanceCompactSuffixOrigin(result.FinalSeq, 2)
+							if nextErr != nil {
+								return nextErr
 							}
-							next := result.FinalSeq + 2
 							expectedSuffixOrigin = &next
 						} else if suffixCount > 0 {
 							result, finishErr := suffix.Finish()
@@ -441,10 +456,17 @@ func streamCompactFiles(location recorder.EvidenceLocation, files []string, sess
 							if err := finishSuffix(); err != nil {
 								return fmt.Errorf("record v1 suffix before redaction tombstone: %w", err)
 							}
-							next := result.FinalSeq + 2
+							next, nextErr := advanceCompactSuffixOrigin(result.FinalSeq, 2)
+							if nextErr != nil {
+								return nextErr
+							}
 							expectedSuffixOrigin = &next
 						} else if expectedSuffixOrigin != nil {
-							*expectedSuffixOrigin = *expectedSuffixOrigin + 1
+							next, nextErr := advanceCompactSuffixOrigin(*expectedSuffixOrigin, 1)
+							if nextErr != nil {
+								return nextErr
+							}
+							*expectedSuffixOrigin = next
 						} else {
 							next := uint64(1)
 							expectedSuffixOrigin = &next

--- a/internal/cli/evidence/compact_stream.go
+++ b/internal/cli/evidence/compact_stream.go
@@ -14,15 +14,19 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/luckyPipewrench/pipelock/internal/contract"
 	contractreceipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/evidencename"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	legacyreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
@@ -186,7 +190,20 @@ func (w *compactStreamWriter) close() error {
 }
 
 func sameCompactProof(a, b compactStreamProof) bool {
-	return a.bytes == b.bytes && a.sum == b.sum && a.v1Count == b.v1Count && a.v1Head == b.v1Head && a.v2Count == b.v2Count && a.v2Head == b.v2Head
+	if a.bytes != b.bytes || a.sum != b.sum || a.v1Count != b.v1Count || a.v1Head != b.v1Head || a.v1Degraded != b.v1Degraded || a.v1FirstGap != b.v1FirstGap || a.v1TailGap != b.v1TailGap || a.v2Count != b.v2Count || a.v2Head != b.v2Head || len(a.degradations) != len(b.degradations) || len(a.v1Suffixes) != len(b.v1Suffixes) {
+		return false
+	}
+	for i := range a.degradations {
+		if a.degradations[i] != b.degradations[i] {
+			return false
+		}
+	}
+	for i := range a.v1Suffixes {
+		if a.v1Suffixes[i] != b.v1Suffixes[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func sameCompactNameSet(a, b []string) bool {
@@ -227,13 +244,62 @@ var compactKnownRecorderTypes = map[string]struct{}{
 }
 
 type compactStreamProof struct {
-	files   []compactStreamFile
-	bytes   int64
-	sum     string
-	v1Count uint64
-	v1Head  string
-	v2Count uint64
-	v2Head  string
+	files        []compactStreamFile
+	bytes        int64
+	sum          string
+	v1Count      uint64
+	v1Head       string
+	v1Degraded   bool
+	v1FirstGap   bool
+	v1TailGap    bool
+	degradations []compactReceiptDegradation
+	v1Suffixes   []compactReceiptSuffix
+	v2Count      uint64
+	v2Head       string
+}
+
+type compactReceiptSuffix struct {
+	Count          uint64 `json:"signed_receipts"`
+	OriginSeq      uint64 `json:"origin_seq"`
+	OriginPrevHash string `json:"origin_prev_hash"`
+	FinalSeq       uint64 `json:"final_seq"`
+	Head           string `json:"head"`
+}
+
+type compactReceiptDegradation struct {
+	File              string `json:"file"`
+	RecorderSeq       uint64 `json:"recorder_seq"`
+	OriginalSize      int64  `json:"original_size"`
+	CheckpointCovered bool   `json:"checkpoint_covered"`
+	Reason            string `json:"reason"`
+}
+
+const compactLegacyRedactionReason = "known whole-receipt redaction tombstone"
+
+type compactLegacyReceiptTombstone struct {
+	Redacted         bool        `json:"redacted"`
+	DetectedPatterns []string    `json:"detected_patterns"`
+	OriginalSize     json.Number `json:"original_size"`
+}
+
+func decodeCompactLegacyReceiptTombstone(raw []byte) (int64, bool) {
+	if err := jsonscan.RejectDuplicateKeys(raw); err != nil {
+		return 0, false
+	}
+	var tombstone compactLegacyReceiptTombstone
+	if err := contract.DecodeStrictJSON(raw, &tombstone); err != nil || !tombstone.Redacted || len(tombstone.DetectedPatterns) == 0 {
+		return 0, false
+	}
+	for _, marker := range tombstone.DetectedPatterns {
+		if !strings.HasPrefix(marker, "[REDACTED:") || !strings.HasSuffix(marker, "]") || len(marker) <= len("[REDACTED:]") || strings.ContainsAny(marker, "\r\n") {
+			return 0, false
+		}
+	}
+	size, err := strconv.ParseInt(string(tombstone.OriginalSize), 10, 64)
+	if err != nil || size <= 0 {
+		return 0, false
+	}
+	return size, true
 }
 
 // compactOuterVerifier checks the recorder envelope while each line is still
@@ -297,13 +363,31 @@ func streamCompactFiles(location recorder.EvidenceLocation, files []string, sess
 	var proof compactStreamProof
 	h := sha256.New()
 	outer := compactOuterVerifier{key: key}
-	v1, err := legacyreceipt.NewStreamingVerifier(hex.EncodeToString(key))
+	keyHex := hex.EncodeToString(key)
+	v1, err := legacyreceipt.NewStreamingVerifier(keyHex)
 	if err != nil {
 		return compactStreamProof{}, fmt.Errorf("initialize v1 receipt verifier: %w", err)
 	}
 	v2, err := contractreceipt.NewPinnedStreamingVerifier(key)
 	if err != nil {
 		return compactStreamProof{}, fmt.Errorf("initialize v2 receipt verifier: %w", err)
+	}
+	var suffix *legacyreceipt.UnanchoredSuffixVerifier
+	var suffixCount uint64
+	var expectedSuffixOrigin *uint64
+	var v1EntrySeen bool
+	finishSuffix := func() error {
+		if suffix == nil || suffixCount == 0 {
+			return nil
+		}
+		result, finishErr := suffix.Finish()
+		if finishErr != nil {
+			return finishErr
+		}
+		proof.v1Suffixes = append(proof.v1Suffixes, compactReceiptSuffix{Count: result.Count, OriginSeq: result.OriginSeq, OriginPrevHash: result.OriginPrevHash, FinalSeq: result.FinalSeq, Head: result.Head})
+		suffix = nil
+		suffixCount = 0
+		return nil
 	}
 	for _, name := range files {
 		path := filepath.Join(location.Dir, name)
@@ -328,12 +412,71 @@ func streamCompactFiles(location recorder.EvidenceLocation, files []string, sess
 				if _, ok := compactKnownRecorderTypes[entry.Type]; !ok {
 					return fmt.Errorf("unknown recorder entry type %q at seq %d", entry.Type, entry.Sequence)
 				}
+				if entry.Type == "checkpoint" {
+					for i := range proof.degradations {
+						proof.degradations[i].CheckpointCovered = true
+					}
+				}
 				switch entry.Type {
 				case "action_receipt":
-					if err := v1.Add(entry.RawDetail); err != nil {
-						return fmt.Errorf("verify v1 action_receipt at recorder seq %d: %w", entry.Sequence, err)
+					originalSize, tombstone := decodeCompactLegacyReceiptTombstone(entry.RawDetail)
+					if !v1EntrySeen {
+						proof.v1FirstGap = tombstone
+						v1EntrySeen = true
 					}
-					proof.v1Count++
+					proof.v1TailGap = tombstone
+					if tombstone {
+						if !proof.v1Degraded && proof.v1Count > 0 {
+							result := v1.Finish()
+							if !result.Valid {
+								return fmt.Errorf("verify v1 receipt prefix before redaction tombstone: %s", result.Error)
+							}
+							next := result.FinalSeq + 2
+							expectedSuffixOrigin = &next
+						} else if suffixCount > 0 {
+							result, finishErr := suffix.Finish()
+							if finishErr != nil {
+								return fmt.Errorf("finish v1 suffix before redaction tombstone: %w", finishErr)
+							}
+							if err := finishSuffix(); err != nil {
+								return fmt.Errorf("record v1 suffix before redaction tombstone: %w", err)
+							}
+							next := result.FinalSeq + 2
+							expectedSuffixOrigin = &next
+						} else if expectedSuffixOrigin != nil {
+							*expectedSuffixOrigin = *expectedSuffixOrigin + 1
+						} else {
+							next := uint64(1)
+							expectedSuffixOrigin = &next
+						}
+						proof.v1Degraded = true
+						proof.degradations = append(proof.degradations, compactReceiptDegradation{File: name, RecorderSeq: entry.Sequence, OriginalSize: originalSize, Reason: compactLegacyRedactionReason})
+					} else if proof.v1Degraded {
+						if suffix == nil {
+							suffix, err = legacyreceipt.NewUnanchoredSuffixVerifier(keyHex)
+							if err != nil {
+								return fmt.Errorf("initialize v1 suffix verifier: %w", err)
+							}
+						}
+						if err := suffix.Add(entry.RawDetail); err != nil {
+							return fmt.Errorf("verify v1 action_receipt after degraded chain at recorder seq %d: %w", entry.Sequence, err)
+						}
+						if suffixCount == 0 && expectedSuffixOrigin != nil {
+							result, finishErr := suffix.Finish()
+							if finishErr != nil {
+								return fmt.Errorf("inspect v1 suffix origin: %w", finishErr)
+							}
+							if result.OriginSeq != *expectedSuffixOrigin {
+								return fmt.Errorf("verify v1 action_receipt after degraded chain at recorder seq %d: expected suffix chain_seq %d, got %d", entry.Sequence, *expectedSuffixOrigin, result.OriginSeq)
+							}
+						}
+						suffixCount++
+						proof.v1Count++
+					} else if err := v1.Add(entry.RawDetail); err != nil {
+						return fmt.Errorf("verify v1 action_receipt at recorder seq %d: %w", entry.Sequence, err)
+					} else {
+						proof.v1Count++
+					}
 				case contractreceipt.EvidenceEntryType:
 					if err := v2.AddRaw(entry.RawDetail); err != nil {
 						return fmt.Errorf("verify v2 evidence_receipt at recorder seq %d: %w", entry.Sequence, err)
@@ -377,12 +520,16 @@ func streamCompactFiles(location recorder.EvidenceLocation, files []string, sess
 	if proof.v1Count == 0 && proof.v2Count == 0 {
 		return compactStreamProof{}, fmt.Errorf("session %q contains no signed evidence receipts", session)
 	}
-	if proof.v1Count > 0 {
+	if proof.v1Count > 0 && !proof.v1Degraded {
 		result := v1.Finish()
 		if !result.Valid {
 			return compactStreamProof{}, fmt.Errorf("verify v1 receipt chain: %s", result.Error)
 		}
 		proof.v1Head = result.RootHash
+	} else if proof.v1Degraded {
+		if err := finishSuffix(); err != nil {
+			return compactStreamProof{}, fmt.Errorf("finish v1 degraded suffix: %w", err)
+		}
 	}
 	if proof.v2Count > 0 {
 		result := v2.Finish()

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -705,12 +705,18 @@ func TestAdvanceCompactSuffixOriginRejectsOverflow(t *testing.T) {
 		t.Fatalf("advance suffix origin = %d, %v; want 43", got, err)
 	}
 	for _, tc := range []struct {
+		name    string
 		current uint64
 		delta   uint64
-	}{{current: ^uint64(0), delta: 1}, {current: ^uint64(0) - 1, delta: 2}} {
-		if _, err := advanceCompactSuffixOrigin(tc.current, tc.delta); err == nil || !strings.Contains(err.Error(), "overflows") {
-			t.Fatalf("advance suffix origin (%d, %d) error = %v", tc.current, tc.delta, err)
-		}
+	}{
+		{name: "max plus one", current: ^uint64(0), delta: 1},
+		{name: "max minus one plus two", current: ^uint64(0) - 1, delta: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := advanceCompactSuffixOrigin(tc.current, tc.delta); err == nil || !strings.Contains(err.Error(), "overflows") {
+				t.Fatalf("advance suffix origin (%d, %d) error = %v", tc.current, tc.delta, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -231,6 +231,39 @@ func TestStreamCompactFilesVerifiesSignedOuterCheckpoint(t *testing.T) {
 	}
 }
 
+func TestStreamCompactFilesReportsCheckpointCoverageAfterGap(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1, SignCheckpoints: true}, nil, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Record(recorder.Entry{SessionID: "proxy", Type: "action_receipt", EventKind: "proxy_decision", Transport: "fetch", Summary: "signed", Detail: receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "before-gap")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Record(recorder.Entry{SessionID: "proxy", Type: "action_receipt", EventKind: "proxy_decision", Transport: "fetch", Summary: "gap", Detail: map[string]any{"redacted": true, "detected_patterns": []string{"[REDACTED:test pattern]"}, "original_size": 42}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
+	names, err := compactStreamNames(location, "proxy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof, err := streamCompactFiles(location, names, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
+	if err != nil {
+		t.Fatalf("stream checkpoint-covered gap: %v", err)
+	}
+	if len(proof.degradations) != 1 || !proof.degradations[0].CheckpointCovered {
+		t.Fatalf("degradations=%+v, want one checkpoint-covered gap", proof.degradations)
+	}
+}
+
 func TestRunCompactSupportsOversizeLegacyShardAndResumeAppend(t *testing.T) {
 	if !supportsCompactExchangeTest() {
 		t.Skip("atomic evidence directory exchange is unsupported")
@@ -610,7 +643,7 @@ func TestCompactStreamHelpersCompareWholeProofs(t *testing.T) {
 	if !sameCompactProof(base, base) {
 		t.Fatal("same proof did not compare equal")
 	}
-	for _, changed := range []compactStreamProof{{bytes: 2}, {sum: "other"}, {v1Count: 4}, {v1Head: "other"}, {v2Count: 4}, {v2Head: "other"}} {
+	for _, changed := range []compactStreamProof{{bytes: 2}, {sum: "other"}, {v1Count: 4}, {v1Head: "other"}, {v1Degraded: true}, {v1FirstGap: true}, {v1TailGap: true}, {degradations: []compactReceiptDegradation{{RecorderSeq: 9}}}, {v1Suffixes: []compactReceiptSuffix{{OriginSeq: 9}}}, {v2Count: 4}, {v2Head: "other"}} {
 		candidate := base
 		if changed.bytes != 0 {
 			candidate.bytes = changed.bytes
@@ -624,6 +657,21 @@ func TestCompactStreamHelpersCompareWholeProofs(t *testing.T) {
 		if changed.v1Head != "" {
 			candidate.v1Head = changed.v1Head
 		}
+		if changed.v1Degraded {
+			candidate.v1Degraded = true
+		}
+		if changed.v1FirstGap {
+			candidate.v1FirstGap = true
+		}
+		if changed.v1TailGap {
+			candidate.v1TailGap = true
+		}
+		if changed.degradations != nil {
+			candidate.degradations = changed.degradations
+		}
+		if changed.v1Suffixes != nil {
+			candidate.v1Suffixes = changed.v1Suffixes
+		}
 		if changed.v2Count != 0 {
 			candidate.v2Count = changed.v2Count
 		}
@@ -633,6 +681,19 @@ func TestCompactStreamHelpersCompareWholeProofs(t *testing.T) {
 		if sameCompactProof(base, candidate) {
 			t.Fatalf("different proof compared equal: %#v", candidate)
 		}
+	}
+	withDetails := base
+	withDetails.degradations = []compactReceiptDegradation{{RecorderSeq: 1}}
+	withDetails.v1Suffixes = []compactReceiptSuffix{{OriginSeq: 2}}
+	differentDegradation := withDetails
+	differentDegradation.degradations = []compactReceiptDegradation{{RecorderSeq: 9}}
+	if sameCompactProof(withDetails, differentDegradation) {
+		t.Fatal("different degradation content compared equal")
+	}
+	differentSuffix := withDetails
+	differentSuffix.v1Suffixes = []compactReceiptSuffix{{OriginSeq: 7}}
+	if sameCompactProof(withDetails, differentSuffix) {
+		t.Fatal("different suffix content compared equal")
 	}
 	if sameCompactNameSet([]string{"a"}, []string{"a", "b"}) || sameCompactNameSet([]string{"a"}, []string{"b"}) || !sameCompactNameSet([]string{"a", "b"}, []string{"a", "b"}) {
 		t.Fatal("unexpected compact name-set comparison")
@@ -876,6 +937,300 @@ func TestStreamCompactFilesAcceptsMixedV1AndV2ReceiptFamilies(t *testing.T) {
 	}
 }
 
+func TestCompactLegacyReceiptTombstoneClassifierFailsClosed(t *testing.T) {
+	valid := `{"redacted":true,"detected_patterns":["[REDACTED:AWS access key pattern]"],"original_size":1234}`
+	if size, ok := decodeCompactLegacyReceiptTombstone([]byte(valid)); !ok || size != 1234 {
+		t.Fatalf("valid historical tombstone = size %d ok %t", size, ok)
+	}
+	validConfiguredName := `{"redacted":true,"detected_patterns":["[REDACTED:Vendor token [prod]]"],"original_size":2097152}`
+	if size, ok := decodeCompactLegacyReceiptTombstone([]byte(validConfiguredName)); !ok || size != 2097152 {
+		t.Fatalf("valid configured-name tombstone = size %d ok %t", size, ok)
+	}
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "extra field", raw: `{"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":1,"extra":true}`},
+		{name: "missing field", raw: `{"redacted":true,"original_size":1}`},
+		{name: "false", raw: `{"redacted":false,"detected_patterns":["[REDACTED:x]"],"original_size":1}`},
+		{name: "empty patterns", raw: `{"redacted":true,"detected_patterns":[],"original_size":1}`},
+		{name: "bad marker", raw: `{"redacted":true,"detected_patterns":["secret"],"original_size":1}`},
+		{name: "fractional size", raw: `{"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":1.5}`},
+		{name: "duplicate key", raw: `{"redacted":true,"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":1}`},
+		{name: "marshal error tombstone", raw: `{"redacted":true,"reason":"marshal error"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := decodeCompactLegacyReceiptTombstone([]byte(tc.raw)); ok {
+				t.Fatal("malformed tombstone accepted")
+			}
+		})
+	}
+}
+
+func TestStreamCompactFilesPreservesKnownReceiptDegradation(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "first")
+	firstHash, err := legacyreceipt.ReceiptHash(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterGap := receiptForCompactV1(t, priv, 2, firstHash, "after-gap")
+	afterGapHash, err := legacyreceipt.ReceiptHash(afterGap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	suffixTail := receiptForCompactV1(t, priv, 3, afterGapHash, "suffix-tail")
+	tombstone := map[string]any{"redacted": true, "detected_patterns": []string{"[REDACTED:AWS access key pattern]"}, "original_size": 777}
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	writeChain := func(receipts ...legacyreceipt.Receipt) {
+		t.Helper()
+		outerPrev := recorder.GenesisHash
+		var data bytes.Buffer
+		details := []any{first, tombstone}
+		for _, receipt := range receipts {
+			details = append(details, receipt)
+		}
+		for i, detail := range details {
+			e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: "action_receipt", EventKind: "proxy_decision", Transport: "fetch", Summary: "legacy", Detail: detail, PrevHash: outerPrev}
+			e.Hash = recorder.ComputeHash(e)
+			outerPrev = e.Hash
+			line, marshalErr := json.Marshal(e)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			data.Write(line)
+			data.WriteByte('\n')
+		}
+		if err := os.WriteFile(path, data.Bytes(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeChain(afterGap, suffixTail)
+	location := recorder.EvidenceLocation{Root: dir, Dir: dir}
+	proof, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
+	if err != nil {
+		t.Fatalf("stream degraded legacy receipts: %v", err)
+	}
+	if !proof.v1Degraded || proof.v1Count != 3 || proof.v1Head != "" || len(proof.degradations) != 1 || len(proof.v1Suffixes) != 1 || proof.v1Suffixes[0].Count != 2 || proof.v1Suffixes[0].Head == "" {
+		t.Fatalf("degraded proof = %+v", proof)
+	}
+	want := compactReceiptDegradation{File: "evidence-proxy-0.jsonl", RecorderSeq: 1, OriginalSize: 777, Reason: compactLegacyRedactionReason}
+	if proof.degradations[0] != want {
+		t.Fatalf("degradation = %+v, want %+v", proof.degradations[0], want)
+	}
+	if proof.degradations[0].CheckpointCovered {
+		t.Fatal("gap without a later checkpoint reported checkpoint coverage")
+	}
+	manifest := manifestReceiptVerification(proof)
+	if manifest.Status != "degraded" || manifest.V1ChainHead != "" || len(manifest.Degradations) != 1 || len(manifest.V1Suffixes) != 1 {
+		t.Fatalf("manifest receipt proof = %+v", manifest)
+	}
+
+	brokenTail := receiptForCompactV1(t, priv, 3, "unrelated-signed-head", "broken-suffix-tail")
+	writeChain(afterGap, brokenTail)
+	if _, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "chain_prev_hash mismatch") {
+		t.Fatalf("broken linked suffix error = %v", err)
+	}
+
+	afterGap.ActionRecord.Target = "https://api.vendor.example/tampered"
+	writeChain(afterGap)
+	if _, err := streamCompactFiles(location, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil }); err == nil || !strings.Contains(err.Error(), "after degraded chain") {
+		t.Fatalf("tampered receipt after tombstone error = %v", err)
+	}
+}
+
+func TestStreamCompactFilesHandlesLeadingConsecutiveAndMultipleGaps(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone := map[string]any{"redacted": true, "detected_patterns": []string{"[REDACTED:test pattern]"}, "original_size": 42}
+	makeReceipt := func(seq uint64, prev, id string) legacyreceipt.Receipt {
+		return receiptForCompactV1(t, priv, seq, prev, id)
+	}
+	for _, tc := range []struct {
+		name          string
+		details       []any
+		wantGaps      int
+		wantSuffixes  int
+		wantSuffixSeq []uint64
+	}{
+		{name: "leading gap", details: []any{tombstone, makeReceipt(1, "unknown-gap-head", "leading-origin")}, wantGaps: 1, wantSuffixes: 1, wantSuffixSeq: []uint64{1}},
+		{name: "consecutive gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, tombstone, makeReceipt(3, "unknown-two-gap-head", "consecutive-origin")}, wantGaps: 2, wantSuffixes: 1, wantSuffixSeq: []uint64{3}},
+		{name: "separated gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, makeReceipt(2, "unknown-first-gap-head", "first-origin"), tombstone, makeReceipt(4, "unknown-second-gap-head", "second-origin")}, wantGaps: 2, wantSuffixes: 2, wantSuffixSeq: []uint64{2, 4}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			outerPrev := recorder.GenesisHash
+			var data bytes.Buffer
+			for i, detail := range tc.details {
+				entry := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: "action_receipt", EventKind: "proxy_decision", Transport: "fetch", Summary: "legacy", Detail: detail, PrevHash: outerPrev}
+				entry.Hash = recorder.ComputeHash(entry)
+				outerPrev = entry.Hash
+				line, marshalErr := json.Marshal(entry)
+				if marshalErr != nil {
+					t.Fatal(marshalErr)
+				}
+				data.Write(line)
+				data.WriteByte('\n')
+			}
+			if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), data.Bytes(), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			proof, err := streamCompactFiles(recorder.EvidenceLocation{Root: dir, Dir: dir}, []string{"evidence-proxy-0.jsonl"}, "proxy", pub, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
+			if err != nil {
+				t.Fatalf("stream gaps: %v", err)
+			}
+			if len(proof.degradations) != tc.wantGaps || len(proof.v1Suffixes) != tc.wantSuffixes {
+				t.Fatalf("proof gaps=%d suffixes=%d, want %d/%d", len(proof.degradations), len(proof.v1Suffixes), tc.wantGaps, tc.wantSuffixes)
+			}
+			for i, want := range tc.wantSuffixSeq {
+				if proof.v1Suffixes[i].OriginSeq != want {
+					t.Fatalf("suffix %d origin=%d, want %d", i, proof.v1Suffixes[i].OriginSeq, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunCompactPublishesDegradedReceiptProof(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1 := receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "before-redaction")
+	tombstone := map[string]any{"redacted": true, "detected_patterns": []string{"[REDACTED:AWS access key pattern]"}, "original_size": 777}
+	v1AfterGap := receiptForCompactV1(t, priv, 2, "unknown-destroyed-receipt-head", "after-redaction")
+	v2 := compactSignedReceipt(t, priv, 0, contractreceipt.GenesisHash)
+
+	outerPrev := recorder.GenesisHash
+	var source bytes.Buffer
+	for i, item := range []struct {
+		typ    string
+		detail any
+	}{{"action_receipt", v1}, {"action_receipt", tombstone}, {"action_receipt", v1AfterGap}, {contractreceipt.EvidenceEntryType, v2}} {
+		e := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: item.typ, EventKind: "proxy_decision", Transport: "fetch", Summary: item.typ, Detail: item.detail, PrevHash: outerPrev}
+		e.Hash = recorder.ComputeHash(e)
+		outerPrev = e.Hash
+		line, marshalErr := json.Marshal(e)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		source.Write(line)
+		source.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), source.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := compactCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub)})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--allow-degraded-receipts") {
+		t.Fatalf("compact without degraded acknowledgement error = %v", err)
+	}
+	if active, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "evidence-proxy-0.jsonl"))); readErr != nil || !bytes.Equal(active, source.Bytes()) {
+		t.Fatalf("refused compaction changed source: err=%v", readErr)
+	}
+	cmd = compactCmd()
+	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub), "--allow-degraded-receipts=2"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "DEGRADED by 1") {
+		t.Fatalf("compact with wrong degraded count error = %v", err)
+	}
+
+	cmd = compactCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub), "--allow-degraded-receipts=1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("compact degraded legacy receipts: %v", err)
+	}
+	if !strings.Contains(out.String(), "receipt proof: DEGRADED") {
+		t.Fatalf("command output = %q", out.String())
+	}
+	archives, err := filepath.Glob(filepath.Join(parent, ".pipelock-evidence-archive-*"))
+	if err != nil || len(archives) != 1 {
+		t.Fatalf("archives = %v, err = %v", archives, err)
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(archives[0], "compaction-manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest compactManifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Version != 2 || manifest.ReceiptVerification.Status != "degraded" || manifest.ReceiptVerification.V1ChainHead != "" || len(manifest.ReceiptVerification.Degradations) != 1 {
+		t.Fatalf("manifest = %+v", manifest)
+	}
+	active, err := os.ReadFile(filepath.Clean(filepath.Join(dir, "evidence-proxy-0.jsonl")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(active, source.Bytes()) {
+		t.Fatal("degraded compaction changed JSONL bytes")
+	}
+}
+
+func TestRunCompactRefusesFirstOrLastV1Gap(t *testing.T) {
+	if !supportsCompactExchangeTest() {
+		t.Skip("atomic evidence directory exchange is unsupported")
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone := map[string]any{"redacted": true, "detected_patterns": []string{"[REDACTED:test pattern]"}, "original_size": 42}
+	for _, tc := range []struct {
+		name    string
+		details []any
+	}{
+		{name: "first", details: []any{tombstone, receiptForCompactV1(t, priv, 1, "unknown-gap-head", "suffix")}},
+		{name: "last", details: []any{receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "prefix"), tombstone}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			outerPrev := recorder.GenesisHash
+			var source bytes.Buffer
+			for i, detail := range tc.details {
+				entry := recorder.Entry{Version: recorder.CurrentWriteEntryVersion, Sequence: uint64(i), Timestamp: time.Unix(int64(i+1), 0).UTC(), SessionID: "proxy", Type: "action_receipt", EventKind: "proxy_decision", Transport: "fetch", Summary: "legacy", Detail: detail, PrevHash: outerPrev}
+				entry.Hash = recorder.ComputeHash(entry)
+				outerPrev = entry.Hash
+				line, marshalErr := json.Marshal(entry)
+				if marshalErr != nil {
+					t.Fatal(marshalErr)
+				}
+				source.Write(line)
+				source.WriteByte('\n')
+			}
+			path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+			if err := os.WriteFile(path, source.Bytes(), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := runCompact(compactCmd(), compactOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub), allowDegradedReceipts: 1})
+			if err == nil || !strings.Contains(err.Error(), "receipt resume cannot load") {
+				t.Fatalf("edge-gap compact error=%v", err)
+			}
+			active, readErr := os.ReadFile(filepath.Clean(path))
+			if readErr != nil || !bytes.Equal(active, source.Bytes()) {
+				t.Fatalf("refused edge-gap compact changed source: err=%v", readErr)
+			}
+		})
+	}
+}
+
 func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, prev string) contractreceipt.EvidenceReceipt {
 	t.Helper()
 	payload, err := json.Marshal(contractreceipt.PayloadShadowDeltaStruct{
@@ -903,16 +1258,21 @@ func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, pre
 
 func receiptForCompactMixedV1(t *testing.T, priv ed25519.PrivateKey) legacyreceipt.Receipt {
 	t.Helper()
+	return receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "compact-mixed-v1")
+}
+
+func receiptForCompactV1(t *testing.T, priv ed25519.PrivateKey, seq uint64, prev, actionID string) legacyreceipt.Receipt {
+	t.Helper()
 	r, err := legacyreceipt.Sign(legacyreceipt.ActionRecord{
 		Version:       legacyreceipt.ActionRecordVersion,
-		ActionID:      "compact-mixed-v1",
+		ActionID:      actionID,
 		ActionType:    legacyreceipt.ActionRead,
 		Timestamp:     time.Unix(1, 0).UTC(),
 		Target:        "https://api.vendor.example/compact",
 		Verdict:       "allow",
 		Transport:     "fetch",
-		ChainPrevHash: legacyreceipt.GenesisHash,
-		ChainSeq:      0,
+		ChainPrevHash: prev,
+		ChainSeq:      seq,
 	}, priv)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -700,6 +700,20 @@ func TestCompactStreamHelpersCompareWholeProofs(t *testing.T) {
 	}
 }
 
+func TestAdvanceCompactSuffixOriginRejectsOverflow(t *testing.T) {
+	if got, err := advanceCompactSuffixOrigin(41, 2); err != nil || got != 43 {
+		t.Fatalf("advance suffix origin = %d, %v; want 43", got, err)
+	}
+	for _, tc := range []struct {
+		current uint64
+		delta   uint64
+	}{{current: ^uint64(0), delta: 1}, {current: ^uint64(0) - 1, delta: 2}} {
+		if _, err := advanceCompactSuffixOrigin(tc.current, tc.delta); err == nil || !strings.Contains(err.Error(), "overflows") {
+			t.Fatalf("advance suffix origin (%d, %d) error = %v", tc.current, tc.delta, err)
+		}
+	}
+}
+
 func TestStreamCompactToStageClosesOnFailureAndPublishesOnSuccess(t *testing.T) {
 	opts := newCompactFixture(t)
 	pub, err := hex.DecodeString(opts.publicKey)
@@ -956,6 +970,8 @@ func TestCompactLegacyReceiptTombstoneClassifierFailsClosed(t *testing.T) {
 		{name: "empty patterns", raw: `{"redacted":true,"detected_patterns":[],"original_size":1}`},
 		{name: "bad marker", raw: `{"redacted":true,"detected_patterns":["secret"],"original_size":1}`},
 		{name: "fractional size", raw: `{"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":1.5}`},
+		{name: "zero size", raw: `{"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":0}`},
+		{name: "negative size", raw: `{"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":-1}`},
 		{name: "duplicate key", raw: `{"redacted":true,"redacted":true,"detected_patterns":["[REDACTED:x]"],"original_size":1}`},
 		{name: "marshal error tombstone", raw: `{"redacted":true,"reason":"marshal error"}`},
 	} {
@@ -964,6 +980,17 @@ func TestCompactLegacyReceiptTombstoneClassifierFailsClosed(t *testing.T) {
 				t.Fatal("malformed tombstone accepted")
 			}
 		})
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := json.Marshal(receiptForCompactV1(t, priv, 0, legacyreceipt.GenesisHash, "not-a-tombstone"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := decodeCompactLegacyReceiptTombstone(signed); ok {
+		t.Fatal("complete signed v1 receipt was classified as a tombstone")
 	}
 }
 
@@ -1015,7 +1042,7 @@ func TestStreamCompactFilesPreservesKnownReceiptDegradation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stream degraded legacy receipts: %v", err)
 	}
-	if !proof.v1Degraded || proof.v1Count != 3 || proof.v1Head != "" || len(proof.degradations) != 1 || len(proof.v1Suffixes) != 1 || proof.v1Suffixes[0].Count != 2 || proof.v1Suffixes[0].Head == "" {
+	if !proof.v1Degraded || proof.v1Count != 3 || proof.v1Head != "" || len(proof.degradations) != 1 || len(proof.v1Suffixes) != 2 || proof.v1Suffixes[0].Count != 1 || proof.v1Suffixes[0].OriginSeq != 0 || proof.v1Suffixes[0].OriginPrevHash != legacyreceipt.GenesisHash || proof.v1Suffixes[1].Count != 2 || proof.v1Suffixes[1].Head == "" {
 		t.Fatalf("degraded proof = %+v", proof)
 	}
 	want := compactReceiptDegradation{File: "evidence-proxy-0.jsonl", RecorderSeq: 1, OriginalSize: 777, Reason: compactLegacyRedactionReason}
@@ -1026,7 +1053,7 @@ func TestStreamCompactFilesPreservesKnownReceiptDegradation(t *testing.T) {
 		t.Fatal("gap without a later checkpoint reported checkpoint coverage")
 	}
 	manifest := manifestReceiptVerification(proof)
-	if manifest.Status != "degraded" || manifest.V1ChainHead != "" || len(manifest.Degradations) != 1 || len(manifest.V1Suffixes) != 1 {
+	if manifest.Status != "degraded" || manifest.V1ChainHead != "" || len(manifest.Degradations) != 1 || len(manifest.V1Suffixes) != 2 {
 		t.Fatalf("manifest receipt proof = %+v", manifest)
 	}
 
@@ -1060,8 +1087,8 @@ func TestStreamCompactFilesHandlesLeadingConsecutiveAndMultipleGaps(t *testing.T
 		wantSuffixSeq []uint64
 	}{
 		{name: "leading gap", details: []any{tombstone, makeReceipt(1, "unknown-gap-head", "leading-origin")}, wantGaps: 1, wantSuffixes: 1, wantSuffixSeq: []uint64{1}},
-		{name: "consecutive gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, tombstone, makeReceipt(3, "unknown-two-gap-head", "consecutive-origin")}, wantGaps: 2, wantSuffixes: 1, wantSuffixSeq: []uint64{3}},
-		{name: "separated gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, makeReceipt(2, "unknown-first-gap-head", "first-origin"), tombstone, makeReceipt(4, "unknown-second-gap-head", "second-origin")}, wantGaps: 2, wantSuffixes: 2, wantSuffixSeq: []uint64{2, 4}},
+		{name: "consecutive gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, tombstone, makeReceipt(3, "unknown-two-gap-head", "consecutive-origin")}, wantGaps: 2, wantSuffixes: 2, wantSuffixSeq: []uint64{0, 3}},
+		{name: "separated gaps", details: []any{makeReceipt(0, legacyreceipt.GenesisHash, "prefix"), tombstone, makeReceipt(2, "unknown-first-gap-head", "first-origin"), tombstone, makeReceipt(4, "unknown-second-gap-head", "second-origin")}, wantGaps: 2, wantSuffixes: 3, wantSuffixSeq: []uint64{0, 2, 4}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -1131,7 +1158,14 @@ func TestRunCompactPublishesDegradedReceiptProof(t *testing.T) {
 		source.Write(line)
 		source.WriteByte('\n')
 	}
-	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), source.Bytes(), 0o600); err != nil {
+	split := bytes.IndexByte(source.Bytes(), '\n') + 1
+	if split <= 0 {
+		t.Fatal("source has no first JSONL record")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), source.Bytes()[:split], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-1.jsonl"), source.Bytes()[split:], 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1142,16 +1176,22 @@ func TestRunCompactPublishesDegradedReceiptProof(t *testing.T) {
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--allow-degraded-receipts") {
 		t.Fatalf("compact without degraded acknowledgement error = %v", err)
 	}
-	if active, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "evidence-proxy-0.jsonl"))); readErr != nil || !bytes.Equal(active, source.Bytes()) {
-		t.Fatalf("refused compaction changed source: err=%v", readErr)
+	if first, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "evidence-proxy-0.jsonl"))); readErr != nil || !bytes.Equal(first, source.Bytes()[:split]) {
+		t.Fatalf("refused compaction changed first source shard: err=%v", readErr)
+	}
+	if second, readErr := os.ReadFile(filepath.Clean(filepath.Join(dir, "evidence-proxy-1.jsonl"))); readErr != nil || !bytes.Equal(second, source.Bytes()[split:]) {
+		t.Fatalf("refused compaction changed second source shard: err=%v", readErr)
 	}
 	cmd = compactCmd()
+	var wrongCountOut bytes.Buffer
+	cmd.SetOut(&wrongCountOut)
 	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub), "--allow-degraded-receipts=2"})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "DEGRADED by 1") {
 		t.Fatalf("compact with wrong degraded count error = %v", err)
 	}
 
 	cmd = compactCmd()
+	out.Reset()
 	cmd.SetOut(&out)
 	cmd.SetArgs([]string{"--receipt-dir", dir, "--session", "proxy", "--key", hex.EncodeToString(pub), "--allow-degraded-receipts=1"})
 	if err := cmd.Execute(); err != nil {

--- a/internal/mcp/parentwatch_ws_test.go
+++ b/internal/mcp/parentwatch_ws_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -104,6 +105,107 @@ func TestSessionExit_WSStopsBridge(t *testing.T) {
 	// with respect to each other, so reading the buffer the instant done fires
 	// races the write and fails under load. Poll for the explanation instead of
 	// assuming it has already landed.
+	testwait.For(t, 5*time.Second, func() bool {
+		return logBuf.contains("spawning session exited")
+	}, "missing session-exit explanation in operator log, got %q", logBuf.String())
+}
+
+func TestSessionExit_WSCancellationDuringDialIsClean(t *testing.T) {
+	clientIn := newBlockingReader()
+	defer func() { _ = clientIn.Close() }()
+	sc := testScannerForWS(t)
+	var parentDied atomic.Bool
+	dialStarted := make(chan struct{})
+	var dialOnce sync.Once
+	var clientOut, logBuf lockedHTTPBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunWSProxy(context.Background(), clientIn, &clientOut, &logBuf, "ws://api.vendor.example/mcp", MCPProxyOpts{
+			Scanner: sc,
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				dialOnce.Do(func() { close(dialStarted) })
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			sessionExitForTest: &sessionExitTestHooks{watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid: func() int {
+					if parentDied.Load() {
+						return orphanedPPID
+					}
+					return 4242
+				},
+			}},
+		})
+	}()
+
+	select {
+	case <-dialStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket dial never started")
+	}
+	parentDied.Store(true)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunWSProxy after session exit during dial = %v, want clean teardown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket dial stayed alive after the spawning session exited")
+	}
+	testwait.For(t, 5*time.Second, func() bool {
+		return logBuf.contains("spawning session exited")
+	}, "missing session-exit explanation in operator log, got %q", logBuf.String())
+}
+
+func TestSessionExit_WSAuthorityDialCancellationIsClean(t *testing.T) {
+	msg := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"com.pipelock/authority":"grant"}}}` + "\n"
+	var parentDied atomic.Bool
+	dialStarted := make(chan struct{})
+	var dialOnce sync.Once
+	var clientOut, logBuf lockedHTTPBuffer
+	done := make(chan error, 1)
+	go func() {
+		done <- RunWSProxy(context.Background(), strings.NewReader(msg), &clientOut, &logBuf, "ws://api.vendor.example/mcp", MCPProxyOpts{
+			Scanner:              testScannerForWS(t),
+			AuthorityVerifier:    allowAuthorityVerifier(nil),
+			AuthorityActor:       "agent-a",
+			AuthorityDestination: "ws://api.vendor.example/mcp",
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				dialOnce.Do(func() { close(dialStarted) })
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			sessionExitForTest: &sessionExitTestHooks{watch: parentWatchOpts{
+				interval:  time.Millisecond,
+				startPPID: 4242,
+				getppid: func() int {
+					if parentDied.Load() {
+						return orphanedPPID
+					}
+					return 4242
+				},
+			}},
+		})
+	}()
+
+	select {
+	case <-dialStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("authority-delayed WebSocket dial never started")
+	}
+	parentDied.Store(true)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunWSProxy after session exit during authority-delayed dial = %v, want clean teardown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("authority-delayed WebSocket dial stayed alive after the spawning session exited")
+	}
 	testwait.For(t, 5*time.Second, func() bool {
 		return logBuf.contains("spawning session exited")
 	}, "missing session-exit explanation in operator log, got %q", logBuf.String())

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -148,6 +148,9 @@ func RunWSProxy(
 	}
 	if opts.AuthorityVerifier == nil {
 		if err := startUpstream(); err != nil {
+			if sessionExit.inProgress() && errors.Is(err, context.Canceled) {
+				return nil
+			}
 			return err
 		}
 	}
@@ -225,6 +228,9 @@ func RunWSProxy(
 		// until the first message has passed every existing gate plus the grant
 		// check in scanHTTPInputDecision.
 		if err := startUpstream(); err != nil {
+			if sessionExit.inProgress() && errors.Is(err, context.Canceled) {
+				break
+			}
 			stdinErr = err
 			break
 		}

--- a/internal/receipt/bytes_verify.go
+++ b/internal/receipt/bytes_verify.go
@@ -109,6 +109,9 @@ func verifyV1SuffixBytesWithKey(raw []byte, expectedKeyHex string) error {
 	if strictErr == nil {
 		return nil
 	}
+	if err := jsonscan.RejectDuplicateKeys(raw); err != nil {
+		return fmt.Errorf("decode legacy v1 suffix envelope: %w", err)
+	}
 	var top map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &top); err != nil {
 		return fmt.Errorf("decode legacy v1 suffix envelope: %w", err)
@@ -119,6 +122,12 @@ func verifyV1SuffixBytesWithKey(raw []byte, expectedKeyHex string) error {
 	}
 	if _, ok := action["detected_patterns"]; !ok {
 		return strictErr
+	}
+	canonicalAction, _ := json.Marshal(action) // RawMessage values were validated by json.Unmarshal above.
+	top["action_record"] = canonicalAction
+	canonicalRaw, _ := json.Marshal(top) // RawMessage values were validated by json.Unmarshal above.
+	if !bytes.Equal(raw, canonicalRaw) {
+		return fmt.Errorf("legacy v1 suffix bytes do not match the historical emitted JSON shape")
 	}
 	receipt, err := Unmarshal(raw)
 	if err != nil {

--- a/internal/receipt/bytes_verify.go
+++ b/internal/receipt/bytes_verify.go
@@ -22,6 +22,131 @@ type receiptBytesEnvelopeV1 struct {
 	SignerKey    string          `json:"signer_key"`
 }
 
+// UnanchoredSuffixResult describes a contiguous v1 receipt segment whose
+// earlier chain history is unavailable. OriginPrevHash is recorded rather than
+// trusted: the verifier can prove the suffix from OriginSeq onward, not the
+// missing predecessor it references.
+type UnanchoredSuffixResult struct {
+	Count          uint64
+	OriginSeq      uint64
+	OriginPrevHash string
+	FinalSeq       uint64
+	Head           string
+}
+
+// UnanchoredSuffixVerifier verifies a bounded stream that starts after an
+// irrecoverable historical gap. Its first receipt must be signed by the
+// caller-pinned key. Every later receipt must use that same key, be valid in
+// its exact emitted-byte representation, and continue the suffix directly.
+// Key transitions are deliberately unsupported: accepting one without its
+// missing predecessor would make the new key's authority unverifiable.
+type UnanchoredSuffixVerifier struct {
+	expectedKeyHex string
+	seen           bool
+	failed         error
+	result         UnanchoredSuffixResult
+}
+
+// NewUnanchoredSuffixVerifier creates a verifier pinned to one trusted v1
+// signer key. A suffix cannot use trust-on-first-use because its missing
+// predecessor is precisely the trust boundary that cannot be reconstructed.
+func NewUnanchoredSuffixVerifier(expectedKeyHex string) (*UnanchoredSuffixVerifier, error) {
+	if expectedKeyHex == "" {
+		return nil, fmt.Errorf("unanchored suffix verification requires a trusted public key")
+	}
+	key, err := hex.DecodeString(expectedKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode trusted public key: %w", err)
+	}
+	if len(key) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid trusted public key length: got %d, want %d", len(key), ed25519.PublicKeySize)
+	}
+	return &UnanchoredSuffixVerifier{expectedKeyHex: expectedKeyHex}, nil
+}
+
+// Add verifies one exact v1 receipt and advances the suffix. Once it fails,
+// the verifier stays failed so a caller cannot accidentally continue from a
+// corrupted or substituted record.
+func (v *UnanchoredSuffixVerifier) Add(raw []byte) error {
+	if v.failed != nil {
+		return v.failed
+	}
+	if err := verifyV1SuffixBytesWithKey(raw, v.expectedKeyHex); err != nil {
+		return v.latch(err)
+	}
+	r, _ := Unmarshal(raw)
+	if r.ActionRecord.KeyTransition != nil {
+		return v.latch(fmt.Errorf("key_transition is unsupported in an unanchored receipt suffix"))
+	}
+	if v.seen {
+		if v.result.FinalSeq == ^uint64(0) {
+			return v.latch(fmt.Errorf("unanchored suffix sequence overflows after %d", v.result.FinalSeq))
+		}
+		if r.ActionRecord.ChainSeq != v.result.FinalSeq+1 {
+			return v.latch(fmt.Errorf("unanchored suffix sequence break: expected %d, got %d", v.result.FinalSeq+1, r.ActionRecord.ChainSeq))
+		}
+		if r.ActionRecord.ChainPrevHash != v.result.Head {
+			return v.latch(fmt.Errorf("unanchored suffix chain_prev_hash mismatch"))
+		}
+	}
+	head, _ := ReceiptHash(r)
+	if !v.seen {
+		v.result.OriginSeq = r.ActionRecord.ChainSeq
+		v.result.OriginPrevHash = r.ActionRecord.ChainPrevHash
+		v.seen = true
+	}
+	v.result.Count++
+	v.result.FinalSeq = r.ActionRecord.ChainSeq
+	v.result.Head = head
+	return nil
+}
+
+// verifyV1SuffixBytesWithKey preserves the one deliberate v1 parser
+// compatibility rule for historical action_record.detected_patterns metadata.
+// All ordinary receipts retain the stricter exact-emitted-byte check.
+func verifyV1SuffixBytesWithKey(raw []byte, expectedKeyHex string) error {
+	strictErr := VerifyV1BytesWithKey(raw, expectedKeyHex)
+	if strictErr == nil {
+		return nil
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return fmt.Errorf("decode legacy v1 suffix envelope: %w", err)
+	}
+	var action map[string]json.RawMessage
+	if err := json.Unmarshal(top["action_record"], &action); err != nil {
+		return fmt.Errorf("decode legacy v1 suffix action_record: %w", err)
+	}
+	if _, ok := action["detected_patterns"]; !ok {
+		return strictErr
+	}
+	receipt, err := Unmarshal(raw)
+	if err != nil {
+		return err
+	}
+	if err := VerifyWithKey(receipt, expectedKeyHex); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *UnanchoredSuffixVerifier) latch(err error) error {
+	v.failed = err
+	return err
+}
+
+// Finish returns the verified suffix boundary. Empty or failed suffixes do not
+// yield a proof because there is no signed trusted origin to report.
+func (v *UnanchoredSuffixVerifier) Finish() (UnanchoredSuffixResult, error) {
+	if v.failed != nil {
+		return UnanchoredSuffixResult{}, v.failed
+	}
+	if !v.seen {
+		return UnanchoredSuffixResult{}, fmt.Errorf("empty unanchored receipt suffix")
+	}
+	return v.result, nil
+}
+
 // VerifyV1BytesWithKey verifies a v1 receipt from the exact JSON bytes supplied
 // by the caller. It is additive: existing object-taking verification continues
 // to use VerifyWithKey.

--- a/internal/receipt/bytes_verify_suffix_test.go
+++ b/internal/receipt/bytes_verify_suffix_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUnanchoredSuffixVerifierAcceptsTrustedContiguousSuffix(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	chain := buildUnanchoredSuffix(t, priv, 41, "lost-predecessor-head", 3)
+	v, err := NewUnanchoredSuffixVerifier(hex.EncodeToString(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, receipt := range chain {
+		if err := v.Add(mustMarshalReceipt(t, receipt)); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	got, err := v.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHead := mustHash(t, chain[len(chain)-1])
+	if got.Count != 3 || got.OriginSeq != 41 || got.OriginPrevHash != "lost-predecessor-head" || got.FinalSeq != 43 || got.Head != wantHead {
+		t.Fatalf("suffix result=%+v", got)
+	}
+}
+
+func TestUnanchoredSuffixVerifierAcceptsLegacyDetectedPatternsOrigin(t *testing.T) {
+	raw, keyHex := legacyDetectedPatternsFixture(t)
+	v, err := NewUnanchoredSuffixVerifier(keyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.Add(raw); err != nil {
+		t.Fatalf("Add legacy detected_patterns receipt: %v", err)
+	}
+	result, err := v.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 1 || result.OriginSeq != 2 || result.Head == "" {
+		t.Fatalf("legacy suffix result=%+v", result)
+	}
+}
+
+func TestUnanchoredSuffixVerifierRejectsBrokenSuffixes(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	chain := buildUnanchoredSuffix(t, priv, 9, "lost-predecessor-head", 3)
+	_, otherPriv := generateTestKey(t)
+
+	splice := signChainReceipt(t, priv, 10, "other-segment-head", time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC))
+	badSignature := chain[1]
+	badSignature.ActionRecord.Target = "https://api.vendor.example/tampered"
+	transition := chain[1]
+	transition.ActionRecord.KeyTransition = &KeyTransition{PriorSignerKey: hex.EncodeToString(pub), PriorChainSeq: 9, PriorChainHash: mustHash(t, chain[0])}
+	transition = resignSuffixReceipt(t, transition, priv)
+	signerChange := signChainReceipt(t, otherPriv, 10, mustHash(t, chain[0]), time.Date(2026, 4, 2, 0, 0, 1, 0, time.UTC))
+	maxSeq := signChainReceipt(t, priv, ^uint64(0), "lost-predecessor-head", time.Date(2026, 4, 2, 0, 0, 2, 0, time.UTC))
+	wrappedSeq := signChainReceipt(t, priv, 0, mustHash(t, maxSeq), time.Date(2026, 4, 2, 0, 0, 3, 0, time.UTC))
+
+	for _, tc := range []struct {
+		name     string
+		receipts []Receipt
+		want     string
+	}{
+		{name: "deletion", receipts: []Receipt{chain[0], chain[2]}, want: "sequence break"},
+		{name: "reorder", receipts: []Receipt{chain[1], chain[0]}, want: "sequence break"},
+		{name: "duplicate", receipts: []Receipt{chain[0], chain[1], chain[1]}, want: "sequence break"},
+		{name: "splice", receipts: []Receipt{chain[0], splice}, want: "chain_prev_hash mismatch"},
+		{name: "bad signature", receipts: []Receipt{chain[0], badSignature}, want: "signature verification failed"},
+		{name: "signer change", receipts: []Receipt{chain[0], signerChange}, want: "does not match expected key"},
+		{name: "key transition", receipts: []Receipt{chain[0], transition}, want: "key_transition is unsupported"},
+		{name: "sequence overflow", receipts: []Receipt{maxSeq, wrappedSeq}, want: "sequence overflows"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := NewUnanchoredSuffixVerifier(hex.EncodeToString(pub))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, receipt := range tc.receipts {
+				err = v.Add(mustMarshalReceipt(t, receipt))
+				if err != nil {
+					break
+				}
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Add error=%v, want %q", err, tc.want)
+			}
+			if repeatedErr := v.Add(mustMarshalReceipt(t, chain[0])); repeatedErr == nil || repeatedErr.Error() != err.Error() {
+				t.Fatalf("latched Add error=%v, want %v", repeatedErr, err)
+			}
+			if _, finishErr := v.Finish(); finishErr == nil || finishErr.Error() != err.Error() {
+				t.Fatalf("Finish error=%v, want latched %v", finishErr, err)
+			}
+		})
+	}
+}
+
+func TestUnanchoredSuffixVerifierRejectsMissingTrustAndEmptySuffix(t *testing.T) {
+	if _, err := NewUnanchoredSuffixVerifier(""); err == nil {
+		t.Fatal("empty trusted key accepted")
+	}
+	if _, err := NewUnanchoredSuffixVerifier("not-hex"); err == nil || !strings.Contains(err.Error(), "decode trusted public key") {
+		t.Fatalf("invalid hex key error=%v", err)
+	}
+	if _, err := NewUnanchoredSuffixVerifier("00"); err == nil || !strings.Contains(err.Error(), "invalid trusted public key length") {
+		t.Fatalf("short key error=%v", err)
+	}
+	pub, _ := generateTestKey(t)
+	v, err := NewUnanchoredSuffixVerifier(hex.EncodeToString(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v.Finish(); err == nil || err.Error() != "empty unanchored receipt suffix" {
+		t.Fatalf("empty Finish error=%v", err)
+	}
+}
+
+func TestVerifyV1SuffixBytesWithKeyRejectsMalformedLegacyFallbacks(t *testing.T) {
+	if err := verifyV1SuffixBytesWithKey([]byte("{"), strings.Repeat("00", ed25519.PublicKeySize)); err == nil || !strings.Contains(err.Error(), "decode legacy v1 suffix envelope") {
+		t.Fatalf("malformed envelope error=%v", err)
+	}
+	if err := verifyV1SuffixBytesWithKey([]byte(`{"action_record":"not-an-object"}`), strings.Repeat("00", ed25519.PublicKeySize)); err == nil || !strings.Contains(err.Error(), "decode legacy v1 suffix action_record") {
+		t.Fatalf("malformed action_record error=%v", err)
+	}
+	raw, keyHex := legacyDetectedPatternsFixture(t)
+	unknown := mutateLegacyActionRecord(t, raw, func(action map[string]json.RawMessage) {
+		action["unknown_field"] = json.RawMessage(`true`)
+	})
+	if err := verifyV1SuffixBytesWithKey(unknown, keyHex); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("legacy unknown-field error=%v", err)
+	}
+	tampered := mutateLegacyActionRecord(t, raw, func(action map[string]json.RawMessage) {
+		action["target"] = json.RawMessage(`"https://api.vendor.example/tampered"`)
+	})
+	if err := verifyV1SuffixBytesWithKey(tampered, keyHex); err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("legacy tamper error=%v", err)
+	}
+}
+
+func buildUnanchoredSuffix(t *testing.T, priv ed25519.PrivateKey, originSeq uint64, originPrev string, count int) []Receipt {
+	t.Helper()
+	chain := make([]Receipt, 0, count)
+	prev := originPrev
+	base := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	for i := range count {
+		receipt := signChainReceipt(t, priv, originSeq+uint64(i), prev, base.Add(time.Duration(i)*time.Second))
+		chain = append(chain, receipt)
+		prev = mustHash(t, receipt)
+	}
+	return chain
+}
+
+func mustMarshalReceipt(t *testing.T, receipt Receipt) []byte {
+	t.Helper()
+	raw, err := Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func resignSuffixReceipt(t *testing.T, receipt Receipt, priv ed25519.PrivateKey) Receipt {
+	t.Helper()
+	resigned, err := Sign(receipt.ActionRecord, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resigned
+}

--- a/internal/receipt/bytes_verify_suffix_test.go
+++ b/internal/receipt/bytes_verify_suffix_test.go
@@ -4,6 +4,7 @@
 package receipt
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -144,6 +145,14 @@ func TestVerifyV1SuffixBytesWithKeyRejectsMalformedLegacyFallbacks(t *testing.T)
 	})
 	if err := verifyV1SuffixBytesWithKey(tampered, keyHex); err == nil || !strings.Contains(err.Error(), "signature verification failed") {
 		t.Fatalf("legacy tamper error=%v", err)
+	}
+	duplicate := bytes.Replace(raw, []byte(`"version":1`), []byte(`"version":1,"version":1`), 1)
+	if err := verifyV1SuffixBytesWithKey(duplicate, keyHex); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("legacy duplicate-key error=%v", err)
+	}
+	alternateWhitespace := append([]byte(" "), raw...)
+	if err := verifyV1SuffixBytesWithKey(alternateWhitespace, keyHex); err == nil || !strings.Contains(err.Error(), "historical emitted JSON shape") {
+		t.Fatalf("legacy alternate-byte-shape error=%v", err)
 	}
 }
 

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -634,6 +634,10 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		e.recordFailure(FailReasonMarshal)
 		return fmt.Errorf("marshaling receipt: %w", err)
 	}
+	if err := e.recorder.ValidateSignedReceiptDetail(json.RawMessage(receiptJSON)); err != nil {
+		e.recordFailure(FailReasonRecord)
+		return fmt.Errorf("validating signed receipt for recording: %w", err)
+	}
 
 	// Advance chain state BEFORE persist. Record may write the entry
 	// and then fail on checkpoint/rotation. If we left chain state

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -51,11 +51,11 @@ const (
 	// retry loop. O_EXCL still prevents every overwrite on every attempt.
 	maxEscrowNameAttempts = 16
 
-	// recorderTypeReceipt is the entry type for action receipts. These get
-	// selective field redaction (target/pattern only) instead of full detail
-	// replacement, preserving receipt structure for audit while preventing
-	// plaintext secrets in evidence files.
-	recorderTypeReceipt = "action_receipt"
+	// Signed receipt details must never be mutated after signing. If recorder
+	// DLP finds a secret in either receipt format, recording fails closed before
+	// any bytes are written.
+	recorderTypeReceipt         = "action_receipt"
+	recorderTypeEvidenceReceipt = "evidence_receipt"
 
 	// eventKindCheckpoint is the EventKind value stamped on checkpoint
 	// entries written by the recorder. Fixed value - checkpoints are an
@@ -504,6 +504,11 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 	e.Sequence = r.seq
 	e.Timestamp = time.Now().UTC()
 	e.PrevHash = r.prevHash
+	if e.Type == recorderTypeReceipt || e.Type == recorderTypeEvidenceReceipt {
+		if err := r.ValidateSignedReceiptDetail(e.Detail); err != nil {
+			return Entry{}, err
+		}
+	}
 
 	// Raw escrow: encrypt detail before redaction. Escrow must succeed
 	// when enabled -- silent drops would lose raw evidence.
@@ -526,9 +531,7 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 	// Raw escrow preserves the exact detail passed to the recorder for
 	// forensic replay.
 	if r.cfg.Redact && r.redactFn != nil {
-		if e.Type == recorderTypeReceipt {
-			e.Detail = r.redactReceiptDetail(e.Detail)
-		} else {
+		if e.Type != recorderTypeReceipt && e.Type != recorderTypeEvidenceReceipt {
 			e.Detail = r.redactDetail(e.Detail)
 		}
 	}
@@ -539,6 +542,16 @@ func (r *Recorder) prepareAndWriteEntryLocked(e Entry, notify bool) (Entry, erro
 		return Entry{}, fmt.Errorf("writing entry: %w", err)
 	}
 	return e, nil
+}
+
+// ValidateSignedReceiptDetail checks whether a signed receipt can be persisted
+// without post-signature redaction. Emitters call this before advancing their
+// chain state; Record repeats it at the write boundary.
+func (r *Recorder) ValidateSignedReceiptDetail(detail any) error {
+	if r == nil || !r.cfg.Redact || r.redactFn == nil {
+		return nil
+	}
+	return r.validateReceiptDetailClean(detail)
 }
 
 // runPostRecordMaintenanceLocked applies checkpoint and rotation thresholds
@@ -763,82 +776,22 @@ func (r *Recorder) redactDetail(detail any) any {
 	}
 }
 
-// redactReceiptDetail selectively redacts sensitive fields (target, pattern)
-// in a receipt entry while preserving the receipt structure. Current receipt
-// emitters sanitize those fields before signing, so this should return the
-// detail unchanged for normal receipts. If a malformed, legacy, or unexpected
-// receipt still contains a DLP hit, fail closed rather than writing a secret
-// to the evidence file; that fallback may make that receipt unverifiable.
-func (r *Recorder) redactReceiptDetail(detail any) any {
+// validateReceiptDetailClean prevents post-signature mutation. Receipt emitters
+// sanitize fields before signing; a hit here means the signed object is unsafe
+// to persist and cannot be redacted without invalidating its proof.
+func (r *Recorder) validateReceiptDetailClean(detail any) error {
 	if detail == nil {
 		return nil
 	}
 
 	raw, err := json.Marshal(detail)
 	if err != nil {
-		// Fail-closed: can't inspect, don't pass through unredacted.
-		return map[string]any{
-			"redacted": true,
-			"reason":   "marshal error",
-		}
+		return fmt.Errorf("scan signed receipt detail before recording: marshal detail: %w", err)
 	}
-
-	// Quick check: does the whole detail contain any DLP matches?
-	result := r.redactFn(context.Background(), string(raw))
-	if result.Clean {
-		return detail // No secrets found, no redaction needed
+	if result := r.redactFn(context.Background(), string(raw)); !result.Clean {
+		return errors.New("signed receipt detail contains sensitive data; refusing to record unverifiable redaction")
 	}
-
-	// Parse as map to access nested fields
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return r.redactDetail(detail) // fallback to full redaction
-	}
-
-	ar, ok := m["action_record"].(map[string]any)
-	if !ok {
-		return r.redactDetail(detail) // not a receipt structure, fallback
-	}
-
-	// Redact sensitive fields that may contain secrets.
-	var redactedFields []string
-	for _, field := range []string{"target", "pattern"} {
-		if val, exists := ar[field]; exists {
-			valStr, isStr := val.(string)
-			if !isStr || valStr == "" {
-				continue
-			}
-			fieldResult := r.redactFn(context.Background(), valStr)
-			if !fieldResult.Clean {
-				ar[field] = "[REDACTED]"
-				redactedFields = append(redactedFields, field)
-			}
-		}
-	}
-
-	// Fail-closed: if the quick-check found DLP matches but none were in
-	// target/pattern, a secret is hiding in an unexpected field. Fall back
-	// to full redaction rather than letting it through.
-	if len(redactedFields) == 0 {
-		return r.redactDetail(detail)
-	}
-
-	ar["redacted_fields"] = redactedFields
-	m["action_record"] = ar
-
-	// Re-scan after selective redaction: if a secret was in both target
-	// AND an unexpected field (e.g., agent), the per-field loop caught
-	// target but the other field survives. Fall back to full redaction
-	// if the partially redacted receipt still has DLP matches.
-	partialJSON, err := json.Marshal(m)
-	if err != nil {
-		return r.redactDetail(detail)
-	}
-	if rescan := r.redactFn(context.Background(), string(partialJSON)); !rescan.Clean {
-		return r.redactDetail(detail)
-	}
-
-	return m
+	return nil
 }
 
 // writeEscrow encrypts raw detail JSON with X25519 NaCl box and writes to sidecar.

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -4,6 +4,7 @@
 package recorder_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -2619,6 +2620,10 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalDetail, marshalErr := json.Marshal(tt.detail)
+			if marshalErr != nil && !tt.wantRecordError {
+				t.Fatalf("marshal original detail: %v", marshalErr)
+			}
 			subDir := t.TempDir()
 			subCfg := recorder.Config{
 				Enabled:            true,
@@ -2677,6 +2682,9 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 
 			detailJSON, _ := json.Marshal(entries[0].Detail)
 			detailStr := string(detailJSON)
+			if !tt.wantFullRedact && (tt.entryType == "action_receipt" || tt.entryType == "evidence_receipt") && !bytes.Equal(detailJSON, originalDetail) {
+				t.Fatalf("clean signed receipt detail changed after recording:\n got: %s\nwant: %s", detailJSON, originalDetail)
+			}
 
 			if tt.wantFullRedact {
 				// Non-receipt: entire detail replaced with redaction wrapper

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -2546,13 +2546,11 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 	fakeKey := "AK" + "IA" + "IOSFODNN7EXAMPLE"
 
 	tests := []struct {
-		name      string
-		entryType string
-		detail    any
-		// For receipts: selective redaction (target/pattern only, structure preserved).
-		// For non-receipts: full redaction (entire detail replaced).
-		wantSelectiveRedact bool
-		wantFullRedact      bool
+		name            string
+		entryType       string
+		detail          any
+		wantRecordError bool
+		wantFullRedact  bool
 	}{
 		{
 			name:      "receipt target field is redacted",
@@ -2569,7 +2567,7 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 				"signature":  "ed25519:deadbeef",
 				"signer_key": "cafebabe",
 			},
-			wantSelectiveRedact: true,
+			wantRecordError: true,
 		},
 		{
 			name:      "receipt without secrets is preserved",
@@ -2588,6 +2586,23 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 			},
 		},
 		{
+			name:            "v2 signed receipt with secret is rejected",
+			entryType:       "evidence_receipt",
+			detail:          map[string]any{"record_type": "evidence_receipt_v2", "payload": map[string]any{"rule_id": fakeKey}, "signature": "ed25519:deadbeef", "signer_key": "cafebabe"},
+			wantRecordError: true,
+		},
+		{
+			name:      "v2 signed receipt without secrets is preserved",
+			entryType: "evidence_receipt",
+			detail:    map[string]any{"record_type": "evidence_receipt_v2", "payload": map[string]any{"rule_id": "safe-rule"}, "signature": "ed25519:deadbeef", "signer_key": "cafebabe"},
+		},
+		{
+			name:            "unmarshalable signed receipt is rejected",
+			entryType:       "action_receipt",
+			detail:          func() {},
+			wantRecordError: true,
+		},
+		{
 			name:           "non-receipt entry gets full redaction",
 			entryType:      "request",
 			detail:         map[string]string{"url": "https://example.com/?key=" + fakeKey},
@@ -2597,8 +2612,8 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 			name:      "receipt without action_record falls back to full redaction",
 			entryType: "action_receipt",
 			// Malformed receipt: missing action_record key triggers fallback
-			detail:         map[string]string{"target": "https://example.com/?key=" + fakeKey},
-			wantFullRedact: true,
+			detail:          map[string]string{"target": "https://example.com/?key=" + fakeKey},
+			wantRecordError: true,
 		},
 	}
 
@@ -2624,6 +2639,27 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 				Summary:   "test entry",
 				Detail:    tt.detail,
 			})
+			if tt.wantRecordError {
+				if err == nil || (!strings.Contains(err.Error(), "refusing to record unverifiable redaction") && !strings.Contains(err.Error(), "scan signed receipt detail before recording")) {
+					t.Fatalf("Record error = %v, want signed receipt redaction refusal", err)
+				}
+				if closeErr := subRec.Close(); closeErr != nil {
+					t.Fatalf("Close: %v", closeErr)
+				}
+				entries, readErr := recorder.ReadEntries(filepath.Join(subDir, "evidence-test-session-0.jsonl"))
+				if errors.Is(readErr, os.ErrNotExist) {
+					return
+				}
+				if readErr != nil {
+					t.Fatalf("ReadEntries: %v", readErr)
+				}
+				for _, entry := range entries {
+					if entry.Type == tt.entryType {
+						t.Fatalf("rejected signed receipt was persisted: %+v", entry)
+					}
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Record: %v", err)
 			}
@@ -2655,66 +2691,8 @@ func TestRecorder_ReceiptRedaction(t *testing.T) {
 				}
 			}
 
-			if tt.wantSelectiveRedact {
-				// Receipt: target field redacted, structure preserved
-				detailMap, ok := entries[0].Detail.(map[string]any)
-				if !ok {
-					t.Fatal("receipt detail should be a map")
-				}
-
-				// Signature and signer_key preserved
-				if _, hasSig := detailMap["signature"]; !hasSig {
-					t.Error("receipt should preserve signature field")
-				}
-				if _, hasKey := detailMap["signer_key"]; !hasKey {
-					t.Error("receipt should preserve signer_key field")
-				}
-
-				// action_record structure preserved
-				ar, arOK := detailMap["action_record"].(map[string]any)
-				if !arOK {
-					t.Fatal("receipt should preserve action_record structure")
-				}
-
-				// Target is redacted
-				if target, ok := ar["target"].(string); !ok || target != "[REDACTED]" {
-					t.Errorf("target should be [REDACTED], got %v", ar["target"])
-				}
-
-				// Secret not present in serialized form
-				if strings.Contains(detailStr, fakeKey) {
-					t.Error("secret should not appear in receipt detail")
-				}
-
-				// Non-sensitive fields preserved
-				if verdict, ok := ar["verdict"].(string); !ok || verdict != "block" {
-					t.Errorf("verdict should be preserved, got %v", ar["verdict"])
-				}
-				if actionType, ok := ar["action_type"].(string); !ok || actionType != "read" {
-					t.Errorf("action_type should be preserved, got %v", ar["action_type"])
-				}
-				if transport, ok := ar["transport"].(string); !ok || transport != testTransport {
-					t.Errorf("transport should be preserved, got %v", ar["transport"])
-				}
-
-				// redacted_fields annotation present
-				rf, rfOK := ar["redacted_fields"].([]any)
-				if !rfOK {
-					t.Fatal("receipt should have redacted_fields annotation")
-				}
-				found := false
-				for _, f := range rf {
-					if f == "target" {
-						found = true
-					}
-				}
-				if !found {
-					t.Error("redacted_fields should include 'target'")
-				}
-			}
-
 			// Clean receipt (no secrets): no modifications
-			if !tt.wantSelectiveRedact && !tt.wantFullRedact && tt.entryType == "action_receipt" {
+			if !tt.wantRecordError && !tt.wantFullRedact && tt.entryType == "action_receipt" {
 				detailMap, ok := entries[0].Detail.(map[string]any)
 				if !ok {
 					t.Fatal("receipt detail should be a map")


### PR DESCRIPTION
## What changed

- Prevent recorder redaction from mutating signed v1 and v2 receipts; unsafe signed details now fail before persistence.
- Compact recognized legacy v1 tombstones only with count-bound acknowledgement, preserve gaps as degraded, and verify every post-gap receipt suffix.

Degraded compaction remains non-green by default, publishes no complete v1 chain head, and rejects broken suffix linkage. Reviewers should distrust the unsigned tombstone classification and verify the acknowledgement count and checkpoint-coverage reporting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compaction supports oversized legacy shards with bounded memory and byte-preserving copying.
  - Added receipt-chain verification for unanchored suffixes, including signatures, ordering, and linkage checks.
  - Compaction reports verified or acknowledged degraded proofs with detailed verification metadata.

- **Bug Fixes**
  - Rejects invalid receipt gaps, malformed legacy tombstones, and unsupported degraded proofs.
  - Prevents sensitive or malformed signed receipts from being recorded.
  - WebSocket sessions now exit cleanly during cancellation.

- **Documentation**
  - Expanded guidance for validation, archives, verification, restart, and retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->