### PR TITLE
fix(proxy): fail closed on hostname metrics listener dials

### DIFF
--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -739,6 +739,7 @@ func (s *Server) Start(ctx context.Context) (startErr error) {
 			}
 			return err
 		}
+		s.proxy.UpdateMetricsDialTargetFromBoundAddr(metricsLn.Addr().String())
 		metricsSrv := newHTTPServer(metricsMux)
 		lifecycleWG.Add(1)
 		go func() { //nolint:gosec // G118: graceful shutdown after <-ctx.Done(); using ctx as parent would skip the grace period

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -243,3 +243,91 @@ func TestConfiguredWildcardMetricsListenerBlocksLocalAddressesOnNumericPort(t *t
 		}
 	})
 }
+
+func localhostIPv4(t *testing.T) net.IP {
+	t.Helper()
+	resolved, err := net.DefaultResolver.LookupHost(t.Context(), "localhost")
+	if err != nil {
+		t.Fatalf("lookup localhost: %v", err)
+	}
+	for _, addr := range resolved {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if v4 := ip.To4(); v4 != nil && v4.IsLoopback() {
+			return v4
+		}
+	}
+	t.Fatal("localhost did not resolve to an IPv4 loopback address")
+	return nil
+}
+
+func assertConfiguredMetricsDenied(t *testing.T, err error) {
+	t.Helper()
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "configured metrics listener") {
+		t.Fatalf("error = %T %v, want configured-metrics denial", err, err)
+	}
+}
+
+// TestHostnameConfiguredMetricsListenerBlocksResolvedAddress is the
+// reproduction for the hostname fail-open: MetricsListen is a hostname
+// (localhost), the dial target is the IP that hostname resolves to, and
+// the generic SSRF IP allowlist would otherwise permit the hop. Before
+// the fix, net.ParseIP("localhost") is nil and the guard returns nil
+// (ALLOW). After the fix, the same dial is denied.
+func TestHostnameConfiguredMetricsListenerBlocksResolvedAddress(t *testing.T) {
+	loopback := localhostIPv4(t)
+	const metricsPort = "9091"
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("localhost", metricsPort)
+	p := &Proxy{}
+	p.ConfigPtr().Store(cfg)
+
+	err := p.blockIfConfiguredMetricsTarget(t.Context(), loopback.String(), metricsPort, loopback)
+	assertConfiguredMetricsDenied(t, err)
+}
+
+func TestHostnameConfiguredMetricsListenerBlocksDialThroughAllowlist(t *testing.T) {
+	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer metricsServer.Close()
+
+	metricsAddr := strings.TrimPrefix(metricsServer.URL, "http://")
+	metricsHost, metricsPort, err := net.SplitHostPort(metricsAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsIP := net.ParseIP(metricsHost)
+	if metricsIP == nil || !metricsIP.Equal(localhostIPv4(t)) {
+		t.Fatalf("test listener %s is not the IPv4 localhost address this reproduction dials", metricsAddr)
+	}
+
+	cfg := config.Defaults()
+	cfg.Internal = config.Defaults().Internal
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8"}
+	cfg.MetricsListen = net.JoinHostPort("localhost", metricsPort)
+	sc, err := scanner.NewWithOptions(cfg, scanner.Options{})
+	if err != nil {
+		t.Fatalf("scanner.NewWithOptions: %v", err)
+	}
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		sc.Close()
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	conn, dialErr := p.ssrfSafeDialContext(ctx, "tcp", metricsAddr)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if dialErr == nil {
+		t.Fatalf("dial to %s succeeded; hostname-configured metrics guard failed open", metricsAddr)
+	}
+	assertConfiguredMetricsDenied(t, dialErr)
+}

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -465,6 +465,58 @@ func TestHostnameMetricsListenerRefreshReresolvesSameListen(t *testing.T) {
 	}
 }
 
+func TestBoundMetricsListenerAddressOverridesHostnameResolution(t *testing.T) {
+	boundListener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = boundListener.Close() })
+	boundHost, boundPort, err := net.SplitHostPort(boundListener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundIP := net.ParseIP(boundHost)
+	if boundIP == nil {
+		t.Fatalf("bound listener host %q is not an IP address", boundHost)
+	}
+
+	var lookups atomic.Int64
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			lookups.Add(1)
+			return []string{"192.0.2.10"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", boundPort)
+	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
+
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), boundIP.String(), boundPort, boundIP); err != nil {
+		t.Fatalf("precondition: stale hostname resolution blocked bound address: %v", err)
+	}
+
+	p.UpdateMetricsDialTargetFromBoundAddr(boundListener.Addr().String())
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), boundIP.String(), boundPort, boundIP))
+	if got := lookups.Load(); got != 1 {
+		t.Fatalf("lookups = %d, want 1; the bound numeric address must not be resolved", got)
+	}
+}
+
+func TestMalformedBoundMetricsListenerAddressFailsClosed(t *testing.T) {
+	p := &Proxy{}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p.ConfigPtr().Store(cfg)
+	p.UpdateMetricsDialTargetFromBoundAddr("not-a-host-port")
+
+	err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10"))
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "cannot verify") {
+		t.Fatalf("error = %T %v, want cannot-verify denial", err, err)
+	}
+}
+
 func TestMetricsDialTargetRefreshClearsEmptyListen(t *testing.T) {
 	var nilProxy *Proxy
 	nilProxy.refreshMetricsDialTarget("localhost:9091")
@@ -502,6 +554,21 @@ func TestMalformedMetricsListenAllowsDial(t *testing.T) {
 			t.Fatalf("unparseable metrics port blocked: %v", err)
 		}
 	})
+}
+
+func TestHostnameMetricsListenerWithSignedPortFromLoadBlocks(t *testing.T) {
+	cfg, err := config.LoadBytes([]byte("metrics_listen: metrics.internal:+9091\n"))
+	if err != nil {
+		t.Fatalf("config.LoadBytes: %v", err)
+	}
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{"192.0.2.10"}, nil
+		},
+	}
+	p.ConfigPtr().Store(cfg)
+
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
 }
 
 func TestHostnameMetricsListenerSkipsUnparseableLookupRecords(t *testing.T) {

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -465,6 +465,57 @@ func TestHostnameMetricsListenerRefreshReresolvesSameListen(t *testing.T) {
 	}
 }
 
+func TestMetricsDialTargetRefreshClearsEmptyListen(t *testing.T) {
+	var nilProxy *Proxy
+	nilProxy.refreshMetricsDialTarget("localhost:9091")
+
+	p := &Proxy{}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p.lookupMetricsHost = func(context.Context, string) ([]string, error) {
+		return []string{"192.0.2.10"}, nil
+	}
+	p.ConfigPtr().Store(cfg)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
+	p.refreshMetricsDialTarget("")
+	if cached := p.metricsTargetPtr.Load(); cached != nil {
+		t.Fatal("empty listen left a cached metrics target")
+	}
+}
+
+func TestMalformedMetricsListenAllowsDial(t *testing.T) {
+	t.Run("unparseable address", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.MetricsListen = "not-a-host-port"
+		p := &Proxy{}
+		p.ConfigPtr().Store(cfg)
+		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")); err != nil {
+			t.Fatalf("unparseable MetricsListen blocked: %v", err)
+		}
+	})
+	t.Run("unparseable port", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.MetricsListen = "localhost:notaport"
+		p := &Proxy{}
+		p.ConfigPtr().Store(cfg)
+		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")); err != nil {
+			t.Fatalf("unparseable metrics port blocked: %v", err)
+		}
+	})
+}
+
+func TestHostnameMetricsListenerSkipsUnparseableLookupRecords(t *testing.T) {
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{"not-an-ip", "192.0.2.10"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p.ConfigPtr().Store(cfg)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
+}
+
 func TestLiteralMetricsListenerDoesNotLookupHost(t *testing.T) {
 	var lookups atomic.Int64
 	p := &Proxy{

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -224,6 +224,7 @@ func TestConfiguredWildcardMetricsListenerBlocksLocalAddressesOnNumericPort(t *t
 			cfg.MetricsListen = listen
 			p := &Proxy{}
 			p.ConfigPtr().Store(cfg)
+			p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 			err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1"))
 			var blocked *ssrfDialBlockError
@@ -238,6 +239,7 @@ func TestConfiguredWildcardMetricsListenerBlocksLocalAddressesOnNumericPort(t *t
 		cfg.MetricsListen = ":9091"
 		p := &Proxy{}
 		p.ConfigPtr().Store(cfg)
+		p.refreshMetricsDialTarget(cfg.MetricsListen)
 		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9092", net.ParseIP("127.0.0.1")); err != nil {
 			t.Fatalf("different port blocked: %v", err)
 		}
@@ -284,6 +286,7 @@ func TestHostnameConfiguredMetricsListenerBlocksResolvedAddress(t *testing.T) {
 	cfg.MetricsListen = net.JoinHostPort("localhost", metricsPort)
 	p := &Proxy{}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	err := p.blockIfConfiguredMetricsTarget(t.Context(), loopback.String(), metricsPort, loopback)
 	assertConfiguredMetricsDenied(t, err)
@@ -341,6 +344,7 @@ func TestHostnameMetricsListenerUnresolvableFailsClosed(t *testing.T) {
 		},
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1"))
 	var blocked *ssrfDialBlockError
@@ -361,6 +365,7 @@ func TestHostnameMetricsListenerEmptyResolutionFailsClosed(t *testing.T) {
 		},
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10"))
 	var blocked *ssrfDialBlockError
@@ -378,6 +383,7 @@ func TestHostnameMetricsListenerAllowsUnrelatedIPAndPort(t *testing.T) {
 		},
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.11", "9091", net.ParseIP("192.0.2.11")); err != nil {
 		t.Fatalf("unrelated IP blocked: %v", err)
@@ -398,6 +404,7 @@ func TestHostnameMetricsListenerLookupCachedAcrossDials(t *testing.T) {
 		},
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	ip := net.ParseIP("192.0.2.10")
 	for range 8 {
 		assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", ip))
@@ -426,6 +433,7 @@ func TestHostnameMetricsListenerReloadsWhenListenChanges(t *testing.T) {
 	cfgA := config.Defaults()
 	cfgA.MetricsListen = net.JoinHostPort("metrics-a.internal", "9091")
 	p.ConfigPtr().Store(cfgA)
+	p.refreshMetricsDialTarget(cfgA.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
 	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.20", "9091", net.ParseIP("192.0.2.20")); err != nil {
 		t.Fatalf("other IP blocked before reload: %v", err)
@@ -434,6 +442,7 @@ func TestHostnameMetricsListenerReloadsWhenListenChanges(t *testing.T) {
 	cfgB := config.Defaults()
 	cfgB.MetricsListen = net.JoinHostPort("metrics-b.internal", "9091")
 	p.ConfigPtr().Store(cfgB)
+	p.refreshMetricsDialTarget(cfgB.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.20", "9091", net.ParseIP("192.0.2.20")))
 	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")); err != nil {
 		t.Fatalf("previous metrics IP still blocked after reload: %v", err)
@@ -456,6 +465,7 @@ func TestHostnameMetricsListenerRefreshReresolvesSameListen(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
 
 	p.refreshMetricsDialTarget(cfg.MetricsListen)
@@ -508,6 +518,7 @@ func TestMalformedBoundMetricsListenerAddressFailsClosed(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	p.UpdateMetricsDialTargetFromBoundAddr("not-a-host-port")
 
 	err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10"))
@@ -528,6 +539,7 @@ func TestMetricsDialTargetRefreshClearsEmptyListen(t *testing.T) {
 		return []string{"192.0.2.10"}, nil
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
 	p.refreshMetricsDialTarget("")
 	if cached := p.metricsTargetPtr.Load(); cached != nil {
@@ -541,6 +553,7 @@ func TestMalformedMetricsListenAllowsDial(t *testing.T) {
 		cfg.MetricsListen = "not-a-host-port"
 		p := &Proxy{}
 		p.ConfigPtr().Store(cfg)
+		p.refreshMetricsDialTarget(cfg.MetricsListen)
 		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")); err != nil {
 			t.Fatalf("unparseable MetricsListen blocked: %v", err)
 		}
@@ -550,6 +563,7 @@ func TestMalformedMetricsListenAllowsDial(t *testing.T) {
 		cfg.MetricsListen = "localhost:notaport"
 		p := &Proxy{}
 		p.ConfigPtr().Store(cfg)
+		p.refreshMetricsDialTarget(cfg.MetricsListen)
 		if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")); err != nil {
 			t.Fatalf("unparseable metrics port blocked: %v", err)
 		}
@@ -567,6 +581,7 @@ func TestHostnameMetricsListenerWithSignedPortFromLoadBlocks(t *testing.T) {
 		},
 	}
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
 }
@@ -580,7 +595,92 @@ func TestHostnameMetricsListenerSkipsUnparseableLookupRecords(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
+}
+
+// TestBoundMetricsTargetSurvivesUnrelatedReload pins the reload direction of the
+// bound-address handoff. With a configured port of 0 the configured string
+// carries no usable port, so rebuilding the target from it during an unrelated
+// reload would drop the only value a dial can match and silently reopen the
+// metrics listener to every mediated transport.
+func TestBoundMetricsTargetSurvivesUnrelatedReload(t *testing.T) {
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{"127.0.0.1"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = "metrics.internal:0"
+	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
+
+	// The listener binds an ephemeral port and reports what it actually got,
+	// which is the only form carrying a port a dial can match.
+	p.UpdateMetricsDialTargetFromBoundAddr("127.0.0.1:44321")
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "44321", net.ParseIP("127.0.0.1")))
+
+	// An unrelated reload leaves metrics_listen untouched.
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "44321", net.ParseIP("127.0.0.1")))
+}
+
+// TestChangedMetricsListenReplacesBoundTarget is the other direction: a reload
+// that genuinely changes metrics_listen must stop defending the retired port
+// and start defending the new one, or the guard protects an address the process
+// no longer listens on while leaving the live one open.
+func TestChangedMetricsListenReplacesBoundTarget(t *testing.T) {
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{"127.0.0.1"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = "metrics.internal:0"
+	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
+	p.UpdateMetricsDialTargetFromBoundAddr("127.0.0.1:44322")
+
+	changed := config.Defaults()
+	changed.MetricsListen = "127.0.0.1:44323"
+	p.ConfigPtr().Store(changed)
+	p.refreshMetricsDialTarget(changed.MetricsListen)
+
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "44322", net.ParseIP("127.0.0.1")); err != nil {
+		t.Fatalf("dial to the retired metrics port = %v, want it no longer treated as the metrics listener", err)
+	}
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "44323", net.ParseIP("127.0.0.1")))
+}
+
+// TestUnpublishedMetricsTargetFailsClosedWithoutLookup covers a dial reaching
+// the guard with no published snapshot. The dial path deliberately does not
+// resolve, because doing so would block every mediated request for up to the
+// lookup timeout and concurrent misses would each repeat the work. The only
+// honest answers are block-as-unverifiable or allow, and allow is the fail-open
+// this guard exists to prevent.
+func TestUnpublishedMetricsTargetFailsClosedWithoutLookup(t *testing.T) {
+	var lookups atomic.Int64
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			lookups.Add(1)
+			return []string{"10.1.2.3"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p.ConfigPtr().Store(cfg)
+	// Deliberately publish nothing, standing in for a stale or absent snapshot.
+
+	err := p.blockIfConfiguredMetricsTarget(t.Context(), "metrics.internal", "9091", net.ParseIP("10.1.2.3"))
+	if err == nil {
+		t.Fatal("dial with no published metrics target was allowed, want an unverifiable denial")
+	}
+	if !strings.Contains(err.Error(), "cannot verify") {
+		t.Fatalf("denial reason = %v, want a cannot-verify denial", err)
+	}
+	if got := lookups.Load(); got != 0 {
+		t.Fatalf("lookups on the dial path = %d, want 0", got)
+	}
 }
 
 func TestLiteralMetricsListenerDoesNotLookupHost(t *testing.T) {
@@ -594,6 +694,7 @@ func TestLiteralMetricsListenerDoesNotLookupHost(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.MetricsListen = "127.0.0.1:9091"
 	p.ConfigPtr().Store(cfg)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")))
 	if got := lookups.Load(); got != 0 {
 		t.Fatalf("lookups = %d, want 0 for a literal MetricsListen", got)

--- a/internal/proxy/metrics_containment_test.go
+++ b/internal/proxy/metrics_containment_test.go
@@ -331,3 +331,153 @@ func TestHostnameConfiguredMetricsListenerBlocksDialThroughAllowlist(t *testing.
 	}
 	assertConfiguredMetricsDenied(t, dialErr)
 }
+
+func TestHostnameMetricsListenerUnresolvableFailsClosed(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p := &Proxy{
+		lookupMetricsHost: func(_ context.Context, host string) ([]string, error) {
+			return nil, fmt.Errorf("stub nxdomain for %s", host)
+		},
+	}
+	p.ConfigPtr().Store(cfg)
+
+	err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1"))
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "cannot verify") {
+		t.Fatalf("error = %T %v, want cannot-verify denial", err, err)
+	}
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9092", net.ParseIP("127.0.0.1")); err != nil {
+		t.Fatalf("different port blocked while hostname was unverified: %v", err)
+	}
+}
+
+func TestHostnameMetricsListenerEmptyResolutionFailsClosed(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{}, nil
+		},
+	}
+	p.ConfigPtr().Store(cfg)
+
+	err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10"))
+	var blocked *ssrfDialBlockError
+	if !errors.As(err, &blocked) || !strings.Contains(blocked.detail, "cannot verify") {
+		t.Fatalf("error = %T %v, want cannot-verify denial", err, err)
+	}
+}
+
+func TestHostnameMetricsListenerAllowsUnrelatedIPAndPort(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			return []string{"192.0.2.10"}, nil
+		},
+	}
+	p.ConfigPtr().Store(cfg)
+
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.11", "9091", net.ParseIP("192.0.2.11")); err != nil {
+		t.Fatalf("unrelated IP blocked: %v", err)
+	}
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9092", net.ParseIP("192.0.2.10")); err != nil {
+		t.Fatalf("different port blocked: %v", err)
+	}
+}
+
+func TestHostnameMetricsListenerLookupCachedAcrossDials(t *testing.T) {
+	var lookups atomic.Int64
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			lookups.Add(1)
+			return []string{"192.0.2.10"}, nil
+		},
+	}
+	p.ConfigPtr().Store(cfg)
+	ip := net.ParseIP("192.0.2.10")
+	for range 8 {
+		assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", ip))
+	}
+	if got := lookups.Load(); got != 1 {
+		t.Fatalf("lookups = %d, want 1 (hot path must not resolve per dial)", got)
+	}
+}
+
+func TestHostnameMetricsListenerReloadsWhenListenChanges(t *testing.T) {
+	var seen []string
+	p := &Proxy{
+		lookupMetricsHost: func(_ context.Context, host string) ([]string, error) {
+			seen = append(seen, host)
+			switch host {
+			case "metrics-a.internal":
+				return []string{"192.0.2.10"}, nil
+			case "metrics-b.internal":
+				return []string{"192.0.2.20"}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %s", host)
+			}
+		},
+	}
+
+	cfgA := config.Defaults()
+	cfgA.MetricsListen = net.JoinHostPort("metrics-a.internal", "9091")
+	p.ConfigPtr().Store(cfgA)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.20", "9091", net.ParseIP("192.0.2.20")); err != nil {
+		t.Fatalf("other IP blocked before reload: %v", err)
+	}
+
+	cfgB := config.Defaults()
+	cfgB.MetricsListen = net.JoinHostPort("metrics-b.internal", "9091")
+	p.ConfigPtr().Store(cfgB)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.20", "9091", net.ParseIP("192.0.2.20")))
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")); err != nil {
+		t.Fatalf("previous metrics IP still blocked after reload: %v", err)
+	}
+	if len(seen) != 2 || seen[0] != "metrics-a.internal" || seen[1] != "metrics-b.internal" {
+		t.Fatalf("lookups = %v, want [metrics-a.internal metrics-b.internal]", seen)
+	}
+}
+
+func TestHostnameMetricsListenerRefreshReresolvesSameListen(t *testing.T) {
+	var lookups atomic.Int64
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			if lookups.Add(1) == 1 {
+				return []string{"192.0.2.10"}, nil
+			}
+			return []string{"192.0.2.20"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = net.JoinHostPort("metrics.internal", "9091")
+	p.ConfigPtr().Store(cfg)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")))
+
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.20", "9091", net.ParseIP("192.0.2.20")))
+	if err := p.blockIfConfiguredMetricsTarget(t.Context(), "192.0.2.10", "9091", net.ParseIP("192.0.2.10")); err != nil {
+		t.Fatalf("stale metrics IP still blocked after refresh: %v", err)
+	}
+}
+
+func TestLiteralMetricsListenerDoesNotLookupHost(t *testing.T) {
+	var lookups atomic.Int64
+	p := &Proxy{
+		lookupMetricsHost: func(context.Context, string) ([]string, error) {
+			lookups.Add(1)
+			return []string{"127.0.0.1"}, nil
+		},
+	}
+	cfg := config.Defaults()
+	cfg.MetricsListen = "127.0.0.1:9091"
+	p.ConfigPtr().Store(cfg)
+	assertConfiguredMetricsDenied(t, p.blockIfConfiguredMetricsTarget(t.Context(), "127.0.0.1", "9091", net.ParseIP("127.0.0.1")))
+	if got := lookups.Load(); got != 0 {
+		t.Fatalf("lookups = %d, want 0 for a literal MetricsListen", got)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3610,7 +3610,7 @@ var errMetricsHostnameNoIPs = errors.New("hostname resolved to no IP addresses")
 // would stop blocking the bound address if DNS later moved.
 type metricsDialTarget struct {
 	listen      string
-	port        uint64
+	port        uint16
 	unspecified bool
 	ips         []net.IP
 	resolveErr  error
@@ -3642,6 +3642,38 @@ func (p *Proxy) refreshMetricsDialTarget(listen string) {
 	p.metricsTargetPtr.Store(p.buildMetricsDialTarget(listen))
 }
 
+// UpdateMetricsDialTargetFromBoundAddr replaces a hostname-derived metrics
+// target with the numeric address the metrics listener actually bound. The
+// listener resolves a hostname independently from config load, so retaining
+// the earlier lookup could leave the dial guard comparing against a stale IP.
+func (p *Proxy) UpdateMetricsDialTargetFromBoundAddr(addr string) {
+	if p == nil {
+		return
+	}
+	cfg := p.CurrentConfig()
+	if cfg == nil || cfg.MetricsListen == "" {
+		p.metricsTargetPtr.Store(nil)
+		return
+	}
+	target := p.buildMetricsDialTarget(addr)
+	if target == nil {
+		_, configuredPort, configuredErr := net.SplitHostPort(cfg.MetricsListen)
+		port, portErr := strconv.Atoi(configuredPort)
+		if configuredErr == nil && portErr == nil && port > 0 && port <= 65535 {
+			p.metricsTargetPtr.Store(&metricsDialTarget{
+				listen:     cfg.MetricsListen,
+				port:       uint16(port),
+				resolveErr: fmt.Errorf("parse bound metrics listener %q", addr),
+			})
+			return
+		}
+		p.metricsTargetPtr.Store(nil)
+		return
+	}
+	target.listen = cfg.MetricsListen
+	p.metricsTargetPtr.Store(target)
+}
+
 func (p *Proxy) cachedMetricsDialTarget(listen string) *metricsDialTarget {
 	if cached := p.metricsTargetPtr.Load(); cached != nil && cached.listen == listen {
 		return cached
@@ -3656,12 +3688,12 @@ func (p *Proxy) buildMetricsDialTarget(listen string) *metricsDialTarget {
 	if err != nil {
 		return nil
 	}
-	wantPort, wantErr := strconv.ParseUint(metricsPort, 10, 16)
-	target := &metricsDialTarget{listen: listen, port: wantPort}
-	if wantErr != nil {
-		target.port = 0
+	wantPort, wantErr := strconv.Atoi(metricsPort)
+	target := &metricsDialTarget{listen: listen}
+	if wantErr != nil || wantPort < 1 || wantPort > 65535 {
 		return target
 	}
+	target.port = uint16(wantPort)
 	metricsIP := net.ParseIP(metricsHost)
 	if strings.TrimSpace(metricsHost) == "" || (metricsIP != nil && metricsIP.IsUnspecified()) {
 		target.unspecified = true
@@ -3711,7 +3743,7 @@ func (p *Proxy) blockIfConfiguredMetricsTarget(ctx context.Context, host, port s
 		return nil
 	}
 	gotPort, gotErr := strconv.ParseUint(port, 10, 16)
-	if gotErr != nil || target.port == 0 || target.port != gotPort || ip == nil {
+	if gotErr != nil || target.port == 0 || target.port != uint16(gotPort) || ip == nil {
 		return nil
 	}
 	if target.unspecified {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -412,6 +412,8 @@ type Proxy struct {
 	wd                   *health.Watchdog                      // wedge-detection watchdog (nil = disabled)
 	metricsSuppressed    bool                                  // never publish /metrics or /stats on this listener
 	probeInflight        atomic.Bool                           // singleflight guard for scannerProbe (prevents goroutine leak when scanner wedges)
+	metricsTargetPtr     atomic.Pointer[metricsDialTarget]     // resolved metrics listener; rebuilt when MetricsListen changes
+	lookupMetricsHost    func(context.Context, string) ([]string, error)
 }
 
 // Option configures optional Proxy behavior.
@@ -556,6 +558,7 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 	}
 	p.cfgPtr.Store(cfg)
 	p.scannerPtr.Store(sc)
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 
 	if p.currentContractLoader() == nil {
 		loader, loaderErr := buildContractLoader(cfg)
@@ -1974,6 +1977,7 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.cfgPtr.Store(cfg)
 		p.contractLoaderPtr.Store(contractLoader)
 	}
+	p.refreshMetricsDialTarget(cfg.MetricsListen)
 	p.disableCEE(&cfg.CrossRequestDetection)
 	if p.wd != nil {
 		p.wd.BeatConfig()
@@ -3592,6 +3596,107 @@ func blockIfNonOverridableSSRFTarget(ctx context.Context, host string, ip net.IP
 	return nil
 }
 
+// metricsHostnameLookupTimeout bounds the one lookup used to resolve a
+// hostname MetricsListen value. The result is cached for that listen
+// string so the hot dial path never blocks on DNS.
+const metricsHostnameLookupTimeout = time.Second
+
+var errMetricsHostnameNoIPs = errors.New("hostname resolved to no IP addresses")
+
+// metricsDialTarget is the resolved metrics listener compared against
+// each dial. It is built at config load and whenever MetricsListen
+// changes, not on every request. There is no TTL: the metrics socket is
+// bound once for a given listen string, and re-resolving on a timer
+// would stop blocking the bound address if DNS later moved.
+type metricsDialTarget struct {
+	listen      string
+	port        uint64
+	unspecified bool
+	ips         []net.IP
+	resolveErr  error
+}
+
+func configuredMetricsBlockDetail(host, port string) string {
+	return fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port)
+}
+
+func unverifiedMetricsBlockDetail(host, port, kind string, err error) string {
+	return fmt.Sprintf("SSRF blocked: cannot verify whether %s:%s reaches the %s metrics listener: %v", host, port, kind, err)
+}
+
+func (p *Proxy) metricsHostLookup() func(context.Context, string) ([]string, error) {
+	if p != nil && p.lookupMetricsHost != nil {
+		return p.lookupMetricsHost
+	}
+	return net.DefaultResolver.LookupHost
+}
+
+func (p *Proxy) refreshMetricsDialTarget(listen string) {
+	if p == nil {
+		return
+	}
+	if listen == "" {
+		p.metricsTargetPtr.Store(nil)
+		return
+	}
+	p.metricsTargetPtr.Store(p.buildMetricsDialTarget(listen))
+}
+
+func (p *Proxy) cachedMetricsDialTarget(listen string) *metricsDialTarget {
+	if cached := p.metricsTargetPtr.Load(); cached != nil && cached.listen == listen {
+		return cached
+	}
+	built := p.buildMetricsDialTarget(listen)
+	p.metricsTargetPtr.Store(built)
+	return built
+}
+
+func (p *Proxy) buildMetricsDialTarget(listen string) *metricsDialTarget {
+	metricsHost, metricsPort, err := net.SplitHostPort(listen)
+	if err != nil {
+		return nil
+	}
+	wantPort, wantErr := strconv.ParseUint(metricsPort, 10, 16)
+	target := &metricsDialTarget{listen: listen, port: wantPort}
+	if wantErr != nil {
+		target.port = 0
+		return target
+	}
+	metricsIP := net.ParseIP(metricsHost)
+	if strings.TrimSpace(metricsHost) == "" || (metricsIP != nil && metricsIP.IsUnspecified()) {
+		target.unspecified = true
+		return target
+	}
+	if metricsIP != nil {
+		if v4 := metricsIP.To4(); v4 != nil {
+			metricsIP = v4
+		}
+		target.ips = []net.IP{metricsIP}
+		return target
+	}
+	lookupCtx, cancel := context.WithTimeout(context.Background(), metricsHostnameLookupTimeout)
+	defer cancel()
+	addrs, lookupErr := p.metricsHostLookup()(lookupCtx, metricsHost)
+	if lookupErr != nil {
+		target.resolveErr = lookupErr
+		return target
+	}
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if v4 := ip.To4(); v4 != nil {
+			ip = v4
+		}
+		target.ips = append(target.ips, ip)
+	}
+	if len(target.ips) == 0 {
+		target.resolveErr = errMetricsHostnameNoIPs
+	}
+	return target
+}
+
 // blockIfConfiguredMetricsTarget keeps the contained agent from using a broad
 // SSRF exception to query the proxy's own metrics listener. This check belongs
 // in the dial path, before trusted-domain, IP-allowlist, and grant exceptions,
@@ -3601,36 +3706,33 @@ func (p *Proxy) blockIfConfiguredMetricsTarget(ctx context.Context, host, port s
 	if cfg == nil || cfg.MetricsListen == "" {
 		return nil
 	}
-	metricsHost, metricsPort, err := net.SplitHostPort(cfg.MetricsListen)
-	if err != nil {
+	target := p.cachedMetricsDialTarget(cfg.MetricsListen)
+	if target == nil {
 		return nil
 	}
-	wantPort, wantErr := strconv.ParseUint(metricsPort, 10, 16)
 	gotPort, gotErr := strconv.ParseUint(port, 10, 16)
-	if wantErr != nil || gotErr != nil || wantPort == 0 || wantPort != gotPort || ip == nil {
+	if gotErr != nil || target.port == 0 || target.port != gotPort || ip == nil {
 		return nil
 	}
-	metricsIP := net.ParseIP(metricsHost)
-	if strings.TrimSpace(metricsHost) == "" || (metricsIP != nil && metricsIP.IsUnspecified()) {
+	if target.unspecified {
 		local, localErr := isLocalInterfaceIP(ip)
 		if localErr != nil {
-			return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: cannot verify whether %s:%s reaches the wildcard metrics listener: %v", host, port, localErr))
+			return newSSRFDialBlockError(ctx, host, ip, unverifiedMetricsBlockDetail(host, port, "wildcard", localErr))
 		}
 		if !local {
 			return nil
 		}
-		return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port))
+		return newSSRFDialBlockError(ctx, host, ip, configuredMetricsBlockDetail(host, port))
 	}
-	if metricsIP == nil {
-		return nil
+	if target.resolveErr != nil {
+		return newSSRFDialBlockError(ctx, host, ip, unverifiedMetricsBlockDetail(host, port, "hostname", target.resolveErr))
 	}
-	if metricsV4 := metricsIP.To4(); metricsV4 != nil {
-		metricsIP = metricsV4
+	for _, metricsIP := range target.ips {
+		if metricsIP.Equal(ip) {
+			return newSSRFDialBlockError(ctx, host, ip, configuredMetricsBlockDetail(host, port))
+		}
 	}
-	if !metricsIP.Equal(ip) {
-		return nil
-	}
-	return newSSRFDialBlockError(ctx, host, ip, fmt.Sprintf("SSRF blocked: %s:%s is the configured metrics listener", host, port))
+	return nil
 }
 
 func isLocalInterfaceIP(ip net.IP) (bool, error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3603,17 +3603,30 @@ const metricsHostnameLookupTimeout = time.Second
 
 var errMetricsHostnameNoIPs = errors.New("hostname resolved to no IP addresses")
 
-// metricsDialTarget is the resolved metrics listener compared against
-// each dial. It is built at config load and whenever MetricsListen
-// changes, not on every request. There is no TTL: the metrics socket is
-// bound once for a given listen string, and re-resolving on a timer
-// would stop blocking the bound address if DNS later moved.
+// errMetricsTargetUnpublished marks a dial reaching the guard before the
+// resolved metrics target was published, or after the published one stopped
+// matching the configured listener. The dial path does not resolve, so this
+// state is reported as unverifiable rather than treated as permission.
+var errMetricsTargetUnpublished = errors.New("metrics listener target not published for the configured listen address")
+
+// metricsDialTarget is the resolved metrics listener compared against each
+// dial. It is published at config load, at reload, and when the listener
+// reports the address it actually bound; it is never built on the dial path.
+// There is no TTL: the metrics socket is bound once for a given listen string,
+// and re-resolving on a timer would stop blocking the bound address if DNS
+// later moved.
+//
+// bound records that this snapshot came from a real listener bind rather than
+// from parsing the configured string. That distinction is load-bearing when the
+// configured port is 0, because the configured form carries no port at all and
+// rebuilding from it would discard the only value that can match a dial.
 type metricsDialTarget struct {
 	listen      string
 	port        uint16
 	unspecified bool
 	ips         []net.IP
 	resolveErr  error
+	bound       bool
 }
 
 func configuredMetricsBlockDetail(host, port string) string {
@@ -3637,6 +3650,15 @@ func (p *Proxy) refreshMetricsDialTarget(listen string) {
 	}
 	if listen == "" {
 		p.metricsTargetPtr.Store(nil)
+		return
+	}
+	// A reload that leaves metrics_listen unchanged must not replace a target
+	// that came from a real bind. With a configured port of 0 the rebuilt
+	// target carries port 0, the dial guard treats port 0 as nothing to match,
+	// and an unrelated reload would silently reopen the metrics listener to
+	// every mediated transport. The listener is only rebound when the address
+	// changes, and that path publishes its own target.
+	if cached := p.metricsTargetPtr.Load(); cached != nil && cached.bound && cached.listen == listen {
 		return
 	}
 	p.metricsTargetPtr.Store(p.buildMetricsDialTarget(listen))
@@ -3664,6 +3686,7 @@ func (p *Proxy) UpdateMetricsDialTargetFromBoundAddr(addr string) {
 				listen:     cfg.MetricsListen,
 				port:       uint16(port),
 				resolveErr: fmt.Errorf("parse bound metrics listener %q", addr),
+				bound:      true,
 			})
 			return
 		}
@@ -3671,16 +3694,35 @@ func (p *Proxy) UpdateMetricsDialTargetFromBoundAddr(addr string) {
 		return
 	}
 	target.listen = cfg.MetricsListen
+	target.bound = true
 	p.metricsTargetPtr.Store(target)
 }
 
+// cachedMetricsDialTarget returns the published snapshot for listen. It never
+// builds one, because building resolves a hostname and this runs on the dial
+// path for every mediated request: doing that work here would block the request
+// for up to the lookup timeout, and concurrent misses would each repeat it,
+// which is a denial-of-service shape rather than a guard. A snapshot that is
+// missing or belongs to a different listen string means the published state is
+// stale, so the target reports itself unverifiable and the guard blocks, which
+// matches how an unresolvable hostname is already handled.
 func (p *Proxy) cachedMetricsDialTarget(listen string) *metricsDialTarget {
 	if cached := p.metricsTargetPtr.Load(); cached != nil && cached.listen == listen {
 		return cached
 	}
-	built := p.buildMetricsDialTarget(listen)
-	p.metricsTargetPtr.Store(built)
-	return built
+	_, configuredPort, splitErr := net.SplitHostPort(listen)
+	if splitErr != nil {
+		return nil
+	}
+	port, portErr := strconv.Atoi(configuredPort)
+	if portErr != nil || port < 1 || port > 65535 {
+		return nil
+	}
+	return &metricsDialTarget{
+		listen:     listen,
+		port:       uint16(port),
+		resolveErr: errMetricsTargetUnpublished,
+	}
 }
 
 func (p *Proxy) buildMetricsDialTarget(listen string) *metricsDialTarget {


### PR DESCRIPTION
## What changed

The SSRF dial guard that stops mediated traffic reaching Pipelock's own metrics listener now covers a listener configured by hostname. Previously it parsed the configured host as a literal IP and returned allow when that parse failed, so any deployment whose metrics_listen used a name rather than an address had no guard at all on the path the guard's own comment calls the convergence point for every mediated transport. It also rejected a signed port form that both config validation and the listener itself accept, which had the same effect for a configuration that loads and runs.

The resolved listener is published as a snapshot at config load, at reload, and when the listener reports the address it actually bound. The dial path only reads that snapshot and never builds one, because building resolves a hostname and doing that per request would block a mediated request for up to the lookup timeout while concurrent misses each repeated the work. A snapshot that is missing or no longer matches the configured listener is reported as unverifiable and blocks, which is how an unresolvable hostname was already handled.

A reload that leaves metrics_listen unchanged keeps the bound snapshot. That matters when the configured port is 0, because the configured string then carries no port a dial can match, so rebuilding from it during an unrelated reload would drop the bound port and reopen the listener to a trusted-domain or allowlist exception. The snapshot is replaced when the configured listener genuinely changes, so the guard stops defending a retired port and starts defending the new one.

The failure directions to distrust are both of them. A guard on this path that leans permissive silently removes the protection for a whole class of deployment, and it does so again on the next reload if reload rebuilds from a value that lost the bound port. A guard that leans strict adds latency or refusals to every mediated request, which is why resolution happens outside the request path and the dial path does no work beyond comparing. Reviewers should confirm that reload preserves an unchanged listener and replaces a changed one, that no lookup can occur on a dial, and that a literal-IP listener behaves exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe connections to configured metrics listeners, including hostname-based addresses.
  * Metrics listener addresses are refreshed when configuration changes or listeners bind to a new address.
  * Failed or invalid hostname resolution is handled safely.
  * Active listener addresses are recognized correctly for more accurate connection blocking.

* **Tests**
  * Added coverage for hostname resolution, caching, configuration reloads, malformed addresses, and literal IP listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->