### PR TITLE
docs: add Gauntlet candidate workflow badge

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: Pipelock Gauntlet Candidate
+name: Pipelock Gauntlet
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Pipelock emits mediator-signed [action receipts](https://pipelab.org/learn/actio
   <a href="#what-it-does">Features</a> ·
   <a href="#how-it-works">Architecture</a> ·
   <a href="#docs">Docs</a> ·
-  <a href="https://playground.pipelab.org">Playground</a> ·
+  <a href="https://pipelab.org/playground">Playground</a> ·
   <a href="https://pipelab.org/blog/">Blog</a> ·
   <a href="https://app.dosu.dev/bcccd1cf-be85-4c0e-ae05-edeb0ff50b59/ask">Ask Dosu</a>
 </p>
 
 <p align="center">
-  <strong>Try it in your browser at the <a href="https://playground.pipelab.org">live playground</a>. If Pipelock earns it, <a href="https://github.com/luckyPipewrench/pipelock/stargazers">star the repo</a> so other people find it.</strong>
+  <strong>Try it in your browser at the <a href="https://pipelab.org/playground">live playground</a>. If Pipelock earns it, <a href="https://github.com/luckyPipewrench/pipelock/stargazers">star the repo</a> so other people find it.</strong>
 </p>
 
 ---
@@ -218,7 +218,7 @@ The free single-session evidence viewer shown above is separate. It needs no lic
 
 [**agent-egress-bench**](https://github.com/luckyPipewrench/agent-egress-bench) runs a corpus of agent-exfiltration and prompt-injection attacks against Pipelock, or against any other tool. The numbers come from a run anyone can repeat, not a claim.
 
-[**See the live results**](https://pipelab.org/gauntlet/) · [**Run it yourself**](https://github.com/luckyPipewrench/agent-egress-bench)
+[**See the live results**](https://pipelab.org/gauntlet/results/) · [**Run it yourself**](https://github.com/luckyPipewrench/agent-egress-bench)
 
 </div>
 
@@ -749,7 +749,7 @@ Pipelock is tested like a security product. The open-source core has unit, integ
 | CI matrix | Go 1.25 + 1.26, CodeQL, golangci-lint |
 | Supply chain | SLSA provenance, CycloneDX SBOM, cosign signatures |
 
-Run `make test` to verify locally. First-party benchmark evidence: the public [agent-egress-bench](https://github.com/luckyPipewrench/agent-egress-bench) corpus. See the [live results](https://pipelab.org/gauntlet/).
+Run `make test` to verify locally. First-party benchmark evidence: the public [agent-egress-bench](https://github.com/luckyPipewrench/agent-egress-bench) corpus. See the [live results](https://pipelab.org/gauntlet/results/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml"><img alt="CI" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml/badge.svg"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml"><img alt="Security" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml/badge.svg"></a>
+  <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"><img alt="Gauntlet" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml/badge.svg"></a>
   <a href="go.mod"><img alt="Go 1.25+" src="https://img.shields.io/github/go-mod/go-version/luckyPipewrench/pipelock?logo=go&label=Go"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/releases"><img alt="Release" src="https://img.shields.io/github/v/release/luckyPipewrench/pipelock"></a>
 </p>
@@ -35,7 +36,7 @@
 
 Pipelock sits between AI agents and the network. It inspects mediated HTTP, WebSocket, MCP, and A2A traffic, plus CONNECT tunnel contents when TLS interception is enabled, for secret exfiltration, prompt injection, SSRF, tool poisoning, and risky tool-call chains. Plain CONNECT without interception is scanned at the hostname and URL level.
 
-Pipelock emits mediator-signed [action receipts](https://pipelab.org/learn/action-receipt-spec/) over content-aware boundary decisions, so a reviewer can verify what Pipelock decided outside the agent runtime. The public [agent-egress-bench](https://github.com/luckyPipewrench/agent-egress-bench) corpus exercises the detections. Learn more: [Open-source AI firewall](https://pipelab.org/learn/open-source-ai-firewall/).
+Pipelock emits mediator-signed [action receipts](https://pipelab.org/learn/action-receipt-spec/) over content-aware boundary decisions, so a reviewer can verify what Pipelock decided outside the agent runtime. The public [agent-egress-bench](https://github.com/luckyPipewrench/agent-egress-bench) corpus exercises the detections. The [Gauntlet](https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml) workflow is the product's scheduled candidate exam against a pinned corpus commit; it does not auto-publish a public score. Learn more: [Open-source AI firewall](https://pipelab.org/learn/open-source-ai-firewall/).
 
 **Works with:** Claude Code · OpenAI Codex · Cline · OpenCode · Zed · Cursor · VS Code · JetBrains · OpenAI Agents SDK · Google ADK · AutoGen · CrewAI · LangGraph
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml"><img alt="CI" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/ci.yaml/badge.svg"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml"><img alt="Security" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/security.yaml/badge.svg"></a>
-  <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"><img alt="Gauntlet" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml/badge.svg"></a>
+  <a href="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"><img alt="Gauntlet exam" src="https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml/badge.svg"></a>
   <a href="go.mod"><img alt="Go 1.25+" src="https://img.shields.io/github/go-mod/go-version/luckyPipewrench/pipelock?logo=go&label=Go"></a>
   <a href="https://github.com/luckyPipewrench/pipelock/releases"><img alt="Release" src="https://img.shields.io/github/v/release/luckyPipewrench/pipelock"></a>
 </p>

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -10,9 +10,14 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
 EXPECTED_AEB_REF = "2d6cb1d6e1a6d8a11b8e5a1649e7dee1c6e56aea"
+GAUNTLET_WORKFLOW_URL = (
+    "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
+)
+GAUNTLET_BADGE_URL = GAUNTLET_WORKFLOW_URL + "/badge.svg"
 EVIDENCE_FILES = (
     "continuous-gauntlet-pipelock.json",
     "promotion-decision.json",
@@ -128,6 +133,23 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
         self.assertIn("schedule:", trigger)
         self.assertNotIn("pull_request", trigger)
         self.assertNotRegex(trigger, r"(?m)^\s+push:")
+
+    def test_readme_exposes_gauntlet_candidate_badge(self):
+        readme = README.read_text(encoding="utf-8")
+        self.assertTrue(
+            GAUNTLET_BADGE_URL in readme,
+            "README missing Gauntlet candidate badge URL",
+        )
+        self.assertTrue(
+            f'href="{GAUNTLET_WORKFLOW_URL}"' in readme,
+            "README missing Gauntlet candidate workflow link",
+        )
+        self.assertTrue('alt="Gauntlet"' in readme, "README missing Gauntlet badge alt text")
+        self.assertTrue(
+            "does not auto-publish a public score" in readme,
+            "README missing candidate-exam non-publish sentence",
+        )
+        self.assertNotRegex(readme, r"(?i)\bnightly\b")
 
     def test_checkout_credentials_and_actions_are_pinned(self):
         checkout_count = self.workflow.count("uses: actions/checkout@")

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -170,6 +170,10 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
             PUBLIC_RESULTS_URL in readme,
             "README missing the public Gauntlet results page",
         )
+        self.assertIsNone(
+            re.search(r"https://pipelab\.org/gauntlet/(?!results/)", readme),
+            "README still has a Gauntlet link that is not /gauntlet/results/",
+        )
         self.assertNotRegex(readme, r"(?i)\bnightly\b")
 
     def test_checkout_credentials_and_actions_are_pinned(self):

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -18,6 +18,9 @@ GAUNTLET_WORKFLOW_URL = (
     "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
 )
 GAUNTLET_BADGE_URL = GAUNTLET_WORKFLOW_URL + "/badge.svg"
+PLAYGROUND_PAGE_URL = "https://pipelab.org/playground"
+PLAYGROUND_BROKER_ORIGIN = "https://playground.pipelab.org"
+PUBLIC_RESULTS_URL = "https://pipelab.org/gauntlet/results/"
 EVIDENCE_FILES = (
     "continuous-gauntlet-pipelock.json",
     "promotion-decision.json",
@@ -148,6 +151,19 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
         self.assertTrue(
             "does not auto-publish a public score" in readme,
             "README missing candidate-exam non-publish sentence",
+        )
+        self.assertTrue(
+            PLAYGROUND_PAGE_URL in readme,
+            "README missing the public playground page",
+        )
+        self.assertNotIn(
+            PLAYGROUND_BROKER_ORIGIN,
+            readme,
+            "README must not send people to the playground broker origin",
+        )
+        self.assertTrue(
+            PUBLIC_RESULTS_URL in readme,
+            "README missing the public Gauntlet results page",
         )
         self.assertNotRegex(readme, r"(?i)\bnightly\b")
 

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -147,7 +147,12 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
             f'href="{GAUNTLET_WORKFLOW_URL}"' in readme,
             "README missing Gauntlet candidate workflow link",
         )
-        self.assertTrue('alt="Gauntlet"' in readme, "README missing Gauntlet badge alt text")
+        self.assertTrue('alt="Gauntlet exam"' in readme, "README missing Gauntlet exam badge alt text")
+        self.assertNotIn(
+            'alt="Agent Egress Bench"',
+            readme,
+            "the scheduled-exam badge must not use the corpus repo name",
+        )
         self.assertTrue(
             "does not auto-publish a public score" in readme,
             "README missing candidate-exam non-publish sentence",


### PR DESCRIPTION
## What changed

Add a README badge for the scheduled Gauntlet candidate workflow. The README says a completed run doesn't publish a public score by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Gauntlet workflow status badge to the README.
  * Documented the scheduled Gauntlet candidate exam run and clarified that it does not automatically publish a public score.
  * Updated Playground and Gauntlet results links to their current locations.

* **Tests**
  * Added validation for the README’s Gauntlet badge, workflow details, terminology, Playground link, and public results link.

* **Chores**
  * Renamed the Gauntlet workflow for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->