### PR TITLE
feat(evidence): inventory legacy recorder epochs

### DIFF
--- a/internal/cli/evidence/evidence.go
+++ b/internal/cli/evidence/evidence.go
@@ -41,6 +41,8 @@ func Cmd() *cobra.Command {
 	cmd.AddCommand(compactCmd())
 	cmd.AddCommand(inspectEpochsCmd())
 	cmd.AddCommand(verifyEpochPinCmd())
+	cmd.AddCommand(inventoryLegacyEpochsCmd())
+	cmd.AddCommand(verifyLegacyEpochInventoryCmd())
 	cmd.AddCommand(doctorCmd())
 	cmd.AddCommand(verifyCertCmd())
 	return cmd

--- a/internal/cli/evidence/legacy_epoch_inventory.go
+++ b/internal/cli/evidence/legacy_epoch_inventory.go
@@ -1,0 +1,538 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	legacyInventoryVersion      = 1
+	legacyInventoryKind         = "pipelock-legacy-epoch-inventory"
+	maxLegacyInventoryEpochs    = 1024
+	maxLegacyInventoryRuns      = 16384
+	maxLegacyInventoryAnomalies = 65536
+)
+
+var (
+	legacyInventoryWrite         = func(file *os.File, data []byte) (int, error) { return file.Write(data) }
+	legacyInventoryFileSync      = func(file *os.File) error { return file.Sync() }
+	legacyInventoryMarshal       = marshalLegacyInventory
+	legacyInventoryParentMatches = func(output *inspectOutput, parent string) (bool, error) { return output.parentMatches(parent) }
+)
+
+type legacyInventoryOptions struct {
+	receiptDir, locationID, sessionID, outFile string
+}
+
+type verifyLegacyInventoryOptions struct {
+	receiptDir, locationID, sessionID, inventoryFile, inventorySHA256 string
+}
+
+type legacyInventoryDocument struct {
+	Version      int                    `json:"version"`
+	Kind         string                 `json:"kind"`
+	SessionID    string                 `json:"session_id"`
+	SourceBytes  int64                  `json:"source_bytes"`
+	SourceSHA256 string                 `json:"snapshot_source_sha256"`
+	SourceFiles  []legacyInventoryFile  `json:"source_files"`
+	Epochs       []legacyInventoryEpoch `json:"epochs"`
+}
+
+type legacyInventoryFile struct {
+	Name   string `json:"name"`
+	Bytes  int64  `json:"bytes"`
+	SHA256 string `json:"sha256"`
+}
+
+type legacyInventoryEpoch struct {
+	Epoch                  uint64                   `json:"epoch"`
+	StartSequence          uint64                   `json:"start_seq"`
+	EndSequence            uint64                   `json:"end_seq"`
+	StartHash              string                   `json:"start_hash"`
+	EndHash                string                   `json:"end_hash"`
+	StartFile              string                   `json:"start_file"`
+	EndFile                string                   `json:"end_file"`
+	EntryCount             uint64                   `json:"entry_count"`
+	Assurance              string                   `json:"assurance"`
+	CheckpointStatus       string                   `json:"checkpoint_status"`
+	CheckpointCount        uint64                   `json:"checkpoint_count"`
+	StrictReceiptCount     uint64                   `json:"strictly_verified_receipts"`
+	StrictReceiptErrors    uint64                   `json:"strict_receipt_errors"`
+	RotationEndorsements   uint64                   `json:"rotation_endorsements"`
+	SignerRuns             []legacySignerRun        `json:"signer_runs"`
+	SourceFiles            []legacyInventoryFile    `json:"source_files"`
+	SourceMappings         []legacySourceMapping    `json:"source_mappings"`
+	Anomalies              []legacyInventoryAnomaly `json:"anomalies"`
+	outerIntegrityFailures uint64
+}
+
+type legacySignerRun struct {
+	SignerKey           *string `json:"signer_key"`
+	FirstSequence       uint64  `json:"first_recorder_seq"`
+	LastSequence        uint64  `json:"last_recorder_seq"`
+	ReceiptCount        uint64  `json:"receipt_count"`
+	StrictVerifiedCount uint64  `json:"strictly_verified"`
+	StrictErrors        uint64  `json:"strict_errors"`
+}
+
+type legacySourceMapping struct {
+	File   string `json:"file"`
+	Offset int64  `json:"offset"`
+	Bytes  int64  `json:"bytes"`
+}
+
+type legacyInventoryAnomaly struct {
+	Kind     string `json:"kind"`
+	File     string `json:"file"`
+	Offset   int64  `json:"offset"`
+	Sequence uint64 `json:"sequence"`
+}
+
+func inventoryLegacyEpochsCmd() *cobra.Command {
+	opts := legacyInventoryOptions{}
+	cmd := &cobra.Command{
+		Use:   "inventory-legacy-epochs",
+		Short: "Inventory legacy recorder epochs without granting trust",
+		Long:  "Walk one stopped recorder session and write a bounded, canonical inventory of every source byte, recorder epoch, signer run, and anomaly. Observing a signer never makes it trusted.",
+		Args:  cobra.NoArgs,
+		RunE:  func(cmd *cobra.Command, _ []string) error { return runInventoryLegacyEpochs(cmd, opts) },
+	}
+	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "", "stopped flight-recorder evidence directory or immutable snapshot")
+	cmd.Flags().StringVar(&opts.locationID, "location", "", "location path relative to the evidence directory")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "", "session ID to inventory")
+	cmd.Flags().StringVar(&opts.outFile, "out", "", "new file outside the evidence directory for canonical inventory JSON")
+	_ = cmd.MarkFlagRequired("receipt-dir")
+	_ = cmd.MarkFlagRequired("session")
+	_ = cmd.MarkFlagRequired("out")
+	return cmd
+}
+
+func verifyLegacyEpochInventoryCmd() *cobra.Command {
+	opts := verifyLegacyInventoryOptions{}
+	cmd := &cobra.Command{
+		Use:   "verify-legacy-epoch-inventory",
+		Short: "Recompute and verify an exact legacy epoch inventory",
+		Long:  "Strictly decode a pinned inventory, recompute it from every source byte, and require canonical byte-for-byte equality. Missing runs, anomalies, files, or source drift fail closed.",
+		Args:  cobra.NoArgs,
+		RunE:  func(cmd *cobra.Command, _ []string) error { return runVerifyLegacyEpochInventory(cmd, opts) },
+	}
+	cmd.Flags().StringVar(&opts.receiptDir, "receipt-dir", "", "stopped flight-recorder evidence directory or immutable snapshot")
+	cmd.Flags().StringVar(&opts.locationID, "location", "", "location path relative to the evidence directory")
+	cmd.Flags().StringVar(&opts.sessionID, "session", "", "session ID to verify")
+	cmd.Flags().StringVar(&opts.inventoryFile, "inventory", "", "canonical inventory JSON file")
+	cmd.Flags().StringVar(&opts.inventorySHA256, "sha256", "", "expected SHA-256 of the exact inventory bytes")
+	_ = cmd.MarkFlagRequired("receipt-dir")
+	_ = cmd.MarkFlagRequired("session")
+	_ = cmd.MarkFlagRequired("inventory")
+	_ = cmd.MarkFlagRequired("sha256")
+	return cmd
+}
+
+func runInventoryLegacyEpochs(cmd *cobra.Command, opts legacyInventoryOptions) error {
+	location, err := resolveLegacyInventoryLocation(opts.receiptDir, opts.locationID, opts.sessionID)
+	if err != nil {
+		return err
+	}
+	out, parent, err := resolveLegacyInventoryOutput(opts.outFile, location.Root)
+	if err != nil {
+		return err
+	}
+	output, err := prepareInspectOutput(parent, filepath.Base(out), location.Root)
+	if err != nil {
+		return fmt.Errorf("create --out: %w", err)
+	}
+	published := false
+	defer func() {
+		if !published {
+			_ = output.remove()
+		}
+		_ = output.close()
+	}()
+	lock, err := compactAcquireLock(location.Dir)
+	if err != nil {
+		return fmt.Errorf("lock stopped evidence directory: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+	document, err := buildLegacyInventory(location, strings.TrimSpace(opts.sessionID))
+	if err != nil {
+		return err
+	}
+	data, err := legacyInventoryMarshal(document)
+	if err != nil {
+		return err
+	}
+	if _, err := legacyInventoryWrite(output.file, data); err != nil {
+		return fmt.Errorf("write --out: %w", err)
+	}
+	if err := legacyInventoryFileSync(output.file); err != nil {
+		return fmt.Errorf("sync --out: %w", err)
+	}
+	if err := inspectSyncDirectory(output); err != nil {
+		return fmt.Errorf("sync --out parent: %w", err)
+	}
+	matches, err := legacyInventoryParentMatches(output, parent)
+	if err != nil {
+		return fmt.Errorf("verify --out parent identity: %w", err)
+	}
+	if !matches {
+		return errors.New("--out parent changed during inventory")
+	}
+	published = true
+	digest := sha256.Sum256(data)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s  %s\n", hex.EncodeToString(digest[:]), out)
+	return nil
+}
+
+func runVerifyLegacyEpochInventory(cmd *cobra.Command, opts verifyLegacyInventoryOptions) error {
+	location, err := resolveLegacyInventoryLocation(opts.receiptDir, opts.locationID, opts.sessionID)
+	if err != nil {
+		return err
+	}
+	wantDigest := strings.ToLower(strings.TrimSpace(opts.inventorySHA256))
+	if len(wantDigest) != sha256.Size*2 {
+		return errors.New("--sha256 must be a 64-character hexadecimal SHA-256")
+	}
+	if _, err := hex.DecodeString(wantDigest); err != nil {
+		return errors.New("--sha256 must be hexadecimal")
+	}
+	data, err := os.ReadFile(filepath.Clean(opts.inventoryFile))
+	if err != nil {
+		return fmt.Errorf("read --inventory: %w", err)
+	}
+	if int64(len(data)) > recorder.MaxEvidenceReadFileBytes {
+		return fmt.Errorf("--inventory exceeds %d-byte limit", recorder.MaxEvidenceReadFileBytes)
+	}
+	gotDigest := sha256.Sum256(data)
+	if hex.EncodeToString(gotDigest[:]) != wantDigest {
+		return errors.New("--inventory SHA-256 does not match --sha256")
+	}
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return fmt.Errorf("decode --inventory: %w", err)
+	}
+	var supplied legacyInventoryDocument
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&supplied); err != nil {
+		return fmt.Errorf("decode --inventory: %w", err)
+	}
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return errors.New("decode --inventory: trailing JSON value")
+	}
+	if supplied.Version != legacyInventoryVersion || supplied.Kind != legacyInventoryKind || supplied.SessionID != strings.TrimSpace(opts.sessionID) {
+		return errors.New("--inventory identity does not match requested version, kind, and session")
+	}
+	lock, err := compactAcquireLock(location.Dir)
+	if err != nil {
+		return fmt.Errorf("lock stopped evidence directory: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+	recomputed, err := buildLegacyInventory(location, strings.TrimSpace(opts.sessionID))
+	if err != nil {
+		return err
+	}
+	want, err := legacyInventoryMarshal(recomputed)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(data, want) {
+		return errors.New("inventory differs from full recomputation; source bytes or recorded files, epochs, runs, mappings, or anomalies changed")
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "verified %s  %s\n", wantDigest, filepath.Clean(opts.inventoryFile))
+	return nil
+}
+
+func resolveLegacyInventoryLocation(root, locationID, session string) (recorder.EvidenceLocation, error) {
+	if strings.TrimSpace(session) == "" {
+		return recorder.EvidenceLocation{}, errors.New("--session is required")
+	}
+	cleanRoot, err := validateReceiptDir(root)
+	if err != nil {
+		return recorder.EvidenceLocation{}, err
+	}
+	location, err := recorder.ResolveEvidenceLocation(cleanRoot, locationID)
+	if err != nil {
+		return recorder.EvidenceLocation{}, fmt.Errorf("resolve evidence location: %w", err)
+	}
+	return location, nil
+}
+
+func resolveLegacyInventoryOutput(name, evidenceRoot string) (string, string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", "", errors.New("--out is required")
+	}
+	out, err := filepath.Abs(filepath.Clean(name))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve --out: %w", err)
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(out))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve --out parent: %w", err)
+	}
+	out = filepath.Join(parent, filepath.Base(out))
+	if rel, relErr := filepath.Rel(evidenceRoot, out); relErr != nil || rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+		return "", "", errors.New("--out must be outside the evidence directory")
+	}
+	return out, parent, nil
+}
+
+func marshalLegacyInventory(document legacyInventoryDocument) ([]byte, error) {
+	data, err := json.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("encode legacy inventory: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func buildLegacyInventory(location recorder.EvidenceLocation, session string) (legacyInventoryDocument, error) {
+	names, err := inspectEpochSourceNames(location, session)
+	if err != nil {
+		return legacyInventoryDocument{}, err
+	}
+	doc := legacyInventoryDocument{Version: legacyInventoryVersion, Kind: legacyInventoryKind, SessionID: session, SourceFiles: make([]legacyInventoryFile, 0, len(names)), Epochs: make([]legacyInventoryEpoch, 0)}
+	aggregate := sha256.New()
+	var epoch *legacyInventoryEpoch
+	seenSigner := make(map[string]struct{})
+	for _, name := range names {
+		fileHash := sha256.New()
+		var offset int64
+		err := recorder.StreamEvidenceLocationFileForOfflineCompaction(location, name, func(source io.Reader, info os.FileInfo) error {
+			reader := bufio.NewReaderSize(source, 64*1024)
+			for {
+				line, readErr := reader.ReadBytes('\n')
+				if len(line) > 0 {
+					if errors.Is(readErr, io.EOF) {
+						return fmt.Errorf("source shard %q does not end in newline", name)
+					}
+					if len(line) > recorder.MaxEntryLineBytes+1 {
+						return fmt.Errorf("source shard %q entry at byte %d exceeds %d-byte limit", name, offset, recorder.MaxEntryLineBytes)
+					}
+					_, _ = aggregate.Write(line)
+					_, _ = fileHash.Write(line)
+					doc.SourceBytes += int64(len(line))
+					payload := bytes.TrimSuffix(line, []byte{'\n'})
+					payload = bytes.TrimSuffix(payload, []byte{'\r'})
+					entry, parseErr := recorder.ParseEntryLine(payload)
+					if parseErr != nil {
+						return fmt.Errorf("parse source shard %q at byte %d: %w", name, offset, parseErr)
+					}
+					if entry.SessionID != session {
+						return fmt.Errorf("source shard %q at byte %d contains session %q, want %q", name, offset, entry.SessionID, session)
+					}
+					if epoch == nil || (epoch.EntryCount > 0 && entry.Sequence == 0) {
+						if len(doc.Epochs) >= maxLegacyInventoryEpochs {
+							return fmt.Errorf("legacy inventory exceeds %d epochs", maxLegacyInventoryEpochs)
+						}
+						doc.Epochs = append(doc.Epochs, legacyInventoryEpoch{Epoch: uint64(len(doc.Epochs)), StartSequence: entry.Sequence, StartHash: entry.Hash, Assurance: "receipts_strictly_verified", CheckpointStatus: "none", SignerRuns: []legacySignerRun{}, SourceFiles: []legacyInventoryFile{}, SourceMappings: []legacySourceMapping{}, Anomalies: []legacyInventoryAnomaly{}})
+						epoch = &doc.Epochs[len(doc.Epochs)-1]
+						seenSigner = make(map[string]struct{})
+					}
+					if err := addLegacyInventoryEntry(epoch, name, offset, int64(len(line)), entry, seenSigner); err != nil {
+						return err
+					}
+					offset += int64(len(line))
+				}
+				if readErr != nil {
+					if !errors.Is(readErr, io.EOF) {
+						return fmt.Errorf("read source shard %q: %w", name, readErr)
+					}
+					break
+				}
+			}
+			if offset != info.Size() {
+				return fmt.Errorf("source shard %q changed size during inventory", name)
+			}
+			return nil
+		})
+		if err != nil {
+			return legacyInventoryDocument{}, err
+		}
+		doc.SourceFiles = append(doc.SourceFiles, legacyInventoryFile{Name: name, Bytes: offset, SHA256: hex.EncodeToString(fileHash.Sum(nil))})
+	}
+	if len(doc.Epochs) == 0 {
+		return legacyInventoryDocument{}, fmt.Errorf("session %q contains no recorder entries", session)
+	}
+	fileByName := make(map[string]legacyInventoryFile, len(doc.SourceFiles))
+	for _, source := range doc.SourceFiles {
+		fileByName[source.Name] = source
+	}
+	for i := range doc.Epochs {
+		seenFile := make(map[string]struct{})
+		for _, mapping := range doc.Epochs[i].SourceMappings {
+			if _, exists := seenFile[mapping.File]; exists {
+				continue
+			}
+			seenFile[mapping.File] = struct{}{}
+			doc.Epochs[i].SourceFiles = append(doc.Epochs[i].SourceFiles, fileByName[mapping.File])
+		}
+		finalizeLegacyEpoch(&doc.Epochs[i])
+	}
+	doc.SourceSHA256 = hex.EncodeToString(aggregate.Sum(nil))
+	return doc, nil
+}
+
+func addLegacyInventoryEntry(epoch *legacyInventoryEpoch, file string, offset, size int64, entry recorder.Entry, seenSigner map[string]struct{}) error {
+	if epoch.EntryCount > 0 {
+		if entry.Sequence != epoch.EndSequence+1 {
+			kind := "sequence_gap"
+			if entry.Sequence <= epoch.EndSequence {
+				kind = "sequence_overlap"
+			}
+			if err := addLegacyAnomaly(epoch, kind, file, offset, entry.Sequence, true); err != nil {
+				return err
+			}
+		}
+		if entry.PrevHash != epoch.EndHash {
+			if err := addLegacyAnomaly(epoch, "previous_hash_mismatch", file, offset, entry.Sequence, true); err != nil {
+				return err
+			}
+		}
+	} else if entry.Sequence != 0 || entry.PrevHash != recorder.GenesisHash {
+		if err := addLegacyAnomaly(epoch, "non_genesis_epoch_start", file, offset, entry.Sequence, true); err != nil {
+			return err
+		}
+	}
+	if epoch.EntryCount == 0 {
+		epoch.StartFile = file
+	}
+	if recorder.ComputeHash(entry) != entry.Hash {
+		if err := addLegacyAnomaly(epoch, "stored_hash_mismatch", file, offset, entry.Sequence, true); err != nil {
+			return err
+		}
+	}
+	if len(epoch.SourceMappings) > 0 {
+		last := &epoch.SourceMappings[len(epoch.SourceMappings)-1]
+		if last.File == file && last.Offset+last.Bytes == offset {
+			last.Bytes += size
+		} else {
+			epoch.SourceMappings = append(epoch.SourceMappings, legacySourceMapping{File: file, Offset: offset, Bytes: size})
+		}
+	} else {
+		epoch.SourceMappings = append(epoch.SourceMappings, legacySourceMapping{File: file, Offset: offset, Bytes: size})
+	}
+	epoch.EntryCount++
+	epoch.EndSequence = entry.Sequence
+	epoch.EndHash = entry.Hash
+	epoch.EndFile = file
+	switch entry.Type {
+	case "action_receipt":
+		return addLegacyReceipt(epoch, file, offset, entry, seenSigner)
+	case "checkpoint":
+		epoch.CheckpointCount++
+		var detail recorder.CheckpointDetail
+		if err := json.Unmarshal(entry.RawDetail, &detail); err != nil {
+			return fmt.Errorf("decode checkpoint in %q at byte %d: %w", file, offset, err)
+		}
+		if strings.TrimSpace(detail.Signature) == "" {
+			epoch.CheckpointStatus = "unsigned_observed"
+			return addLegacyAnomaly(epoch, "unsigned_checkpoint", file, offset, entry.Sequence, false)
+		}
+		if epoch.CheckpointStatus == "none" {
+			epoch.CheckpointStatus = "signed_observed"
+		}
+	case "rotation_endorsement":
+		epoch.RotationEndorsements++
+		return addLegacyAnomaly(epoch, "rotation_endorsement_observed", file, offset, entry.Sequence, false)
+	default:
+		if _, ok := compactKnownRecorderTypes[entry.Type]; !ok {
+			return addLegacyAnomaly(epoch, "unknown_entry_type", file, offset, entry.Sequence, false)
+		}
+	}
+	return nil
+}
+
+func addLegacyReceipt(epoch *legacyInventoryEpoch, file string, offset int64, entry recorder.Entry, seenSigner map[string]struct{}) error {
+	var envelope struct {
+		SignerKey string `json:"signer_key"`
+	}
+	_ = json.Unmarshal(entry.RawDetail, &envelope)
+	strict, strictErr := receipt.Unmarshal(entry.RawDetail)
+	if strictErr == nil {
+		envelope.SignerKey = strict.SignerKey
+		strictErr = receipt.VerifyInternalConsistencyOnly(strict)
+	}
+	key := strings.TrimSpace(envelope.SignerKey)
+	var keyPointer *string
+	if key != "" {
+		keyPointer = &key
+	}
+	newRun := len(epoch.SignerRuns) == 0 || signerRunKey(epoch.SignerRuns[len(epoch.SignerRuns)-1]) != key
+	if newRun {
+		if len(epoch.SignerRuns) >= maxLegacyInventoryRuns {
+			return fmt.Errorf("legacy inventory exceeds %d signer runs", maxLegacyInventoryRuns)
+		}
+		if len(epoch.SignerRuns) > 0 {
+			if err := addLegacyAnomaly(epoch, "signer_change", file, offset, entry.Sequence, false); err != nil {
+				return err
+			}
+		}
+		if _, exists := seenSigner[key]; key != "" && exists {
+			if err := addLegacyAnomaly(epoch, "signer_key_reentry", file, offset, entry.Sequence, false); err != nil {
+				return err
+			}
+		}
+		if key != "" {
+			seenSigner[key] = struct{}{}
+		}
+		epoch.SignerRuns = append(epoch.SignerRuns, legacySignerRun{SignerKey: keyPointer, FirstSequence: entry.Sequence})
+	}
+	run := &epoch.SignerRuns[len(epoch.SignerRuns)-1]
+	run.LastSequence = entry.Sequence
+	run.ReceiptCount++
+	if strictErr != nil {
+		run.StrictErrors++
+		epoch.StrictReceiptErrors++
+		return addLegacyAnomaly(epoch, "strict_receipt_error", file, offset, entry.Sequence, false)
+	}
+	run.StrictVerifiedCount++
+	epoch.StrictReceiptCount++
+	return nil
+}
+
+func signerRunKey(run legacySignerRun) string {
+	if run.SignerKey == nil {
+		return ""
+	}
+	return *run.SignerKey
+}
+
+func addLegacyAnomaly(epoch *legacyInventoryEpoch, kind, file string, offset int64, sequence uint64, outerFailure bool) error {
+	if len(epoch.Anomalies) >= maxLegacyInventoryAnomalies {
+		return fmt.Errorf("legacy inventory exceeds %d anomalies", maxLegacyInventoryAnomalies)
+	}
+	epoch.Anomalies = append(epoch.Anomalies, legacyInventoryAnomaly{Kind: kind, File: file, Offset: offset, Sequence: sequence})
+	if outerFailure {
+		epoch.outerIntegrityFailures++
+	}
+	return nil
+}
+
+func finalizeLegacyEpoch(epoch *legacyInventoryEpoch) {
+	switch {
+	case epoch.outerIntegrityFailures > 0:
+		epoch.Assurance = "broken"
+	case len(epoch.Anomalies) > 0 || epoch.StrictReceiptErrors > 0:
+		epoch.Assurance = "observed_only"
+	case epoch.StrictReceiptCount == 0:
+		epoch.Assurance = "outer_verified"
+	default:
+		epoch.Assurance = "receipts_strictly_verified"
+	}
+}

--- a/internal/cli/evidence/legacy_epoch_inventory.go
+++ b/internal/cli/evidence/legacy_epoch_inventory.go
@@ -213,7 +213,13 @@ func runVerifyLegacyEpochInventory(cmd *cobra.Command, opts verifyLegacyInventor
 	if _, err := hex.DecodeString(wantDigest); err != nil {
 		return errors.New("--sha256 must be hexadecimal")
 	}
-	data, err := os.ReadFile(filepath.Clean(opts.inventoryFile))
+	inventoryPath := filepath.Clean(opts.inventoryFile)
+	file, err := os.Open(inventoryPath) // #nosec G304 -- operator-selected inventory is verified before use.
+	if err != nil {
+		return fmt.Errorf("read --inventory: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, recorder.MaxEvidenceReadFileBytes+1))
 	if err != nil {
 		return fmt.Errorf("read --inventory: %w", err)
 	}
@@ -314,9 +320,12 @@ func buildLegacyInventory(location recorder.EvidenceLocation, session string) (l
 		fileHash := sha256.New()
 		var offset int64
 		err := recorder.StreamEvidenceLocationFileForOfflineCompaction(location, name, func(source io.Reader, info os.FileInfo) error {
-			reader := bufio.NewReaderSize(source, 64*1024)
+			reader := bufio.NewReaderSize(source, recorder.MaxEntryLineBytes+1)
 			for {
-				line, readErr := reader.ReadBytes('\n')
+				line, readErr := reader.ReadSlice('\n')
+				if errors.Is(readErr, bufio.ErrBufferFull) {
+					return fmt.Errorf("source shard %q entry at byte %d exceeds %d-byte limit", name, offset, recorder.MaxEntryLineBytes)
+				}
 				if len(line) > 0 {
 					if errors.Is(readErr, io.EOF) {
 						return fmt.Errorf("source shard %q does not end in newline", name)

--- a/internal/cli/evidence/legacy_epoch_inventory_test.go
+++ b/internal/cli/evidence/legacy_epoch_inventory_test.go
@@ -271,6 +271,40 @@ func TestAddLegacyInventoryEntryClassifiesBranches(t *testing.T) {
 	}
 }
 
+func TestLegacyInventoryBoundsFailClosed(t *testing.T) {
+	t.Run("anomalies", func(t *testing.T) {
+		epoch := legacyInventoryEpoch{Anomalies: make([]legacyInventoryAnomaly, maxLegacyInventoryAnomalies)}
+		err := addLegacyAnomaly(&epoch, "sequence_gap", "a.jsonl", 0, 1, false)
+		if err == nil || !strings.Contains(err.Error(), "anomalies") {
+			t.Fatalf("error = %v, want anomalies bound", err)
+		}
+	})
+
+	t.Run("signer runs", func(t *testing.T) {
+		epoch := legacyInventoryEpoch{SignerRuns: make([]legacySignerRun, maxLegacyInventoryRuns)}
+		entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "action_receipt", json.RawMessage(`{"signer_key":"`+strings.Repeat("c", 64)+`"}`))
+		err := addLegacyReceipt(&epoch, "a.jsonl", 0, entry, make(map[string]struct{}))
+		if err == nil || !strings.Contains(err.Error(), "signer runs") {
+			t.Fatalf("error = %v, want signer-runs bound", err)
+		}
+	})
+
+	t.Run("epochs", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+		entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "capture", map[string]string{"safe": "value"})
+		line := legacyInventoryTestLine(t, entry)
+		wire := bytes.Repeat(line, maxLegacyInventoryEpochs+1)
+		if err := os.WriteFile(path, wire, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+		if err == nil || !strings.Contains(err.Error(), "epochs") {
+			t.Fatalf("error = %v, want epochs bound", err)
+		}
+	})
+}
+
 func TestBuildLegacyInventoryRecordsSignerReentryAndEpochs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "evidence-proxy-0.jsonl")

--- a/internal/cli/evidence/legacy_epoch_inventory_test.go
+++ b/internal/cli/evidence/legacy_epoch_inventory_test.go
@@ -1,0 +1,422 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package evidence
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	legacyreceipt "github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestVerifyLegacyInventoryRoundTripAndSourceDrift(t *testing.T) {
+	dir := t.TempDir()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed := receiptForCompactV1(t, privateKey, 0, legacyreceipt.GenesisHash, "legacy-inventory-valid")
+	entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "action_receipt", signed)
+	source := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	sourceBytes := legacyInventoryTestLine(t, entry)
+	if err := os.WriteFile(source, sourceBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := doc.Epochs[0].Assurance; got != "receipts_strictly_verified" {
+		t.Fatalf("assurance = %q, want receipts_strictly_verified", got)
+	}
+	data, err := marshalLegacyInventory(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventory := filepath.Join(t.TempDir(), "inventory.json")
+	if err := os.WriteFile(inventory, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	opts := verifyLegacyInventoryOptions{receiptDir: dir, sessionID: "proxy", inventoryFile: inventory, inventorySHA256: hex.EncodeToString(digest[:])}
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	if err := runVerifyLegacyEpochInventory(cmd, opts); err != nil {
+		t.Fatalf("verify unchanged inventory: %v", err)
+	}
+	originalLock := compactAcquireLock
+	compactAcquireLock = func(string) (*recorder.EvidenceCeremonyLock, error) { return nil, errors.New("injected verify lock") }
+	err = runVerifyLegacyEpochInventory(cmd, opts)
+	compactAcquireLock = originalLock
+	if err == nil || !strings.Contains(err.Error(), "injected verify lock") {
+		t.Fatalf("verify lock error = %v", err)
+	}
+	originalMarshal := legacyInventoryMarshal
+	legacyInventoryMarshal = func(legacyInventoryDocument) ([]byte, error) { return nil, errors.New("injected verify marshal") }
+	err = runVerifyLegacyEpochInventory(cmd, opts)
+	legacyInventoryMarshal = originalMarshal
+	if err == nil || !strings.Contains(err.Error(), "injected verify marshal") {
+		t.Fatalf("verify marshal error = %v", err)
+	}
+	drift := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "capture", map[string]string{"drift": "recorded"})
+	if err := os.WriteFile(source, append(sourceBytes, legacyInventoryTestLine(t, drift)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runVerifyLegacyEpochInventory(cmd, opts)
+	if err == nil || !strings.Contains(err.Error(), "differs from full recomputation") {
+		t.Fatalf("verify drifted source error = %v, want exact-recomputation refusal", err)
+	}
+	if err := os.WriteFile(source, []byte("not-json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runVerifyLegacyEpochInventory(cmd, opts)
+	if err == nil || !strings.Contains(err.Error(), "parse source shard") {
+		t.Fatalf("verify malformed source error = %v", err)
+	}
+}
+
+func TestRunInventoryLegacyEpochsPublishesCanonicalOutput(t *testing.T) {
+	dir := t.TempDir()
+	entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "capture", map[string]string{"safe": "value"})
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), legacyInventoryTestLine(t, entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "inventory.json")
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "proxy", outFile: out}); err != nil {
+		t.Fatalf("runInventoryLegacyEpochs: %v", err)
+	}
+	// #nosec G304 -- out is a test-owned path below t.TempDir.
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	if !strings.Contains(stdout.String(), hex.EncodeToString(digest[:])) {
+		t.Fatalf("stdout = %q, want published digest", stdout.String())
+	}
+	if err := runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "proxy", outFile: out}); err == nil || !strings.Contains(err.Error(), "create --out") {
+		t.Fatalf("second publication error = %v, want exclusive-create refusal", err)
+	}
+	if err := runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "", outFile: filepath.Join(t.TempDir(), "bad.json")}); err == nil || !strings.Contains(err.Error(), "--session") {
+		t.Fatalf("missing session error = %v", err)
+	}
+	if err := runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "proxy", outFile: filepath.Join(dir, "inside.json")}); err == nil || !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("inside output error = %v", err)
+	}
+}
+
+func TestRunInventoryLegacyEpochsFailsClosedAtPublicationBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "capture", map[string]string{"safe": "value"})
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), legacyInventoryTestLine(t, entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalWrite := legacyInventoryWrite
+	originalFileSync := legacyInventoryFileSync
+	originalMarshal := legacyInventoryMarshal
+	originalParentMatches := legacyInventoryParentMatches
+	originalDirectorySync := inspectSyncDirectory
+	originalLock := compactAcquireLock
+	restore := func() {
+		legacyInventoryWrite = originalWrite
+		legacyInventoryFileSync = originalFileSync
+		legacyInventoryMarshal = originalMarshal
+		legacyInventoryParentMatches = originalParentMatches
+		inspectSyncDirectory = originalDirectorySync
+		compactAcquireLock = originalLock
+	}
+	t.Cleanup(restore)
+	tests := []struct {
+		name, want string
+		inject     func()
+	}{
+		{name: "write", want: "write --out", inject: func() {
+			legacyInventoryWrite = func(*os.File, []byte) (int, error) { return 0, errors.New("injected write") }
+		}},
+		{name: "file sync", want: "sync --out", inject: func() { legacyInventoryFileSync = func(*os.File) error { return errors.New("injected file sync") } }},
+		{name: "directory sync", want: "sync --out parent", inject: func() {
+			inspectSyncDirectory = func(*inspectOutput) error { return errors.New("injected directory sync") }
+		}},
+		{name: "parent identity error", want: "verify --out parent identity", inject: func() {
+			legacyInventoryParentMatches = func(*inspectOutput, string) (bool, error) { return false, errors.New("injected identity") }
+		}},
+		{name: "parent changed", want: "parent changed", inject: func() {
+			legacyInventoryParentMatches = func(*inspectOutput, string) (bool, error) { return false, nil }
+		}},
+		{name: "marshal", want: "injected marshal", inject: func() {
+			legacyInventoryMarshal = func(legacyInventoryDocument) ([]byte, error) { return nil, errors.New("injected marshal") }
+		}},
+		{name: "lock", want: "lock stopped", inject: func() {
+			compactAcquireLock = func(string) (*recorder.EvidenceCeremonyLock, error) { return nil, errors.New("injected lock") }
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restore()
+			tc.inject()
+			cmd := &cobra.Command{}
+			cmd.SetOut(new(bytes.Buffer))
+			err := runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "proxy", outFile: filepath.Join(t.TempDir(), "inventory.json")})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyLegacyInventoryRejectsMalformedPinsBeforeEnumeration(t *testing.T) {
+	dir := t.TempDir()
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	missingRoot := filepath.Join(t.TempDir(), "missing-root")
+	err := runVerifyLegacyEpochInventory(cmd, verifyLegacyInventoryOptions{receiptDir: missingRoot, sessionID: "proxy", inventoryFile: "unused", inventorySHA256: strings.Repeat("0", 64)})
+	if err == nil {
+		t.Fatal("missing evidence root accepted")
+	}
+	write := func(t *testing.T, data []byte) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "inventory.json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	tests := []struct {
+		name, digest, want string
+		data               []byte
+		missing            bool
+	}{
+		{name: "short digest", digest: "aa", data: []byte("{}\n"), want: "64-character"},
+		{name: "non-hex digest", digest: strings.Repeat("z", 64), data: []byte("{}\n"), want: "hexadecimal"},
+		{name: "digest mismatch", digest: strings.Repeat("0", 64), data: []byte("{}\n"), want: "does not match"},
+		{name: "duplicate keys", data: []byte(`{"version":1,"version":1}` + "\n"), want: "duplicate"},
+		{name: "invalid json", data: []byte("{\n"), want: "decode --inventory"},
+		{name: "unknown field", data: []byte(`{"version":1,"kind":"pipelock-legacy-epoch-inventory","session_id":"proxy","unknown":true}` + "\n"), want: "decode --inventory"},
+		{name: "trailing json", data: []byte(`{"version":1,"kind":"pipelock-legacy-epoch-inventory","session_id":"proxy"} {}` + "\n"), want: "trailing"},
+		{name: "wrong identity", data: []byte(`{"version":2,"kind":"wrong","session_id":"proxy"}` + "\n"), want: "identity"},
+		{name: "oversized inventory", data: bytes.Repeat([]byte{' '}, int(recorder.MaxEvidenceReadFileBytes)+1), want: "exceeds"},
+		{name: "missing file", digest: strings.Repeat("0", 64), want: "read --inventory", missing: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "missing.json")
+			if !tc.missing {
+				path = write(t, tc.data)
+			}
+			digest := tc.digest
+			if digest == "" {
+				sum := sha256.Sum256(tc.data)
+				digest = hex.EncodeToString(sum[:])
+			}
+			err := runVerifyLegacyEpochInventory(cmd, verifyLegacyInventoryOptions{receiptDir: dir, sessionID: "proxy", inventoryFile: path, inventorySHA256: digest})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAddLegacyInventoryEntryClassifiesBranches(t *testing.T) {
+	epoch := legacyInventoryEpoch{Assurance: "receipts_strictly_verified", CheckpointStatus: "none", SignerRuns: []legacySignerRun{}, SourceMappings: []legacySourceMapping{}, Anomalies: []legacyInventoryAnomaly{}}
+	seen := make(map[string]struct{})
+	first := legacyInventoryTestEntry(t, 2, "wrong-genesis", "capture", map[string]string{"safe": "value"})
+	first.Hash = "wrong-hash"
+	if err := addLegacyInventoryEntry(&epoch, "a.jsonl", 0, 10, first, seen); err != nil {
+		t.Fatal(err)
+	}
+	second := legacyInventoryTestEntry(t, 1, "wrong-prev", "capture", map[string]string{"safe": "value"})
+	if err := addLegacyInventoryEntry(&epoch, "b.jsonl", 0, 11, second, seen); err != nil {
+		t.Fatal(err)
+	}
+	signedCheckpoint := legacyInventoryTestEntry(t, 2, second.Hash, "checkpoint", recorder.CheckpointDetail{Signature: "observed"})
+	if err := addLegacyInventoryEntry(&epoch, "b.jsonl", 11, 12, signedCheckpoint, seen); err != nil {
+		t.Fatal(err)
+	}
+	endorsement := legacyInventoryTestEntry(t, 3, signedCheckpoint.Hash, "rotation_endorsement", map[string]string{"observed": "only"})
+	if err := addLegacyInventoryEntry(&epoch, "b.jsonl", 23, 13, endorsement, seen); err != nil {
+		t.Fatal(err)
+	}
+	unknown := legacyInventoryTestEntry(t, 4, endorsement.Hash, "future_type", map[string]string{"observed": "only"})
+	if err := addLegacyInventoryEntry(&epoch, "b.jsonl", 36, 14, unknown, seen); err != nil {
+		t.Fatal(err)
+	}
+	if epoch.RotationEndorsements != 1 || epoch.CheckpointStatus != "signed_observed" || epoch.outerIntegrityFailures == 0 {
+		t.Fatalf("classification = %#v", epoch)
+	}
+	finalizeLegacyEpoch(&epoch)
+	if epoch.Assurance != "broken" {
+		t.Fatalf("assurance = %q, want broken", epoch.Assurance)
+	}
+	outerOnly := legacyInventoryEpoch{}
+	finalizeLegacyEpoch(&outerOnly)
+	if outerOnly.Assurance != "outer_verified" {
+		t.Fatalf("outer-only assurance = %q", outerOnly.Assurance)
+	}
+}
+
+func TestBuildLegacyInventoryRecordsSignerReentryAndEpochs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "evidence-proxy-0.jsonl")
+	var wire []byte
+	prev := recorder.GenesisHash
+	for seq, key := range []string{strings.Repeat("a", 64), strings.Repeat("b", 64), strings.Repeat("a", 64)} {
+		detail := json.RawMessage(`{"signer_key":"` + key + `"}`)
+		entry := legacyInventoryTestEntry(t, uint64(seq), prev, "action_receipt", detail)
+		prev = entry.Hash
+		wire = append(wire, legacyInventoryTestLine(t, entry)...)
+	}
+	checkpoint := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "checkpoint", recorder.CheckpointDetail{})
+	wire = append(wire, legacyInventoryTestLine(t, checkpoint)...)
+	if err := os.WriteFile(path, wire, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err != nil {
+		t.Fatalf("buildLegacyInventory: %v", err)
+	}
+	if len(doc.Epochs) != 2 {
+		t.Fatalf("epochs = %d, want 2", len(doc.Epochs))
+	}
+	first := doc.Epochs[0]
+	if len(first.SignerRuns) != 3 || signerRunKey(first.SignerRuns[0]) != signerRunKey(first.SignerRuns[2]) {
+		t.Fatalf("signer runs = %#v, want A-B-A", first.SignerRuns)
+	}
+	if !legacyInventoryHasAnomaly(first, "signer_key_reentry") || first.Assurance != "observed_only" {
+		t.Fatalf("first epoch assurance/anomalies = %q %#v", first.Assurance, first.Anomalies)
+	}
+	second := doc.Epochs[1]
+	if second.CheckpointStatus != "unsigned_observed" || !legacyInventoryHasAnomaly(second, "unsigned_checkpoint") {
+		t.Fatalf("checkpoint = %q %#v", second.CheckpointStatus, second.Anomalies)
+	}
+	if len(first.SourceMappings) != 1 || first.SourceMappings[0].Bytes >= int64(len(wire)) {
+		t.Fatalf("first epoch mapping does not bind only its byte range: %#v", first.SourceMappings)
+	}
+	if len(first.SourceFiles) != 1 || first.SourceFiles[0].SHA256 != doc.SourceFiles[0].SHA256 {
+		t.Fatalf("epoch source file digest missing: %#v", first.SourceFiles)
+	}
+}
+
+func TestVerifyLegacyInventoryRejectsHandTruncatedRun(t *testing.T) {
+	dir := t.TempDir()
+	keyA, keyB := strings.Repeat("a", 64), strings.Repeat("b", 64)
+	first := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "action_receipt", json.RawMessage(`{"signer_key":"`+keyA+`"}`))
+	second := legacyInventoryTestEntry(t, 1, first.Hash, "action_receipt", json.RawMessage(`{"signer_key":"`+keyB+`"}`))
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), append(legacyInventoryTestLine(t, first), legacyInventoryTestLine(t, second)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc.Epochs[0].SignerRuns = doc.Epochs[0].SignerRuns[:1]
+	data, err := marshalLegacyInventory(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventory := filepath.Join(t.TempDir(), "inventory.json")
+	if err := os.WriteFile(inventory, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	err = runVerifyLegacyEpochInventory(cmd, verifyLegacyInventoryOptions{receiptDir: dir, sessionID: "proxy", inventoryFile: inventory, inventorySHA256: hex.EncodeToString(digest[:])})
+	if err == nil || !strings.Contains(err.Error(), "differs from full recomputation") {
+		t.Fatalf("runVerifyLegacyEpochInventory error = %v, want exact-recomputation refusal", err)
+	}
+}
+
+func TestBuildLegacyInventoryRejectsUnterminatedShard(t *testing.T) {
+	dir := t.TempDir()
+	entry := legacyInventoryTestEntry(t, 0, recorder.GenesisHash, "capture", map[string]string{"safe": "value"})
+	line := legacyInventoryTestLine(t, entry)
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), bytes.TrimSuffix(line, []byte{'\n'}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy")
+	if err == nil || !strings.Contains(err.Error(), "does not end in newline") {
+		t.Fatalf("buildLegacyInventory error = %v, want unterminated-shard refusal", err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	err = runInventoryLegacyEpochs(cmd, legacyInventoryOptions{receiptDir: dir, sessionID: "proxy", outFile: filepath.Join(t.TempDir(), "inventory.json")})
+	if err == nil || !strings.Contains(err.Error(), "does not end in newline") {
+		t.Fatalf("runInventoryLegacyEpochs error = %v, want unterminated-shard refusal", err)
+	}
+}
+
+func TestLegacyInventoryPathValidationBranches(t *testing.T) {
+	if _, err := resolveLegacyInventoryLocation(filepath.Join(t.TempDir(), "missing"), "", "proxy"); err == nil {
+		t.Fatal("missing evidence root accepted")
+	}
+	dir := t.TempDir()
+	if _, err := resolveLegacyInventoryLocation(dir, "../escape", "proxy"); err == nil {
+		t.Fatal("escaping location accepted")
+	}
+	if _, _, err := resolveLegacyInventoryOutput("", dir); err == nil || !strings.Contains(err.Error(), "--out") {
+		t.Fatalf("empty output error = %v", err)
+	}
+	if _, _, err := resolveLegacyInventoryOutput(filepath.Join(t.TempDir(), "missing-parent", "inventory.json"), dir); err == nil || !strings.Contains(err.Error(), "parent") {
+		t.Fatalf("missing parent error = %v", err)
+	}
+	if _, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy"); err == nil || !strings.Contains(err.Error(), "no evidence shards") {
+		t.Fatalf("empty source error = %v", err)
+	}
+	overlong := append(bytes.Repeat([]byte{'x'}, recorder.MaxEntryLineBytes+1), '\n')
+	if err := os.WriteFile(filepath.Join(dir, "evidence-proxy-0.jsonl"), overlong, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buildLegacyInventory(recorder.EvidenceLocation{Root: dir, Dir: dir}, "proxy"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("overlong source error = %v", err)
+	}
+}
+
+func legacyInventoryTestEntry(t *testing.T, seq uint64, prev, entryType string, detail any) recorder.Entry {
+	t.Helper()
+	rawDetail, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := recorder.Entry{Version: 1, Sequence: seq, Timestamp: time.Unix(1, 0).UTC(), SessionID: "proxy", Type: entryType, Transport: "test", Summary: "inventory fixture", Detail: detail, RawDetail: rawDetail, PrevHash: prev}
+	entry.Hash = recorder.ComputeHash(entry)
+	if entry.Hash == "" {
+		t.Fatal("empty recorder hash")
+	}
+	return entry
+}
+
+func legacyInventoryTestLine(t *testing.T, entry recorder.Entry) []byte {
+	t.Helper()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(data, '\n')
+}
+
+func legacyInventoryHasAnomaly(epoch legacyInventoryEpoch, kind string) bool {
+	for _, anomaly := range epoch.Anomalies {
+		if anomaly.Kind == kind {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changed

- Add a bounded read-only command that records exact legacy recorder epochs, source mappings, signer runs, receipt results, and anomalies without granting historical trust.
- Add an independent verifier that rebuilds the inventory from the source and requires canonical byte equality.

Incomplete enumeration, source drift, malformed input, and omitted runs or anomalies fail closed. Reviewers should distrust any path that upgrades observational assurance or derives current signing authority from historical keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to inventory legacy recorder epochs and verify inventory results.
  * Inventory generation scans evidence sources, validates entries, detects anomalies, and publishes canonical output.
  * Verification confirms the inventory matches current evidence sources exactly.

* **Bug Fixes**
  * Added safeguards against malformed, incomplete, truncated, oversized, or modified evidence inputs.
  * Improved detection of signer changes, checkpoint issues, and incomplete recording runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->