### PR TITLE
docs: reconcile CI check names and guidance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,6 @@ jobs:
   # Pipelock scans the PR diff before anything else runs. If the scan
   # finds credential leaks, injection patterns, or security misconfigs,
   # all downstream jobs are skipped — no compromised code executes.
-  # Pipelock scans the PR diff before anything else runs. If the scan finds
-  # credential leaks, all downstream jobs are skipped, so no compromised code
-  # executes.
   #
   # The scanner is BUILT FROM THE DEFAULT BRANCH rather than downloaded as a
   # release. A released binary is frozen at the last tag, so a scanner fix on
@@ -531,7 +528,7 @@ jobs:
           GOOS=aix GOARCH=ppc64 go test -c -o /tmp/recorder-aix.test ./internal/recorder
           GOOS=aix GOARCH=ppc64 go test -c -o /tmp/license-aix.test ./internal/license
 
-  # The reviewer's own tests, which no pull request has ever run.
+  # The reviewer's own regression suite now runs on pull requests.
   #
   # The repositories that kept their own copy of the reviewer ran these as a
   # step inside the review itself. That never gated anything: a review is

--- a/.github/workflows/verifiers.yaml
+++ b/.github/workflows/verifiers.yaml
@@ -2,9 +2,9 @@ name: Verifiers
 
 # Gates the TypeScript and Rust reference verifiers under sdk/verifiers/.
 # The Go conformance suite under sdk/conformance/ is already gated by the
-# existing CI workflow's `test` job. This file adds matching CI coverage
-# for the non-Go reference verifiers so changes that break either one fail
-# at the PR stage instead of merging silently.
+# existing CI workflow's `test (1.25)` and `test (1.26)` aggregate jobs. This
+# file adds matching CI coverage for the non-Go reference verifiers. Changes
+# that break either one fail at the PR stage instead of merging silently.
 #
 # Security note: no run: step in this workflow consumes untrusted
 # github.event.* input. Every command runs over repo-controlled paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Branch naming:
 
 ### Pre-Commit Checklist
 
-These match exactly what CI checks. Both must pass with zero issues.
+Run both before opening a pull request. They cover the core local Go checks; CI also runs platform, build, dependency, workflow, and security jobs.
 
 ```bash
 golangci-lint run ./...          # Full lint (19 linters, see .golangci.yml)
@@ -44,7 +44,7 @@ go test -race -count=1 ./...     # All tests with race detector
 ## Pull Requests
 
 1. Fill in a clear description of what changed and why
-2. CI runs 6 required checks: **test** (Go 1.25 + 1.26 matrix), **lint**, **build**, **govulncheck**, **CodeQL**, **pipelock** (self-scan)
+2. CI requires eight GitHub Actions contexts: **security-scan**, **test (1.25)**, **test (1.26)**, **test-macos**, **lint**, **build**, **govulncheck**, and **codeql**. The advisory **Pipelock CI Summary** rolls them up for readability but isn't a required context.
 3. Address reviewer feedback and bot comments. Automated AI review (e.g. CodeRabbit) is **advisory only** — maintainers make all security decisions, and a bot's passing status or summary does not by itself mean a change was security-reviewed.
 4. PRs are squash-merged
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ All contributions are welcome via pull request. See [CONTRIBUTING.md](CONTRIBUTI
 
 Pull requests require:
 
-- Passing CI (test, lint, build, CodeQL, govulncheck)
+- Passing every required CI context listed in [CONTRIBUTING.md](CONTRIBUTING.md#pull-requests)
 - At least one approving review
 - All review threads resolved
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test-sharded:
 		scripts/run-race-test.sh --shard $$shard || exit $$?; \
 	done
 
-# Run every enterprise shard sequentially (mirrors the CI test-enterprise matrix).
+# Run every enterprise shard sequentially (mirrors both CI enterprise matrices).
 test-sharded-enterprise:
 	@for shard in $(TEST_SHARDS); do \
 		echo "=== enterprise test shard: $$shard ==="; \

--- a/docs/compliance/eu-ai-act-mapping.md
+++ b/docs/compliance/eu-ai-act-mapping.md
@@ -194,7 +194,7 @@ How Pipelock maps to NIST AI Risk Management Framework functions, with EU AI Act
 | NIST Subcategory | Description | Pipelock Feature | EU AI Act |
 |-----------------|-------------|-----------------|-----------|
 | MEASURE 1.1 | Metrics selected and documented | Prometheus: `pipelock_requests_total`, `pipelock_scanner_hits_total`, `pipelock_request_duration_seconds` | Art. 12 |
-| MEASURE 2.5 | System demonstrated valid and reliable | CI: 6 required checks (test, lint, build, govulncheck, CodeQL, pipelock self-scan), CodeQL analysis, full test suite with race detector (see [README](../../README.md#testing)) | Art. 15 |
+| MEASURE 2.5 | System demonstrated valid and reliable | CI: eight required contexts (security scan; Go 1.25 and 1.26 aggregates; macOS test; lint; build with Helm as a transitive prerequisite; govulncheck on default and enterprise graphs; CodeQL), plus race-tested OSS and enterprise matrices (see [README](../../README.md#testing)) | Art. 15 |
 | MEASURE 2.6 | Evaluated for misuse and abuse | Scanning layers target misuse: DLP catches exfiltration, SSRF catches internal probing, injection detection catches hijacking | Art. 9, 15 |
 | MEASURE 2.7 | Security and resilience evaluated | Security audit completed (26 of 32 items fixed); DNS rebinding protection; fail-closed architecture | Art. 15 |
 | MEASURE 3.1 | Risks tracked on ongoing basis | Prometheus real-time tracking; zerolog persistent timeline; both queryable and alertable | Art. 12 |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -37,8 +37,7 @@ asserts every consumer of the loaded config flows through
 
 ## Required Automated Checks
 
-Run these before tagging locally, and keep the matching GitHub Actions checks
-required on `main`:
+Run these release-specific checks locally before tagging:
 
 ```bash
 make release-audit
@@ -47,6 +46,8 @@ make runtime-policy-audit
 go test -race -count=1 ./...
 golangci-lint run ./...
 ```
+
+Pull requests have a separate server-side contract. The `main` ruleset requires `security-scan`, `test (1.25)`, `test (1.26)`, `test-macos`, `lint`, `build`, `govulncheck`, and `codeql`.
 
 For a one-shot local gate:
 
@@ -68,7 +69,7 @@ make debt-check
 - After the tag exists, refresh Pipelock dogfood workflow pins that point at the
   prior Pipelock release SHA; use the full tag commit SHA and update the version
   comment together.
-- Confirm `Hardening / workflow-audit` and `Hardening / runtime-critical` are
+- Confirm `Hardening / workflow-audit` and `Hardening / runtime-policy` are
   green on the candidate commit.
 - Review the `Hardening / hardening-report` summary for policy-drift or debt
   warnings.


### PR DESCRIPTION
## What changed
- Correct the public required-check list to match the eight active contexts and distinguish local release gates from server-side PR checks.
- Remove stale workflow comments and names left behind by the CI topology and reviewer-test changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which checks run locally versus in CI for pull requests and releases.
  * Updated required CI context guidance and corrected the referenced hardening check.
  * Synchronized governance, compliance, and release documentation with current validation and testing coverage.
* **Chores**
  * Improved workflow and build-target comments to accurately describe security scans, regression testing, and enterprise test matrices.
  * No functional workflow or product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->