### PR TITLE
ci: test linux/arm64 natively

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -497,6 +497,56 @@ jobs:
       - name: internal/config test package builds on Windows
         run: go test -count=1 -run "TestWindows" ./internal/config/...
 
+  # Native linux/arm64 lane. GoReleaser publishes a linux/arm64 binary
+  # (.goreleaser.yaml) and no job has ever executed a test on that architecture,
+  # so three of six published Go targets ran zero tests. arm64 is not a
+  # theoretical target here: it is Graviton, Ampere, Apple Silicon Linux VMs, and
+  # the single-board machines an evaluator is most likely to reach for.
+  #
+  # The architecture is load-bearing for containment, not incidental. seccomp is
+  # built only for linux && amd64 (internal/sandbox/seccomp_linux.go), so an
+  # arm64 binary composes against seccomp_other.go and reports that layer
+  # unavailable. In the CLI's default non-strict mode a missing layer reduces
+  # containment and only logs it, so the arm64 degradation path is exactly the
+  # behavior that most needs a test and had none. The seccomp tests themselves
+  # are tagged linux && amd64 and stay out of this lane by construction; what
+  # runs here is the shared sandbox code deciding what to do when a layer is
+  # absent.
+  #
+  # TARGETED, like the macOS and Windows lanes above, not full parity. The amd64
+  # matrix remains the exhaustive lane.
+  test-linux-arm64:
+    needs: [security-scan]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+
+      # A published target that has never been compiled natively can break in
+      # ways cross-compilation catches and ways it does not, and `go build` never
+      # builds _test.go files, so a test package that cannot compile on arm64
+      # would stay invisible to it.
+      - name: Verify arm64 build (OSS + enterprise)
+        run: |
+          go build ./...
+          go build -tags enterprise ./...
+
+      - name: Sandbox behavior on an architecture without seccomp
+        run: go test -race -count=1 ./internal/sandbox/...
+
+      # Preflight is what tells an operator which layers they are actually
+      # getting. On arm64 it must report seccomp as unavailable rather than
+      # claiming it, and it must do so without erroring.
+      - name: Preflight reports the real arm64 layer set
+        run: go test -race -count=1 -run "TestPreflight|TestDetect" ./internal/sandbox/...
+
   # Exercise the browser target's concrete fail-closed filesystem fallbacks,
   # then compile the same contracts for WASI and AIX so build-tag gaps cannot
   # silently remove their implementations.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -637,6 +637,33 @@ jobs:
       - name: golangci-lint (enterprise)
         run: golangci-lint run --build-tags enterprise ./...
 
+      # Test files are compiled by `go test`, never by `go build`, so a test file
+      # that references a symbol guarded to one architecture makes an entire test
+      # package uncompilable there while every build job stays green. That is not
+      # hypothetical: internal/sandbox's test package could not compile on
+      # linux/arm64 at all, because coverage_deep_test.go was tagged plain linux
+      # while the seccomp filter builder and BPF helpers it calls exist only under
+      # linux && amd64. A published target therefore had zero sandbox test
+      # coverage and nothing said so. The same shape hit internal/config on
+      # Windows previously via syscall.Mkfifo.
+      #
+      # `go vet` compiles test files, so cross-targeting it catches the class on
+      # this amd64 runner without needing hardware for every target. It runs here
+      # rather than in each native lane so a target with no lane is still covered.
+      #
+      # windows/amd64 and windows/arm64 are deliberately NOT in this list yet:
+      # internal/cli/contain and internal/emit have test files with this exact
+      # defect on Windows today, tracked separately. Adding them here before that
+      # is fixed would land a knowingly-red required check, and a check people
+      # expect to be red stops being read. Add both the moment that lands.
+      - name: Test code compiles for every published non-Windows target
+        run: |
+          set -euo pipefail
+          for target in linux/arm64 darwin/amd64 darwin/arm64; do
+            printf '==> %s\n' "$target"
+            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet ./...
+          done
+
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 

--- a/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
+++ b/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && amd64
+
+// These tests exercise the seccomp filter builder and its syscall lists, which
+// exist only in seccomp_linux.go under linux && amd64. They lived in
+// coverage_deep_test.go, tagged plain linux, so the whole sandbox test package
+// failed to COMPILE on linux/arm64 and that architecture had no sandbox test
+// coverage at all. `go build ./...` cannot catch that, because it never builds
+// test files, which is why a native arm64 lane found it and cross-compilation
+// did not. Same shape as the internal/config Mkfifo break on Windows.
+
+package sandbox
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// buildSeccompFilter: verify filter properties.
+// ---------------------------------------------------------------------------
+
+func TestBuildSeccompFilter_BestEffortAndStrict(t *testing.T) {
+	bestEffort := buildSeccompFilter(false)
+	strict := buildSeccompFilter(true)
+
+	const minInstructions = 4
+	if len(bestEffort) < minInstructions {
+		t.Errorf("best-effort filter too short: %d instructions", len(bestEffort))
+	}
+	if len(strict) < minInstructions {
+		t.Errorf("strict filter too short: %d instructions", len(strict))
+	}
+
+	t.Logf("best-effort: %d instructions, strict: %d instructions", len(bestEffort), len(strict))
+}
+
+// ---------------------------------------------------------------------------
+// seccomp conditionals: verify instruction counts.
+// ---------------------------------------------------------------------------
+
+func TestSeccompConditionals_InstructionCounts(t *testing.T) {
+	cloneInsns := cloneConditional()
+	clone3Strict := clone3Conditional(true)
+	clone3BestEff := clone3Conditional(false)
+	socketInsns := socketConditional()
+	personalityInsns := personalityConditional()
+
+	tests := []struct {
+		name  string
+		count int
+		got   int
+	}{
+		{name: "clone", count: 5, got: len(cloneInsns)},
+		{name: "clone3_strict", count: 2, got: len(clone3Strict)},
+		{name: "clone3_besteff", count: 2, got: len(clone3BestEff)},
+		{name: "socket", count: 5, got: len(socketInsns)},
+		{name: "personality", count: 9, got: len(personalityInsns)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.count {
+				t.Errorf("%s: got %d instructions, want %d", tt.name, tt.got, tt.count)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// allowedSyscalls / killSyscalls / denySyscalls: no dups, no overlap.
+// ---------------------------------------------------------------------------
+
+func TestSyscallLists_NoDuplicates(t *testing.T) {
+	lists := map[string][]uint32{
+		"allowed": allowedSyscalls(),
+		"kill":    killSyscalls(),
+		"deny":    denySyscalls(),
+	}
+
+	for name, list := range lists {
+		t.Run(name, func(t *testing.T) {
+			if len(list) == 0 {
+				t.Errorf("%s syscall list is empty", name)
+			}
+			seen := make(map[uint32]bool, len(list))
+			for _, nr := range list {
+				if seen[nr] {
+					t.Errorf("%s: duplicate syscall number %d", name, nr)
+				}
+				seen[nr] = true
+			}
+		})
+	}
+}
+
+func TestSyscallLists_NoOverlap(t *testing.T) {
+	allow := make(map[uint32]bool)
+	for _, nr := range allowedSyscalls() {
+		allow[nr] = true
+	}
+	kill := make(map[uint32]bool)
+
+	for _, nr := range killSyscalls() {
+		if allow[nr] {
+			t.Errorf("syscall %d is in both allowed and kill lists", nr)
+		}
+		kill[nr] = true
+	}
+	for _, nr := range denySyscalls() {
+		if allow[nr] {
+			t.Errorf("syscall %d is in both allowed and deny lists", nr)
+		}
+		if kill[nr] {
+			t.Errorf("syscall %d is in both kill and deny lists", nr)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BPF helpers: verify instruction codes.
+// ---------------------------------------------------------------------------
+
+func TestBPFHelpers(t *testing.T) {
+	t.Run("bpfLoad", func(t *testing.T) {
+		insn := bpfLoad(42)
+		if insn.K != 42 {
+			t.Errorf("K = %d, want 42", insn.K)
+		}
+	})
+
+	t.Run("bpfJumpEq", func(t *testing.T) {
+		insn := bpfJumpEq(100, 2, 3)
+		if insn.K != 100 {
+			t.Errorf("K = %d, want 100", insn.K)
+		}
+		if insn.Jt != 2 {
+			t.Errorf("Jt = %d, want 2", insn.Jt)
+		}
+		if insn.Jf != 3 {
+			t.Errorf("Jf = %d, want 3", insn.Jf)
+		}
+	})
+
+	t.Run("bpfRet", func(t *testing.T) {
+		insn := bpfRet(0x7FFF0001)
+		if insn.K != 0x7FFF0001 {
+			t.Errorf("K = %d, want %d", insn.K, 0x7FFF0001)
+		}
+	})
+
+	t.Run("bpfJumpSet", func(t *testing.T) {
+		insn := bpfJumpSet(0xFF, 1, 0)
+		if insn.K != 0xFF {
+			t.Errorf("K = %d, want 255", insn.K)
+		}
+		if insn.Jt != 1 {
+			t.Errorf("Jt = %d, want 1", insn.Jt)
+		}
+	})
+}

--- a/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
+++ b/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
@@ -13,57 +13,128 @@
 
 package sandbox
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
 
 // ---------------------------------------------------------------------------
 // buildSeccompFilter: verify filter properties.
 // ---------------------------------------------------------------------------
 
-func TestBuildSeccompFilter_BestEffortAndStrict(t *testing.T) {
-	bestEffort := buildSeccompFilter(false)
-	strict := buildSeccompFilter(true)
-
-	const minInstructions = 4
-	if len(bestEffort) < minInstructions {
-		t.Errorf("best-effort filter too short: %d instructions", len(bestEffort))
-	}
-	if len(strict) < minInstructions {
-		t.Errorf("strict filter too short: %d instructions", len(strict))
-	}
-
-	t.Logf("best-effort: %d instructions, strict: %d instructions", len(bestEffort), len(strict))
-}
-
-// ---------------------------------------------------------------------------
-// seccomp conditionals: verify instruction counts.
-// ---------------------------------------------------------------------------
-
-func TestSeccompConditionals_InstructionCounts(t *testing.T) {
-	cloneInsns := cloneConditional()
-	clone3Strict := clone3Conditional(true)
-	clone3BestEff := clone3Conditional(false)
-	socketInsns := socketConditional()
-	personalityInsns := personalityConditional()
-
-	tests := []struct {
-		name  string
-		count int
-		got   int
-	}{
-		{name: "clone", count: 5, got: len(cloneInsns)},
-		{name: "clone3_strict", count: 2, got: len(clone3Strict)},
-		{name: "clone3_besteff", count: 2, got: len(clone3BestEff)},
-		{name: "socket", count: 5, got: len(socketInsns)},
-		{name: "personality", count: 9, got: len(personalityInsns)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.got != tt.count {
-				t.Errorf("%s: got %d instructions, want %d", tt.name, tt.got, tt.count)
+func TestBuildSeccompFilter_ArchitectureGuardAndPrologue(t *testing.T) {
+	// An instruction COUNT proves nothing about a filter. A regression that
+	// removed the wrong-architecture kill, or turned it into an allow, would keep
+	// the same length and pass. The architecture guard is what stops a 32-bit or
+	// x32 syscall ABI from being interpreted against x86-64 syscall numbers, so a
+	// silent change there re-opens every number-based rule below it.
+	for _, strict := range []bool{false, true} {
+		name := "best_effort"
+		if strict {
+			name = "strict"
+		}
+		t.Run(name, func(t *testing.T) {
+			prog := buildSeccompFilter(strict)
+			if len(prog) < 4 {
+				t.Fatalf("filter has %d instructions, want at least the four-instruction prologue", len(prog))
+			}
+			want := []unix.SockFilter{
+				bpfLoad(offsetArch),
+				bpfJumpEq(unix.AUDIT_ARCH_X86_64, 1, 0),
+				bpfRet(unix.SECCOMP_RET_KILL_PROCESS),
+				bpfLoad(offsetNR),
+			}
+			for idx, expected := range want {
+				if prog[idx] != expected {
+					t.Errorf("instruction %d = %+v, want %+v", idx, prog[idx], expected)
+				}
+			}
+			// Stated explicitly because it is the property that matters rather than
+			// a consequence of the comparison above: a matching architecture skips
+			// one instruction to reach the syscall load, and any other architecture
+			// falls through to a kill rather than a permissive return.
+			if prog[2].Code != unix.BPF_RET|unix.BPF_K || prog[2].K != unix.SECCOMP_RET_KILL_PROCESS {
+				t.Errorf("wrong-architecture action = %+v, want a kill return", prog[2])
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// seccomp conditionals: verify the decision each branch encodes.
+// ---------------------------------------------------------------------------
+
+func TestSeccompConditionals_EncodeTheIntendedDecision(t *testing.T) {
+	deny := bpfRet(unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM))
+	allow := bpfRet(unix.SECCOMP_RET_ALLOW)
+
+	// Lengths are still asserted, because the surrounding filter's jump offsets
+	// are computed from them, but every case also pins the ACTION its branch
+	// takes. The strict and best-effort clone3 pair is the clearest example of
+	// why: both are two instructions, and the only difference between blocking
+	// clone3 and permitting it is which return the second instruction is.
+	t.Run("clone_denies_new_namespaces_and_allows_the_rest", func(t *testing.T) {
+		insns := cloneConditional()
+		if len(insns) != 5 {
+			t.Fatalf("clone conditional = %d instructions, want 5", len(insns))
+		}
+		if insns[0] != bpfJumpEq(unix.SYS_CLONE, 0, 4) {
+			t.Errorf("clone guard = %+v, want a jump that skips the block for other syscalls", insns[0])
+		}
+		if insns[1] != bpfLoad(offsetArgs0) {
+			t.Errorf("clone flag load = %+v, want the first argument", insns[1])
+		}
+		if insns[2] != bpfJumpSet(cloneNewMask, 0, 1) {
+			t.Errorf("namespace test = %+v, want a CLONE_NEW mask test falling through to deny", insns[2])
+		}
+		if insns[3] != deny {
+			t.Errorf("namespace-creation action = %+v, want EPERM", insns[3])
+		}
+		if insns[4] != allow {
+			t.Errorf("plain-clone action = %+v, want allow", insns[4])
+		}
+	})
+
+	t.Run("clone3_strict_denies_and_best_effort_allows", func(t *testing.T) {
+		strict := clone3Conditional(true)
+		bestEffort := clone3Conditional(false)
+		if len(strict) != 2 || len(bestEffort) != 2 {
+			t.Fatalf("clone3 conditionals = %d and %d instructions, want 2 each", len(strict), len(bestEffort))
+		}
+		if strict[1] != deny {
+			t.Errorf("strict clone3 action = %+v, want EPERM", strict[1])
+		}
+		if bestEffort[1] != allow {
+			t.Errorf("best-effort clone3 action = %+v, want allow", bestEffort[1])
+		}
+		if strict[1] == bestEffort[1] {
+			t.Error("strict and best-effort clone3 encode the same action, so strict mode is not stricter")
+		}
+	})
+
+	t.Run("socket_and_personality_keep_their_deny_branch", func(t *testing.T) {
+		for name, insns := range map[string][]unix.SockFilter{
+			"socket":      socketConditional(),
+			"personality": personalityConditional(),
+		} {
+			denies := 0
+			for _, insn := range insns {
+				if insn == deny {
+					denies++
+				}
+			}
+			if denies == 0 {
+				t.Errorf("%s conditional encodes no EPERM branch, so its restriction is gone: %+v", name, insns)
+			}
+		}
+		if got := len(socketConditional()); got != 5 {
+			t.Errorf("socket conditional = %d instructions, want 5", got)
+		}
+		if got := len(personalityConditional()); got != 9 {
+			t.Errorf("personality conditional = %d instructions, want 9", got)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -121,40 +192,43 @@ func TestSyscallLists_NoOverlap(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBPFHelpers(t *testing.T) {
-	t.Run("bpfLoad", func(t *testing.T) {
-		insn := bpfLoad(42)
-		if insn.K != 42 {
-			t.Errorf("K = %d, want 42", insn.K)
-		}
-	})
+	// Every field is asserted, not just K. An opcode or a false-branch offset is
+	// as load-bearing as the constant: a helper emitting the wrong Code produces a
+	// filter the kernel interprets differently, and a wrong Jf sends the
+	// no-match case to the wrong instruction, which is how a deny becomes a
+	// fall-through.
+	tests := []struct {
+		name string
+		got  unix.SockFilter
+		want unix.SockFilter
+	}{
+		{
+			name: "bpfLoad",
+			got:  bpfLoad(42),
+			want: unix.SockFilter{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: 42},
+		},
+		{
+			name: "bpfJumpEq",
+			got:  bpfJumpEq(100, 2, 3),
+			want: unix.SockFilter{Code: unix.BPF_JMP | 0x10 | unix.BPF_K, K: 100, Jt: 2, Jf: 3},
+		},
+		{
+			name: "bpfRet",
+			got:  bpfRet(0x7FFF0001),
+			want: unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: 0x7FFF0001},
+		},
+		{
+			name: "bpfJumpSet",
+			got:  bpfJumpSet(0xFF, 1, 0),
+			want: unix.SockFilter{Code: unix.BPF_JMP | 0x40 | unix.BPF_K, K: 0xFF, Jt: 1, Jf: 0},
+		},
+	}
 
-	t.Run("bpfJumpEq", func(t *testing.T) {
-		insn := bpfJumpEq(100, 2, 3)
-		if insn.K != 100 {
-			t.Errorf("K = %d, want 100", insn.K)
-		}
-		if insn.Jt != 2 {
-			t.Errorf("Jt = %d, want 2", insn.Jt)
-		}
-		if insn.Jf != 3 {
-			t.Errorf("Jf = %d, want 3", insn.Jf)
-		}
-	})
-
-	t.Run("bpfRet", func(t *testing.T) {
-		insn := bpfRet(0x7FFF0001)
-		if insn.K != 0x7FFF0001 {
-			t.Errorf("K = %d, want %d", insn.K, 0x7FFF0001)
-		}
-	})
-
-	t.Run("bpfJumpSet", func(t *testing.T) {
-		insn := bpfJumpSet(0xFF, 1, 0)
-		if insn.K != 0xFF {
-			t.Errorf("K = %d, want 255", insn.K)
-		}
-		if insn.Jt != 1 {
-			t.Errorf("Jt = %d, want 1", insn.Jt)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %+v, want %+v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
+++ b/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
@@ -160,13 +160,30 @@ func TestSeccompConditionals_EncodeTheIntendedDecision(t *testing.T) {
 		if insns[allowIdx] != bpfRet(unix.SECCOMP_RET_ALLOW) {
 			t.Errorf("personality allow return = %+v, want allow", insns[allowIdx])
 		}
-		// Each accepted value must jump PAST the deny return to the allow return.
-		for idx := 2; idx < denyIdx; idx++ {
+		// The accepted VALUES are stated here independently, not read back from the
+		// implementation's own constants, because the set of personalities the
+		// sandbox tolerates is the security decision. Asserting only opcodes and
+		// jump targets leaves a changed constant free to admit an unintended
+		// personality while every other assertion still passes.
+		//
+		// PER_LINUX, ADDR_NO_RANDOMIZE, PER_LINUX32, PER_LINUX32|ADDR_NO_RANDOMIZE,
+		// and the 0xFFFFFFFF query form. Adding a value here is a deliberate
+		// widening of what a contained process may ask the kernel to emulate.
+		wantAccepted := []uint32{0x00000000, 0x00000008, 0x00020000, 0x00020008, 0xFFFFFFFF}
+		if got := denyIdx - 2; got != len(wantAccepted) {
+			t.Fatalf("personality accepts %d values, want exactly %d", got, len(wantAccepted))
+		}
+		for offset, wantK := range wantAccepted {
+			idx := 2 + offset
 			insn := insns[idx]
 			if insn.Code != unix.BPF_JMP|0x10|unix.BPF_K {
 				t.Errorf("personality instruction %d = %+v, want an equality jump", idx, insn)
 				continue
 			}
+			if insn.K != wantK {
+				t.Errorf("personality instruction %d tests value %#x, want %#x", idx, insn.K, wantK)
+			}
+			// Each accepted value must jump PAST the deny return to the allow return.
 			if target := idx + 1 + int(insn.Jt); target != allowIdx {
 				t.Errorf("accepted personality value at %d jumps to %d, want the allow return at %d", idx, target, allowIdx)
 			}

--- a/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
+++ b/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
@@ -166,10 +166,14 @@ func TestSeccompConditionals_EncodeTheIntendedDecision(t *testing.T) {
 		// jump targets leaves a changed constant free to admit an unintended
 		// personality while every other assertion still passes.
 		//
-		// PER_LINUX, ADDR_NO_RANDOMIZE, PER_LINUX32, PER_LINUX32|ADDR_NO_RANDOMIZE,
-		// and the 0xFFFFFFFF query form. Adding a value here is a deliberate
-		// widening of what a contained process may ask the kernel to emulate.
-		wantAccepted := []uint32{0x00000000, 0x00000008, 0x00020000, 0x00020008, 0xFFFFFFFF}
+		// PER_LINUX, PER_LINUX32, ADDR_NO_RANDOMIZE, PER_LINUX32|ADDR_NO_RANDOMIZE,
+		// and the 0xFFFFFFFF query form, with the values Linux actually defines in
+		// include/uapi/linux/personality.h. Written out here rather than read from
+		// the implementation's constants precisely because those constants were
+		// mislabelled: they admitted UNAME26 (0x00020000) while refusing the real
+		// ADDR_NO_RANDOMIZE (0x00040000). Adding a value to this list is a
+		// deliberate widening of what a contained process may ask the kernel for.
+		wantAccepted := []uint32{0x00000000, 0x00000008, 0x00040000, 0x00040008, 0xFFFFFFFF}
 		if got := denyIdx - 2; got != len(wantAccepted) {
 			t.Fatalf("personality accepts %d values, want exactly %d", got, len(wantAccepted))
 		}

--- a/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
+++ b/internal/sandbox/coverage_deep_seccomp_linux_amd64_test.go
@@ -113,26 +113,66 @@ func TestSeccompConditionals_EncodeTheIntendedDecision(t *testing.T) {
 		}
 	})
 
-	t.Run("socket_and_personality_keep_their_deny_branch", func(t *testing.T) {
-		for name, insns := range map[string][]unix.SockFilter{
-			"socket":      socketConditional(),
-			"personality": personalityConditional(),
-		} {
-			denies := 0
-			for _, insn := range insns {
-				if insn == deny {
-					denies++
-				}
-			}
-			if denies == 0 {
-				t.Errorf("%s conditional encodes no EPERM branch, so its restriction is gone: %+v", name, insns)
+	t.Run("socket_guards_the_socket_syscall_and_denies_AF_VSOCK", func(t *testing.T) {
+		// Counting deny branches is not enough: a guard pointed at the wrong
+		// syscall, or one testing the wrong address family, still contains exactly
+		// one EPERM return. AF_VSOCK is the family that can reach a hypervisor past
+		// network-namespace isolation, so both the syscall it guards and the family
+		// it refuses are the point.
+		insns := socketConditional()
+		if len(insns) != 5 {
+			t.Fatalf("socket conditional = %d instructions, want 5", len(insns))
+		}
+		want := []unix.SockFilter{
+			bpfJumpEq(unix.SYS_SOCKET, 0, 4),
+			bpfLoad(offsetArgs0),
+			bpfJumpEq(afVSOCK, 0, 1),
+			bpfRet(unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)),
+			bpfRet(unix.SECCOMP_RET_ALLOW),
+		}
+		for idx, expected := range want {
+			if insns[idx] != expected {
+				t.Errorf("socket instruction %d = %+v, want %+v", idx, insns[idx], expected)
 			}
 		}
-		if got := len(socketConditional()); got != 5 {
-			t.Errorf("socket conditional = %d instructions, want 5", got)
+	})
+
+	t.Run("personality_guards_its_syscall_and_denies_unlisted_values", func(t *testing.T) {
+		// Every allowed personality value jumps to the allow return, and anything
+		// unlisted falls through to EPERM. Asserting the jump targets is what makes
+		// that fall-through real: an offset that skips the deny return would turn
+		// this whole block into an unconditional allow while keeping its length and
+		// its EPERM instruction.
+		insns := personalityConditional()
+		if len(insns) != 9 {
+			t.Fatalf("personality conditional = %d instructions, want 9", len(insns))
 		}
-		if got := len(personalityConditional()); got != 9 {
-			t.Errorf("personality conditional = %d instructions, want 9", got)
+		if insns[0] != bpfJumpEq(unix.SYS_PERSONALITY, 0, 8) {
+			t.Errorf("personality guard = %+v, want a jump over the whole block for other syscalls", insns[0])
+		}
+		if insns[1] != bpfLoad(offsetArgs0) {
+			t.Errorf("personality value load = %+v, want the first argument", insns[1])
+		}
+		denyIdx, allowIdx := 7, 8
+		if insns[denyIdx] != bpfRet(unix.SECCOMP_RET_ERRNO|uint32(unix.EPERM)) {
+			t.Errorf("personality fall-through = %+v, want EPERM", insns[denyIdx])
+		}
+		if insns[allowIdx] != bpfRet(unix.SECCOMP_RET_ALLOW) {
+			t.Errorf("personality allow return = %+v, want allow", insns[allowIdx])
+		}
+		// Each accepted value must jump PAST the deny return to the allow return.
+		for idx := 2; idx < denyIdx; idx++ {
+			insn := insns[idx]
+			if insn.Code != unix.BPF_JMP|0x10|unix.BPF_K {
+				t.Errorf("personality instruction %d = %+v, want an equality jump", idx, insn)
+				continue
+			}
+			if target := idx + 1 + int(insn.Jt); target != allowIdx {
+				t.Errorf("accepted personality value at %d jumps to %d, want the allow return at %d", idx, target, allowIdx)
+			}
+			if insn.Jf != 0 {
+				t.Errorf("personality instruction %d has Jf=%d, want fall-through to the next test", idx, insn.Jf)
+			}
 		}
 	})
 }

--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -332,25 +332,6 @@ func TestValidatePolicy_AllowDirEvalSymlinksRejectsMissing(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildSeccompFilter: verify filter properties.
-// ---------------------------------------------------------------------------
-
-func TestBuildSeccompFilter_BestEffortAndStrict(t *testing.T) {
-	bestEffort := buildSeccompFilter(false)
-	strict := buildSeccompFilter(true)
-
-	const minInstructions = 4
-	if len(bestEffort) < minInstructions {
-		t.Errorf("best-effort filter too short: %d instructions", len(bestEffort))
-	}
-	if len(strict) < minInstructions {
-		t.Errorf("strict filter too short: %d instructions", len(strict))
-	}
-
-	t.Logf("best-effort: %d instructions, strict: %d instructions", len(bestEffort), len(strict))
-}
-
-// ---------------------------------------------------------------------------
 // Capabilities.Summary: additional edge cases.
 // ---------------------------------------------------------------------------
 
@@ -741,88 +722,6 @@ func TestLayerNameConstants(t *testing.T) {
 				t.Errorf("Layer%s = %q, want %q", tt.name, tt.got, tt.want)
 			}
 		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// seccomp conditionals: verify instruction counts.
-// ---------------------------------------------------------------------------
-
-func TestSeccompConditionals_InstructionCounts(t *testing.T) {
-	cloneInsns := cloneConditional()
-	clone3Strict := clone3Conditional(true)
-	clone3BestEff := clone3Conditional(false)
-	socketInsns := socketConditional()
-	personalityInsns := personalityConditional()
-
-	tests := []struct {
-		name  string
-		count int
-		got   int
-	}{
-		{name: "clone", count: 5, got: len(cloneInsns)},
-		{name: "clone3_strict", count: 2, got: len(clone3Strict)},
-		{name: "clone3_besteff", count: 2, got: len(clone3BestEff)},
-		{name: "socket", count: 5, got: len(socketInsns)},
-		{name: "personality", count: 9, got: len(personalityInsns)},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.got != tt.count {
-				t.Errorf("%s: got %d instructions, want %d", tt.name, tt.got, tt.count)
-			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// allowedSyscalls / killSyscalls / denySyscalls: no dups, no overlap.
-// ---------------------------------------------------------------------------
-
-func TestSyscallLists_NoDuplicates(t *testing.T) {
-	lists := map[string][]uint32{
-		"allowed": allowedSyscalls(),
-		"kill":    killSyscalls(),
-		"deny":    denySyscalls(),
-	}
-
-	for name, list := range lists {
-		t.Run(name, func(t *testing.T) {
-			if len(list) == 0 {
-				t.Errorf("%s syscall list is empty", name)
-			}
-			seen := make(map[uint32]bool, len(list))
-			for _, nr := range list {
-				if seen[nr] {
-					t.Errorf("%s: duplicate syscall number %d", name, nr)
-				}
-				seen[nr] = true
-			}
-		})
-	}
-}
-
-func TestSyscallLists_NoOverlap(t *testing.T) {
-	allow := make(map[uint32]bool)
-	for _, nr := range allowedSyscalls() {
-		allow[nr] = true
-	}
-	kill := make(map[uint32]bool)
-
-	for _, nr := range killSyscalls() {
-		if allow[nr] {
-			t.Errorf("syscall %d is in both allowed and kill lists", nr)
-		}
-		kill[nr] = true
-	}
-	for _, nr := range denySyscalls() {
-		if allow[nr] {
-			t.Errorf("syscall %d is in both allowed and deny lists", nr)
-		}
-		if kill[nr] {
-			t.Errorf("syscall %d is in both kill and deny lists", nr)
-		}
 	}
 }
 
@@ -1496,49 +1395,6 @@ func TestBuildRules_AllSlicesFilled(t *testing.T) {
 	if len(rules) != 4 {
 		t.Errorf("expected 4 rules, got %d", len(rules))
 	}
-}
-
-// ---------------------------------------------------------------------------
-// BPF helpers: verify instruction codes.
-// ---------------------------------------------------------------------------
-
-func TestBPFHelpers(t *testing.T) {
-	t.Run("bpfLoad", func(t *testing.T) {
-		insn := bpfLoad(42)
-		if insn.K != 42 {
-			t.Errorf("K = %d, want 42", insn.K)
-		}
-	})
-
-	t.Run("bpfJumpEq", func(t *testing.T) {
-		insn := bpfJumpEq(100, 2, 3)
-		if insn.K != 100 {
-			t.Errorf("K = %d, want 100", insn.K)
-		}
-		if insn.Jt != 2 {
-			t.Errorf("Jt = %d, want 2", insn.Jt)
-		}
-		if insn.Jf != 3 {
-			t.Errorf("Jf = %d, want 3", insn.Jf)
-		}
-	})
-
-	t.Run("bpfRet", func(t *testing.T) {
-		insn := bpfRet(0x7FFF0001)
-		if insn.K != 0x7FFF0001 {
-			t.Errorf("K = %d, want %d", insn.K, 0x7FFF0001)
-		}
-	})
-
-	t.Run("bpfJumpSet", func(t *testing.T) {
-		insn := bpfJumpSet(0xFF, 1, 0)
-		if insn.K != 0xFF {
-			t.Errorf("K = %d, want 255", insn.K)
-		}
-		if insn.Jt != 1 {
-			t.Errorf("Jt = %d, want 1", insn.Jt)
-		}
-	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/sandbox/seccomp_linux.go
+++ b/internal/sandbox/seccomp_linux.go
@@ -212,18 +212,26 @@ func socketConditional() []unix.SockFilter {
 // personality syscall to known-safe values. Unexpected personality values
 // could alter syscall behavior in ways that weaken containment.
 func personalityConditional() []unix.SockFilter {
+	// Values from include/uapi/linux/personality.h. The previous set was
+	// mislabelled and enforced a different policy than its comments described:
+	// 0x00000008 is PER_LINUX32, not ADDR_NO_RANDOMIZE, and 0x00020000 is UNAME26,
+	// not PER_LINUX32. So the filter admitted UNAME26, which nothing here ever
+	// intended to allow and which makes uname report a 2.6 kernel to the contained
+	// process, while refusing the real ADDR_NO_RANDOMIZE that the comments claimed
+	// to permit. Both directions were wrong: one permission too many and one
+	// legitimate request denied.
 	const (
-		personalityQuery      = 0xFFFFFFFF // query current personality
-		addrNoRandomize       = 0x00000008 // ADDR_NO_RANDOMIZE
-		perLinux32            = 0x00020000 // PER_LINUX32
-		perLinux32NoRandomize = 0x00020008 // PER_LINUX32 | ADDR_NO_RANDOMIZE
+		personalityQuery      = 0xFFFFFFFF // query current personality, changes nothing
+		perLinux32            = 0x00000008 // PER_LINUX32
+		addrNoRandomize       = 0x00040000 // ADDR_NO_RANDOMIZE, disables ASLR for this process
+		perLinux32NoRandomize = 0x00040008 // PER_LINUX32 | ADDR_NO_RANDOMIZE
 	)
 	return []unix.SockFilter{
 		bpfJumpEq(unix.SYS_PERSONALITY, 0, 8),               // if personality, check args; else skip 8
 		bpfLoad(offsetArgs0),                                // load personality value
 		bpfJumpEq(0, 5, 0),                                  // 0 (PER_LINUX) → allow
-		bpfJumpEq(addrNoRandomize, 4, 0),                    // ADDR_NO_RANDOMIZE → allow
-		bpfJumpEq(perLinux32, 3, 0),                         // PER_LINUX32 → allow
+		bpfJumpEq(perLinux32, 4, 0),                         // PER_LINUX32 → allow
+		bpfJumpEq(addrNoRandomize, 3, 0),                    // ADDR_NO_RANDOMIZE → allow
 		bpfJumpEq(perLinux32NoRandomize, 2, 0),              // PER_LINUX32 | ADDR_NO_RANDOMIZE → allow
 		bpfJumpEq(personalityQuery, 1, 0),                   // 0xFFFFFFFF (query) → allow
 		bpfRet(unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)), // deny: unexpected personality value


### PR DESCRIPTION
## What changed

CI now runs a targeted native linux/arm64 lane. GoReleaser publishes a linux/arm64 binary and no job had ever executed a test on that architecture, so three of the six published Go targets ran zero tests.

The architecture is load-bearing for containment rather than incidental. seccomp is built only for `linux && amd64`, so an arm64 binary composes against the unavailable-layer implementation and reports that layer absent. In the CLI's default non-strict mode a missing layer reduces containment and only logs it, so the arm64 degradation path is precisely the behavior that most needed a test and had none. The lane builds both tag variants natively, since `go build` never compiles test files and a test package that cannot build on arm64 would otherwise stay invisible, then runs the sandbox package and the preflight and capability-detection tests that decide what an operator is told they are getting.

It is targeted rather than full parity, matching the existing macOS and Windows lanes. The amd64 matrix remains the exhaustive one.

Two things a reviewer should weigh rather than assume. The lane is not part of the required-check summary, following the Windows lane's precedent, so a red result here is visible on a pull request without blocking a merge; promoting it to a gate is a deliberate second step once it has a track record. And its first execution is this pull request, so this run is also the verification that the hosted arm64 runner label and the arm64 test result are what the change assumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sandbox security filtering for process personality settings, ensuring supported configurations are handled correctly and unauthorized values are denied.

* **Tests**
  * Added native Linux ARM64 CI coverage for OSS and enterprise builds.
  * Added sandbox race-detection coverage and seccomp-unavailable reporting checks.
  * Expanded cross-platform validation for supported Linux and macOS targets.
  * Increased coverage for security filtering and syscall handling across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->