### PR TITLE
fix(conductor): reject overflowing skew capabilities

### DIFF
--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1500,7 +1500,7 @@ func (c CapabilitiesResponse) ValidateWithLocalThresholdCap(maxThreshold int) er
 	if !slices.Contains(c.ReceiptEntryVersions, recorder.CurrentWriteEntryVersion) {
 		return fmt.Errorf("%w: receipt_entry_versions must include recorder write version %d", ErrInvalidState, recorder.CurrentWriteEntryVersion)
 	}
-	if c.MaxCreatedSkewSeconds <= 0 || time.Duration(c.MaxCreatedSkewSeconds)*time.Second > MaxAllowedAuditSkew {
+	if c.MaxCreatedSkewSeconds <= 0 || c.MaxCreatedSkewSeconds > int(MaxAllowedAuditSkew/time.Second) {
 		return fmt.Errorf("%w: max_created_skew_seconds=%d", ErrSkewExceeded, c.MaxCreatedSkewSeconds)
 	}
 	for name, value := range map[string]int{

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -328,9 +328,10 @@ func TestCapabilitiesResponse_RequiresMTLSAndThresholds(t *testing.T) {
 		t.Fatalf("Validate() over skew cap = %v, want ErrSkewExceeded", err)
 	}
 
+	overflowingSkewSeconds := int64(math.MaxInt64)/int64(time.Second) + 1
 	if strconv.IntSize == 64 {
 		caps = validCapabilitiesResponse()
-		caps.MaxCreatedSkewSeconds = int(int64(math.MaxInt64)/int64(time.Second) + 1)
+		caps.MaxCreatedSkewSeconds = int(overflowingSkewSeconds)
 		err = caps.Validate()
 		if !errors.Is(err, ErrSkewExceeded) {
 			t.Fatalf("Validate() overflowing skew = %v, want ErrSkewExceeded", err)

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -325,6 +326,15 @@ func TestCapabilitiesResponse_RequiresMTLSAndThresholds(t *testing.T) {
 	err = caps.Validate()
 	if !errors.Is(err, ErrSkewExceeded) {
 		t.Fatalf("Validate() over skew cap = %v, want ErrSkewExceeded", err)
+	}
+
+	if strconv.IntSize == 64 {
+		caps = validCapabilitiesResponse()
+		caps.MaxCreatedSkewSeconds = int(int64(math.MaxInt64)/int64(time.Second) + 1)
+		err = caps.Validate()
+		if !errors.Is(err, ErrSkewExceeded) {
+			t.Fatalf("Validate() overflowing skew = %v, want ErrSkewExceeded", err)
+		}
 	}
 
 	caps = validCapabilitiesResponse()


### PR DESCRIPTION
## What changed

Reject conductor capability skew values before duration conversion can overflow and bypass ceiling validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of maximum timestamp skew values.
  * Correctly rejects excessively large skew settings, including values beyond the supported range.

* **Tests**
  * Added coverage for oversized skew values to ensure validation behaves consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->