### PR TITLE
feat(rules): warn beyond tested bundle versions

### DIFF
--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -64,6 +64,17 @@ func warnUnverifiableBundleVersion(w io.Writer, err error) {
 	_, _ = fmt.Fprintf(w, "warning: the bundle is installed, but this build will refuse to LOAD it at runtime until rules.allow_unversioned_bundle_load is set\n")
 }
 
+func warnTestedThroughPipelock(w io.Writer, testedThrough, currentVersion string) error {
+	warning, err := domrules.TestedThroughPipelockWarning(testedThrough, currentVersion)
+	if err != nil {
+		return err
+	}
+	if warning != "" {
+		_, _ = fmt.Fprintf(w, "warning: %s\n", warning)
+	}
+	return nil
+}
+
 // loadRulesConfig loads the pipelock config for trusted key resolution.
 // Resolution is explicit --config, then PIPELOCK_CONFIG, then the shared
 // user/system discovery path. CWD-local pipelock.yaml is intentionally ignored:
@@ -514,11 +525,13 @@ func timeNowUTC() string {
 
 // bundleListEntry is the JSON representation for "rules list --json".
 type bundleListEntry struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Source  string `json:"source"`
-	Signed  bool   `json:"signed"`
-	LastChk string `json:"last_check,omitempty"`
+	Name                  string `json:"name"`
+	Version               string `json:"version"`
+	TestedThroughPipelock string `json:"tested_through_pipelock,omitempty"`
+	Source                string `json:"source"`
+	Signed                bool   `json:"signed"`
+	LastChk               string `json:"last_check,omitempty"`
+	CompatibilityWarning  string `json:"compatibility_warning,omitempty"`
 }
 
 func rulesListCmd() *cobra.Command {
@@ -552,13 +565,21 @@ func rulesListCmd() *cobra.Command {
 				if err != nil {
 					continue // skip directories without lock files
 				}
-				bundles = append(bundles, bundleListEntry{
+				entry := bundleListEntry{
 					Name:    e.Name(),
 					Version: lf.InstalledVersion,
 					Source:  lf.Source,
 					Signed:  !lf.Unsigned,
 					LastChk: lf.LastCheck,
-				})
+				}
+				bundlePath := filepath.Clean(filepath.Join(dir, e.Name(), "bundle.yaml"))
+				if data, readErr := os.ReadFile(bundlePath); readErr == nil {
+					if bundle, parseErr := domrules.ParseBundle(data); parseErr == nil {
+						entry.TestedThroughPipelock = bundle.TestedThroughPipelock
+						entry.CompatibilityWarning, _ = domrules.TestedThroughPipelockWarning(bundle.TestedThroughPipelock, cliutil.Version)
+					}
+				}
+				bundles = append(bundles, entry)
 			}
 
 			if len(bundles) == 0 {
@@ -580,6 +601,12 @@ func rulesListCmd() *cobra.Command {
 				_, _ = fmt.Fprintf(out, "%-30s v%-14s %s  (%s)\n", b.Name, b.Version, signedLabel, b.Source)
 				if b.LastChk != "" {
 					_, _ = fmt.Fprintf(out, "  last checked: %s\n", b.LastChk)
+				}
+				if b.TestedThroughPipelock != "" {
+					_, _ = fmt.Fprintf(out, "  tested through Pipelock: %s\n", b.TestedThroughPipelock)
+				}
+				if b.CompatibilityWarning != "" {
+					_, _ = fmt.Fprintf(out, "  warning: %s\n", b.CompatibilityWarning)
 				}
 			}
 			return nil
@@ -690,6 +717,9 @@ func installLocal(out io.Writer, rulesDir, localPath string, allowUnsigned, allo
 		}
 		warnUnverifiableBundleVersion(out, err)
 	}
+	if err := warnTestedThroughPipelock(out, bundle.TestedThroughPipelock, cliutil.Version); err != nil {
+		return err
+	}
 
 	// Check pipelock-* prefix reservation: local unsigned bundles cannot use it.
 	if strings.HasPrefix(bundle.Name, "pipelock-") {
@@ -792,6 +822,9 @@ func installRemote(opts installRemoteOptions) error {
 			return err
 		}
 		warnUnverifiableBundleVersion(out, err)
+	}
+	if err := warnTestedThroughPipelock(out, bundle.TestedThroughPipelock, cliutil.Version); err != nil {
+		return err
 	}
 
 	digest := sha256Hex(bundleData)
@@ -1086,6 +1119,9 @@ func updateBundle(opts updateBundleOpts) error {
 			return err
 		}
 		warnUnverifiableBundleVersion(opts.Out, err)
+	}
+	if err := warnTestedThroughPipelock(opts.Out, bundle.TestedThroughPipelock, cliutil.Version); err != nil {
+		return err
 	}
 
 	// Compare versions.

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -532,11 +532,15 @@ type bundleListEntry struct {
 	Signed                bool   `json:"signed"`
 	LastChk               string `json:"last_check,omitempty"`
 	CompatibilityWarning  string `json:"compatibility_warning,omitempty"`
+	CompatibilityStatus   string `json:"compatibility_status,omitempty"`
 }
 
 func rulesListCmd() *cobra.Command {
-	var rulesDir string
-	var jsonOut bool
+	var (
+		rulesDir   string
+		jsonOut    bool
+		configFile string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -545,6 +549,7 @@ func rulesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			dir := domrules.ResolveRulesDir(rulesDir)
 			out := cmd.OutOrStdout()
+			policy, policyErr := rulesTrustPolicy(configFile, cmd.ErrOrStderr())
 
 			entries, err := os.ReadDir(dir)
 			if err != nil {
@@ -573,11 +578,20 @@ func rulesListCmd() *cobra.Command {
 					LastChk: lf.LastCheck,
 				}
 				bundlePath := filepath.Clean(filepath.Join(dir, e.Name(), "bundle.yaml"))
-				if data, readErr := os.ReadFile(bundlePath); readErr == nil {
-					if bundle, parseErr := domrules.ParseBundle(data); parseErr == nil {
+				if policyErr != nil {
+					entry.CompatibilityStatus = "unverified: loading trust policy: " + policyErr.Error()
+				} else if data, readErr := os.ReadFile(bundlePath); readErr == nil {
+					if verifyErr := domrules.VerifyIntegrityBytesWithPolicy(data, filepath.Dir(bundlePath), lf.Unsigned, lf.SignerFingerprint, lf.BundleSHA256, policy); verifyErr != nil {
+						entry.CompatibilityStatus = "unverified: " + verifyErr.Error()
+					} else if bundle, parseErr := domrules.ParseBundle(data); parseErr != nil {
+						entry.CompatibilityStatus = "unverified: parsing bundle: " + parseErr.Error()
+					} else {
 						entry.TestedThroughPipelock = bundle.TestedThroughPipelock
 						entry.CompatibilityWarning, _ = domrules.TestedThroughPipelockWarning(bundle.TestedThroughPipelock, cliutil.Version)
+						entry.CompatibilityStatus = "verified"
 					}
+				} else {
+					entry.CompatibilityStatus = "unverified: reading bundle: " + readErr.Error()
 				}
 				bundles = append(bundles, entry)
 			}
@@ -602,6 +616,9 @@ func rulesListCmd() *cobra.Command {
 				if b.LastChk != "" {
 					_, _ = fmt.Fprintf(out, "  last checked: %s\n", b.LastChk)
 				}
+				if b.CompatibilityStatus != "" {
+					_, _ = fmt.Fprintf(out, "  compatibility metadata: %s\n", b.CompatibilityStatus)
+				}
 				if b.TestedThroughPipelock != "" {
 					_, _ = fmt.Fprintf(out, "  tested through Pipelock: %s\n", b.TestedThroughPipelock)
 				}
@@ -615,6 +632,7 @@ func rulesListCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&rulesDir, "rules-dir", "", "override rules directory")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "output as JSON")
+	cmd.Flags().StringVar(&configFile, "config", "", "config file for trusted keys")
 	return cmd
 }
 

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -265,7 +265,7 @@ func TestWarnTestedThroughPipelock(t *testing.T) {
 	if err := warnTestedThroughPipelock(&out, "1.2.0", "1.3.0"); err != nil {
 		t.Fatalf("warnTestedThroughPipelock() error = %v", err)
 	}
-	if !strings.Contains(out.String(), "warning:") || !strings.Contains(out.String(), "remains loaded") {
+	if !strings.Contains(out.String(), "warning:") || !strings.Contains(out.String(), "tested_through_pipelock is advisory") {
 		t.Fatalf("warnTestedThroughPipelock() output = %q, want advisory warning", out.String())
 	}
 }

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -150,6 +150,39 @@ func setupUnsignedBundle(t *testing.T, rulesDir, bundleName string, bundleData [
 	}
 }
 
+// setupSignedBundle creates a bundle.yaml, detached signature, and lock file.
+func setupSignedBundle(t *testing.T, rulesDir, bundleName string, bundleData []byte, pub ed25519.PublicKey, priv ed25519.PrivateKey) {
+	t.Helper()
+
+	bundleDir := filepath.Join(rulesDir, bundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("creating bundle dir: %v", err)
+	}
+
+	bundlePath := filepath.Join(bundleDir, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, bundleData, 0o600); err != nil {
+		t.Fatalf("writing bundle: %v", err)
+	}
+
+	sig := ed25519.Sign(priv, bundleData)
+	if err := os.WriteFile(bundlePath+".sig", []byte(base64.StdEncoding.EncodeToString(sig)+"\n"), 0o600); err != nil {
+		t.Fatalf("writing signature: %v", err)
+	}
+
+	hash := sha256.Sum256(bundleData)
+	lf := &domrules.LockFile{
+		InstalledVersion:  testBundleVersion,
+		InstalledAt:       "2026-03-15T10:00:00Z",
+		Source:            "https://rules.example/test-bundle/bundle.yaml",
+		LastCheck:         "2026-03-15T10:00:00Z",
+		BundleSHA256:      hex.EncodeToString(hash[:]),
+		SignerFingerprint: hex.EncodeToString(pub),
+	}
+	if err := domrules.WriteLockFile(filepath.Join(bundleDir, "bundle.lock"), lf); err != nil {
+		t.Fatalf("writing lock file: %v", err)
+	}
+}
+
 // Tests in this file that call testRootCmd() are intentionally NOT parallel
 // because cobra commands share global state during execution.
 // Tests that mutate domrules keyring globals or httpsOnlyClient are also
@@ -258,6 +291,9 @@ func TestRulesList_JSON(t *testing.T) {
 	if entries[0].TestedThroughPipelock != "1.2.0" {
 		t.Errorf("TestedThroughPipelock = %q, want 1.2.0", entries[0].TestedThroughPipelock)
 	}
+	if entries[0].CompatibilityStatus != "verified" {
+		t.Errorf("CompatibilityStatus = %q, want verified", entries[0].CompatibilityStatus)
+	}
 }
 
 func TestWarnTestedThroughPipelock(t *testing.T) {
@@ -298,8 +334,93 @@ func TestRulesList_TextShowsTestedThroughWarning(t *testing.T) {
 		t.Fatalf("rules list: %v", err)
 	}
 	output := buf.String()
-	if !strings.Contains(output, "tested through Pipelock: 1.2.0") || !strings.Contains(output, "warning: bundle tested through") {
+	if !strings.Contains(output, "compatibility metadata: verified") || !strings.Contains(output, "tested through Pipelock: 1.2.0") || !strings.Contains(output, "warning: bundle tested through") {
 		t.Fatalf("rules list output = %q, want tested-through ceiling and warning", output)
+	}
+}
+
+func TestRulesList_DoesNotReportCompatibilityFromTamperedBundle(t *testing.T) {
+	originalVersion := cliutil.Version
+	cliutil.Version = "10.0.0"
+	t.Cleanup(func() { cliutil.Version = originalVersion })
+
+	rulesDir := t.TempDir()
+	bundleData := []byte(strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1))
+	setupUnsignedBundle(t, rulesDir, testBundleName, bundleData)
+
+	tamperedData := []byte(strings.Replace(string(bundleData), "1.2.0", "9.9.9", 1))
+	bundlePath := filepath.Join(rulesDir, testBundleName, "bundle.yaml")
+	if err := os.WriteFile(bundlePath, tamperedData, 0o600); err != nil {
+		t.Fatalf("tampering bundle: %v", err)
+	}
+
+	cmd := testRootCmd()
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"rules", "list", "--rules-dir", rulesDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rules list must remain available when a bundle fails verification: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "compatibility metadata: unverified: integrity check: SHA-256 mismatch") {
+		t.Fatalf("rules list output = %q, want unverified compatibility status", output)
+	}
+	if strings.Contains(output, "9.9.9") || strings.Contains(output, "tested through Pipelock:") || strings.Contains(output, "warning: bundle tested through") {
+		t.Fatalf("rules list output = %q, must not report tampered compatibility metadata", output)
+	}
+}
+
+func TestRulesList_UnavailableTrustPolicySuppressesCompatibility(t *testing.T) {
+	rulesDir := t.TempDir()
+	bundleData := []byte(strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1))
+	setupUnsignedBundle(t, rulesDir, testBundleName, bundleData)
+
+	cmd := testRootCmd()
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"rules", "list", "--rules-dir", rulesDir, "--config", filepath.Join(t.TempDir(), "missing.yaml")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rules list must remain available when the trust policy cannot load: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "compatibility metadata: unverified: loading trust policy:") {
+		t.Fatalf("rules list output = %q, want unverified compatibility status", output)
+	}
+	if strings.Contains(output, "tested through Pipelock:") || strings.Contains(output, "warning: bundle tested through") {
+		t.Fatalf("rules list output = %q, must not report compatibility metadata without a trust policy", output)
+	}
+}
+
+func TestRulesList_UsesConfiguredTrustPolicyForCompatibility(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generating signing key: %v", err)
+	}
+	setRulesKeyringHexForTest(t, "")
+
+	rulesDir := t.TempDir()
+	bundleData := []byte(strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1))
+	setupSignedBundle(t, rulesDir, testBundleName, bundleData, pub, priv)
+
+	configPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+	configData := []byte("rules:\n  trust_embedded_keys: false\n  trusted_keys:\n    - name: test-signer\n      public_key: " + hex.EncodeToString(pub) + "\n")
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cmd := testRootCmd()
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"rules", "list", "--rules-dir", rulesDir, "--config", configPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rules list: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "compatibility metadata: verified") || !strings.Contains(output, "tested through Pipelock: 1.2.0") {
+		t.Fatalf("rules list output = %q, want compatibility metadata verified under configured trust policy", output)
 	}
 }
 

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -228,7 +228,8 @@ func TestRulesList_WithBundle(t *testing.T) {
 
 func TestRulesList_JSON(t *testing.T) {
 	rulesDir := t.TempDir()
-	setupUnsignedBundle(t, rulesDir, testBundleName, []byte(validBundleYAML))
+	bundleYAML := strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1)
+	setupUnsignedBundle(t, rulesDir, testBundleName, []byte(bundleYAML))
 
 	cmd := testRootCmd()
 	buf := &strings.Builder{}
@@ -253,6 +254,52 @@ func TestRulesList_JSON(t *testing.T) {
 	}
 	if entries[0].Signed {
 		t.Error("expected Signed = false for unsigned bundle")
+	}
+	if entries[0].TestedThroughPipelock != "1.2.0" {
+		t.Errorf("TestedThroughPipelock = %q, want 1.2.0", entries[0].TestedThroughPipelock)
+	}
+}
+
+func TestWarnTestedThroughPipelock(t *testing.T) {
+	var out strings.Builder
+	if err := warnTestedThroughPipelock(&out, "1.2.0", "1.3.0"); err != nil {
+		t.Fatalf("warnTestedThroughPipelock() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "warning:") || !strings.Contains(out.String(), "remains loaded") {
+		t.Fatalf("warnTestedThroughPipelock() output = %q, want advisory warning", out.String())
+	}
+}
+
+func TestWarnTestedThroughPipelockMalformedCeiling(t *testing.T) {
+	var out strings.Builder
+	err := warnTestedThroughPipelock(&out, "1.2", "1.3.0")
+	if err == nil || !strings.Contains(err.Error(), "tested_through_pipelock") {
+		t.Fatalf("warnTestedThroughPipelock() error = %v, want malformed ceiling error", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("warnTestedThroughPipelock() wrote %q before returning an error", out.String())
+	}
+}
+
+func TestRulesList_TextShowsTestedThroughWarning(t *testing.T) {
+	originalVersion := cliutil.Version
+	cliutil.Version = "1.3.0"
+	t.Cleanup(func() { cliutil.Version = originalVersion })
+
+	rulesDir := t.TempDir()
+	bundleYAML := strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1)
+	setupUnsignedBundle(t, rulesDir, testBundleName, []byte(bundleYAML))
+
+	cmd := testRootCmd()
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"rules", "list", "--rules-dir", rulesDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("rules list: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "tested through Pipelock: 1.2.0") || !strings.Contains(output, "warning: bundle tested through") {
+		t.Fatalf("rules list output = %q, want tested-through ceiling and warning", output)
 	}
 }
 
@@ -691,7 +738,12 @@ func TestRulesUpdate_NotInstalled(t *testing.T) {
 }
 
 func TestRulesUpdate_RemoteUpToDate(t *testing.T) {
-	bundleData := []byte(validBundleYAML)
+	originalVersion := cliutil.Version
+	cliutil.Version = "1.3.0"
+	t.Cleanup(func() { cliutil.Version = originalVersion })
+
+	bundleYAML := strings.Replace(validBundleYAML, "min_pipelock: \"0.1.0\"", "min_pipelock: \"0.1.0\"\ntested_through_pipelock: \"1.2.0\"", 1)
+	bundleData := []byte(bundleYAML)
 
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
@@ -765,6 +817,9 @@ func TestRulesUpdate_RemoteUpToDate(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "already up to date") {
 		t.Errorf("expected 'already up to date', got %q", output)
+	}
+	if !strings.Contains(output, "tested through Pipelock") {
+		t.Errorf("expected tested-through warning, got %q", output)
 	}
 
 	// Verify last_check was updated.

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -18,21 +18,22 @@ import (
 
 // Bundle represents a parsed and validated rule bundle.
 type Bundle struct {
-	FormatVersion    int      `yaml:"format_version"`
-	Name             string   `yaml:"name"`
-	Version          string   `yaml:"version"`
-	Author           string   `yaml:"author"`
-	Description      string   `yaml:"description"`
-	Homepage         string   `yaml:"homepage"`
-	MinPipelock      string   `yaml:"min_pipelock"`
-	License          string   `yaml:"license"`
-	Tier             string   `yaml:"tier"`              // standard, community, pro (v2+)
-	MonotonicVersion uint64   `yaml:"monotonic_version"` // rollback-prevention counter (v2+)
-	PublishedAt      string   `yaml:"published_at"`      // RFC 3339 timestamp (v2+)
-	ExpiresAt        string   `yaml:"expires_at"`        // RFC 3339 timestamp (v2+)
-	RequiredFeatures []string `yaml:"required_features"` // engine features needed (v2+, enforced at load time)
-	KeyID            string   `yaml:"key_id"`            // signing key fingerprint (v2+)
-	Rules            []Rule   `yaml:"rules"`
+	FormatVersion         int      `yaml:"format_version"`
+	Name                  string   `yaml:"name"`
+	Version               string   `yaml:"version"`
+	Author                string   `yaml:"author"`
+	Description           string   `yaml:"description"`
+	Homepage              string   `yaml:"homepage"`
+	MinPipelock           string   `yaml:"min_pipelock"`
+	TestedThroughPipelock string   `yaml:"tested_through_pipelock"`
+	License               string   `yaml:"license"`
+	Tier                  string   `yaml:"tier"`              // standard, community, pro (v2+)
+	MonotonicVersion      uint64   `yaml:"monotonic_version"` // rollback-prevention counter (v2+)
+	PublishedAt           string   `yaml:"published_at"`      // RFC 3339 timestamp (v2+)
+	ExpiresAt             string   `yaml:"expires_at"`        // RFC 3339 timestamp (v2+)
+	RequiredFeatures      []string `yaml:"required_features"` // engine features needed (v2+, enforced at load time)
+	KeyID                 string   `yaml:"key_id"`            // signing key fingerprint (v2+)
+	Rules                 []Rule   `yaml:"rules"`
 }
 
 // Rule represents a single detection rule within a bundle.
@@ -122,6 +123,8 @@ var KnownFeatures = map[string]bool{
 // featureNameRegex validates required_features entries: 1-64 chars,
 // lowercase alphanumeric + underscores.
 var featureNameRegex = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
+
+var strictSemverRegex = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 // CheckRequiredFeatures verifies that every feature in required is well-formed
 // and is a known engine feature. Returns an error naming the first invalid or
@@ -238,6 +241,12 @@ func (b *Bundle) Validate() error {
 
 	if b.Description == "" {
 		return fmt.Errorf("validate bundle: description must not be empty")
+	}
+
+	if b.TestedThroughPipelock != "" {
+		if _, err := parseStrictSemverVersion(b.TestedThroughPipelock); err != nil {
+			return fmt.Errorf("validate bundle: invalid tested_through_pipelock %q: %w", b.TestedThroughPipelock, err)
+		}
 	}
 
 	// V2+ fields are required when format_version >= 2.
@@ -465,6 +474,34 @@ func CheckMinPipelock(minVersion, currentVersion string, allowUnversioned bool) 
 	return nil
 }
 
+// TestedThroughPipelockWarning reports when a released Pipelock binary is
+// newer than the bundle's advisory tested ceiling. It never rejects a bundle:
+// min_pipelock remains the fail-closed compatibility requirement.
+func TestedThroughPipelockWarning(testedThrough, currentVersion string) (string, error) {
+	if testedThrough == "" {
+		return "", nil
+	}
+
+	ceiling, err := parseStrictSemverVersion(testedThrough)
+	if err != nil {
+		return "", fmt.Errorf("check tested through pipelock: invalid tested_through_pipelock %q: %w", testedThrough, err)
+	}
+
+	effectiveVersion := stripDirtyMarker(currentVersion)
+	if isDevelopmentCurrentVersion(effectiveVersion) {
+		return "", nil
+	}
+	current, err := parseTestedThroughCurrentVersion(effectiveVersion)
+	if err != nil {
+		return "", nil
+	}
+	if compareStrictSemverVersion(current, ceiling) <= 0 {
+		return "", nil
+	}
+
+	return fmt.Sprintf("bundle tested through Pipelock %q, but running %q; the bundle remains loaded because tested_through_pipelock is advisory", testedThrough, currentVersion), nil
+}
+
 type semverVersion struct {
 	major      int
 	minor      int
@@ -515,6 +552,41 @@ func parseSemverVersion(s string) (semverVersion, error) {
 	}
 
 	return semverVersion{major: major, minor: minor, patch: patch, prerelease: prerelease}, nil
+}
+
+func parseStrictSemverVersion(s string) (strictSemverVersion, error) {
+	return parseStrictSemverParts(s)
+}
+
+type strictSemverVersion struct {
+	major      string
+	minor      string
+	patch      string
+	prerelease string
+}
+
+func parseTestedThroughCurrentVersion(s string) (strictSemverVersion, error) {
+	return parseStrictSemverParts(strings.TrimPrefix(s, "v"))
+}
+
+func parseStrictSemverParts(s string) (strictSemverVersion, error) {
+	if !strictSemverRegex.MatchString(s) {
+		return strictSemverVersion{}, fmt.Errorf("must be SemVer 2.0.0")
+	}
+	releaseAndPrerelease := strings.SplitN(strings.SplitN(s, "+", 2)[0], "-", 2)
+	if len(releaseAndPrerelease) == 2 {
+		for _, identifier := range strings.Split(releaseAndPrerelease[1], ".") {
+			if len(identifier) > 1 && identifier[0] == '0' && isDigits(identifier) {
+				return strictSemverVersion{}, fmt.Errorf("numeric prerelease identifier %q must not contain leading zeroes", identifier)
+			}
+		}
+	}
+	release := strings.Split(releaseAndPrerelease[0], ".")
+	prerelease := ""
+	if len(releaseAndPrerelease) == 2 {
+		prerelease = releaseAndPrerelease[1]
+	}
+	return strictSemverVersion{major: release[0], minor: release[1], patch: release[2], prerelease: prerelease}, nil
 }
 
 // stripDirtyMarker removes a trailing git-describe dirty marker so the rest of
@@ -651,6 +723,54 @@ func comparePrerelease(a, b string) int {
 		}
 	}
 	return cmpInt(len(aParts), len(bParts))
+}
+
+func compareStrictSemverVersion(a, b strictSemverVersion) int {
+	for _, versions := range [][2]string{{a.major, b.major}, {a.minor, b.minor}, {a.patch, b.patch}} {
+		if cmp := compareDecimalStrings(versions[0], versions[1]); cmp != 0 {
+			return cmp
+		}
+	}
+	if a.prerelease == b.prerelease {
+		return 0
+	}
+	if a.prerelease == "" {
+		return 1
+	}
+	if b.prerelease == "" {
+		return -1
+	}
+	return compareStrictPrerelease(a.prerelease, b.prerelease)
+}
+
+func compareStrictPrerelease(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		if aParts[i] == bParts[i] {
+			continue
+		}
+		aNumeric := isDigits(aParts[i])
+		bNumeric := isDigits(bParts[i])
+		switch {
+		case aNumeric && bNumeric:
+			return compareDecimalStrings(aParts[i], bParts[i])
+		case aNumeric:
+			return -1
+		case bNumeric:
+			return 1
+		default:
+			return strings.Compare(aParts[i], bParts[i])
+		}
+	}
+	return cmpInt(len(aParts), len(bParts))
+}
+
+func compareDecimalStrings(a, b string) int {
+	if len(a) != len(b) {
+		return cmpInt(len(a), len(b))
+	}
+	return strings.Compare(a, b)
 }
 
 // compareSemver returns -1 if a < b, 0 if equal, 1 if a > b.

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -499,7 +499,7 @@ func TestedThroughPipelockWarning(testedThrough, currentVersion string) (string,
 		return "", nil
 	}
 
-	return fmt.Sprintf("bundle tested through Pipelock %q, but running %q; the bundle remains loaded because tested_through_pipelock is advisory", testedThrough, currentVersion), nil
+	return fmt.Sprintf("bundle tested through Pipelock %q, but running %q; tested_through_pipelock is advisory", testedThrough, currentVersion), nil
 }
 
 type semverVersion struct {

--- a/internal/rules/bundle_test.go
+++ b/internal/rules/bundle_test.go
@@ -873,6 +873,99 @@ func TestCheckMinPipelock_InvalidVersions(t *testing.T) {
 	}
 }
 
+func TestTestedThroughPipelockWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		testedThrough string
+		current       string
+		wantWarning   bool
+		wantErr       bool
+	}{
+		{name: "omitted", current: "1.3.0"},
+		{name: "exact ceiling", testedThrough: "1.3.0", current: "1.3.0"},
+		{name: "newer binary warns", testedThrough: "1.3.0", current: "1.4.0", wantWarning: true},
+		{name: "development build is not ordered", testedThrough: "1.3.0", current: "devel"},
+		{name: "malformed current version is not ordered", testedThrough: "1.3.0", current: "not-a-version"},
+		{name: "arbitrary-size release exact ceiling", testedThrough: "18446744073709551616.0.0", current: "18446744073709551616.0.0+build.7"},
+		{name: "arbitrary-size prerelease current warns", testedThrough: "1.0.0-99999999999999999999", current: "1.0.0-100000000000000000000", wantWarning: true},
+		{name: "arbitrary-size prerelease build metadata does not change ordering", testedThrough: "1.0.0-100000000000000000000", current: "1.0.0-99999999999999999999+build.7"},
+		{name: "malformed ceiling fails", testedThrough: "01.3.0", current: "1.4.0", wantErr: true},
+		{name: "leading zero prerelease fails", testedThrough: "1.3.0-01", current: "1.4.0", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			warning, err := TestedThroughPipelockWarning(tc.testedThrough, tc.current)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("TestedThroughPipelockWarning(%q, %q) error = %v, wantErr = %v", tc.testedThrough, tc.current, err, tc.wantErr)
+			}
+			if (warning != "") != tc.wantWarning {
+				t.Fatalf("TestedThroughPipelockWarning(%q, %q) warning = %q, wantWarning = %v", tc.testedThrough, tc.current, warning, tc.wantWarning)
+			}
+		})
+	}
+}
+
+func TestCompareStrictSemverVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "major", a: "2.0.0", b: "1.99.99", want: 1},
+		{name: "minor", a: "1.2.0", b: "1.1.99", want: 1},
+		{name: "patch", a: "1.1.2", b: "1.1.1", want: 1},
+		{name: "release follows prerelease", a: "1.0.0", b: "1.0.0-preview.1", want: 1},
+		{name: "prerelease precedes release", a: "1.0.0-preview.1", b: "1.0.0", want: -1},
+		{name: "equal identifier continues", a: "1.0.0-preview.1", b: "1.0.0-preview.2", want: -1},
+		{name: "numeric prerelease", a: "1.0.0-2", b: "1.0.0-10", want: -1},
+		{name: "numeric precedes text", a: "1.0.0-1", b: "1.0.0-alpha", want: -1},
+		{name: "text follows numeric", a: "1.0.0-alpha", b: "1.0.0-1", want: 1},
+		{name: "text lexical", a: "1.0.0-beta", b: "1.0.0-alpha", want: 1},
+		{name: "longer prerelease wins after shared prefix", a: "1.0.0-alpha.1", b: "1.0.0-alpha", want: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a, err := parseStrictSemverVersion(tc.a)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err := parseStrictSemverVersion(tc.b)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := compareStrictSemverVersion(a, b); got != tc.want {
+				t.Fatalf("compareStrictSemverVersion(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_TestedThroughPipelockMalformed(t *testing.T) {
+	t.Parallel()
+
+	b := &Bundle{
+		FormatVersion:         1,
+		Name:                  testValidBundleName,
+		Version:               testValidVersion,
+		Author:                testValidAuthor,
+		Description:           testValidDesc,
+		TestedThroughPipelock: "1.2",
+		Rules:                 []Rule{testDLPRule("tested-through-001", confidenceHigh, StatusStable)},
+	}
+	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "tested_through_pipelock") {
+		t.Fatalf("Validate() error = %v, want tested_through_pipelock validation error", err)
+	}
+}
+
 func TestValidate_AllSeverities(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -106,17 +106,18 @@ const (
 
 // LoadedBundle describes a successfully loaded bundle (for diagnostics).
 type LoadedBundle struct {
-	Name             string
-	Version          string
-	Tier             string // standard, community, pro (v2+)
-	MonotonicVersion uint64 // rollback-prevention counter (v2+)
-	Source           string
-	Rules            int // total rules loaded after filtering
-	DLP              int
-	Injection        int
-	ToolPoison       int
-	Unsigned         bool
-	Expired          bool // bundle is past expires_at but loaded in stale mode
+	Name                  string
+	Version               string
+	TestedThroughPipelock string
+	Tier                  string // standard, community, pro (v2+)
+	MonotonicVersion      uint64 // rollback-prevention counter (v2+)
+	Source                string
+	Rules                 int // total rules loaded after filtering
+	DLP                   int
+	Injection             int
+	ToolPoison            int
+	Unsigned              bool
+	Expired               bool // bundle is past expires_at but loaded in stale mode
 }
 
 // IntegrityErrors returns load failures that indicate installed-bundle
@@ -334,6 +335,12 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassAvailability})
 		return
 	}
+	if warning, err := TestedThroughPipelockWarning(bundle.TestedThroughPipelock, opts.PipelockVersion); err != nil {
+		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassIntegrity})
+		return
+	} else if warning != "" {
+		ctx.Result.Warnings = append(ctx.Result.Warnings, fmt.Sprintf("bundle %q: %s", bundle.Name, warning))
+	}
 
 	// Check pipelock-* name reservation: only official signers allowed.
 	// Track official status for degraded-mode detection (based on verified
@@ -394,12 +401,13 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 
 	// Filter and convert rules.
 	loaded := LoadedBundle{
-		Name:             bundle.Name,
-		Version:          bundle.Version,
-		Tier:             bundle.Tier,
-		MonotonicVersion: bundle.MonotonicVersion,
-		Source:           lock.Source,
-		Unsigned:         lock.Unsigned,
+		Name:                  bundle.Name,
+		Version:               bundle.Version,
+		TestedThroughPipelock: bundle.TestedThroughPipelock,
+		Tier:                  bundle.Tier,
+		MonotonicVersion:      bundle.MonotonicVersion,
+		Source:                lock.Source,
+		Unsigned:              lock.Unsigned,
 	}
 
 	for i := range bundle.Rules {

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -631,6 +631,34 @@ func TestLoadBundles_MinPipelockTooHigh(t *testing.T) {
 	}
 }
 
+func TestLoadBundles_TestedThroughPipelockWarning(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "tested-ceiling")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	b := testBundle("tested-ceiling", []Rule{testDLPRule("tested-ceiling-001", confidenceHigh, StatusStable)})
+	b.TestedThroughPipelock = "1.2.0"
+	writeUnsignedBundle(t, bundleDir, b)
+
+	result := LoadBundles(dir, LoadOptions{MinConfidence: confidenceLow, PipelockVersion: "1.3.0"})
+	if len(result.Errors) != 0 || len(result.Loaded) != 1 {
+		t.Fatalf("LoadBundles() errors=%v loaded=%v, want loaded bundle without errors", result.Errors, result.Loaded)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "tested through") {
+		t.Fatalf("LoadBundles() warnings=%v, want tested-through warning", result.Warnings)
+	}
+
+	b.MinPipelock = "2.0.0"
+	writeUnsignedBundle(t, bundleDir, b)
+	result = LoadBundles(dir, LoadOptions{MinConfidence: confidenceLow, PipelockVersion: "1.3.0"})
+	if len(result.Errors) != 1 || !strings.Contains(result.Errors[0].Reason, "below minimum") {
+		t.Fatalf("LoadBundles() errors=%v, want fail-closed minimum-version rejection", result.Errors)
+	}
+}
+
 func TestLoadBundles_ConfidenceFilterHigh(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed
- Accept an optional signed tested_through_pipelock ceiling and warn when a newer released Pipelock version loads, installs, updates, or lists the bundle.
- Keep the ceiling advisory while malformed ceilings and unmet min_pipelock requirements still stop the bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle listings now show the Pipelock version through which each bundle was tested.
  * Added compatibility warnings when the running Pipelock version exceeds a bundle’s tested version.
  * Warnings appear during bundle installation, updates, and rule listings in text and JSON output.
  * Rule listings now display bundle verification status.

* **Bug Fixes**
  * Invalid tested-version metadata is detected and reported.
  * Bundle verification failures are clearly reported as unverified metadata.
  * Compatible bundles continue loading despite advisory version warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->