### PR TITLE
fix(shield): name the cap and every remedy on an oversize block

### DIFF
--- a/docs/guides/receipt-transports.md
+++ b/docs/guides/receipt-transports.md
@@ -9,7 +9,7 @@ Pipelock emits Ed25519-signed action receipts for enforcement decisions across p
 | `fetch` | URL block | scanner layer name | URL scan finding in enforce or escalated audit mode |
 | `fetch` | Redirect block | `redirect` | Cross-origin redirect blocked |
 | `fetch` | Response size | `response_size` or `budget` | Response exceeds config limit or byte budget |
-| `fetch` | Shield oversize | `shield_oversize` | Response exceeds browser shield size limit |
+| `fetch` | Shield oversize | `shield_oversize` | Shieldable response exceeded `browser_shield.max_shield_bytes`; pattern names the host, size, and remedies |
 | `fetch` | Media policy | `media_policy` | Blocked media type |
 | `fetch` | Response scan | `response_scan` | Prompt injection detected in response content |
 | `fetch` | Header DLP | `dlp_header` | Secret found in request headers |

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2505,6 +2505,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Browser Shield on forward proxy responses. Use post-redirect host
 		// so exempt_domains checks match the actual response origin.
+		shieldBodyLen := len(respBody)
 		var shieldBlocked bool
 		var shieldSummary *receipt.ShieldSummary
 		respBody, shieldSummary, shieldBlocked = p.applyShield(respBody, resp.Header.Get("Content-Type"), fwdRespHost, resp.Header, cfg, actx, clientIP, requestID, TransportForward, actionID)
@@ -2512,7 +2513,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			p.metrics.RecordBlocked(fwdRespHost, "shield_oversize", time.Since(start), agentLabel)
 			writeBlockedError(w,
 				blockInfoFor(blockreason.BrowserShieldOversize, "shield_oversize"),
-				"blocked: response body exceeds browser shield size limit", http.StatusForbidden)
+				"blocked: "+shieldOversizeBlockReason(fwdRespHost, shieldBodyLen, cfg.BrowserShield.MaxShieldBytes), http.StatusForbidden)
 			outcomeStatus = strconv.Itoa(http.StatusForbidden)
 			outcomeBytes = int64(len(respBody))
 			outcomeReason = "shield_oversize"

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -2035,6 +2035,7 @@ func newInterceptHandler(
 
 		// Browser Shield on intercepted response body.
 		if ic.Proxy != nil {
+			shieldBodyLen := len(respBody)
 			var shieldBlocked bool
 			var shieldSummary *receipt.ShieldSummary
 			respBody, shieldSummary, shieldBlocked = ic.Proxy.applyShield(respBody, resp.Header.Get("Content-Type"), ic.TargetHost, resp.Header, ic.Config, actx, ic.ClientIP, ic.RequestID, TransportConnect, actionID)
@@ -2042,7 +2043,7 @@ func newInterceptHandler(
 				ic.Metrics.RecordTLSResponseBlocked("shield_oversize")
 				writeBlockedError(w,
 					blockInfoFor(blockreason.BrowserShieldOversize, "shield_oversize"),
-					"blocked: response body exceeds browser shield size limit", http.StatusForbidden)
+					"blocked: "+shieldOversizeBlockReason(ic.TargetHost, shieldBodyLen, ic.Config.BrowserShield.MaxShieldBytes), http.StatusForbidden)
 				emitBlockedPostRoundTripOutcome(http.StatusForbidden, "shield_oversize")
 				return
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5337,14 +5337,16 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 	// Use the final response origin (after redirects), not the original request
 	// URL. An exempt origin that 302s to a non-exempt host must still be shielded.
 	shieldHost := resp.Request.URL.Hostname()
+	shieldBodyLen := len(body)
 	body, _, shieldBlocked := p.applyShield(body, contentType, shieldHost, resp.Header, cfg, actx, clientIP, requestID, TransportFetch, actionID)
 	if shieldBlocked {
+		reason := shieldOversizeBlockReason(shieldHost, shieldBodyLen, cfg.BrowserShield.MaxShieldBytes)
 		p.metrics.RecordBlocked(parsed.Hostname(), "shield_oversize", time.Since(start), agentLabel)
 		emitFetchReceipt(receipt.EmitOpts{
 			ActionID:  actionID,
 			Verdict:   config.ActionBlock,
 			Layer:     "shield_oversize",
-			Pattern:   "response body exceeds browser shield size limit",
+			Pattern:   reason,
 			Transport: "fetch",
 			Method:    http.MethodGet,
 			Target:    displayURL,
@@ -5355,7 +5357,7 @@ func (p *Proxy) handleFetch(w http.ResponseWriter, r *http.Request) {
 			blockInfoFor(blockreason.BrowserShieldOversize, "shield_oversize"),
 			http.StatusForbidden, FetchResponse{
 				URL: displayURL, Agent: agent, Blocked: true,
-				BlockReason: "response body exceeds browser shield size limit",
+				BlockReason: reason,
 			})
 		outcomeStatus = strconv.Itoa(http.StatusForbidden)
 		outcomeBytes = int64(len(body))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -3214,7 +3214,7 @@ func (p *Proxy) applyShield(body []byte, contentType, hostname string, respHeade
 			p.logger.LogAnomaly(actx, "shield_oversize", fmt.Sprintf("response body %d bytes exceeds max_shield_bytes %d", len(body), cfg.BrowserShield.MaxShieldBytes), 0)
 			return body, nil, false
 		default: // block: fail-closed, return 403
-			p.logger.LogBlocked(actx, "shield_oversize", fmt.Sprintf("response body %d bytes exceeds max_shield_bytes %d (action: block)", len(body), cfg.BrowserShield.MaxShieldBytes))
+			p.logger.LogBlocked(actx, "shield_oversize", shieldOversizeBlockReason(hostname, len(body), cfg.BrowserShield.MaxShieldBytes))
 			return nil, nil, true
 		}
 	}

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -1627,6 +1627,117 @@ func TestProxy_ReceiptEmission_PostFetchResponseSize(t *testing.T) {
 	}
 }
 
+// TestProxy_ReceiptEmission_PostFetchShieldOversize keeps the user-visible
+// fetch error and the signed receipt pattern aligned with the browser-shield
+// decision that produced them.
+func TestProxy_ReceiptEmission_PostFetchShieldOversize(t *testing.T) {
+	t.Parallel()
+
+	body := "<html>" + strings.Repeat("x", 64) + "</html>"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "test-hash",
+		Principal:  "test",
+		Actor:      "test",
+	})
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.DLP.Patterns = nil
+	cfg.ResponseScanning.Enabled = false
+	cfg.BrowserShield.Enabled = true
+	cfg.BrowserShield.MaxShieldBytes = 16
+	cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	p, err := New(cfg, logger, sc, metrics.New(),
+		WithRecorder(rec),
+		WithReceiptEmitter(emitter),
+	)
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	wantReason := shieldOversizeBlockReason(upstreamURL.Hostname(), len(body), cfg.BrowserShield.MaxShieldBytes)
+
+	handler := p.buildHandler(p.buildMux())
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+upstream.URL+"/oversize", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fetch response: %v", err)
+	}
+	if resp.BlockReason != wantReason {
+		t.Errorf("fetch block reason = %q, want %q", resp.BlockReason, wantReason)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var found bool
+	for _, entry := range readAllEntries(t, dir) {
+		if entry.Type != receiptEntryType {
+			continue
+		}
+		detailJSON, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("marshal receipt detail: %v", err)
+		}
+		recorded, err := receipt.Unmarshal(detailJSON)
+		if err != nil {
+			t.Fatalf("unmarshal receipt: %v", err)
+		}
+		if recorded.ActionRecord.Verdict == actionBlock && recorded.ActionRecord.Layer == "shield_oversize" {
+			found = true
+			if recorded.ActionRecord.Pattern != wantReason {
+				t.Errorf("receipt pattern = %q, want %q", recorded.ActionRecord.Pattern, wantReason)
+			}
+			if err := receipt.VerifyInternalConsistencyOnly(recorded); err != nil {
+				t.Fatalf("receipt verification failed: %v", err)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no block receipt with layer=shield_oversize found")
+	}
+}
+
 // TestProxy_ReceiptEmission_ForwardResponseSize verifies that the forward
 // proxy's fail-closed response-size block emits a terminal receipt.
 func TestProxy_ReceiptEmission_ForwardResponseSize(t *testing.T) {

--- a/internal/proxy/response_size.go
+++ b/internal/proxy/response_size.go
@@ -33,3 +33,22 @@ func responseSizeExemptScanBlockReason(host string, size, limit int64) string {
 	}
 	return fmt.Sprintf("size-exempt response from %s is %d bytes, exceeding bounded scan ceiling %d bytes; raise response_scanning.size_exempt_scan_max_bytes or configure response_scanning.unscannable_passthrough for deliberately unscannable opaque content", host, size, limit)
 }
+
+// shieldOversizeBlockReason explains a browser-shield oversize block the way
+// responseSizeBlockReason explains a scan-ceiling block: the host, the size,
+// the cap that fired, and every knob that changes the outcome. A bare "exceeds
+// browser shield size limit" sent operators hunting through the config for a
+// knob the message never named; legal texts and long specs trip this cap
+// routinely, so the block page has to carry its own remediation.
+func shieldOversizeBlockReason(host string, size, limit int) string {
+	if host == "" {
+		host = "unknown-host"
+	}
+	return fmt.Sprintf(
+		"response from %s is %d bytes, exceeding browser_shield.max_shield_bytes %d; "+
+			"raise browser_shield.max_shield_bytes, set browser_shield.oversize_action to scan_head "+
+			"(shields the first max_shield_bytes and passes the rest unshielded), "+
+			"or add the trusted host to browser_shield.exempt_domains",
+		host, size, limit,
+	)
+}

--- a/internal/proxy/shield_oversize_forward_test.go
+++ b/internal/proxy/shield_oversize_forward_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// The shield oversize reason is emitted by three callers: the fetch handler,
+// the absolute-URI forward path, and CONNECT interception. The fetch caller has
+// its own receipt test; this covers the forward path, which can regress
+// independently because it computes the body length and hostname itself.
+func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T) {
+	t.Parallel()
+
+	body := "<html>" + strings.Repeat("x", 256) + "</html>"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	emitter := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder:   rec,
+		PrivKey:    priv,
+		ConfigHash: "test-hash",
+		Principal:  "test",
+		Actor:      "test",
+	})
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.DLP.Patterns = nil
+	cfg.ResponseScanning.Enabled = false
+	cfg.BrowserShield.Enabled = true
+	cfg.BrowserShield.MaxShieldBytes = 16
+	cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+	cfg.ForwardProxy.Enabled = true
+	// The forward path records its evidence through the deferred outcome
+	// receipt, which only emits when receipts are required. The fetch path
+	// emits its block receipt unconditionally; that asymmetry is pre-existing
+	// and is noted as adjacent work, not changed here.
+	cfg.FlightRecorder.RequireReceipts = true
+	cfg.ApplyDefaults()
+
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New(), WithRecorder(rec), WithReceiptEmitter(emitter))
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	wantReason := shieldOversizeBlockReason(upstreamURL.Hostname(), len(body), cfg.BrowserShield.MaxShieldBytes)
+
+	proxySrv := newIPv4Server(t, p.buildHandler(p.buildMux()))
+	t.Cleanup(proxySrv.Close)
+
+	proxyURL, err := url.Parse(proxySrv.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		Timeout:   10 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL+"/oversize", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("forward request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 on the forward path, got %d", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(respBody), "xxxxxxxxxxxxxxxx") {
+		t.Fatal("forward block leaked the unshielded upstream body")
+	}
+	// Same explaining reason the fetch path returns: host, size, cap, remedies.
+	if !strings.Contains(string(respBody), wantReason) {
+		t.Errorf("forward block body = %s, want it to contain %q", respBody, wantReason)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	var found bool
+	for _, entry := range readAllEntries(t, dir) {
+		if entry.Type != receiptEntryType {
+			continue
+		}
+		detailJSON, err := json.Marshal(entry.Detail)
+		if err != nil {
+			t.Fatalf("marshal receipt detail: %v", err)
+		}
+		recorded, err := receipt.Unmarshal(detailJSON)
+		if err != nil {
+			t.Fatalf("unmarshal receipt: %v", err)
+		}
+		// The forward transport records a terminal OUTCOME receipt naming the
+		// reason, rather than the fetch path's block receipt. Assert the
+		// evidence this transport actually produces.
+		if strings.Contains(recorded.ActionRecord.Pattern, "shield_oversize") {
+			found = true
+			if err := receipt.VerifyInternalConsistencyOnly(recorded); err != nil {
+				t.Fatalf("receipt verification failed: %v", err)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("forward path emitted no receipt naming shield_oversize")
+	}
+}

--- a/internal/proxy/shield_oversize_forward_test.go
+++ b/internal/proxy/shield_oversize_forward_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -84,6 +85,7 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 		t.Fatalf("parse upstream URL: %v", err)
 	}
 	wantReason := shieldOversizeBlockReason(upstreamURL.Hostname(), len(body), cfg.BrowserShield.MaxShieldBytes)
+	wantOutcomePattern := receiptOutcomePattern(strconv.Itoa(http.StatusForbidden), 0, "shield_oversize")
 
 	proxySrv := newIPv4Server(t, p.buildHandler(p.buildMux()))
 	t.Cleanup(proxySrv.Close)
@@ -135,10 +137,17 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 		if err != nil {
 			t.Fatalf("unmarshal receipt: %v", err)
 		}
-		// The forward transport records a terminal OUTCOME receipt naming the
-		// reason, rather than the fetch path's block receipt. Assert the
-		// evidence this transport actually produces.
-		if strings.Contains(recorded.ActionRecord.Pattern, "shield_oversize") {
+		// The forward transport records a terminal OUTCOME receipt rather than
+		// the fetch path's block receipt, so match its exact composed pattern.
+		// A substring match on "shield_oversize" alone would pass on any
+		// receipt that merely mentions the layer, which proves nothing.
+		//
+		// Note what this pins down: the outcome receipt carries the SHORT
+		// reason only. The detailed text naming the cap and its remedies goes
+		// to the client but never into the evidence chain, so an auditor
+		// reading receipts cannot see which limit fired. Recorded as adjacent
+		// work rather than widened into this change.
+		if recorded.ActionRecord.Pattern == wantOutcomePattern {
 			found = true
 			if err := receipt.VerifyInternalConsistencyOnly(recorded); err != nil {
 				t.Fatalf("receipt verification failed: %v", err)
@@ -146,6 +155,6 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 		}
 	}
 	if !found {
-		t.Fatal("forward path emitted no receipt naming shield_oversize")
+		t.Fatalf("forward path emitted no outcome receipt with pattern %q", wantOutcomePattern)
 	}
 }

--- a/internal/proxy/shield_oversize_forward_test.go
+++ b/internal/proxy/shield_oversize_forward_test.go
@@ -4,9 +4,11 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,7 +42,7 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 	defer upstream.Close()
 
 	dir := t.TempDir()
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
 	}
@@ -125,6 +127,7 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 	}
 
 	var found bool
+	trustedKey := hex.EncodeToString(pub)
 	for _, entry := range readAllEntries(t, dir) {
 		if entry.Type != receiptEntryType {
 			continue
@@ -148,10 +151,17 @@ func TestForwardProxy_ShieldOversize_BlocksWithTheExplainingReason(t *testing.T)
 		// reading receipts cannot see which limit fired. Recorded as adjacent
 		// work rather than widened into this change.
 		if recorded.ActionRecord.Pattern == wantOutcomePattern {
-			found = true
-			if err := receipt.VerifyInternalConsistencyOnly(recorded); err != nil {
-				t.Fatalf("receipt verification failed: %v", err)
+			if err := receipt.VerifyV1BytesWithKey(entry.RawDetail, trustedKey); err != nil {
+				t.Fatalf("receipt authenticity verification failed: %v", err)
 			}
+			tampered := bytes.Replace(entry.RawDetail, []byte(upstreamURL.Hostname()), []byte("tampered.example"), 1)
+			if bytes.Equal(tampered, entry.RawDetail) {
+				t.Fatal("receipt fixture does not contain the upstream host needed for the tamper check")
+			}
+			if err := receipt.VerifyV1BytesWithKey(tampered, trustedKey); err == nil {
+				t.Fatal("receipt authenticity verification accepted a modified target")
+			}
+			found = true
 		}
 	}
 	if !found {

--- a/internal/proxy/shield_oversize_reason_test.go
+++ b/internal/proxy/shield_oversize_reason_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// The shield oversize block page used to say only "exceeds browser shield size
+// limit", naming neither the cap nor a knob. Operators hitting it on legal
+// texts and long specs could not tell which of two 5 MiB ceilings fired or
+// what would let the page through. The message now carries the host, the
+// size, the cap, and every remedy, mirroring responseSizeBlockReason.
+func TestShieldOversizeBlockReason_NamesCapAndEveryRemedy(t *testing.T) {
+	t.Parallel()
+
+	got := shieldOversizeBlockReason("law.example", 7_340_032, 5*1024*1024)
+	for _, want := range []string{
+		"law.example",
+		"7340032 bytes",
+		"browser_shield.max_shield_bytes 5242880",
+		"raise browser_shield.max_shield_bytes",
+		"browser_shield.oversize_action to scan_head",
+		"browser_shield.exempt_domains",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reason %q missing %q", got, want)
+		}
+	}
+}
+
+func TestShieldOversizeBlockReason_UnknownHost(t *testing.T) {
+	t.Parallel()
+
+	got := shieldOversizeBlockReason("", 10, 5)
+	if !strings.HasPrefix(got, "response from unknown-host is 10 bytes") {
+		t.Fatalf("unexpected reason: %q", got)
+	}
+}


### PR DESCRIPTION
## What changed

A browser-shield oversize block now names the host, the byte size, the cap it exceeded, and every knob that changes the outcome, on all four surfaces that report it: the forward proxy, CONNECT interception, fetch, and the audit line. It previously returned "blocked: response body exceeds browser shield size limit", which named neither the cap nor a remedy, so an operator hitting it on a long document could not tell which of two 5 MiB ceilings had fired or what to change.

This is a diagnostic change only. No allow or deny path moves, and the scan_head and warn branches are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser Shield oversize blocks now identify the affected host, response size, and configured limit.
  * Added remediation guidance, including increasing the limit, switching scan modes, or exempting the host.
  * Oversize details are consistent across fetch responses and signed receipts.
  * Unknown hosts are clearly identified when host information is unavailable.

* **Documentation**
  * Updated receipt documentation to describe enhanced oversize event details and receipt patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->