### PR TITLE
feat(receipts): emit native AEL evidence

### DIFF
--- a/internal/ael/emitter.go
+++ b/internal/ael/emitter.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ael emits native Agent Evidence Levels v0.1 artifacts.
+package ael
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+const (
+	recordVersion = 1
+	recorderID    = "pipelock"
+	zeroHash      = "0000000000000000000000000000000000000000000000000000000000000000"
+	maxSafeInt    = uint64(1<<53 - 1)
+)
+
+var runIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+type Activity struct{ Class, ID, Direction string }
+
+type manifest struct {
+	Format    int                `json:"ael_format"`
+	Coverage  string             `json:"coverage"`
+	Custody   string             `json:"custody"`
+	Recorders []manifestRecorder `json:"recorders"`
+	Runs      []string           `json:"runs"`
+}
+
+type manifestRecorder struct {
+	File string `json:"file"`
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Run  string `json:"run"`
+}
+
+type artifactOps struct {
+	mkdir          func(string, os.FileMode) error
+	writeExclusive func(string, []byte, os.FileMode) error
+	openFile       func(string, int, os.FileMode) (*os.File, error)
+	syncDirectory  func(string) error
+}
+
+var systemArtifactOps = artifactOps{
+	mkdir:          os.Mkdir,
+	writeExclusive: writeExclusive,
+	openFile:       os.OpenFile,
+	syncDirectory:  syncDirectory,
+}
+
+// Emitter writes one artifact consumed directly by stock aelcheck.
+type Emitter struct {
+	privKey    ed25519.PrivateKey
+	run, keyID string
+	hmax       int
+	htol       int
+	now        func() time.Time
+	file       *os.File
+	dir        string
+
+	mu             sync.Mutex
+	seq            uint64
+	prev           string
+	opened, closed bool
+	lastErr        error
+}
+
+// NewEmitter creates the manifest, published key, and compact record stream.
+// Initialization errors are sticky and surface through the first lifecycle
+// emission so require_receipts can fail closed.
+func NewEmitter(rec *recorder.Recorder, privKey ed25519.PrivateKey, run string, heartbeatSeconds int) *Emitter {
+	if rec == nil || len(privKey) != ed25519.PrivateKeySize || !runIDPattern.MatchString(run) || rec.Dir() == "" {
+		return nil
+	}
+	pub := privKey.Public().(ed25519.PublicKey)
+	sum := sha256.Sum256(pub)
+	if heartbeatSeconds < 0 {
+		heartbeatSeconds = 0
+	}
+	heartbeatTolerance := 0
+	if heartbeatSeconds > 0 {
+		heartbeatTolerance = max(1, heartbeatSeconds/10)
+	}
+	e := &Emitter{privKey: privKey, run: run, keyID: hex.EncodeToString(sum[:]), hmax: heartbeatSeconds, htol: heartbeatTolerance, now: time.Now, prev: zeroHash}
+	e.lastErr = e.initializeArtifact(rec.Dir(), pub)
+	return e
+}
+
+func (e *Emitter) Dir() string {
+	if e == nil {
+		return ""
+	}
+	return e.dir
+}
+
+func (e *Emitter) initializeArtifact(recorderDir string, pub ed25519.PublicKey) error {
+	return e.initializeArtifactWithOps(recorderDir, pub, systemArtifactOps)
+}
+
+func (e *Emitter) initializeArtifactWithOps(recorderDir string, pub ed25519.PublicKey, ops artifactOps) error {
+	root := filepath.Join(filepath.Clean(recorderDir), "ael")
+	if err := ensureDirectory(root); err != nil {
+		return fmt.Errorf("prepare AEL artifact root: %w", err)
+	}
+	e.dir = filepath.Join(root, e.run)
+	if err := ops.mkdir(e.dir, 0o750); err != nil {
+		return fmt.Errorf("create AEL run directory: %w", err)
+	}
+	for _, name := range []string{"keys", "recorders"} {
+		if err := ops.mkdir(filepath.Join(e.dir, name), 0o750); err != nil {
+			return fmt.Errorf("create AEL %s directory: %w", name, err)
+		}
+	}
+	if err := ops.writeExclusive(filepath.Join(e.dir, "keys", e.keyID+".pub"), []byte(base64.StdEncoding.EncodeToString(pub)), 0o600); err != nil {
+		return fmt.Errorf("publish AEL key: %w", err)
+	}
+	m := manifest{Format: 1, Runs: []string{e.run}, Recorders: []manifestRecorder{{ID: recorderID, Run: e.run, Key: e.keyID, File: "recorders/pipelock.jsonl"}}, Coverage: "mediated-only", Custody: "same-process"}
+	manifestBytes, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal AEL manifest: %w", err)
+	}
+	if err := ops.writeExclusive(filepath.Join(e.dir, "manifest.json"), manifestBytes, 0o600); err != nil {
+		return fmt.Errorf("write AEL manifest: %w", err)
+	}
+	e.file, err = ops.openFile(filepath.Join(e.dir, "recorders", "pipelock.jsonl"), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create AEL record stream: %w", err)
+	}
+	for _, path := range []string{filepath.Join(e.dir, "keys"), filepath.Join(e.dir, "recorders"), e.dir, root, filepath.Clean(recorderDir)} {
+		if err := ops.syncDirectory(path); err != nil {
+			_ = e.file.Close()
+			return fmt.Errorf("sync AEL artifact directory: %w", err)
+		}
+	}
+	return nil
+}
+
+func ensureDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// A concurrently-starting sibling can win the race to create the shared
+		// artifact root between this Lstat and our Mkdir. Tolerate that benign
+		// EEXIST, then fall through to re-stat and enforce the same
+		// symlink/directory invariant on whatever now exists — a racing attacker
+		// who planted a symlink or file still lands in the refusal below.
+		if mkErr := os.Mkdir(path, 0o750); mkErr != nil && !errors.Is(mkErr, os.ErrExist) {
+			return mkErr
+		}
+		if info, err = os.Lstat(path); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("refuse non-directory or symlink at %s", path)
+	}
+	return nil
+}
+
+func writeExclusive(path string, data []byte, mode os.FileMode) error {
+	// #nosec G304 -- callers construct paths from the recorder root plus fixed
+	// names or validated lowercase-hex identifiers; no request input reaches it.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(data); err == nil {
+		err = f.Sync()
+	}
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func (e *Emitter) EmitOpen() error      { return e.emit("open", nil, true) }
+func (e *Emitter) EmitHeartbeat() error { return e.emit("heartbeat", nil, false) }
+func (e *Emitter) EmitClose() error     { return e.emit("close", nil, true) }
+
+func (e *Emitter) EmitActivity(activity Activity, durable bool) error {
+	if activity.Class == "" || activity.ID == "" {
+		return errors.New("AEL activity class and id are required")
+	}
+	switch activity.Direction {
+	case "in", "out", "internal":
+	default:
+		return fmt.Errorf("invalid AEL activity direction %q", activity.Direction)
+	}
+	return e.emit("activity", map[string]any{"event": map[string]any{"class": activity.Class, "dir": activity.Direction, "id": activity.ID}}, durable)
+}
+
+func (e *Emitter) Opened() bool {
+	if e == nil {
+		return false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.opened
+}
+
+func (e *Emitter) emit(kind string, extra map[string]any, durable bool) error {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.lastErr != nil {
+		return fmt.Errorf("native AEL emitter unhealthy: %w", e.lastErr)
+	}
+	if e.closed {
+		return errors.New("native AEL run is closed")
+	}
+	if kind == "open" {
+		if e.opened || e.seq != 0 {
+			return errors.New("native AEL run is already open")
+		}
+	} else if !e.opened {
+		return errors.New("native AEL run is not open")
+	}
+	if e.seq > maxSafeInt {
+		e.lastErr = errors.New("native AEL sequence exceeds the canonical JSON safe-integer limit")
+		return e.lastErr
+	}
+	payload := map[string]any{"key": e.keyID, "prev": e.prev, "recorder": recorderID, "run": e.run, "seq": e.seq, "ts": e.now().UTC().Format(time.RFC3339Nano), "type": kind, "v": recordVersion}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	if kind == "open" {
+		payload["hmax"], payload["htol"] = e.hmax, e.htol
+	}
+	if kind == "close" {
+		payload["count"], payload["head"] = e.seq+1, e.prev
+	}
+	canonical, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal canonical AEL payload: %w", err)
+	}
+	sig := ed25519.Sign(e.privKey, canonical)
+	line := base64.RawURLEncoding.EncodeToString(canonical) + "." + base64.RawURLEncoding.EncodeToString(sig) + "\n"
+	next := sha256.Sum256(canonical)
+	// Advance first: persistence failure leaves a detectable gap, never a fork.
+	e.seq++
+	e.prev = hex.EncodeToString(next[:])
+	if kind == "open" {
+		e.opened = true
+	}
+	if kind == "close" {
+		e.closed = true
+	}
+	if _, err = e.file.WriteString(line); err == nil && durable {
+		err = e.file.Sync()
+	}
+	if err != nil {
+		e.lastErr = err
+		return fmt.Errorf("persist native AEL %s: %w", kind, err)
+	}
+	if kind == "close" {
+		if err := e.file.Close(); err != nil {
+			e.lastErr = err
+			return fmt.Errorf("close native AEL stream: %w", err)
+		}
+		if err := syncDirectory(filepath.Join(e.dir, "recorders")); err != nil {
+			e.lastErr = err
+			return fmt.Errorf("sync closed native AEL stream directory: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/ael/emitter.go
+++ b/internal/ael/emitter.go
@@ -213,6 +213,26 @@ func (e *Emitter) Opened() bool {
 	return e.opened
 }
 
+// Abort closes a staged record stream without claiming a terminal lifecycle
+// record. It is used only when the owning runtime cannot publish the emitter.
+func (e *Emitter) Abort() error {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.file == nil {
+		return nil
+	}
+	err := e.file.Close()
+	e.file = nil
+	e.closed = true
+	if err != nil {
+		e.lastErr = err
+	}
+	return err
+}
+
 func (e *Emitter) emit(kind string, extra map[string]any, durable bool) error {
 	if e == nil {
 		return nil

--- a/internal/ael/emitter_test.go
+++ b/internal/ael/emitter_test.go
@@ -197,8 +197,23 @@ func TestNewEmitterRejectsNonPipelockRunID(t *testing.T) {
 		t.Fatalf("recorder.New: %v", err)
 	}
 	t.Cleanup(func() { _ = rec.Close() })
-	if emitter := NewEmitter(rec, priv, "../../escape", 30); emitter != nil {
-		t.Fatal("NewEmitter accepted a path-shaped run ID")
+	for _, run := range []string{
+		"",
+		".",
+		"..",
+		"short",
+		"0123456789ABCDEF0123456789ABCDEF",
+		"gggggggggggggggggggggggggggggggg",
+		"/123456789abcdef0123456789abcdef",
+		`0123456789abcdef0123456789abcd\x`,
+		"0123456789abcdef/123456789abcde",
+		"../../escape",
+	} {
+		t.Run(fmt.Sprintf("%q", run), func(t *testing.T) {
+			if emitter := NewEmitter(rec, priv, run, 30); emitter != nil {
+				t.Fatalf("NewEmitter accepted run ID %q", run)
+			}
+		})
 	}
 }
 
@@ -385,9 +400,6 @@ func TestEmitterNilAndFilesystemRefusals(t *testing.T) {
 	}
 	if err := writeExclusive(filePath, []byte("replacement"), 0o600); err == nil {
 		t.Fatal("writeExclusive replaced an existing file")
-	}
-	if err := syncDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
-		t.Fatal("syncDirectory accepted a missing path")
 	}
 }
 

--- a/internal/ael/emitter_test.go
+++ b/internal/ael/emitter_test.go
@@ -185,6 +185,40 @@ func TestEmitterPersistenceFailureIsSticky(t *testing.T) {
 	}
 }
 
+func TestEmitterAbortClosesStagedStream(t *testing.T) {
+	t.Parallel()
+	var nilEmitter *Emitter
+	if err := nilEmitter.Abort(); err != nil {
+		t.Fatalf("nil Abort: %v", err)
+	}
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	emitter := NewEmitter(rec, priv, "fedcba9876543210fedcba9876543210", 30)
+	if emitter == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if emitter.Opened() {
+		t.Fatal("staged emitter unexpectedly open")
+	}
+	if err := emitter.Abort(); err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if err := emitter.Abort(); err != nil {
+		t.Fatalf("second Abort: %v", err)
+	}
+	if err := emitter.EmitOpen(); err == nil || !strings.Contains(err.Error(), "run is closed") {
+		t.Fatalf("EmitOpen after Abort error = %v", err)
+	}
+}
+
 func TestNewEmitterRejectsNonPipelockRunID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/ael/emitter_test.go
+++ b/internal/ael/emitter_test.go
@@ -1,0 +1,479 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package ael
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+)
+
+func TestEmitterWritesDirectlySignedClosedChain(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	const runID = "0123456789abcdef0123456789abcdef"
+	emitter := NewEmitter(rec, priv, runID, 30)
+	if emitter == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	now := time.Date(2026, time.August, 27, 1, 2, 3, 0, time.UTC)
+	emitter.now = func() time.Time {
+		value := now
+		now = now.Add(time.Second)
+		return value
+	}
+	if err := emitter.EmitOpen(); err != nil {
+		t.Fatalf("EmitOpen: %v", err)
+	}
+	if err := emitter.EmitActivity(Activity{Class: "read", ID: "action-1", Direction: "in"}, true); err != nil {
+		t.Fatalf("EmitActivity: %v", err)
+	}
+	if err := emitter.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat: %v", err)
+	}
+	if err := emitter.EmitClose(); err != nil {
+		t.Fatalf("EmitClose: %v", err)
+	}
+	if err := rec.Record(recorder.Entry{SessionID: "proxy", Type: "decision", Summary: "discovery control"}); err != nil {
+		t.Fatalf("Record discovery control: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	locations, err := recorder.DiscoverEvidenceLocations(dir)
+	if err != nil {
+		t.Fatalf("DiscoverEvidenceLocations: %v", err)
+	}
+	if len(locations) != 1 || locations[0].ID != "" {
+		t.Fatalf("native AEL subtree changed recorder discovery: %+v", locations)
+	}
+
+	lines := readAELLines(t, emitter.Dir())
+	if len(lines) != 4 {
+		t.Fatalf("AEL record count = %d, want 4", len(lines))
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(emitter.Dir(), "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var gotManifest map[string]any
+	if err := json.Unmarshal(manifestBytes, &gotManifest); err != nil {
+		t.Fatalf("manifest JSON: %v", err)
+	}
+	if strings.HasSuffix(string(manifestBytes), "\n") {
+		t.Fatal("manifest has trailing bytes and is not canonical")
+	}
+	// Encoding the decoded controlled-shape map must reproduce the exact bytes.
+	canonicalManifest, err := json.Marshal(gotManifest)
+	if err != nil {
+		t.Fatalf("re-marshal manifest: %v", err)
+	}
+	if string(canonicalManifest) != string(manifestBytes) {
+		t.Fatalf("manifest is not canonical: %s", manifestBytes)
+	}
+	wantTypes := []string{"open", "activity", "heartbeat", "close"}
+	prev := zeroHash
+	var previousPayload []byte
+	for index, line := range lines {
+		parts := strings.Split(line, ".")
+		if len(parts) != 2 {
+			t.Fatalf("line %d has %d compact parts, want 2", index, len(parts))
+		}
+		payload, decodeErr := base64.RawURLEncoding.DecodeString(parts[0])
+		if decodeErr != nil {
+			t.Fatalf("decode payload %d: %v", index, decodeErr)
+		}
+		sig, decodeErr := base64.RawURLEncoding.DecodeString(parts[1])
+		if decodeErr != nil {
+			t.Fatalf("decode signature %d: %v", index, decodeErr)
+		}
+		if !ed25519.Verify(pub, payload, sig) {
+			t.Fatalf("record %d signature does not verify over exact payload bytes", index)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("unmarshal payload %d: %v", index, err)
+		}
+		if decoded["type"] != wantTypes[index] {
+			t.Fatalf("record %d type = %v, want %q", index, decoded["type"], wantTypes[index])
+		}
+		if decoded["seq"] != float64(index) {
+			t.Fatalf("record %d seq = %v", index, decoded["seq"])
+		}
+		if decoded["prev"] != prev {
+			t.Fatalf("record %d prev = %v, want %s", index, decoded["prev"], prev)
+		}
+		if index > 0 {
+			sum := sha256.Sum256(previousPayload)
+			if decoded["prev"] != hex.EncodeToString(sum[:]) {
+				t.Fatalf("record %d does not hash the previous payload", index)
+			}
+		}
+		previousPayload = payload
+		sum := sha256.Sum256(payload)
+		prev = hex.EncodeToString(sum[:])
+	}
+
+	var closePayload map[string]any
+	closeBytes, _ := base64.RawURLEncoding.DecodeString(strings.Split(lines[3], ".")[0])
+	if err := json.Unmarshal(closeBytes, &closePayload); err != nil {
+		t.Fatalf("unmarshal close: %v", err)
+	}
+	if closePayload["count"] != float64(4) {
+		t.Fatalf("close count = %v, want 4", closePayload["count"])
+	}
+	headSum := sha256.Sum256(previousPayloadForLine(t, lines[2]))
+	if closePayload["head"] != hex.EncodeToString(headSum[:]) {
+		t.Fatalf("close head = %v, want heartbeat hash", closePayload["head"])
+	}
+}
+
+func TestEmitterPersistenceFailureIsSticky(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	emitter := NewEmitter(rec, priv, "fedcba9876543210fedcba9876543210", 30)
+	if emitter == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if err := emitter.file.Close(); err != nil {
+		t.Fatalf("close record stream: %v", err)
+	}
+	firstErr := emitter.EmitOpen()
+	if firstErr == nil || !strings.Contains(firstErr.Error(), "persist native AEL open") {
+		t.Fatalf("EmitOpen error = %v", firstErr)
+	}
+	secondErr := emitter.EmitHeartbeat()
+	if secondErr == nil || !strings.Contains(secondErr.Error(), "native AEL emitter unhealthy") {
+		t.Fatalf("EmitHeartbeat after persistence failure = %v", secondErr)
+	}
+}
+
+func TestNewEmitterRejectsNonPipelockRunID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	if emitter := NewEmitter(rec, priv, "../../escape", 30); emitter != nil {
+		t.Fatal("NewEmitter accepted a path-shaped run ID")
+	}
+}
+
+func TestNewEmitterConcurrentSharedRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+
+	const count = 16
+	emitters := make([]*Emitter, count)
+	var wg sync.WaitGroup
+	for index := range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			run := fmt.Sprintf("%032x", index+1)
+			emitters[index] = NewEmitter(rec, priv, run, 30)
+		}()
+	}
+	wg.Wait()
+	for index, emitter := range emitters {
+		if emitter == nil {
+			t.Fatalf("NewEmitter %d returned nil", index)
+		}
+		if err := emitter.EmitOpen(); err != nil {
+			t.Fatalf("EmitOpen %d: %v", index, err)
+		}
+		if err := emitter.EmitClose(); err != nil {
+			t.Fatalf("EmitClose %d: %v", index, err)
+		}
+	}
+}
+
+func TestNewEmitterRefusesSymlinkArtifactRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "ael")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	emitter := NewEmitter(rec, priv, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 30)
+	if emitter == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if err := emitter.EmitOpen(); err == nil || !strings.Contains(err.Error(), "refuse non-directory or symlink") {
+		t.Fatalf("EmitOpen error = %v, want symlink refusal", err)
+	}
+	if entries, readErr := os.ReadDir(outside); readErr != nil {
+		t.Fatalf("ReadDir outside: %v", readErr)
+	} else if len(entries) != 0 {
+		t.Fatalf("symlink target received artifacts: %v", entries)
+	}
+}
+
+func TestEmitterLifecycleRefusalsAndBounds(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	emitter := NewEmitter(rec, priv, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", -1)
+	if emitter == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if emitter.hmax != 0 || emitter.htol != 0 {
+		t.Fatalf("negative heartbeat normalized to hmax=%d htol=%d", emitter.hmax, emitter.htol)
+	}
+	if err := emitter.EmitHeartbeat(); err == nil || !strings.Contains(err.Error(), "not open") {
+		t.Fatalf("heartbeat before open error = %v", err)
+	}
+	if err := emitter.EmitActivity(Activity{}, false); err == nil || !strings.Contains(err.Error(), "class and id") {
+		t.Fatalf("empty activity error = %v", err)
+	}
+	if err := emitter.EmitActivity(Activity{Class: "read", ID: "id", Direction: "sideways"}, false); err == nil || !strings.Contains(err.Error(), "invalid AEL activity direction") {
+		t.Fatalf("invalid direction error = %v", err)
+	}
+	if err := emitter.EmitOpen(); err != nil {
+		t.Fatalf("EmitOpen: %v", err)
+	}
+	if !emitter.Opened() {
+		t.Fatal("Opened = false after open")
+	}
+	if err := emitter.EmitOpen(); err == nil || !strings.Contains(err.Error(), "already open") {
+		t.Fatalf("duplicate open error = %v", err)
+	}
+	if err := emitter.EmitActivity(Activity{Class: "actuate", ID: "id", Direction: "internal"}, false); err != nil {
+		t.Fatalf("EmitActivity internal: %v", err)
+	}
+	if err := emitter.emit("activity", map[string]any{"unsupported": make(chan int)}, false); err == nil || !strings.Contains(err.Error(), "marshal canonical AEL payload") {
+		t.Fatalf("unsupported canonical payload error = %v", err)
+	}
+	if err := emitter.EmitClose(); err != nil {
+		t.Fatalf("EmitClose: %v", err)
+	}
+	if err := emitter.EmitHeartbeat(); err == nil || !strings.Contains(err.Error(), "run is closed") {
+		t.Fatalf("heartbeat after close error = %v", err)
+	}
+
+	bounded := NewEmitter(rec, priv, "cccccccccccccccccccccccccccccccc", 10)
+	if bounded == nil {
+		t.Fatal("bounded NewEmitter returned nil")
+	}
+	bounded.opened = true
+	bounded.seq = maxSafeInt + 1
+	if err := bounded.EmitHeartbeat(); err == nil || !strings.Contains(err.Error(), "safe-integer") {
+		t.Fatalf("unsafe sequence error = %v", err)
+	}
+}
+
+func TestEmitterNilAndFilesystemRefusals(t *testing.T) {
+	t.Parallel()
+	var nilEmitter *Emitter
+	if nilEmitter.Dir() != "" || nilEmitter.Opened() {
+		t.Fatal("nil emitter reported state")
+	}
+	if err := nilEmitter.EmitOpen(); err != nil {
+		t.Fatalf("nil EmitOpen: %v", err)
+	}
+	if emitter := NewEmitter(nil, nil, "dddddddddddddddddddddddddddddddd", 1); emitter != nil {
+		t.Fatal("NewEmitter accepted nil recorder and key")
+	}
+
+	dir := t.TempDir()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	t.Cleanup(func() { _ = rec.Close() })
+	if emitter := NewEmitter(rec, priv[:ed25519.SeedSize], "dddddddddddddddddddddddddddddddd", 1); emitter != nil {
+		t.Fatal("NewEmitter accepted short private key")
+	}
+	const duplicateRun = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	first := NewEmitter(rec, priv, duplicateRun, 1)
+	if first == nil {
+		t.Fatal("first NewEmitter returned nil")
+	}
+	second := NewEmitter(rec, priv, duplicateRun, 1)
+	if second == nil {
+		t.Fatal("second NewEmitter returned nil")
+	}
+	if err := second.EmitOpen(); err == nil || !strings.Contains(err.Error(), "create AEL run directory") {
+		t.Fatalf("duplicate run error = %v", err)
+	}
+
+	filePath := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := ensureDirectory(filePath); err == nil || !strings.Contains(err.Error(), "refuse non-directory") {
+		t.Fatalf("ensureDirectory file error = %v", err)
+	}
+	if err := ensureDirectory(filepath.Join(filePath, "child")); err == nil {
+		t.Fatal("ensureDirectory below file succeeded")
+	}
+	if err := ensureDirectory(filepath.Join(t.TempDir(), "missing-parent", "child")); err == nil {
+		t.Fatal("ensureDirectory with missing parent succeeded")
+	}
+	if err := writeExclusive(filePath, []byte("replacement"), 0o600); err == nil {
+		t.Fatal("writeExclusive replaced an existing file")
+	}
+	if err := syncDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("syncDirectory accepted a missing path")
+	}
+}
+
+func TestInitializeArtifactFailureStages(t *testing.T) {
+	t.Parallel()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tests := []struct {
+		name        string
+		failMkdir   int
+		failWrite   int
+		failOpen    bool
+		failSync    int
+		wantMessage string
+	}{
+		{name: "run directory", failMkdir: 1, wantMessage: "create AEL run directory"},
+		{name: "child directory", failMkdir: 2, wantMessage: "create AEL keys directory"},
+		{name: "key publication", failWrite: 1, wantMessage: "publish AEL key"},
+		{name: "manifest publication", failWrite: 2, wantMessage: "write AEL manifest"},
+		{name: "record stream", failOpen: true, wantMessage: "create AEL record stream"},
+		{name: "directory sync", failSync: 1, wantMessage: "sync AEL artifact directory"},
+	}
+	for index, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ops := systemArtifactOps
+			mkdirCalls := 0
+			ops.mkdir = func(path string, mode os.FileMode) error {
+				mkdirCalls++
+				if mkdirCalls == tc.failMkdir {
+					return errors.New("injected mkdir failure")
+				}
+				return os.Mkdir(path, mode)
+			}
+			writeCalls := 0
+			ops.writeExclusive = func(path string, data []byte, mode os.FileMode) error {
+				writeCalls++
+				if writeCalls == tc.failWrite {
+					return errors.New("injected write failure")
+				}
+				return writeExclusive(path, data, mode)
+			}
+			ops.openFile = func(path string, flags int, mode os.FileMode) (*os.File, error) {
+				if tc.failOpen {
+					return nil, errors.New("injected open failure")
+				}
+				// #nosec G304 -- path is built below this test's temporary directory.
+				return os.OpenFile(path, flags, mode)
+			}
+			syncCalls := 0
+			ops.syncDirectory = func(path string) error {
+				syncCalls++
+				if syncCalls == tc.failSync {
+					return errors.New("injected sync failure")
+				}
+				return syncDirectory(path)
+			}
+			emitter := &Emitter{
+				run:   fmt.Sprintf("%032x", index+100),
+				keyID: strings.Repeat("a", 64),
+			}
+			err := emitter.initializeArtifactWithOps(dir, pub, ops)
+			if err == nil || !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf("initializeArtifactWithOps error = %v, want %q", err, tc.wantMessage)
+			}
+		})
+	}
+}
+
+func readAELLines(t *testing.T, dir string) []string {
+	t.Helper()
+	// #nosec G304 -- dir is the emitter-owned directory returned by the test.
+	raw, err := os.ReadFile(filepath.Join(dir, "recorders", "pipelock.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(raw)), "\n")
+}
+
+func previousPayloadForLine(t *testing.T, line string) []byte {
+	t.Helper()
+	payload, err := base64.RawURLEncoding.DecodeString(strings.Split(line, ".")[0])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return payload
+}

--- a/internal/ael/sync_directory_darwin.go
+++ b/internal/ael/sync_directory_darwin.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package ael
+
+// macOS does not support fsync on directory descriptors. Artifact files still
+// receive their own fsync before this best-effort directory durability step.
+func syncDirectory(string) error { return nil }

--- a/internal/ael/sync_directory_noop_test.go
+++ b/internal/ael/sync_directory_noop_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows || darwin
+
+package ael
+
+import "testing"
+
+func TestSyncDirectoryIsNoop(t *testing.T) {
+	t.Parallel()
+	if err := syncDirectory("ignored"); err != nil {
+		t.Fatalf("syncDirectory no-op: %v", err)
+	}
+}

--- a/internal/ael/sync_directory_unix.go
+++ b/internal/ael/sync_directory_unix.go
@@ -10,8 +10,20 @@ import (
 	"path/filepath"
 )
 
+type directorySyncer interface {
+	Sync() error
+	Close() error
+}
+
 func syncDirectory(path string) error {
-	dir, err := os.Open(filepath.Clean(path))
+	return syncDirectoryWithOpen(path, func(name string) (directorySyncer, error) {
+		// #nosec G304 -- the artifact directory is intentionally operator-configured.
+		return os.Open(name)
+	})
+}
+
+func syncDirectoryWithOpen(path string, open func(string) (directorySyncer, error)) error {
+	dir, err := open(filepath.Clean(path))
 	if err != nil {
 		return err
 	}

--- a/internal/ael/sync_directory_unix.go
+++ b/internal/ael/sync_directory_unix.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package ael
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	err = dir.Sync()
+	closeErr := dir.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}

--- a/internal/ael/sync_directory_unix.go
+++ b/internal/ael/sync_directory_unix.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Pipelock contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows
+//go:build !windows && !darwin
 
 package ael
 

--- a/internal/ael/sync_directory_unix_test.go
+++ b/internal/ael/sync_directory_unix_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows && !darwin
+
+package ael
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncDirectoryRejectsMissingPath(t *testing.T) {
+	t.Parallel()
+	if err := syncDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("syncDirectory accepted a missing path")
+	}
+}

--- a/internal/ael/sync_directory_unix_test.go
+++ b/internal/ael/sync_directory_unix_test.go
@@ -6,13 +6,54 @@
 package ael
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 )
+
+type fakeDirectorySyncer struct {
+	syncErr  error
+	closeErr error
+	closed   bool
+}
+
+func (f *fakeDirectorySyncer) Sync() error { return f.syncErr }
+
+func (f *fakeDirectorySyncer) Close() error {
+	f.closed = true
+	return f.closeErr
+}
 
 func TestSyncDirectoryRejectsMissingPath(t *testing.T) {
 	t.Parallel()
 	if err := syncDirectory(filepath.Join(t.TempDir(), "missing")); err == nil {
 		t.Fatal("syncDirectory accepted a missing path")
+	}
+}
+
+func TestSyncDirectoryReturnsSyncErrorAndCloses(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("sync failed")
+	dir := &fakeDirectorySyncer{syncErr: wantErr}
+	err := syncDirectoryWithOpen("directory", func(string) (directorySyncer, error) {
+		return dir, nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("syncDirectoryWithOpen error = %v, want %v", err, wantErr)
+	}
+	if !dir.closed {
+		t.Fatal("syncDirectoryWithOpen did not close directory after sync failure")
+	}
+}
+
+func TestSyncDirectoryReturnsCloseError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("close failed")
+	dir := &fakeDirectorySyncer{closeErr: wantErr}
+	err := syncDirectoryWithOpen("directory", func(string) (directorySyncer, error) {
+		return dir, nil
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("syncDirectoryWithOpen error = %v, want %v", err, wantErr)
 	}
 }

--- a/internal/ael/sync_directory_windows.go
+++ b/internal/ael/sync_directory_windows.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package ael
+
+// Windows does not expose a portable directory-fsync operation. The artifact
+// files themselves are still flushed before lifecycle emission returns.
+func syncDirectory(string) error { return nil }

--- a/internal/metrics/receipt.go
+++ b/internal/metrics/receipt.go
@@ -18,6 +18,7 @@ var receiptEmitFailureReasons = map[string]bool{
 	"hash":        true,
 	"marshal":     true,
 	"record":      true,
+	"ael":         true,
 	"sync":        true,
 	"sealed":      true,
 	"unavailable": true,

--- a/internal/metrics/receipt_test.go
+++ b/internal/metrics/receipt_test.go
@@ -19,6 +19,7 @@ func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("chain_init")
 	m.RecordEmitFailure("record")
+	m.RecordEmitFailure("ael")
 	m.RecordEmitFailure("sync")
 	m.RecordEmitFailure("unavailable")
 
@@ -27,6 +28,9 @@ func TestRecordEmitFailure_CanonicalReasons(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("record")); got != 1 {
 		t.Errorf("record = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("ael")); got != 1 {
+		t.Errorf("ael = %v, want 1", got)
 	}
 	if got := testutil.ToFloat64(m.receiptEmitFailures.WithLabelValues("sync")); got != 1 {
 		t.Errorf("sync = %v, want 1", got)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1956,6 +1956,23 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.reloadLocked()
 	}
 
+	// A signer rotation gives native AEL a new key-scoped run. Close the old
+	// run while admissions are excluded and before publishing any new runtime
+	// state, so every replaced emitter has an explicit terminal record. The
+	// replacement's open was staged durably above; a close failure aborts the
+	// reload and leaves the old emitter fail-closed through its sticky AEL error.
+	if current := p.receiptEmitterPtr.Load(); current != nil && !receiptStage.reuseExisting && current != receiptStage.emitter {
+		if err := current.CloseNativeAEL(); err != nil {
+			p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+				fmt.Errorf("native AEL rotation close failed, keeping old config: %w", err))
+			sc.Close()
+			if newEd != nil {
+				newEd.Close()
+			}
+			return false
+		}
+	}
+
 	// Publish both emitters now that staging has fully succeeded. The
 	// atomic.Pointer swaps are individually atomic; between them, a
 	// request can observe "new envelope + old receipt" for a few

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1951,8 +1951,7 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	// here cannot leave the current receipt chain behind a staged record.
 	currentReceiptEmitter := p.receiptEmitterPtr.Load()
 	if current := currentReceiptEmitter; current != nil && !receiptStage.reuseExisting && current != receiptStage.emitter {
-		if err := current.CloseNativeAEL(); err != nil {
-			current.MarkUnhealthy(err)
+		if err := current.RetireNativeAEL(); err != nil {
 			p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
 				fmt.Errorf("native AEL rotation close failed, keeping old config: %w", err))
 			sc.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1935,18 +1935,6 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 			}
 		}
 	}
-	if cfg.FlightRecorder.SigningKeyPath != "" && p.recorder != nil && !receiptStage.reuseExisting && receiptStage.emitter != nil {
-		if err := receiptStage.emitter.EmitSessionOpen(); err != nil {
-			p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
-				fmt.Errorf("session_open receipt emit failed, keeping old config: %w", err))
-			sc.Close()
-			if newEd != nil {
-				newEd.Close()
-			}
-			return false
-		}
-	}
-
 	// Staging above may load keys and build evidence components. Keep that I/O
 	// off the request snapshot lock; only publication and in-place state changes
 	// need to exclude CEE admissions.
@@ -1959,12 +1947,32 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 	// A signer rotation gives native AEL a new key-scoped run. Close the old
 	// run while admissions are excluded and before publishing any new runtime
 	// state, so every replaced emitter has an explicit terminal record. The
-	// replacement's open was staged durably above; a close failure aborts the
-	// reload and leaves the old emitter fail-closed through its sticky AEL error.
-	if current := p.receiptEmitterPtr.Load(); current != nil && !receiptStage.reuseExisting && current != receiptStage.emitter {
+	// replacement open is persisted only after this close succeeds, so aborting
+	// here cannot leave the current receipt chain behind a staged record.
+	currentReceiptEmitter := p.receiptEmitterPtr.Load()
+	if current := currentReceiptEmitter; current != nil && !receiptStage.reuseExisting && current != receiptStage.emitter {
 		if err := current.CloseNativeAEL(); err != nil {
+			current.MarkUnhealthy(err)
 			p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
 				fmt.Errorf("native AEL rotation close failed, keeping old config: %w", err))
+			sc.Close()
+			if newEd != nil {
+				newEd.Close()
+			}
+			return false
+		}
+	}
+	if cfg.FlightRecorder.SigningKeyPath != "" && p.recorder != nil && !receiptStage.reuseExisting && receiptStage.emitter != nil {
+		if err := receiptStage.emitter.EmitSessionOpen(); err != nil {
+			// The old AEL run is already terminal. If the replacement receipt was
+			// written before its paired AEL open failed, the old emitter's chain
+			// head is stale. Brick it explicitly so no later request can fork the
+			// signed receipt chain while the reload remains uncommitted.
+			if currentReceiptEmitter != nil {
+				currentReceiptEmitter.MarkUnhealthy(err)
+			}
+			p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
+				fmt.Errorf("session_open receipt emit failed, keeping old config fail-closed: %w", err))
 			sc.Close()
 			if newEd != nil {
 				newEd.Close()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1856,6 +1856,15 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		}
 		return false
 	}
+	receiptStagePublished := receiptStage.reuseExisting || receiptStage.emitter == nil
+	defer func() {
+		if receiptStagePublished {
+			return
+		}
+		if err := receiptStage.emitter.AbortNativeAEL(); err != nil {
+			p.logger.LogError(audit.NewMethodLogContext("RELOAD"), fmt.Errorf("close unpublished native AEL emitter: %w", err))
+		}
+	}()
 	contractLoader, contractErr := buildContractLoader(cfg)
 	if contractErr != nil {
 		p.logger.LogError(audit.NewMethodLogContext("RELOAD"),
@@ -2011,6 +2020,7 @@ func (p *Proxy) Reload(cfg *config.Config, sc *scanner.Scanner) bool {
 		p.receiptEmitterPtr.Store(receiptStage.emitter)
 		p.v2EmitterPtr.Store(receiptStage.v2)
 		p.receiptKeyPath = receiptStage.keyPath
+		receiptStagePublished = true
 	}
 
 	// Apply enabled CEE components before publishing their config. A stricter

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -970,6 +970,9 @@ fetch_proxy:
 	if afterEmitter := p.receiptEmitterPtr.Load(); afterEmitter != beforeEmitter {
 		t.Fatal("receipt emitter changed even though reload session_open emission failed")
 	}
+	if beforeEmitter.HealthError() == nil {
+		t.Fatal("retained emitter remained healthy after replacement advanced the shared receipt chain")
+	}
 
 	handler := p.buildHandler(p.buildMux())
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url=https://evil.example.com/exfil", nil)
@@ -1000,24 +1003,13 @@ fetch_proxy:
 		}
 		receipts = append(receipts, r)
 	}
-	if len(receipts) != 2 {
-		t.Fatalf("receipt count = %d, want old session_open and old-policy block receipt", len(receipts))
+	if len(receipts) != 1 {
+		t.Fatalf("receipt count = %d, want only the old session_open and no forked post-failure receipt", len(receipts))
 	}
 	if receipts[0].ActionRecord.SessionControl == nil ||
 		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {
 		t.Fatalf("first receipt session_control = %+v, want old session_open",
 			receipts[0].ActionRecord.SessionControl)
-	}
-	if receipts[1].ActionRecord.SessionControl != nil {
-		t.Fatalf("post-failure request unexpectedly carried session_control: %+v",
-			receipts[1].ActionRecord.SessionControl)
-	}
-	if want := cfg.CanonicalPolicyHash(); receipts[1].ActionRecord.PolicyHash != want {
-		t.Fatalf("post-failure receipt policy hash = %q, want old hash %q",
-			receipts[1].ActionRecord.PolicyHash, want)
-	}
-	if receipts[1].ActionRecord.PolicyHash == reloadCfg.CanonicalPolicyHash() {
-		t.Fatal("post-failure receipt unexpectedly attested failed reload config")
 	}
 	result := receipt.VerifyChainTrusted(receipts, []string{hex.EncodeToString(pub)})
 	if !result.Valid {
@@ -1418,6 +1410,9 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	if p.receiptEmitterPtr.Load() != newEmitter {
 		t.Fatal("failed native AEL rotation published the replacement emitter")
 	}
+	if newEmitter.HealthError() == nil {
+		t.Fatal("failed native AEL rotation did not brick the retained emitter")
+	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -1447,8 +1442,8 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	if len(receipts) == 0 {
 		t.Fatal("no receipt found after key rotation reload")
 	}
-	if len(receipts) != 5 {
-		t.Fatalf("receipt count = %d, want startup open, rotated open, blocked fetch, shutdown close, and staged failed-reload open", len(receipts))
+	if len(receipts) != 4 {
+		t.Fatalf("receipt count = %d, want startup open, rotated open, blocked fetch, and shutdown close", len(receipts))
 	}
 	if receipts[0].ActionRecord.SessionControl == nil ||
 		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {

--- a/internal/proxy/receipt_test.go
+++ b/internal/proxy/receipt_test.go
@@ -6,6 +6,7 @@ package proxy
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1344,6 +1345,15 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	if origEmitter == nil {
 		t.Fatal("expected non-nil emitter before reload")
 	}
+	aelRoot := filepath.Join(recDir, "ael")
+	beforeRuns, err := os.ReadDir(aelRoot)
+	if err != nil {
+		t.Fatalf("ReadDir AEL before rotation: %v", err)
+	}
+	if len(beforeRuns) != 1 {
+		t.Fatalf("AEL runs before rotation = %d, want 1", len(beforeRuns))
+	}
+	originalAELRun := filepath.Join(aelRoot, beforeRuns[0].Name())
 
 	// Reload with key B - should replace the emitter.
 	reloadCfg := config.Defaults()
@@ -1362,6 +1372,29 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	if newEmitter == origEmitter {
 		t.Fatal("expected NEW emitter instance after key rotation, got same pointer")
 	}
+	// #nosec G304 -- originalAELRun came from this test's recorder directory.
+	originalAELLines, err := os.ReadFile(filepath.Join(originalAELRun, "recorders", "pipelock.jsonl"))
+	if err != nil {
+		t.Fatalf("read original AEL run: %v", err)
+	}
+	encodedLines := strings.Split(strings.TrimSpace(string(originalAELLines)), "\n")
+	lastParts := strings.Split(encodedLines[len(encodedLines)-1], ".")
+	if len(lastParts) != 2 {
+		t.Fatalf("original AEL terminal record has %d compact parts", len(lastParts))
+	}
+	terminalPayload, err := base64.RawURLEncoding.DecodeString(lastParts[0])
+	if err != nil {
+		t.Fatalf("decode original AEL terminal payload: %v", err)
+	}
+	var terminalRecord struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(terminalPayload, &terminalRecord); err != nil {
+		t.Fatalf("unmarshal original AEL terminal payload: %v", err)
+	}
+	if terminalRecord.Type != "close" {
+		t.Fatalf("original AEL terminal type = %q, want close", terminalRecord.Type)
+	}
 
 	// Emit a receipt via a request and verify it is signed with key B.
 	handler := p.buildHandler(p.buildMux())
@@ -1373,6 +1406,18 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 		t.Errorf("expected 403, got %d", w.Code)
 	}
 
+	if err := newEmitter.EmitSessionClose("test complete"); err != nil {
+		t.Fatalf("EmitSessionClose B: %v", err)
+	}
+	// A replacement attempt after the current native run has closed must abort
+	// instead of publishing another emitter over an unclosable lifecycle.
+	failedReloadScanner := scanner.MustNew(cfg)
+	if p.Reload(cfg, failedReloadScanner) {
+		t.Fatal("reload succeeded after native AEL rotation close failure")
+	}
+	if p.receiptEmitterPtr.Load() != newEmitter {
+		t.Fatal("failed native AEL rotation published the replacement emitter")
+	}
 	if err := rec.Close(); err != nil {
 		t.Fatalf("recorder.Close: %v", err)
 	}
@@ -1402,8 +1447,8 @@ func TestProxy_ReloadRotatesSigningKey(t *testing.T) {
 	if len(receipts) == 0 {
 		t.Fatal("no receipt found after key rotation reload")
 	}
-	if len(receipts) != 3 {
-		t.Fatalf("receipt count = %d, want startup open, rotated open, and blocked fetch receipt", len(receipts))
+	if len(receipts) != 5 {
+		t.Fatalf("receipt count = %d, want startup open, rotated open, blocked fetch, shutdown close, and staged failed-reload open", len(receipts))
 	}
 	if receipts[0].ActionRecord.SessionControl == nil ||
 		receipts[0].ActionRecord.SessionControl.Kind != receipt.SessionControlOpen {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -725,6 +725,15 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		}
 		return emitErr
 	}
+	if err := e.emitNativeAEL(ar, sessionControl, durable); err != nil {
+		e.recordFailure(FailReasonAEL)
+		emitErr := fmt.Errorf("emitting native AEL record: %w", err)
+		// The receipt is already persisted and its chain position consumed. Do not
+		// advertise lifecycle success, and quarantine the emitter so a retry cannot
+		// duplicate that receipt while the paired AEL stream is unhealthy.
+		e.MarkUnhealthy(emitErr)
+		return emitErr
+	}
 	if openControl {
 		e.sessionOpenEmitted = true
 		e.openNonce = sessionControl.Open.OpenNonce
@@ -734,10 +743,6 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	}
 	if sessionControl != nil && sessionControl.Kind == SessionControlHeartbeat {
 		e.lastHeartbeat = ar.Timestamp
-	}
-	if err := e.emitNativeAEL(ar, sessionControl, durable); err != nil {
-		e.recordFailure(FailReasonAEL)
-		return fmt.Errorf("emitting native AEL record: %w", err)
 	}
 
 	// Notify the observer (if any) AFTER the receipt is durably recorded, so a
@@ -827,6 +832,14 @@ func (e *Emitter) CloseNativeAEL() error {
 		return fmt.Errorf("closing native AEL run: %w", err)
 	}
 	return nil
+}
+
+// AbortNativeAEL releases a staged native emitter that will not be published.
+func (e *Emitter) AbortNativeAEL() error {
+	if e == nil || e.nativeAEL == nil {
+		return nil
+	}
+	return e.nativeAEL.Abort()
 }
 
 var errEmitterRetired = errors.New("receipt emitter retired after signer rotation")

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -86,19 +86,20 @@ const (
 // Emitter produces signed action receipts and writes them to the flight recorder.
 // It is safe for concurrent use - the underlying recorder handles its own locking.
 type Emitter struct {
-	recorder   *recorder.Recorder
-	privKey    ed25519.PrivateKey
-	configHash atomic.Value // stores string; updated on hot reload
-	principal  string
-	actor      string
-	metrics    MetricsSink
-	onReceipt  func(rcpt *Receipt)
-	now        func() time.Time
-	initErr    error
-	healthMu   sync.RWMutex
-	healthErr  error
-	runNonce   string
-	nativeAEL  *aelpkg.Emitter
+	recorder               *recorder.Recorder
+	privKey                ed25519.PrivateKey
+	configHash             atomic.Value // stores string; updated on hot reload
+	principal              string
+	actor                  string
+	metrics                MetricsSink
+	onReceipt              func(rcpt *Receipt)
+	now                    func() time.Time
+	initErr                error
+	healthMu               sync.RWMutex
+	healthErr              error
+	beforeChainLockForTest func()
+	runNonce               string
+	nativeAEL              *aelpkg.Emitter
 
 	// Chain state - mutex-protected, updated on each Emit.
 	chainMu       sync.Mutex
@@ -505,6 +506,9 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		sideEffect = sideEffectFromMCPAction(actionType)
 		reversibility = ReversibilityUnknown
 	}
+	if e.beforeChainLockForTest != nil {
+		e.beforeChainLockForTest()
+	}
 
 	// Chain integrity: lock covers stamp → sign → hash → persist → advance.
 	// The mutex must span from timestamp through persist so concurrent Emit
@@ -513,6 +517,13 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	// of reusing the same prev_hash/seq and forking the chain.
 	e.chainMu.Lock()
 	defer e.chainMu.Unlock()
+	// Retirement can happen after the optimistic check above while this emit
+	// waits for chainMu. Re-check under the chain lock so a call admitted before
+	// signer rotation cannot append after the old native AEL run is closed.
+	if healthErr := e.HealthError(); healthErr != nil {
+		e.recordFailure(FailReasonUnavailable)
+		return fmt.Errorf("receipt emitter unhealthy: %w", healthErr)
+	}
 
 	if e.rootEmitted {
 		e.recordFailure(FailReasonSealed)
@@ -815,6 +826,28 @@ func (e *Emitter) CloseNativeAEL() error {
 		e.recordFailure(FailReasonAEL)
 		return fmt.Errorf("closing native AEL run: %w", err)
 	}
+	return nil
+}
+
+var errEmitterRetired = errors.New("receipt emitter retired after signer rotation")
+
+// RetireNativeAEL atomically closes the native run and bricks this emitter so
+// stale or already-admitted calls cannot append receipts after key rotation.
+func (e *Emitter) RetireNativeAEL() error {
+	if e == nil {
+		return nil
+	}
+	e.chainMu.Lock()
+	defer e.chainMu.Unlock()
+	if e.nativeAEL != nil && e.nativeAEL.Opened() {
+		if err := e.nativeAEL.EmitClose(); err != nil {
+			e.recordFailure(FailReasonAEL)
+			closeErr := fmt.Errorf("closing native AEL run: %w", err)
+			e.MarkUnhealthy(closeErr)
+			return closeErr
+		}
+	}
+	e.MarkUnhealthy(errEmitterRetired)
 	return nil
 }
 

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -207,8 +207,11 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 		e.initErr = fmt.Errorf("generate run nonce: %w", nonceErr)
 		return e
 	}
-	e.nativeAEL = aelpkg.NewEmitter(cfg.Recorder, cfg.PrivKey, runNonce, cfg.HeartbeatSeconds)
 	e.initErr = e.resumeChain()
+	if e.initErr != nil {
+		return e
+	}
+	e.nativeAEL = aelpkg.NewEmitter(cfg.Recorder, cfg.PrivKey, runNonce, cfg.HeartbeatSeconds)
 	return e
 }
 

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	aelpkg "github.com/luckyPipewrench/pipelock/internal/ael"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/evidencename"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
@@ -69,6 +70,8 @@ const (
 	FailReasonMarshal = "marshal"
 	// FailReasonRecord is a recorder-write failure.
 	FailReasonRecord = "record"
+	// FailReasonAEL is a native AEL artifact emission failure.
+	FailReasonAEL = "ael"
 	// FailReasonSync is a recorder durability-sync failure.
 	FailReasonSync = "sync"
 	// FailReasonSealed is an emit attempt after the transcript root was emitted.
@@ -95,6 +98,7 @@ type Emitter struct {
 	healthMu   sync.RWMutex
 	healthErr  error
 	runNonce   string
+	nativeAEL  *aelpkg.Emitter
 
 	// Chain state - mutex-protected, updated on each Emit.
 	chainMu       sync.Mutex
@@ -203,6 +207,7 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 		e.initErr = fmt.Errorf("generate run nonce: %w", nonceErr)
 		return e
 	}
+	e.nativeAEL = aelpkg.NewEmitter(cfg.Recorder, cfg.PrivKey, runNonce, cfg.HeartbeatSeconds)
 	e.initErr = e.resumeChain()
 	return e
 }
@@ -716,6 +721,10 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	if sessionControl != nil && sessionControl.Kind == SessionControlHeartbeat {
 		e.lastHeartbeat = ar.Timestamp
 	}
+	if err := e.emitNativeAEL(ar, sessionControl, durable); err != nil {
+		e.recordFailure(FailReasonAEL)
+		return fmt.Errorf("emitting native AEL record: %w", err)
+	}
 
 	// Notify the observer (if any) AFTER the receipt is durably recorded, so a
 	// streamed decision can never appear before it exists on disk. The call is
@@ -727,6 +736,82 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		e.onReceipt(&rc)
 	}
 
+	return nil
+}
+
+func (e *Emitter) emitNativeAEL(ar ActionRecord, control *SessionControl, durable bool) error {
+	if e.nativeAEL == nil {
+		return nil
+	}
+	ensureOpen := func() error {
+		if e.nativeAEL.Opened() {
+			return nil
+		}
+		return e.nativeAEL.EmitOpen()
+	}
+	if control != nil {
+		switch control.Kind {
+		case SessionControlOpen:
+			return e.nativeAEL.EmitOpen()
+		case SessionControlHeartbeat:
+			if !e.sessionOpenEmitted {
+				return nil
+			}
+			if err := ensureOpen(); err != nil {
+				return err
+			}
+			return e.nativeAEL.EmitHeartbeat()
+		case SessionControlClose:
+			if !e.sessionOpenEmitted {
+				return nil
+			}
+			if err := ensureOpen(); err != nil {
+				return err
+			}
+			return e.nativeAEL.EmitClose()
+		}
+	}
+	// Receipt emitters are also used directly by compatibility tools and unit
+	// callers that do not establish a process lifecycle. Native AEL is emitted
+	// only for a run with an explicit open record; production runtimes always
+	// open the session before mediating traffic.
+	if !e.sessionOpenEmitted {
+		return nil
+	}
+	if err := ensureOpen(); err != nil {
+		return err
+	}
+	direction := "internal"
+	switch ar.ActionType {
+	case ActionRead:
+		direction = "in"
+	case ActionWrite, ActionDelegate, ActionSpend, ActionCommit, ActionActuate:
+		direction = "out"
+	}
+	return e.nativeAEL.EmitActivity(aelpkg.Activity{
+		Class:     string(ar.ActionType),
+		ID:        ar.ActionID,
+		Direction: direction,
+	}, durable)
+}
+
+// CloseNativeAEL closes this emitter's native AEL run when the proxy replaces
+// the receipt emitter during a live signer rotation. The receipt chain records
+// its existing key-transition boundary on the replacement emitter; AEL uses an
+// explicit close/open pair because each signing key owns a separate run.
+func (e *Emitter) CloseNativeAEL() error {
+	if e == nil {
+		return nil
+	}
+	e.chainMu.Lock()
+	defer e.chainMu.Unlock()
+	if e.nativeAEL == nil || !e.nativeAEL.Opened() {
+		return nil
+	}
+	if err := e.nativeAEL.EmitClose(); err != nil {
+		e.recordFailure(FailReasonAEL)
+		return fmt.Errorf("closing native AEL run: %w", err)
+	}
 	return nil
 }
 

--- a/internal/receipt/emitter_ael_test.go
+++ b/internal/receipt/emitter_ael_test.go
@@ -67,7 +67,13 @@ func TestEmitterCloseNativeAELForRotation(t *testing.T) {
 	if err := nilEmitter.CloseNativeAEL(); err != nil {
 		t.Fatalf("nil CloseNativeAEL: %v", err)
 	}
+	if err := nilEmitter.AbortNativeAEL(); err != nil {
+		t.Fatalf("nil AbortNativeAEL: %v", err)
+	}
 	bareEmitter := &Emitter{}
+	if err := bareEmitter.AbortNativeAEL(); err != nil {
+		t.Fatalf("bare AbortNativeAEL: %v", err)
+	}
 	if err := bareEmitter.emitNativeAEL(ActionRecord{}, nil, false); err != nil {
 		t.Fatalf("emitNativeAEL without native emitter: %v", err)
 	}
@@ -125,5 +131,28 @@ func TestEmitterRetireNativeAELRejectsStaleAndAlreadyAdmittedHeartbeats(t *testi
 	}
 	if err := e.EmitHeartbeat(); err == nil || !strings.Contains(err.Error(), "retired after signer rotation") {
 		t.Fatalf("stale heartbeat error = %v", err)
+	}
+}
+
+func TestEmitterNativeAELFailureQuarantinesWithoutLifecycleSuccess(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, HeartbeatSeconds: 30})
+	if err := e.nativeAEL.Abort(); err != nil {
+		t.Fatalf("Abort native AEL: %v", err)
+	}
+	if err := e.EmitSessionOpen(); err == nil || !strings.Contains(err.Error(), "emitting native AEL record") {
+		t.Fatalf("EmitSessionOpen error = %v, want native AEL failure", err)
+	}
+	if e.sessionOpenEmitted || e.openNonce != "" {
+		t.Fatalf("failed native open advanced lifecycle: emitted=%t nonce=%q", e.sessionOpenEmitted, e.openNonce)
+	}
+	if e.HealthError() == nil {
+		t.Fatal("failed native open did not quarantine receipt emitter")
+	}
+	if err := e.EmitSessionOpen(); err == nil || !strings.Contains(err.Error(), "receipt emitter unhealthy") {
+		t.Fatalf("retry error = %v, want quarantined emitter", err)
 	}
 }

--- a/internal/receipt/emitter_ael_test.go
+++ b/internal/receipt/emitter_ael_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestEmitterNativeAELLifecycle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, HeartbeatSeconds: 30})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.EmitDurable(EmitOpts{ActionID: NewActionID(), Method: "GET", Target: "https://api.vendor.example/data", Verdict: config.ActionAllow, Transport: "fetch"}); err != nil {
+		t.Fatalf("EmitDurable: %v", err)
+	}
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Fatalf("EmitHeartbeat: %v", err)
+	}
+	if err := e.EmitSessionClose("test complete"); err != nil {
+		t.Fatalf("EmitSessionClose: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(e.nativeAEL.Dir(), "recorders", "pipelock.jsonl"))
+	if err != nil {
+		t.Fatalf("read native AEL stream: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	want := []string{"open", "activity", "heartbeat", "close"}
+	if len(lines) != len(want) {
+		t.Fatalf("AEL record count = %d, want %d", len(lines), len(want))
+	}
+	for index, line := range lines {
+		payload, decodeErr := base64.RawURLEncoding.DecodeString(strings.Split(line, ".")[0])
+		if decodeErr != nil {
+			t.Fatalf("decode record %d: %v", index, decodeErr)
+		}
+		var record struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(payload, &record); err != nil {
+			t.Fatalf("unmarshal record %d: %v", index, err)
+		}
+		if record.Type != want[index] {
+			t.Fatalf("record %d type = %q, want %q", index, record.Type, want[index])
+		}
+	}
+}
+
+func TestEmitterCloseNativeAELForRotation(t *testing.T) {
+	t.Parallel()
+	var nilEmitter *Emitter
+	if err := nilEmitter.CloseNativeAEL(); err != nil {
+		t.Fatalf("nil CloseNativeAEL: %v", err)
+	}
+	bareEmitter := &Emitter{}
+	if err := bareEmitter.emitNativeAEL(ActionRecord{}, nil, false); err != nil {
+		t.Fatalf("emitNativeAEL without native emitter: %v", err)
+	}
+
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, HeartbeatSeconds: 30})
+	if err := e.CloseNativeAEL(); err != nil {
+		t.Fatalf("CloseNativeAEL before open: %v", err)
+	}
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.CloseNativeAEL(); err != nil {
+		t.Fatalf("CloseNativeAEL: %v", err)
+	}
+	if err := e.EmitDurable(EmitOpts{ActionID: NewActionID(), Method: "GET", Target: "https://api.vendor.example/data", Verdict: config.ActionAllow, Transport: "fetch"}); err == nil || !strings.Contains(err.Error(), "emitting native AEL record") {
+		t.Fatalf("receipt after native close error = %v", err)
+	}
+	if err := e.CloseNativeAEL(); err == nil || !strings.Contains(err.Error(), "run is closed") {
+		t.Fatalf("second CloseNativeAEL error = %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}

--- a/internal/receipt/emitter_ael_test.go
+++ b/internal/receipt/emitter_ael_test.go
@@ -95,3 +95,35 @@ func TestEmitterCloseNativeAELForRotation(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 }
+
+func TestEmitterRetireNativeAELRejectsStaleAndAlreadyAdmittedHeartbeats(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, HeartbeatSeconds: 30})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	admitted := make(chan struct{})
+	release := make(chan struct{})
+	e.beforeChainLockForTest = func() {
+		close(admitted)
+		<-release
+	}
+	heartbeatErr := make(chan error, 1)
+	go func() { heartbeatErr <- e.EmitHeartbeat() }()
+	<-admitted
+	e.beforeChainLockForTest = nil
+	if err := e.RetireNativeAEL(); err != nil {
+		t.Fatalf("RetireNativeAEL: %v", err)
+	}
+	close(release)
+	if err := <-heartbeatErr; err == nil || !strings.Contains(err.Error(), "retired after signer rotation") {
+		t.Fatalf("already-admitted heartbeat error = %v", err)
+	}
+	if err := e.EmitHeartbeat(); err == nil || !strings.Contains(err.Error(), "retired after signer rotation") {
+		t.Fatalf("stale heartbeat error = %v", err)
+	}
+}

--- a/internal/receipt/emitter_ael_test.go
+++ b/internal/receipt/emitter_ael_test.go
@@ -139,6 +139,7 @@ func TestEmitterNativeAELFailureQuarantinesWithoutLifecycleSuccess(t *testing.T)
 	dir := t.TempDir()
 	_, priv := generateTestKey(t)
 	rec := newTestRecorder(t, dir, priv)
+	t.Cleanup(func() { _ = rec.Close() })
 	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv, ConfigHash: testConfigHash, HeartbeatSeconds: 30})
 	if err := e.nativeAEL.Abort(); err != nil {
 		t.Fatalf("Abort native AEL: %v", err)

--- a/internal/receipt/emitter_persistence_failure_test.go
+++ b/internal/receipt/emitter_persistence_failure_test.go
@@ -90,6 +90,9 @@ func TestEmitterMalformedPersistedEvidenceBricksEmission(t *testing.T) {
 	if err := e.InitError(); err == nil || !strings.Contains(err.Error(), "reading existing evidence file") {
 		t.Fatalf("InitError = %v, want malformed persisted evidence rejection", err)
 	}
+	if _, statErr := os.Stat(filepath.Join(dir, "ael")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("failed receipt-chain recovery created AEL artifacts: %v", statErr)
+	}
 
 	err := e.Emit(EmitOpts{
 		ActionID:  NewActionID(),


### PR DESCRIPTION
## What changed

- Emit native AEL v0.1 open, activity, heartbeat, and close records directly from the signed receipt lifecycle. Canonical AEL payload bytes are signed directly, and AEL persistence failures prevent required receipts from succeeding.
- Store each key-scoped run beside flight-recorder evidence and close the old run during live signer rotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed, hash-chained evidence records for lifecycle events, heartbeats, and receipt activities.
  * Added durable evidence artifacts, manifests, public-key publication, and recorder streams.
  * Integrated evidence recording with receipt emission, configuration reloads, and signer rotation.

* **Bug Fixes**
  * Improved failure handling, filesystem protections, concurrency safety, and lifecycle validation.
  * Prevented failed reloads from replacing healthy configuration or leaving incomplete evidence runs.

* **Tests**
  * Added coverage for signing, persistence failures, rotation, validation, concurrency, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->