### PR TITLE
fix(config): reject overflowing duration values

### DIFF
--- a/internal/config/duration_seconds_test.go
+++ b/internal/config/duration_seconds_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestValidateRejectsIntegerDurationOverflow(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("overflowing whole-second value is not representable as int on 32-bit hosts")
+	}
+
+	overflow := int(maxConfigDurationSeconds + 1)
+	tests := []struct {
+		name  string
+		field string
+		mut   func(*Config)
+	}{
+		{
+			name: "conductor created skew", field: "conductor.created_skew_seconds",
+			mut: func(cfg *Config) { cfg.Conductor.CreatedSkewSeconds = overflow },
+		},
+		{
+			name: "MCP input response timeout", field: "mcp_input_scanning.response_timeout_seconds",
+			mut: func(cfg *Config) { cfg.MCPInputScanning.ResponseTimeoutSeconds = overflow },
+		},
+		{
+			name: "fetch timeout", field: "fetch_proxy.timeout_seconds",
+			mut: func(cfg *Config) { cfg.FetchProxy.TimeoutSeconds = overflow },
+		},
+		{
+			name: "response ask timeout", field: "response_scanning.ask_timeout_seconds",
+			mut: func(cfg *Config) { cfg.ResponseScanning.AskTimeoutSeconds = overflow },
+		},
+		{
+			name:  "forward maximum tunnel",
+			field: "forward_proxy.max_tunnel_seconds",
+			mut: func(cfg *Config) {
+				cfg.ForwardProxy.Enabled = true
+				cfg.ForwardProxy.MaxTunnelSeconds = overflow
+			},
+		},
+		{
+			name:  "forward idle timeout",
+			field: "forward_proxy.idle_timeout_seconds",
+			mut: func(cfg *Config) {
+				cfg.ForwardProxy.Enabled = true
+				cfg.ForwardProxy.IdleTimeoutSeconds = overflow
+			},
+		},
+		{
+			name:  "websocket maximum connection",
+			field: "websocket_proxy.max_connection_seconds",
+			mut: func(cfg *Config) {
+				cfg.WebSocketProxy.Enabled = true
+				cfg.WebSocketProxy.MaxConnectionSeconds = overflow
+			},
+		},
+		{
+			name:  "websocket idle timeout",
+			field: "websocket_proxy.idle_timeout_seconds",
+			mut: func(cfg *Config) {
+				cfg.WebSocketProxy.Enabled = true
+				cfg.WebSocketProxy.IdleTimeoutSeconds = overflow
+			},
+		},
+		{
+			name:  "tool chain window",
+			field: "tool_chain_detection.window_seconds",
+			mut: func(cfg *Config) {
+				cfg.ToolChainDetection.Enabled = true
+				cfg.ToolChainDetection.Action = ActionBlock
+				cfg.ToolChainDetection.WindowSize = 4
+				cfg.ToolChainDetection.WindowSeconds = overflow
+			},
+		},
+		{
+			name: "reverse request timeout", field: "reverse_proxy.request_timeout_seconds",
+			mut: func(cfg *Config) { cfg.ReverseProxy.RequestTimeoutSeconds = overflow },
+		},
+		{
+			name: "defer timeout", field: "defer.timeout_seconds",
+			mut: func(cfg *Config) { cfg.Defer.TimeoutSeconds = overflow },
+		},
+		{
+			name: "session cleanup interval", field: "session_profiling.cleanup_interval_seconds",
+			mut: func(cfg *Config) { cfg.SessionProfiling.CleanupIntervalSeconds = overflow },
+		},
+		{
+			name: "adaptive level duration", field: "adaptive_enforcement.level_duration_seconds",
+			mut: func(cfg *Config) { cfg.AdaptiveEnforcement.LevelDurationSeconds = overflow },
+		},
+		{
+			name: "adaptive deescalation check", field: "adaptive_enforcement.deescalation_check_seconds",
+			mut: func(cfg *Config) { cfg.AdaptiveEnforcement.DeescalationCheckSeconds = overflow },
+		},
+		{
+			name: "health watchdog interval", field: "health_watchdog.interval_seconds",
+			mut: func(cfg *Config) { cfg.HealthWatchdog.IntervalSeconds = overflow },
+		},
+		{
+			name: "OTLP timeout", field: "emit.otlp.timeout_seconds",
+			mut: func(cfg *Config) { cfg.Emit.OTLP.TimeoutSeconds = overflow },
+		},
+		{
+			name: "forwarder timeout", field: "emit.forwarder.timeout_seconds",
+			mut: func(cfg *Config) { cfg.Emit.Forwarder.TimeoutSeconds = overflow },
+		},
+		{
+			name: "webhook timeout", field: "emit.webhook.timeout_seconds",
+			mut: func(cfg *Config) { cfg.Emit.Webhook.TimeoutSecs = overflow },
+		},
+		{
+			name: "mediation envelope created skew", field: "mediation_envelope.created_skew_seconds",
+			mut: func(cfg *Config) { cfg.MediationEnvelope.CreatedSkewSeconds = overflow },
+		},
+		{
+			name: "airlock drain timeout", field: "airlock.timers.drain_timeout_seconds",
+			mut: func(cfg *Config) { cfg.Airlock.Timers.DrainTimeoutSeconds = overflow },
+		},
+		{
+			name: "session profiling window", field: "session_profiling.window_minutes",
+			mut: func(cfg *Config) { cfg.SessionProfiling.WindowMinutes = int(maxConfigDurationMinutes + 1) },
+		},
+		{
+			name: "session profiling TTL", field: "session_profiling.session_ttl_minutes",
+			mut: func(cfg *Config) { cfg.SessionProfiling.SessionTTLMinutes = int(maxConfigDurationMinutes + 1) },
+		},
+		{
+			name: "cross-request entropy window", field: "cross_request_detection.entropy_budget.window_minutes",
+			mut: func(cfg *Config) {
+				cfg.CrossRequestDetection.EntropyBudget.WindowMinutes = int(maxConfigDurationMinutes + 1)
+			},
+		},
+		{
+			name: "cross-request fragment window", field: "cross_request_detection.fragment_reassembly.window_minutes",
+			mut: func(cfg *Config) {
+				cfg.CrossRequestDetection.FragmentReassembly.WindowMinutes = int(maxConfigDurationMinutes + 1)
+			},
+		},
+		{
+			name: "airlock soft timer", field: "airlock.timers.soft_minutes",
+			mut: func(cfg *Config) { cfg.Airlock.Timers.SoftMinutes = int(maxConfigDurationMinutes + 1) },
+		},
+		{
+			name: "airlock hard timer", field: "airlock.timers.hard_minutes",
+			mut: func(cfg *Config) { cfg.Airlock.Timers.HardMinutes = int(maxConfigDurationMinutes + 1) },
+		},
+		{
+			name: "airlock drain timer", field: "airlock.timers.drain_minutes",
+			mut: func(cfg *Config) { cfg.Airlock.Timers.DrainMinutes = int(maxConfigDurationMinutes + 1) },
+		},
+		{
+			name: "flight recorder retention", field: "flight_recorder.retention_days",
+			mut: func(cfg *Config) { cfg.FlightRecorder.RetentionDays = int(maxConfigDurationDays + 1) },
+		},
+		{
+			name: "agent budget window", field: "agents.worker.budget.window_minutes",
+			mut: func(cfg *Config) {
+				cfg.Agents = make(map[string]AgentProfile)
+				cfg.Agents["worker"] = AgentProfile{Budget: BudgetConfig{WindowMinutes: int(maxConfigDurationMinutes + 1)}}
+			},
+		},
+		{
+			name: "agent wall clock", field: "agents.worker.budget.max_wall_clock_minutes",
+			mut: func(cfg *Config) {
+				cfg.Agents = make(map[string]AgentProfile)
+				cfg.Agents["worker"] = AgentProfile{Budget: BudgetConfig{MaxWallClockMinutes: int(maxConfigDurationMinutes + 1)}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			tt.mut(cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected %s overflow to be rejected", tt.field)
+			}
+			if !strings.Contains(err.Error(), tt.field) || !strings.Contains(err.Error(), "too large") {
+				t.Fatalf("error = %q, want field-specific upper-bound rejection", err)
+			}
+		})
+	}
+}
+
+func TestValidateIntegerDurationAcceptsLargestSafeValues(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("largest duration-second value is not representable as int on 32-bit hosts")
+	}
+	cfg := Defaults()
+	cfg.ForwardProxy.IdleTimeoutSeconds = int(maxConfigDurationSeconds)
+	cfg.Airlock.Timers.HardMinutes = int(maxConfigDurationMinutes)
+	cfg.FlightRecorder.RetentionDays = int(maxConfigDurationDays)
+	if err := cfg.validateIntegerDurationBounds(); err != nil {
+		t.Fatalf("largest safe duration rejected: %v", err)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -158,6 +159,67 @@ func todayUTC() time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
+// Integer duration bounds leave room for runtime consumers that add a fixed
+// grace period or multiply the configured interval. Each bound is still more
+// than 97 years, so rejecting larger values cannot affect a useful timeout.
+const (
+	maxConfigDurationSeconds = int64((1<<63 - 1) / time.Second / 3)
+	maxConfigDurationMinutes = int64((1<<63 - 1) / time.Minute / 3)
+	maxConfigDurationDays    = int64((1<<63 - 1) / (24 * time.Hour) / 3)
+)
+
+type integerDurationBound struct {
+	name  string
+	value int
+	max   int64
+}
+
+func (c *Config) validateIntegerDurationBounds() error {
+	fields := []integerDurationBound{
+		{name: "conductor.created_skew_seconds", value: c.Conductor.CreatedSkewSeconds, max: maxConfigDurationSeconds},
+		{name: "mcp_input_scanning.response_timeout_seconds", value: c.MCPInputScanning.ResponseTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "fetch_proxy.timeout_seconds", value: c.FetchProxy.TimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "response_scanning.ask_timeout_seconds", value: c.ResponseScanning.AskTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "forward_proxy.max_tunnel_seconds", value: c.ForwardProxy.MaxTunnelSeconds, max: maxConfigDurationSeconds},
+		{name: "forward_proxy.idle_timeout_seconds", value: c.ForwardProxy.IdleTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "websocket_proxy.max_connection_seconds", value: c.WebSocketProxy.MaxConnectionSeconds, max: maxConfigDurationSeconds},
+		{name: "websocket_proxy.idle_timeout_seconds", value: c.WebSocketProxy.IdleTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "reverse_proxy.request_timeout_seconds", value: c.ReverseProxy.RequestTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "defer.timeout_seconds", value: c.Defer.TimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "session_profiling.cleanup_interval_seconds", value: c.SessionProfiling.CleanupIntervalSeconds, max: maxConfigDurationSeconds},
+		{name: "adaptive_enforcement.level_duration_seconds", value: c.AdaptiveEnforcement.LevelDurationSeconds, max: maxConfigDurationSeconds},
+		{name: "adaptive_enforcement.deescalation_check_seconds", value: c.AdaptiveEnforcement.DeescalationCheckSeconds, max: maxConfigDurationSeconds},
+		{name: "health_watchdog.interval_seconds", value: c.HealthWatchdog.IntervalSeconds, max: maxConfigDurationSeconds},
+		{name: "emit.otlp.timeout_seconds", value: c.Emit.OTLP.TimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "emit.forwarder.timeout_seconds", value: c.Emit.Forwarder.TimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "emit.webhook.timeout_seconds", value: c.Emit.Webhook.TimeoutSecs, max: maxConfigDurationSeconds},
+		{name: "tool_chain_detection.window_seconds", value: c.ToolChainDetection.WindowSeconds, max: maxConfigDurationSeconds},
+		{name: "mediation_envelope.created_skew_seconds", value: c.MediationEnvelope.CreatedSkewSeconds, max: maxConfigDurationSeconds},
+		{name: "airlock.timers.drain_timeout_seconds", value: c.Airlock.Timers.DrainTimeoutSeconds, max: maxConfigDurationSeconds},
+		{name: "session_profiling.window_minutes", value: c.SessionProfiling.WindowMinutes, max: maxConfigDurationMinutes},
+		{name: "session_profiling.session_ttl_minutes", value: c.SessionProfiling.SessionTTLMinutes, max: maxConfigDurationMinutes},
+		{name: "cross_request_detection.entropy_budget.window_minutes", value: c.CrossRequestDetection.EntropyBudget.WindowMinutes, max: maxConfigDurationMinutes},
+		{name: "cross_request_detection.fragment_reassembly.window_minutes", value: c.CrossRequestDetection.FragmentReassembly.WindowMinutes, max: maxConfigDurationMinutes},
+		{name: "airlock.timers.soft_minutes", value: c.Airlock.Timers.SoftMinutes, max: maxConfigDurationMinutes},
+		{name: "airlock.timers.hard_minutes", value: c.Airlock.Timers.HardMinutes, max: maxConfigDurationMinutes},
+		{name: "airlock.timers.drain_minutes", value: c.Airlock.Timers.DrainMinutes, max: maxConfigDurationMinutes},
+		{name: "flight_recorder.retention_days", value: c.FlightRecorder.RetentionDays, max: maxConfigDurationDays},
+	}
+	for agentName, profile := range c.Agents {
+		fields = append(fields,
+			integerDurationBound{name: fmt.Sprintf("agents.%s.budget.window_minutes", agentName), value: profile.Budget.WindowMinutes, max: maxConfigDurationMinutes},
+			integerDurationBound{name: fmt.Sprintf("agents.%s.budget.max_wall_clock_minutes", agentName), value: profile.Budget.MaxWallClockMinutes, max: maxConfigDurationMinutes},
+		)
+	}
+	sort.Slice(fields, func(i, j int) bool { return fields[i].name < fields[j].name })
+	for _, field := range fields {
+		if int64(field.value) > field.max {
+			return fmt.Errorf("%s is too large: must be at most %d", field.name, field.max)
+		}
+	}
+	return nil
+}
+
 func isTextualUnscannablePassthroughType(mediaType string) bool {
 	if strings.HasPrefix(mediaType, "text/") {
 		return true
@@ -202,6 +264,9 @@ func (c *Config) Validate() error {
 // callers can surface every advisory emitted before the failing validator.
 func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	var warnings []Warning
+	if err := c.validateIntegerDurationBounds(); err != nil {
+		return warnings, err
+	}
 	if err := c.validateMode(); err != nil {
 		return warnings, err
 	}


### PR DESCRIPTION
## What changed

- Reject configured integer durations before unit conversion can reverse liveness, retention, or history-window behavior.
- Apply one shared bound across seconds-, minutes-, and days-based config fields, including disabled sections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject excessively large duration settings before they can cause errors.
  - Improved validation messages by identifying each invalid configuration field consistently.
  - Added safeguards for duration values expressed in seconds, minutes, days, and budget intervals.

- **Tests**
  - Added coverage for maximum safe duration values and overflow cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->