### PR TITLE
fix(license): make expiry warnings lifetime-aware and tier-specific

### DIFF
--- a/enterprise/cli/license.go
+++ b/enterprise/cli/license.go
@@ -415,6 +415,7 @@ type licenseStatusReport struct {
 	DaysRemaining       int      `json:"days_remaining,omitempty"`
 	WarningBand         int      `json:"warning_band,omitempty"`
 	Severity            string   `json:"severity,omitempty"`
+	Warning             string   `json:"warning,omitempty"`
 	CRLConfigured       bool     `json:"crl_configured"`
 	CRLExpiresAt        string   `json:"crl_expires_at,omitempty"`
 	CRLSHA256           string   `json:"crl_sha256,omitempty"`
@@ -532,6 +533,7 @@ func buildLicenseStatusReport(configFile, crlFile string) (licenseStatusReport, 
 		report.DaysRemaining = warn.DaysRemaining
 		report.WarningBand = warn.ThresholdDays
 		report.Severity = warn.Severity
+		report.Warning = warn.Message()
 	}
 	if err != nil {
 		switch {
@@ -674,8 +676,8 @@ func printLicenseStatus(cmd *cobra.Command, report licenseStatusReport) {
 	}
 	if report.ExpiresAt != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Expires:  %s (%d day(s) remaining)\n", report.ExpiresAt, report.DaysRemaining)
-		if report.WarningBand > 0 {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Warning:  %d-day renewal band (%s)\n", report.WarningBand, report.Severity)
+		if report.Warning != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Warning:  %s\n", report.Warning)
 		}
 	} else if report.Status == licenseStatusValid {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Expires:  never\n")

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -68,12 +68,13 @@ func TestLicenseStatusValidWithWarningBand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	now := time.Now().UTC()
 	lic := license.License{
 		ID:        "lic_status",
 		Email:     "status@example.com",
 		Org:       "Status Org",
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(7 * 24 * time.Hour).Unix(),
+		IssuedAt:  now.Add(-49 * 24 * time.Hour).Unix(),
+		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
 		Features:  []string{license.FeatureAgents, license.FeatureFleet},
 		Tier:      "pro",
 	}
@@ -96,6 +97,9 @@ func TestLicenseStatusValidWithWarningBand(t *testing.T) {
 	if report.Severity != license.ExpirySeverityWarn {
 		t.Errorf("Severity = %q, want warn", report.Severity)
 	}
+	if report.Warning != "license expires in 7 day(s) on "+time.Now().UTC().Add(7*24*time.Hour).Format(time.DateOnly)+"; check billing or token delivery" {
+		t.Errorf("Warning = %q, want subscription billing guidance", report.Warning)
+	}
 	// Entitlements belong on the VERIFIED surface. Without these, status answered
 	// "are you licensed" but not "for what", and the only way to read features was
 	// license inspect, which states plainly that it does not check the signature.
@@ -104,6 +108,45 @@ func TestLicenseStatusValidWithWarningBand(t *testing.T) {
 	}
 	if len(report.Features) != 2 || report.Features[0] != license.FeatureAgents || report.Features[1] != license.FeatureFleet {
 		t.Errorf("Features = %v, want [%s %s]", report.Features, license.FeatureAgents, license.FeatureFleet)
+	}
+}
+
+func TestLicenseStatusTrialWarningMessage(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lic := license.License{
+		ID:        "lic_trial_status",
+		Email:     "trial-status@example.com",
+		IssuedAt:  now.Add(-16 * 24 * time.Hour).Unix(),
+		ExpiresAt: now.Add(14 * 24 * time.Hour).Unix(),
+		Features:  []string{license.FeatureAgents},
+		Tier:      "trial",
+	}
+	token, err := license.Issue(lic, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := buildLicenseStatusReport(writeLicenseStatusConfig(t, token, pub, ""), "")
+	if err != nil {
+		t.Fatalf("buildLicenseStatusReport: %v", err)
+	}
+	if report.WarningBand != 15 || report.Severity != license.ExpirySeverityInfo {
+		t.Fatalf("report = %+v, want 15-day info warning", report)
+	}
+	want := "trial ends in 14 day(s) on " + time.Unix(lic.ExpiresAt, 0).UTC().Format(time.DateOnly) + "; Pro features stop at expiry. Subscribe at https://pipelab.org/pricing/"
+	if report.Warning != want {
+		t.Fatalf("Warning = %q, want %q", report.Warning, want)
+	}
+
+	cmd := licenseStatusCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	printLicenseStatus(cmd, report)
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("printed status missing trial warning: %q", out.String())
 	}
 }
 
@@ -505,6 +548,7 @@ func TestPrintLicenseStatusVariants(t *testing.T) {
 		DaysRemaining:  7,
 		WarningBand:    7,
 		Severity:       "warn",
+		Warning:        "license expires in 7 day(s) on 2026-06-01; check billing or token delivery",
 		Intermediate:   true,
 		CRLConfigured:  true,
 		CRLExpiresAt:   "2026-06-02",

--- a/enterprise/cli/license_test.go
+++ b/enterprise/cli/license_test.go
@@ -97,7 +97,7 @@ func TestLicenseStatusValidWithWarningBand(t *testing.T) {
 	if report.Severity != license.ExpirySeverityWarn {
 		t.Errorf("Severity = %q, want warn", report.Severity)
 	}
-	if report.Warning != "license expires in 7 day(s) on "+time.Now().UTC().Add(7*24*time.Hour).Format(time.DateOnly)+"; check billing or token delivery" {
+	if report.Warning != "license expires in 7 day(s) on "+time.Unix(lic.ExpiresAt, 0).UTC().Format(time.DateOnly)+"; check billing or token delivery" {
 		t.Errorf("Warning = %q, want subscription billing guidance", report.Warning)
 	}
 	// Entitlements belong on the VERIFIED surface. Without these, status answered

--- a/enterprise/config.go
+++ b/enterprise/config.go
@@ -321,8 +321,11 @@ func EnforceLicenseGate(c *config.Config) {
 		return
 	}
 
-	// Store expiry for runtime enforcement. Zero means perpetual.
+	// Store verified claims for runtime enforcement and expiry warnings.
+	// A zero expiry means perpetual.
 	c.LicenseExpiresAt = lic.ExpiresAt
+	c.LicenseIssuedAt = lic.IssuedAt
+	c.LicenseTier = lic.Tier
 	c.LicenseID = lic.ID
 	c.LicenseAgentsFeature = true
 	if crlLoaded {

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -664,14 +664,18 @@ func TestEnforceLicenseGate_ValidLicense(t *testing.T) {
 	cfg.LicensePublicKey = pubHex
 
 	EnforceLicenseGate(cfg)
+	fixture, err := license.DecodeUnverified(token)
+	if err != nil {
+		t.Fatalf("decode test license: %v", err)
+	}
 	if cfg.Agents == nil {
 		t.Error("expected agents to remain with valid license")
 	}
 	if cfg.LicenseExpiresAt == 0 {
 		t.Error("expected non-zero LicenseExpiresAt after valid license")
 	}
-	if cfg.LicenseIssuedAt == 0 {
-		t.Error("expected non-zero LicenseIssuedAt after valid license")
+	if cfg.LicenseIssuedAt != fixture.IssuedAt {
+		t.Errorf("LicenseIssuedAt = %d, want fixture claim %d", cfg.LicenseIssuedAt, fixture.IssuedAt)
 	}
 	if cfg.LicenseTier != "pro" {
 		t.Errorf("LicenseTier = %q, want pro", cfg.LicenseTier)

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -671,8 +671,8 @@ func TestEnforceLicenseGate_ValidLicense(t *testing.T) {
 	if cfg.Agents == nil {
 		t.Error("expected agents to remain with valid license")
 	}
-	if cfg.LicenseExpiresAt == 0 {
-		t.Error("expected non-zero LicenseExpiresAt after valid license")
+	if cfg.LicenseExpiresAt != fixture.ExpiresAt {
+		t.Errorf("LicenseExpiresAt = %d, want fixture claim %d", cfg.LicenseExpiresAt, fixture.ExpiresAt)
 	}
 	if cfg.LicenseIssuedAt != fixture.IssuedAt {
 		t.Errorf("LicenseIssuedAt = %d, want fixture claim %d", cfg.LicenseIssuedAt, fixture.IssuedAt)

--- a/enterprise/config_test.go
+++ b/enterprise/config_test.go
@@ -536,11 +536,14 @@ func testLicenseKeyPair(t *testing.T) (token string, pubHex string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	now := time.Now().UTC()
 	lic := license.License{
 		ID:        "lic_test123",
 		Email:     "test@example.com",
+		IssuedAt:  now.Unix(),
 		Features:  []string{license.FeatureAgents},
-		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+		ExpiresAt: now.Add(24 * time.Hour).Unix(),
+		Tier:      "pro",
 	}
 	tok, err := license.Issue(lic, priv)
 	if err != nil {
@@ -666,6 +669,12 @@ func TestEnforceLicenseGate_ValidLicense(t *testing.T) {
 	}
 	if cfg.LicenseExpiresAt == 0 {
 		t.Error("expected non-zero LicenseExpiresAt after valid license")
+	}
+	if cfg.LicenseIssuedAt == 0 {
+		t.Error("expected non-zero LicenseIssuedAt after valid license")
+	}
+	if cfg.LicenseTier != "pro" {
+		t.Errorf("LicenseTier = %q, want pro", cfg.LicenseTier)
 	}
 	if !cfg.LicenseAgentsFeature {
 		t.Error("expected LicenseAgentsFeature=true after valid agents license")

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -1657,11 +1657,23 @@ func (l *Logger) LogRuleBundleDegraded(ev RuleBundleDegradedEvent) {
 	}
 }
 
+// LicenseExpiryWarning is the operator-facing data for an active license
+// expiry band.
+type LicenseExpiryWarning struct {
+	LicenseID     string
+	Tier          string
+	ThresholdDays int
+	DaysRemaining int
+	Severity      string
+	ExpiresAt     string
+	Message       string
+}
+
 // LogLicenseExpiry logs a renewal warning for the active enterprise license.
-func (l *Logger) LogLicenseExpiry(licenseID string, thresholdDays, daysRemaining int, severity, expiresAt string) {
+func (l *Logger) LogLicenseExpiry(warning LicenseExpiryWarning) {
 	level := l.zl.Info()
 	emitSeverity := emit.SeverityInfo
-	switch severity {
+	switch warning.Severity {
 	case severityCritical, "error":
 		level = l.zl.Error()
 		emitSeverity = emit.SeverityCritical
@@ -1670,12 +1682,14 @@ func (l *Logger) LogLicenseExpiry(licenseID string, thresholdDays, daysRemaining
 		emitSeverity = emit.SeverityWarn
 	}
 	e := newLogEntry(level, EventLicenseExpiry).
-		str("license_id", licenseID).
-		intField("threshold_days", thresholdDays).
-		intField("days_remaining", daysRemaining).
-		str("severity", severity).
-		str("expires_at", expiresAt)
-	e.msg("license expiry warning")
+		str("license_id", warning.LicenseID).
+		str("tier", warning.Tier).
+		intField("threshold_days", warning.ThresholdDays).
+		intField("days_remaining", warning.DaysRemaining).
+		str("severity", warning.Severity).
+		str("expires_at", warning.ExpiresAt).
+		str("message", warning.Message)
+	e.msg(warning.Message)
 
 	if l.emitter != nil {
 		l.emitter.EmitWithSeverity(context.Background(), emitSeverity, string(EventLicenseExpiry), e.fields)

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -4732,7 +4732,15 @@ func TestLogLicenseExpiry(t *testing.T) {
 			logger, sink := newLoggerWithEmitter(t)
 			defer logger.Close()
 
-			logger.LogLicenseExpiry("lic_expiry", 14, 13, tt.severity, "2026-06-01T00:00:00Z")
+			logger.LogLicenseExpiry(LicenseExpiryWarning{
+				LicenseID:     "lic_expiry",
+				Tier:          "trial",
+				ThresholdDays: 14,
+				DaysRemaining: 13,
+				Severity:      tt.severity,
+				ExpiresAt:     "2026-06-01T00:00:00Z",
+				Message:       "trial ends in 13 day(s)",
+			})
 
 			ev, ok := sink.lastEvent()
 			if !ok {
@@ -4747,6 +4755,9 @@ func TestLogLicenseExpiry(t *testing.T) {
 			if ev.Fields["license_id"] != "lic_expiry" {
 				t.Errorf("license_id = %v, want lic_expiry", ev.Fields["license_id"])
 			}
+			if ev.Fields["tier"] != "trial" {
+				t.Errorf("tier = %v, want trial", ev.Fields["tier"])
+			}
 			if ev.Fields["threshold_days"] != 14 {
 				t.Errorf("threshold_days = %v, want 14", ev.Fields["threshold_days"])
 			}
@@ -4758,6 +4769,9 @@ func TestLogLicenseExpiry(t *testing.T) {
 			}
 			if ev.Fields["expires_at"] != "2026-06-01T00:00:00Z" {
 				t.Errorf("expires_at = %v, want timestamp", ev.Fields["expires_at"])
+			}
+			if ev.Fields["message"] != "trial ends in 13 day(s)" {
+				t.Errorf("message = %v, want operator warning", ev.Fields["message"])
 			}
 		})
 	}

--- a/internal/cli/diag/doctor.go
+++ b/internal/cli/diag/doctor.go
@@ -245,9 +245,9 @@ func checkDoctorLicense(cfg *config.Config) doctorReportCheck {
 			Configured: true,
 			Reachable:  true,
 			Enforcing:  true,
-			Detail: fmt.Sprintf("license %s expires in %d day(s) on %s; %d-day renewal band severity=%s",
-				lic.ID, warning.DaysRemaining, warning.ExpiresAt.Format(time.DateOnly), warning.ThresholdDays, warning.Severity),
-			Next: "renew or refresh the license before expiry disables enterprise agent profiles",
+			Detail: fmt.Sprintf("license %s: %s; %d-day lifetime-aware band severity=%s",
+				lic.ID, warning.Message(), warning.ThresholdDays, warning.Severity),
+			Next: "act before the shown expiry to avoid licensed runtime surfaces stopping",
 		}
 	}
 	detail := "license token is configured"

--- a/internal/cli/diag/doctor_test.go
+++ b/internal/cli/diag/doctor_test.go
@@ -398,9 +398,10 @@ func TestBuildDoctorReportShowsLicenseExpiryWarning(t *testing.T) {
 	lic := license.License{
 		ID:        "lic_doctor_warning",
 		Email:     "doctor@example.com",
-		IssuedAt:  now.Unix(),
-		ExpiresAt: now.Add(7 * 24 * time.Hour).Unix(),
+		IssuedAt:  now.Add(-11 * 24 * time.Hour).Unix(),
+		ExpiresAt: now.Add(3 * 24 * time.Hour).Unix(),
 		Features:  []string{license.FeatureAgents},
+		Tier:      "trial",
 	}
 	token, err := license.Issue(lic, priv)
 	if err != nil {
@@ -415,8 +416,15 @@ func TestBuildDoctorReportShowsLicenseExpiryWarning(t *testing.T) {
 	if check.Status != doctorStatusWarn {
 		t.Fatalf("license status = %+v, want warning", check)
 	}
-	if !strings.Contains(check.Detail, "7-day renewal band") {
-		t.Fatalf("detail = %q, want renewal band", check.Detail)
+	for _, want := range []string{
+		"trial ends in",
+		"Pro features stop at expiry.",
+		"Subscribe at https://pipelab.org/pricing/",
+		"4-day lifetime-aware band",
+	} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("detail = %q, want %q", check.Detail, want)
+		}
 	}
 }
 
@@ -479,6 +487,7 @@ func TestDoctorLicenseStatusBranches(t *testing.T) {
 	t.Run("thirty day expiry band is info", func(t *testing.T) {
 		lic := active
 		lic.ID = "lic_doctor_30"
+		lic.IssuedAt = now.Add(-31 * 24 * time.Hour).Unix()
 		lic.ExpiresAt = now.Add(29 * 24 * time.Hour).Unix()
 		token, err := license.Issue(lic, priv)
 		if err != nil {
@@ -488,7 +497,7 @@ func TestDoctorLicenseStatusBranches(t *testing.T) {
 		cfg.LicenseKey = token
 		cfg.LicensePublicKey = hex.EncodeToString(pub)
 		check := checkDoctorLicense(cfg)
-		if check.Status != doctorStatusInfo || !strings.Contains(check.Detail, "30-day renewal band") {
+		if check.Status != doctorStatusInfo || !strings.Contains(check.Detail, "30-day lifetime-aware band") {
 			t.Fatalf("check = %+v, want info renewal band", check)
 		}
 	})

--- a/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
+++ b/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
@@ -8,6 +8,7 @@ package runtime
 import "testing"
 
 func TestNewServer_ConductorCarriesVerifiedLicenseWarningMetadata(t *testing.T) {
+	t.Setenv("PIPELOCK_HOME", t.TempDir())
 	s, _ := newConductorApplyTestServer(t)
 	cfg := s.proxy.CurrentConfig()
 	if cfg.LicenseIssuedAt == 0 || cfg.LicenseExpiresAt == 0 {

--- a/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
+++ b/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
@@ -16,4 +16,8 @@ func TestNewServer_ConductorCarriesVerifiedLicenseWarningMetadata(t *testing.T) 
 	if cfg.LicenseTier != "enterprise" {
 		t.Fatalf("LicenseTier = %q, want enterprise", cfg.LicenseTier)
 	}
+	stderr := s.opts.Stderr.(*stderrSyncWriter).w.(*syncBuffer)
+	if !stderr.contains("license expires in 1 day(s)") {
+		t.Fatalf("startup warning did not use verified license metadata: %s", stderr.String())
+	}
 }

--- a/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
+++ b/internal/cli/runtime/conductor_license_metadata_enterprise_test.go
@@ -1,0 +1,19 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import "testing"
+
+func TestNewServer_ConductorCarriesVerifiedLicenseWarningMetadata(t *testing.T) {
+	s, _ := newConductorApplyTestServer(t)
+	cfg := s.proxy.CurrentConfig()
+	if cfg.LicenseIssuedAt == 0 || cfg.LicenseExpiresAt == 0 {
+		t.Fatalf("runtime license timestamps = issued=%d expires=%d, want verified claims", cfg.LicenseIssuedAt, cfg.LicenseExpiresAt)
+	}
+	if cfg.LicenseTier != "enterprise" {
+		t.Fatalf("LicenseTier = %q, want enterprise", cfg.LicenseTier)
+	}
+}

--- a/internal/cli/runtime/conductor_license_test.go
+++ b/internal/cli/runtime/conductor_license_test.go
@@ -29,6 +29,7 @@ import (
 // env vars via t.Setenv's normal restoration.
 func setTestFleetLicense(t *testing.T) {
 	t.Helper()
+	now := time.Now().UTC()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
@@ -36,8 +37,8 @@ func setTestFleetLicense(t *testing.T) {
 	tok, err := license.Issue(license.License{
 		ID:        "test-fleet-license",
 		Email:     "test@example.com",
-		IssuedAt:  time.Now().Unix(),
-		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		IssuedAt:  now.Add(-time.Hour).Unix(),
+		ExpiresAt: now.Add(time.Hour).Unix(),
 		Features:  []string{license.FeatureAgents, license.FeatureFleet},
 		Tier:      "enterprise",
 	}, priv)

--- a/internal/cli/runtime/license_expiry.go
+++ b/internal/cli/runtime/license_expiry.go
@@ -27,7 +27,9 @@ func emitLicenseExpiryWarning(cfg *config.Config, logger *audit.Logger, sentryCl
 	now := time.Now()
 	status := license.ExpiryStatus(license.License{
 		ID:        cfg.LicenseID,
+		IssuedAt:  cfg.LicenseIssuedAt,
 		ExpiresAt: cfg.LicenseExpiresAt,
+		Tier:      cfg.LicenseTier,
 	}, now)
 	if !status.Active {
 		return
@@ -43,13 +45,22 @@ func emitLicenseExpiryWarning(cfg *config.Config, logger *audit.Logger, sentryCl
 	}
 
 	expiresAt := status.ExpiresAt.Format(time.DateOnly)
+	message := status.Message()
 	if logger != nil {
-		logger.LogLicenseExpiry(status.LicenseID, status.ThresholdDays, status.DaysRemaining, status.Severity, expiresAt)
+		logger.LogLicenseExpiry(audit.LicenseExpiryWarning{
+			LicenseID:     status.LicenseID,
+			Tier:          status.Tier,
+			ThresholdDays: status.ThresholdDays,
+			DaysRemaining: status.DaysRemaining,
+			Severity:      status.Severity,
+			ExpiresAt:     expiresAt,
+			Message:       message,
+		})
 	}
-	_, _ = fmt.Fprintf(stderr, "WARNING: license expires in %d day(s) on %s\n",
-		status.DaysRemaining, expiresAt)
+	_, _ = fmt.Fprintf(stderr, "WARNING: %s\n", message)
 	if sentryClient != nil {
-		sentryClient.AddBreadcrumb("license", "license expiry warning", status.Severity, map[string]any{
+		sentryClient.AddBreadcrumb("license", message, status.Severity, map[string]any{
+			"tier":           status.Tier,
 			"threshold_days": fmt.Sprintf("%d", status.ThresholdDays),
 			"days_remaining": fmt.Sprintf("%d", status.DaysRemaining),
 			"expires_at":     expiresAt,

--- a/internal/cli/runtime/license_expiry_test.go
+++ b/internal/cli/runtime/license_expiry_test.go
@@ -25,13 +25,18 @@ func TestEmitLicenseExpiryWarningIdempotent(t *testing.T) {
 
 	cfg := config.Defaults()
 	cfg.LicenseID = "lic_runtime"
+	cfg.LicenseIssuedAt = time.Now().Add(-38 * 24 * time.Hour).Unix()
 	cfg.LicenseExpiresAt = time.Now().Add(7 * 24 * time.Hour).Unix()
+	cfg.LicenseTier = "pro"
 
 	var stderr bytes.Buffer
 	emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
 	first := stderr.String()
 	if !strings.Contains(first, "expires in") {
 		t.Fatalf("first warning missing: %q", first)
+	}
+	if !strings.Contains(first, "check billing or token delivery") {
+		t.Fatalf("first warning missing subscription action: %q", first)
 	}
 	if _, err := os.Stat(filepath.Join(home, "state", licenseExpiryStateFile)); err != nil {
 		t.Fatalf("state file not written: %v", err)
@@ -41,6 +46,103 @@ func TestEmitLicenseExpiryWarningIdempotent(t *testing.T) {
 	emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
 	if stderr.String() != "" {
 		t.Fatalf("second warning should be suppressed, got %q", stderr.String())
+	}
+}
+
+func TestEmitLicenseExpiryWarningTrialLifetimeAndMessage(t *testing.T) {
+	home := t.TempDir()
+	oldHome := cliutil.PipelockHome
+	cliutil.PipelockHome = home
+	t.Cleanup(func() { cliutil.PipelockHome = oldHome })
+
+	now := time.Now().UTC()
+	atIssuance := config.Defaults()
+	atIssuance.LicenseID = "lic_trial_new"
+	atIssuance.LicenseIssuedAt = now.Unix()
+	atIssuance.LicenseExpiresAt = now.Add(30 * 24 * time.Hour).Unix()
+	atIssuance.LicenseTier = "trial"
+
+	var stderr bytes.Buffer
+	emitLicenseExpiryWarning(atIssuance, audit.NewNop(), nil, &stderr)
+	if stderr.Len() != 0 {
+		t.Fatalf("new trial emitted an expiry warning: %q", stderr.String())
+	}
+
+	approaching := config.Defaults()
+	approaching.LicenseID = "lic_trial_approaching"
+	approaching.LicenseIssuedAt = now.Add(-16 * 24 * time.Hour).Unix()
+	approaching.LicenseExpiresAt = now.Add(14 * 24 * time.Hour).Unix()
+	approaching.LicenseTier = "trial"
+
+	emitLicenseExpiryWarning(approaching, audit.NewNop(), nil, &stderr)
+	got := stderr.String()
+	for _, want := range []string{
+		"WARNING: trial ends in",
+		"Pro features stop at expiry.",
+		"Subscribe at https://pipelab.org/pricing/",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("trial warning missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestEmitLicenseExpiryWarningStateFailuresStillEmit(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string)
+		want  string
+	}{
+		{
+			name:  "absent state",
+			setup: func(_ *testing.T, _ string) {},
+		},
+		{
+			name: "corrupt state",
+			setup: func(t *testing.T, home string) {
+				path := filepath.Join(home, "state", licenseExpiryStateFile)
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "state unavailable",
+		},
+		{
+			name: "unreadable state path",
+			setup: func(t *testing.T, home string) {
+				if err := os.MkdirAll(filepath.Join(home, "state", licenseExpiryStateFile), 0o750); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "state unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			oldHome := cliutil.PipelockHome
+			cliutil.PipelockHome = home
+			t.Cleanup(func() { cliutil.PipelockHome = oldHome })
+			tt.setup(t, home)
+
+			cfg := config.Defaults()
+			cfg.LicenseID = "lic_state_failure"
+			cfg.LicenseIssuedAt = time.Now().Add(-38 * 24 * time.Hour).Unix()
+			cfg.LicenseExpiresAt = time.Now().Add(7 * 24 * time.Hour).Unix()
+			cfg.LicenseTier = "pro"
+			var stderr bytes.Buffer
+			emitLicenseExpiryWarning(cfg, audit.NewNop(), nil, &stderr)
+			if !strings.Contains(stderr.String(), "license expires in") {
+				t.Fatalf("warning suppressed by %s: %q", tt.name, stderr.String())
+			}
+			if tt.want != "" && !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("warning missing %q: %q", tt.want, stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -395,8 +395,6 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			s.reportContainmentMetricsDrift(cfg, "startup", containmentErr)
 		}
 	}
-	emitLicenseExpiryWarning(cfg, logger, sentryClient, opts.Stderr)
-
 	runtimeMode := config.RuntimeForward
 	if hasMCPListen {
 		runtimeMode = config.RuntimeForwardWithMCPListener
@@ -452,6 +450,7 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		cfg.LicenseExpiresAt = lic.ExpiresAt
 		cfg.LicenseTier = lic.Tier
 	}
+	emitLicenseExpiryWarning(cfg, logger, sentryClient, opts.Stderr)
 	if err := s.initConductorApplyAndAudit(cfg, m); err != nil {
 		s.cleanup()
 		return nil, err

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -448,7 +448,9 @@ func NewServer(opts ServerOpts) (*Server, error) {
 			return nil, err
 		}
 		cfg.LicenseID = lic.ID
+		cfg.LicenseIssuedAt = lic.IssuedAt
 		cfg.LicenseExpiresAt = lic.ExpiresAt
+		cfg.LicenseTier = lic.Tier
 	}
 	if err := s.initConductorApplyAndAudit(cfg, m); err != nil {
 		s.cleanup()

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -363,11 +363,12 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 			// analogue of the agents preserve path above.
 			_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: new license inputs could not be verified; Conductor fleet entitlement unchanged, follower stays running — requires restart for license re-verification\n")
 		}
-		// Carry forward runtime-derived license expiry.
-		// LicenseExpiresAt is set by EnforceLicenseGate at startup,
-		// not parsed from YAML. Always preserve the old value until
-		// restart.
+		// Carry forward runtime-derived license warning metadata. These claims
+		// are set after token verification at startup, not parsed from YAML.
+		// Always preserve the old values until restart.
 		newCfg.LicenseExpiresAt = oldCfg.LicenseExpiresAt
+		newCfg.LicenseIssuedAt = oldCfg.LicenseIssuedAt
+		newCfg.LicenseTier = oldCfg.LicenseTier
 		newCfg.LicenseID = oldCfg.LicenseID
 		newCfg.LicenseCRLExpiresAt = oldCfg.LicenseCRLExpiresAt
 		newCfg.LicenseCRLSHA256 = oldCfg.LicenseCRLSHA256

--- a/internal/cli/runtime/server_reload_license_test.go
+++ b/internal/cli/runtime/server_reload_license_test.go
@@ -101,7 +101,9 @@ func TestServer_ReloadUnverifiableLicenseInputPreservesAgents(t *testing.T) {
 	}
 	oldCfg.LicenseKey = tok
 	oldCfg.LicensePublicKey = pubHex
+	oldCfg.LicenseIssuedAt = time.Now().Add(-16 * 24 * time.Hour).Unix()
 	oldCfg.LicenseExpiresAt = time.Now().Add(time.Hour).Unix()
+	oldCfg.LicenseTier = "trial"
 
 	// Simulate EnforceLicenseGate's strip at reload-Load (no _default profile, so
 	// the failed verification leaves Agents nil) while the new CRL input is
@@ -119,6 +121,11 @@ func TestServer_ReloadUnverifiableLicenseInputPreservesAgents(t *testing.T) {
 	}
 	if _, ok := live.Agents["agent-a"]; !ok {
 		t.Fatalf("named agent not preserved restart-only: %+v", live.Agents)
+	}
+	if live.LicenseIssuedAt != oldCfg.LicenseIssuedAt || live.LicenseExpiresAt != oldCfg.LicenseExpiresAt || live.LicenseTier != oldCfg.LicenseTier {
+		t.Fatalf("runtime warning metadata changed across reload: got issued=%d expires=%d tier=%q want issued=%d expires=%d tier=%q",
+			live.LicenseIssuedAt, live.LicenseExpiresAt, live.LicenseTier,
+			oldCfg.LicenseIssuedAt, oldCfg.LicenseExpiresAt, oldCfg.LicenseTier)
 	}
 	if !buf.contains("new license inputs could not be verified") {
 		t.Fatalf("stderr missing unverifiable-input warning:\n%s", buf.String())

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -175,6 +175,8 @@ func (c *Config) policySemanticView() canonicalPolicyView {
 	view.LicenseCRLMaxAgeError = ""
 	view.LicensePublicKey = ""
 	view.LicenseExpiresAt = 0
+	view.LicenseIssuedAt = 0
+	view.LicenseTier = ""
 	view.LicenseID = ""
 	view.LicenseCRLExpiresAt = 0
 	view.LicenseCRLSHA256 = ""

--- a/internal/config/license_runtime_metadata_test.go
+++ b/internal/config/license_runtime_metadata_test.go
@@ -13,6 +13,11 @@ func TestCanonicalPolicyHash_ExcludesRuntimeLicenseWarningMetadata(t *testing.T)
 	withLicenseMetadata.LicenseExpiresAt = 1_782_788_400
 	withLicenseMetadata.LicenseTier = "trial"
 
+	view := withLicenseMetadata.policySemanticView().Config
+	if view.LicenseID != "" || view.LicenseIssuedAt != 0 || view.LicenseExpiresAt != 0 || view.LicenseTier != "" {
+		t.Fatalf("canonical view retained runtime license warning metadata: id=%q issued=%d expires=%d tier=%q", view.LicenseID, view.LicenseIssuedAt, view.LicenseExpiresAt, view.LicenseTier)
+	}
+
 	if got, want := withLicenseMetadata.CanonicalPolicyHash(), base.CanonicalPolicyHash(); got != want {
 		t.Fatalf("runtime license metadata changed canonical policy hash: got %s want %s", got, want)
 	}

--- a/internal/config/license_runtime_metadata_test.go
+++ b/internal/config/license_runtime_metadata_test.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestCanonicalPolicyHash_ExcludesRuntimeLicenseWarningMetadata(t *testing.T) {
+	base := Defaults()
+	withLicenseMetadata := base.Clone()
+	withLicenseMetadata.LicenseID = "lic_runtime"
+	withLicenseMetadata.LicenseIssuedAt = 1_778_900_400
+	withLicenseMetadata.LicenseExpiresAt = 1_782_788_400
+	withLicenseMetadata.LicenseTier = "trial"
+
+	if got, want := withLicenseMetadata.CanonicalPolicyHash(), base.CanonicalPolicyHash(); got != want {
+		t.Fatalf("runtime license metadata changed canonical policy hash: got %s want %s", got, want)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -469,10 +469,13 @@ type Config struct {
 	SSRF             SSRF     `yaml:"ssrf"`
 	DNS              DNS      `yaml:"dns"`
 
-	// LicenseExpiresAt is the Unix timestamp of the license expiry, populated
-	// by EnforceLicenseGate(). Zero means perpetual. Used for runtime expiry
-	// enforcement so agents are disabled even without a config reload.
-	LicenseExpiresAt int64 `yaml:"-"`
+	// LicenseExpiresAt, LicenseIssuedAt, and LicenseTier are claims from the
+	// verified license token, populated at runtime. They are used for expiry
+	// enforcement and lifetime-aware warning messages, never parsed from YAML.
+	// A zero expiry means perpetual.
+	LicenseExpiresAt int64  `yaml:"-"`
+	LicenseIssuedAt  int64  `yaml:"-" json:"-"`
+	LicenseTier      string `yaml:"-" json:"-"`
 	// LicenseID and CRL metadata are runtime-derived from the verified
 	// license token and CRL. They are excluded from policy serialization.
 	LicenseID               string `yaml:"-" json:"-"`

--- a/internal/license/expiry.go
+++ b/internal/license/expiry.go
@@ -21,12 +21,32 @@ const (
 	ExpirySeverityError = "error"
 
 	expiryDay = 24 * time.Hour
+
+	trialTier          = "trial"
+	enterpriseEvalTier = "enterprise_eval"
+	pricingURL         = "https://pipelab.org/pricing/"
 )
+
+type expiryBand struct {
+	name     string
+	divisor  int
+	maximum  time.Duration
+	severity string
+}
+
+var expiryBands = [...]expiryBand{
+	{name: "early", divisor: 2, maximum: 30 * expiryDay, severity: ExpirySeverityInfo},
+	{name: "mid", divisor: 4, maximum: 14 * expiryDay, severity: ExpirySeverityWarn},
+	{name: "late", divisor: 8, maximum: 7 * expiryDay, severity: ExpirySeverityWarn},
+	{name: "final", divisor: 2, maximum: expiryDay, severity: ExpirySeverityError},
+}
 
 // ExpiryWarning describes the active renewal warning band for a license.
 type ExpiryWarning struct {
 	Active        bool
 	LicenseID     string
+	Tier          string
+	Band          string
 	ThresholdDays int
 	DaysRemaining int
 	Severity      string
@@ -34,33 +54,40 @@ type ExpiryWarning struct {
 }
 
 // ExpiryWarningState records the last emitted renewal warning. It is safe to
-// persist locally because it contains only the opaque license ID and threshold.
+// persist locally because it contains only the opaque license ID and band.
 type ExpiryWarningState struct {
 	LicenseID      string    `json:"license_id"`
+	Band           string    `json:"band,omitempty"`
 	ThresholdDays  int       `json:"threshold_days"`
 	LastEmittedUTC time.Time `json:"last_emitted_utc"`
 }
 
-// ExpiryStatus returns the current warning band for lic at now. Perpetual and
-// already-expired licenses do not produce renewal warnings.
+// ExpiryStatus returns the current warning band for lic at now. A valid issued
+// time makes each band relative to the token's own lifetime, capped at the
+// long-lived-license thresholds. Perpetual and already-expired licenses do not
+// produce renewal warnings. Tokens without a usable issued time fall back to
+// the legacy absolute bands so a malformed claim cannot silently suppress a
+// renewal warning.
 func ExpiryStatus(lic License, now time.Time) ExpiryWarning {
 	if lic.ExpiresAt <= 0 {
-		return ExpiryWarning{LicenseID: lic.ID}
+		return ExpiryWarning{LicenseID: lic.ID, Tier: lic.Tier}
 	}
 	expiresAt := time.Unix(lic.ExpiresAt, 0).UTC()
 	remaining := expiresAt.Sub(now.UTC())
 	if remaining <= 0 {
 		return ExpiryWarning{
 			LicenseID:     lic.ID,
+			Tier:          lic.Tier,
 			DaysRemaining: 0,
 			ExpiresAt:     expiresAt,
 		}
 	}
 	days := int(math.Ceil(float64(remaining) / float64(expiryDay)))
-	threshold := expiryThreshold(days)
-	if threshold == 0 {
+	band, threshold := expiryBandFor(lic.IssuedAt, now, expiresAt, remaining)
+	if band == nil {
 		return ExpiryWarning{
 			LicenseID:     lic.ID,
+			Tier:          lic.Tier,
 			DaysRemaining: days,
 			ExpiresAt:     expiresAt,
 		}
@@ -68,27 +95,51 @@ func ExpiryStatus(lic License, now time.Time) ExpiryWarning {
 	return ExpiryWarning{
 		Active:        true,
 		LicenseID:     lic.ID,
+		Tier:          lic.Tier,
+		Band:          band.name,
 		ThresholdDays: threshold,
 		DaysRemaining: days,
-		Severity:      expirySeverity(threshold),
+		Severity:      band.severity,
 		ExpiresAt:     expiresAt,
 	}
 }
 
+// Message returns the operator-facing warning text for an active expiry band.
+func (w ExpiryWarning) Message() string {
+	if !w.Active {
+		return ""
+	}
+	expiresAt := w.ExpiresAt.Format(time.DateOnly)
+	switch w.Tier {
+	case trialTier:
+		return fmt.Sprintf("trial ends in %d day(s) on %s; Pro features stop at expiry. Subscribe at %s", w.DaysRemaining, expiresAt, pricingURL)
+	case enterpriseEvalTier:
+		return fmt.Sprintf("Enterprise evaluation ends in %d day(s) on %s; licensed runtime surfaces stop at expiry. See %s", w.DaysRemaining, expiresAt, pricingURL)
+	default:
+		return fmt.Sprintf("license expires in %d day(s) on %s; check billing or token delivery", w.DaysRemaining, expiresAt)
+	}
+}
+
 // ShouldEmitExpiryWarning returns true when a warning should be emitted for
-// the current band. The same license and threshold emits once; a new license
-// or a lower threshold emits again.
+// the current band. The same license and band emits once; a new license or a
+// later band emits again.
 func ShouldEmitExpiryWarning(current ExpiryWarning, previous ExpiryWarningState) bool {
 	if !current.Active {
 		return false
 	}
-	return previous.LicenseID != current.LicenseID ||
-		previous.ThresholdDays != current.ThresholdDays
+	if previous.LicenseID != current.LicenseID {
+		return true
+	}
+	if current.Band != "" && previous.Band != "" {
+		return previous.Band != current.Band
+	}
+	return previous.ThresholdDays != current.ThresholdDays
 }
 
 func NewExpiryWarningState(current ExpiryWarning, now time.Time) ExpiryWarningState {
 	return ExpiryWarningState{
 		LicenseID:      current.LicenseID,
+		Band:           current.Band,
 		ThresholdDays:  current.ThresholdDays,
 		LastEmittedUTC: now.UTC(),
 	}
@@ -131,30 +182,38 @@ func SaveExpiryWarningState(path string, state ExpiryWarningState) error {
 	return nil
 }
 
-func expiryThreshold(daysRemaining int) int {
+func expiryBandFor(issuedAt int64, now, expiresAt time.Time, remaining time.Duration) (*expiryBand, int) {
+	issued := time.Unix(issuedAt, 0).UTC()
+	if issuedAt <= 0 || issued.After(now.UTC()) || !issued.Before(expiresAt) {
+		return legacyExpiryBand(daysRemaining(remaining))
+	}
+
+	lifetime := expiresAt.Sub(issued)
+	for i := len(expiryBands) - 1; i >= 0; i-- {
+		band := &expiryBands[i]
+		threshold := min(lifetime/time.Duration(band.divisor), band.maximum)
+		if remaining <= threshold {
+			return band, daysRemaining(threshold)
+		}
+	}
+	return nil, 0
+}
+
+func legacyExpiryBand(days int) (*expiryBand, int) {
 	switch {
-	case daysRemaining <= 1:
-		return 1
-	case daysRemaining <= 7:
-		return 7
-	case daysRemaining <= 14:
-		return 14
-	case daysRemaining <= 30:
-		return 30
+	case days <= 1:
+		return &expiryBands[3], 1
+	case days <= 7:
+		return &expiryBands[2], 7
+	case days <= 14:
+		return &expiryBands[1], 14
+	case days <= 30:
+		return &expiryBands[0], 30
 	default:
-		return 0
+		return nil, 0
 	}
 }
 
-func expirySeverity(threshold int) string {
-	switch threshold {
-	case 1:
-		return ExpirySeverityError
-	case 7, 14:
-		return ExpirySeverityWarn
-	case 30:
-		return ExpirySeverityInfo
-	default:
-		return ""
-	}
+func daysRemaining(remaining time.Duration) int {
+	return int(math.Ceil(float64(remaining) / float64(expiryDay)))
 }

--- a/internal/license/expiry_test.go
+++ b/internal/license/expiry_test.go
@@ -6,34 +6,57 @@ package license
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
 
-func TestExpiryStatusThresholdBands(t *testing.T) {
+func TestExpiryStatusLifetimeAwareBands(t *testing.T) {
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name          string
-		expiresIn     time.Duration
+		lifetime      time.Duration
+		remaining     time.Duration
 		wantActive    bool
+		wantBand      string
 		wantThreshold int
 		wantSeverity  string
 	}{
-		{"outside warning window", 31 * expiryDay, false, 0, ""},
-		{"thirty days", 30 * expiryDay, true, 30, ExpirySeverityInfo},
-		{"fourteen days", 14 * expiryDay, true, 14, ExpirySeverityWarn},
-		{"seven days", 7 * expiryDay, true, 7, ExpirySeverityWarn},
-		{"one day", expiryDay, true, 1, ExpirySeverityError},
+		{"30 day trial at issuance", 30 * expiryDay, 30 * expiryDay, false, "", 0, ""},
+		{"30 day trial early", 30 * expiryDay, 15 * expiryDay, true, "early", 15, ExpirySeverityInfo},
+		{"30 day trial mid", 30 * expiryDay, 7 * expiryDay, true, "mid", 8, ExpirySeverityWarn},
+		{"30 day trial late", 30 * expiryDay, 3 * expiryDay, true, "late", 4, ExpirySeverityWarn},
+		{"30 day trial final", 30 * expiryDay, expiryDay, true, "final", 1, ExpirySeverityError},
+		{"45 day paid token at issuance", 45 * expiryDay, 45 * expiryDay, false, "", 0, ""},
+		{"45 day paid token early", 45 * expiryDay, 22 * expiryDay, true, "early", 23, ExpirySeverityInfo},
+		{"45 day paid token mid", 45 * expiryDay, 11 * expiryDay, true, "mid", 12, ExpirySeverityWarn},
+		{"45 day paid token late", 45 * expiryDay, 5 * expiryDay, true, "late", 6, ExpirySeverityWarn},
+		{"45 day paid token final", 45 * expiryDay, expiryDay, true, "final", 1, ExpirySeverityError},
+		{"60 day evaluation at issuance", 60 * expiryDay, 60 * expiryDay, false, "", 0, ""},
+		{"60 day evaluation early", 60 * expiryDay, 30 * expiryDay, true, "early", 30, ExpirySeverityInfo},
+		{"60 day evaluation mid", 60 * expiryDay, 14 * expiryDay, true, "mid", 14, ExpirySeverityWarn},
+		{"60 day evaluation late", 60 * expiryDay, 7 * expiryDay, true, "late", 7, ExpirySeverityWarn},
+		{"60 day evaluation final", 60 * expiryDay, expiryDay, true, "final", 1, ExpirySeverityError},
+		{"long lived license at issuance", 365 * expiryDay, 365 * expiryDay, false, "", 0, ""},
+		{"long lived license early", 365 * expiryDay, 30 * expiryDay, true, "early", 30, ExpirySeverityInfo},
+		{"long lived license mid", 365 * expiryDay, 14 * expiryDay, true, "mid", 14, ExpirySeverityWarn},
+		{"long lived license late", 365 * expiryDay, 7 * expiryDay, true, "late", 7, ExpirySeverityWarn},
+		{"long lived license final", 365 * expiryDay, expiryDay, true, "final", 1, ExpirySeverityError},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expiresAt := now.Add(tt.remaining)
 			status := ExpiryStatus(License{
 				ID:        "lic_test",
-				ExpiresAt: now.Add(tt.expiresIn).Unix(),
+				IssuedAt:  expiresAt.Add(-tt.lifetime).Unix(),
+				ExpiresAt: expiresAt.Unix(),
 			}, now)
 			if status.Active != tt.wantActive {
 				t.Fatalf("Active = %v, want %v; status=%+v", status.Active, tt.wantActive, status)
+			}
+			if status.Band != tt.wantBand {
+				t.Errorf("Band = %q, want %q", status.Band, tt.wantBand)
 			}
 			if status.ThresholdDays != tt.wantThreshold {
 				t.Errorf("ThresholdDays = %d, want %d", status.ThresholdDays, tt.wantThreshold)
@@ -45,32 +68,154 @@ func TestExpiryStatusThresholdBands(t *testing.T) {
 	}
 }
 
+func TestExpiryStatusUsesLegacyBandsForUnusableIssuedAt(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		issuedAt int64
+		expires  int64
+	}{
+		{"missing", 0, now.Add(30 * expiryDay).Unix()},
+		{"future", now.Add(expiryDay).Unix(), now.Add(30 * expiryDay).Unix()},
+		{"after expiry", now.Add(31 * expiryDay).Unix(), now.Add(30 * expiryDay).Unix()},
+		{"equal expiry", now.Add(30 * expiryDay).Unix(), now.Add(30 * expiryDay).Unix()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := ExpiryStatus(License{ID: "lic_bad_iat", IssuedAt: tt.issuedAt, ExpiresAt: tt.expires}, now)
+			if !status.Active || status.Band != "early" || status.ThresholdDays != 30 || status.Severity != ExpirySeverityInfo {
+				t.Fatalf("status = %+v, want legacy 30-day info band", status)
+			}
+		})
+	}
+}
+
+func TestLegacyExpiryBand(t *testing.T) {
+	tests := []struct {
+		name          string
+		days          int
+		wantBand      string
+		wantThreshold int
+	}{
+		{"final", 1, "final", 1},
+		{"late", 2, "late", 7},
+		{"mid", 8, "mid", 14},
+		{"early", 15, "early", 30},
+		{"outside", 31, "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			band, threshold := legacyExpiryBand(tt.days)
+			if tt.wantBand == "" {
+				if band != nil || threshold != 0 {
+					t.Fatalf("legacyExpiryBand(%d) = %v, %d; want nil, 0", tt.days, band, threshold)
+				}
+				return
+			}
+			if band == nil || band.name != tt.wantBand || threshold != tt.wantThreshold {
+				t.Fatalf("legacyExpiryBand(%d) = %v, %d; want %s, %d", tt.days, band, threshold, tt.wantBand, tt.wantThreshold)
+			}
+		})
+	}
+}
+
 func TestExpiryStatusNoWarningForPerpetualOrExpired(t *testing.T) {
 	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
 	for _, lic := range []License{
 		{ID: "lic_perpetual"},
-		{ID: "lic_expired", ExpiresAt: now.Add(-time.Hour).Unix()},
+		{ID: "lic_expired", IssuedAt: now.Add(-30 * expiryDay).Unix(), ExpiresAt: now.Add(-time.Hour).Unix()},
 	} {
 		status := ExpiryStatus(lic, now)
 		if status.Active {
 			t.Fatalf("ExpiryStatus(%s).Active = true, want false", lic.ID)
 		}
+		if status.DaysRemaining != 0 && lic.ExpiresAt > 0 {
+			t.Fatalf("ExpiryStatus(%s).DaysRemaining = %d, want 0", lic.ID, status.DaysRemaining)
+		}
+	}
+}
+
+func TestExpiryStatusSkipsDuplicateShortLifetimeBands(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	status := ExpiryStatus(License{
+		ID:        "lic_short",
+		IssuedAt:  now.Add(-18 * time.Hour).Unix(),
+		ExpiresAt: now.Add(6 * time.Hour).Unix(),
+	}, now)
+	if !status.Active || status.Band != "final" || status.ThresholdDays != 1 || status.Severity != ExpirySeverityError {
+		t.Fatalf("status = %+v, want final band after duplicate short-lived bands are skipped", status)
+	}
+	if ShouldEmitExpiryWarning(status, NewExpiryWarningState(status, now)) {
+		t.Fatal("the same final band should not re-emit after a successful run")
+	}
+}
+
+func TestExpiryWarningMessage(t *testing.T) {
+	expiresAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		tier string
+		want string
+	}{
+		{
+			name: "trial",
+			tier: trialTier,
+			want: "trial ends in 7 day(s) on 2026-06-01; Pro features stop at expiry. Subscribe at https://pipelab.org/pricing/",
+		},
+		{
+			name: "enterprise evaluation",
+			tier: enterpriseEvalTier,
+			want: "Enterprise evaluation ends in 7 day(s) on 2026-06-01; licensed runtime surfaces stop at expiry. See https://pipelab.org/pricing/",
+		},
+		{
+			name: "subscription",
+			tier: "pro",
+			want: "license expires in 7 day(s) on 2026-06-01; check billing or token delivery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warning := ExpiryWarning{Active: true, Tier: tt.tier, DaysRemaining: 7, ExpiresAt: expiresAt}
+			if got := warning.Message(); got != tt.want {
+				t.Fatalf("Message() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	if got := (ExpiryWarning{}).Message(); got != "" {
+		t.Fatalf("inactive Message() = %q, want empty", got)
 	}
 }
 
 func TestShouldEmitExpiryWarningIdempotentPerBand(t *testing.T) {
-	current := ExpiryWarning{Active: true, LicenseID: "lic_test", ThresholdDays: 14}
+	current := ExpiryWarning{Active: true, LicenseID: "lic_test", Band: "mid", ThresholdDays: 8}
 	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{}) {
 		t.Fatal("first warning should emit")
 	}
-	if ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 14}) {
-		t.Fatal("same license and threshold should not emit twice")
+	if ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", Band: "mid", ThresholdDays: 8}) {
+		t.Fatal("same license and band should not emit twice")
 	}
-	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 30}) {
-		t.Fatal("threshold change should emit")
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", Band: "early", ThresholdDays: 15}) {
+		t.Fatal("a skipped intermediate band must not suppress the current band")
 	}
-	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_other", ThresholdDays: 14}) {
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_other", Band: "mid", ThresholdDays: 8}) {
 		t.Fatal("license change should emit")
+	}
+	if ShouldEmitExpiryWarning(ExpiryWarning{}, ExpiryWarningState{}) {
+		t.Fatal("inactive warning should not emit")
+	}
+}
+
+func TestShouldEmitExpiryWarningSupportsLegacyState(t *testing.T) {
+	current := ExpiryWarning{Active: true, LicenseID: "lic_test", Band: "early", ThresholdDays: 15}
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 30}) {
+		t.Fatal("legacy state with a different absolute band must not suppress the new lifetime-aware band")
+	}
+	if ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", ThresholdDays: 15}) {
+		t.Fatal("legacy state with the same threshold should continue suppressing a duplicate warning")
 	}
 }
 
@@ -79,7 +224,8 @@ func TestExpiryWarningStateRoundTrip(t *testing.T) {
 	want := NewExpiryWarningState(ExpiryWarning{
 		Active:        true,
 		LicenseID:     "lic_state",
-		ThresholdDays: 7,
+		Band:          "late",
+		ThresholdDays: 4,
 	}, time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC))
 	if err := SaveExpiryWarningState(path, want); err != nil {
 		t.Fatalf("SaveExpiryWarningState: %v", err)
@@ -88,7 +234,7 @@ func TestExpiryWarningStateRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadExpiryWarningState: %v", err)
 	}
-	if got.LicenseID != want.LicenseID || got.ThresholdDays != want.ThresholdDays || !got.LastEmittedUTC.Equal(want.LastEmittedUTC) {
+	if got.LicenseID != want.LicenseID || got.Band != want.Band || got.ThresholdDays != want.ThresholdDays || !got.LastEmittedUTC.Equal(want.LastEmittedUTC) {
 		t.Fatalf("state mismatch: got %+v want %+v", got, want)
 	}
 }
@@ -112,22 +258,31 @@ func TestExpiryWarningStateErrorsAndNoopPaths(t *testing.T) {
 	if _, err := LoadExpiryWarningState(badJSON); err == nil {
 		t.Fatal("expected parse error")
 	}
+	if _, err := LoadExpiryWarningState(dir); err == nil {
+		t.Fatal("expected unreadable state error for directory path")
+	}
+
+	legacy := filepath.Join(dir, "legacy.json")
+	if err := os.WriteFile(legacy, []byte(`{"license_id":"lic_legacy","threshold_days":30,"last_emitted_utc":"2026-05-23T12:00:00Z"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := LoadExpiryWarningState(legacy)
+	if err != nil {
+		t.Fatalf("LoadExpiryWarningState legacy: %v", err)
+	}
+	if state.Band != "" || state.ThresholdDays != 30 || !strings.EqualFold(state.LicenseID, "lic_legacy") {
+		t.Fatalf("legacy state = %+v, want older schema preserved", state)
+	}
 
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err := SaveExpiryWarningState(filepath.Join(blocker, "state.json"), ExpiryWarningState{})
+	err = SaveExpiryWarningState(filepath.Join(blocker, "state.json"), ExpiryWarningState{})
 	if err == nil {
 		t.Fatal("expected directory creation error")
 	}
-}
-
-func TestExpirySeverityDefault(t *testing.T) {
-	if got := expirySeverity(99); got != "" {
-		t.Fatalf("expirySeverity(99) = %q, want empty", got)
-	}
-	if ShouldEmitExpiryWarning(ExpiryWarning{}, ExpiryWarningState{}) {
-		t.Fatal("inactive warning should not emit")
+	if err := SaveExpiryWarningState(dir, ExpiryWarningState{}); err == nil {
+		t.Fatal("expected write error for directory state path")
 	}
 }

--- a/internal/license/expiry_test.go
+++ b/internal/license/expiry_test.go
@@ -201,6 +201,9 @@ func TestShouldEmitExpiryWarningIdempotentPerBand(t *testing.T) {
 	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", Band: "early", ThresholdDays: 15}) {
 		t.Fatal("a skipped intermediate band must not suppress the current band")
 	}
+	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_test", Band: "early", ThresholdDays: 8}) {
+		t.Fatal("a state from a different named band must not suppress the current band when their threshold days match")
+	}
 	if !ShouldEmitExpiryWarning(current, ExpiryWarningState{LicenseID: "lic_other", Band: "mid", ThresholdDays: 8}) {
 		t.Fatal("license change should emit")
 	}


### PR DESCRIPTION
## What changed

License renewal warnings are now relative to the token's own lifetime instead of a fixed 30/14/7/1-day ladder, and the message says what the operator should actually do about it.

The fixed ladder was wrong for short-lived tokens: a freshly issued 30-day trial has thirty days remaining, so the first thing a new trial user saw was an expiry warning. On a security product an over-eager warning is a real failure direction, because the operator learns to ignore the channel. Bands are now one half, one quarter, and one eighth of the token's lifetime, each still capped at the old 30, 14, and 7-day thresholds, plus a final one-day band. A 60-day evaluation and any longer license keep their existing schedule exactly; a 30-day trial now warns at roughly 15, 7, 3, and 1 days with nothing at issuance.

A token whose issued time is missing, zero, in the future, or later than its expiry falls back to the old absolute ladder rather than computing a lifetime from a nonsense claim, so a malformed token cannot silently suppress a renewal warning. The persisted once-per-band state now keys on the band name and still accepts state files written before this change.

The wording is tier-aware across every surface that reports it, which are the running proxy's stderr, the audit line, `pipelock doctor`, and the license CLI. A trial is told its trial is ending and where to subscribe, because nothing is broken and the action is to buy. A paid license is told to check billing or token delivery, because a paid token refreshes and an approaching expiry means that stopped working. Distrust the band arithmetic in `expiryBandFor` first: it decides whether a warning is seen at all, and both directions of getting it wrong are bad, a missed expiry on one side and a muted channel on the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - License expiry warnings now adapt to the license lifetime and display clear status bands.
  - Trial, enterprise evaluation, and standard licenses receive tier-specific guidance, including subscription or billing actions.
  - License status reports and diagnostic output include generated warning messages.
  - Audit records and runtime notifications now provide richer license details.

- **Bug Fixes**
  - Warnings still appear when local license state is missing, corrupted, or inaccessible.
  - License warning metadata remains consistent across server reloads.
  - Verified license details are preserved for accurate expiry notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->