### PR TITLE
feat(status): warn before license expiry

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -177,7 +177,7 @@ func statusLicenseState(cfg *config.Config, now time.Time) statusLicense {
 		return statusLicense{State: "not_configured", Detail: "no enterprise license configured"}
 	case cfg.LicenseRevoked:
 		return statusLicense{State: "revoked", ID: cfg.LicenseID, Detail: cfg.LicenseRevocationReason}
-	case cfg.LicenseExpiresAt > 0 && now.Unix() > cfg.LicenseExpiresAt:
+	case cfg.LicenseExpiresAt > 0 && now.Unix() >= cfg.LicenseExpiresAt:
 		return statusLicense{State: "expired", ID: cfg.LicenseID, Detail: time.Unix(cfg.LicenseExpiresAt, 0).UTC().Format(time.DateOnly)}
 	case cfg.LicenseAgentsFeature:
 		return statusLicense{State: "active", ID: cfg.LicenseID, Detail: "agents feature enabled", Warning: warning}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/killswitch"
+	"github.com/luckyPipewrench/pipelock/internal/license"
 )
 
 type statusReport struct {
@@ -44,9 +45,10 @@ type statusScanner struct {
 }
 
 type statusLicense struct {
-	State  string `json:"state"`
-	ID     string `json:"id,omitempty"`
-	Detail string `json:"detail,omitempty"`
+	State   string `json:"state"`
+	ID      string `json:"id,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Warning string `json:"warning,omitempty"`
 }
 
 type statusKillSwitchReport struct {
@@ -164,6 +166,12 @@ func modeAction(cfg *config.Config) string {
 }
 
 func statusLicenseState(cfg *config.Config, now time.Time) statusLicense {
+	warning := license.ExpiryStatus(license.License{
+		ID:        cfg.LicenseID,
+		IssuedAt:  cfg.LicenseIssuedAt,
+		ExpiresAt: cfg.LicenseExpiresAt,
+		Tier:      cfg.LicenseTier,
+	}, now).Message()
 	switch {
 	case cfg.LicenseKey == "":
 		return statusLicense{State: "not_configured", Detail: "no enterprise license configured"}
@@ -172,9 +180,9 @@ func statusLicenseState(cfg *config.Config, now time.Time) statusLicense {
 	case cfg.LicenseExpiresAt > 0 && now.Unix() > cfg.LicenseExpiresAt:
 		return statusLicense{State: "expired", ID: cfg.LicenseID, Detail: time.Unix(cfg.LicenseExpiresAt, 0).UTC().Format(time.DateOnly)}
 	case cfg.LicenseAgentsFeature:
-		return statusLicense{State: "active", ID: cfg.LicenseID, Detail: "agents feature enabled"}
+		return statusLicense{State: "active", ID: cfg.LicenseID, Detail: "agents feature enabled", Warning: warning}
 	case cfg.LicenseID != "":
-		return statusLicense{State: "configured", ID: cfg.LicenseID, Detail: "license token loaded"}
+		return statusLicense{State: "configured", ID: cfg.LicenseID, Detail: "license token loaded", Warning: warning}
 	default:
 		return statusLicense{State: "configured", Detail: "license token configured; verification status unavailable in this build"}
 	}
@@ -234,6 +242,9 @@ func printStatusReport(w io.Writer, report statusReport) {
 		_, _ = fmt.Fprintf(w, " - %s", terminalDisplay(report.License.Detail))
 	}
 	_, _ = fmt.Fprintln(w)
+	if report.License.Warning != "" {
+		_, _ = fmt.Fprintf(w, "License warning: %s\n", terminalDisplay(report.License.Warning))
+	}
 	_, _ = fmt.Fprintf(w, "Kill switch: active=%t", report.KillSwitch.Active)
 	if report.KillSwitch.Detail != "" {
 		_, _ = fmt.Fprintf(w, " (%s)", terminalDisplay(report.KillSwitch.Detail))

--- a/internal/cli/status_helpers_test.go
+++ b/internal/cli/status_helpers_test.go
@@ -59,6 +59,43 @@ func TestStatusLicenseStateRoutes(t *testing.T) {
 	}
 }
 
+func TestStatusLicenseStateExpiryWarning(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	base := &config.Config{
+		LicenseKey:      "tok",
+		LicenseID:       "lic-1",
+		LicenseIssuedAt: now.Add(-30 * 24 * time.Hour).Unix(),
+		LicenseTier:     "trial",
+	}
+
+	t.Run("outside warning band", func(t *testing.T) {
+		cfg := *base
+		cfg.LicenseExpiresAt = now.Add(31 * 24 * time.Hour).Unix()
+		if got := statusLicenseState(&cfg, now).Warning; got != "" {
+			t.Fatalf("warning = %q, want empty", got)
+		}
+	})
+
+	t.Run("warning band", func(t *testing.T) {
+		cfg := *base
+		cfg.LicenseExpiresAt = now.Add(7 * 24 * time.Hour).Unix()
+		if got, want := statusLicenseState(&cfg, now).Warning, "trial ends in 7 day(s) on 2026-08-23; Pro features stop at expiry. Subscribe at https://pipelab.org/pricing/"; got != want {
+			t.Fatalf("warning = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		cfg := *base
+		cfg.LicenseExpiresAt = now.Add(-time.Hour).Unix()
+		got := statusLicenseState(&cfg, now)
+		if got.State != "expired" || got.Warning != "" {
+			t.Fatalf("expired license = %+v, want expired without renewal warning", got)
+		}
+	})
+}
+
 func TestModeActionAuditWarns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/status_helpers_test.go
+++ b/internal/cli/status_helpers_test.go
@@ -105,6 +105,15 @@ func TestStatusLicenseStateExpiryWarning(t *testing.T) {
 			t.Fatalf("expired license = %+v, want expired without renewal warning", got)
 		}
 	})
+
+	t.Run("exact expiry second", func(t *testing.T) {
+		cfg := *base
+		cfg.LicenseExpiresAt = now.Unix()
+		got := statusLicenseState(&cfg, now)
+		if got.State != "expired" || got.Warning != "" {
+			t.Fatalf("license at expiry second = %+v, want expired without renewal warning", got)
+		}
+	})
 }
 
 func TestModeActionAuditWarns(t *testing.T) {

--- a/internal/cli/status_helpers_test.go
+++ b/internal/cli/status_helpers_test.go
@@ -81,8 +81,19 @@ func TestStatusLicenseStateExpiryWarning(t *testing.T) {
 	t.Run("warning band", func(t *testing.T) {
 		cfg := *base
 		cfg.LicenseExpiresAt = now.Add(7 * 24 * time.Hour).Unix()
-		if got, want := statusLicenseState(&cfg, now).Warning, "trial ends in 7 day(s) on 2026-08-23; Pro features stop at expiry. Subscribe at https://pipelab.org/pricing/"; got != want {
-			t.Fatalf("warning = %q, want %q", got, want)
+		got := statusLicenseState(&cfg, now).Warning
+		if !strings.Contains(got, "trial ends in 7 day(s) on 2026-08-23") || !strings.Contains(got, "Pro features stop at expiry") {
+			t.Fatalf("warning = %q, want stable expiry guidance", got)
+		}
+	})
+
+	t.Run("active warning band", func(t *testing.T) {
+		cfg := *base
+		cfg.LicenseAgentsFeature = true
+		cfg.LicenseExpiresAt = now.Add(7 * 24 * time.Hour).Unix()
+		got := statusLicenseState(&cfg, now)
+		if got.State != "active" || got.ID != "lic-1" || !strings.Contains(got.Warning, "trial ends in 7 day(s)") {
+			t.Fatalf("active license = %+v, want active with expiry warning", got)
 		}
 	})
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -97,6 +97,26 @@ func TestStatusCmd_TextIncludesLicenseAndSources(t *testing.T) {
 	}
 }
 
+func TestStatusReportPrintsLicenseWarning(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.LicenseKey = "tok"
+	cfg.LicenseID = "lic-1"
+	cfg.LicenseTier = "trial"
+	now := time.Now().UTC()
+	cfg.LicenseIssuedAt = now.Add(-30 * 24 * time.Hour).Unix()
+	cfg.LicenseExpiresAt = now.Add(7 * 24 * time.Hour).Unix()
+
+	report := buildStatusReport(cfg, "test-config.yaml")
+	if report.License.Warning == "" {
+		t.Fatal("expected active expiry warning")
+	}
+	var text bytes.Buffer
+	printStatusReport(&text, report)
+	if !strings.Contains(text.String(), "License warning: "+report.License.Warning) {
+		t.Fatalf("status text missing license warning:\n%s", text.String())
+	}
+}
+
 func TestStatusCmd_InvalidConfigReturnsExitConfig(t *testing.T) {
 	missingConfig := filepath.Join(t.TempDir(), "missing.yaml")
 	out, err := runStatusCmd(t, "--config", missingConfig)

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -115,6 +115,27 @@ func TestStatusReportPrintsLicenseWarning(t *testing.T) {
 	if !strings.Contains(text.String(), "License warning: "+report.License.Warning) {
 		t.Fatalf("status text missing license warning:\n%s", text.String())
 	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal warning report: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode warning report: %v", err)
+	}
+	licenseJSON, ok := decoded["license"].(map[string]any)
+	if !ok || licenseJSON["warning"] != report.License.Warning {
+		t.Fatalf("license JSON = %#v, want warning %q", decoded["license"], report.License.Warning)
+	}
+
+	noWarning := buildStatusReport(config.Defaults(), "test-config.yaml")
+	encoded, err = json.Marshal(noWarning)
+	if err != nil {
+		t.Fatalf("marshal no-warning report: %v", err)
+	}
+	if strings.Contains(string(encoded), `"warning"`) {
+		t.Fatalf("no-warning JSON includes warning field: %s", encoded)
+	}
 }
 
 func TestStatusCmd_InvalidConfigReturnsExitConfig(t *testing.T) {


### PR DESCRIPTION
## What changed

pipelock status now includes the existing proactive license-expiry warning in text and JSON while keeping expired, revoked, and unconfigured states unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added license expiry warnings to status reports.
  * Displays a dedicated warning when an active or configured trial license is nearing expiration, including the expiry date.
  * Warning details are also included in JSON status output when applicable.
  * Expired licenses continue to be identified as expired without an additional warning.
  * Licenses expiring immediately are now recognized as expired, ensuring status information is accurate at the expiration time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->