### PR TITLE
feat: enable the zero-amount Pro trial with one active trial per email

### DIFF
--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -237,7 +237,14 @@ func LoadConfig() (*Config, error) {
 		if !validTiers[product.Tier] || product.Tier != tierTrial {
 			return nil, fmt.Errorf("ORDER_PRODUCTS product %s has invalid one-time tier %q", product.ProductID, product.Tier)
 		}
-		if product.AmountCents <= 0 {
+		// A trial is deliberately a zero-amount product; every other one-time
+		// tier must carry a real price so a misconfigured paid product can
+		// never silently become free.
+		if product.Tier == tierTrial {
+			if product.AmountCents < 0 {
+				return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set a non-negative amount_cents", product.ProductID)
+			}
+		} else if product.AmountCents <= 0 {
 			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set positive amount_cents", product.ProductID)
 		}
 		if product.Currency == "" {

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -237,15 +237,13 @@ func LoadConfig() (*Config, error) {
 		if !validTiers[product.Tier] || product.Tier != tierTrial {
 			return nil, fmt.Errorf("ORDER_PRODUCTS product %s has invalid one-time tier %q", product.ProductID, product.Tier)
 		}
-		// A trial is deliberately a zero-amount product; every other one-time
-		// tier must carry a real price so a misconfigured paid product can
-		// never silently become free.
-		if product.Tier == tierTrial {
-			if product.AmountCents < 0 {
-				return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set a non-negative amount_cents", product.ProductID)
-			}
-		} else if product.AmountCents <= 0 {
-			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set positive amount_cents", product.ProductID)
+		// A trial is deliberately a zero-amount product, and the tier check
+		// above already restricts ORDER_PRODUCTS to the trial tier, so only
+		// negative amounts are invalid here. If a non-trial one-time tier is
+		// ever allowed, it must reinstate a positive-amount requirement so a
+		// misconfigured paid product can never silently become free.
+		if product.AmountCents < 0 {
+			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set a non-negative amount_cents", product.ProductID)
 		}
 		if product.Currency == "" {
 			return nil, fmt.Errorf("ORDER_PRODUCTS product %s must set currency", product.ProductID)

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -247,12 +247,27 @@ func TestLoadConfig_OrderProducts(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_OrderProductsAcceptZeroAmountTrial(t *testing.T) {
+	// A trial is deliberately a zero-amount product; only negative amounts are
+	// rejected for the trial tier, while non-trial one-time products keep the
+	// positive-amount requirement.
+	setRequiredConfigEnv(t)
+	t.Setenv("ORDER_PRODUCTS", "prod_trial_free:trial:0:usd")
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig rejected a zero-amount trial product: %v", err)
+	}
+	if len(cfg.OrderProducts) != 1 || cfg.OrderProducts[0].AmountCents != 0 {
+		t.Fatalf("OrderProducts = %+v, want one zero-amount trial product", cfg.OrderProducts)
+	}
+}
+
 func TestLoadConfig_OrderProductsRejectMalformed(t *testing.T) {
 	for _, value := range []string{
 		"prod_only",
 		":trial:100:usd",
 		"prod_trial:pro:100:usd",
-		"prod_trial:trial:0:usd",
+		"prod_trial:trial:-1:usd",
 		"prod_trial:trial:not-money:usd",
 		"prod_trial:trial:100:",
 		"prod_trial:trial:100:usd,prod_trial:trial:100:usd",

--- a/enterprise/licenseservice/eval_coverage_test.go
+++ b/enterprise/licenseservice/eval_coverage_test.go
@@ -329,3 +329,121 @@ func TestCountActiveTrialForEmailClosedDB(t *testing.T) {
 		t.Error("CountActiveTrialForEmail on closed db should error")
 	}
 }
+
+func TestCountActiveTrialForEmailCanonicalizesLegacyRows(t *testing.T) {
+	db := openTestDB(t)
+	ctx := t.Context()
+	now := time.Now()
+	periodEnd := now.Add(10 * 24 * time.Hour)
+	legacyUmlaut := "ÜSER@Example.com"
+
+	rows := []*Entitlement{
+		{
+			SubscriptionID:   "order_legacy_ascii",
+			CustomerEmail:    "DELTA@Example.com",
+			ProductID:        "prod_trial_free",
+			Tier:             tierTrial,
+			Status:           statusActive,
+			CurrentPeriodEnd: periodEnd,
+		},
+		{
+			SubscriptionID:   "order_legacy_umlaut",
+			CustomerEmail:    legacyUmlaut,
+			ProductID:        "prod_trial_free",
+			Tier:             tierTrial,
+			Status:           statusActive,
+			CurrentPeriodEnd: periodEnd,
+		},
+		{
+			SubscriptionID:   "order_legacy_garbage",
+			CustomerEmail:    "not-an-email",
+			ProductID:        "prod_trial_free",
+			Tier:             tierTrial,
+			Status:           statusActive,
+			CurrentPeriodEnd: periodEnd,
+		},
+		{
+			SubscriptionID:   "order_expired_umlaut",
+			CustomerEmail:    legacyUmlaut,
+			ProductID:        "prod_trial_free",
+			Tier:             tierTrial,
+			Status:           statusActive,
+			CurrentPeriodEnd: now.Add(-time.Hour),
+		},
+	}
+	for _, row := range rows {
+		if err := db.Upsert(ctx, row); err != nil {
+			t.Fatalf("seed %s: %v", row.SubscriptionID, err)
+		}
+	}
+
+	got, err := db.CountActiveTrialForEmail(ctx, "delta@example.com", now)
+	if err != nil {
+		t.Fatalf("ascii legacy count: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("ascii legacy count = %d, want 1", got)
+	}
+
+	got, err = db.CountActiveTrialForEmail(ctx, "üser@example.com", now)
+	if err != nil {
+		t.Fatalf("non-ASCII legacy count: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("non-ASCII legacy count = %d, want 1", got)
+	}
+
+	got, err = db.CountActiveTrialForEmail(ctx, "other@example.com", now)
+	if err != nil {
+		t.Fatalf("unrelated email count: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("unrelated email count = %d, want 0 (garbage and expired rows must not match)", got)
+	}
+}
+
+func TestCollectTrialEmailsScanAndIterErrors(t *testing.T) {
+	got, err := collectTrialEmails(&stubTrialRows{emails: []string{"DELTA@Example.com", "not-an-email"}})
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if len(got) != 2 || got[0] != "DELTA@Example.com" || got[1] != "not-an-email" {
+		t.Fatalf("happy path emails = %#v", got)
+	}
+
+	if _, err := collectTrialEmails(&stubTrialRows{emails: []string{"a@example.com"}, scanErr: errors.New("scan failed")}); err == nil {
+		t.Fatal("scan error must fail closed")
+	}
+	if _, err := collectTrialEmails(&stubTrialRows{iterErr: errors.New("iter failed")}); err == nil {
+		t.Fatal("iteration error must fail closed")
+	}
+}
+
+type stubTrialRows struct {
+	emails  []string
+	idx     int
+	scanErr error
+	iterErr error
+}
+
+func (s *stubTrialRows) Next() bool {
+	if s.idx >= len(s.emails) {
+		return false
+	}
+	s.idx++
+	return true
+}
+
+func (s *stubTrialRows) Scan(dest ...any) error {
+	if s.scanErr != nil {
+		return s.scanErr
+	}
+	ptr, ok := dest[0].(*string)
+	if !ok {
+		return errors.New("scan dest is not *string")
+	}
+	*ptr = s.emails[s.idx-1]
+	return nil
+}
+
+func (s *stubTrialRows) Err() error { return s.iterErr }

--- a/enterprise/licenseservice/eval_coverage_test.go
+++ b/enterprise/licenseservice/eval_coverage_test.go
@@ -319,3 +319,13 @@ func TestHandleOrderRefund_DuplicateIsNoop(t *testing.T) {
 		t.Fatalf("refund replay: %v", err)
 	}
 }
+
+func TestCountActiveTrialForEmailClosedDB(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := db.CountActiveTrialForEmail(t.Context(), "a@b.com", time.Now()); err == nil {
+		t.Error("CountActiveTrialForEmail on closed db should error")
+	}
+}

--- a/enterprise/licenseservice/eval_store.go
+++ b/enterprise/licenseservice/eval_store.go
@@ -265,19 +265,69 @@ func (e *EntitlementDB) CountActiveEvalForEmail(ctx context.Context, normalizedE
 // email at mint time, mirroring the Enterprise Eval rule. It bounds only
 // same-email repeats; a fresh email is a new trial by design, which is
 // acceptable because trials gate multi-agent coordination and never detection.
-// The comparison folds the stored email's case so a legacy trial row persisted
-// before canonical storage still counts against its normalized form.
+//
+// Matching happens in Go through NormalizeEmail, not SQL LOWER. SQLite's
+// LOWER (and this driver's build, which has no ICU) only folds ASCII, so a
+// legacy row stored as ÜSER@Example.com would miss üser@example.com and
+// mint a second trial. Application-level canonicalization is the same key
+// the webhook writes for new rows. Unparseable stored values are skipped:
+// they cannot be this identity, because the incoming address already
+// survived NormalizeEmail.
 func (e *EntitlementDB) CountActiveTrialForEmail(ctx context.Context, normalizedEmail string, now time.Time) (int, error) {
+	if err := errForceCountActiveTrial; err != nil {
+		return 0, fmt.Errorf("count active trial for %s: %w", normalizedEmail, err)
+	}
 	const query = `
-	SELECT COUNT(*) FROM entitlements
-	WHERE tier = ? AND status = ? AND LOWER(customer_email) = ? AND current_period_end > ?
+	SELECT customer_email FROM entitlements
+	WHERE tier = ? AND status = ? AND current_period_end > ?
 	`
-	var count int
-	err := e.db.QueryRowContext(ctx, query, tierTrial, statusActive, normalizedEmail, now.UTC()).Scan(&count)
+	rows, err := e.db.QueryContext(ctx, query, tierTrial, statusActive, now.UTC())
 	if err != nil {
 		return 0, fmt.Errorf("count active trial for %s: %w", normalizedEmail, err)
 	}
+	defer func() { _ = rows.Close() }()
+
+	emails, err := collectTrialEmails(rows)
+	if err != nil {
+		return 0, fmt.Errorf("count active trial for %s: %w", normalizedEmail, err)
+	}
+	count := 0
+	for _, stored := range emails {
+		canonical, nerr := NormalizeEmail(stored)
+		if nerr != nil {
+			continue
+		}
+		if canonical == normalizedEmail {
+			count++
+		}
+	}
 	return count, nil
+}
+
+// errForceCountActiveTrial is set only in tests so HandleOrderEvent can
+// exercise the count-error return without closing the database (GetBySubscriptionID
+// would fail first). Production leaves it nil.
+var errForceCountActiveTrial error
+
+type trialEmailRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
+
+func collectTrialEmails(rows trialEmailRows) ([]string, error) {
+	var emails []string
+	for rows.Next() {
+		var stored string
+		if err := rows.Scan(&stored); err != nil {
+			return nil, err
+		}
+		emails = append(emails, stored)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return emails, nil
 }
 
 // ErrEvalOrderNotMintable means the eval order's persisted state changed (refund,

--- a/enterprise/licenseservice/eval_store.go
+++ b/enterprise/licenseservice/eval_store.go
@@ -260,6 +260,24 @@ func (e *EntitlementDB) CountActiveEvalForEmail(ctx context.Context, normalizedE
 	return count, nil
 }
 
+// CountActiveTrialForEmail returns the number of active, unexpired trial
+// entitlements for a normalized email. Used to enforce one active trial per
+// email at mint time, mirroring the Enterprise Eval rule. It bounds only
+// same-email repeats; a fresh email is a new trial by design, which is
+// acceptable because trials gate multi-agent coordination and never detection.
+func (e *EntitlementDB) CountActiveTrialForEmail(ctx context.Context, normalizedEmail string, now time.Time) (int, error) {
+	const query = `
+	SELECT COUNT(*) FROM entitlements
+	WHERE tier = ? AND status = ? AND customer_email = ? AND current_period_end > ?
+	`
+	var count int
+	err := e.db.QueryRowContext(ctx, query, tierTrial, statusActive, normalizedEmail, now.UTC()).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active trial for %s: %w", normalizedEmail, err)
+	}
+	return count, nil
+}
+
 // ErrEvalOrderNotMintable means the eval order's persisted state changed (refund,
 // revocation, or an existing mint) between validation and the mint transaction,
 // so minting must be refused.

--- a/enterprise/licenseservice/eval_store.go
+++ b/enterprise/licenseservice/eval_store.go
@@ -265,10 +265,12 @@ func (e *EntitlementDB) CountActiveEvalForEmail(ctx context.Context, normalizedE
 // email at mint time, mirroring the Enterprise Eval rule. It bounds only
 // same-email repeats; a fresh email is a new trial by design, which is
 // acceptable because trials gate multi-agent coordination and never detection.
+// The comparison folds the stored email's case so a legacy trial row persisted
+// before canonical storage still counts against its normalized form.
 func (e *EntitlementDB) CountActiveTrialForEmail(ctx context.Context, normalizedEmail string, now time.Time) (int, error) {
 	const query = `
 	SELECT COUNT(*) FROM entitlements
-	WHERE tier = ? AND status = ? AND customer_email = ? AND current_period_end > ?
+	WHERE tier = ? AND status = ? AND LOWER(customer_email) = ? AND current_period_end > ?
 	`
 	var count int
 	err := e.db.QueryRowContext(ctx, query, tierTrial, statusActive, normalizedEmail, now.UTC()).Scan(&count)

--- a/enterprise/licenseservice/normalize_test.go
+++ b/enterprise/licenseservice/normalize_test.go
@@ -15,6 +15,7 @@ func TestNormalizeEmail(t *testing.T) {
 		wantErr bool
 	}{
 		{"lowercases address and domain", "Buyer@Example.COM", "buyer@example.com", false},
+		{"lowercases non-ASCII local part", "ÜSER@Example.com", "üser@example.com", false},
 		{"trims surrounding whitespace", "  buyer@example.com  ", "buyer@example.com", false},
 		{"preserves plus tags", "buyer+eval@example.com", "buyer+eval@example.com", false},
 		{"preserves dots in local part", "first.last@example.com", "first.last@example.com", false},

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -951,25 +951,41 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 	}
 
 	// One active trial per normalized email, mirroring the Enterprise Eval
-	// rule. Checked only for a FIRST processing of this order: a webhook
-	// replay of an already-processed order must stay idempotent rather than
-	// tripping over the entitlement it created itself. Fail closed on a
-	// normalization or count error: never mint on an unverifiable state.
-	if tier == tierTrial && existing == nil {
+	// rule. The entitlement stores the NORMALIZED email (the eval precedent)
+	// so the count comparison and the stored identity share one canonical
+	// key; storing the raw order email would let a case variant of the same
+	// address bypass the check. The dedupe runs only for a FIRST processing
+	// of this order: a webhook replay of an already-processed order must
+	// stay idempotent rather than tripping over the entitlement it created
+	// itself. Fail closed on a normalization or count error: never mint on
+	// an unverifiable state. The count-then-write pair is serialized by
+	// processMu; the service runs as a single writer against its SQLite
+	// store, and a database-level constraint for multi-writer deployments is
+	// tracked separately.
+	customerEmail := order.Customer.Email
+	if tier == tierTrial {
 		email, err := NormalizeEmail(order.Customer.Email)
 		if err != nil {
 			return fmt.Errorf("normalize trial email for order %s: %w", order.ID, err)
 		}
-		active, err := h.db.CountActiveTrialForEmail(ctx, email, time.Now())
-		if err != nil {
-			return fmt.Errorf("count active trial for order %s: %w", order.ID, err)
-		}
-		if active > 0 {
-			_ = h.ledger.LogError(order.ID, "trial denied", fmt.Errorf("an active trial already exists for this email"))
-			h.log.Info().
-				Str("order_id", order.ID).
-				Msg("ignoring trial order: an active trial already exists for this email")
-			return nil
+		customerEmail = email
+		if existing == nil {
+			active, err := h.db.CountActiveTrialForEmail(ctx, email, time.Now())
+			if err != nil {
+				return fmt.Errorf("count active trial for order %s: %w", order.ID, err)
+			}
+			if active > 0 {
+				denial := fmt.Errorf("an active trial already exists for this email")
+				if lerr := h.ledger.LogError(order.ID, "trial denied", denial); lerr != nil {
+					h.log.Warn().Err(lerr).
+						Str("order_id", order.ID).
+						Msg("trial denial could not be recorded in the audit ledger")
+				}
+				h.log.Warn().
+					Str("order_id", order.ID).
+					Msg("trial order denied: an active trial already exists for this email")
+				return nil
+			}
 		}
 	}
 
@@ -982,7 +998,7 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 
 	ent := &Entitlement{
 		SubscriptionID:   order.ID, // Use order_id as unique key.
-		CustomerEmail:    order.Customer.Email,
+		CustomerEmail:    customerEmail,
 		ProductID:        order.Product.ID,
 		Tier:             tier,
 		BillingInterval:  billingIntervalOneTime,

--- a/enterprise/licenseservice/webhook.go
+++ b/enterprise/licenseservice/webhook.go
@@ -950,6 +950,29 @@ func (h *WebhookHandler) HandleOrderEvent(ctx context.Context, event *PolarWebho
 		return fmt.Errorf("load existing entitlement for order %s: %w", order.ID, err)
 	}
 
+	// One active trial per normalized email, mirroring the Enterprise Eval
+	// rule. Checked only for a FIRST processing of this order: a webhook
+	// replay of an already-processed order must stay idempotent rather than
+	// tripping over the entitlement it created itself. Fail closed on a
+	// normalization or count error: never mint on an unverifiable state.
+	if tier == tierTrial && existing == nil {
+		email, err := NormalizeEmail(order.Customer.Email)
+		if err != nil {
+			return fmt.Errorf("normalize trial email for order %s: %w", order.ID, err)
+		}
+		active, err := h.db.CountActiveTrialForEmail(ctx, email, time.Now())
+		if err != nil {
+			return fmt.Errorf("count active trial for order %s: %w", order.ID, err)
+		}
+		if active > 0 {
+			_ = h.ledger.LogError(order.ID, "trial denied", fmt.Errorf("an active trial already exists for this email"))
+			h.log.Info().
+				Str("order_id", order.ID).
+				Msg("ignoring trial order: an active trial already exists for this email")
+			return nil
+		}
+	}
+
 	var periodEnd time.Time
 	if existing != nil {
 		periodEnd = existing.CurrentPeriodEnd

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -110,6 +111,9 @@ func newTestSetup(t *testing.T) *testSetup {
 					}
 					if local == "gammaupper" {
 						email = "GAMMA@Example.com"
+					}
+					if local == "umlaut" {
+						email = "üser@example.com"
 					}
 				}
 				_, _ = fmt.Fprintf(w, `{
@@ -3203,8 +3207,8 @@ func TestHandleOrderEvent_TrialVariantEmailCannotDoubleDip(t *testing.T) {
 
 func TestHandleOrderEvent_TrialLegacyCaseVariantRowStillCounts(t *testing.T) {
 	// A trial entitlement persisted before canonical storage may hold a raw
-	// case-variant email. The active-trial count folds the stored email's case,
-	// so that legacy row still denies a new trial for the normalized form.
+	// case-variant email. The active-trial count canonicalizes stored emails
+	// in Go, so that legacy row still denies a new trial for the normalized form.
 	ts := newTestSetup(t)
 	ctx := t.Context()
 
@@ -3229,6 +3233,54 @@ func TestHandleOrderEvent_TrialLegacyCaseVariantRowStillCounts(t *testing.T) {
 	}
 	if ent != nil {
 		t.Fatalf("canonical trial minted past an active legacy case-variant row: %+v", ent)
+	}
+}
+
+func TestHandleOrderEvent_TrialLegacyNonASCIICaseVariantRowStillCounts(t *testing.T) {
+	// SQLite LOWER is ASCII-only. A legacy row stored as ÜSER@Example.com must
+	// still block üser@example.com; SQL LOWER would miss it and mint a second trial.
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	legacy := &Entitlement{
+		SubscriptionID:   "order_legacy_umlaut",
+		CustomerEmail:    "ÜSER@Example.com",
+		ProductID:        "prod_trial_free",
+		Tier:             tierTrial,
+		Status:           statusActive,
+		CurrentPeriodEnd: time.Now().Add(10 * 24 * time.Hour),
+	}
+	if err := ts.db.Upsert(ctx, legacy); err != nil {
+		t.Fatalf("seed legacy non-ASCII trial entitlement: %v", err)
+	}
+
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_10_umlaut", "üser@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent canonical trial after non-ASCII legacy row: %v", err)
+	}
+	ent, err := ts.db.GetBySubscriptionID(ctx, "order_free_10_umlaut")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if ent != nil {
+		t.Fatalf("canonical trial minted past an active legacy non-ASCII case-variant row: %+v", ent)
+	}
+}
+
+func TestHandleOrderEvent_TrialCountErrorFailsClosed(t *testing.T) {
+	ts := newTestSetup(t)
+	errForceCountActiveTrial = errors.New("forced count failure")
+	t.Cleanup(func() { errForceCountActiveTrial = nil })
+
+	err := ts.handler.HandleOrderEvent(t.Context(), zeroTrialOrderEvent(t, "order_free_12_epsilon", "epsilon@example.com"))
+	if err == nil || !strings.Contains(err.Error(), "count active trial") {
+		t.Fatalf("expected count active trial failure, got %v", err)
+	}
+	ent, dbErr := ts.db.GetBySubscriptionID(t.Context(), "order_free_12_epsilon")
+	if dbErr != nil {
+		t.Fatalf("GetBySubscriptionID: %v", dbErr)
+	}
+	if ent != nil {
+		t.Fatalf("trial minted after a count error: %+v", ent)
 	}
 }
 

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -3201,6 +3201,37 @@ func TestHandleOrderEvent_TrialVariantEmailCannotDoubleDip(t *testing.T) {
 	}
 }
 
+func TestHandleOrderEvent_TrialLegacyCaseVariantRowStillCounts(t *testing.T) {
+	// A trial entitlement persisted before canonical storage may hold a raw
+	// case-variant email. The active-trial count folds the stored email's case,
+	// so that legacy row still denies a new trial for the normalized form.
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	legacy := &Entitlement{
+		SubscriptionID:   "order_legacy_delta",
+		CustomerEmail:    "DELTA@Example.com",
+		ProductID:        "prod_trial_free",
+		Tier:             tierTrial,
+		Status:           statusActive,
+		CurrentPeriodEnd: time.Now().Add(10 * 24 * time.Hour),
+	}
+	if err := ts.db.Upsert(ctx, legacy); err != nil {
+		t.Fatalf("seed legacy trial entitlement: %v", err)
+	}
+
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_7_delta", "delta@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent canonical trial after legacy row: %v", err)
+	}
+	ent, err := ts.db.GetBySubscriptionID(ctx, "order_free_7_delta")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if ent != nil {
+		t.Fatalf("canonical trial minted past an active legacy case-variant row: %+v", ent)
+	}
+}
+
 func TestHandleOrderEvent_TrialUnnormalizableEmailFailsClosed(t *testing.T) {
 	ts := newTestSetup(t)
 	err := ts.handler.HandleOrderEvent(t.Context(), zeroTrialOrderEvent(t, "order_free_9_bademail", "not-an-email"))

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -95,6 +95,26 @@ func newTestSetup(t *testing.T) *testSetup {
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/v1/orders/") {
 			orderID := strings.TrimPrefix(r.URL.Path, "/v1/orders/")
+			// Zero-amount trial orders: order_free_<n>_<email-local-part>
+			// maps to the prod_trial_free product so tests can vary the
+			// customer email per order and exercise the per-email dedupe.
+			if rest, ok := strings.CutPrefix(orderID, "order_free_"); ok {
+				email := testCustomerEmail
+				if _, local, found := strings.Cut(rest, "_"); found {
+					email = local + "@example.com"
+				}
+				_, _ = fmt.Fprintf(w, `{
+					"id": %q,
+					"billing_reason": "purchase",
+					"status": "paid",
+					"paid": true,
+					"net_amount": 0,
+					"currency": "usd",
+					"customer": {"email": %q, "metadata": {}},
+					"product": {"id": "prod_trial_free", "name": "Pipelock Pro Trial", "metadata": {"pipelock_tier": "trial"}}
+				}`, orderID, email)
+				return
+			}
 			productID, tier := "prod_trial", tierTrial
 			org := "testcorp"
 			if orderID == "order_trial_123" {
@@ -155,6 +175,7 @@ func newTestSetup(t *testing.T) *testSetup {
 		OrderProducts: []OrderProductConfig{
 			{ProductID: "prod_trial", Tier: tierTrial, AmountCents: 100, Currency: "usd"},
 			{ProductID: "prod_trial_test", Tier: tierTrial, AmountCents: 100, Currency: "usd"},
+			{ProductID: "prod_trial_free", Tier: tierTrial, AmountCents: 0, Currency: "usd"},
 		},
 	}
 
@@ -3004,5 +3025,81 @@ func TestHandleOrderEvent_ReplayIsIdempotent(t *testing.T) {
 	}
 	if !ent2.CurrentPeriodEnd.Equal(firstPeriodEnd) {
 		t.Errorf("replay changed period end: got %v, want %v (stable)", ent2.CurrentPeriodEnd, firstPeriodEnd)
+	}
+}
+
+// zeroTrialOrderEvent builds an order.created event for the zero-amount trial
+// product with the given order ID and customer email.
+func zeroTrialOrderEvent(t *testing.T, orderID, email string) *PolarWebhookEvent {
+	t.Helper()
+	orderData, err := json.Marshal(map[string]interface{}{
+		"id":             orderID,
+		"billing_reason": "purchase",
+		"status":         "paid",
+		"paid":           true,
+		"net_amount":     0,
+		"currency":       "usd",
+		"customer": map[string]interface{}{
+			"email":    email,
+			"metadata": map[string]string{},
+		},
+		"product": map[string]interface{}{
+			"id":       "prod_trial_free",
+			"name":     "Pipelock Pro Trial",
+			"metadata": map[string]string{"pipelock_tier": "trial"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal order data: %v", err)
+	}
+	return &PolarWebhookEvent{Type: EventOrderCreated, Data: json.RawMessage(orderData)}
+}
+
+func TestHandleOrderEvent_ZeroAmountTrialMintsOncePerEmail(t *testing.T) {
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	// First zero-amount trial order mints.
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_1_alpha", "alpha@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent first trial: %v", err)
+	}
+	ent, err := ts.db.GetBySubscriptionID(ctx, "order_free_1_alpha")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if ent == nil || ent.Tier != tierTrial || ent.LastLicenseID == "" {
+		t.Fatalf("first zero-amount trial did not mint: %+v", ent)
+	}
+
+	// A webhook replay of the SAME order stays idempotent: no error, no
+	// second entitlement, and the per-email dedupe must not trip on the
+	// entitlement this order created itself.
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_1_alpha", "alpha@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent replay: %v", err)
+	}
+
+	// A SECOND order for the same email is refused: acknowledged without a
+	// mint, so webhook retries stop, but no new entitlement appears.
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_2_alpha", "alpha@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent duplicate-email trial: %v", err)
+	}
+	dup, err := ts.db.GetBySubscriptionID(ctx, "order_free_2_alpha")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID duplicate: %v", err)
+	}
+	if dup != nil {
+		t.Fatalf("second trial for the same email minted an entitlement: %+v", dup)
+	}
+
+	// A different email still mints normally.
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_3_beta", "beta@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent second email: %v", err)
+	}
+	other, err := ts.db.GetBySubscriptionID(ctx, "order_free_3_beta")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID other: %v", err)
+	}
+	if other == nil || other.LastLicenseID == "" {
+		t.Fatalf("trial for a different email did not mint: %+v", other)
 	}
 }

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -105,6 +105,12 @@ func newTestSetup(t *testing.T) *testSetup {
 					if local == "bademail" {
 						email = "not-an-email"
 					}
+					if local == "alphaupper" {
+						email = "ALPHA@Example.com"
+					}
+					if local == "gammaupper" {
+						email = "GAMMA@Example.com"
+					}
 				}
 				_, _ = fmt.Fprintf(w, `{
 					"id": %q,
@@ -3075,10 +3081,26 @@ func TestHandleOrderEvent_ZeroAmountTrialMintsOncePerEmail(t *testing.T) {
 	}
 
 	// A webhook replay of the SAME order stays idempotent: no error, no
-	// second entitlement, and the per-email dedupe must not trip on the
-	// entitlement this order created itself.
+	// second entitlement, no new license, and no state drift. The per-email
+	// dedupe must not trip on the entitlement this order created itself.
 	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_1_alpha", "alpha@example.com")); err != nil {
 		t.Fatalf("HandleOrderEvent replay: %v", err)
+	}
+	replayed, err := ts.db.GetBySubscriptionID(ctx, "order_free_1_alpha")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID after replay: %v", err)
+	}
+	if replayed == nil {
+		t.Fatal("entitlement vanished after replay")
+	}
+	if replayed.LastLicenseID != ent.LastLicenseID {
+		t.Fatalf("replay minted a new license: %q -> %q", ent.LastLicenseID, replayed.LastLicenseID)
+	}
+	if replayed.LastDeliveryStatus != ent.LastDeliveryStatus {
+		t.Fatalf("replay changed delivery status: %q -> %q", ent.LastDeliveryStatus, replayed.LastDeliveryStatus)
+	}
+	if ent.LastLicenseExpiresAt == nil || replayed.LastLicenseExpiresAt == nil || !replayed.LastLicenseExpiresAt.Equal(*ent.LastLicenseExpiresAt) {
+		t.Fatalf("replay changed license expiry: %v -> %v", ent.LastLicenseExpiresAt, replayed.LastLicenseExpiresAt)
 	}
 
 	// A SECOND order for the same email is refused: acknowledged without a
@@ -3094,6 +3116,19 @@ func TestHandleOrderEvent_ZeroAmountTrialMintsOncePerEmail(t *testing.T) {
 		t.Fatalf("second trial for the same email minted an entitlement: %+v", dup)
 	}
 
+	// A case variant of the same email is also refused: the entitlement
+	// stores the normalized email, so the canonical keys collide.
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_4_alphaupper", "ALPHA@Example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent variant-email trial: %v", err)
+	}
+	variant, err := ts.db.GetBySubscriptionID(ctx, "order_free_4_alphaupper")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID variant: %v", err)
+	}
+	if variant != nil {
+		t.Fatalf("case-variant email minted a second trial: %+v", variant)
+	}
+
 	// A different email still mints normally.
 	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_3_beta", "beta@example.com")); err != nil {
 		t.Fatalf("HandleOrderEvent second email: %v", err)
@@ -3104,6 +3139,65 @@ func TestHandleOrderEvent_ZeroAmountTrialMintsOncePerEmail(t *testing.T) {
 	}
 	if other == nil || other.LastLicenseID == "" {
 		t.Fatalf("trial for a different email did not mint: %+v", other)
+	}
+}
+
+func TestHandleOrderEvent_TrialDenialSurvivesAuditLedgerFailure(t *testing.T) {
+	// A duplicate trial is still acknowledged without a mint when the audit
+	// ledger cannot record the denial; the failure is surfaced in the
+	// structured log instead of aborting webhook handling.
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_7_delta", "delta@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent first trial: %v", err)
+	}
+	if err := ts.handler.ledger.Close(); err != nil {
+		t.Fatalf("close ledger: %v", err)
+	}
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_8_delta", "delta@example.com")); err != nil {
+		t.Fatalf("duplicate trial with a failed ledger must still acknowledge: %v", err)
+	}
+	dup, err := ts.db.GetBySubscriptionID(ctx, "order_free_8_delta")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID: %v", err)
+	}
+	if dup != nil {
+		t.Fatalf("duplicate trial minted despite denial: %+v", dup)
+	}
+}
+
+func TestHandleOrderEvent_TrialVariantEmailCannotDoubleDip(t *testing.T) {
+	// The FIRST order arrives with a non-canonical email form. If the
+	// entitlement stored the raw order email, a later canonical-form order
+	// would not match the count query and would mint a second trial. Storing
+	// the normalized email closes that variant bypass.
+	ts := newTestSetup(t)
+	ctx := t.Context()
+
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_5_gammaupper", "GAMMA@Example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent uppercase first trial: %v", err)
+	}
+	first, err := ts.db.GetBySubscriptionID(ctx, "order_free_5_gammaupper")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID first: %v", err)
+	}
+	if first == nil || first.LastLicenseID == "" {
+		t.Fatalf("uppercase-email trial did not mint: %+v", first)
+	}
+	if first.CustomerEmail != "gamma@example.com" {
+		t.Fatalf("entitlement stored a non-canonical email: %q", first.CustomerEmail)
+	}
+
+	if err := ts.handler.HandleOrderEvent(ctx, zeroTrialOrderEvent(t, "order_free_6_gamma", "gamma@example.com")); err != nil {
+		t.Fatalf("HandleOrderEvent canonical second trial: %v", err)
+	}
+	second, err := ts.db.GetBySubscriptionID(ctx, "order_free_6_gamma")
+	if err != nil {
+		t.Fatalf("GetBySubscriptionID second: %v", err)
+	}
+	if second != nil {
+		t.Fatalf("canonical-form order double-dipped past an uppercase first trial: %+v", second)
 	}
 }
 

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -102,6 +102,9 @@ func newTestSetup(t *testing.T) *testSetup {
 				email := testCustomerEmail
 				if _, local, found := strings.Cut(rest, "_"); found {
 					email = local + "@example.com"
+					if local == "bademail" {
+						email = "not-an-email"
+					}
 				}
 				_, _ = fmt.Fprintf(w, `{
 					"id": %q,
@@ -3101,5 +3104,20 @@ func TestHandleOrderEvent_ZeroAmountTrialMintsOncePerEmail(t *testing.T) {
 	}
 	if other == nil || other.LastLicenseID == "" {
 		t.Fatalf("trial for a different email did not mint: %+v", other)
+	}
+}
+
+func TestHandleOrderEvent_TrialUnnormalizableEmailFailsClosed(t *testing.T) {
+	ts := newTestSetup(t)
+	err := ts.handler.HandleOrderEvent(t.Context(), zeroTrialOrderEvent(t, "order_free_9_bademail", "not-an-email"))
+	if err == nil || !strings.Contains(err.Error(), "normalize trial email") {
+		t.Fatalf("expected a normalize failure, got %v", err)
+	}
+	ent, dbErr := ts.db.GetBySubscriptionID(t.Context(), "order_free_9_bademail")
+	if dbErr != nil {
+		t.Fatalf("GetBySubscriptionID: %v", dbErr)
+	}
+	if ent != nil {
+		t.Fatalf("trial with an unnormalizable email must not mint: %+v", ent)
 	}
 }


### PR DESCRIPTION
## What changed

- Enables the already-shipped trial fulfillment path for a zero-amount product: ORDER_PRODUCTS now accepts amount_cents 0 for the trial tier (negative stays rejected, and the tier allowlist still restricts one-time products to trials), and minting enforces one active trial per normalized email, mirroring the Enterprise Eval rule.
- This touches an authorization boundary, so the failure directions are stated for review: the order path keeps every existing gate (server-side re-fetch from the payment provider, paid-status, product, tier, price, and currency pinning), an unnormalizable email fails closed before minting, a same-email repeat is acknowledged without a mint, and webhook replays of an already-processed order stay idempotent. Reviewers should distrust any path where a webhook body rather than the re-fetched order supplies an authorization fact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zero-amount trial products are now supported.
  * Trial licenses are limited to one active trial per normalized email address.
  * Email matching is case-insensitive and supports non-ASCII characters.
  * Replayed orders remain safely idempotent.

* **Bug Fixes**
  * Negative-value trial products continue to be rejected.
  * Trial issuance fails safely when email validation or eligibility checks encounter errors.
  * Improved handling of legacy email formats when evaluating trial eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->