### PR TITLE
ci: shorten proxy and build critical path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -713,13 +713,12 @@ jobs:
             exit 1
           fi
 
-  # Helm remains a separate diagnostic job, but the required `build` context
-  # intentionally carries its result through `needs`. Keep that dependency
-  # until a separately approved ruleset change makes `helm` required itself.
-  build:
+  # Compile in parallel with tests and lint so a successful critical path does
+  # not pay the build cost after the slowest test shard has already finished.
+  build-binaries:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [security-scan, test-go125, test-go126, lint, helm]
+    needs: [security-scan]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -757,6 +756,40 @@ jobs:
         run: |
           GOOS=windows GOARCH=amd64 go build -tags enterprise -trimpath -o /tmp/pipelock-windows-amd64.exe ./cmd/pipelock
           GOOS=windows GOARCH=arm64 go build -tags enterprise -trimpath -o /tmp/pipelock-windows-arm64.exe ./cmd/pipelock
+
+  # Helm remains a separate diagnostic job, but the required `build` context
+  # intentionally carries its result through `needs`. Keep that dependency
+  # until a separately approved ruleset change makes `helm` required itself.
+  # The parallel build-binaries producer also flows through this gate, so a
+  # compilation failure cannot present as a successful required build check.
+  build:
+    needs: [security-scan, test-go125, test-go126, lint, helm, build-binaries]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report required build evidence
+        env:
+          SECURITY_SCAN_RESULT: ${{ needs.security-scan.result }}
+          TEST_GO125_RESULT: ${{ needs.test-go125.result }}
+          TEST_GO126_RESULT: ${{ needs.test-go126.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          HELM_RESULT: ${{ needs.helm.result }}
+          BUILD_BINARIES_RESULT: ${{ needs.build-binaries.result }}
+        run: |
+          set -euo pipefail
+          for result in \
+            "$SECURITY_SCAN_RESULT" \
+            "$TEST_GO125_RESULT" \
+            "$TEST_GO126_RESULT" \
+            "$LINT_RESULT" \
+            "$HELM_RESULT" \
+            "$BUILD_BINARIES_RESULT"; do
+            if [ "$result" != success ]; then
+              echo "required build evidence is incomplete or failed" >&2
+              exit 1
+            fi
+          done
 
   # Operator-facing rollup only. Branch protection continues to evaluate the
   # required producer checks independently.

--- a/internal/proxy/response_size_hint_test.go
+++ b/internal/proxy/response_size_hint_test.go
@@ -86,3 +86,27 @@ func TestReverseObservedBodyBytesPreservesKnownInformation(t *testing.T) {
 		})
 	}
 }
+
+func TestReverseProxyResponseScanBodyLimit(t *testing.T) {
+	t.Parallel()
+	if reverseProxyMaxBodyBytes != 1<<20 {
+		t.Fatalf("production response scan body limit = %d, want exactly 1 MiB", reverseProxyMaxBodyBytes)
+	}
+
+	for _, tc := range []struct {
+		name string
+		rp   *ReverseProxyHandler
+		want int
+	}{
+		{name: "nil handler uses production limit", want: reverseProxyMaxBodyBytes},
+		{name: "zero value uses production limit", rp: &ReverseProxyHandler{}, want: reverseProxyMaxBodyBytes},
+		{name: "test override", rp: &ReverseProxyHandler{responseBodyLimit: 4096}, want: 4096},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.rp.responseScanBodyLimit(); got != tc.want {
+				t.Fatalf("responseScanBodyLimit() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -88,6 +88,16 @@ type ReverseProxyHandler struct {
 	sizeExemptScanBudget sizeExemptScanBudget
 	requestScanBudget    reverseRequestScanBudget
 	reloadMu             *sync.RWMutex
+	// responseBodyLimit is an internal test seam. Production construction leaves
+	// it zero, which responseScanBodyLimit maps to the fixed 1 MiB safety limit.
+	responseBodyLimit int
+}
+
+func (rp *ReverseProxyHandler) responseScanBodyLimit() int {
+	if rp != nil && rp.responseBodyLimit > 0 {
+		return rp.responseBodyLimit
+	}
+	return reverseProxyMaxBodyBytes
 }
 
 // reverseRequestScanBudget bounds the configured body-scan reservations held
@@ -1473,6 +1483,7 @@ func reverseRequestContext(resp *http.Response) context.Context {
 }
 
 func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
+	responseBodyLimit := rp.responseScanBodyLimit()
 	cfg, _ := resp.Request.Context().Value(ctxKeyReverseEnvelopeCfg).(*config.Config)
 	sc, _ := resp.Request.Context().Value(ctxKeyReverseScanner).(*scanner.Scanner)
 	if cfg == nil || sc == nil {
@@ -1839,7 +1850,7 @@ func (rp *ReverseProxyHandler) modifyResponse(resp *http.Response) error {
 				resp.Header.Del("Digest")
 				resp.Header.Del("Content-MD5")
 			}
-			if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt && len(body) > reverseProxyMaxBodyBytes {
+			if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt && len(body) > responseBodyLimit {
 				if match, ok := matchUnscannablePassthrough(unscannablePassthroughRequest{
 					Host:              revHost,
 					Path:              resp.Request.URL.EscapedPath(),
@@ -1879,7 +1890,7 @@ responseScanning:
 	if isBinaryMIME(mediaCT) {
 		binaryOutcomeReason := mediaUnscannedOutcome
 		if cfg.FlightRecorder.RequireReceipts && cfg.ResponseScanning.Enabled && revRespSizeExempt {
-			limited := io.LimitReader(resp.Body, int64(reverseProxyMaxBodyBytes)+1)
+			limited := io.LimitReader(resp.Body, int64(responseBodyLimit)+1)
 			body, err := io.ReadAll(limited)
 			if err != nil {
 				_ = resp.Body.Close()
@@ -1902,7 +1913,7 @@ responseScanning:
 				recordReverseOutcome(http.StatusForbidden, -1, "response_read_error")
 				return nil
 			}
-			if len(body) > reverseProxyMaxBodyBytes {
+			if len(body) > responseBodyLimit {
 				if match, ok := matchUnscannablePassthrough(unscannablePassthroughRequest{
 					Host:              revHost,
 					Path:              resp.Request.URL.EscapedPath(),
@@ -2059,7 +2070,7 @@ responseScanning:
 
 	// Read response body with size limit. Use a separate limited reader
 	// so the original body remains open for oversized passthrough.
-	maxBytes := reverseProxyMaxBodyBytes
+	maxBytes := responseBodyLimit
 	shieldOnly := !cfg.ResponseScanning.Enabled && shieldActiveForHost
 	if shieldOnly && cfg.BrowserShield.MaxShieldBytes > 0 {
 		// Browser Shield is independent of response injection scanning. When it

--- a/internal/proxy/reverse_shield_oversize_test.go
+++ b/internal/proxy/reverse_shield_oversize_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	oversizeShieldTail    = "<footer>tail-must-remain-byte-for-byte</footer></body></html>"
-	oversizeShieldTestCap = 2048
+	oversizeShieldTail                  = "<footer>tail-must-remain-byte-for-byte</footer></body></html>"
+	oversizeShieldTestCap               = 2048
+	oversizeShieldResponseScanTestLimit = 16 * 1024
 )
 
 // oversizeShieldPage returns an HTML page carrying a tracking pixel, larger
@@ -589,10 +590,10 @@ func TestReverseProxy_ShieldUnderCap_ScrubsWholeBody(t *testing.T) {
 func TestReverseProxy_ShieldSizeExempt_ScrubsBoundedWholeBody(t *testing.T) {
 	const shieldCap = 2048
 
-	page := "<html><body>" + strings.Repeat("safe document text ", reverseProxyMaxBodyBytes/19+1) +
+	page := "<html><body>" + strings.Repeat("safe document text ", oversizeShieldResponseScanTestLimit/19+1) +
 		`<img src="https://tracker.vendor.example/p.gif" width="1" height="1"></body></html>`
-	if len(page) <= reverseProxyMaxBodyBytes {
-		t.Fatalf("test page size %d must exceed normal reverse scan ceiling %d", len(page), reverseProxyMaxBodyBytes)
+	if len(page) <= oversizeShieldResponseScanTestLimit {
+		t.Fatalf("test page size %d must exceed test response scan ceiling %d", len(page), oversizeShieldResponseScanTestLimit)
 	}
 
 	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -610,10 +611,15 @@ func TestReverseProxy_ShieldSizeExempt_ScrubsBoundedWholeBody(t *testing.T) {
 		responseScanningEnabled bool
 		scanMaxBytes            int
 		inflightMaxBytes        int
+		useProductionLimit      bool
+		oversizeAction          string
 		wantStatus              int
+		wantTracker             bool
 		wantBodyContains        string
 	}{
 		{name: "response_scanning_enabled", responseScanningEnabled: true, scanMaxBytes: len(page) + 1024, wantStatus: http.StatusOK},
+		{name: "response_scanning_exceeds_test_bounded_ceiling", responseScanningEnabled: true, scanMaxBytes: oversizeShieldResponseScanTestLimit / 2, oversizeAction: config.ShieldOversizeWarn, wantStatus: http.StatusForbidden, wantBodyContains: "response_scanning.size_exempt_scan_max_bytes"},
+		{name: "response_scanning_same_body_below_production_ceiling", responseScanningEnabled: true, scanMaxBytes: oversizeShieldResponseScanTestLimit / 2, useProductionLimit: true, oversizeAction: config.ShieldOversizeWarn, wantStatus: http.StatusOK, wantTracker: true},
 		{name: "shield_only", responseScanningEnabled: false, scanMaxBytes: len(page) + 1024, wantStatus: http.StatusOK},
 		{name: "shield_only_exceeds_bounded_ceiling", responseScanningEnabled: false, scanMaxBytes: shieldCap * 2, wantStatus: http.StatusForbidden},
 		{name: "shield_only_exceeds_inflight_budget", responseScanningEnabled: false, scanMaxBytes: len(page) + 1024, inflightMaxBytes: shieldCap, wantStatus: http.StatusForbidden, wantBodyContains: "response_scanning.size_exempt_scan_max_inflight_bytes"},
@@ -627,6 +633,9 @@ func TestReverseProxy_ShieldSizeExempt_ScrubsBoundedWholeBody(t *testing.T) {
 			cfg.BrowserShield.StripTrackingPixels = true
 			cfg.BrowserShield.MaxShieldBytes = shieldCap
 			cfg.BrowserShield.OversizeAction = config.ShieldOversizeBlock
+			if tc.oversizeAction != "" {
+				cfg.BrowserShield.OversizeAction = tc.oversizeAction
+			}
 			cfg.ResponseScanning.SizeExemptDomains = []string{"127.0.0.1"}
 			cfg.ResponseScanning.SizeExemptScanMaxBytes = tc.scanMaxBytes
 			cfg.ResponseScanning.SizeExemptScanMaxInflightBytes = cfg.ResponseScanning.SizeExemptScanMaxBytes
@@ -645,6 +654,14 @@ func TestReverseProxy_ShieldSizeExempt_ScrubsBoundedWholeBody(t *testing.T) {
 			logger, _ := audit.New("json", "stdout", "", false, false)
 			t.Cleanup(logger.Close)
 			handler := NewReverseProxy(upstreamURL, &cfgPtr, &scPtr, logger, metrics.New(), killswitch.New(cfg), nil, shield.NewEngine(nil))
+			wantResponseBodyLimit := reverseProxyMaxBodyBytes
+			if !tc.useProductionLimit {
+				handler.responseBodyLimit = oversizeShieldResponseScanTestLimit
+				wantResponseBodyLimit = oversizeShieldResponseScanTestLimit
+			}
+			if got := handler.responseScanBodyLimit(); got != wantResponseBodyLimit {
+				t.Fatalf("response scan ceiling = %d, want %d", got, wantResponseBodyLimit)
+			}
 			proxySrv := httptest.NewServer(handler)
 			t.Cleanup(proxySrv.Close)
 
@@ -657,8 +674,9 @@ func TestReverseProxy_ShieldSizeExempt_ScrubsBoundedWholeBody(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read response: %v", err)
 			}
-			if tc.wantStatus == http.StatusOK && strings.Contains(string(body), "tracker.vendor.example") {
-				t.Fatal("tracking pixel beyond the ordinary shield cap survived whole-body shielding")
+			trackerPresent := strings.Contains(string(body), "tracker.vendor.example")
+			if tc.wantStatus == http.StatusOK && trackerPresent != tc.wantTracker {
+				t.Fatalf("tracking pixel present = %v, want %v", trackerPresent, tc.wantTracker)
 			}
 			if tc.wantStatus == http.StatusOK && !strings.Contains(string(body), "</body></html>") {
 				t.Fatal("bounded whole-body shielding did not preserve the response tail")

--- a/scripts/test_ci_security_workflow.py
+++ b/scripts/test_ci_security_workflow.py
@@ -46,6 +46,7 @@ class CISecurityWorkflowTest(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = WORKFLOW.read_text(encoding="utf-8")
         self.govulncheck = job_block(self.workflow, "govulncheck")
+        self.build_binaries = job_block(self.workflow, "build-binaries")
         self.build = job_block(self.workflow, "build")
 
     def assert_govulncheck_contract(self, job: str) -> None:
@@ -136,6 +137,66 @@ exit "$DEFAULT_STATUS"
             "the required `build` context\n  # intentionally carries its result through `needs`",
             self.workflow,
         )
+
+    def test_build_compiles_in_parallel_without_weakening_required_gate(self) -> None:
+        producer_needs = re.search(r"(?m)^\s+needs:\s*\[([^]]+)\]$", self.build_binaries)
+        self.assertIsNotNone(producer_needs, "build-binaries needs list not found")
+        self.assertEqual(
+            {"security-scan"},
+            {dependency.strip() for dependency in producer_needs.group(1).split(",")},
+        )
+
+        gate_needs = re.search(r"(?m)^\s+needs:\s*\[([^]]+)\]$", self.build)
+        self.assertIsNotNone(gate_needs, "build needs list not found")
+        self.assertEqual(
+            {"security-scan", "test-go125", "test-go126", "lint", "helm", "build-binaries"},
+            {dependency.strip() for dependency in gate_needs.group(1).split(",")},
+        )
+        self.assertIn("if: ${{ always() }}", self.build)
+        for result in (
+            "SECURITY_SCAN_RESULT",
+            "TEST_GO125_RESULT",
+            "TEST_GO126_RESULT",
+            "LINT_RESULT",
+            "HELM_RESULT",
+            "BUILD_BINARIES_RESULT",
+        ):
+            self.assertIn(f'"${result}"', self.build)
+
+    def test_required_build_gate_fails_closed_for_every_incomplete_result(self) -> None:
+        script = step_script(self.build, "Report required build evidence")
+        result_names = (
+            "SECURITY_SCAN_RESULT",
+            "TEST_GO125_RESULT",
+            "TEST_GO126_RESULT",
+            "LINT_RESULT",
+            "HELM_RESULT",
+            "BUILD_BINARIES_RESULT",
+        )
+        base_env = os.environ.copy()
+        base_env.update({name: "success" for name in result_names})
+        success = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", script],
+            check=False,
+            env=base_env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(0, success.returncode, success.stderr)
+
+        for name in result_names:
+            for evidence in ("failure", "cancelled", "skipped", ""):
+                with self.subTest(name=name, evidence=evidence):
+                    env = base_env.copy()
+                    env[name] = evidence
+                    result = subprocess.run(
+                        ["bash", "-euo", "pipefail", "-c", script],
+                        check=False,
+                        env=env,
+                        text=True,
+                        capture_output=True,
+                    )
+                    self.assertNotEqual(0, result.returncode)
 
     def test_helm_transitive_gate_contract_rejects_removed_dependency(self) -> None:
         needs_match = re.search(r"(?m)^(\s+needs:\s*\[)([^]]+)(\])$", self.build)


### PR DESCRIPTION
## What changed
- Start binary compilation beside the test matrices while preserving `build` as a fail-closed gate over every required result.
- Use a smaller internal boundary for the repeated Shield test while keeping the production 1 MiB limit and real-size integration coverage unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response scanning safeguards with a configurable body-size limit while retaining the 1 MiB default.
  * Expanded protection and handling for oversized responses.

* **Chores**
  * Added parallel binary build and verification checks to the continuous integration process.
  * Strengthened build validation so incomplete or unsuccessful required checks prevent a successful build.

* **Tests**
  * Added coverage for response-size limits, oversized responses, and CI workflow failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->