### PR TITLE
evidence: lock writers and verify legacy epoch pins

### DIFF
--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -40,6 +40,7 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(expireCmd())
 	cmd.AddCommand(compactCmd())
 	cmd.AddCommand(inspectEpochsCmd())
+	cmd.AddCommand(verifyEpochPinCmd())
 	cmd.AddCommand(doctorCmd())
 	cmd.AddCommand(verifyCertCmd())
 	return cmd

--- a/internal/cli/evidence/inspect_epochs.go
+++ b/internal/cli/evidence/inspect_epochs.go
@@ -36,6 +36,19 @@ type inspectEpochsDocument struct {
 	CheckpointVerification compactManifestCheckpointVerification `json:"checkpoint_verification"`
 }
 
+func inspectEpochsDocumentFromProof(session string, proof compactStreamProof) inspectEpochsDocument {
+	receipts := manifestReceiptVerification(proof)
+	if len(proof.v1Epochs) > 1 {
+		receipts.Status = "verified_per_epoch"
+		if proof.v1Degraded {
+			receipts.Status = "degraded_per_epoch"
+		}
+		receipts.V1Count = 0
+		receipts.V1ChainHead = ""
+	}
+	return inspectEpochsDocument{Version: 1, SessionID: session, SourceBytes: proof.bytes, SourceSHA256: proof.sum, SourceFiles: manifestStreamFiles(proof.files), RecorderEpochs: append([]compactEpochProof{}, proof.v1Epochs...), ReceiptVerification: receipts, CheckpointVerification: manifestCheckpointVerification(proof)}
+}
+
 var inspectSyncDirectory = func(output *inspectOutput) error { return output.syncParent() }
 
 func inspectEpochsCmd() *cobra.Command {
@@ -108,21 +121,7 @@ func runInspectEpochs(cmd *cobra.Command, opts inspectEpochsOptions) error {
 	if err != nil {
 		return fmt.Errorf("verify epoch boundaries: %w", err)
 	}
-	receipts := manifestReceiptVerification(proof)
-	if len(proof.v1Epochs) > 1 {
-		// Independent v1 epochs do not share a meaningful aggregate head or
-		// suffix. Keep their proofs on recorder_epochs and retain only the v2
-		// chain, which remains a separate contract.
-		receipts.Status = "verified_per_epoch"
-		if proof.v1Degraded {
-			receipts.Status = "degraded_per_epoch"
-		}
-		receipts.V1Count = 0
-		receipts.V1ChainHead = ""
-		receipts.Degradations = nil
-		receipts.V1Suffixes = nil
-	}
-	document := inspectEpochsDocument{Version: 1, SessionID: opts.sessionID, SourceBytes: proof.bytes, SourceSHA256: proof.sum, SourceFiles: manifestStreamFiles(proof.files), RecorderEpochs: append([]compactEpochProof{}, proof.v1Epochs...), ReceiptVerification: receipts, CheckpointVerification: manifestCheckpointVerification(proof)}
+	document := inspectEpochsDocumentFromProof(opts.sessionID, proof)
 	data, err := json.Marshal(document)
 	if err != nil {
 		return fmt.Errorf("encode epoch boundaries: %w", err)

--- a/internal/cli/evidence/verify_epoch_pin.go
+++ b/internal/cli/evidence/verify_epoch_pin.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+type verifyEpochPinOptions struct {
+	receiptDir, locationID, sessionID, publicKey, pinFile, pinSHA256 string
+}
+
+func verifyEpochPinCmd() *cobra.Command {
+	opts := verifyEpochPinOptions{}
+	cmd := &cobra.Command{Use: "verify-epoch-pin", Short: "Verify an exact epoch inspection pin", Long: "Verify that a canonical inspect-epochs document and its checksum still match one stopped recorder session. This consistency check does not authorize or perform evidence retirement.", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, _ []string) error { return runVerifyEpochPin(cmd, opts) }}
+	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "", "flight-recorder evidence directory")
+	cmd.Flags().StringVar(&opts.locationID, "location", "", "location path relative to the evidence directory")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "", "session ID to verify")
+	cmd.Flags().StringVar(&opts.publicKey, "key", "", "trusted receipt signing public key (inline or file)")
+	cmd.Flags().StringVar(&opts.pinFile, "pin", "", "inspect-epochs JSON approved by the operator")
+	cmd.Flags().StringVar(&opts.pinSHA256, "pin-sha256", "", "expected SHA-256 of the exact pin bytes")
+	for _, name := range []string{"receipt-dir", "session", "key", "pin", "pin-sha256"} {
+		_ = cmd.MarkFlagRequired(name)
+	}
+	return cmd
+}
+
+func runVerifyEpochPin(cmd *cobra.Command, opts verifyEpochPinOptions) error {
+	if strings.TrimSpace(opts.sessionID) == "" {
+		return errors.New("--session is required")
+	}
+	expectedDigest, err := parseEpochPinDigest(opts.pinSHA256)
+	if err != nil {
+		return err
+	}
+	pinBytes, pin, err := readEpochPin(opts.pinFile, expectedDigest)
+	if err != nil {
+		return err
+	}
+	if pin.SessionID != opts.sessionID {
+		return fmt.Errorf("epoch pin session %q does not match --session %q", pin.SessionID, opts.sessionID)
+	}
+	if len(pin.RecorderEpochs) < 2 {
+		return fmt.Errorf("epoch pin contains %d recorder epoch(s); verification requires a multi-epoch history", len(pin.RecorderEpochs))
+	}
+	var signedReceipts uint64
+	for _, epoch := range pin.RecorderEpochs {
+		if epoch.V1Degraded || epoch.V1FirstGap || epoch.V1TailGap {
+			return fmt.Errorf("epoch pin receipt proof is degraded in legacy epoch %d; a clean per-epoch receipt proof is required", epoch.Epoch)
+		}
+		signedReceipts += epoch.V1Count
+	}
+	if pin.ReceiptVerification.Status != "verified_per_epoch" || signedReceipts == 0 {
+		return fmt.Errorf("epoch pin receipt proof is %q with %d signed receipt(s); a clean per-epoch receipt proof is required", pin.ReceiptVerification.Status, signedReceipts)
+	}
+	if len(pin.CheckpointVerification.Unsigned) != 0 {
+		return fmt.Errorf("epoch pin contains %d unsigned checkpoint(s); a fully signed checkpoint proof is required", len(pin.CheckpointVerification.Unsigned))
+	}
+	root, err := validateReceiptDir(opts.receiptDir)
+	if err != nil {
+		return err
+	}
+	location, err := recorder.ResolveEvidenceLocation(root, opts.locationID)
+	if err != nil {
+		return fmt.Errorf("resolve evidence location: %w", err)
+	}
+	key, err := signing.LoadPublicKey(strings.TrimSpace(opts.publicKey))
+	if err != nil {
+		return fmt.Errorf("load --key: %w", err)
+	}
+	lock, err := compactAcquireLock(location.Dir)
+	if err != nil {
+		return fmt.Errorf("lock stopped evidence directory: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+	names, err := inspectEpochSourceNames(location, opts.sessionID)
+	if err != nil {
+		return err
+	}
+	proof, err := compactVerifyStream(location, names, opts.sessionID, key, func(compactStreamFile, []byte, recorder.Entry) error { return nil })
+	if err != nil {
+		return fmt.Errorf("re-verify epoch source: %w", err)
+	}
+	currentBytes, err := json.Marshal(inspectEpochsDocumentFromProof(opts.sessionID, proof))
+	if err != nil {
+		return fmt.Errorf("encode current epoch boundaries: %w", err)
+	}
+	currentBytes = append(currentBytes, '\n')
+	if !bytes.Equal(pinBytes, currentBytes) {
+		return errors.New("epoch source no longer matches the supplied inspection pin")
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "epoch inspection pin verified: %s  %s\nconsistency check only; no evidence changed and retirement is not authorized\n", hex.EncodeToString(expectedDigest), opts.pinFile)
+	return nil
+}
+
+func parseEpochPinDigest(raw string) ([]byte, error) {
+	decoded, err := hex.DecodeString(strings.TrimSpace(raw))
+	if err != nil || len(decoded) != sha256.Size {
+		return nil, errors.New("--pin-sha256 must be exactly 64 hexadecimal characters")
+	}
+	return decoded, nil
+}
+
+func readEpochPin(path string, expectedDigest []byte) ([]byte, inspectEpochsDocument, error) {
+	// #nosec G304 -- --pin is an explicit operator-selected input.
+	f, err := os.Open(strings.TrimSpace(path))
+	if err != nil {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("open --pin: %w", err)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(f, (8<<20)+1))
+	closeErr := f.Close()
+	if readErr != nil {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("read --pin: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("close --pin: %w", closeErr)
+	}
+	if len(data) > 8<<20 {
+		return nil, inspectEpochsDocument{}, errors.New("--pin exceeds 8 MiB")
+	}
+	digest := sha256.Sum256(data)
+	if !bytes.Equal(digest[:], expectedDigest) {
+		return nil, inspectEpochsDocument{}, errors.New("--pin SHA-256 does not match --pin-sha256")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var document inspectEpochsDocument
+	if err := decoder.Decode(&document); err != nil {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("decode --pin: %w", err)
+	}
+	if document.Version != 1 {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("unsupported epoch pin version %d", document.Version)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, inspectEpochsDocument{}, errors.New("decode --pin: trailing JSON value")
+	}
+	canonical, err := json.Marshal(document)
+	if err != nil {
+		return nil, inspectEpochsDocument{}, fmt.Errorf("encode --pin canonically: %w", err)
+	}
+	canonical = append(canonical, '\n')
+	if !bytes.Equal(data, canonical) {
+		return nil, inspectEpochsDocument{}, errors.New("--pin is not canonical inspect-epochs output")
+	}
+	return data, document, nil
+}

--- a/internal/cli/evidence/verify_epoch_pin_test.go
+++ b/internal/cli/evidence/verify_epoch_pin_test.go
@@ -1,0 +1,285 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestVerifyEpochPinBindsExactPinAndCurrentSource(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "recorder")
+	if err := os.Mkdir(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeInspectEpochFixture(t, dir, priv)
+	pinPath := filepath.Join(parent, "epochs.json")
+	if err := runInspectEpochs(inspectEpochsOutputCommand(&bytes.Buffer{}), inspectEpochsOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub), outFile: pinPath}); err != nil {
+		t.Fatalf("inspect epochs: %v", err)
+	}
+	// #nosec G304 -- pinPath is the test's own inspection output.
+	pin, err := os.ReadFile(pinPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(pin)
+	valid := verifyEpochPinOptions{receiptDir: dir, sessionID: "proxy", publicKey: hex.EncodeToString(pub), pinFile: pinPath, pinSHA256: hex.EncodeToString(digest[:])}
+	var out bytes.Buffer
+	if err := runVerifyEpochPin(inspectEpochsOutputCommand(&out), valid); err != nil {
+		t.Fatalf("verify epoch pin: %v", err)
+	}
+	if !strings.Contains(out.String(), "epoch inspection pin verified") {
+		t.Fatalf("output = %q", out.String())
+	}
+	if !strings.Contains(out.String(), "retirement is not authorized") {
+		t.Fatalf("output overclaims preflight: %q", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "evidence-proxy-0.jsonl")); err != nil {
+		t.Fatalf("preflight mutated source: %v", err)
+	}
+
+	t.Run("wrong digest", func(t *testing.T) {
+		opts := valid
+		opts.pinSHA256 = strings.Repeat("0", sha256.Size*2)
+		err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts)
+		if err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("empty session", func(t *testing.T) {
+		opts := valid
+		opts.sessionID = " "
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts); err == nil || !strings.Contains(err.Error(), "--session is required") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("session mismatch", func(t *testing.T) {
+		opts := valid
+		opts.sessionID = "other"
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts); err == nil || !strings.Contains(err.Error(), "does not match --session") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("noncanonical pin", func(t *testing.T) {
+		noncanonicalPath := filepath.Join(parent, "noncanonical.json")
+		noncanonical := append([]byte(" "), pin...)
+		if err := os.WriteFile(noncanonicalPath, noncanonical, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(noncanonical)
+		opts := valid
+		opts.pinFile = noncanonicalPath
+		opts.pinSHA256 = hex.EncodeToString(sum[:])
+		err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts)
+		if err == nil || !strings.Contains(err.Error(), "not canonical") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("degraded receipt proof", func(t *testing.T) {
+		var document inspectEpochsDocument
+		if err := json.Unmarshal(pin, &document); err != nil {
+			t.Fatal(err)
+		}
+		document.ReceiptVerification.Status = "degraded_per_epoch"
+		document.RecorderEpochs[0].V1Degraded = true
+		writePinAndExpectError(t, parent, document, valid, "degraded in legacy epoch")
+	})
+
+	t.Run("single epoch", func(t *testing.T) {
+		var document inspectEpochsDocument
+		if err := json.Unmarshal(pin, &document); err != nil {
+			t.Fatal(err)
+		}
+		document.RecorderEpochs = document.RecorderEpochs[:1]
+		writePinAndExpectError(t, parent, document, valid, "multi-epoch history")
+	})
+
+	t.Run("zero signed receipts", func(t *testing.T) {
+		var document inspectEpochsDocument
+		if err := json.Unmarshal(pin, &document); err != nil {
+			t.Fatal(err)
+		}
+		for i := range document.RecorderEpochs {
+			document.RecorderEpochs[i].V1Count = 0
+		}
+		writePinAndExpectError(t, parent, document, valid, "0 signed receipt")
+	})
+
+	t.Run("unsigned checkpoint proof", func(t *testing.T) {
+		var document inspectEpochsDocument
+		if err := json.Unmarshal(pin, &document); err != nil {
+			t.Fatal(err)
+		}
+		document.CheckpointVerification.Unsigned = []compactUnsignedCheckpoint{{Epoch: 0, RecorderSeq: 1}}
+		writePinAndExpectError(t, parent, document, valid, "unsigned checkpoint")
+	})
+
+	t.Run("bad receipt directory", func(t *testing.T) {
+		opts := valid
+		opts.receiptDir = filepath.Join(parent, "missing")
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts); err == nil {
+			t.Fatal("missing receipt directory accepted")
+		}
+	})
+
+	t.Run("bad location", func(t *testing.T) {
+		opts := valid
+		opts.locationID = "../outside"
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts); err == nil || !strings.Contains(err.Error(), "resolve evidence location") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("bad key", func(t *testing.T) {
+		opts := valid
+		opts.publicKey = "bad"
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), opts); err == nil || !strings.Contains(err.Error(), "load --key") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("active writer", func(t *testing.T) {
+		rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = rec.Close() }()
+		if err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), valid); err == nil || !strings.Contains(err.Error(), "lock stopped evidence directory") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("source changed", func(t *testing.T) {
+		path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+		// #nosec G304 -- path is the test's own evidence fixture.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		original := append([]byte(nil), data...)
+		defer func() {
+			if err := os.WriteFile(path, original, 0o600); err != nil {
+				t.Errorf("restore source: %v", err)
+			}
+		}()
+		data[len(data)/2] ^= 1
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err = runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), valid)
+		if err == nil || !strings.Contains(err.Error(), "re-verify epoch source") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("valid source drift", func(t *testing.T) {
+		path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+		// #nosec G304 -- path is the test's own evidence fixture.
+		original, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := os.WriteFile(path, original, 0o600); err != nil {
+				t.Errorf("restore source: %v", err)
+			}
+		}()
+		lines := bytes.Split(bytes.TrimSpace(original), []byte{'\n'})
+		var entry recorder.Entry
+		if err := json.Unmarshal(lines[1], &entry); err != nil {
+			t.Fatal(err)
+		}
+		entry.Timestamp = time.Unix(99, 0).UTC()
+		entry.Hash = recorder.ComputeHash(entry)
+		lines[1], err = json.Marshal(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed := append(bytes.Join(lines, []byte{'\n'}), '\n')
+		if err := os.WriteFile(path, changed, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err = runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), valid)
+		if err == nil || !strings.Contains(err.Error(), "no longer matches") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func writePinAndExpectError(t *testing.T, parent string, document inspectEpochsDocument, valid verifyEpochPinOptions, want string) {
+	t.Helper()
+	data, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	path := filepath.Join(parent, strings.ReplaceAll(t.Name(), "/", "-")+".json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	valid.pinFile = path
+	valid.pinSHA256 = hex.EncodeToString(digest[:])
+	err = runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), valid)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
+func TestVerifyEpochPinRejectsMalformedDigestBeforeReadingPin(t *testing.T) {
+	err := runVerifyEpochPin(inspectEpochsOutputCommand(&bytes.Buffer{}), verifyEpochPinOptions{sessionID: "proxy", pinFile: filepath.Join(t.TempDir(), "missing"), pinSHA256: "bad"})
+	if err == nil || !strings.Contains(err.Error(), "exactly 64 hexadecimal") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestReadEpochPinRejectsMalformedInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{name: "malformed JSON", data: []byte("{\n"), want: "decode --pin"},
+		{name: "unsupported version", data: []byte("{\"version\":2}\n"), want: "unsupported epoch pin version"},
+		{name: "trailing value", data: []byte("{\"version\":1} true\n"), want: "trailing JSON value"},
+		{name: "oversized", data: bytes.Repeat([]byte("x"), (8<<20)+1), want: "exceeds 8 MiB"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "pin.json")
+			if err := os.WriteFile(path, test.data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			digest := sha256.Sum256(test.data)
+			_, _, err := readEpochPin(path, digest[:])
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, _, err := readEpochPin(missing, make([]byte, sha256.Size)); err == nil || !strings.Contains(err.Error(), "open --pin") {
+		t.Fatalf("missing pin error = %v", err)
+	}
+}

--- a/internal/cli/runtime/dashboard_snapshot_enterprise.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise.go
@@ -7,11 +7,13 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
 func init() {
@@ -70,8 +72,18 @@ func writeDashboardRuntimeSnapshotTick(opts dashboardRuntimeSnapshotOptions, pat
 		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot unavailable: %v\n", err)
 		return
 	}
-	if err := runtimesnapshot.Write(path, snap); err != nil {
-		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot write failed: %v\n", err)
+	var writeErr error
+	if opts.StartupConfig == nil {
+		writeErr = errors.New("startup config is required for dashboard runtime snapshot writes")
+	} else if opts.StartupConfig.FlightRecorder.Dir == "" {
+		writeErr = runtimesnapshot.Write(path, snap)
+	} else {
+		writeErr = recorder.WithEvidenceWriterCeremonyLock(opts.StartupConfig.FlightRecorder.Dir, func() error {
+			return runtimesnapshot.Write(path, snap)
+		})
+	}
+	if writeErr != nil {
+		_, _ = fmt.Fprintf(opts.Stderr, "pipelock: dashboard runtime snapshot write failed: %v\n", writeErr)
 	}
 }
 

--- a/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
+++ b/internal/cli/runtime/dashboard_snapshot_enterprise_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/enterprise/dashboard/runtimesnapshot"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/testwait"
 )
 
@@ -217,6 +218,32 @@ func TestWriteDashboardRuntimeSnapshotTickReportsWriteFailure(t *testing.T) {
 	}, path, "producer")
 	if !strings.Contains(stderr.String(), "dashboard runtime snapshot write failed") {
 		t.Fatalf("stderr = %q, want write failure", stderr.String())
+	}
+}
+
+func TestDashboardRuntimeSnapshotCannotWriteDuringEvidenceCeremony(t *testing.T) {
+	dir := t.TempDir()
+	lock, err := recorder.AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Skipf("evidence ceremony lock unavailable: %v", err)
+	}
+	defer func() { _ = lock.Close() }()
+	cfg := config.Defaults()
+	cfg.FlightRecorder.Dir = dir
+	path := filepath.Join(dir, "dashboard", "runtime-snapshot.json")
+	var stderr strings.Builder
+	writeDashboardRuntimeSnapshotTick(dashboardRuntimeSnapshotOptions{
+		Context:        context.Background(),
+		BudgetProvider: &fakeAgentBudgetSnapshotProvider{},
+		StartupConfig:  cfg,
+		CurrentConfig:  func() *config.Config { return cfg },
+		Stderr:         &stderr,
+	}, path, "producer")
+	if !strings.Contains(stderr.String(), "locking recorder against receipt ceremonies") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("snapshot write ran during ceremony: %v", err)
 	}
 }
 

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -323,7 +323,10 @@ func buildDeferManager(cfg *config.Config, warningWriter io.Writer) *deferred.Ma
 		MaxPendingBytes:      cfg.Defer.MaxPendingBytes,
 		MaxCascadeDepth:      cfg.Defer.MaxCascadeDepth,
 		JournalPath:          deferJournalPath(cfg),
-		Warningf:             warningf,
+		JournalWriteGuard: func(write func() error) error {
+			return recorder.WithEvidenceWriterCeremonyLock(cfg.FlightRecorder.Dir, write)
+		},
+		Warningf: warningf,
 	})
 }
 

--- a/internal/cli/runtime/mcp_test.go
+++ b/internal/cli/runtime/mcp_test.go
@@ -413,6 +413,33 @@ func TestBuildDeferManagerAndSurfaceValidation(t *testing.T) {
 	}
 }
 
+func TestDeferredJournalCannotWriteDuringEvidenceCeremony(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Defaults()
+	cfg.Defer.Enabled = true
+	cfg.FlightRecorder.Dir = dir
+	manager := buildDeferManager(cfg, io.Discard)
+	lock, err := recorder.AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Skipf("evidence ceremony lock unavailable: %v", err)
+	}
+	defer func() { _ = lock.Close() }()
+	err = manager.Hold(deferred.HeldAction{
+		DeferID:   "locked",
+		ActionID:  "locked",
+		Target:    "tool",
+		SizeBytes: 1,
+		Authority: deferred.AuthoritySnapshot{SessionID: "s1", SessionIDOriginal: "s1"},
+		Resolve:   func(deferred.Resolution) {},
+	})
+	if err == nil || !strings.Contains(err.Error(), "locking recorder against receipt ceremonies") {
+		t.Fatalf("Hold error = %v, want ceremony lock failure", err)
+	}
+	if _, err := os.Stat(manager.JournalPath()); !os.IsNotExist(err) {
+		t.Fatalf("deferred journal write ran during ceremony: %v", err)
+	}
+}
+
 func TestRecoverDeferredActionsBlocksPendingJournal(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.Defaults()

--- a/internal/deferred/manager.go
+++ b/internal/deferred/manager.go
@@ -59,6 +59,7 @@ type Config struct {
 	MaxPendingBytes      int
 	MaxCascadeDepth      int
 	JournalPath          string
+	JournalWriteGuard    func(func() error) error
 	Warningf             func(format string, args ...any)
 }
 
@@ -681,23 +682,29 @@ func (m *Manager) appendJournal(entry journalEntry) error {
 	m.journalMu.Lock()
 	defer m.journalMu.Unlock()
 
-	path := filepath.Clean(m.cfg.JournalPath)
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
+	write := func() error {
+		path := filepath.Clean(m.cfg.JournalPath)
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(append(data, '\n')); err != nil {
+			return err
+		}
+		return nil
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
+	if m.cfg.JournalWriteGuard != nil {
+		return m.cfg.JournalWriteGuard(write)
 	}
-	defer func() { _ = f.Close() }()
-	data, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(append(data, '\n')); err != nil {
-		return err
-	}
-	return nil
+	return write()
 }
 
 // PendingJournal returns held actions from a prior process that lack a terminal

--- a/internal/recorder/ceremony_lock.go
+++ b/internal/recorder/ceremony_lock.go
@@ -66,6 +66,30 @@ func acquireEvidenceWriterCeremonyLock(dir string) (*os.File, os.FileInfo, error
 	return file, info, nil
 }
 
+// WithEvidenceWriterCeremonyLock runs one non-recorder evidence write under
+// the same shared directory lock used by Recorder. An offline ceremony holding
+// the exclusive lock makes this fail before fn can mutate the directory.
+func WithEvidenceWriterCeremonyLock(dir string, fn func() error) (err error) {
+	if fn == nil {
+		return errors.New("evidence writer callback is required")
+	}
+	file, _, err := acquireEvidenceWriterCeremonyLock(dir)
+	if err != nil {
+		return err
+	}
+	if file == nil {
+		return fn()
+	}
+	defer func() {
+		recovered := recover()
+		err = errors.Join(err, unlockEvidenceFile(file), file.Close())
+		if recovered != nil {
+			panic(recovered)
+		}
+	}()
+	return fn()
+}
+
 func (r *Recorder) ensureEvidenceWriterCeremonyLock(dirInfo os.FileInfo) error {
 	if !supportsEvidenceCeremonyLock() {
 		return nil
@@ -98,7 +122,7 @@ func (r *Recorder) releaseEvidenceWriterCeremonyLock() error {
 }
 
 func openEvidenceCeremonyLock(dir string) (*os.File, os.FileInfo, error) {
-	file, err := os.Open(filepath.Clean(dir))
+	file, err := os.OpenFile(filepath.Clean(dir), os.O_RDONLY|evidenceReadNoFollowFlag, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening evidence directory for receipt ceremony lock: %w", err)
 	}

--- a/internal/recorder/ceremony_lock_test.go
+++ b/internal/recorder/ceremony_lock_test.go
@@ -191,7 +191,7 @@ func TestEvidenceCeremonyLockErrorAndEmptyLifecyclePaths(t *testing.T) {
 	}
 }
 
-func TestEvidenceWriterCeremonyLockReleasesAfterPanic(t *testing.T) {
+func TestEvidenceWriterCeremonyLockReleasesAfterCallbackFailure(t *testing.T) {
 	if !supportsEvidenceCeremonyLock() {
 		t.Skip("platform does not provide cross-process ceremony locking")
 	}
@@ -210,6 +210,17 @@ func TestEvidenceWriterCeremonyLockReleasesAfterPanic(t *testing.T) {
 	}
 	if err := lock.Close(); err != nil {
 		t.Fatalf("close ceremony lock: %v", err)
+	}
+	sentinel := errors.New("injected callback failure")
+	if err := WithEvidenceWriterCeremonyLock(dir, func() error { return sentinel }); !errors.Is(err, sentinel) {
+		t.Fatalf("writer callback error = %v, want sentinel", err)
+	}
+	lock, err = AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Fatalf("ceremony lock remained held after callback error: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("close ceremony lock after callback error: %v", err)
 	}
 }
 

--- a/internal/recorder/ceremony_lock_test.go
+++ b/internal/recorder/ceremony_lock_test.go
@@ -66,7 +66,74 @@ func TestEvidenceCeremonyLockRequiresStoppedRecorder(t *testing.T) {
 	}
 }
 
+func TestRecorderDoesNotProbeWhileCeremonyOwnsDirectory(t *testing.T) {
+	if !supportsEvidenceCeremonyLock() {
+		t.Skip("platform does not provide cross-process ceremony locking")
+	}
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	lock, err := AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lock.Close() }()
+	originalProbe := recorderCreateWritabilityProbe
+	probeCalled := false
+	recorderCreateWritabilityProbe = func(string, string) (*os.File, error) {
+		probeCalled = true
+		return nil, errors.New("probe must not run")
+	}
+	t.Cleanup(func() { recorderCreateWritabilityProbe = originalProbe })
+	_, err = New(Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, key)
+	if err == nil || !strings.Contains(err.Error(), "locking recorder against receipt ceremonies") {
+		t.Fatalf("recorder start error = %v", err)
+	}
+	if probeCalled {
+		t.Fatal("recorder mutated the evidence directory before acquiring its ceremony lock")
+	}
+}
+
+func TestEvidenceCeremonyLockBlocksOtherDirectoryWriters(t *testing.T) {
+	if !supportsEvidenceCeremonyLock() {
+		t.Skip("platform does not provide cross-process ceremony locking")
+	}
+	dir := t.TempDir()
+	lock, err := AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	err = WithEvidenceWriterCeremonyLock(dir, func() error {
+		called = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "locking recorder against receipt ceremonies") {
+		t.Fatalf("competing writer error = %v", err)
+	}
+	if called {
+		t.Fatal("competing writer callback ran during offline ceremony")
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := WithEvidenceWriterCeremonyLock(dir, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("writer rejected after ceremony: %v", err)
+	}
+	if !called {
+		t.Fatal("writer callback did not run after ceremony")
+	}
+}
+
 func TestEvidenceCeremonyLockErrorAndEmptyLifecyclePaths(t *testing.T) {
+	if err := WithEvidenceWriterCeremonyLock(t.TempDir(), nil); err == nil || !strings.Contains(err.Error(), "callback is required") {
+		t.Fatalf("nil writer callback error = %v", err)
+	}
 	if !supportsEvidenceCeremonyLock() {
 		t.Skip("platform does not provide cross-process ceremony locking")
 	}
@@ -121,6 +188,42 @@ func TestEvidenceCeremonyLockErrorAndEmptyLifecyclePaths(t *testing.T) {
 	}
 	if err := rec.releaseEvidenceWriterCeremonyLock(); err != nil {
 		t.Fatalf("release acquired writer lock: %v", err)
+	}
+}
+
+func TestEvidenceWriterCeremonyLockReleasesAfterPanic(t *testing.T) {
+	if !supportsEvidenceCeremonyLock() {
+		t.Skip("platform does not provide cross-process ceremony locking")
+	}
+	dir := t.TempDir()
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("writer callback panic was not propagated")
+			}
+		}()
+		_ = WithEvidenceWriterCeremonyLock(dir, func() error { panic("injected") })
+	}()
+	lock, err := AcquireEvidenceCeremonyLock(dir)
+	if err != nil {
+		t.Fatalf("ceremony lock remained held after callback panic: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("close ceremony lock: %v", err)
+	}
+}
+
+func TestEvidenceCeremonyLockRejectsSymlinkDirectory(t *testing.T) {
+	if !supportsEvidenceCeremonyLock() {
+		t.Skip("platform does not provide cross-process ceremony locking")
+	}
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "evidence-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AcquireEvidenceCeremonyLock(link); err == nil {
+		t.Fatal("ceremony lock followed a symlink directory")
 	}
 }
 

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -29,6 +29,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
+var recorderCreateWritabilityProbe = os.CreateTemp
+
 // Default values for recorder configuration.
 const (
 	defaultCheckpointInterval = 1000
@@ -228,6 +230,17 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 	if err := os.MkdirAll(filepath.Clean(cfg.Dir), dirPermissions); err != nil {
 		return nil, fmt.Errorf("creating evidence directory: %w", err)
 	}
+	ceremonyLock, ceremonyDir, err := acquireEvidenceWriterCeremonyLock(cfg.Dir)
+	if err != nil {
+		return nil, err
+	}
+	lockTransferred := false
+	defer func() {
+		if !lockTransferred && ceremonyLock != nil {
+			_ = unlockEvidenceFile(ceremonyLock)
+			_ = ceremonyLock.Close()
+		}
+	}()
 
 	// Writability probe: fail closed at startup if the evidence directory
 	// exists but is not writable. Without this, pipelock boots successfully
@@ -235,7 +248,7 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 	// wrong filesystem perms) and silently drops every receipt's persistence
 	// while still enforcing policy - round-3 of the pre-tag gate finding. Operators end up
 	// running in a degraded, non-auditable state without a clear signal.
-	probe, probeErr := os.CreateTemp(filepath.Clean(cfg.Dir), ".pipelock-writability-probe-*")
+	probe, probeErr := recorderCreateWritabilityProbe(filepath.Clean(cfg.Dir), ".pipelock-writability-probe-*")
 	if probeErr != nil {
 		return nil, fmt.Errorf("evidence directory %s is not writable (receipts would not persist): %w", cfg.Dir, probeErr)
 	}
@@ -268,12 +281,9 @@ func New(cfg Config, redactFn RedactFunc, privKey ed25519.PrivateKey) (*Recorder
 		r.escrowPub = &pub
 	}
 
-	ceremonyLock, ceremonyDir, err := acquireEvidenceWriterCeremonyLock(cfg.Dir)
-	if err != nil {
-		return nil, err
-	}
 	r.ceremonyLock = ceremonyLock
 	r.ceremonyDir = ceremonyDir
+	lockTransferred = true
 	r.evidenceDir = ceremonyDir
 	if r.evidenceDir == nil {
 		r.evidenceDir, err = os.Stat(filepath.Clean(cfg.Dir))


### PR DESCRIPTION
## What changed
- Put recorder startup probes, dashboard snapshots, and deferred-action journal writes under the shared evidence ceremony lock.
- Add `verify-epoch-pin` to bind a canonical multi-epoch inspection file to an unchanged stopped session and reject degraded proof.

Lock contention and degraded or changed evidence fail closed. Reviewers should distrust any writer under the evidence directory that bypasses the shared lock, and any verification result not derived from the exact canonical pin bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `verify-epoch-pin` evidence command for validating pinned epoch inspection documents against current evidence.
  - Verification checks receipt proofs, signed checkpoints, exact epoch boundaries, and source integrity without authorizing retirement or modifying evidence.

- **Bug Fixes**
  - Prevented dashboard snapshots and deferred journal writes during exclusive evidence ceremonies.
  - Improved recorder startup and evidence-directory locking to prevent conflicting writes and partial updates.
  - Added stricter validation for malformed, oversized, noncanonical, or unsupported pin data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->