### PR TITLE
ci(observability): attribute Go shard runtime

### DIFF
--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -41,6 +41,8 @@ def stream_events(
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
+        if not isinstance(event, dict):
+            continue
 
         observed_at = clock()
         if first_event_at is None:

--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -14,6 +14,13 @@ from collections.abc import Callable, Iterable
 from typing import TextIO
 
 
+def escape_terminal_text(value: str) -> str:
+    return "".join(
+        character if character.isprintable() else f"\\u{ord(character):04x}"
+        for character in value
+    )
+
+
 def format_duration(seconds: float) -> str:
     if seconds >= 60:
         minutes, remainder = divmod(seconds, 60)
@@ -54,7 +61,11 @@ def stream_events(
 
         action = event.get("Action")
         package = event.get("Package")
-        if action not in {"pass", "fail", "skip"} or not isinstance(package, str):
+        if (
+            not isinstance(action, str)
+            or action not in {"pass", "fail", "skip"}
+            or not isinstance(package, str)
+        ):
             continue
 
         elapsed = event.get("Elapsed", 0.0)
@@ -62,7 +73,8 @@ def stream_events(
             elapsed = 0.0
 
         print(
-            f"[{label}] {action:<4} {format_duration(float(elapsed)):>8} {package}",
+            f"[{escape_terminal_text(label)}] {action:<4} "
+            f"{format_duration(float(elapsed)):>8} {escape_terminal_text(package)}",
             file=out,
             flush=True,
         )
@@ -72,7 +84,7 @@ def stream_events(
     span = 0.0 if last_event_at is None else last_event_at - first_event_at
     trailing = 0.0 if last_event_at is None else finished - last_event_at
     print(
-        f"[{label}] first JSON lead: {format_duration(lead)}; "
+        f"[{escape_terminal_text(label)}] first JSON lead: {format_duration(lead)}; "
         f"JSON stream span: {format_duration(span)}; "
         f"post-stream tail: {format_duration(trailing)}",
         file=out,

--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 import time
 from collections.abc import Callable, Iterable
@@ -19,6 +20,16 @@ def escape_terminal_text(value: str) -> str:
         character if character.isprintable() else f"\\u{ord(character):04x}"
         for character in value
     )
+
+
+def normalize_elapsed(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    try:
+        elapsed = float(value)
+    except OverflowError:
+        return 0.0
+    return elapsed if math.isfinite(elapsed) and elapsed > 0 else 0.0
 
 
 def format_duration(seconds: float) -> str:
@@ -68,13 +79,11 @@ def stream_events(
         ):
             continue
 
-        elapsed = event.get("Elapsed", 0.0)
-        if not isinstance(elapsed, (int, float)):
-            elapsed = 0.0
+        elapsed = normalize_elapsed(event.get("Elapsed", 0.0))
 
         print(
             f"[{escape_terminal_text(label)}] {action:<4} "
-            f"{format_duration(float(elapsed)):>8} {escape_terminal_text(package)}",
+            f"{format_duration(elapsed):>8} {escape_terminal_text(package)}",
             file=out,
             flush=True,
         )

--- a/scripts/stream_go_test_json.py
+++ b/scripts/stream_go_test_json.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
+from collections.abc import Callable, Iterable
+from typing import TextIO
 
 
 def format_duration(seconds: float) -> str:
@@ -16,6 +19,63 @@ def format_duration(seconds: float) -> str:
         minutes, remainder = divmod(seconds, 60)
         return f"{int(minutes)}m{remainder:04.1f}s"
     return f"{seconds:.1f}s"
+
+
+def stream_events(
+    lines: Iterable[str],
+    *,
+    raw: TextIO,
+    label: str,
+    out: TextIO,
+    clock: Callable[[], float] = time.monotonic,
+) -> None:
+    started = clock()
+    first_event_at: float | None = None
+    last_event_at: float | None = None
+
+    for line in lines:
+        raw.write(line)
+        raw.flush()
+
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        observed_at = clock()
+        if first_event_at is None:
+            first_event_at = observed_at
+        last_event_at = observed_at
+
+        if event.get("Test"):
+            continue
+
+        action = event.get("Action")
+        package = event.get("Package")
+        if action not in {"pass", "fail", "skip"} or not isinstance(package, str):
+            continue
+
+        elapsed = event.get("Elapsed", 0.0)
+        if not isinstance(elapsed, (int, float)):
+            elapsed = 0.0
+
+        print(
+            f"[{label}] {action:<4} {format_duration(float(elapsed)):>8} {package}",
+            file=out,
+            flush=True,
+        )
+
+    finished = clock()
+    lead = 0.0 if first_event_at is None else first_event_at - started
+    span = 0.0 if last_event_at is None else last_event_at - first_event_at
+    trailing = 0.0 if last_event_at is None else finished - last_event_at
+    print(
+        f"[{label}] first JSON lead: {format_duration(lead)}; "
+        f"JSON stream span: {format_duration(span)}; "
+        f"post-stream tail: {format_duration(trailing)}",
+        file=out,
+        flush=True,
+    )
 
 
 def main() -> int:
@@ -27,31 +87,7 @@ def main() -> int:
     args = parser.parse_args()
 
     with open(args.json_out, "w", encoding="utf-8") as raw:
-        for line in sys.stdin:
-            raw.write(line)
-            raw.flush()
-
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            if event.get("Test"):
-                continue
-
-            action = event.get("Action")
-            package = event.get("Package")
-            if action not in {"pass", "fail", "skip"} or not isinstance(package, str):
-                continue
-
-            elapsed = event.get("Elapsed", 0.0)
-            if not isinstance(elapsed, (int, float)):
-                elapsed = 0.0
-
-            print(
-                f"[{args.label}] {action:<4} {format_duration(float(elapsed)):>8} {package}",
-                flush=True,
-            )
+        stream_events(sys.stdin, raw=raw, label=args.label, out=sys.stdout)
 
     return 0
 

--- a/scripts/stream_go_test_json_test.py
+++ b/scripts/stream_go_test_json_test.py
@@ -15,6 +15,7 @@ class StreamGoTestJSONTest(unittest.TestCase):
         readings = iter([10.0, 12.5, 15.0, 16.0])
         lines = [
             "not json\n",
+            "null\n",
             json.dumps({"Action": "start", "Package": "example.com/proxy"}) + "\n",
             json.dumps(
                 {

--- a/scripts/stream_go_test_json_test.py
+++ b/scripts/stream_go_test_json_test.py
@@ -89,6 +89,44 @@ class StreamGoTestJSONTest(unittest.TestCase):
         self.assertIn("[proxy\\u001b[0m] pass", output)
         self.assertIn("example.com/\\u001b[2Jproxy", output)
 
+    def test_invalid_elapsed_values_fall_back_without_stopping_summary(self):
+        readings = iter([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        lines = [
+            json.dumps(
+                {"Action": "pass", "Package": "example.com/bool", "Elapsed": True}
+            )
+            + "\n",
+            '{"Action":"pass","Package":"example.com/infinite","Elapsed":1e400}\n',
+            json.dumps(
+                {"Action": "pass", "Package": "example.com/negative", "Elapsed": -1}
+            )
+            + "\n",
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/valid",
+                    "Elapsed": 1.5,
+                }
+            )
+            + "\n",
+        ]
+        out = io.StringIO()
+
+        stream_go_test_json.stream_events(
+            lines,
+            raw=io.StringIO(),
+            label="proxy",
+            out=out,
+            clock=lambda: next(readings),
+        )
+
+        output = out.getvalue()
+        self.assertIn("0.0s example.com/bool", output)
+        self.assertIn("0.0s example.com/infinite", output)
+        self.assertIn("0.0s example.com/negative", output)
+        self.assertIn("1.5s example.com/valid", output)
+        self.assertIn("first JSON lead:", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/stream_go_test_json_test.py
+++ b/scripts/stream_go_test_json_test.py
@@ -61,6 +61,34 @@ class StreamGoTestJSONTest(unittest.TestCase):
             out.getvalue(),
         )
 
+    def test_ignores_non_string_action_and_escapes_terminal_controls(self):
+        readings = iter([1.0, 2.0, 3.0, 4.0])
+        lines = [
+            json.dumps({"Action": [], "Package": "example.com/ignored"}) + "\n",
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/\x1b[2Jproxy",
+                    "Elapsed": 1.0,
+                }
+            )
+            + "\n",
+        ]
+        out = io.StringIO()
+
+        stream_go_test_json.stream_events(
+            lines,
+            raw=io.StringIO(),
+            label="proxy\x1b[0m",
+            out=out,
+            clock=lambda: next(readings),
+        )
+
+        output = out.getvalue()
+        self.assertNotIn("\x1b", output)
+        self.assertIn("[proxy\\u001b[0m] pass", output)
+        self.assertIn("example.com/\\u001b[2Jproxy", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/stream_go_test_json_test.py
+++ b/scripts/stream_go_test_json_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+import io
+import json
+import unittest
+
+import stream_go_test_json
+
+
+class StreamGoTestJSONTest(unittest.TestCase):
+    def test_reports_first_event_lead_stream_span_and_tail(self):
+        readings = iter([10.0, 12.5, 15.0, 16.0])
+        lines = [
+            "not json\n",
+            json.dumps({"Action": "start", "Package": "example.com/proxy"}) + "\n",
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/proxy",
+                    "Elapsed": 2.0,
+                }
+            )
+            + "\n",
+        ]
+        raw = io.StringIO()
+        out = io.StringIO()
+
+        stream_go_test_json.stream_events(
+            lines,
+            raw=raw,
+            label="proxy",
+            out=out,
+            clock=lambda: next(readings),
+        )
+
+        self.assertEqual(raw.getvalue(), "".join(lines))
+        output = out.getvalue()
+        self.assertIn("[proxy] pass     2.0s example.com/proxy", output)
+        self.assertIn("first JSON lead: 2.5s", output)
+        self.assertIn("JSON stream span: 2.5s", output)
+        self.assertIn("post-stream tail: 1.0s", output)
+
+    def test_empty_stream_reports_zero_timings(self):
+        readings = iter([3.0, 8.0])
+        out = io.StringIO()
+
+        stream_go_test_json.stream_events(
+            [],
+            raw=io.StringIO(),
+            label="empty",
+            out=out,
+            clock=lambda: next(readings),
+        )
+
+        self.assertIn(
+            "first JSON lead: 0.0s; JSON stream span: 0.0s; post-stream tail: 0.0s",
+            out.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -43,6 +43,8 @@ def parse_events(lines: list[str]) -> dict[str, PackageResult]:
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
+        if not isinstance(event, dict):
+            continue
 
         package = event.get("Package")
         if not isinstance(package, str) or package == "":

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -172,7 +172,7 @@ def print_summary(
                 file=out,
             )
             for line in test_result.output:
-                print(line, file=out)
+                print(escape_terminal_text(line), file=out)
 
     package_output_failures = [
         (package, result) for package, result in failures if result.output
@@ -182,7 +182,7 @@ def print_summary(
         for package, result in package_output_failures:
             print(f"--- {escape_terminal_text(package)} ---", file=out)
             for line in result.output:
-                print(line, file=out)
+                print(escape_terminal_text(line), file=out)
 
 
 def has_failed_packages(results: dict[str, PackageResult]) -> bool:

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -88,7 +88,12 @@ def format_duration(seconds: float) -> str:
 
 
 def print_summary(
-    results: dict[str, PackageResult], *, label: str, top: int, out: object = sys.stdout
+    results: dict[str, PackageResult],
+    *,
+    label: str,
+    top: int,
+    top_tests: int = 25,
+    out: object = sys.stdout,
 ) -> None:
     packages = [
         (package, result)
@@ -106,6 +111,27 @@ def print_summary(
             f"  {format_duration(result.elapsed):>8}  {result.action:<4}  {package}",
             file=out,
         )
+
+    tests = [
+        (package, test, test_result)
+        for package, result in packages
+        for test, test_result in result.tests.items()
+        if test_result.action in {"pass", "fail", "skip"}
+    ]
+    tests.sort(key=lambda item: item[2].elapsed, reverse=True)
+    if tests:
+        print(f"slowest {min(top_tests, len(tests))} tests:", file=out)
+        print(
+            "  elapsed values can overlap for parallel tests; they are wall-clock "
+            "attribution, not exclusive CPU time",
+            file=out,
+        )
+        for package, test, test_result in tests[:top_tests]:
+            print(
+                f"  {format_duration(test_result.elapsed):>8}  "
+                f"{test_result.action:<4}  {package} {test}",
+                file=out,
+            )
 
     failures = [(package, result) for package, result in packages if result.action == "fail"]
     if not failures:
@@ -148,13 +174,18 @@ def main() -> int:
     )
     parser.add_argument("--label", default="go test", help="label printed in the summary")
     parser.add_argument("--top", type=int, default=20, help="number of slow packages to print")
+    parser.add_argument(
+        "--top-tests", type=int, default=25, help="number of slow tests to print"
+    )
     args = parser.parse_args()
 
     if args.top < 1:
         parser.error("--top must be at least 1")
+    if args.top_tests < 1:
+        parser.error("--top-tests must be at least 1")
 
     results = parse_events(sys.stdin.readlines())
-    print_summary(results, label=args.label, top=args.top)
+    print_summary(results, label=args.label, top=args.top, top_tests=args.top_tests)
     if has_failed_packages(results):
         return 1
     return 0

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -16,6 +16,13 @@ from dataclasses import dataclass, field
 FAILED_OUTPUT_LIMIT = 80
 
 
+def escape_terminal_text(value: str) -> str:
+    return "".join(
+        character if character.isprintable() else f"\\u{ord(character):04x}"
+        for character in value
+    )
+
+
 @dataclass
 class _ActionResult:
     action: str = ""
@@ -105,12 +112,13 @@ def print_summary(
     packages.sort(key=lambda item: item[1].elapsed, reverse=True)
 
     total = sum(result.elapsed for _, result in packages)
-    print(f"Go test package timing ({label})", file=out)
+    print(f"Go test package timing ({escape_terminal_text(label)})", file=out)
     print(f"packages: {len(packages)}; summed package time: {format_duration(total)}", file=out)
     print(f"slowest {min(top, len(packages))} packages:", file=out)
     for package, result in packages[:top]:
         print(
-            f"  {format_duration(result.elapsed):>8}  {result.action:<4}  {package}",
+            f"  {format_duration(result.elapsed):>8}  {result.action:<4}  "
+            f"{escape_terminal_text(package)}",
             file=out,
         )
 
@@ -131,7 +139,8 @@ def print_summary(
         for package, test, test_result in tests[:top_tests]:
             print(
                 f"  {format_duration(test_result.elapsed):>8}  "
-                f"{test_result.action:<4}  {package} {test}",
+                f"{test_result.action:<4}  {escape_terminal_text(package)} "
+                f"{escape_terminal_text(test)}",
                 file=out,
             )
 
@@ -149,7 +158,8 @@ def print_summary(
         print("failed tests:", file=out)
         for package, test, test_result in all_failed_tests:
             print(
-                f"--- {package} {test} ({format_duration(test_result.elapsed)}) ---",
+                f"--- {escape_terminal_text(package)} {escape_terminal_text(test)} "
+                f"({format_duration(test_result.elapsed)}) ---",
                 file=out,
             )
             for line in test_result.output:
@@ -161,7 +171,7 @@ def print_summary(
     if package_output_failures:
         print("failed package output tails:", file=out)
         for package, result in package_output_failures:
-            print(f"--- {package} ---", file=out)
+            print(f"--- {escape_terminal_text(package)} ---", file=out)
             for line in result.output:
                 print(line, file=out)
 

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import collections
 import json
+import math
 import sys
 from dataclasses import dataclass, field
 
@@ -21,6 +22,16 @@ def escape_terminal_text(value: str) -> str:
         character if character.isprintable() else f"\\u{ord(character):04x}"
         for character in value
     )
+
+
+def normalize_elapsed(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    try:
+        elapsed = float(value)
+    except OverflowError:
+        return 0.0
+    return elapsed if math.isfinite(elapsed) and elapsed > 0 else 0.0
 
 
 @dataclass
@@ -75,16 +86,14 @@ def parse_events(lines: list[str]) -> dict[str, PackageResult]:
             continue
 
         if action in {"pass", "fail", "skip"}:
-            elapsed = event.get("Elapsed", 0.0)
+            elapsed = normalize_elapsed(event.get("Elapsed", 0.0))
             if test_result is not None:
                 test_result.action = action
-                if isinstance(elapsed, (int, float)):
-                    test_result.elapsed = float(elapsed)
+                test_result.elapsed = elapsed
                 continue
 
             result.action = action
-            if isinstance(elapsed, (int, float)):
-                result.elapsed = float(elapsed)
+            result.elapsed = elapsed
 
     return results
 

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -227,6 +227,36 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         self.assertNotIn("example.com/proxy TestFast", summary)
         self.assertIn("wall-clock attribution, not exclusive CPU time", summary)
 
+    def test_escapes_terminal_controls_in_report_names(self):
+        lines = [
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/\x1b[2Jproxy",
+                    "Test": "TestSlow\nspoof",
+                    "Elapsed": 1.0,
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/\x1b[2Jproxy",
+                    "Elapsed": 1.0,
+                }
+            ),
+        ]
+
+        results = summarize_go_test_json.parse_events(lines)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(
+            results, label="unit\x1b[0m", top=1, top_tests=1, out=out
+        )
+
+        summary = out.getvalue()
+        self.assertNotIn("\x1b", summary)
+        self.assertIn("unit\\u001b[0m", summary)
+        self.assertIn("example.com/\\u001b[2Jproxy TestSlow\\u000aspoof", summary)
+
     def test_main_returns_nonzero_when_final_package_action_fails(self):
         lines = "\n".join(
             [

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -257,6 +257,34 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         self.assertIn("unit\\u001b[0m", summary)
         self.assertIn("example.com/\\u001b[2Jproxy TestSlow\\u000aspoof", summary)
 
+    def test_invalid_elapsed_values_fall_back_without_stopping_summary(self):
+        lines = [
+            json.dumps(
+                {"Action": "pass", "Package": "example.com/bool", "Elapsed": True}
+            ),
+            '{"Action":"pass","Package":"example.com/infinite","Elapsed":1e400}',
+            json.dumps(
+                {"Action": "pass", "Package": "example.com/negative", "Elapsed": -1}
+            ),
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/valid",
+                    "Elapsed": 1.5,
+                }
+            ),
+        ]
+
+        results = summarize_go_test_json.parse_events(lines)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(results, label="unit", top=4, out=out)
+
+        summary = out.getvalue()
+        self.assertIn("0.0s  pass  example.com/bool", summary)
+        self.assertIn("0.0s  pass  example.com/infinite", summary)
+        self.assertIn("0.0s  pass  example.com/negative", summary)
+        self.assertIn("1.5s  pass  example.com/valid", summary)
+
     def test_main_returns_nonzero_when_final_package_action_fails(self):
         lines = "\n".join(
             [

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -175,6 +175,7 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         results = summarize_go_test_json.parse_events(
             [
                 "not json",
+                "null",
                 json.dumps(
                     {
                         "Action": "pass",

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -257,6 +257,50 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         self.assertIn("unit\\u001b[0m", summary)
         self.assertIn("example.com/\\u001b[2Jproxy TestSlow\\u000aspoof", summary)
 
+    def test_escapes_terminal_controls_in_failure_output(self):
+        lines = [
+            json.dumps(
+                {
+                    "Action": "output",
+                    "Package": "example.com/proxy",
+                    "Test": "TestFailure",
+                    "Output": "test output\x1b[2J\rspoof\n",
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "fail",
+                    "Package": "example.com/proxy",
+                    "Test": "TestFailure",
+                    "Elapsed": 1.0,
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "output",
+                    "Package": "example.com/proxy",
+                    "Output": "package output\x1b[0m\n",
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "fail",
+                    "Package": "example.com/proxy",
+                    "Elapsed": 1.0,
+                }
+            ),
+        ]
+
+        results = summarize_go_test_json.parse_events(lines)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(results, label="unit", top=1, out=out)
+
+        summary = out.getvalue()
+        self.assertNotIn("\x1b", summary)
+        self.assertNotIn("\r", summary)
+        self.assertIn("test output\\u001b[2J\\u000dspoof", summary)
+        self.assertIn("package output\\u001b[0m", summary)
+
     def test_invalid_elapsed_values_fall_back_without_stopping_summary(self):
         lines = [
             json.dumps(

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -187,6 +187,45 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
 
         self.assertEqual(results["example.com/pkg"].action, "pass")
 
+    def test_summarizes_slowest_tests_with_parallelism_caveat(self):
+        lines = [
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/proxy",
+                    "Test": "TestFast",
+                    "Elapsed": 1.0,
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/proxy",
+                    "Test": "TestSlow",
+                    "Elapsed": 12.5,
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "pass",
+                    "Package": "example.com/proxy",
+                    "Elapsed": 13.0,
+                }
+            ),
+        ]
+
+        results = summarize_go_test_json.parse_events(lines)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(
+            results, label="unit", top=1, top_tests=1, out=out
+        )
+
+        summary = out.getvalue()
+        self.assertIn("slowest 1 tests:", summary)
+        self.assertIn("12.5s  pass  example.com/proxy TestSlow", summary)
+        self.assertNotIn("example.com/proxy TestFast", summary)
+        self.assertIn("wall-clock attribution, not exclusive CPU time", summary)
+
     def test_main_returns_nonzero_when_final_package_action_fails(self):
         lines = "\n".join(
             [
@@ -255,6 +294,19 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--top must be at least 1", stderr.getvalue())
+
+    def test_main_rejects_non_positive_top_tests(self):
+        with (
+            mock.patch.object(
+                sys, "argv", ["summarize_go_test_json.py", "--top-tests", "0"]
+            ),
+            mock.patch.object(sys, "stderr", io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            summarize_go_test_json.main()
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--top-tests must be at least 1", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Report the slowest individual tests and split each Go shard's runtime into first-event lead, test-stream duration, and trailing time so proxy CI bottlenecks can be optimized from measured evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer Go test streaming diagnostics, including lead, stream-span, and post-stream timing.
  - Added summaries of the slowest passing, failing, or skipped tests.
  - Added the `--top-tests` option to control how many slow tests are displayed.
  - Added wall-clock attribution guidance for reported durations.
- **Bug Fixes**
  - Improved handling of malformed events and invalid timing values.
  - Escaped non-printable characters to prevent terminal formatting issues.
- **Validation**
  - Invalid non-positive `--top-tests` values now produce a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->