### PR TITLE
fix(conductor): scope audit reads and deny removed-follower ingest

### DIFF
--- a/docs/guides/conductor-production-runbook.md
+++ b/docs/guides/conductor-production-runbook.md
@@ -798,11 +798,11 @@ but it does not turn an invalid inventory into healthy delivery evidence.
 ## 14. Remove a follower
 
 `pipelock conductor follower remove` decommissions one exact follower identity.
-It deletes the active enrollment record from the Conductor store, so the
-follower disappears from `fleet status` and future audit evidence signed by that
-enrolled audit key is rejected. The command is admin-only and requires the full
-org/fleet/instance/environment tuple; a wrong or already-removed follower fails
-loud instead of being treated as success.
+It replaces the active enrollment with an inactive tombstone. The follower
+disappears from `fleet status`, and the removed identity can't submit evidence
+with its enrolled or matching static audit key. The command is admin-only and
+requires the full org/fleet/instance/environment tuple; a wrong or
+already-removed follower fails loud instead of being treated as success.
 
 ```bash
 pipelock conductor follower remove \

--- a/docs/security/agent-firewall-conductor-threat-model.md
+++ b/docs/security/agent-firewall-conductor-threat-model.md
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
 | SSRF to metadata/private networks | URL scanner SSRF layer after DLP/blocklist pre-resolution checks. |
 | Malicious or stale policy bundle | Signed bundle verification, payload hash, lineage checks, and not-before skew bounded by `MessageNotBeforeSkew`. |
 | Fleet-wide emergency-control forgery | Purpose-bound Ed25519 threshold keys for remote kill and rollback. |
-| Revoked follower evidence accepted after decommission | Enrollment-store audit-key resolver; `conductor follower remove` deletes the active enrollment so future evidence fails signature-key resolution. |
+| Revoked follower evidence accepted after decommission | Enrollment-store audit-key resolver; `conductor follower remove` retains an inactive tombstone so the removed identity can't use a static audit key. |
 | Rollback of license revocation state | Signed CRL generation high-water and monotonic recovery path. |
 | Conductor storage loss | Offline backup/restore of storage state plus separate secret/KMS restore for private keys. |
 

--- a/enterprise/cli/conductor/follower.go
+++ b/enterprise/cli/conductor/follower.go
@@ -69,11 +69,11 @@ func followerRemoveCmd() *cobra.Command {
 		Short: "Remove an enrolled follower from Conductor trust",
 		Long: `Remove an enrolled follower from the Conductor enrollment store.
 
-Removal is an admin-only decommission action. It deletes the follower's active
-enrollment record, so the follower no longer appears in fleet status and future
-audit evidence signed with its enrolled audit key is rejected. The exact
-org/fleet/instance/environment tuple is required; an unknown follower fails
-loud instead of being treated as success.`,
+Removal is an admin-only decommission action. It replaces the active enrollment
+with an inactive tombstone. The follower no longer appears in fleet status, and
+the removed identity can't submit evidence with its enrolled or matching static
+audit key. The exact org/fleet/instance/environment tuple is required; an
+unknown follower fails loud instead of being treated as success.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := license.VerifyFleetWithOptions(license.FleetVerifyInputs{CRLFile: opts.client.licenseCRLFile}); err != nil {

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -211,8 +211,8 @@ func startConductor(ctx context.Context, storageDir string, opts Options, materi
 		return nil, err
 	}
 	auditQueryAuth, err := controlplane.ScopedBearerAuditQueryAuthorizer([]controlplane.ScopedBearerCredential{
-		{Token: material.auditorToken, Role: controlplane.RoleAuditor},
-		{Token: material.adminToken, Role: controlplane.RoleAdmin},
+		{Token: material.auditorToken, Role: controlplane.RoleAuditor, OrgID: opts.OrgID},
+		{Token: material.adminToken, Role: controlplane.RoleAdmin, OrgID: opts.OrgID},
 	})
 	if err != nil {
 		_ = auditStore.Close()

--- a/enterprise/conductor/controlplane/audit_ingest_test.go
+++ b/enterprise/conductor/controlplane/audit_ingest_test.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -118,6 +119,107 @@ func TestHandlerRejectsInvalidAuditBatch(t *testing.T) {
 				t.Fatalf("response leaked %q: %s", tc.mustHide, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestHandlerRemovedFollowerCannotIngestViaStaticAuditFallback(t *testing.T) {
+	// Premise: a follower removed from the live roster can still have audit
+	// batches accepted if a static trusted audit key matches the same
+	// identity, because CompositeAuditKeyResolver falls back to
+	// StaticAuditKeyResolver after ResolveEnrolledAuditKey fails. Removal
+	// must fail closed for future ingest even when that static key remains.
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	pub, priv := testAuditSigner(t)
+	issued, err := enrollments.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "tok-removed-static",
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	if _, err := enrollments.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken() error = %v", err)
+	}
+
+	static, err := StaticAuditKeyResolver([]StaticAuditKey{{
+		KeyID: "audit-key-1",
+		Key: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		OrgID:      identity.OrgID,
+		FleetID:    identity.FleetID,
+		InstanceID: identity.InstanceID,
+	}})
+	if err != nil {
+		t.Fatalf("StaticAuditKeyResolver() error = %v", err)
+	}
+	sink := &captureAuditSink{}
+	handler := newAuditIngestTestHandler(t, sink, CompositeAuditKeyResolver(enrollments, static), 0)
+
+	payload := []byte(`{"entry":"ok"}`)
+	enrolled := postAuditBatch(t, handler, signedAuditIngestRequest(t, identity, payload, priv, testNow))
+	if enrolled.Code != http.StatusAccepted {
+		t.Fatalf("enrolled ingest status = %d body=%s, want 202", enrolled.Code, enrolled.Body.String())
+	}
+
+	if _, err := enrollments.RemoveEnrolledFollower(context.Background(), RemoveEnrolledFollowerRequest{
+		Identity: identity,
+		Now:      testNow,
+	}); err != nil {
+		t.Fatalf("RemoveEnrolledFollower() error = %v", err)
+	}
+
+	removed := postAuditBatch(t, handler, signedAuditIngestRequest(t, identity, payload, priv, testNow))
+	if removed.Code != http.StatusUnauthorized {
+		t.Fatalf("removed follower static-fallback ingest status = %d body=%s, want 401", removed.Code, removed.Body.String())
+	}
+	if len(sink.batches) != 1 {
+		t.Fatalf("sink batch count = %d, want 1 (only the enrolled ingest)", len(sink.batches))
+	}
+}
+
+func TestHandlerNeverEnrolledFollowerStillIngestsViaStaticAuditFallback(t *testing.T) {
+	// Static keys remain a bootstrap path for identities that were never on
+	// the roster. Removal-fail-closed must not take that path with it.
+	enrollments, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	pub, priv := testAuditSigner(t)
+	static, err := StaticAuditKeyResolver([]StaticAuditKey{{
+		KeyID: "audit-key-1",
+		Key: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		OrgID:      identity.OrgID,
+		FleetID:    identity.FleetID,
+		InstanceID: identity.InstanceID,
+	}})
+	if err != nil {
+		t.Fatalf("StaticAuditKeyResolver() error = %v", err)
+	}
+	sink := &captureAuditSink{}
+	handler := newAuditIngestTestHandler(t, sink, CompositeAuditKeyResolver(enrollments, static), 0)
+	w := postAuditBatch(t, handler, signedAuditIngestRequest(t, identity, []byte(`{"entry":"ok"}`), priv, testNow))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("never-enrolled static-fallback ingest status = %d body=%s, want 202", w.Code, w.Body.String())
 	}
 }
 

--- a/enterprise/conductor/controlplane/auth.go
+++ b/enterprise/conductor/controlplane/auth.go
@@ -153,10 +153,9 @@ func ScopedBearerBundleAuthorizer(creds []ScopedBearerCredential) (BundleAuthori
 // ScopedBearerFollowerListAuthorizer authorizes a follower-roster read. Like
 // the audit-query authorizer it admits admin and auditor (reader) roles and
 // enforces the credential's org/fleet scope against the requested query, so a
-// token scoped to org A cannot enumerate org B's followers. Unlike the
-// historical audit-query semantics, roster reads reject empty-org admin/auditor
-// credentials at construction time: an unscoped read token is a cross-org
-// enumeration token.
+// token scoped to org A cannot enumerate org B's followers. It also rejects
+// empty-org admin/auditor credentials at construction time: an unscoped read
+// token is a cross-org enumeration token.
 func ScopedBearerFollowerListAuthorizer(creds []ScopedBearerCredential) (FollowerListAuthorizer, error) {
 	normalized, err := normalizeScopedBearerCredentials(creds)
 	if err != nil {
@@ -214,10 +213,22 @@ func ScopedBearerStreamStatusAuthorizer(creds []ScopedBearerCredential) (StreamS
 	}, nil
 }
 
+// ScopedBearerAuditQueryAuthorizer authorizes an audit-metadata read. Like
+// the follower-roster and stream-status authorizers it admits admin and
+// auditor (reader) roles and enforces the credential's org/fleet scope
+// against the requested query, so a token scoped to org A cannot enumerate
+// org B's audit metadata. It also rejects empty-org admin/auditor
+// credentials at construction time for the same reason those siblings do:
+// an unscoped read token is a cross-org enumeration token.
 func ScopedBearerAuditQueryAuthorizer(creds []ScopedBearerCredential) (AuditQueryAuthorizer, error) {
 	normalized, err := normalizeScopedBearerCredentials(creds)
 	if err != nil {
 		return nil, err
+	}
+	for _, cred := range normalized {
+		if (cred.Role == RoleAdmin || cred.Role == RoleAuditor) && cred.OrgID == "" {
+			return nil, fmt.Errorf("%w: org_id required for audit query credential", ErrAuditQueryForbidden)
+		}
 	}
 	return func(r *http.Request, q AuditBatchQuery) error {
 		cred, ok := matchBearerCredential(r, normalized)

--- a/enterprise/conductor/controlplane/auth_test.go
+++ b/enterprise/conductor/controlplane/auth_test.go
@@ -152,7 +152,7 @@ func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
 	}
 	auditor, err := ScopedBearerAuditQueryAuthorizer([]ScopedBearerCredential{
 		{Token: "audit-token", Role: RoleAuditor, OrgID: "org-main", FleetID: "prod"},
-		{Token: "admin-token", Role: RoleAdmin},
+		{Token: "admin-token", Role: RoleAdmin, OrgID: "org-main"},
 	})
 	if err != nil {
 		t.Fatalf("ScopedBearerAuditQueryAuthorizer() error = %v", err)
@@ -213,6 +213,45 @@ func TestScopedBearerFollowerListAuthorizerRejectsUnscopedReadCredentials(t *tes
 		Role:  RoleAuditor,
 	}}); !errors.Is(err, ErrFollowerListForbidden) {
 		t.Fatalf("ScopedBearerFollowerListAuthorizer(unscoped auditor) error = %v, want ErrFollowerListForbidden", err)
+	}
+}
+
+func TestScopedBearerAuditQueryAuthorizerRejectsUnscopedReadCredentials(t *testing.T) {
+	// Empty-org admin/auditor credentials are cross-org enumeration tokens
+	// because scopedCredentialAllows treats a blank OrgID as matching every
+	// org. Construction must refuse them, matching the follower-list and
+	// stream-status authorizers. Whitespace-only org_id normalizes to empty
+	// and must be rejected identically.
+	for _, tc := range []struct {
+		name string
+		cred ScopedBearerCredential
+	}{
+		{"empty-org admin", ScopedBearerCredential{Token: "admin-token", Role: RoleAdmin}},
+		{"empty-org auditor", ScopedBearerCredential{Token: "audit-token", Role: RoleAuditor}},
+		{"whitespace-org admin", ScopedBearerCredential{Token: "admin-token", Role: RoleAdmin, OrgID: "   "}},
+		{"tab-org auditor", ScopedBearerCredential{Token: "audit-token", Role: RoleAuditor, OrgID: "\t"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ScopedBearerAuditQueryAuthorizer([]ScopedBearerCredential{tc.cred})
+			if !errors.Is(err, ErrAuditQueryForbidden) {
+				t.Fatalf("ScopedBearerAuditQueryAuthorizer(%+v) error = %v, want ErrAuditQueryForbidden", tc.cred, err)
+			}
+			if err == nil || !strings.Contains(err.Error(), "org_id required for audit query credential") {
+				t.Fatalf("ScopedBearerAuditQueryAuthorizer(%+v) error = %v, want actionable org_id required message", tc.cred, err)
+			}
+		})
+	}
+
+	auth, err := ScopedBearerAuditQueryAuthorizer([]ScopedBearerCredential{{
+		Token: "admin-token",
+		Role:  RoleAdmin,
+		OrgID: "org-main",
+	}})
+	if err != nil {
+		t.Fatalf("ScopedBearerAuditQueryAuthorizer(scoped admin) error = %v, want nil", err)
+	}
+	if err := auth(bearerRequest(t, AuditBatchesPath, "admin-token"), AuditBatchQuery{OrgID: "org-other", FleetID: "prod"}); !errors.Is(err, ErrAuditQueryForbidden) {
+		t.Fatalf("scoped admin query for unrelated org error = %v, want ErrAuditQueryForbidden", err)
 	}
 }
 

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -328,7 +328,9 @@ func (s *FileEnrollmentStore) CreateEnrollmentToken(_ context.Context, spec Enro
 	}
 	s.data.Tokens[spec.TokenID] = record
 	if err := s.saveLocked(); err != nil {
-		delete(s.data.Tokens, spec.TokenID)
+		if !errors.Is(err, errDurableWritePostRename) {
+			delete(s.data.Tokens, spec.TokenID)
+		}
 		return IssuedEnrollmentToken{}, err
 	}
 	return IssuedEnrollmentToken{TokenID: spec.TokenID, Token: token, ExpiresAt: expires}, nil
@@ -394,13 +396,15 @@ func (s *FileEnrollmentStore) ConsumeEnrollmentToken(_ context.Context, req Cons
 		s.data.RuntimeStatus = make(map[string]FollowerRuntimeStatus)
 	}
 	if err := s.saveLocked(); err != nil {
-		token.ConsumedAt = nil
-		token.ConsumedByID = ""
-		s.data.Tokens[tokenID] = token
-		if hadPreviousFollower {
-			s.data.Followers[followerKey] = previousFollower
-		} else {
-			delete(s.data.Followers, followerKey)
+		if !errors.Is(err, errDurableWritePostRename) {
+			token.ConsumedAt = nil
+			token.ConsumedByID = ""
+			s.data.Tokens[tokenID] = token
+			if hadPreviousFollower {
+				s.data.Followers[followerKey] = previousFollower
+			} else {
+				delete(s.data.Followers, followerKey)
+			}
 		}
 		return EnrolledFollower{}, err
 	}
@@ -619,10 +623,12 @@ func (s *FileEnrollmentStore) UpsertFollowerRuntimeStatus(_ context.Context, sta
 	}
 	s.data.RuntimeStatus[key] = normalized
 	if err := s.saveLocked(); err != nil {
-		if hadPrevious {
-			s.data.RuntimeStatus[key] = previous
-		} else {
-			delete(s.data.RuntimeStatus, key)
+		if !errors.Is(err, errDurableWritePostRename) {
+			if hadPrevious {
+				s.data.RuntimeStatus[key] = previous
+			} else {
+				delete(s.data.RuntimeStatus, key)
+			}
 		}
 		return FollowerRuntimeStatus{}, err
 	}
@@ -743,10 +749,12 @@ func (s *FileEnrollmentStore) RevokeEnrollmentToken(_ context.Context, req Revok
 	token.RevokedAt = &revokedAt
 	s.data.Tokens[tokenID] = token
 	if err := s.saveLocked(); err != nil {
-		// Roll back the in-memory mutation so a failed durable write does not
-		// leave a token that looks revoked in memory but is not on disk.
-		token.RevokedAt = nil
-		s.data.Tokens[tokenID] = token
+		if !errors.Is(err, errDurableWritePostRename) {
+			// Roll back the in-memory mutation so a failed durable write does not
+			// leave a token that looks revoked in memory but is not on disk.
+			token.RevokedAt = nil
+			s.data.Tokens[tokenID] = token
+		}
 		return EnrollmentTokenSummary{}, err
 	}
 	return token.summary(now), nil

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -420,7 +420,11 @@ func (s *FileEnrollmentStore) ResolveEnrolledAuditKey(identity FollowerIdentity,
 	defer s.mu.Unlock()
 	follower, ok := s.data.Followers[followerEnrollmentKey(identity)]
 	if !ok {
-		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+		// The static resolver is a bootstrap path only for an identity that
+		// has never been enrolled. Preserve that distinction for the composite
+		// resolver without exposing it at the HTTP boundary, which still maps
+		// every verification failure to the same denial.
+		return conductor.SignatureKey{}, fmt.Errorf("%w: %w", conductor.ErrSignatureVerification, ErrFollowerNotFound)
 	}
 	if !follower.Active {
 		return conductor.SignatureKey{}, fmt.Errorf("%w: %w", conductor.ErrSignatureVerification, errFollowerDecommissioned)
@@ -513,9 +517,16 @@ func (s *FileEnrollmentStore) RemoveEnrolledFollower(_ context.Context, req Remo
 	delete(s.data.RuntimeStatus, key)
 	s.data.Followers[key] = decommissioned
 	if err := s.saveLocked(); err != nil {
-		s.data.Followers[key] = follower
-		if hadStatus {
-			s.data.RuntimeStatus[key] = previousStatus
+		// Once rename has completed, the on-disk record may already be the
+		// tombstone even when the directory fsync reports an error. Keep the
+		// in-memory state decommissioned in that uncertain state; restoring the
+		// active key would make this process accept traffic the next restart may
+		// reject.
+		if !errors.Is(err, errDurableWritePostRename) {
+			s.data.Followers[key] = follower
+			if hadStatus {
+				s.data.RuntimeStatus[key] = previousStatus
+			}
 		}
 		return FollowerSummary{}, err
 	}
@@ -876,7 +887,10 @@ func CompositeAuditKeyResolver(primary EnrollmentStore, fallback AuditKeyResolve
 			if err == nil {
 				return key, nil
 			}
-			if errors.Is(err, errFollowerDecommissioned) {
+			// Do not turn a known identity's revoked, mismatched, or unreadable
+			// enrollment state into authorization by a static key. Static keys are
+			// bootstrap-only and may fill an explicit never-enrolled miss.
+			if !errors.Is(err, ErrFollowerNotFound) {
 				return conductor.SignatureKey{}, conductor.ErrSignatureVerification
 			}
 		}

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -59,6 +59,12 @@ var (
 	// already done its one job and re-revoking it must fail loud rather than
 	// pretend to undo an enrollment.
 	ErrEnrollmentTokenNotPending = errors.New("conductor enrollment token is not pending")
+
+	// errFollowerDecommissioned is returned by ResolveEnrolledAuditKey when
+	// the identity was enrolled and then removed. CompositeAuditKeyResolver
+	// must not fall back to a static audit key for that identity: removal is
+	// a revocation of audit ingest, not a miss that bootstrap keys can fill.
+	errFollowerDecommissioned = errors.New("conductor follower decommissioned")
 )
 
 type EnrollmentStore interface {
@@ -413,7 +419,13 @@ func (s *FileEnrollmentStore) ResolveEnrolledAuditKey(identity FollowerIdentity,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	follower, ok := s.data.Followers[followerEnrollmentKey(identity)]
-	if !ok || !follower.Active || follower.AuditKeyID != signerKeyID {
+	if !ok {
+		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
+	}
+	if !follower.Active {
+		return conductor.SignatureKey{}, fmt.Errorf("%w: %w", conductor.ErrSignatureVerification, errFollowerDecommissioned)
+	}
+	if follower.AuditKeyID != signerKeyID {
 		return conductor.SignatureKey{}, conductor.ErrSignatureVerification
 	}
 	return follower.AuditKey, nil
@@ -436,6 +448,9 @@ func (s *FileEnrollmentStore) ListEnrolledFollowers(_ context.Context, q Followe
 	defer s.mu.Unlock()
 	out := make(followerSummaryMaxHeap, 0, limit)
 	for _, follower := range s.data.Followers {
+		if !follower.Active {
+			continue
+		}
 		if q.OrgID != "" && follower.Identity.OrgID != q.OrgID {
 			continue
 		}
@@ -469,10 +484,11 @@ func (s *FileEnrollmentStore) ListEnrolledFollowers(_ context.Context, q Followe
 	return []FollowerSummary(out), nil
 }
 
-// RemoveEnrolledFollower deletes one active follower enrollment from the
-// Conductor trust store. After the delete, ResolveEnrolledAuditKey no longer
-// returns that follower's audit key, so future audit evidence from the removed
-// follower fails closed. Unknown or already-removed followers return
+// RemoveEnrolledFollower decommissions one active follower enrollment. The
+// identity is retained as an inactive tombstone so later audit ingest cannot
+// be re-authorized by a static trusted key that still matches.
+// ResolveEnrolledAuditKey fails closed, and CompositeAuditKeyResolver must
+// not fall back. Unknown or already-removed followers return
 // ErrFollowerNotFound; the command is idempotent in side effect but never
 // silently treats a missing follower as success.
 func (s *FileEnrollmentStore) RemoveEnrolledFollower(_ context.Context, req RemoveEnrolledFollowerRequest) (FollowerSummary, error) {
@@ -490,9 +506,12 @@ func (s *FileEnrollmentStore) RemoveEnrolledFollower(_ context.Context, req Remo
 	if !ok || !follower.Active {
 		return FollowerSummary{}, ErrFollowerNotFound
 	}
-	delete(s.data.Followers, key)
+	decommissioned := follower
+	decommissioned.Active = false
+	decommissioned.AuditKey = conductor.SignatureKey{}
 	previousStatus, hadStatus := s.data.RuntimeStatus[key]
 	delete(s.data.RuntimeStatus, key)
+	s.data.Followers[key] = decommissioned
 	if err := s.saveLocked(); err != nil {
 		s.data.Followers[key] = follower
 		if hadStatus {
@@ -645,6 +664,9 @@ func (s *FileEnrollmentStore) ListEnrolledFollowersForPreflight(_ context.Contex
 	defer s.mu.Unlock()
 	out := make([]FollowerSummary, 0)
 	for _, follower := range s.data.Followers {
+		if !follower.Active {
+			continue
+		}
 		if q.OrgID != "" && follower.Identity.OrgID != q.OrgID {
 			continue
 		}
@@ -853,6 +875,9 @@ func CompositeAuditKeyResolver(primary EnrollmentStore, fallback AuditKeyResolve
 			key, err := primary.ResolveEnrolledAuditKey(identity, signerKeyID)
 			if err == nil {
 				return key, nil
+			}
+			if errors.Is(err, errFollowerDecommissioned) {
+				return conductor.SignatureKey{}, conductor.ErrSignatureVerification
 			}
 		}
 		if fallback != nil {

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -469,6 +469,21 @@ func TestCreateEnrollmentTokenKeepsPendingStateAfterPostRenameSyncFailure(t *tes
 	if len(tokens) != 1 || tokens[0].State != EnrollmentTokenStatePending {
 		t.Fatalf("tokens after post-rename failure = %+v, want one pending token", tokens)
 	}
+
+	// The rename succeeded and only the directory sync failed, so the token is
+	// already on disk. Asserting against the same in-memory store cannot show
+	// that; reopening the file is what proves the retained state is durable.
+	reopened, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reopen) error = %v", err)
+	}
+	persisted, err := reopened.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: tokenID, Now: testNow})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens(reopened) error = %v", err)
+	}
+	if len(persisted) != 1 || persisted[0].State != EnrollmentTokenStatePending {
+		t.Fatalf("tokens from reopened store = %+v, want one pending token", persisted)
+	}
 }
 
 func TestConsumeEnrollmentTokenRollsBackBeforeRenameFailure(t *testing.T) {
@@ -537,6 +552,19 @@ func TestConsumeEnrollmentTokenKeepsConsumedStateAfterPostRenameSyncFailure(t *t
 	}
 	if _, err := store.ResolveEnrolledAuditKey(identity, request.AuditKeyID); err != nil {
 		t.Fatalf("ResolveEnrolledAuditKey() error = %v, want enrolled key", err)
+	}
+
+	// Same reason as the create case: prove the consumed state and the enrolled
+	// key survived to disk rather than only to the in-memory map.
+	reopened, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reopen) error = %v", err)
+	}
+	if _, err := reopened.ConsumeEnrollmentToken(context.Background(), request); !errors.Is(err, ErrEnrollmentTokenConsumed) {
+		t.Fatalf("ConsumeEnrollmentToken(reopened) error = %v, want ErrEnrollmentTokenConsumed", err)
+	}
+	if _, err := reopened.ResolveEnrolledAuditKey(identity, request.AuditKeyID); err != nil {
+		t.Fatalf("ResolveEnrolledAuditKey(reopened) error = %v, want enrolled key", err)
 	}
 }
 

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -359,5 +360,213 @@ func TestFileEnrollmentStoreRevokeIsDurableAndConsumedNotRevokable(t *testing.T)
 	// A second store cannot re-revoke a revoked token.
 	if _, err := reopened.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: "durable-token", Now: testNow}); !errors.Is(err, ErrEnrollmentTokenNotPending) {
 		t.Fatalf("re-revoke after restart error = %v, want ErrEnrollmentTokenNotPending", err)
+	}
+}
+
+func TestRevokeEnrollmentTokenKeepsRevocationAfterPostRenameSyncFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"post", "rename", "revoke"}, "-")
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  tokenID,
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+
+	originalSyncDirectory := syncDirectory
+	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
+	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
+	if _, err := store.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: tokenID, Now: testNow}); !errors.Is(err, errDurableWritePostRename) {
+		t.Fatalf("RevokeEnrollmentToken(post-rename sync failure) error = %v, want errDurableWritePostRename", err)
+	}
+	syncDirectory = originalSyncDirectory
+
+	pub, _ := testAuditSigner(t)
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-post-rename-revoke",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}); !errors.Is(err, ErrEnrollmentTokenInvalid) {
+		t.Fatalf("ConsumeEnrollmentToken(revoked token) error = %v, want ErrEnrollmentTokenInvalid", err)
+	}
+
+	reloaded, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reload) error = %v", err)
+	}
+	tokens, err := reloaded.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: tokenID})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens() error = %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].State != EnrollmentTokenStateRevoked {
+		t.Fatalf("tokens after reload = %+v, want one revoked token", tokens)
+	}
+}
+
+func TestCreateEnrollmentTokenRollsBackBeforeRenameFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"pre", "rename", "create"}, "-")
+	store.path = filepath.Dir(path)
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  tokenID,
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	}); err == nil {
+		t.Fatal("CreateEnrollmentToken() error = nil, want pre-rename write error")
+	}
+	store.path = path
+	tokens, err := store.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: tokenID, Now: testNow})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens() error = %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("tokens after pre-rename failure = %+v, want none", tokens)
+	}
+}
+
+func TestCreateEnrollmentTokenKeepsPendingStateAfterPostRenameSyncFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"post", "rename", "create"}, "-")
+	originalSyncDirectory := syncDirectory
+	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
+	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  tokenID,
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	}); !errors.Is(err, errDurableWritePostRename) {
+		t.Fatalf("CreateEnrollmentToken(post-rename sync failure) error = %v, want errDurableWritePostRename", err)
+	}
+	syncDirectory = originalSyncDirectory
+	tokens, err := store.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: tokenID, Now: testNow})
+	if err != nil {
+		t.Fatalf("ListEnrollmentTokens() error = %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].State != EnrollmentTokenStatePending {
+		t.Fatalf("tokens after post-rename failure = %+v, want one pending token", tokens)
+	}
+}
+
+func TestConsumeEnrollmentTokenRollsBackBeforeRenameFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"pre", "rename", "consume"}, "-")
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{TokenID: tokenID, Identity: identity, Expires: testNow.Add(time.Hour), Now: testNow})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	request := ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-pre-rename-consume",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+	store.path = filepath.Dir(path)
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), request); err == nil {
+		t.Fatal("ConsumeEnrollmentToken() error = nil, want pre-rename write error")
+	}
+	store.path = path
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), request); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken() after rollback error = %v, want success", err)
+	}
+}
+
+func TestConsumeEnrollmentTokenKeepsConsumedStateAfterPostRenameSyncFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"post", "rename", "consume"}, "-")
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{TokenID: tokenID, Identity: identity, Expires: testNow.Add(time.Hour), Now: testNow})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	pub, _ := testAuditSigner(t)
+	request := ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-post-rename-consume",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}
+	originalSyncDirectory := syncDirectory
+	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
+	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), request); !errors.Is(err, errDurableWritePostRename) {
+		t.Fatalf("ConsumeEnrollmentToken(post-rename sync failure) error = %v, want errDurableWritePostRename", err)
+	}
+	syncDirectory = originalSyncDirectory
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), request); !errors.Is(err, ErrEnrollmentTokenConsumed) {
+		t.Fatalf("ConsumeEnrollmentToken(retry) error = %v, want ErrEnrollmentTokenConsumed", err)
+	}
+	if _, err := store.ResolveEnrolledAuditKey(identity, request.AuditKeyID); err != nil {
+		t.Fatalf("ResolveEnrolledAuditKey() error = %v, want enrolled key", err)
+	}
+}
+
+func TestRevokeEnrollmentTokenRollsBackBeforeRenameFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	tokenID := strings.Join([]string{"pre", "rename", "revoke"}, "-")
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{TokenID: tokenID, Identity: identity, Expires: testNow.Add(time.Hour), Now: testNow})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	store.path = filepath.Dir(path)
+	if _, err := store.RevokeEnrollmentToken(context.Background(), RevokeEnrollmentTokenRequest{TokenID: tokenID, Now: testNow}); err == nil {
+		t.Fatal("RevokeEnrollmentToken() error = nil, want pre-rename write error")
+	}
+	store.path = path
+	pub, _ := testAuditSigner(t)
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-pre-rename-revoke",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken() after rollback error = %v, want success", err)
 	}
 }

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -8,6 +8,7 @@ package controlplane
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -587,6 +588,83 @@ func TestRemovedFollowerCanReEnroll(t *testing.T) {
 	}
 	if len(summaries) != 1 {
 		t.Fatalf("roster entries = %d, want 1 after re-enrollment", len(summaries))
+	}
+}
+
+func TestReenrolledFollowerCannotUseRetiredStaticAuditKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	oldPub, _ := testAuditSigner(t)
+	newPub, _ := testAuditSigner(t)
+
+	enroll := func(tokenID, keyID string, pub ed25519.PublicKey) error {
+		issued, issueErr := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+			TokenID:  tokenID,
+			Identity: identity,
+			Expires:  testNow.Add(time.Hour),
+			Now:      testNow,
+		})
+		if issueErr != nil {
+			return issueErr
+		}
+		_, consumeErr := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+			Token:      issued.Token,
+			AuditKeyID: keyID,
+			AuditKey: conductor.SignatureKey{
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposeAuditBatchSigning,
+			},
+			Now: testNow,
+		})
+		return consumeErr
+	}
+
+	if err := enroll("tok-retired-static-1", "audit-key-old", oldPub); err != nil {
+		t.Fatalf("initial enrollment error = %v", err)
+	}
+	if _, err := store.RemoveEnrolledFollower(context.Background(), RemoveEnrolledFollowerRequest{Identity: identity, Now: testNow}); err != nil {
+		t.Fatalf("RemoveEnrolledFollower() error = %v", err)
+	}
+	if err := enroll("tok-retired-static-2", "audit-key-new", newPub); err != nil {
+		t.Fatalf("re-enrollment error = %v", err)
+	}
+	reloaded, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reload) error = %v", err)
+	}
+
+	fallbackHits := 0
+	resolver := CompositeAuditKeyResolver(reloaded, func(FollowerIdentity, string) (conductor.SignatureKey, error) {
+		fallbackHits++
+		return conductor.SignatureKey{PublicKey: oldPub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	})
+	if _, err := resolver(identity, "audit-key-old"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(retired static key) error = %v, want ErrSignatureVerification", err)
+	}
+	if fallbackHits != 0 {
+		t.Fatalf("static fallback hits = %d, want 0 for retired key after re-enrollment", fallbackHits)
+	}
+	if _, err := resolver(identity, "audit-key-new"); err != nil {
+		t.Fatalf("resolver(active key) error = %v, want nil", err)
+	}
+}
+
+func TestCompositeAuditKeyResolverDoesNotFallBackAfterPrimaryError(t *testing.T) {
+	pub, _ := testAuditSigner(t)
+	fallbackHits := 0
+	resolver := CompositeAuditKeyResolver(truncatedPreflightEnrollmentStore{}, func(FollowerIdentity, string) (conductor.SignatureKey, error) {
+		fallbackHits++
+		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	})
+	if _, err := resolver(defaultFollowerIdentity(), "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(primary error) error = %v, want ErrSignatureVerification", err)
+	}
+	if fallbackHits != 0 {
+		t.Fatalf("static fallback hits = %d, want 0 after primary error", fallbackHits)
 	}
 }
 

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -470,6 +470,57 @@ func TestCompositeAuditKeyResolverFallsBack(t *testing.T) {
 	}
 }
 
+func TestCompositeAuditKeyResolverDoesNotFallBackAfterRemoval(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	pub, _ := testAuditSigner(t)
+	issued, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "tok-composite-remove",
+		Identity: identity,
+		Expires:  testNow.Add(time.Hour),
+		Now:      testNow,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnrollmentToken() error = %v", err)
+	}
+	if _, err := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+		Token:      issued.Token,
+		AuditKeyID: "audit-key-1",
+		AuditKey: conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		},
+		Now: testNow,
+	}); err != nil {
+		t.Fatalf("ConsumeEnrollmentToken() error = %v", err)
+	}
+	if _, err := store.RemoveEnrolledFollower(context.Background(), RemoveEnrolledFollowerRequest{
+		Identity: identity,
+		Now:      testNow,
+	}); err != nil {
+		t.Fatalf("RemoveEnrolledFollower() error = %v", err)
+	}
+
+	fallbackHits := 0
+	fallback := func(FollowerIdentity, string) (conductor.SignatureKey, error) {
+		fallbackHits++
+		return conductor.SignatureKey{
+			PublicKey:  pub,
+			KeyPurpose: signing.PurposeAuditBatchSigning,
+		}, nil
+	}
+	resolver := CompositeAuditKeyResolver(store, fallback)
+	if _, err := resolver(identity, "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("resolver(removed) error = %v, want ErrSignatureVerification", err)
+	}
+	if fallbackHits != 0 {
+		t.Fatalf("static fallback hits = %d, want 0 after follower removal", fallbackHits)
+	}
+}
+
 func TestHandlerEnrollmentEndpointErrors(t *testing.T) {
 	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
 	if err != nil {

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -521,6 +521,75 @@ func TestCompositeAuditKeyResolverDoesNotFallBackAfterRemoval(t *testing.T) {
 	}
 }
 
+// TestRemovedFollowerCanReEnroll pins the availability direction of the
+// decommission tombstone. RemoveEnrolledFollower retains an inactive record so
+// audit ingest cannot be re-authorized by a static key, but that record must
+// never become a permanent bar to re-enrolling the same identity: a follower
+// rebuilt on the same host has to be able to come back. The enrollment guard
+// admits an inactive record by design; this test keeps it that way.
+func TestRemovedFollowerCanReEnroll(t *testing.T) {
+	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	pub, _ := testAuditSigner(t)
+
+	enroll := func(tokenID, keyID string) error {
+		issued, issueErr := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+			TokenID:  tokenID,
+			Identity: identity,
+			Expires:  testNow.Add(time.Hour),
+			Now:      testNow,
+		})
+		if issueErr != nil {
+			return issueErr
+		}
+		_, consumeErr := store.ConsumeEnrollmentToken(context.Background(), ConsumeEnrollmentTokenRequest{
+			Token:      issued.Token,
+			AuditKeyID: keyID,
+			AuditKey: conductor.SignatureKey{
+				PublicKey:  pub,
+				KeyPurpose: signing.PurposeAuditBatchSigning,
+			},
+			Now: testNow,
+		})
+		return consumeErr
+	}
+
+	if err := enroll("tok-reenroll-1", "audit-key-1"); err != nil {
+		t.Fatalf("first enrollment error = %v", err)
+	}
+	if _, err := store.RemoveEnrolledFollower(context.Background(), RemoveEnrolledFollowerRequest{
+		Identity: identity,
+		Now:      testNow,
+	}); err != nil {
+		t.Fatalf("RemoveEnrolledFollower() error = %v", err)
+	}
+
+	// The tombstone must not block a fresh enrollment of the same identity.
+	if err := enroll("tok-reenroll-2", "audit-key-2"); err != nil {
+		t.Fatalf("re-enrollment after removal error = %v, want success", err)
+	}
+
+	// The re-enrolled follower resolves on its NEW key and not the retired one.
+	if _, err := store.ResolveEnrolledAuditKey(identity, "audit-key-2"); err != nil {
+		t.Fatalf("ResolveEnrolledAuditKey(new key) error = %v, want success", err)
+	}
+	if _, err := store.ResolveEnrolledAuditKey(identity, "audit-key-1"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("ResolveEnrolledAuditKey(retired key) error = %v, want ErrSignatureVerification", err)
+	}
+
+	// A re-enrolled follower is active again, so it reappears on the roster.
+	summaries, err := store.ListEnrolledFollowers(context.Background(), FollowerListQuery{OrgID: identity.OrgID, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListEnrolledFollowers() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("roster entries = %d, want 1 after re-enrollment", len(summaries))
+	}
+}
+
 func TestHandlerEnrollmentEndpointErrors(t *testing.T) {
 	store, err := OpenFileEnrollmentStore(filepath.Join(t.TempDir(), "enrollments.json"))
 	if err != nil {

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1231,6 +1231,13 @@ func TestRemoveEnrolledFollowerKeepsTombstoneAfterPostRenameSyncFailure(t *testi
 	identity := defaultFollowerIdentity()
 	mustEnrollFollower(t, store, "tok-post-rename-sync", identity, "audit-key-post-rename-sync")
 
+	// Removal deletes the follower's runtime status alongside the enrollment.
+	// Without a status present that branch never runs, so the test would pass
+	// while the changed deletion path stayed unexercised.
+	if _, err := store.UpsertFollowerRuntimeStatus(context.Background(), runtimeStatus(identity, "1.2.3", strings.Repeat("f", 64))); err != nil {
+		t.Fatalf("UpsertFollowerRuntimeStatus() error = %v", err)
+	}
+
 	originalSyncDirectory := syncDirectory
 	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
 	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
@@ -1248,12 +1255,27 @@ func TestRemoveEnrolledFollowerKeepsTombstoneAfterPostRenameSyncFailure(t *testi
 		t.Fatalf("followers after post-rename sync failure = %+v, want tombstone hidden from roster", followers)
 	}
 
+	liveStatuses, err := store.ListFollowerRuntimeStatus(context.Background(), RuntimeStatusQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListFollowerRuntimeStatus() error = %v", err)
+	}
+	if len(liveStatuses) != 0 {
+		t.Fatalf("runtime statuses after post-rename sync failure = %+v, want the removed follower's status gone", liveStatuses)
+	}
+
 	reloaded, err := OpenFileEnrollmentStore(path)
 	if err != nil {
 		t.Fatalf("OpenFileEnrollmentStore(reload) error = %v", err)
 	}
 	if _, err := reloaded.ResolveEnrolledAuditKey(identity, "audit-key-post-rename-sync"); !errors.Is(err, conductor.ErrSignatureVerification) {
 		t.Fatalf("ResolveEnrolledAuditKey(reload) error = %v, want signature verification failure", err)
+	}
+	reloadedStatuses, err := reloaded.ListFollowerRuntimeStatus(context.Background(), RuntimeStatusQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListFollowerRuntimeStatus(reload) error = %v", err)
+	}
+	if len(reloadedStatuses) != 0 {
+		t.Fatalf("runtime statuses from reopened store = %+v, want the removal to have persisted", reloadedStatuses)
 	}
 }
 
@@ -1301,6 +1323,20 @@ func TestUpsertFollowerRuntimeStatusKeepsStatusAfterPostRenameSyncFailure(t *tes
 	}
 	if len(statuses) != 1 || statuses[0].PipelockVersion != want.PipelockVersion {
 		t.Fatalf("statuses after post-rename failure = %+v, want %+v", statuses, want)
+	}
+
+	// The rename committed and only the directory sync failed, so the status is
+	// on disk. Reopening is what proves that rather than the in-memory map.
+	reopened, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reopen) error = %v", err)
+	}
+	persisted, err := reopened.ListFollowerRuntimeStatus(context.Background(), RuntimeStatusQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListFollowerRuntimeStatus(reopened) error = %v", err)
+	}
+	if len(persisted) != 1 || persisted[0].PipelockVersion != want.PipelockVersion {
+		t.Fatalf("statuses from reopened store = %+v, want %+v", persisted, want)
 	}
 }
 

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1222,6 +1222,41 @@ func TestRemoveEnrolledFollowerRestoresRuntimeStatusOnSaveFailure(t *testing.T) 
 	}
 }
 
+func TestRemoveEnrolledFollowerKeepsTombstoneAfterPostRenameSyncFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	mustEnrollFollower(t, store, "tok-post-rename-sync", identity, "audit-key-post-rename-sync")
+
+	originalSyncDirectory := syncDirectory
+	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
+	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
+	if _, err := store.RemoveEnrolledFollower(context.Background(), RemoveEnrolledFollowerRequest{Identity: identity, Now: testNow}); !errors.Is(err, errDurableWritePostRename) {
+		t.Fatalf("RemoveEnrolledFollower(post-rename sync failure) error = %v, want errDurableWritePostRename", err)
+	}
+	if _, err := store.ResolveEnrolledAuditKey(identity, "audit-key-post-rename-sync"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("ResolveEnrolledAuditKey() after post-rename sync failure error = %v, want signature verification failure", err)
+	}
+	followers, err := store.ListEnrolledFollowers(context.Background(), FollowerListQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListEnrolledFollowers() error = %v", err)
+	}
+	if len(followers) != 0 {
+		t.Fatalf("followers after post-rename sync failure = %+v, want tombstone hidden from roster", followers)
+	}
+
+	reloaded, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore(reload) error = %v", err)
+	}
+	if _, err := reloaded.ResolveEnrolledAuditKey(identity, "audit-key-post-rename-sync"); !errors.Is(err, conductor.ErrSignatureVerification) {
+		t.Fatalf("ResolveEnrolledAuditKey(reload) error = %v, want signature verification failure", err)
+	}
+}
+
 type truncatedPreflightEnrollmentStore struct {
 	followers []FollowerSummary
 	statuses  []FollowerRuntimeStatus

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1257,6 +1257,53 @@ func TestRemoveEnrolledFollowerKeepsTombstoneAfterPostRenameSyncFailure(t *testi
 	}
 }
 
+func TestUpsertFollowerRuntimeStatusRollsBackNewStatusBeforeRenameFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	mustEnrollFollower(t, store, "tok-runtime-pre-rename", identity, "audit-key-runtime-pre-rename")
+	store.path = filepath.Dir(path)
+	if _, err := store.UpsertFollowerRuntimeStatus(context.Background(), runtimeStatus(identity, "1.2.3", strings.Repeat("d", 64))); err == nil {
+		t.Fatal("UpsertFollowerRuntimeStatus() error = nil, want pre-rename write error")
+	}
+	store.path = path
+	statuses, err := store.ListFollowerRuntimeStatus(context.Background(), RuntimeStatusQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListFollowerRuntimeStatus() error = %v", err)
+	}
+	if len(statuses) != 0 {
+		t.Fatalf("statuses after pre-rename failure = %+v, want none", statuses)
+	}
+}
+
+func TestUpsertFollowerRuntimeStatusKeepsStatusAfterPostRenameSyncFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	store, err := OpenFileEnrollmentStore(path)
+	if err != nil {
+		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
+	}
+	identity := defaultFollowerIdentity()
+	mustEnrollFollower(t, store, "tok-runtime-post-rename", identity, "audit-key-runtime-post-rename")
+	want := runtimeStatus(identity, "1.2.3", strings.Repeat("e", 64))
+	originalSyncDirectory := syncDirectory
+	syncDirectory = func(string) error { return errors.New("injected directory sync failure") }
+	t.Cleanup(func() { syncDirectory = originalSyncDirectory })
+	if _, err := store.UpsertFollowerRuntimeStatus(context.Background(), want); !errors.Is(err, errDurableWritePostRename) {
+		t.Fatalf("UpsertFollowerRuntimeStatus(post-rename sync failure) error = %v, want errDurableWritePostRename", err)
+	}
+	syncDirectory = originalSyncDirectory
+	statuses, err := store.ListFollowerRuntimeStatus(context.Background(), RuntimeStatusQuery{OrgID: identity.OrgID})
+	if err != nil {
+		t.Fatalf("ListFollowerRuntimeStatus() error = %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].PipelockVersion != want.PipelockVersion {
+		t.Fatalf("statuses after post-rename failure = %+v, want %+v", statuses, want)
+	}
+}
+
 type truncatedPreflightEnrollmentStore struct {
 	followers []FollowerSummary
 	statuses  []FollowerRuntimeStatus

--- a/enterprise/conductor/controlplane/store.go
+++ b/enterprise/conductor/controlplane/store.go
@@ -78,6 +78,11 @@ var (
 	ErrAuditBatchConflict    = errors.New("conductor audit batch conflicts with accepted batch")
 	ErrAuditForkDetected     = errors.New("conductor audit sequence fork detected")
 	ErrUnsupportedRollback   = errors.New("conductor control plane rollback publication not implemented")
+	// errDurableWritePostRename identifies a directory-sync failure after the
+	// atomic rename made the new bytes visible. Callers must not roll back their
+	// in-memory security state on this error because persistence is uncertain.
+	errDurableWritePostRename = errors.New("conductor control plane write may have committed before directory fsync failed")
+	syncDirectory             = fsyncDir
 	// ErrVersionBelowStreamMax is returned by a forward publish whose version is
 	// not strictly greater than the highest version EVER published in the stream,
 	// yet is not below the current (possibly rolled-back) head. After a rollback
@@ -1317,7 +1322,10 @@ func durableWrite(path string, data []byte) error {
 	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("conductor control plane rename temp: %w", err)
 	}
-	return fsyncDir(dir)
+	if err := syncDirectory(dir); err != nil {
+		return fmt.Errorf("%w: %w", errDurableWritePostRename, err)
+	}
+	return nil
 }
 
 func fsyncDir(dir string) error {


### PR DESCRIPTION
## What changed

Two control-plane authorization gaps close here.

The audit-query authorizer now refuses an admin or auditor credential that carries no organization at construction time, which its follower-roster and stream-status siblings already did. The shared scope matcher treats an empty organization on a credential as matching every organization, so such a token could read every organization's audit metadata. This is an operator-visible breaking change: a conductor configured with an unscoped audit credential today will refuse to start, and the error names the missing field.

Removing a follower now records an inactive tombstone instead of deleting the enrollment outright. Deletion left the composite key resolver unable to tell a follower that was never enrolled from one that had been revoked, so it fell through to a statically trusted bootstrap key and kept accepting audit batches from a removed follower. The resolver now fails closed on a decommissioned identity, and roster and preflight listings skip inactive records so the operator-visible roster is unchanged.

The failure directions to distrust are the two the tombstone creates. Retaining the record must not become a permanent bar to re-enrolling the same identity, since a follower rebuilt on the same host has to be able to return; a regression test pins that. And the inactive record must not leak into any surface that treats it as an active follower. Reviewers should confirm both, and confirm the construction-time refusal cannot be reached by a legitimate scoped credential.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Removed followers are decommissioned rather than deleted, preventing evidence submission with retired audit keys.
  * Organization-scoped audit queries reject missing, whitespace-only, or mismatched scopes.
  * Re-enrolled followers receive fresh audit-key validation.

* **Reliability**
  * Enrollment, removal, and runtime-status updates preserve consistent state when storage synchronization fails.

* **Documentation**
  * Updated command help, operational guidance, and threat-model documentation to reflect decommissioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->