### PR TITLE
docs(config): stop the upstream example expiring on the clock

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3467,7 +3467,7 @@ reverse_proxy:
     port: 443
     reason: "submission endpoint"
     added: "2026-05-26"
-    expires: "2026-08-24"
+    expires: "2099-12-31"
   max_body_bytes: 1048576
   request_timeout_seconds: 10
 ```


### PR DESCRIPTION
## What changed

The trusted-upstream example in the configuration guide carried a ninety-day expiry fixed at authoring time. That date lapsed on 2026-08-24, and because the config-example startability check boots every example as a real config, the check began refusing it. That check runs inside lint, so from that date every pull request went red on a document nobody had touched. The expiry now sits far enough out that it cannot lapse, matching the other dated example in the same file.

The failure direction worth distrusting here is the one that already happened: a dated value inside an example is validated against the wall clock, so it passes on the day it is written and fails later with no change to the repository. Reviewers should treat any remaining wall-clock date in an executable example as the same latent failure, and prefer a date that cannot lapse over one that merely lapses later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the reverse-proxy Submit Profile configuration example with a later expiration date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->