### PR TITLE
ci: align local and release race tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          python3 -m unittest scripts.test_ci_test_packages
+          python3 -m unittest scripts.test_ci_test_packages scripts.test_race_test_shape
 
           tmpdir="$(mktemp -d)"
           trap 'rm -rf "$tmpdir"' EXIT
@@ -123,15 +123,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          tag_args=()
-          package_args=("--shard" "$TEST_SHARD")
+          race_args=("--shard" "$TEST_SHARD")
           if [ -n "$GO_TEST_TAGS" ]; then
-            tag_args=("-tags" "$GO_TEST_TAGS")
-            package_args=("--tags" "$GO_TEST_TAGS" "${package_args[@]}")
+            race_args=("--tags" "$GO_TEST_TAGS" "${race_args[@]}")
           fi
-
-          packages="$(python3 scripts/ci_test_packages.py "${package_args[@]}")"
-          go test "${tag_args[@]}" -race -count=1 -timeout 30m $packages
+          scripts/run-race-test.sh "${race_args[@]}"
 
   # Source-tree conformance proves the implementations agree. This gate proves
   # the packages customers can install accept a receipt from this candidate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ Pre-commit parity for OSS and enterprise builds:
 ```bash
 golangci-lint run --new-from-rev=HEAD ./...
 golangci-lint run --build-tags enterprise --new-from-rev=HEAD ./...
-go test -race -count=1 ./...
-go test -tags enterprise -race -count=1 ./...
+make test
+make test-sharded-enterprise
 ```
 
 Full-repo CI-equivalent lint:
@@ -96,7 +96,7 @@ Emission is non-blocking for webhook output through an async buffer; syslog is s
 
 ## Testing
 
-- Race detector command: `go test -race -count=1 ./...`
+- Race detector command: `make test` (OSS) or `make test-sharded-enterprise` (enterprise)
 - Coverage target for new code: 95%, including error paths.
 - Test-count command: `go test -v ./... 2>&1 | grep -c -- '--- PASS:'`
 - Synchronization uses channels or poll-with-deadline, not `time.Sleep`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Pipelock is an agent firewall: a network and tool proxy that mediates AI-agent H
 
 ```bash
 make build          # Compile with version ldflags
-make test           # go test -race -count=1 ./...
+make test           # Run the OSS race suite as sequential CI-shaped shards
 make test-cover     # Write coverage.html
 make lint           # go vet + golangci-lint v2 + gofumpt check
 make bench          # Scanner and MCP benchmarks

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ install:
 	go install $(LDFLAGS) ./cmd/pipelock
 
 test:
-	go test -race -count=1 ./...
+	$(MAKE) --no-print-directory test-sharded
 
 test-wasm-verifier:
 	node --test deploy/wasm-verify/chain-parity.test.js
 
 test-runtime-critical:
-	go test -race -count=1 -timeout 15m ./internal/config ./internal/cli ./internal/mcp ./internal/proxy
+	scripts/run-race-test.sh --packages "./internal/config ./internal/cli ./internal/mcp ./internal/proxy"
 
 # Test shards mirror CI (scripts/ci_test_packages.py): the three heavy packages
 # (proxy, scanner, mcp) plus three balanced rest shards. Their union is the same
@@ -62,37 +62,25 @@ FORCE:
 
 # Run one CI-equivalent OSS shard, e.g. `make test-shard-proxy`.
 test-shard-%: FORCE
-	packages=$$(python3 scripts/ci_test_packages.py --shard $*) || exit $$?; \
-	package_parallelism=2; \
-	if [ "$*" = "proxy" ]; then package_parallelism=1; fi; \
-	go test -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages
+	scripts/run-race-test.sh --shard $*
 
 # Run one CI-equivalent enterprise shard, e.g. `make test-shard-enterprise-mcp`.
 test-shard-enterprise-%: FORCE
-	packages=$$(python3 scripts/ci_test_packages.py --tags enterprise --shard $*) || exit $$?; \
-	package_parallelism=2; \
-	if [ "$*" = "proxy" ]; then package_parallelism=1; fi; \
-	go test -tags enterprise -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages
+	scripts/run-race-test.sh --tags enterprise --shard $*
 
 # Run every OSS shard sequentially: same coverage as `make test`, sharded and
 # labelled (serial to respect the local single-race-at-a-time constraint).
 test-sharded:
 	@for shard in $(TEST_SHARDS); do \
 		echo "=== OSS test shard: $$shard ==="; \
-		packages=$$(python3 scripts/ci_test_packages.py --shard $$shard) || exit $$?; \
-		package_parallelism=2; \
-		if [ "$$shard" = "proxy" ]; then package_parallelism=1; fi; \
-		go test -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
+		scripts/run-race-test.sh --shard $$shard || exit $$?; \
 	done
 
 # Run every enterprise shard sequentially (mirrors the CI test-enterprise matrix).
 test-sharded-enterprise:
 	@for shard in $(TEST_SHARDS); do \
 		echo "=== enterprise test shard: $$shard ==="; \
-		packages=$$(python3 scripts/ci_test_packages.py --tags enterprise --shard $$shard) || exit $$?; \
-		package_parallelism=2; \
-		if [ "$$shard" = "proxy" ]; then package_parallelism=1; fi; \
-		go test -tags enterprise -race -p=$$package_parallelism -parallel=2 -count=1 -timeout=15m $$packages || exit $$?; \
+		scripts/run-race-test.sh --tags enterprise --shard $$shard || exit $$?; \
 	done
 
 # test-replay-harness exercises the synthetic replay regression suite:
@@ -100,10 +88,10 @@ test-sharded-enterprise:
 # Refresh goldens after intentional logic changes:
 #   go test ./internal/capture -run TestReplayHarness -update
 test-replay-harness:
-	go test -race -count=1 -run TestReplayHarness ./internal/capture
+	scripts/run-race-test.sh --packages ./internal/capture --run TestReplayHarness
 
 test-cover:
-	go test -race -coverprofile=coverage.out ./...
+	go test -count=1 -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
@@ -161,7 +149,7 @@ runtime-policy-audit:
 debt-check:
 	golangci-lint run --enable-only dupl,gocyclo,gocognit,maintidx ./...
 
-release-check: test lint test-runtime-critical test-replay-harness release-audit runtime-policy-audit
+release-check: test lint release-audit runtime-policy-audit
 
 tidy-check:
 	go mod tidy

--- a/scripts/run-race-test.sh
+++ b/scripts/run-race-test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Run one repository-defined race-test selection. Keep the scheduler shape here
+# so local shard targets and release verification cannot quietly disagree about
+# fan-out, repeat count, or deadline.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: run-race-test.sh (--shard NAME | --packages "./pkg ...") [options]
+
+Options:
+  --tags TAGS             Go build tags (for example: enterprise)
+  --run PATTERN           Go test -run pattern
+  --coverprofile PATH     Write a Go coverage profile
+  --json                  Emit go test JSON
+  --print-command         Print the command without running it
+EOF
+}
+
+shard=""
+package_list=""
+tags=""
+run_pattern=""
+coverprofile=""
+json=false
+print_command=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --shard)
+      shard="${2:-}"
+      shift 2
+      ;;
+    --packages)
+      package_list="${2:-}"
+      shift 2
+      ;;
+    --tags)
+      tags="${2:-}"
+      shift 2
+      ;;
+    --run)
+      run_pattern="${2:-}"
+      shift 2
+      ;;
+    --coverprofile)
+      coverprofile="${2:-}"
+      shift 2
+      ;;
+    --json)
+      json=true
+      shift
+      ;;
+    --print-command)
+      print_command=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "run-race-test.sh: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "$shard" && -n "$package_list" ]] || [[ -z "$shard" && -z "$package_list" ]]; then
+  echo "run-race-test.sh: pass exactly one of --shard or --packages" >&2
+  usage
+  exit 2
+fi
+
+package_parallelism=2
+if [[ -n "$shard" ]]; then
+  package_args=(--shard "$shard")
+  if [[ -n "$tags" ]]; then
+    package_args=(--tags "$tags" "${package_args[@]}")
+  fi
+  package_list="$(python3 scripts/ci_test_packages.py "${package_args[@]}")"
+  if [[ "$shard" == "proxy" ]]; then
+    # The proxy shard has two race-instrumented packages. Keep them sequential
+    # while leaving t.Parallel tests inside each package at the common limit.
+    package_parallelism=1
+  fi
+fi
+
+read -r -a packages <<<"$package_list"
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "run-race-test.sh: package selection was empty" >&2
+  exit 1
+fi
+
+cmd=(go test -race "-p=$package_parallelism" -parallel=2 -count=1 -timeout=15m)
+if [[ -n "$tags" ]]; then
+  cmd+=(-tags "$tags")
+fi
+if [[ -n "$run_pattern" ]]; then
+  cmd+=(-run "$run_pattern")
+fi
+if [[ -n "$coverprofile" ]]; then
+  cmd+=("-coverprofile=$coverprofile")
+fi
+if [[ "$json" == true ]]; then
+  cmd+=(-json)
+fi
+cmd+=("${packages[@]}")
+
+if [[ "$print_command" == true ]]; then
+  printf '%q ' "${cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${cmd[@]}"

--- a/scripts/test_race_test_shape.py
+++ b/scripts/test_race_test_shape.py
@@ -20,6 +20,10 @@ CI_RACE_PRODUCERS = (
     "test-enterprise-go126",
 )
 LEGACY_CI_RACE_PRODUCERS = ("test-oss", "test-enterprise")
+RUNNER_COMMAND = re.compile(
+    r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:bash\s+)?scripts/run-race-test\.sh(?:\s|$)"
+)
+DIRECT_RACE_COMMAND = re.compile(r"(?:^|[;&|]\s*)go test\b.*(?:^|\s)-race(?:\s|$)")
 
 
 def printed_command(*args: str) -> str:
@@ -41,14 +45,36 @@ def job_block(workflow: str, name: str) -> str:
     return workflow[start:end]
 
 
-def job_invokes_race_runner(job: str) -> bool:
-    for line in job.splitlines():
+def race_execution_counts(block: str) -> tuple[int, int]:
+    runner_count = 0
+    direct_count = 0
+    for line in block.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        if "scripts/run-race-test.sh" in stripped:
-            return True
-    return False
+        if RUNNER_COMMAND.search(stripped):
+            runner_count += 1
+        if DIRECT_RACE_COMMAND.search(stripped):
+            direct_count += 1
+    return runner_count, direct_count
+
+
+def make_target_block(makefile: str, name: str) -> str:
+    marker = f"{name}:"
+    start = makefile.index(marker)
+    next_target = re.search(
+        r"(?m)^[A-Za-z0-9_.%/-]+(?:\s[^:]*)?:",
+        makefile[start + len(marker) :],
+    )
+    end = len(makefile) if next_target is None else start + len(marker) + next_target.start()
+    return makefile[start:end]
+
+
+def workflow_step_block(workflow: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = workflow.index(marker)
+    next_step = workflow.find("\n      - ", start + len(marker))
+    return workflow[start:] if next_step == -1 else workflow[start:next_step]
 
 
 def ci_race_shape_errors(ci: str) -> list[str]:
@@ -57,6 +83,7 @@ def ci_race_shape_errors(ci: str) -> list[str]:
     delegated: list[str] = []
     inline: list[str] = []
     drifted: list[str] = []
+    mixed: list[str] = []
     split_topology = any(f"  {name}:\n" in ci for name in CI_RACE_PRODUCERS)
     producer_names = CI_RACE_PRODUCERS if split_topology else LEGACY_CI_RACE_PRODUCERS
     for name in producer_names:
@@ -65,13 +92,23 @@ def ci_race_shape_errors(ci: str) -> list[str]:
         except ValueError:
             errors.append(f"missing {name}")
             continue
-        if job_invokes_race_runner(job):
+        runner_count, direct_count = race_execution_counts(job)
+        if runner_count and direct_count:
+            mixed.append(name)
+            continue
+        if runner_count:
             delegated.append(name)
             continue
-        if '-p="$package_parallelism" -parallel=2' in job and "-timeout=15m -count=1" in job:
+        if (
+            direct_count
+            and '-p="$package_parallelism" -parallel=2' in job
+            and "-timeout=15m -count=1" in job
+        ):
             inline.append(name)
         else:
             drifted.append(name)
+    if mixed:
+        errors.append(f"CI race jobs mixed runner delegation with direct race execution: {mixed}")
     if drifted:
         errors.append(f"CI race jobs drifted from shared shape: {drifted}")
     if delegated and inline:
@@ -104,10 +141,24 @@ class TestRaceTestShape(unittest.TestCase):
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
         release = (ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
 
-        self.assertRegex(makefile, r"(?m)^test:\n\t\$\(MAKE\) --no-print-directory test-sharded$")
-        self.assertIn("scripts/run-race-test.sh --shard", makefile)
-        self.assertIn("scripts/run-race-test.sh --packages", makefile)
-        self.assertIn("scripts/run-race-test.sh \"${race_args[@]}\"", release)
+        test_target = make_target_block(makefile, "test")
+        self.assertEqual(test_target.count("$(MAKE) --no-print-directory test-sharded"), 1)
+        for target in (
+            "test-runtime-critical",
+            "test-shard-%",
+            "test-shard-enterprise-%",
+            "test-sharded",
+            "test-sharded-enterprise",
+        ):
+            with self.subTest(target=target):
+                self.assertEqual(
+                    race_execution_counts(make_target_block(makefile, target)),
+                    (1, 0),
+                )
+        self.assertEqual(
+            race_execution_counts(workflow_step_block(release, "Run tests")),
+            (1, 0),
+        )
 
     def test_ci_keeps_the_same_race_shape_until_it_delegates_to_the_runner(self) -> None:
         ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
@@ -134,6 +185,29 @@ class TestRaceTestShape(unittest.TestCase):
         )
         errors = ci_race_shape_errors(commented)
         self.assertTrue(any("drifted from shared shape" in error for error in errors), errors)
+
+    def test_non_command_runner_mention_does_not_disable_the_shape_contract(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+        mentioned = ci.replace(
+            "          set -o pipefail",
+            '          echo "scripts/run-race-test.sh is the preferred path"\n          set -o pipefail',
+            1,
+        ).replace('-p="$package_parallelism" -parallel=2', "-p=8 -parallel=8")
+        errors = ci_race_shape_errors(mentioned)
+        self.assertTrue(any("drifted from shared shape" in error for error in errors), errors)
+
+    def test_partial_runner_delegation_fails_the_contract(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+        first_producer = "test-oss-go125" if "  test-oss-go125:\n" in ci else "test-oss"
+        mixed = ci.replace(
+            "          set -o pipefail",
+            "          scripts/run-race-test.sh --shard proxy\n          set -o pipefail",
+            1,
+        )
+        self.assertIn(
+            f"CI race jobs mixed runner delegation with direct race execution: ['{first_producer}']",
+            ci_race_shape_errors(mixed),
+        )
 
     def test_invalid_selection_fails_before_running_go(self) -> None:
         result = subprocess.run(

--- a/scripts/test_race_test_shape.py
+++ b/scripts/test_race_test_shape.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the repository-owned race-test invocation shape."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run-race-test.sh"
+CI_RACE_PRODUCERS = (
+    "test-oss-go125",
+    "test-oss-go126",
+    "test-enterprise-go125",
+    "test-enterprise-go126",
+)
+LEGACY_CI_RACE_PRODUCERS = ("test-oss", "test-enterprise")
+
+
+def printed_command(*args: str) -> str:
+    result = subprocess.run(
+        ["bash", str(RUNNER), *args, "--print-command"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def job_block(workflow: str, name: str) -> str:
+    marker = f"  {name}:\n"
+    start = workflow.index(marker)
+    next_job = re.search(r"(?m)^  [A-Za-z0-9_-]+:\n", workflow[start + len(marker) :])
+    end = len(workflow) if next_job is None else start + len(marker) + next_job.start()
+    return workflow[start:end]
+
+
+def job_invokes_race_runner(job: str) -> bool:
+    for line in job.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "scripts/run-race-test.sh" in stripped:
+            return True
+    return False
+
+
+def ci_race_shape_errors(ci: str) -> list[str]:
+    """Return CI race-shape contract breaks so synthetic drift can fail closed."""
+    errors = []
+    delegated: list[str] = []
+    inline: list[str] = []
+    drifted: list[str] = []
+    split_topology = any(f"  {name}:\n" in ci for name in CI_RACE_PRODUCERS)
+    producer_names = CI_RACE_PRODUCERS if split_topology else LEGACY_CI_RACE_PRODUCERS
+    for name in producer_names:
+        try:
+            job = job_block(ci, name)
+        except ValueError:
+            errors.append(f"missing {name}")
+            continue
+        if job_invokes_race_runner(job):
+            delegated.append(name)
+            continue
+        if '-p="$package_parallelism" -parallel=2' in job and "-timeout=15m -count=1" in job:
+            inline.append(name)
+        else:
+            drifted.append(name)
+    if drifted:
+        errors.append(f"CI race jobs drifted from shared shape: {drifted}")
+    if delegated and inline:
+        errors.append("CI race jobs mixed runner delegation with inline shape")
+    if not delegated and not inline and not drifted:
+        errors.append("CI race producers were not found")
+    return errors
+
+
+class TestRaceTestShape(unittest.TestCase):
+    def test_oss_proxy_shape_limits_package_fanout(self) -> None:
+        command = printed_command("--shard", "proxy")
+
+        self.assertIn("go test -race -p=1 -parallel=2 -count=1 -timeout=15m", command)
+        self.assertIn("github.com/luckyPipewrench/pipelock/internal/proxy", command)
+
+    def test_enterprise_rest_shape_uses_common_limits(self) -> None:
+        command = printed_command("--shard", "rest-0", "--tags", "enterprise")
+
+        self.assertIn("go test -race -p=2 -parallel=2 -count=1 -timeout=15m", command)
+        self.assertIn("-tags enterprise", command)
+
+    def test_named_package_selection_cannot_bypass_common_limits(self) -> None:
+        command = printed_command("--packages", "./internal/config ./internal/mcp")
+
+        self.assertIn("go test -race -p=2 -parallel=2 -count=1 -timeout=15m", command)
+        self.assertIn("./internal/config ./internal/mcp", command)
+
+    def test_local_and_release_targets_delegate_to_the_runner(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        release = (ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
+
+        self.assertRegex(makefile, r"(?m)^test:\n\t\$\(MAKE\) --no-print-directory test-sharded$")
+        self.assertIn("scripts/run-race-test.sh --shard", makefile)
+        self.assertIn("scripts/run-race-test.sh --packages", makefile)
+        self.assertIn("scripts/run-race-test.sh \"${race_args[@]}\"", release)
+
+    def test_ci_keeps_the_same_race_shape_until_it_delegates_to_the_runner(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+        self.assertEqual(ci_race_shape_errors(ci), [])
+
+    def test_one_drifted_ci_race_job_fails_the_contract(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+        first_producer = "test-oss-go125" if "  test-oss-go125:\n" in ci else "test-oss"
+        drifted = ci.replace(
+            'go test -race -p="$package_parallelism" -parallel=2 -timeout=15m -count=1 -json \\',
+            "go test -race -p=8 -parallel=8 -timeout=15m -count=1 -json \\",
+            1,
+        )
+        self.assertIn(
+            f"CI race jobs drifted from shared shape: ['{first_producer}']",
+            ci_race_shape_errors(drifted),
+        )
+
+    def test_comment_mention_of_the_runner_does_not_disable_the_shape_contract(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
+        commented = "  # later: scripts/run-race-test.sh\n" + ci.replace(
+            '-p="$package_parallelism" -parallel=2',
+            "-p=8 -parallel=8",
+        )
+        errors = ci_race_shape_errors(commented)
+        self.assertTrue(any("drifted from shared shape" in error for error in errors), errors)
+
+    def test_invalid_selection_fails_before_running_go(self) -> None:
+        result = subprocess.run(
+            ["bash", str(RUNNER), "--shard", "mcp", "--packages", "./internal/mcp"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("exactly one", result.stderr)
+
+    def test_release_check_does_not_repeat_packages_covered_by_test(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        release_check = next(
+            line for line in makefile.splitlines() if line.startswith("release-check:")
+        )
+
+        self.assertEqual(
+            release_check,
+            "release-check: test lint release-audit runtime-policy-audit",
+        )
+        self.assertIn("test-replay-harness:", makefile)
+        self.assertIn("test-runtime-critical:", makefile)
+
+    def test_ordinary_coverage_is_not_a_second_race_suite(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        coverage_target = makefile.split("test-cover:", 1)[1].split("\n\n", 1)[0]
+
+        self.assertIn("go test -count=1 -coverprofile=coverage.out ./...", coverage_target)
+        self.assertNotIn("-race", coverage_target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_race_test_shape.py
+++ b/scripts/test_race_test_shape.py
@@ -20,10 +20,14 @@ CI_RACE_PRODUCERS = (
     "test-enterprise-go126",
 )
 LEGACY_CI_RACE_PRODUCERS = ("test-oss", "test-enterprise")
+SHELL_ASSIGNMENT = r"[A-Za-z_][A-Za-z0-9_]*=(?:[^\s\"']*|\"[^\"]*\"|'[^']*')"
+COMMAND_PREFIX = rf"(?:env\s+)?(?:{SHELL_ASSIGNMENT}\s+)*"
 RUNNER_COMMAND = re.compile(
-    r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:bash\s+)?scripts/run-race-test\.sh(?:\s|$)"
+    rf"^{COMMAND_PREFIX}(?:bash\s+)?scripts/run-race-test\.sh(?:\s|$)"
 )
-DIRECT_RACE_COMMAND = re.compile(r"(?:^|[;&|]\s*)go test\b.*(?:^|\s)-race(?:\s|$)")
+DIRECT_RACE_COMMAND = re.compile(
+    rf"(?:^|[;&|]\s*){COMMAND_PREFIX}go test\b.*(?:^|\s)-race(?:\s|$)"
+)
 
 
 def printed_command(*args: str) -> str:
@@ -199,15 +203,23 @@ class TestRaceTestShape(unittest.TestCase):
     def test_partial_runner_delegation_fails_the_contract(self) -> None:
         ci = (ROOT / ".github/workflows/ci.yaml").read_text(encoding="utf-8")
         first_producer = "test-oss-go125" if "  test-oss-go125:\n" in ci else "test-oss"
-        mixed = ci.replace(
-            "          set -o pipefail",
-            "          scripts/run-race-test.sh --shard proxy\n          set -o pipefail",
-            1,
-        )
-        self.assertIn(
-            f"CI race jobs mixed runner delegation with direct race execution: ['{first_producer}']",
-            ci_race_shape_errors(mixed),
-        )
+        for prefix in ("", 'GOFLAGS="" ', "env GOFLAGS=-mod=readonly "):
+            with self.subTest(prefix=prefix):
+                mixed = ci.replace(
+                    "          set -o pipefail",
+                    "          scripts/run-race-test.sh --shard proxy\n          set -o pipefail",
+                    1,
+                ).replace("go test -race", f"{prefix}go test -race", 1)
+                self.assertIn(
+                    f"CI race jobs mixed runner delegation with direct race execution: ['{first_producer}']",
+                    ci_race_shape_errors(mixed),
+                )
+
+    def test_assignment_prefixed_commands_count_as_executable(self) -> None:
+        block = """GOFLAGS="" scripts/run-race-test.sh --shard proxy
+env CGO_ENABLED=1 go test -race ./internal/proxy
+"""
+        self.assertEqual(race_execution_counts(block), (1, 1))
 
     def test_invalid_selection_fails_before_running_go(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
## What changed
- Route local and release race tests through one repository-owned runner with consistent package fan-out, parallelism, count, and timeout.
- Keep coverage separate from race execution, and make the workflow contract fail if any producer drifts or delegates only part of the test run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Standardized race-test execution across local development and continuous integration.
  - Added validation for test commands, shard configuration, timeouts, and duplicate coverage.
  - Improved support for selected suites, tags, coverage, and structured output.

- **Chores**
  - Centralized race-test configuration and shard handling.
  - Updated release checks to use the consolidated testing flow.

- **Documentation**
  - Updated contributor guidance to reflect the sequential, CI-aligned race-test process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->