### PR TITLE
ci: make Go version test gates truthful

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,15 +114,16 @@ jobs:
             --exclude sdk/conformance/testdata/aarp-corpus/ \
             < "${diff_file}"
 
-  test-oss:
+  # Keep each Go minor in a separate producer. A matrix-level aggregate cannot
+  # distinguish which minor failed: its single result is red for either one.
+  test-oss-go125:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    name: test-oss (${{ matrix.go-version }}, ${{ matrix.shard }})
+    name: test-oss (1.25, ${{ matrix.shard }})
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25', '1.26']
         shard: ['proxy', 'scanner', 'mcp', 'rest-0', 'rest-1', 'rest-2']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -132,7 +133,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.25'
 
       - name: Verify dependencies
         run: bash scripts/ci-retry.sh go mod verify
@@ -140,12 +141,9 @@ jobs:
       - name: Download dependencies
         run: bash scripts/ci-retry.sh go mod download
 
-      - name: Replay harness (deterministic regression)
-        run: make test-replay-harness
-
       - name: Run tests (OSS)
         env:
-          TEST_LABEL: OSS Go ${{ matrix.go-version }} ${{ matrix.shard }}
+          TEST_LABEL: OSS Go 1.25 ${{ matrix.shard }}
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
@@ -172,15 +170,14 @@ jobs:
           fi
           exit "$test_status"
 
-  test-enterprise:
+  test-oss-go126:
     needs: [security-scan]
     runs-on: ubuntu-latest
-    name: test-enterprise (${{ matrix.go-version }}, ${{ matrix.shard }})
+    name: test-oss (1.26, ${{ matrix.shard }})
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25', '1.26']
         shard: ['proxy', 'scanner', 'mcp', 'rest-0', 'rest-1', 'rest-2']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -190,7 +187,55 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.26'
+
+      - name: Verify dependencies
+        run: bash scripts/ci-retry.sh go mod verify
+
+      - name: Download dependencies
+        run: bash scripts/ci-retry.sh go mod download
+
+      - name: Run tests (OSS)
+        env:
+          TEST_LABEL: OSS Go 1.26 ${{ matrix.shard }}
+          TEST_SHARD: ${{ matrix.shard }}
+        run: |
+          set -o pipefail
+          set +e
+          packages="$(python3 scripts/ci_test_packages.py --shard "$TEST_SHARD")" || exit $?
+          package_parallelism=2
+          if [ "$TEST_SHARD" = "proxy" ]; then
+            package_parallelism=1
+          fi
+          bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
+            go test -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \
+            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-oss.json
+          test_status=$?
+          python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-oss.json
+          summary_status=$?
+          if [ "$summary_status" -ne 0 ]; then
+            exit "$summary_status"
+          fi
+          exit "$test_status"
+
+  test-enterprise-go125:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    name: test-enterprise (1.25, ${{ matrix.shard }})
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['proxy', 'scanner', 'mcp', 'rest-0', 'rest-1', 'rest-2']
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25'
 
       - name: Verify dependencies
         run: bash scripts/ci-retry.sh go mod verify
@@ -199,9 +244,8 @@ jobs:
         run: bash scripts/ci-retry.sh go mod download
 
       - name: Run tests (enterprise with coverage)
-        if: matrix.go-version == '1.25'
         env:
-          TEST_LABEL: enterprise Go ${{ matrix.go-version }} ${{ matrix.shard }}
+          TEST_LABEL: enterprise Go 1.25 ${{ matrix.shard }}
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -o pipefail
@@ -228,38 +272,7 @@ jobs:
           fi
           exit "$test_status"
 
-      - name: Run tests (enterprise)
-        if: matrix.go-version != '1.25'
-        env:
-          TEST_LABEL: enterprise Go ${{ matrix.go-version }} ${{ matrix.shard }}
-          TEST_SHARD: ${{ matrix.shard }}
-        run: |
-          set -o pipefail
-          set +e
-          packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
-          package_parallelism=2
-          if [ "$TEST_SHARD" = "proxy" ]; then
-            # The proxy shard has two race-instrumented packages. Running them
-            # sequentially lowers peak memory without serializing t.Parallel
-            # tests inside either package.
-            package_parallelism=1
-          fi
-          # Public runners are 4 vCPU, and -race multiplies scheduler pressure.
-          # Keep package and intra-package test fan-out below CPU count so
-          # deadline/timer tests are not starved by the shard matrix.
-          bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
-            go test -tags enterprise -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \
-            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
-          test_status=$?
-          python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json
-          summary_status=$?
-          if [ "$summary_status" -ne 0 ]; then
-            exit "$summary_status"
-          fi
-          exit "$test_status"
-
       - name: Upload coverage
-        if: matrix.go-version == '1.25'
         # Coverage upload is best-effort telemetry: the Codecov uploader's own
         # CLI-integrity GPG check intermittently fails to fetch Codecov's public
         # key ("no valid OpenPGP data found"), which exits non-zero regardless of
@@ -270,6 +283,54 @@ jobs:
         with:
           files: ./coverage-${{ matrix.shard }}.out
           fail_ci_if_error: false
+
+  test-enterprise-go126:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    name: test-enterprise (1.26, ${{ matrix.shard }})
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['proxy', 'scanner', 'mcp', 'rest-0', 'rest-1', 'rest-2']
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+
+      - name: Verify dependencies
+        run: bash scripts/ci-retry.sh go mod verify
+
+      - name: Download dependencies
+        run: bash scripts/ci-retry.sh go mod download
+
+      - name: Run tests (enterprise)
+        env:
+          TEST_LABEL: enterprise Go 1.26 ${{ matrix.shard }}
+          TEST_SHARD: ${{ matrix.shard }}
+        run: |
+          set -o pipefail
+          set +e
+          packages="$(python3 scripts/ci_test_packages.py --tags enterprise --shard "$TEST_SHARD")" || exit $?
+          package_parallelism=2
+          if [ "$TEST_SHARD" = "proxy" ]; then
+            package_parallelism=1
+          fi
+          bash scripts/ci-test-with-retry.sh --packages "$packages" -- \
+            go test -tags enterprise -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \
+            | python3 scripts/stream_go_test_json.py --label "$TEST_LABEL" --json-out /tmp/go-test-enterprise.json
+          test_status=$?
+          python3 scripts/summarize_go_test_json.py --label "$TEST_LABEL" < /tmp/go-test-enterprise.json
+          summary_status=$?
+          if [ "$summary_status" -ne 0 ]; then
+            exit "$summary_status"
+          fi
+          exit "$test_status"
 
   test-subprocess-coverage:
     needs: [security-scan]
@@ -309,24 +370,63 @@ jobs:
           files: ./coverage-subprocess.out
           fail_ci_if_error: false
 
-  test:
-    needs: [test-oss, test-enterprise, test-subprocess-coverage]
+  test-go125:
+    needs: [security-scan, test-oss-go125, test-enterprise-go125, test-subprocess-coverage]
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: test (${{ matrix.go-version }})
+    name: test (1.25)
     timeout-minutes: 5
-    strategy:
-      matrix:
-        go-version: ['1.25', '1.26']
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: ${{ needs.security-scan.result == 'success' }}
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        if: ${{ needs.security-scan.result == 'success' }}
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25'
+      - name: Replay harness (deterministic regression)
+        if: ${{ needs.security-scan.result == 'success' }}
+        run: make test-replay-harness
       - name: Required check compatibility gate
         run: |
-          echo "test-oss result: ${{ needs.test-oss.result }}"
-          echo "test-enterprise result: ${{ needs.test-enterprise.result }}"
+          echo "security-scan result: ${{ needs.security-scan.result }}"
+          echo "test-oss-go125 result: ${{ needs.test-oss-go125.result }}"
+          echo "test-enterprise-go125 result: ${{ needs.test-enterprise-go125.result }}"
           echo "test-subprocess-coverage result: ${{ needs.test-subprocess-coverage.result }}"
-          test "${{ needs.test-oss.result }}" = "success"
-          test "${{ needs.test-enterprise.result }}" = "success"
+          test "${{ needs.security-scan.result }}" = "success"
+          test "${{ needs.test-oss-go125.result }}" = "success"
+          test "${{ needs.test-enterprise-go125.result }}" = "success"
           test "${{ needs.test-subprocess-coverage.result }}" = "success"
+
+  test-go126:
+    needs: [security-scan, test-oss-go126, test-enterprise-go126]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: test (1.26)
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: ${{ needs.security-scan.result == 'success' }}
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        if: ${{ needs.security-scan.result == 'success' }}
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+      - name: Replay harness (deterministic regression)
+        if: ${{ needs.security-scan.result == 'success' }}
+        run: make test-replay-harness
+      - name: Required check compatibility gate
+        run: |
+          echo "security-scan result: ${{ needs.security-scan.result }}"
+          echo "test-oss-go126 result: ${{ needs.test-oss-go126.result }}"
+          echo "test-enterprise-go126 result: ${{ needs.test-enterprise-go126.result }}"
+          test "${{ needs.security-scan.result }}" = "success"
+          test "${{ needs.test-oss-go126.result }}" = "success"
+          test "${{ needs.test-enterprise-go126.result }}" = "success"
 
   test-macos:
     needs: [security-scan]
@@ -609,7 +709,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [security-scan, test, lint, helm]
+    needs: [security-scan, test-go125, test-go126, lint, helm]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -647,3 +747,54 @@ jobs:
         run: |
           GOOS=windows GOARCH=amd64 go build -tags enterprise -trimpath -o /tmp/pipelock-windows-amd64.exe ./cmd/pipelock
           GOOS=windows GOARCH=arm64 go build -tags enterprise -trimpath -o /tmp/pipelock-windows-arm64.exe ./cmd/pipelock
+
+  # Operator-facing rollup only. Branch protection continues to evaluate the
+  # required producer checks independently.
+  pipelock-ci-summary:
+    needs: [security-scan, test-go125, test-go126, test-macos, lint, build, govulncheck]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Pipelock CI Summary
+    timeout-minutes: 5
+    steps:
+      - name: Report required check evidence
+        env:
+          SECURITY_SCAN_RESULT: ${{ needs.security-scan.result }}
+          TEST_GO125_RESULT: ${{ needs.test-go125.result }}
+          TEST_GO126_RESULT: ${{ needs.test-go126.result }}
+          MACOS_RESULT: ${{ needs.test-macos.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          GOVULNCHECK_RESULT: ${{ needs.govulncheck.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          summary="$GITHUB_STEP_SUMMARY"
+          printf '%s\n\n' '## Pipelock CI Summary' > "$summary"
+          printf '%s\n\n' '| Required check | Evidence |' >> "$summary"
+          printf '%s\n' '| --- | --- |' >> "$summary"
+
+          record_result() {
+            local name="$1"
+            local result="$2"
+            printf '| %s | %s |\n' "$name" "$result" >> "$summary"
+            case "$result" in
+              success) ;;
+              *) failed=1 ;;
+            esac
+          }
+
+          record_result 'security-scan' "$SECURITY_SCAN_RESULT"
+          record_result 'test (1.25)' "$TEST_GO125_RESULT"
+          record_result 'test (1.26)' "$TEST_GO126_RESULT"
+          record_result 'test-macos' "$MACOS_RESULT"
+          record_result 'lint' "$LINT_RESULT"
+          record_result 'build' "$BUILD_RESULT"
+          record_result 'govulncheck' "$GOVULNCHECK_RESULT"
+
+          printf '\nCodeQL is separately required and runs in its own workflow; it is intentionally outside this summary.\n' >> "$summary"
+
+          if [ "$failed" -ne 0 ]; then
+            printf '\nOne or more required checks failed, were cancelled, skipped unexpectedly, or had unknown evidence.\n' >> "$summary"
+            exit 1
+          fi

--- a/scripts/test_ci_workflow_topology.py
+++ b/scripts/test_ci_workflow_topology.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression contract for CI's required-test topology.
+
+The required check display names are a public merge contract. More importantly,
+each Go-minor aggregate must only consume evidence from that minor; otherwise a
+failure in one matrix cell is reported as a failure in both required checks.
+"""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
+SHARDS = {"proxy", "scanner", "mcp", "rest-0", "rest-1", "rest-2"}
+MINORS = ("125", "126")
+SCAN_SUCCESS_CONDITION = "${{ needs.security-scan.result == 'success' }}"
+ALWAYS_CONDITION = "${{ always() }}"
+REQUIRED_PRODUCERS = {
+    "security-scan",
+    "test-go125",
+    "test-go126",
+    "test-macos",
+    "lint",
+    "build",
+    "govulncheck",
+}
+
+
+def step_runs_unconditionally(step: dict) -> bool:
+    """Return True when a step cannot skip after its job has already started.
+
+    A skipped compatibility or summary step turns `if: always()` into success:
+    prior steps were skipped, not failed, so GitHub reports the job green.
+    """
+    return step.get("if") in (None, ALWAYS_CONDITION, "always()")
+
+
+def workflow_jobs():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def topology_errors(jobs: dict) -> list[str]:
+    """Return every broken topology invariant for useful negative fixtures."""
+    errors = []
+    standalone_replay_jobs = [job for job in jobs if job.startswith("test-replay-go")]
+    if standalone_replay_jobs:
+        errors.append(f"standalone replay jobs remain: {sorted(standalone_replay_jobs)}")
+    for minor in MINORS:
+        oss = f"test-oss-go{minor}"
+        enterprise = f"test-enterprise-go{minor}"
+        aggregate = f"test-go{minor}"
+        for producer in (oss, enterprise, aggregate):
+            if producer not in jobs:
+                errors.append(f"missing {producer}")
+        if any(producer not in jobs for producer in (oss, enterprise, aggregate)):
+            continue
+
+        if set(jobs[oss]["strategy"]["matrix"]["shard"]) != SHARDS:
+            errors.append(f"{oss} does not preserve six shards")
+        if set(jobs[enterprise]["strategy"]["matrix"]["shard"]) != SHARDS:
+            errors.append(f"{enterprise} does not preserve six shards")
+
+        aggregate_needs = set(jobs[aggregate].get("needs", []))
+        expected = {"security-scan", oss, enterprise}
+        if minor == "125":
+            expected.add("test-subprocess-coverage")
+        if aggregate_needs != expected:
+            errors.append(f"{aggregate} needs {sorted(aggregate_needs)}, expected {sorted(expected)}")
+        opposite = "126" if minor == "125" else "125"
+        if any(f"go{opposite}" in dependency for dependency in aggregate_needs):
+            errors.append(f"{aggregate} consumes Go {opposite} evidence")
+        if jobs[aggregate].get("name") != f"test (1.{minor[1:]})":
+            errors.append(f"{aggregate} changed its required display name")
+        if jobs[aggregate].get("if") != ALWAYS_CONDITION:
+            errors.append(f"{aggregate} is skipped instead of failing when a dependency fails")
+
+        aggregate_steps = jobs[aggregate].get("steps", [])
+        if sum(step.get("run") == "make test-replay-harness" for step in aggregate_steps) != 1:
+            errors.append(f"{aggregate} is not a singleton replay producer")
+        setup_steps = [step for step in aggregate_steps if step.get("name") == "Set up Go"]
+        if len(setup_steps) != 1 or setup_steps[0].get("with", {}).get("go-version") != f"1.{minor[1:]}":
+            errors.append(f"{aggregate} does not run replay under Go 1.{minor[1:]}")
+        execution_steps = [
+            step
+            for step in aggregate_steps
+            if step.get("name") in {"Set up Go", "Replay harness (deterministic regression)"}
+            or "uses" in step
+        ]
+        if len(execution_steps) != 3 or any(
+            step.get("if") != SCAN_SUCCESS_CONDITION for step in execution_steps
+        ):
+            errors.append(f"{aggregate} can execute PR code after a failed security scan")
+        gate_steps = [
+            step for step in aggregate_steps if step.get("name") == "Required check compatibility gate"
+        ]
+        if len(gate_steps) != 1 or 'test "${{ needs.security-scan.result }}" = "success"' not in gate_steps[0].get("run", ""):
+            errors.append(f"{aggregate} does not red on a failed security scan")
+        elif not step_runs_unconditionally(gate_steps[0]):
+            errors.append(f"{aggregate} compatibility gate can skip and green after failed evidence")
+        for producer in (oss, enterprise):
+            if any(step.get("run") == "make test-replay-harness" for step in jobs[producer].get("steps", [])):
+                errors.append(f"{producer} runs replay inside every shard")
+
+    missing_required = REQUIRED_PRODUCERS - jobs.keys()
+    if missing_required:
+        errors.append(f"missing required producers: {sorted(missing_required)}")
+
+    summary = jobs.get("pipelock-ci-summary")
+    if summary is None:
+        errors.append("missing advisory summary")
+    else:
+        if summary.get("name") != "Pipelock CI Summary":
+            errors.append("summary changed its operator-facing name")
+        if summary.get("if") != ALWAYS_CONDITION:
+            errors.append("summary must run after failed or cancelled evidence")
+        summary_needs = set(summary.get("needs", []))
+        if not REQUIRED_PRODUCERS <= summary_needs:
+            errors.append("summary does not consume every in-workflow required producer")
+        summary_steps = summary.get("steps", [])
+        if not summary_steps:
+            errors.append("summary has no reporting step")
+            return errors
+        report_step = summary_steps[0]
+        if not step_runs_unconditionally(report_step):
+            errors.append("summary reporting step can skip and green after failed evidence")
+        summary_run = report_step.get("run", "")
+        for required_context in (
+            "security-scan",
+            "test (1.25)",
+            "test (1.26)",
+            "test-macos",
+            "lint",
+            "build",
+            "govulncheck",
+        ):
+            if f"record_result '{required_context}'" not in summary_run:
+                errors.append(f"summary does not report {required_context}")
+        if "*) failed=1 ;;" not in summary_run:
+            errors.append("summary does not fail closed on non-success evidence")
+        if "CodeQL is separately required" not in summary_run:
+            errors.append("summary does not explain its CodeQL boundary")
+    return errors
+
+
+class CIWorkflowTopologyTest(unittest.TestCase):
+    def setUp(self):
+        self.jobs = workflow_jobs()
+
+    def test_topology_is_truthful_and_complete(self):
+        self.assertEqual(topology_errors(self.jobs), [])
+
+    def test_go126_failure_cannot_red_go125_aggregate(self):
+        aggregate_needs = set(self.jobs["test-go125"]["needs"])
+        self.assertFalse(
+            any("go126" in dependency for dependency in aggregate_needs),
+            "a Go 1.26-only failure must not reach test (1.25)",
+        )
+
+    def test_cross_minor_wiring_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        broken["test-go125"]["needs"].append("test-oss-go126")
+        self.assertIn("test-go125 consumes Go 126 evidence", topology_errors(broken))
+
+    def test_missing_replay_step_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        broken["test-go126"]["steps"] = [
+            step
+            for step in broken["test-go126"]["steps"]
+            if step.get("run") != "make test-replay-harness"
+        ]
+        errors = topology_errors(broken)
+        self.assertIn("test-go126 is not a singleton replay producer", errors)
+
+    def test_replay_inside_a_shard_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        broken["test-oss-go125"]["steps"].append(
+            {"name": "Replay harness", "run": "make test-replay-harness"}
+        )
+        self.assertIn("test-oss-go125 runs replay inside every shard", topology_errors(broken))
+
+    def test_unguarded_replay_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        for step in broken["test-go126"]["steps"]:
+            if step.get("run") == "make test-replay-harness":
+                del step["if"]
+        self.assertIn(
+            "test-go126 can execute PR code after a failed security scan",
+            topology_errors(broken),
+        )
+
+    def test_aggregate_without_always_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        del broken["test-go125"]["if"]
+        self.assertIn(
+            "test-go125 is skipped instead of failing when a dependency fails",
+            topology_errors(broken),
+        )
+
+    def test_skip_gated_compatibility_gate_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        for step in broken["test-go126"]["steps"]:
+            if step.get("name") == "Required check compatibility gate":
+                step["if"] = SCAN_SUCCESS_CONDITION
+        self.assertIn(
+            "test-go126 compatibility gate can skip and green after failed evidence",
+            topology_errors(broken),
+        )
+
+    def test_skip_gated_summary_step_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        broken["pipelock-ci-summary"]["steps"][0]["if"] = SCAN_SUCCESS_CONDITION
+        self.assertIn(
+            "summary reporting step can skip and green after failed evidence",
+            topology_errors(broken),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Give each supported Go version its own required aggregate, run replay once per version, and add one advisory summary without hiding the diagnostic shards.
- Keep incomplete, skipped, failed, or cross-wired evidence from producing a green aggregate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Testing**
  - Improved validation across supported Go versions with dedicated compatibility checks.
  - Expanded enterprise test coverage reporting for both supported Go releases.
  - Added safeguards to verify test execution, security checks, replay validation, and required build gates.

- **Chores**
  - CI results now provide a consolidated summary, clearly identifying unsuccessful, cancelled, skipped, or unavailable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->