### PR TITLE
fix(receipts): prove liveness from session start

### DIFF
--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -34,12 +34,8 @@ func startReceiptHeartbeat(
 		interval = time.Minute
 	}
 	emitHeartbeat := func() bool {
-		// No nil check here: receipt.Emitter.EmitHeartbeat is itself nil-safe and
-		// returns nil, so a guard in this scheduler would duplicate that contract
-		// while adding a branch no test can make fail. An adversarial pass proved
-		// exactly that by setting the old guard to false and watching its test
-		// still pass, so the branch is removed rather than documented. Re-adding
-		// one would recreate an unprovable branch.
+		// receipt.Emitter.EmitHeartbeat is nil-safe, so this needs no nil guard of
+		// its own and adding one would create a branch nothing can exercise.
 		e := emitterFn()
 		if err := e.EmitHeartbeat(); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
 			if logW != nil {

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -65,6 +65,16 @@ func startReceiptHeartbeat(
 	if !emitHeartbeat() {
 		return
 	}
+	// Cancellation can arrive while that first emission is in flight, and there is
+	// no point registering a cadence loop for a lifecycle that is already over.
+	// The loop would select ctx.Done() and exit immediately, so this changes no
+	// observable behavior beyond not scheduling the work at all, which is also why
+	// no test accompanies it: distinguishing the two requires cancelling inside
+	// the emission and then racing the ticker against ctx.Done(), and a test
+	// asserting that either flakes or proves nothing.
+	if ctx.Err() != nil {
+		return
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -33,6 +33,36 @@ func startReceiptHeartbeat(
 	if interval <= 0 {
 		interval = time.Minute
 	}
+	emitHeartbeat := func() bool {
+		e := emitterFn()
+		if e == nil {
+			return true
+		}
+		if err := e.EmitHeartbeat(); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
+			if logW != nil {
+				_, _ = fmt.Fprintf(logW, "pipelock: receipt heartbeat emit failed: %v\n", err)
+			}
+			if requireReceipts {
+				e.MarkUnhealthy(err)
+				if onRequiredFailure != nil {
+					onRequiredFailure(err)
+				}
+				return false
+			}
+		}
+		return true
+	}
+
+	// Emit a first non-durable heartbeat before waiting for the cadence ticker.
+	// Every production caller starts this only after its durable session_open
+	// succeeds, so the paired native AEL stream is necessarily open first. This
+	// makes hmax truthful even for a run that ends before one full interval.
+	// Failures retain the existing heartbeat failure direction: optional
+	// recording logs and continues; required recording marks the emitter
+	// unhealthy and asks the owning runtime to stop.
+	if !emitHeartbeat() {
+		return
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -41,21 +71,8 @@ func startReceiptHeartbeat(
 		for {
 			select {
 			case <-ticker.C:
-				e := emitterFn()
-				if e == nil {
-					continue
-				}
-				if err := e.EmitHeartbeat(); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
-					if logW != nil {
-						_, _ = fmt.Fprintf(logW, "pipelock: receipt heartbeat emit failed: %v\n", err)
-					}
-					if requireReceipts {
-						e.MarkUnhealthy(err)
-						if onRequiredFailure != nil {
-							onRequiredFailure(err)
-						}
-						return
-					}
+				if !emitHeartbeat() {
+					return
 				}
 			case <-ctx.Done():
 				return

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -60,6 +60,9 @@ func startReceiptHeartbeat(
 	// Failures retain the existing heartbeat failure direction: optional
 	// recording logs and continues; required recording marks the emitter
 	// unhealthy and asks the owning runtime to stop.
+	if ctx.Err() != nil {
+		return
+	}
 	if !emitHeartbeat() {
 		return
 	}

--- a/internal/cli/runtime/receipt_heartbeat.go
+++ b/internal/cli/runtime/receipt_heartbeat.go
@@ -34,10 +34,13 @@ func startReceiptHeartbeat(
 		interval = time.Minute
 	}
 	emitHeartbeat := func() bool {
+		// No nil check here: receipt.Emitter.EmitHeartbeat is itself nil-safe and
+		// returns nil, so a guard in this scheduler would duplicate that contract
+		// while adding a branch no test can make fail. An adversarial pass proved
+		// exactly that by setting the old guard to false and watching its test
+		// still pass, so the branch is removed rather than documented. Re-adding
+		// one would recreate an unprovable branch.
 		e := emitterFn()
-		if e == nil {
-			return true
-		}
 		if err := e.EmitHeartbeat(); err != nil && !errors.Is(err, receipt.ErrChainSealed) {
 			if logW != nil {
 				_, _ = fmt.Fprintf(logW, "pipelock: receipt heartbeat emit failed: %v\n", err)

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -190,6 +190,74 @@ func TestReceiptHeartbeatWithoutAnEmitterDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestReceiptHeartbeatPreCanceledContextDoesNotEmit(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+	e := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	startReceiptHeartbeat(ctx, &wg, time.Hour, func() *receipt.Emitter { return e }, &log, true, func(err error) {
+		t.Fatalf("pre-canceled heartbeat reported required failure: %v", err)
+	})
+	wg.Wait()
+	if log.Len() != 0 {
+		t.Fatalf("log = %q, want no startup heartbeat attempt", log.String())
+	}
+	entries, err := recorder.ReadEntries(filepath.Join(dir, "evidence-proxy-0.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want only session_open", len(entries))
+	}
+}
+
+func TestReceiptHeartbeatSealedChainIsQuiet(t *testing.T) {
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: dir, CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+	e := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv})
+	if err := e.EmitTranscriptRoot("sealed-before-heartbeat"); err != nil {
+		t.Fatalf("EmitTranscriptRoot: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	startReceiptHeartbeat(ctx, &wg, time.Hour, func() *receipt.Emitter { return e }, &log, true, func(err error) {
+		t.Fatalf("sealed chain reported required failure: %v", err)
+	})
+	cancel()
+	wg.Wait()
+	if log.Len() != 0 {
+		t.Fatalf("log = %q, want ErrChainSealed suppressed", log.String())
+	}
+	if err := e.HealthError(); err != nil {
+		t.Fatalf("HealthError() = %v, want sealed chain to remain healthy", err)
+	}
+}
+
 func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 	dir := t.TempDir()
 	_, priv, err := signing.GenerateKeyPair()
@@ -217,7 +285,6 @@ func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var wg sync.WaitGroup
 	var log bytes.Buffer
 	requiredFailure := make(chan error, 1)
@@ -226,6 +293,7 @@ func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 		cancel()
 	})
 	defer wg.Wait()
+	defer cancel()
 
 	select {
 	case err := <-requiredFailure:
@@ -288,7 +356,6 @@ func TestRequiredCadenceHeartbeatFailureAfterAHealthyStartFailsClosed(t *testing
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var wg sync.WaitGroup
 	var log bytes.Buffer
 	requiredFailure := make(chan error, 1)
@@ -300,6 +367,7 @@ func TestRequiredCadenceHeartbeatFailureAfterAHealthyStartFailsClosed(t *testing
 		cancel()
 	})
 	defer wg.Wait()
+	defer cancel()
 
 	// The immediate beat must land first: without it, closing the recorder below
 	// would race the startup emission and this could pass on the wrong branch.

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -180,18 +181,28 @@ func TestReceiptHeartbeatWithoutAnEmitterStaysQuiet(t *testing.T) {
 	var wg sync.WaitGroup
 	var log bytes.Buffer
 	failures := make(chan error, 1)
-	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return nil }, &log, true, func(err error) {
+	observedCadence := make(chan struct{}, 1)
+	var calls atomic.Int32
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter {
+		if calls.Add(1) >= 3 {
+			select {
+			case observedCadence <- struct{}{}:
+			default:
+			}
+		}
+		return nil
+	}, &log, true, func(err error) {
 		select {
 		case failures <- err:
 		default:
 		}
 	})
-	// Give the cadence loop several intervals to misbehave before trusting the
-	// assertion: a nil-emitter failure on the second beat would otherwise be missed.
 	select {
+	case <-observedCadence:
 	case err := <-failures:
 		t.Fatalf("a nil emitter reported a required-receipt failure: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cadence heartbeat calls")
 	}
 	cancel()
 	wg.Wait()

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -75,7 +75,9 @@ func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	var log bytes.Buffer
-	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log, false, nil)
+	// A one-hour cadence proves this is the immediate startup beat, not a
+	// ticker event. The durable session_open above must still be first.
+	startReceiptHeartbeat(ctx, &wg, time.Hour, func() *receipt.Emitter { return e }, &log, false, nil)
 	waitForHeartbeatReceipt(t, seen)
 	cancel()
 	wg.Wait()
@@ -88,8 +90,14 @@ func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	}
 
 	receipts := readRuntimeReceipts(t, dir, hex.EncodeToString(pub))
-	if len(receipts) < 3 {
-		t.Fatalf("receipts = %d, want open heartbeat close", len(receipts))
+	if len(receipts) != 3 {
+		t.Fatalf("receipts = %d, want exactly open heartbeat close", len(receipts))
+	}
+	wantKinds := []receipt.SessionControlKind{receipt.SessionControlOpen, receipt.SessionControlHeartbeat, receipt.SessionControlClose}
+	for i, want := range wantKinds {
+		if receipts[i].ActionRecord.SessionControl == nil || receipts[i].ActionRecord.SessionControl.Kind != want {
+			t.Fatalf("receipt %d control = %#v, want %q", i, receipts[i].ActionRecord.SessionControl, want)
+		}
 	}
 	last := receipts[len(receipts)-1].ActionRecord.SessionControl
 	if last == nil || last.Close == nil {

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -173,16 +173,26 @@ func TestReceiptHeartbeatCadenceStillBeatsAfterTheFirst(t *testing.T) {
 	}
 }
 
-func TestReceiptHeartbeatWithoutAnEmitterDoesNotPanic(t *testing.T) {
-	// A nil emitter is the pre-session and post-teardown state. It must be a quiet
-	// no-op rather than a panic or a logged failure, because the scheduler is
-	// started and stopped around a lifecycle it does not own.
+func TestReceiptHeartbeatWithoutAnEmitterStaysQuiet(t *testing.T) {
+	// The emitter's nil receiver is the quiet pre-session and post-teardown state.
+	// Required recording must not turn that state into a failure.
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	var log bytes.Buffer
-	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return nil }, &log, true, func(error) {
-		t.Fatal("a nil emitter must not report a required-receipt failure")
+	failures := make(chan error, 1)
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return nil }, &log, true, func(err error) {
+		select {
+		case failures <- err:
+		default:
+		}
 	})
+	// Give the cadence loop several intervals to misbehave before trusting the
+	// assertion: a nil-emitter failure on the second beat would otherwise be missed.
+	select {
+	case err := <-failures:
+		t.Fatalf("a nil emitter reported a required-receipt failure: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
 	cancel()
 	wg.Wait()
 	if log.Len() != 0 {

--- a/internal/cli/runtime/receipt_heartbeat_test.go
+++ b/internal/cli/runtime/receipt_heartbeat_test.go
@@ -113,6 +113,83 @@ func TestReceiptHeartbeatTickerStopsBeforeSeal(t *testing.T) {
 	}
 }
 
+func TestReceiptHeartbeatCadenceStillBeatsAfterTheFirst(t *testing.T) {
+	// The immediate-beat test above runs a one-hour cadence on purpose, so it
+	// cannot exercise the ticker at all. Without this test the periodic path, the
+	// ORIGINAL heartbeat mechanism, would have no coverage: proving the new beat
+	// is immediate must not cost the proof that the old one repeats.
+	dir := t.TempDir()
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	seen := make(chan receipt.Receipt, 16)
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec,
+		PrivKey:  priv,
+		OnReceipt: func(rcpt *receipt.Receipt) {
+			select {
+			case seen <- *rcpt:
+			default:
+			}
+		},
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log, false, nil)
+
+	// Two beats: the immediate one, then at least one from the ticker. Waiting for
+	// the second is what proves the cadence loop ran.
+	waitForHeartbeatReceipt(t, seen)
+	waitForHeartbeatReceipt(t, seen)
+	cancel()
+	wg.Wait()
+
+	receipts := readRuntimeReceipts(t, dir, hex.EncodeToString(pub))
+	heartbeats := 0
+	for _, r := range receipts {
+		if sc := r.ActionRecord.SessionControl; sc != nil && sc.Heartbeat != nil {
+			heartbeats++
+		}
+	}
+	if heartbeats < 2 {
+		t.Fatalf("heartbeat receipts = %d, want at least the immediate beat plus one cadence beat", heartbeats)
+	}
+}
+
+func TestReceiptHeartbeatWithoutAnEmitterDoesNotPanic(t *testing.T) {
+	// A nil emitter is the pre-session and post-teardown state. It must be a quiet
+	// no-op rather than a panic or a logged failure, because the scheduler is
+	// started and stopped around a lifecycle it does not own.
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return nil }, &log, true, func(error) {
+		t.Fatal("a nil emitter must not report a required-receipt failure")
+	})
+	cancel()
+	wg.Wait()
+	if log.Len() != 0 {
+		t.Fatalf("log = %q, want nothing written for a nil emitter", log.String())
+	}
+}
+
 func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 	dir := t.TempDir()
 	_, priv, err := signing.GenerateKeyPair()
@@ -169,6 +246,83 @@ func TestRequiredReceiptHeartbeatFailureMarksEmitterUnhealthy(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "receipt emitter unhealthy") {
 		t.Fatalf("Emit after required heartbeat failure error = %v, want unhealthy", err)
+	}
+}
+
+func TestRequiredCadenceHeartbeatFailureAfterAHealthyStartFailsClosed(t *testing.T) {
+	// The sibling required-failure test closes the recorder BEFORE the scheduler
+	// starts, so its failure now lands on the immediate beat and the cadence
+	// branch it used to cover became unreachable from it. This covers the
+	// remaining direction: a session that starts healthy and loses its recorder
+	// later, which is what a full disk or a revoked key looks like in production.
+	// It must fail closed there too, not just at startup.
+	dir := t.TempDir()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{
+		Enabled:            true,
+		Dir:                dir,
+		CheckpointInterval: 1000,
+	}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+
+	beats := make(chan struct{}, 8)
+	e := receipt.NewEmitter(receipt.EmitterConfig{
+		Recorder: rec,
+		PrivKey:  priv,
+		OnReceipt: func(rcpt *receipt.Receipt) {
+			if sc := rcpt.ActionRecord.SessionControl; sc != nil && sc.Heartbeat != nil {
+				select {
+				case beats <- struct{}{}:
+				default:
+				}
+			}
+		},
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	var log bytes.Buffer
+	requiredFailure := make(chan error, 1)
+	startReceiptHeartbeat(ctx, &wg, time.Millisecond, func() *receipt.Emitter { return e }, &log, true, func(err error) {
+		select {
+		case requiredFailure <- err:
+		default:
+		}
+		cancel()
+	})
+	defer wg.Wait()
+
+	// The immediate beat must land first: without it, closing the recorder below
+	// would race the startup emission and this could pass on the wrong branch.
+	select {
+	case <-beats:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the immediate heartbeat")
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	select {
+	case err := <-requiredFailure:
+		if err == nil {
+			t.Fatal("cadence heartbeat failure callback received nil error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a required cadence heartbeat failure")
+	}
+	if e.HealthError() == nil {
+		t.Fatal("emitter health error was not marked after a required cadence heartbeat failure")
 	}
 }
 

--- a/internal/cli/runtime/receipt_session_open.go
+++ b/internal/cli/runtime/receipt_session_open.go
@@ -10,8 +10,13 @@ var beforeStartupSessionOpenForTest func(*receipt.Emitter) error
 func emitStartupSessionOpen(e *receipt.Emitter) error {
 	if beforeStartupSessionOpenForTest != nil {
 		if err := beforeStartupSessionOpenForTest(e); err != nil {
+			e.MarkUnhealthy(err)
 			return err
 		}
 	}
-	return e.EmitSessionOpen()
+	if err := e.EmitSessionOpen(); err != nil {
+		e.MarkUnhealthy(err)
+		return err
+	}
+	return nil
 }

--- a/internal/cli/runtime/receipt_session_open_test.go
+++ b/internal/cli/runtime/receipt_session_open_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestEmitStartupSessionOpenFailureDisablesLaterLifecycleWrites(t *testing.T) {
+	wantErr := errors.New("session open failed")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+	e := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv})
+	beforeStartupSessionOpenForTest = func(*receipt.Emitter) error { return wantErr }
+	t.Cleanup(func() { beforeStartupSessionOpenForTest = nil })
+
+	err = emitStartupSessionOpen(e)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("emitStartupSessionOpen() error = %v, want %v", err, wantErr)
+	}
+	if !errors.Is(e.HealthError(), wantErr) {
+		t.Fatalf("HealthError() = %v, want %v", e.HealthError(), wantErr)
+	}
+	if receiptEmitterReady(e) {
+		t.Fatal("receiptEmitterReady() = true after session_open failure")
+	}
+}

--- a/internal/cli/runtime/receipt_session_open_test.go
+++ b/internal/cli/runtime/receipt_session_open_test.go
@@ -38,3 +38,29 @@ func TestEmitStartupSessionOpenFailureDisablesLaterLifecycleWrites(t *testing.T)
 		t.Fatal("receiptEmitterReady() = true after session_open failure")
 	}
 }
+
+func TestEmitStartupSessionOpenEmitterFailureDisablesLaterLifecycleWrites(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	rec, err := recorder.New(recorder.Config{Enabled: true, Dir: t.TempDir(), CheckpointInterval: 1000}, nil, priv)
+	if err != nil {
+		t.Fatalf("recorder.New: %v", err)
+	}
+	e := receipt.NewEmitter(receipt.EmitterConfig{Recorder: rec, PrivKey: priv})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+
+	err = emitStartupSessionOpen(e)
+	if err == nil {
+		t.Fatal("emitStartupSessionOpen() error = nil, want closed-recorder failure")
+	}
+	if !errors.Is(e.HealthError(), err) {
+		t.Fatalf("HealthError() = %v, want emitted error %v", e.HealthError(), err)
+	}
+	if receiptEmitterReady(e) {
+		t.Fatal("receiptEmitterReady() = true after emitter session_open failure")
+	}
+}


### PR DESCRIPTION
## What changed

A Pipelock run now proves liveness from the moment its session opens. One non-durable heartbeat is emitted before the cadence ticker starts, after the durable session_open that its production callers already require.

The evidence a run publishes declares a heartbeat cadence, which is a promise to prove liveness at that interval. A run shorter than one interval never produced such a proof, so an independent checker reading that evidence correctly refused the liveness dimension and the run graded a rung lower than a longer but otherwise identical run. The grade encoded how long the process happened to live rather than the quality of the evidence, and with the default cadence that covered every short-lived invocation and every test run. Measured before the change: a four-second session failed the liveness check while a fourteen-second session, idle or serving sixty requests, passed it.

Failure direction is deliberately unchanged. Optional recording logs and continues; required recording marks the emitter unhealthy and asks the owning runtime to stop, exactly as a cadence heartbeat already did. The new emission is non-durable for the same reason the periodic one is: heartbeats are liveness telemetry rather than chain-integrity anchors, and the durable session_open still carries that load and does not wait on this beat.

The heartbeat test previously asserted only that a ticker eventually emitted a beat, which cannot distinguish a first-tick heartbeat from an immediate one. It now runs with a one-hour cadence and asserts the exact control sequence, so the immediate beat is what makes it pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Receipt sessions emit an initial heartbeat immediately upon startup.
  - Ongoing heartbeat updates continue at the configured cadence.
  - Required receipt sessions stop safely when heartbeat delivery fails.

- **Bug Fixes**
  - Improved handling of missing heartbeat emitters and delivery failures without disrupting optional receipt flows.
  - Startup session-opening failures now mark receipt handling as unhealthy and prevent subsequent lifecycle updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->