### PR TITLE
Stop presenting a recorded receipt label as a proven identity

### DIFF
--- a/enterprise/dashboard/agents.tmpl.html
+++ b/enterprise/dashboard/agents.tmpl.html
@@ -122,13 +122,13 @@
     <header class="page-head">
       <div class="eyebrow mono">Evidence &middot; Agents</div>
       <h1>Agent evidence</h1>
-      <p class="lead">Every agent that produced signed receipts in the configured evidence source, with its per-agent chain, anchor, and trusted-key rollup. Read-only. An agent absent here simply has no loaded receipts &mdash; that is not proof it was idle.</p>
-      <div class="summary mono"><b>{{len .Groups}}</b> agent{{if ne (len .Groups) 1}}s{{end}} with loaded evidence{{if .Filter.Agent}} &middot; filtered to &ldquo;{{.Filter.Agent}}&rdquo;{{end}}</div>
+      <p class="lead">Every agent label recorded on signed receipts in the configured evidence source, with its per-label chain, anchor, and trusted-key rollup. Identity not established by v1 receipts: these are recorded labels rather than proven identities. Read-only. A label absent here simply has no loaded receipts &mdash; that is not proof it was idle.</p>
+      <div class="summary mono"><b>{{len .Groups}}</b> recorded label{{if ne (len .Groups) 1}}s{{end}} with loaded evidence{{if .Filter.Agent}} &middot; filtered to &ldquo;{{.Filter.Agent}}&rdquo;{{end}}</div>
     </header>
 
     <form class="filter-form" method="get" action="/agents">
       <div>
-        <label for="f-agent">Agent</label><br>
+        <label for="f-agent">Recorded label</label><br>
         <input type="text" id="f-agent" name="agent" value="{{.Filter.Agent}}" maxlength="128">
       </div>
       <div>
@@ -178,7 +178,7 @@
         </div>
       </div>
     {{else}}
-      <div class="empty">The roster proves which agents have loaded receipt sessions in the configured evidence source. No agents or receipts are loaded from that source for this view or filter. Point <code>pipelock dashboard serve</code> at a flight-recorder evidence directory with <code>--receipt-dir</code>, or clear the current filter.</div>
+      <div class="empty">The roster lists labels recorded on loaded receipts in the configured evidence source; identity not established by v1 receipts. No labels or receipts are loaded from that source for this view or filter. Point <code>pipelock dashboard serve</code> at a flight-recorder evidence directory with <code>--receipt-dir</code>, or clear the current filter.</div>
     {{end}}
   </main>
 </body>

--- a/enterprise/dashboard/agents_test.go
+++ b/enterprise/dashboard/agents_test.go
@@ -142,12 +142,13 @@ func TestHandler_AgentsRendersGroups(t *testing.T) {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "Agent evidence") {
-		t.Fatal("body should contain the agents page heading")
+	// Assert the CLAIM, not the page title. The page keeps its navigational
+	// name; what had to change is the identity claim it made about a v1 label.
+	if !strings.Contains(body, "Identity not established by v1 receipts") {
+		t.Fatal("roster must state that a v1 receipt does not establish identity")
 	}
-	// The designed header carries the honest what-this-proves lead, not a bare title.
-	if !strings.Contains(body, "produced signed receipts in the configured evidence source") {
-		t.Fatal("body should contain the honest agents-page intent lead")
+	if !strings.Contains(body, "recorded labels rather than proven identities") {
+		t.Fatal("roster lead must describe the values as recorded labels")
 	}
 	if !strings.Contains(body, "with loaded evidence") {
 		t.Fatal("body should contain the agent-count summary line")
@@ -168,6 +169,37 @@ func TestHandler_AgentsRendersGroups(t *testing.T) {
 	}
 }
 
+func TestHandler_AgentsDescribesGroupsAsRecordedLabels(t *testing.T) {
+	t.Parallel()
+
+	dir, trusted := writeTrustedHandlerSession(t)
+	handler := New(Options{
+		TrustedOuterAuth: true,
+		ReceiptDir:       dir,
+		TrustedKeys:      trusted,
+		HasFeature:       allowAgentsFeature,
+	})
+
+	for _, path := range []string{"/agents", "/evidence"} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+
+		body := rec.Body.String()
+		for _, want := range []string{
+			"Identity not established by v1 receipts",
+			"Recorded label",
+		} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("%s body missing %q: %s", path, want, body)
+			}
+		}
+	}
+}
+
 func TestHandler_AgentsEmptyStateExplainsReceiptSource(t *testing.T) {
 	t.Parallel()
 
@@ -184,8 +216,9 @@ func TestHandler_AgentsEmptyStateExplainsReceiptSource(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
-		"The roster proves which agents have loaded receipt sessions",
-		"No agents or receipts are loaded",
+		"The roster lists labels recorded on loaded receipts",
+		"Identity not established by v1 receipts",
+		"No labels or receipts are loaded",
 		"--receipt-dir",
 	} {
 		if !strings.Contains(body, want) {

--- a/enterprise/dashboard/evidence.tmpl.html
+++ b/enterprise/dashboard/evidence.tmpl.html
@@ -250,6 +250,7 @@
           <div class="heading">
             <div>
               <h1>Evidence · {{.Evidence.Agent}}</h1>
+              <div class="muted">Recorded label. Identity not established by v1 receipts.</div>
               <div class="muted mono">{{.Evidence.ID}}</div>
             </div>
             <div class="dim mono">{{.Evidence.ReceiptCount}}{{if .Evidence.ReadLimited}}+{{end}} receipts</div>

--- a/enterprise/dashboard/overview.tmpl.html
+++ b/enterprise/dashboard/overview.tmpl.html
@@ -395,9 +395,10 @@
         <span class="badge">{{len .Enforcement.Rows}} groups</span>
       </div>
       <div class="section-body">
+        <p class="dim">Identity not established by v1 receipts. Recorded labels support grouping and filtering.</p>
         {{if .Enforcement.Rows}}
           <table>
-            <thead><tr><th>Decision</th><th>Scanner / rule</th><th>Agent</th><th>Count</th><th>Last seen</th></tr></thead>
+            <thead><tr><th>Decision</th><th>Scanner / rule</th><th>Recorded label</th><th>Count</th><th>Last seen</th></tr></thead>
             <tbody>
               {{range .Enforcement.Rows}}
                 <tr><td class="mono">{{.Verdict}}</td><td>{{.Scanner}}</td><td><a href="{{.Link}}">{{.Agent}}</a></td><td>{{.Count}}</td><td><code>{{.LastSeen}}</code></td></tr>
@@ -427,7 +428,7 @@
         </div>
         {{if .Evidence.Rows}}
           <table>
-            <thead><tr><th>Session</th><th>Agent</th><th>Chain</th><th>Anchor</th><th>Signer</th><th>Receipts</th></tr></thead>
+            <thead><tr><th>Session</th><th>Recorded label</th><th>Chain</th><th>Anchor</th><th>Signer</th><th>Receipts</th></tr></thead>
             <tbody>
               {{range .Evidence.Rows}}
                 <tr><td><a href="{{.Link}}"><code>{{.SessionID}}</code></a></td><td>{{.Agent}}</td><td class="{{.Severity}}">{{.Chain}}</td><td>{{.Anchor}}</td><td>{{.Signer}}</td><td>{{.Receipts}}</td></tr>

--- a/enterprise/dashboard/overview_test.go
+++ b/enterprise/dashboard/overview_test.go
@@ -100,6 +100,8 @@ func TestOverviewHandlerRendersAttentionLedgerAndHonestEmptyStates(t *testing.T)
 	body := rec.Body.String()
 	for _, want := range []string{
 		"Operator Overview",
+		"Identity not established by v1 receipts",
+		"Recorded label",
 		"No aggregate score.",
 		"No fleet source configured",
 		"No conductor decision source configured",


### PR DESCRIPTION
## What changed

The dashboard presented the agent label stored on a receipt as if it were a proven identity. A v1 receipt records the label without recording how it was established, and on a listener with no bound identity the caller supplies that label, so the dashboard was making a claim the evidence does not support.

The agents, evidence, and overview views now show the label as a recorded value and state that identity is not established by v1 receipts, so an operator reading the dashboard during an investigation is not led to trust a name the signature never covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Clarified that agent values shown in v1 receipts are recorded labels, not verified identities.
  - Renamed agent filters and table headings to “Recorded label.”
  - Added explanatory guidance to the Agents, Evidence, and Overview pages.
  - Updated empty-state messaging to reflect the revised terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->