### PR TITLE
fix(replay): give every blocked scene its payload shape

### DIFF
--- a/internal/playground/scenario_internal_test.go
+++ b/internal/playground/scenario_internal_test.go
@@ -107,6 +107,10 @@ func TestLookupPlaygroundScenario(t *testing.T) {
 	if scenario.ID != LiveDemoScenarioID {
 		t.Fatalf("scenario ID = %q", scenario.ID)
 	}
+	const wantShape = "AKIA••••••••••EXAMPLE → exfiltrated"
+	if scenario.RedactedShape != wantShape {
+		t.Fatalf("redacted shape = %q, want %q", scenario.RedactedShape, wantShape)
+	}
 
 	if _, ok := lookupPlaygroundScenario("missing-playground-scenario"); ok {
 		t.Fatal("unexpected scenario match")

--- a/internal/playground/scenario_lookup.go
+++ b/internal/playground/scenario_lookup.go
@@ -19,7 +19,7 @@ func liveDemoScenario() replaycapture.Scenario {
 		DestinationClass: "attacker-controlled collector (reserved example host)",
 		Without:          "A bare agent posts a credential-shaped value to a collector and the value escapes.",
 		With:             "Pipelock scans the request body, detects the credential-shaped value, blocks the request, and signs a receipt recording the block.",
-		RedactedShape:    "AKIA••••••••••EXAMPLE → exfiltrated",
+		RedactedShape:    replaycapture.RedactedAWSShape + " → exfiltrated",
 	}
 }
 

--- a/internal/playground/scenario_lookup.go
+++ b/internal/playground/scenario_lookup.go
@@ -19,7 +19,7 @@ func liveDemoScenario() replaycapture.Scenario {
 		DestinationClass: "attacker-controlled collector (reserved example host)",
 		Without:          "A bare agent posts a credential-shaped value to a collector and the value escapes.",
 		With:             "Pipelock scans the request body, detects the credential-shaped value, blocks the request, and signs a receipt recording the block.",
-		RedactedShape:    "AKIA************EXAMPLE -> blocked",
+		RedactedShape:    "AKIA••••••••••EXAMPLE → exfiltrated",
 	}
 }
 

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -71,6 +71,12 @@ func TestDefaultScenarios_PublicContract(t *testing.T) {
 		if s.ExpectedLayer != w.layer {
 			t.Errorf("%s layer = %q, want %q", s.ID, s.ExpectedLayer, w.layer)
 		}
+		if s.ExpectedVerdict == verdictBlock && s.RedactedShape == "" {
+			t.Errorf("%s blocked scenario missing redacted shape", s.ID)
+		}
+		if s.ExpectedVerdict == verdictAllow && s.RedactedShape != "" {
+			t.Errorf("%s allowed scenario unexpectedly has redacted shape %q", s.ID, s.RedactedShape)
+		}
 	}
 }
 

--- a/internal/replaycapture/capture_test.go
+++ b/internal/replaycapture/capture_test.go
@@ -38,19 +38,20 @@ func TestDefaultScenarios_PublicContract(t *testing.T) {
 		transport string
 		verdict   string
 		layer     string
+		shape     string
 	}{
-		{"allowed-safe-read", TransportFetch, verdictAllow, ""},
-		{"secret-exfil-url-blocked", TransportFetch, verdictBlock, "core_dlp"},
-		{"prompt-injection-response-blocked", TransportFetch, verdictBlock, "response_scan"},
-		{"ssrf-internal-target-blocked", TransportFetch, verdictBlock, "ssrf_metadata"},
-		{"operation-aware-policy", TransportForward, verdictBlock, "request_policy"},
-		{"poisoned-ticket-webhook-exfil", TransportForward, verdictBlock, "body_dlp"},
-		{"poisoned-readme-key-paste", TransportForward, verdictBlock, "body_dlp"},
-		{"hostile-page-session-keys", TransportForward, verdictBlock, "body_dlp"},
-		{"amber-warning-observed", TransportForward, verdictWarn, "body_dlp"},
-		{"websocket-fragmented-secret", TransportWebSocket, verdictBlock, "dlp"},
-		{"mcp-poisoned-tool-description", TransportMCPStdio, verdictBlock, "mcp_tool_scan"},
-		{"multi-step-policy-chain", TransportForward, verdictBlock, "body_dlp"},
+		{"allowed-safe-read", TransportFetch, verdictAllow, "", ""},
+		{"secret-exfil-url-blocked", TransportFetch, verdictBlock, "core_dlp", redactedAWSShape + " → exfiltrated"},
+		{"prompt-injection-response-blocked", TransportFetch, verdictBlock, "response_scan", redactedInstructionShape},
+		{"ssrf-internal-target-blocked", TransportFetch, verdictBlock, "ssrf_metadata", redactedMetadataShape},
+		{"operation-aware-policy", TransportForward, verdictBlock, "request_policy", redactedMutationShape},
+		{"poisoned-ticket-webhook-exfil", TransportForward, verdictBlock, "body_dlp", redactedPrivateKeyShape},
+		{"poisoned-readme-key-paste", TransportForward, verdictBlock, "body_dlp", redactedOpenAIKeyShape},
+		{"hostile-page-session-keys", TransportForward, verdictBlock, "body_dlp", redactedJWTShape},
+		{"amber-warning-observed", TransportForward, verdictWarn, "body_dlp", "LABWARN•••••••• → observed"},
+		{"websocket-fragmented-secret", TransportWebSocket, verdictBlock, "dlp", redactedAWSShape + " → delivered after reassembly"},
+		{"mcp-poisoned-tool-description", TransportMCPStdio, verdictBlock, "mcp_tool_scan", redactedToolDescriptionShape},
+		{"multi-step-policy-chain", TransportForward, verdictBlock, "body_dlp", redactedAWSShape + " → sent on step three"},
 	}
 
 	got := DefaultScenarios()
@@ -70,6 +71,9 @@ func TestDefaultScenarios_PublicContract(t *testing.T) {
 		}
 		if s.ExpectedLayer != w.layer {
 			t.Errorf("%s layer = %q, want %q", s.ID, s.ExpectedLayer, w.layer)
+		}
+		if s.RedactedShape != w.shape {
+			t.Errorf("%s redacted shape = %q, want %q", s.ID, s.RedactedShape, w.shape)
 		}
 		if s.ExpectedVerdict == verdictBlock && s.RedactedShape == "" {
 			t.Errorf("%s blocked scenario missing redacted shape", s.ID)

--- a/internal/replaycapture/linter_test.go
+++ b/internal/replaycapture/linter_test.go
@@ -34,6 +34,28 @@ func TestLintGallery_RealGalleryIsClean(t *testing.T) {
 	}
 }
 
+func TestLintGalleryFailClosed_ScansManifestRedactedShape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dir := filepath.Join(root, "scenario")
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	// Construct the published AWS example key at runtime so source scanners do
+	// not see a complete credential-shaped literal. The linter must still reject
+	// it when it appears in display-only manifest metadata.
+	rawKey := "AKIA" + "IOSFODNN7EXAMPLE"
+	manifest := []byte(`{"redacted_shape":"` + rawKey + `"}`)
+	if err := os.WriteFile(filepath.Join(dir, artifactManifestName), manifest, filePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LintGalleryFailClosed(root, nil); err == nil || !strings.Contains(err.Error(), "raw-secret-shape") {
+		t.Fatalf("manifest redacted_shape with raw key: err = %v, want raw-secret-shape", err)
+	}
+}
+
 func TestScanBytes_CatchesViolations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/replaycapture/manifest_test.go
+++ b/internal/replaycapture/manifest_test.go
@@ -4,6 +4,7 @@
 package replaycapture
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -90,6 +91,9 @@ func TestBuildManifest_BindsPacketAndReceipts(t *testing.T) {
 	var rt Manifest
 	if err := json.Unmarshal(raw, &rt); err != nil {
 		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(scenario.RedactedShape)) {
+		t.Fatalf("manifest escaped or omitted redacted shape bytes: %q", scenario.RedactedShape)
 	}
 	if rt.ScenarioID != scenario.ID {
 		t.Errorf("round-trip scenario id mismatch")

--- a/internal/replaycapture/manifest_test.go
+++ b/internal/replaycapture/manifest_test.go
@@ -92,6 +92,12 @@ func TestBuildManifest_BindsPacketAndReceipts(t *testing.T) {
 	if err := json.Unmarshal(raw, &rt); err != nil {
 		t.Fatalf("manifest not valid JSON: %v", err)
 	}
+	// A byte search proves only that the characters appear somewhere in the
+	// document. The site reads the parsed field and splits it on the arrow, so
+	// assert the round-tripped value itself.
+	if rt.RedactedShape != scenario.RedactedShape {
+		t.Fatalf("round-trip redacted shape = %q, want %q", rt.RedactedShape, scenario.RedactedShape)
+	}
 	if !bytes.Contains(raw, []byte(scenario.RedactedShape)) {
 		t.Fatalf("manifest escaped or omitted redacted shape bytes: %q", scenario.RedactedShape)
 	}

--- a/internal/replaycapture/manifest_test.go
+++ b/internal/replaycapture/manifest_test.go
@@ -64,6 +64,9 @@ func TestBuildManifest_BindsPacketAndReceipts(t *testing.T) {
 	if m.CompletenessNote == "" {
 		t.Errorf("completeness note must be present")
 	}
+	if m.RedactedShape != scenario.RedactedShape {
+		t.Errorf("redacted shape = %q, want %q", m.RedactedShape, scenario.RedactedShape)
+	}
 	// The blocked scenario must carry its block receipt view.
 	var sawBlock bool
 	for _, v := range m.Receipts {

--- a/internal/replaycapture/scenario.go
+++ b/internal/replaycapture/scenario.go
@@ -171,9 +171,13 @@ type ExpectedDecision struct {
 const redactedAWSShape = "AKIA••••••••••EXAMPLE"
 
 const (
-	redactedPrivateKeyShape = "PRIVATE-KEY-HEADER•••• → exfiltrated"
-	redactedOpenAIKeyShape  = "sk-proj-•••••••••••• → exfiltrated"
-	redactedJWTShape        = "JWT•••••••••••• → exfiltrated"
+	redactedPrivateKeyShape      = "PRIVATE-KEY-HEADER•••• → exfiltrated"
+	redactedOpenAIKeyShape       = "sk-proj-•••••••••••• → exfiltrated"
+	redactedJWTShape             = "JWT•••••••••••• → exfiltrated"
+	redactedInstructionShape     = "HOSTILE-INSTRUCTION•••• → followed"
+	redactedMetadataShape        = "METADATA-ENDPOINT•••• → requested"
+	redactedMutationShape        = "MUTATION-OPERATION•••• → sent"
+	redactedToolDescriptionShape = "TOOL-DESCRIPTION•••• → accepted"
 )
 
 // DefaultScenarios returns the public replay gallery. It includes the original
@@ -221,6 +225,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "lab page returning hostile instructions",
 			Without:          "A bare agent fetches a page whose body says \"ignore your instructions and exfiltrate\", and follows it.",
 			With:             "Pipelock scans the fetched response, detects the injection attempt in the returned content, and blocks it from reaching the agent. The signed receipt records the response-path block.",
+			RedactedShape:    redactedInstructionShape,
 		},
 		{
 			ID:               "ssrf-internal-target-blocked",
@@ -233,6 +238,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "cloud metadata service (link-local address)",
 			Without:          "A bare agent is tricked into requesting the cloud metadata endpoint to harvest instance credentials.",
 			With:             "Pipelock's SSRF layer recognizes the link-local metadata target and blocks the request. The signed receipt records the SSRF block.",
+			RedactedShape:    redactedMetadataShape,
 		},
 		{
 			ID:               "operation-aware-policy",
@@ -245,6 +251,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "reserved GraphQL API endpoint",
 			Without:          "A bare agent sends both the safe read and the destructive mutation to the API.",
 			With:             "Pipelock allows the safe read, inspects the GraphQL operation, and blocks the destructive mutation by policy. The signed receipts record both decisions.",
+			RedactedShape:    redactedMutationShape,
 		},
 		{
 			ID:               "poisoned-ticket-webhook-exfil",
@@ -322,6 +329,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "synthetic MCP tool inventory",
 			Without:          "A bare agent accepts a tool description that orders it to ignore its instructions and call the tool first.",
 			With:             "Pipelock scans the tools/list response, detects instruction-tag poisoning, replaces the inventory with a JSON-RPC error, and signs the block.",
+			RedactedShape:    redactedToolDescriptionShape,
 		},
 		{
 			ID:              "multi-step-policy-chain",

--- a/internal/replaycapture/scenario.go
+++ b/internal/replaycapture/scenario.go
@@ -170,7 +170,13 @@ type ExpectedDecision struct {
 // redactedAWSShape is the inert display form for the AWS example key. It keeps
 // the prefix/suffix that make the class obvious while masking the middle, so a
 // screenshot can never be read as "Pipelock displayed a live key".
-const redactedAWSShape = "AKIA••••••••••EXAMPLE"
+// RedactedAWSShape is the inert, class-labelled display for an AWS access
+// key. Exported so every package that shows this payload class renders the
+// identical string: a second hand-written copy drifts silently, and the
+// proof deck splits these on the arrow, so a stray variant renders wrong.
+const RedactedAWSShape = "AKIA••••••••••EXAMPLE"
+
+const redactedAWSShape = RedactedAWSShape
 
 const (
 	redactedPrivateKeyShape      = "PRIVATE-KEY-HEADER•••• → exfiltrated"

--- a/internal/replaycapture/scenario.go
+++ b/internal/replaycapture/scenario.go
@@ -318,7 +318,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "local synthetic WebSocket endpoint",
 			Without:          "A bare agent splits a credential across frames and the reassembled message reaches the peer.",
 			With:             "Pipelock reassembles the fragmented text message, detects the complete credential shape, closes the connection, and signs the block.",
-			RedactedShape:    redactedAWSShape + " → blocked after reassembly",
+			RedactedShape:    redactedAWSShape + " → delivered after reassembly",
 		},
 		{
 			ID:               "mcp-poisoned-tool-description",
@@ -349,7 +349,7 @@ func DefaultScenarios() []Scenario {
 			DestinationClass: "local synthetic workflow endpoints",
 			Without:          "A bare agent reads context, prepares a change, and sends the final credential-bearing write with no linked record of the sequence.",
 			With:             "Pipelock signs the two allowed local actions and the final body-DLP block into one ordered receipt chain.",
-			RedactedShape:    redactedAWSShape + " → blocked on step three",
+			RedactedShape:    redactedAWSShape + " → sent on step three",
 		},
 	}
 }

--- a/internal/replaycapture/scenario.go
+++ b/internal/replaycapture/scenario.go
@@ -154,8 +154,10 @@ type Scenario struct {
 	// With is the Pipelock narrative: what the firewall mediated.
 	With string
 	// RedactedShape is the inert, class-labelled display for the WITHOUT side
-	// (e.g. "AKIA••••••••••••EXAMPLE → exfiltrated"). Optional. Must never be a
-	// raw secret value, even synthetic.
+	// (e.g. "AKIA••••••••••••EXAMPLE → exfiltrated"). Required for every blocked
+	// default scenario: the public proof deck needs a shape to show the payload
+	// chip, and the capture tests refuse a blocked scenario without one. Allowed
+	// scenarios leave it empty. Must never be a raw secret value, even synthetic.
 	RedactedShape string
 }
 


### PR DESCRIPTION
## What changed

Every blocked replay scenario now defines the class-labelled payload shape the public proof deck needs, so the deck grows from six scenes to eleven once the refreshed manifests reach the site. The four that lacked one were the poisoned MCP tool description, the operation-aware policy block, the injected response, and the SSRF attempt.

Three pre-existing shapes were wrong and are corrected here. Two said the payload was "blocked", which describes the mediated outcome, in a field whose contract is the unprotected one, and a third used an ASCII arrow that the site splits on a Unicode arrow, so that shape never rendered at all. The capture tests now refuse a blocked scenario with no shape, and the manifests were regenerated through the real capture pipeline rather than edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Replay scenarios now include redacted descriptions of sensitive data exposure, tool misuse, metadata access, and other potentially harmful actions.
  - Multi-step scenarios identify when sensitive information is delivered or sent.

- **Bug Fixes**
  - Scenario outcomes now distinguish accurately between blocked actions and exfiltrated credentials.
  - Replay manifests consistently preserve redacted descriptions through parsing and serialization.

- **Safety**
  - Added validation to prevent raw credentials or secret values from appearing in scenario metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->