### PR TITLE
fix(conductor): keep signed follower state fresh

### DIFF
--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -198,37 +198,43 @@ func TestProducer_OmitsAppliedStateWhenProviderNil(t *testing.T) {
 }
 
 func TestProducer_AppliedStateHeartbeatRunsIdleAndStopsOnClose(t *testing.T) {
-	fired := make(chan struct{}, 1)
-	var count atomic.Int64
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	finished := make(chan struct{})
 	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
 		EmitAppliedState:          true,
 		EmitAppliedStateHeartbeat: true,
 		HeartbeatInterval:         10 * time.Millisecond,
 		AppliedStateHeartbeat: func(context.Context) error {
-			count.Add(1)
-			select {
-			case fired <- struct{}{}:
-			default:
-			}
+			started <- struct{}{}
+			<-release
+			close(finished)
 			return nil
 		},
 	})
 	select {
-	case <-fired:
+	case <-started:
 	case <-time.After(time.Second):
 		t.Fatal("idle applied-state heartbeat did not fire")
 	}
 	if err := producer.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
-	closedCount := count.Load()
 	select {
 	case <-producer.heartbeatDone:
 	default:
 		t.Fatal("heartbeat goroutine still running after Close")
 	}
-	if count.Load() != closedCount {
-		t.Fatalf("applied-state heartbeat count advanced after close: %d -> %d", closedCount, count.Load())
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight heartbeat callback did not finish after release")
+	}
+	select {
+	case <-started:
+		t.Fatal("applied-state heartbeat started again after close")
+	default:
 	}
 }
 
@@ -258,13 +264,15 @@ func TestProducer_AppliedStateHeartbeatDisabledWithoutNegotiation(t *testing.T) 
 func TestProducer_CloseCancelsActiveAppliedStateHeartbeat(t *testing.T) {
 	started := make(chan struct{})
 	canceled := make(chan struct{})
+	var startedOnce sync.Once
+	var canceledOnce sync.Once
 	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
 		EmitAppliedStateHeartbeat: true,
 		HeartbeatInterval:         time.Millisecond,
 		AppliedStateHeartbeat: func(ctx context.Context) error {
-			close(started)
+			startedOnce.Do(func() { close(started) })
 			<-ctx.Done()
-			close(canceled)
+			canceledOnce.Do(func() { close(canceled) })
 			return ctx.Err()
 		},
 	})

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -6,9 +6,11 @@
 package auditbatcher
 
 import (
+	"context"
 	"crypto/ed25519"
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -94,6 +96,51 @@ func TestProducer_EmitsSignedAppliedStateWhenEnabled(t *testing.T) {
 	// applied-state (it is inside SignablePreimage).
 }
 
+func TestSignAppliedStateHeartbeat(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	heartbeat := conductor.AppliedStateHeartbeat{
+		SchemaVersion: conductor.SchemaVersion,
+		HeartbeatID:   "state-1",
+		OrgID:         "org-main",
+		FleetID:       "prod",
+		InstanceID:    "pl-prod-1",
+		EmittedAt:     now,
+		AppliedState: conductor.FollowerAppliedState{
+			PipelockVersion:       "3.1.0",
+			LastPolicyPollAt:      now,
+			LastSuccessfulApplyAt: now,
+			ObservedAt:            now,
+			ProvenanceAt:          now,
+		},
+	}
+	signed, err := SignAppliedStateHeartbeat(heartbeat, "audit-key-1", priv)
+	if err != nil {
+		t.Fatalf("SignAppliedStateHeartbeat: %v", err)
+	}
+	if err := signed.VerifySignaturesAt(now, func(id string) (conductor.SignatureKey, error) {
+		if id != "audit-key-1" {
+			return conductor.SignatureKey{}, errors.New("unknown key")
+		}
+		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	}); err != nil {
+		t.Fatalf("VerifySignaturesAt: %v", err)
+	}
+	if _, err := SignAppliedStateHeartbeat(heartbeat, "audit-key-1", ed25519.PrivateKey("short")); err == nil {
+		t.Fatal("SignAppliedStateHeartbeat(short key) = nil error")
+	}
+	if _, err := SignAppliedStateHeartbeat(heartbeat, "bad key id", priv); err == nil {
+		t.Fatal("SignAppliedStateHeartbeat(bad signer id) = nil error")
+	}
+	heartbeat.AppliedState.ProvenanceAt = time.Time{}
+	if _, err := SignAppliedStateHeartbeat(heartbeat, "audit-key-1", priv); err == nil {
+		t.Fatal("SignAppliedStateHeartbeat(missing provenance) = nil error")
+	}
+}
+
 func TestProducer_StampsObservedAtWhenProviderLeavesZero(t *testing.T) {
 	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
 	producer, q, auditPub := newAppliedStateProducer(t, ProducerConfig{
@@ -146,5 +193,58 @@ func TestProducer_OmitsAppliedStateWhenProviderNil(t *testing.T) {
 	batch := claimOneBatch(t, q, producer, auditPub)
 	if batch.Envelope.AppliedState != nil {
 		t.Fatalf("AppliedState = %+v, want nil (nil provider)", *batch.Envelope.AppliedState)
+	}
+}
+
+func TestProducer_AppliedStateHeartbeatRunsIdleAndStopsOnClose(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	var count atomic.Int64
+	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
+		EmitAppliedState:          true,
+		EmitAppliedStateHeartbeat: true,
+		HeartbeatInterval:         10 * time.Millisecond,
+		AppliedStateHeartbeat: func(context.Context) error {
+			count.Add(1)
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("idle applied-state heartbeat did not fire")
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	closedCount := count.Load()
+	<-time.After(30 * time.Millisecond)
+	if count.Load() != closedCount {
+		t.Fatalf("applied-state heartbeat count advanced after close: %d -> %d", closedCount, count.Load())
+	}
+}
+
+func TestProducer_AppliedStateHeartbeatDisabledWithoutNegotiation(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
+		// Audit schema v2 enables batch applied-state, but only v3 enables the
+		// recorder-independent heartbeat.
+		EmitAppliedState:  true,
+		HeartbeatInterval: time.Millisecond,
+		AppliedStateHeartbeat: func(context.Context) error {
+			fired <- struct{}{}
+			return nil
+		},
+	})
+	select {
+	case <-fired:
+		t.Fatal("unnegotiated applied-state heartbeat fired")
+	case <-time.After(20 * time.Millisecond):
+	}
+	if err := producer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
 	}
 }

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -221,7 +221,11 @@ func TestProducer_AppliedStateHeartbeatRunsIdleAndStopsOnClose(t *testing.T) {
 		t.Fatalf("Close() error = %v", err)
 	}
 	closedCount := count.Load()
-	<-time.After(30 * time.Millisecond)
+	select {
+	case <-producer.heartbeatDone:
+	default:
+		t.Fatal("heartbeat goroutine still running after Close")
+	}
 	if count.Load() != closedCount {
 		t.Fatalf("applied-state heartbeat count advanced after close: %d -> %d", closedCount, count.Load())
 	}
@@ -239,12 +243,37 @@ func TestProducer_AppliedStateHeartbeatDisabledWithoutNegotiation(t *testing.T) 
 			return nil
 		},
 	})
+	<-producer.heartbeatDone
 	select {
 	case <-fired:
 		t.Fatal("unnegotiated applied-state heartbeat fired")
-	case <-time.After(20 * time.Millisecond):
+	default:
 	}
 	if err := producer.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestProducer_CloseCancelsActiveAppliedStateHeartbeat(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
+		EmitAppliedStateHeartbeat: true,
+		HeartbeatInterval:         time.Millisecond,
+		AppliedStateHeartbeat: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			close(canceled)
+			return ctx.Err()
+		},
+	})
+	<-started
+	if err := producer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("active heartbeat context was not canceled by Close")
 	}
 }

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ed25519"
 	"errors"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -276,4 +277,32 @@ func TestProducer_CloseCancelsActiveAppliedStateHeartbeat(t *testing.T) {
 	default:
 		t.Fatal("active heartbeat context was not canceled by Close")
 	}
+}
+
+func TestProducer_CloseDoesNotWaitForHeartbeatIgnoringCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	producer, _, _ := newAppliedStateProducer(t, ProducerConfig{
+		EmitAppliedStateHeartbeat: true,
+		HeartbeatInterval:         time.Millisecond,
+		AppliedStateHeartbeat: func(context.Context) error {
+			startedOnce.Do(func() { close(started) })
+			<-release
+			return nil
+		},
+	})
+	<-started
+	closed := make(chan struct{})
+	go func() {
+		_ = producer.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("Close blocked on heartbeat callback that ignored cancellation")
+	}
+	close(release)
 }

--- a/enterprise/conductor/auditbatcher/applied_state_test.go
+++ b/enterprise/conductor/auditbatcher/applied_state_test.go
@@ -274,9 +274,45 @@ func TestProducer_CloseCancelsActiveAppliedStateHeartbeat(t *testing.T) {
 	}
 	select {
 	case <-canceled:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("active heartbeat context was not canceled by Close")
 	}
+}
+
+func TestProducer_AppliedStateHeartbeatRetriesAfterTimeout(t *testing.T) {
+	retried := make(chan struct{})
+	var calls atomic.Int64
+	var retriedOnce sync.Once
+	heartbeatContext, heartbeatCancel := context.WithCancel(context.Background())
+	producer := &Producer{
+		emitStateHeartbeat: true,
+		heartbeatInterval:  time.Millisecond,
+		heartbeatTimeout:   10 * time.Millisecond,
+		appliedStateHeartbeat: func(ctx context.Context) error {
+			if calls.Add(1) == 1 {
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			retriedOnce.Do(func() { close(retried) })
+			return nil
+		},
+		heartbeatContext: heartbeatContext,
+		heartbeatCancel:  heartbeatCancel,
+		heartbeatStop:    make(chan struct{}),
+		heartbeatDone:    make(chan struct{}),
+	}
+	go producer.runAppliedStateHeartbeat()
+	select {
+	case <-retried:
+	case <-time.After(time.Second):
+		heartbeatCancel()
+		close(producer.heartbeatStop)
+		<-producer.heartbeatDone
+		t.Fatal("applied-state heartbeat did not retry after a per-attempt timeout")
+	}
+	heartbeatCancel()
+	close(producer.heartbeatStop)
+	<-producer.heartbeatDone
 }
 
 func TestProducer_CloseDoesNotWaitForHeartbeatIgnoringCancellation(t *testing.T) {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -7,6 +7,7 @@ package auditbatcher
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
@@ -25,8 +26,10 @@ import (
 )
 
 const (
-	defaultProducerBuffer       = 4096
-	maxActiveRecorderNamespaces = 1024
+	defaultProducerBuffer                = 4096
+	defaultAppliedStateHeartbeatInterval = time.Minute
+	defaultAppliedStateHeartbeatTimeout  = 5 * time.Second
+	maxActiveRecorderNamespaces          = 1024
 
 	actionReceiptEntryType = "action_receipt"
 	checkpointEntryType    = "checkpoint"
@@ -46,27 +49,32 @@ const (
 // emit.Emitter: enqueue failures need durable drop accounting rather than
 // fire-and-forget sink behavior.
 type Producer struct {
-	queue                *Queue
-	metrics              MetricsSink
-	orgID                string
-	fleetID              string
-	instanceID           string
-	auditSignerKeyID     string
-	recorderKeyID        string
-	followerPubHex       string
-	auditSigner          ed25519.PrivateKey
-	now                  func() time.Time
-	entries              chan recorder.Entry
-	done                 chan struct{}
-	closeOnce            sync.Once
-	sendMu               sync.RWMutex
-	closed               atomic.Bool
-	dropMu               sync.Mutex
-	dropped              map[string]uint64
-	previousSegmentTail  string
-	previousSegmentTails map[string]string
-	emitAppliedState     bool
-	appliedStateProvider func() (conductor.FollowerAppliedState, bool)
+	queue                 *Queue
+	metrics               MetricsSink
+	orgID                 string
+	fleetID               string
+	instanceID            string
+	auditSignerKeyID      string
+	recorderKeyID         string
+	followerPubHex        string
+	auditSigner           ed25519.PrivateKey
+	now                   func() time.Time
+	entries               chan recorder.Entry
+	done                  chan struct{}
+	closeOnce             sync.Once
+	sendMu                sync.RWMutex
+	closed                atomic.Bool
+	dropMu                sync.Mutex
+	dropped               map[string]uint64
+	previousSegmentTail   string
+	previousSegmentTails  map[string]string
+	emitAppliedState      bool
+	emitStateHeartbeat    bool
+	appliedStateProvider  func() (conductor.FollowerAppliedState, bool)
+	appliedStateHeartbeat func(context.Context) error
+	heartbeatInterval     time.Duration
+	heartbeatStop         chan struct{}
+	heartbeatDone         chan struct{}
 }
 
 type ProducerConfig struct {
@@ -89,11 +97,19 @@ type ProducerConfig struct {
 	// false so the wire form is byte-identical to v1 and passes the conductor's
 	// strict unknown-field decoder. Default false = do not emit (fail-safe).
 	EmitAppliedState bool
+	// EmitAppliedStateHeartbeat gates the recorder-independent heartbeat. It
+	// must only be true when capability negotiation confirmed audit schema v3.
+	EmitAppliedStateHeartbeat bool
 	// AppliedStateProvider supplies the current applied-state snapshot when
 	// EmitAppliedState is true. It is a callback so the producer stays decoupled
 	// from applycache/policysync; returning ok=false leaves applied-state off
 	// the batch (best-effort) while the batch itself still flows.
 	AppliedStateProvider func() (conductor.FollowerAppliedState, bool)
+	// AppliedStateHeartbeat sends a recorder-independent signed state update.
+	// It runs periodically only when EmitAppliedState was negotiated. Failures
+	// are best-effort: the next interval retries with a fresh statement.
+	AppliedStateHeartbeat func(context.Context) error
+	HeartbeatInterval     time.Duration
 }
 
 func NewProducer(cfg ProducerConfig) (*Producer, error) {
@@ -126,25 +142,34 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if cfg.Now == nil {
 		cfg.Now = func() time.Time { return time.Now().UTC() }
 	}
+	if cfg.HeartbeatInterval <= 0 {
+		cfg.HeartbeatInterval = defaultAppliedStateHeartbeatInterval
+	}
 	p := &Producer{
-		queue:                cfg.Queue,
-		metrics:              cfg.Metrics,
-		orgID:                cfg.OrgID,
-		fleetID:              cfg.FleetID,
-		instanceID:           cfg.InstanceID,
-		auditSignerKeyID:     cfg.AuditSignerKeyID,
-		recorderKeyID:        cfg.RecorderKeyID,
-		followerPubHex:       hex.EncodeToString(cfg.RecorderPublicKey),
-		auditSigner:          append(ed25519.PrivateKey(nil), cfg.AuditSigner...),
-		now:                  cfg.Now,
-		entries:              make(chan recorder.Entry, cfg.BufferSize),
-		done:                 make(chan struct{}),
-		dropped:              map[string]uint64{},
-		previousSegmentTails: map[string]string{},
-		emitAppliedState:     cfg.EmitAppliedState,
-		appliedStateProvider: cfg.AppliedStateProvider,
+		queue:                 cfg.Queue,
+		metrics:               cfg.Metrics,
+		orgID:                 cfg.OrgID,
+		fleetID:               cfg.FleetID,
+		instanceID:            cfg.InstanceID,
+		auditSignerKeyID:      cfg.AuditSignerKeyID,
+		recorderKeyID:         cfg.RecorderKeyID,
+		followerPubHex:        hex.EncodeToString(cfg.RecorderPublicKey),
+		auditSigner:           append(ed25519.PrivateKey(nil), cfg.AuditSigner...),
+		now:                   cfg.Now,
+		entries:               make(chan recorder.Entry, cfg.BufferSize),
+		done:                  make(chan struct{}),
+		dropped:               map[string]uint64{},
+		previousSegmentTails:  map[string]string{},
+		emitAppliedState:      cfg.EmitAppliedState,
+		emitStateHeartbeat:    cfg.EmitAppliedStateHeartbeat,
+		appliedStateProvider:  cfg.AppliedStateProvider,
+		appliedStateHeartbeat: cfg.AppliedStateHeartbeat,
+		heartbeatInterval:     cfg.HeartbeatInterval,
+		heartbeatStop:         make(chan struct{}),
+		heartbeatDone:         make(chan struct{}),
 	}
 	go p.run()
+	go p.runAppliedStateHeartbeat()
 	return p, nil
 }
 
@@ -175,10 +200,31 @@ func (p *Producer) Close() error {
 		p.sendMu.Lock()
 		defer p.sendMu.Unlock()
 		p.closed.Store(true)
+		close(p.heartbeatStop)
 		close(p.entries)
 		<-p.done
+		<-p.heartbeatDone
 	})
 	return nil
+}
+
+func (p *Producer) runAppliedStateHeartbeat() {
+	defer close(p.heartbeatDone)
+	if !p.emitStateHeartbeat || p.appliedStateHeartbeat == nil {
+		return
+	}
+	ticker := time.NewTicker(p.heartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), defaultAppliedStateHeartbeatTimeout)
+			_ = p.appliedStateHeartbeat(ctx)
+			cancel()
+		case <-p.heartbeatStop:
+			return
+		}
+	}
 }
 
 func (p *Producer) run() {

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -73,6 +73,7 @@ type Producer struct {
 	appliedStateProvider  func() (conductor.FollowerAppliedState, bool)
 	appliedStateHeartbeat func(context.Context) error
 	heartbeatInterval     time.Duration
+	heartbeatTimeout      time.Duration
 	heartbeatContext      context.Context
 	heartbeatCancel       context.CancelFunc
 	heartbeatStop         chan struct{}
@@ -168,6 +169,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 		appliedStateProvider:  cfg.AppliedStateProvider,
 		appliedStateHeartbeat: cfg.AppliedStateHeartbeat,
 		heartbeatInterval:     cfg.HeartbeatInterval,
+		heartbeatTimeout:      defaultAppliedStateHeartbeatTimeout,
 		heartbeatContext:      heartbeatContext,
 		heartbeatCancel:       heartbeatCancel,
 		heartbeatStop:         make(chan struct{}),
@@ -224,7 +226,7 @@ func (p *Producer) runAppliedStateHeartbeat() {
 	for {
 		select {
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(p.heartbeatContext, defaultAppliedStateHeartbeatTimeout)
+			ctx, cancel := context.WithTimeout(p.heartbeatContext, p.heartbeatTimeout)
 			result := make(chan error, 1)
 			go func() {
 				result <- p.appliedStateHeartbeat(ctx)
@@ -234,7 +236,12 @@ func (p *Producer) runAppliedStateHeartbeat() {
 				cancel()
 			case <-ctx.Done():
 				cancel()
-				return
+				select {
+				case <-result:
+					continue
+				case <-p.heartbeatContext.Done():
+					return
+				}
 			}
 		case <-p.heartbeatStop:
 			return

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -225,8 +225,17 @@ func (p *Producer) runAppliedStateHeartbeat() {
 		select {
 		case <-ticker.C:
 			ctx, cancel := context.WithTimeout(p.heartbeatContext, defaultAppliedStateHeartbeatTimeout)
-			_ = p.appliedStateHeartbeat(ctx)
-			cancel()
+			result := make(chan error, 1)
+			go func() {
+				result <- p.appliedStateHeartbeat(ctx)
+			}()
+			select {
+			case <-result:
+				cancel()
+			case <-ctx.Done():
+				cancel()
+				return
+			}
 		case <-p.heartbeatStop:
 			return
 		}

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -108,7 +108,7 @@ type ProducerConfig struct {
 	// the batch (best-effort) while the batch itself still flows.
 	AppliedStateProvider func() (conductor.FollowerAppliedState, bool)
 	// AppliedStateHeartbeat sends a recorder-independent signed state update.
-	// It runs periodically only when EmitAppliedState was negotiated. Failures
+	// It runs periodically only when EmitAppliedStateHeartbeat was negotiated. Failures
 	// are best-effort: the next interval retries with a fresh statement.
 	AppliedStateHeartbeat func(context.Context) error
 	HeartbeatInterval     time.Duration

--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -73,6 +73,8 @@ type Producer struct {
 	appliedStateProvider  func() (conductor.FollowerAppliedState, bool)
 	appliedStateHeartbeat func(context.Context) error
 	heartbeatInterval     time.Duration
+	heartbeatContext      context.Context
+	heartbeatCancel       context.CancelFunc
 	heartbeatStop         chan struct{}
 	heartbeatDone         chan struct{}
 }
@@ -145,6 +147,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if cfg.HeartbeatInterval <= 0 {
 		cfg.HeartbeatInterval = defaultAppliedStateHeartbeatInterval
 	}
+	heartbeatContext, heartbeatCancel := context.WithCancel(context.Background())
 	p := &Producer{
 		queue:                 cfg.Queue,
 		metrics:               cfg.Metrics,
@@ -165,6 +168,8 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 		appliedStateProvider:  cfg.AppliedStateProvider,
 		appliedStateHeartbeat: cfg.AppliedStateHeartbeat,
 		heartbeatInterval:     cfg.HeartbeatInterval,
+		heartbeatContext:      heartbeatContext,
+		heartbeatCancel:       heartbeatCancel,
 		heartbeatStop:         make(chan struct{}),
 		heartbeatDone:         make(chan struct{}),
 	}
@@ -200,6 +205,7 @@ func (p *Producer) Close() error {
 		p.sendMu.Lock()
 		defer p.sendMu.Unlock()
 		p.closed.Store(true)
+		p.heartbeatCancel()
 		close(p.heartbeatStop)
 		close(p.entries)
 		<-p.done
@@ -218,7 +224,7 @@ func (p *Producer) runAppliedStateHeartbeat() {
 	for {
 		select {
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), defaultAppliedStateHeartbeatTimeout)
+			ctx, cancel := context.WithTimeout(p.heartbeatContext, defaultAppliedStateHeartbeatTimeout)
 			_ = p.appliedStateHeartbeat(ctx)
 			cancel()
 		case <-p.heartbeatStop:

--- a/enterprise/conductor/auditbatcher/sign.go
+++ b/enterprise/conductor/auditbatcher/sign.go
@@ -42,3 +42,30 @@ func SignEnvelope(envelope conductor.AuditBatchEnvelope, signerKeyID string, pri
 	}
 	return envelope, nil
 }
+
+// SignAppliedStateHeartbeat signs a recorder-independent applied-state
+// heartbeat with the enrolled follower audit key.
+func SignAppliedStateHeartbeat(heartbeat conductor.AppliedStateHeartbeat, signerKeyID string, priv ed25519.PrivateKey) (conductor.AppliedStateHeartbeat, error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return conductor.AppliedStateHeartbeat{}, fmt.Errorf("auditbatcher: private key length=%d want=%d", len(priv), ed25519.PrivateKeySize)
+	}
+	heartbeat.Signatures = nil
+	preimage, err := heartbeat.SignablePreimage()
+	if err != nil {
+		return conductor.AppliedStateHeartbeat{}, fmt.Errorf("auditbatcher: heartbeat signable preimage: %w", err)
+	}
+	proof := conductor.SignatureProof{
+		SignerKeyID: signerKeyID,
+		KeyPurpose:  signing.PurposeAuditBatchSigning,
+		Algorithm:   conductor.SignatureAlgorithmEd25519,
+		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
+	}
+	if err := proof.Validate(signing.PurposeAuditBatchSigning); err != nil {
+		return conductor.AppliedStateHeartbeat{}, fmt.Errorf("auditbatcher: heartbeat signature proof: %w", err)
+	}
+	heartbeat.Signatures = []conductor.SignatureProof{proof}
+	if err := heartbeat.Validate(); err != nil {
+		return conductor.AppliedStateHeartbeat{}, fmt.Errorf("auditbatcher: signed heartbeat: %w", err)
+	}
+	return heartbeat, nil
+}

--- a/enterprise/conductor/capabilities.go
+++ b/enterprise/conductor/capabilities.go
@@ -42,6 +42,7 @@ type NegotiatedCapabilities struct {
 	AuditSchemaVersion     int
 	CreatedSkew            time.Duration
 	EmergencyStream        bool
+	AppliedStateHeartbeat  bool
 	RemoteKillThreshold    int
 	RollbackThreshold      int
 	TrustRotationThreshold int
@@ -175,6 +176,7 @@ func NegotiateCapabilities(c CapabilitiesResponse, local LocalFollowerCapabiliti
 		// the follower has opted in locally. Either side disabled means polling
 		// fallback only.
 		EmergencyStream:        c.EmergencyStream && local.EmergencyStream,
+		AppliedStateHeartbeat:  c.AuditBatch.Max >= AppliedStateHeartbeatSchemaVersion,
 		RemoteKillThreshold:    c.RemoteKillThreshold,
 		RollbackThreshold:      c.RollbackThreshold,
 		TrustRotationThreshold: c.TrustRotationThreshold,

--- a/enterprise/conductor/capabilities_test.go
+++ b/enterprise/conductor/capabilities_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestNegotiateCapabilities(t *testing.T) {
 	resp := validHandshakeCapabilitiesResponse()
+	resp.AuditBatch.Max = AppliedStateHeartbeatSchemaVersion
 	resp.MaxCreatedSkewSeconds = 120
 
 	got, err := NegotiateCapabilities(resp, LocalFollowerCapabilities{
@@ -37,14 +38,29 @@ func TestNegotiateCapabilities(t *testing.T) {
 	if got.SchemaVersion != SchemaVersion {
 		t.Fatalf("SchemaVersion = %d, want %d", got.SchemaVersion, SchemaVersion)
 	}
-	if got.AuditSchemaVersion != SchemaVersion {
-		t.Fatalf("AuditSchemaVersion = %d, want %d", got.AuditSchemaVersion, SchemaVersion)
+	if got.AuditSchemaVersion != AuditEnvelopeSchemaVersion {
+		t.Fatalf("AuditSchemaVersion = %d, want %d", got.AuditSchemaVersion, AuditEnvelopeSchemaVersion)
 	}
 	if got.CreatedSkew != 60*time.Second {
 		t.Fatalf("CreatedSkew = %s, want 60s", got.CreatedSkew)
 	}
 	if !got.EmergencyStream {
 		t.Fatal("EmergencyStream = false, want true")
+	}
+	if !got.AppliedStateHeartbeat {
+		t.Fatal("AppliedStateHeartbeat = false, want negotiated support")
+	}
+}
+
+func TestNegotiateCapabilities_OldConductorDoesNotEnableHeartbeat(t *testing.T) {
+	resp := validHandshakeCapabilitiesResponse()
+	resp.AuditBatch.Max = AuditEnvelopeSchemaVersion
+	got, err := NegotiateCapabilities(resp, LocalFollowerCapabilities{})
+	if err != nil {
+		t.Fatalf("NegotiateCapabilities() error = %v", err)
+	}
+	if got.AppliedStateHeartbeat {
+		t.Fatal("AppliedStateHeartbeat = true against an old conductor")
 	}
 }
 

--- a/enterprise/conductor/controlplane/applied_state_heartbeat.go
+++ b/enterprise/conductor/controlplane/applied_state_heartbeat.go
@@ -1,0 +1,109 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+)
+
+var ErrAppliedStateReplay = errors.New("conductor applied-state heartbeat is not newer than verified state")
+
+type AcceptedAppliedStateHeartbeat struct {
+	Identity      FollowerIdentity
+	Heartbeat     conductor.AppliedStateHeartbeat
+	HeartbeatHash string
+	ReceivedAt    time.Time
+}
+
+type AppliedStateHeartbeatStatus string
+
+const (
+	AppliedStateHeartbeatAccepted  AppliedStateHeartbeatStatus = "accepted"
+	AppliedStateHeartbeatDuplicate AppliedStateHeartbeatStatus = "duplicate"
+)
+
+type AppliedStateHeartbeatSink interface {
+	IngestAppliedStateHeartbeat(context.Context, AcceptedAppliedStateHeartbeat) (AppliedStateHeartbeatStatus, error)
+}
+
+func (h *Handler) handleAppliedStateHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if h.capabilities.AuditBatch.Max < conductor.AppliedStateHeartbeatSchemaVersion {
+		writeError(w, http.StatusNotImplemented, conductor.ErrUnsupportedSchemaVersion)
+		return
+	}
+	sink, ok := h.auditSink.(AppliedStateHeartbeatSink)
+	if !ok || sink == nil {
+		writeError(w, http.StatusNotImplemented, ErrAuditSinkRequired)
+		return
+	}
+	identity, err := h.followerIdentity(r)
+	if err != nil || identity.Validate() != nil {
+		writeError(w, http.StatusUnauthorized, ErrFollowerRequired)
+		return
+	}
+	var heartbeat conductor.AppliedStateHeartbeat
+	if err := decodeStrictJSON(w, r, h.maxRequestBody, &heartbeat); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, conductor.ErrPayloadTooLarge)
+			return
+		}
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	acceptedAt := h.now()
+	if heartbeat.OrgID != identity.OrgID || heartbeat.FleetID != identity.FleetID || heartbeat.InstanceID != identity.InstanceID {
+		writeAuditIngestError(w, conductor.ErrAudienceMismatch)
+		return
+	}
+	if err := heartbeat.ValidateForConductor(acceptedAt, conductor.DefaultAuditMaxSkew); err != nil {
+		writeAuditIngestError(w, err)
+		return
+	}
+	if err := heartbeat.VerifySignaturesAt(acceptedAt, func(signerKeyID string) (conductor.SignatureKey, error) {
+		return h.auditKeys(identity, signerKeyID)
+	}); err != nil {
+		writeAuditIngestError(w, err)
+		return
+	}
+	heartbeatHash, err := heartbeat.CanonicalHash()
+	if err != nil {
+		writeAuditIngestError(w, err)
+		return
+	}
+	status, err := sink.IngestAppliedStateHeartbeat(r.Context(), AcceptedAppliedStateHeartbeat{
+		Identity:      identity,
+		Heartbeat:     heartbeat,
+		HeartbeatHash: heartbeatHash,
+		ReceivedAt:    acceptedAt,
+	})
+	if err != nil {
+		if errors.Is(err, ErrAppliedStateReplay) {
+			writeError(w, http.StatusConflict, ErrAppliedStateReplay)
+			return
+		}
+		writeAuditSinkError(w, err)
+		return
+	}
+	if status == "" {
+		status = AppliedStateHeartbeatAccepted
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"status":         status,
+		"heartbeat_id":   heartbeat.HeartbeatID,
+		"heartbeat_hash": heartbeatHash,
+		"accepted_at":    acceptedAt.UTC(),
+	})
+}

--- a/enterprise/conductor/controlplane/applied_state_heartbeat_test.go
+++ b/enterprise/conductor/controlplane/applied_state_heartbeat_test.go
@@ -1,0 +1,298 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package controlplane
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
+)
+
+type heartbeatSinkStub struct {
+	status AppliedStateHeartbeatStatus
+	err    error
+}
+
+func (s heartbeatSinkStub) IngestAuditBatch(context.Context, AcceptedAuditBatch) (AuditIngestResult, error) {
+	return AuditIngestResult{}, nil
+}
+
+func (s heartbeatSinkStub) IngestAppliedStateHeartbeat(context.Context, AcceptedAppliedStateHeartbeat) (AppliedStateHeartbeatStatus, error) {
+	return s.status, s.err
+}
+
+func signedAppliedStateHeartbeat(t *testing.T, identity FollowerIdentity, priv ed25519.PrivateKey, id string, observed time.Time) conductor.AppliedStateHeartbeat {
+	t.Helper()
+	state := validTestAppliedState(observed)
+	state.ProvenanceAt = observed
+	heartbeat, err := auditbatcher.SignAppliedStateHeartbeat(conductor.AppliedStateHeartbeat{
+		SchemaVersion: conductor.SchemaVersion,
+		HeartbeatID:   id,
+		OrgID:         identity.OrgID,
+		FleetID:       identity.FleetID,
+		InstanceID:    identity.InstanceID,
+		EmittedAt:     observed,
+		AppliedState:  state,
+	}, "audit-key-1", priv)
+	if err != nil {
+		t.Fatalf("SignAppliedStateHeartbeat() error = %v", err)
+	}
+	return heartbeat
+}
+
+func postAppliedStateHeartbeat(t *testing.T, handler *Handler, heartbeat conductor.AppliedStateHeartbeat) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(heartbeat)
+	if err != nil {
+		t.Fatalf("Marshal(heartbeat) error = %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AppliedStateHeartbeatPath, strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func TestAppliedStateHeartbeat_EndToEndReplayAndRestart(t *testing.T) {
+	pub, priv := testAuditSigner(t)
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store := openTestSQLiteAuditStore(t, dbPath)
+	handler := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 0)
+	identity := defaultFollowerIdentity()
+	first := signedAppliedStateHeartbeat(t, identity, priv, "state-1", testNow.Add(-30*time.Second))
+
+	if w := postAppliedStateHeartbeat(t, handler, first); w.Code != http.StatusAccepted {
+		t.Fatalf("first heartbeat code = %d body=%s", w.Code, w.Body.String())
+	}
+	stored, ok, err := store.GetVerifiedAppliedState(context.Background(), identity.OrgID, identity.FleetID, identity.InstanceID)
+	if err != nil || !ok {
+		t.Fatalf("GetVerifiedAppliedState() = ok %v err %v", ok, err)
+	}
+	if stored.BatchID != first.HeartbeatID || !stored.Verified || !stored.AppliedState.ProvenanceAt.Equal(first.AppliedState.ProvenanceAt) {
+		t.Fatalf("stored heartbeat = %+v", stored)
+	}
+
+	if w := postAppliedStateHeartbeat(t, handler, first); w.Code != http.StatusAccepted || !strings.Contains(w.Body.String(), `"status":"duplicate"`) {
+		t.Fatalf("duplicate heartbeat code = %d body=%s", w.Code, w.Body.String())
+	}
+	older := signedAppliedStateHeartbeat(t, identity, priv, "state-old", testNow.Add(-40*time.Second))
+	if w := postAppliedStateHeartbeat(t, handler, older); w.Code != http.StatusConflict {
+		t.Fatalf("older replay code = %d body=%s, want 409", w.Code, w.Body.String())
+	}
+	sameTime := signedAppliedStateHeartbeat(t, identity, priv, "state-divergent", first.AppliedState.ObservedAt)
+	sameTime.AppliedState.ActiveBundleID = "bundle-divergent"
+	sameTime, err = auditbatcher.SignAppliedStateHeartbeat(sameTime, "audit-key-1", priv)
+	if err != nil {
+		t.Fatalf("resign divergent heartbeat: %v", err)
+	}
+	if w := postAppliedStateHeartbeat(t, handler, sameTime); w.Code != http.StatusConflict {
+		t.Fatalf("same-time divergent heartbeat code = %d body=%s, want 409", w.Code, w.Body.String())
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reopened := openTestSQLiteAuditStore(t, dbPath)
+	restartedHandler := newAuditIngestTestHandler(t, reopened, auditKeyResolverFor(pub), 0)
+	if w := postAppliedStateHeartbeat(t, restartedHandler, older); w.Code != http.StatusConflict {
+		t.Fatalf("post-restart replay code = %d body=%s, want 409", w.Code, w.Body.String())
+	}
+	newer := signedAppliedStateHeartbeat(t, identity, priv, "state-2", testNow.Add(-10*time.Second))
+	if w := postAppliedStateHeartbeat(t, restartedHandler, newer); w.Code != http.StatusAccepted {
+		t.Fatalf("post-restart newer code = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAppliedStateHeartbeat_FailsClosedOnIdentitySignatureAndSkew(t *testing.T) {
+	pub, priv := testAuditSigner(t)
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	handler := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 0)
+	identity := defaultFollowerIdentity()
+
+	spoofed := signedAppliedStateHeartbeat(t, identity, priv, "state-spoof", testNow)
+	spoofed.InstanceID = "another-follower"
+	spoofed, _ = auditbatcher.SignAppliedStateHeartbeat(spoofed, "audit-key-1", priv)
+	if w := postAppliedStateHeartbeat(t, handler, spoofed); w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed identity code = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+
+	_, wrongPriv := testAuditSigner(t)
+	wrongKey := signedAppliedStateHeartbeat(t, identity, wrongPriv, "state-wrong-key", testNow)
+	if w := postAppliedStateHeartbeat(t, handler, wrongKey); w.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong signature code = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+
+	stale := signedAppliedStateHeartbeat(t, identity, priv, "state-stale", testNow.Add(-2*conductor.DefaultAuditMaxSkew))
+	if w := postAppliedStateHeartbeat(t, handler, stale); w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("stale heartbeat code = %d body=%s, want 422", w.Code, w.Body.String())
+	}
+}
+
+func TestAppliedStateHeartbeat_DisabledWhenCapabilityRangeStopsAtV2(t *testing.T) {
+	pub, priv := testAuditSigner(t)
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	handler := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 0)
+	handler.capabilities.AuditBatch.Max = conductor.AuditEnvelopeSchemaVersion
+	heartbeat := signedAppliedStateHeartbeat(t, defaultFollowerIdentity(), priv, "state-v2", testNow)
+	if w := postAppliedStateHeartbeat(t, handler, heartbeat); w.Code != http.StatusNotImplemented {
+		t.Fatalf("v2-only conductor heartbeat code = %d body=%s, want 501", w.Code, w.Body.String())
+	}
+}
+
+func TestAppliedStateHeartbeat_HandlerErrors(t *testing.T) {
+	pub, priv := testAuditSigner(t)
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	handler := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 0)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		body   string
+		want   int
+	}{
+		{name: "method", method: http.MethodGet, want: http.StatusMethodNotAllowed},
+		{name: "malformed_json", method: http.MethodPost, body: `{`, want: http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, AppliedStateHeartbeatPath, strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d body=%s, want %d", w.Code, w.Body.String(), tc.want)
+			}
+		})
+	}
+
+	withoutSink := newAuditIngestTestHandler(t, discardAuditSink{}, auditKeyResolverFor(pub), 0)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, AppliedStateHeartbeatPath, strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	withoutSink.ServeHTTP(w, req)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("missing sink status = %d body=%s, want 501", w.Code, w.Body.String())
+	}
+
+	limited := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 8)
+	limited.maxRequestBody = 1
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, AppliedStateHeartbeatPath, strings.NewReader(`{}`))
+	w = httptest.NewRecorder()
+	limited.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized status = %d body=%s, want 413", w.Code, w.Body.String())
+	}
+
+	identityFailure := newAuditIngestTestHandler(t, store, auditKeyResolverFor(pub), 0)
+	identityFailure.followerIdentity = func(*http.Request) (FollowerIdentity, error) {
+		return FollowerIdentity{}, errors.New("identity unavailable")
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, AppliedStateHeartbeatPath, strings.NewReader(`{}`))
+	w = httptest.NewRecorder()
+	identityFailure.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("identity failure status = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+
+	heartbeat := signedAppliedStateHeartbeat(t, defaultFollowerIdentity(), priv, "state-sink-error", testNow)
+	for _, tc := range []struct {
+		name string
+		sink heartbeatSinkStub
+		want int
+	}{
+		{name: "sink_error", sink: heartbeatSinkStub{err: errors.New("sink failed")}, want: http.StatusInternalServerError},
+		{name: "empty_status_defaults", sink: heartbeatSinkStub{}, want: http.StatusAccepted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newAuditIngestTestHandler(t, tc.sink, auditKeyResolverFor(pub), 0)
+			got := postAppliedStateHeartbeat(t, h, heartbeat)
+			if got.Code != tc.want {
+				t.Fatalf("status = %d body=%s, want %d", got.Code, got.Body.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestAppliedStateHeartbeat_StoreRejectsInvalidAcceptedRecords(t *testing.T) {
+	identity := defaultFollowerIdentity()
+	_, priv := testAuditSigner(t)
+	heartbeat := signedAppliedStateHeartbeat(t, identity, priv, "state-store-errors", testNow)
+	hash, err := heartbeat.CanonicalHash()
+	if err != nil {
+		t.Fatalf("CanonicalHash: %v", err)
+	}
+	accepted := AcceptedAppliedStateHeartbeat{
+		Identity:      identity,
+		Heartbeat:     heartbeat,
+		HeartbeatHash: hash,
+		ReceivedAt:    testNow,
+	}
+	var nilStore *SQLiteAuditStore
+	if _, err := nilStore.IngestAppliedStateHeartbeat(context.Background(), accepted); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("nil store error = %v, want ErrAuditSinkRequired", err)
+	}
+	store := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "audit.db"))
+	var missingContext context.Context
+	if _, err := store.IngestAppliedStateHeartbeat(missingContext, accepted); !errors.Is(err, ErrAuditSinkRequired) {
+		t.Fatalf("missing context error = %v, want ErrAuditSinkRequired", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := store.IngestAppliedStateHeartbeat(canceled, accepted); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled context error = %v, want context.Canceled", err)
+	}
+	mismatched := accepted
+	mismatched.Identity.InstanceID = "another-instance"
+	if _, err := store.IngestAppliedStateHeartbeat(context.Background(), mismatched); !errors.Is(err, conductor.ErrAudienceMismatch) {
+		t.Fatalf("identity mismatch error = %v, want ErrAudienceMismatch", err)
+	}
+	badHash := accepted
+	badHash.HeartbeatHash = strings.Repeat("0", 64)
+	if _, err := store.IngestAppliedStateHeartbeat(context.Background(), badHash); !errors.Is(err, ErrInvalidStoreRecord) {
+		t.Fatalf("hash mismatch error = %v, want ErrInvalidStoreRecord", err)
+	}
+
+	stale := accepted
+	stale.ReceivedAt = testNow.Add(2 * conductor.DefaultAuditMaxSkew)
+	if _, err := store.IngestAppliedStateHeartbeat(context.Background(), stale); !errors.Is(err, conductor.ErrSkewExceeded) {
+		t.Fatalf("stale heartbeat error = %v, want ErrSkewExceeded", err)
+	}
+
+	closed := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "closed.db"))
+	if err := closed.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := closed.IngestAppliedStateHeartbeat(context.Background(), accepted); err == nil {
+		t.Fatal("closed store ingest = nil error")
+	}
+	broken := openTestSQLiteAuditStore(t, filepath.Join(t.TempDir(), "broken.db"))
+	if _, err := broken.db.ExecContext(context.Background(), `DROP TABLE verified_applied_state`); err != nil {
+		t.Fatalf("drop verified_applied_state: %v", err)
+	}
+	if _, err := broken.IngestAppliedStateHeartbeat(context.Background(), accepted); err == nil {
+		t.Fatal("missing table ingest = nil error")
+	}
+
+	freshNow := time.Now().UTC()
+	freshHeartbeat := signedAppliedStateHeartbeat(t, identity, priv, "state-zero-received", freshNow)
+	freshHash, err := freshHeartbeat.CanonicalHash()
+	if err != nil {
+		t.Fatalf("fresh CanonicalHash: %v", err)
+	}
+	if status, err := store.IngestAppliedStateHeartbeat(context.Background(), AcceptedAppliedStateHeartbeat{
+		Identity:      identity,
+		Heartbeat:     freshHeartbeat,
+		HeartbeatHash: freshHash,
+	}); err != nil || status != AppliedStateHeartbeatAccepted {
+		t.Fatalf("zero ReceivedAt ingest = %q, %v", status, err)
+	}
+}

--- a/enterprise/conductor/controlplane/audit_store.go
+++ b/enterprise/conductor/controlplane/audit_store.go
@@ -634,6 +634,88 @@ func upsertVerifiedAppliedStateTx(ctx context.Context, tx *sql.Tx, batch Accepte
 	return nil
 }
 
+// IngestAppliedStateHeartbeat advances the verified fleet view without adding
+// a synthetic audit event. The observed_at comparison is the replay contract:
+// exact retries of the current heartbeat are idempotent, while older,
+// same-time divergent, or out-of-order statements fail closed.
+func (s *SQLiteAuditStore) IngestAppliedStateHeartbeat(ctx context.Context, accepted AcceptedAppliedStateHeartbeat) (AppliedStateHeartbeatStatus, error) {
+	if s == nil || s.db == nil {
+		return "", ErrAuditSinkRequired
+	}
+	if ctx == nil {
+		return "", fmt.Errorf("%w: context", ErrAuditSinkRequired)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if accepted.Heartbeat.OrgID != accepted.Identity.OrgID || accepted.Heartbeat.FleetID != accepted.Identity.FleetID || accepted.Heartbeat.InstanceID != accepted.Identity.InstanceID {
+		return "", conductor.ErrAudienceMismatch
+	}
+	if accepted.ReceivedAt.IsZero() {
+		accepted.ReceivedAt = time.Now().UTC()
+	}
+	if err := accepted.Heartbeat.ValidateForConductor(accepted.ReceivedAt, conductor.DefaultAuditMaxSkew); err != nil {
+		return "", err
+	}
+	hash, err := accepted.Heartbeat.CanonicalHash()
+	if err != nil {
+		return "", err
+	}
+	if hash != accepted.HeartbeatHash {
+		return "", fmt.Errorf("%w: heartbeat_hash mismatch", ErrInvalidStoreRecord)
+	}
+	appliedJSON, err := json.Marshal(accepted.Heartbeat.AppliedState)
+	if err != nil {
+		return "", fmt.Errorf("marshal conductor heartbeat applied state: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin conductor heartbeat transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO verified_applied_state (
+			org_id, fleet_id, instance_id, applied_state_json,
+			signer_key_id, batch_id, envelope_hash, observed_at, verified_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(org_id, fleet_id, instance_id) DO UPDATE SET
+			applied_state_json = excluded.applied_state_json,
+			signer_key_id      = excluded.signer_key_id,
+			batch_id           = excluded.batch_id,
+			envelope_hash      = excluded.envelope_hash,
+			observed_at        = excluded.observed_at,
+			verified_at        = excluded.verified_at
+		WHERE excluded.observed_at > verified_applied_state.observed_at
+	`, accepted.Heartbeat.OrgID, accepted.Heartbeat.FleetID, accepted.Heartbeat.InstanceID, appliedJSON,
+		firstSignerKeyID(accepted.Heartbeat.Signatures), accepted.Heartbeat.HeartbeatID, accepted.HeartbeatHash,
+		accepted.Heartbeat.AppliedState.ObservedAt.UTC(), accepted.ReceivedAt.UTC())
+	if err != nil {
+		return "", fmt.Errorf("upsert conductor heartbeat applied state: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return "", fmt.Errorf("count conductor heartbeat upsert: %w", err)
+	}
+	status := AppliedStateHeartbeatAccepted
+	if rows == 0 {
+		var currentHash string
+		if err := tx.QueryRowContext(ctx, `
+			SELECT envelope_hash FROM verified_applied_state
+			WHERE org_id = ? AND fleet_id = ? AND instance_id = ?
+		`, accepted.Heartbeat.OrgID, accepted.Heartbeat.FleetID, accepted.Heartbeat.InstanceID).Scan(&currentHash); err != nil {
+			return "", fmt.Errorf("read conductor heartbeat replay state: %w", err)
+		}
+		if currentHash != accepted.HeartbeatHash {
+			return "", ErrAppliedStateReplay
+		}
+		status = AppliedStateHeartbeatDuplicate
+	}
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit conductor heartbeat transaction: %w", err)
+	}
+	return status, nil
+}
+
 // GetVerifiedAppliedState returns the latest verified applied-state for one
 // follower, or ok=false when none is recorded.
 func (s *SQLiteAuditStore) GetVerifiedAppliedState(ctx context.Context, orgID, fleetID, instanceID string) (VerifiedAppliedState, bool, error) {

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -463,7 +463,7 @@ func DefaultCapabilities(conductorID string) conductor.CapabilitiesResponse {
 		ConductorBundle:        conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		RemoteKill:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
 		RollbackAuthorization:  conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.SchemaVersion},
-		AuditBatch:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.AuditEnvelopeSchemaVersion},
+		AuditBatch:             conductor.SchemaRange{Min: conductor.SchemaVersion, Max: conductor.AppliedStateHeartbeatSchemaVersion},
 		ReceiptEntryVersions:   conductor.SupportedAuditEntryVersions(),
 		MaxCreatedSkewSeconds:  int(conductor.DefaultAuditMaxSkew / time.Second),
 		EmergencyStream:        false,
@@ -525,6 +525,8 @@ func (h *Handler) serveControlHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleListFollowers(w, r)
 	case FollowerRuntimeStatusPath:
 		h.handleFollowerRuntimeStatus(w, r)
+	case AppliedStateHeartbeatPath:
+		h.handleAppliedStateHeartbeat(w, r)
 	case StreamStatusPath:
 		h.handleStreamStatus(w, r)
 	default:
@@ -585,7 +587,7 @@ func conductorRoute(path string) string {
 		return AuditBatchesPath
 	}
 	switch path {
-	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, RemoteKillPath, RemoteKillEvaluatePath, RollbackAuthorizationsPath, RollbackEvaluatePath, DecisionReplayPath, PublishPolicyBundlePath, PublishPolicyEvaluatePath, LatestPolicyBundlePath, AuditBatchesPath, FollowersPath, FollowerRuntimeStatusPath, StreamStatusPath:
+	case HealthPath, HealthzPath, MetricsPath, ReadyzPath, conductor.CapabilitiesPath, EnrollmentTokensPath, EnrollPath, RemoteKillPath, RemoteKillEvaluatePath, RollbackAuthorizationsPath, RollbackEvaluatePath, DecisionReplayPath, PublishPolicyBundlePath, PublishPolicyEvaluatePath, LatestPolicyBundlePath, AuditBatchesPath, FollowersPath, FollowerRuntimeStatusPath, AppliedStateHeartbeatPath, StreamStatusPath:
 		return path
 	default:
 		return "unknown"

--- a/enterprise/conductor/controlplane/runtime_status.go
+++ b/enterprise/conductor/controlplane/runtime_status.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	FollowerRuntimeStatusPath = "/api/v1/conductor/follower/status"
+	AppliedStateHeartbeatPath = "/api/v1/conductor/follower/applied-state"
 
 	defaultRuntimeStatusStaleAfter  = 5 * time.Minute
 	maxFollowerRuntimeStatusRecords = 10000
@@ -397,6 +398,12 @@ func classifySignedAppliedState(follower FollowerSummary, signed VerifiedApplied
 	}
 	if provenance.IsZero() || now.Sub(provenance) > staleAfter || provenance.After(now.Add(staleAfter)) {
 		return FleetHealthStale, "signed_state_stale"
+	}
+	// A heartbeat proves the follower is alive, not that policy polling is
+	// advancing. Require the signed policy-poll timestamp to stay fresh so a
+	// live process with a dead policy channel cannot present as healthy.
+	if applied.LastPolicyPollAt.IsZero() || now.Sub(applied.LastPolicyPollAt) > staleAfter || applied.LastPolicyPollAt.After(now.Add(staleAfter)) {
+		return FleetHealthStale, "policy_poll_stale"
 	}
 	if applied.LastApplyErrorCode != "" || applied.LastApplyErrorMessage != "" {
 		return FleetHealthApplyFailed, "last_apply_failed"

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -1463,6 +1463,14 @@ func TestClassifySignedAppliedState_DualFreshnessGate(t *testing.T) {
 			wantDrift:  "",
 		},
 		{
+			name:       "fresh heartbeat with stale policy poll is stale",
+			verifiedAt: testNow.Add(-30 * time.Second),
+			provenance: testNow.Add(-30 * time.Second),
+			observed:   testNow.Add(-2 * staleAfter),
+			wantHealth: FleetHealthStale,
+			wantDrift:  "policy_poll_stale",
+		},
+		{
 			name:       "fresh verified but stale provenance is stale",
 			verifiedAt: testNow.Add(-30 * time.Second),
 			provenance: testNow.Add(-2 * staleAfter),

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -1301,6 +1301,9 @@ func (h AppliedStateHeartbeat) ValidateForConductor(now time.Time, maxSkew time.
 	if maxSkew > MaxAllowedAuditSkew {
 		return fmt.Errorf("%w: max_skew %s exceeds ceiling %s", ErrSkewExceeded, maxSkew, MaxAllowedAuditSkew)
 	}
+	now = now.UTC()
+	minStamp := now.Add(-maxSkew)
+	maxStamp := now.Add(maxSkew)
 	for _, candidate := range []struct {
 		field string
 		stamp time.Time
@@ -1309,13 +1312,9 @@ func (h AppliedStateHeartbeat) ValidateForConductor(now time.Time, maxSkew time.
 		{field: "applied_state.observed_at", stamp: h.AppliedState.ObservedAt},
 		{field: "applied_state.provenance_at", stamp: h.AppliedState.ProvenanceAt},
 	} {
-		field, stamp := candidate.field, candidate.stamp
-		delta := now.UTC().Sub(stamp.UTC())
-		if delta < 0 {
-			delta = -delta
-		}
-		if delta > maxSkew {
-			return fmt.Errorf("%w: |now-%s|=%s max_skew=%s", ErrSkewExceeded, field, delta, maxSkew)
+		field, stamp := candidate.field, candidate.stamp.UTC()
+		if stamp.Before(minStamp) || stamp.After(maxStamp) {
+			return fmt.Errorf("%w: %s outside [%s,%s]", ErrSkewExceeded, field, minStamp.Format(time.RFC3339Nano), maxStamp.Format(time.RFC3339Nano))
 		}
 	}
 	return nil

--- a/enterprise/conductor/messages.go
+++ b/enterprise/conductor/messages.go
@@ -69,6 +69,11 @@ const (
 	// follower talking to an old (v1-only) conductor omits applied_state and
 	// stays wire-identical to v1.
 	AuditEnvelopeSchemaVersion = 2
+	// AppliedStateHeartbeatSchemaVersion is advertised through the existing
+	// audit-batch capability range rather than a new top-level capability field.
+	// Older followers strictly reject unknown JSON fields, but safely cap a
+	// larger known range at their local v2 maximum during rolling upgrades.
+	AppliedStateHeartbeatSchemaVersion = 3
 
 	// MaxRuntimeStringBytes bounds each short applied-state / runtime-status
 	// string field (versions, bundle ids, error code). MaxApplyErrorMessageRunes
@@ -445,6 +450,26 @@ type FollowerAppliedState struct {
 	LastApplyErrorMessage          string    `json:"last_apply_error_message,omitempty"`
 	ObservedAt                     time.Time `json:"observed_at"`
 	ProvenanceAt                   time.Time `json:"provenance_at,omitempty"`
+}
+
+// AppliedStateHeartbeat is a follower-signed, recorder-independent statement
+// of the policy and binary state the follower is currently running. It exists
+// so an idle follower can keep its verified fleet state fresh without
+// manufacturing recorder entries or weakening the fleet view to trust the
+// unsigned runtime-status channel.
+//
+// The enclosing identity is bound to the authenticated mTLS follower at
+// ingest. ObservedAt is also the monotonic replay key: a conductor accepts only
+// a statement newer than the verified state it already holds for that follower.
+type AppliedStateHeartbeat struct {
+	SchemaVersion int                  `json:"schema_version"`
+	HeartbeatID   string               `json:"heartbeat_id"`
+	OrgID         string               `json:"org_id"`
+	FleetID       string               `json:"fleet_id"`
+	InstanceID    string               `json:"instance_id"`
+	EmittedAt     time.Time            `json:"emitted_at"`
+	AppliedState  FollowerAppliedState `json:"applied_state"`
+	Signatures    []SignatureProof     `json:"signatures,omitempty"`
 }
 
 type AuditBatchEnvelope struct {
@@ -1224,6 +1249,84 @@ func (a AuditBatchEnvelope) SignablePreimage() ([]byte, error) {
 		unsigned.AppliedState = &applied
 	}
 	return canonicalPreimage(unsigned, "audit_batch")
+}
+
+func (h AppliedStateHeartbeat) SignablePreimage() ([]byte, error) {
+	unsigned := h
+	unsigned.Signatures = nil
+	unsigned.EmittedAt = unsigned.EmittedAt.UTC()
+	unsigned.AppliedState.LastPolicyPollAt = unsigned.AppliedState.LastPolicyPollAt.UTC()
+	unsigned.AppliedState.LastSuccessfulApplyAt = unsigned.AppliedState.LastSuccessfulApplyAt.UTC()
+	unsigned.AppliedState.ObservedAt = unsigned.AppliedState.ObservedAt.UTC()
+	unsigned.AppliedState.ProvenanceAt = unsigned.AppliedState.ProvenanceAt.UTC()
+	return canonicalPreimage(unsigned, "applied_state_heartbeat")
+}
+
+func (h AppliedStateHeartbeat) CanonicalHash() (string, error) {
+	return canonicalHash(h.SignablePreimage)
+}
+
+func (h AppliedStateHeartbeat) Validate() error {
+	if err := validateSchemaVersion(h.SchemaVersion); err != nil {
+		return err
+	}
+	if err := validateIdentifier("heartbeat_id", h.HeartbeatID); err != nil {
+		return err
+	}
+	if err := validateOrgFleet(h.OrgID, h.FleetID); err != nil {
+		return err
+	}
+	if err := validateIdentifier("instance_id", h.InstanceID); err != nil {
+		return err
+	}
+	if h.EmittedAt.IsZero() {
+		return fmt.Errorf("%w: emitted_at", ErrMissingField)
+	}
+	if err := h.AppliedState.Validate(); err != nil {
+		return err
+	}
+	if h.AppliedState.ProvenanceAt.IsZero() {
+		return fmt.Errorf("%w: applied_state.provenance_at", ErrMissingField)
+	}
+	return validateSignatureThreshold(h.Signatures, signing.PurposeAuditBatchSigning, RequiredStandardSigners)
+}
+
+func (h AppliedStateHeartbeat) ValidateForConductor(now time.Time, maxSkew time.Duration) error {
+	if err := h.Validate(); err != nil {
+		return err
+	}
+	if maxSkew <= 0 {
+		maxSkew = DefaultAuditMaxSkew
+	}
+	if maxSkew > MaxAllowedAuditSkew {
+		return fmt.Errorf("%w: max_skew %s exceeds ceiling %s", ErrSkewExceeded, maxSkew, MaxAllowedAuditSkew)
+	}
+	for _, candidate := range []struct {
+		field string
+		stamp time.Time
+	}{
+		{field: "emitted_at", stamp: h.EmittedAt},
+		{field: "applied_state.observed_at", stamp: h.AppliedState.ObservedAt},
+		{field: "applied_state.provenance_at", stamp: h.AppliedState.ProvenanceAt},
+	} {
+		field, stamp := candidate.field, candidate.stamp
+		delta := now.UTC().Sub(stamp.UTC())
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta > maxSkew {
+			return fmt.Errorf("%w: |now-%s|=%s max_skew=%s", ErrSkewExceeded, field, delta, maxSkew)
+		}
+	}
+	return nil
+}
+
+func (h AppliedStateHeartbeat) VerifySignaturesAt(now time.Time, resolve SignatureKeyResolver) error {
+	preimage, err := h.SignablePreimage()
+	if err != nil {
+		return err
+	}
+	return verifySignatureThreshold(now, preimage, h.Signatures, signing.PurposeAuditBatchSigning, RequiredStandardSigners, resolve)
 }
 
 func (a AuditBatchEnvelope) CanonicalHash() (string, error) {

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -1669,6 +1669,100 @@ func TestAuditBatchEnvelope_VerifySignatures(t *testing.T) {
 	}
 }
 
+func TestAppliedStateHeartbeat_CryptoAndValidation(t *testing.T) {
+	now := testNow
+	heartbeat := AppliedStateHeartbeat{
+		SchemaVersion: SchemaVersion,
+		HeartbeatID:   "state-1",
+		OrgID:         "org-main",
+		FleetID:       "prod",
+		InstanceID:    "pl-prod-1",
+		EmittedAt:     now,
+		AppliedState: FollowerAppliedState{
+			PipelockVersion:       "3.1.0",
+			LastPolicyPollAt:      now,
+			LastSuccessfulApplyAt: now,
+			ObservedAt:            now,
+			ProvenanceAt:          now,
+		},
+	}
+	pub, proof := signedProof(t, heartbeat.SignablePreimage, "audit-key-1", signing.PurposeAuditBatchSigning)
+	heartbeat.Signatures = []SignatureProof{proof}
+	resolver := mapResolver(map[string]SignatureKey{
+		"audit-key-1": {PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning},
+	})
+	if err := heartbeat.ValidateForConductor(now, DefaultAuditMaxSkew); err != nil {
+		t.Fatalf("ValidateForConductor: %v", err)
+	}
+	if _, err := heartbeat.CanonicalHash(); err != nil {
+		t.Fatalf("CanonicalHash: %v", err)
+	}
+	if err := heartbeat.VerifySignaturesAt(now, resolver); err != nil {
+		t.Fatalf("VerifySignaturesAt: %v", err)
+	}
+
+	tampered := heartbeat
+	tampered.HeartbeatID = "state-2"
+	if err := tampered.VerifySignaturesAt(now, resolver); !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("VerifySignaturesAt(tampered) = %v, want ErrSignatureVerification", err)
+	}
+	stale := heartbeat
+	stale.EmittedAt = now.Add(-2 * DefaultAuditMaxSkew)
+	if err := stale.ValidateForConductor(now, DefaultAuditMaxSkew); !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForConductor(stale) = %v, want ErrSkewExceeded", err)
+	}
+	if err := heartbeat.ValidateForConductor(now, MaxAllowedAuditSkew+time.Second); !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForConductor(over cap) = %v, want ErrSkewExceeded", err)
+	}
+	missing := heartbeat
+	missing.AppliedState.ProvenanceAt = time.Time{}
+	if err := missing.Validate(); !errors.Is(err, ErrMissingField) {
+		t.Fatalf("Validate(missing provenance) = %v, want ErrMissingField", err)
+	}
+
+	invalidCases := []struct {
+		name   string
+		mutate func(*AppliedStateHeartbeat)
+	}{
+		{name: "schema", mutate: func(h *AppliedStateHeartbeat) { h.SchemaVersion = 0 }},
+		{name: "heartbeat_id", mutate: func(h *AppliedStateHeartbeat) { h.HeartbeatID = "bad id" }},
+		{name: "org", mutate: func(h *AppliedStateHeartbeat) { h.OrgID = "" }},
+		{name: "instance", mutate: func(h *AppliedStateHeartbeat) { h.InstanceID = "bad id" }},
+		{name: "emitted_at", mutate: func(h *AppliedStateHeartbeat) { h.EmittedAt = time.Time{} }},
+		{name: "applied_state", mutate: func(h *AppliedStateHeartbeat) { h.AppliedState.ActiveBundleHash = "bad" }},
+	}
+	for _, tc := range invalidCases {
+		t.Run(tc.name, func(t *testing.T) {
+			invalid := heartbeat
+			tc.mutate(&invalid)
+			if err := invalid.Validate(); err == nil {
+				t.Fatal("Validate() = nil error")
+			}
+		})
+	}
+	invalidForConductor := heartbeat
+	invalidForConductor.SchemaVersion = 0
+	if err := invalidForConductor.ValidateForConductor(now, DefaultAuditMaxSkew); err == nil {
+		t.Fatal("ValidateForConductor(invalid heartbeat) = nil error")
+	}
+
+	if err := heartbeat.ValidateForConductor(now, 0); err != nil {
+		t.Fatalf("ValidateForConductor(default skew) = %v", err)
+	}
+	future := heartbeat
+	future.EmittedAt = now.Add(DefaultAuditMaxSkew / 2)
+	pub, futureProof := signedProof(t, future.SignablePreimage, "audit-key-2", signing.PurposeAuditBatchSigning)
+	future.Signatures = []SignatureProof{futureProof}
+	if err := future.ValidateForConductor(now, DefaultAuditMaxSkew); err != nil {
+		t.Fatalf("ValidateForConductor(future within skew) = %v", err)
+	}
+	if err := future.VerifySignaturesAt(now, mapResolver(map[string]SignatureKey{
+		"audit-key-2": {PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning},
+	})); err != nil {
+		t.Fatalf("VerifySignaturesAt(future) = %v", err)
+	}
+}
+
 func TestValidationEdgeCases(t *testing.T) {
 	t.Run("signature_proof_missing_signer", func(t *testing.T) {
 		err := (SignatureProof{KeyPurpose: signing.PurposePolicyBundleSigning, Algorithm: SignatureAlgorithmEd25519, Signature: testSignature("aa")}).

--- a/enterprise/conductor/messages_test.go
+++ b/enterprise/conductor/messages_test.go
@@ -1711,6 +1711,11 @@ func TestAppliedStateHeartbeat_CryptoAndValidation(t *testing.T) {
 	if err := stale.ValidateForConductor(now, DefaultAuditMaxSkew); !errors.Is(err, ErrSkewExceeded) {
 		t.Fatalf("ValidateForConductor(stale) = %v, want ErrSkewExceeded", err)
 	}
+	extremeFuture := heartbeat
+	extremeFuture.EmittedAt = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+	if err := extremeFuture.ValidateForConductor(now, DefaultAuditMaxSkew); !errors.Is(err, ErrSkewExceeded) {
+		t.Fatalf("ValidateForConductor(extreme future) = %v, want ErrSkewExceeded", err)
+	}
 	if err := heartbeat.ValidateForConductor(now, MaxAllowedAuditSkew+time.Second); !errors.Is(err, ErrSkewExceeded) {
 		t.Fatalf("ValidateForConductor(over cap) = %v, want ErrSkewExceeded", err)
 	}

--- a/enterprise/dashboard/fleetoverview.tmpl.html
+++ b/enterprise/dashboard/fleetoverview.tmpl.html
@@ -205,8 +205,8 @@
                   <td>
                     <div>verified at {{.VerifiedAtDisplay}}</div>
                     <div class="sub mono">signer {{.SignerKeyDisplay}}</div>
-                    <div class="sub mono">batch {{.BatchIDDisplay}}</div>
-                    <div class="sub value mono">envelope {{.EnvelopeHashDisplay}}</div>
+                    <div class="sub mono">evidence {{.BatchIDDisplay}}</div>
+                    <div class="sub value mono">statement {{.EnvelopeHashDisplay}}</div>
                   </td>
                   <td>
                     <div>{{.LastApplyErrorCodeDisplay}}</div>

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -754,23 +754,32 @@ func (s *Server) initConductorProducer(cfg *config.Config, m *metrics.Metrics, r
 	// fail-safe — any handshake failure (or an old v1 conductor) leaves it off,
 	// so batches still flow without applied-state and stay v1-wire-compatible.
 	emitApplied := false
+	emitHeartbeat := false
 	var appliedProvider func() (conductor.FollowerAppliedState, bool)
 	if reporter, ok := s.conductorStatusReporter.(*conductorPolicyStatusReporter); ok && reporter != nil {
 		appliedProvider = reporter.appliedStateProvider()
-		emitApplied = conductorNegotiateEmitAppliedState(cfg.Conductor, stderr)
+		emitApplied, emitHeartbeat = conductorNegotiateAppliedState(cfg.Conductor, stderr)
+		reporter.configureAppliedStateHeartbeat(emitHeartbeat, cfg.Conductor.AuditSigningKeyID, recPrivKey)
 	}
 	producer, err := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
-		Queue:                queue,
-		Metrics:              m,
-		OrgID:                cfg.Conductor.OrgID,
-		FleetID:              cfg.Conductor.FleetID,
-		InstanceID:           cfg.Conductor.InstanceID,
-		AuditSignerKeyID:     cfg.Conductor.AuditSigningKeyID,
-		RecorderKeyID:        cfg.Conductor.RecorderKeyID,
-		AuditSigner:          recPrivKey,
-		RecorderPublicKey:    recPubKey,
-		EmitAppliedState:     emitApplied,
-		AppliedStateProvider: appliedProvider,
+		Queue:                     queue,
+		Metrics:                   m,
+		OrgID:                     cfg.Conductor.OrgID,
+		FleetID:                   cfg.Conductor.FleetID,
+		InstanceID:                cfg.Conductor.InstanceID,
+		AuditSignerKeyID:          cfg.Conductor.AuditSigningKeyID,
+		RecorderKeyID:             cfg.Conductor.RecorderKeyID,
+		AuditSigner:               recPrivKey,
+		RecorderPublicKey:         recPubKey,
+		EmitAppliedState:          emitApplied,
+		EmitAppliedStateHeartbeat: emitHeartbeat,
+		AppliedStateProvider:      appliedProvider,
+		AppliedStateHeartbeat: func(ctx context.Context) error {
+			if reporter, ok := s.conductorStatusReporter.(*conductorPolicyStatusReporter); ok && reporter != nil {
+				return reporter.reportCurrentAppliedStateHeartbeat(ctx)
+			}
+			return nil
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating conductor audit producer: %w", err)
@@ -792,20 +801,20 @@ func conductorRecorderPublicKey(priv ed25519.PrivateKey) (ed25519.PublicKey, err
 	return pub, nil
 }
 
-// conductorNegotiateEmitAppliedState performs a best-effort capabilities
+// conductorNegotiateAppliedState performs a best-effort capabilities
 // handshake and reports whether the conductor accepts audit-envelope schema v2
 // (and therefore the signed applied-state field). It fails safe: any error, or
 // an older v1-only conductor, returns false so the producer omits applied-state
 // and its batches stay byte-identical to v1 past the conductor's strict
 // unknown-field decoder.
-func conductorNegotiateEmitAppliedState(cfg config.Conductor, stderr io.Writer) bool {
+func conductorNegotiateAppliedState(cfg config.Conductor, stderr io.Writer) (bool, bool) {
 	client, err := newConductorMTLSClient(cfg)
 	if err != nil {
-		return false
+		return false, false
 	}
 	capClient, err := conductor.NewCapabilitiesClient(cfg.ConductorURL, client, conductor.LocalFollowerCapabilities{})
 	if err != nil {
-		return false
+		return false, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), conductorAppliedStateHandshakeTimeout)
 	defer cancel()
@@ -814,7 +823,7 @@ func conductorNegotiateEmitAppliedState(cfg config.Conductor, stderr io.Writer) 
 		if stderr != nil {
 			_, _ = fmt.Fprintf(stderr, "  Conductor: applied-state schema negotiation unavailable (%v); omitting signed applied-state\n", err)
 		}
-		return false
+		return false, false
 	}
-	return negotiated.AuditSchemaVersion >= conductor.AuditEnvelopeSchemaVersion
+	return negotiated.AuditSchemaVersion >= conductor.AuditEnvelopeSchemaVersion, negotiated.AppliedStateHeartbeat
 }

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -201,6 +201,25 @@ func TestAppliedStateHeartbeat_FailureDoesNotFailRuntimeStatus(t *testing.T) {
 	}
 }
 
+func TestAppliedStateHeartbeat_RejectsUnexpectedSuccessStatus(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	reporter.latest.Store(&policysync.StatusEvent{PollAt: time.Now().UTC()})
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != controlplane.AppliedStateHeartbeatPath {
+			t.Fatalf("request path = %s, want %s", req.URL.Path, controlplane.AppliedStateHeartbeatPath)
+		}
+		return responseWithBody(http.StatusOK, `{"status":"ok"}`), nil
+	}}
+	if err := reporter.reportCurrentAppliedStateHeartbeat(context.Background()); err == nil {
+		t.Fatal("reportCurrentAppliedStateHeartbeat() error = nil, want rejection of HTTP 200")
+	}
+}
+
 func TestAppliedStateHeartbeat_RemainsOffWithoutNegotiation(t *testing.T) {
 	reporter := newAppliedStateReporter(t)
 	_, priv, err := ed25519.GenerateKey(nil)

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -220,6 +220,26 @@ func TestAppliedStateHeartbeat_CurrentSnapshot(t *testing.T) {
 	}
 }
 
+func TestAppliedStateHeartbeat_CurrentSnapshotWaitsForFirstPoll(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	requests := 0
+	reporter.client = statusReporterDoer{fn: func(*http.Request) (*http.Response, error) {
+		requests++
+		return responseWithBody(http.StatusAccepted, `{"status":"accepted"}`), nil
+	}}
+	if err := reporter.reportCurrentAppliedStateHeartbeat(context.Background()); err != nil {
+		t.Fatalf("reportCurrentAppliedStateHeartbeat() error = %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("heartbeat requests before first policy poll = %d, want 0", requests)
+	}
+}
+
 // TestAppliedStateProvider_MatchesUnsignedStatus proves the signed applied-state
 // and the unsigned runtime-status POST derive from one source, so the two fleet
 // views never disagree on what the follower is running.

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -247,6 +248,70 @@ func TestAppliedStateHeartbeat_CurrentSnapshot(t *testing.T) {
 	}
 	if !got.AppliedState.LastPolicyPollAt.Equal(wantPoll) {
 		t.Fatalf("LastPolicyPollAt = %v, want %v", got.AppliedState.LastPolicyPollAt, wantPoll)
+	}
+}
+
+func TestAppliedStateHeartbeat_CurrentSnapshotCannotPublishAfterNewerStatus(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	olderPoll := time.Now().UTC().Add(-2 * time.Minute)
+	newerPoll := olderPoll.Add(time.Minute)
+	reporter.latest.Store(&policysync.StatusEvent{PollAt: olderPoll})
+	snapshotLoaded := make(chan struct{})
+	releaseSnapshot := make(chan struct{})
+	reporter.afterHeartbeatSnapshot = func() {
+		close(snapshotLoaded)
+		<-releaseSnapshot
+	}
+	primarySent := make(chan struct{})
+	var heartbeatsMu sync.Mutex
+	heartbeatPolls := make([]time.Time, 0, 2)
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case controlplane.FollowerRuntimeStatusPath:
+			close(primarySent)
+			return responseWithBody(http.StatusOK, `{"status":"ok"}`), nil
+		case controlplane.AppliedStateHeartbeatPath:
+			var heartbeat conductor.AppliedStateHeartbeat
+			if err := json.NewDecoder(req.Body).Decode(&heartbeat); err != nil {
+				t.Fatalf("decode heartbeat: %v", err)
+			}
+			heartbeatsMu.Lock()
+			heartbeatPolls = append(heartbeatPolls, heartbeat.AppliedState.LastPolicyPollAt)
+			heartbeatsMu.Unlock()
+			return responseWithBody(http.StatusAccepted, `{"status":"accepted"}`), nil
+		default:
+			t.Fatalf("unexpected request path %s", req.URL.Path)
+			return nil, errors.New("unreachable")
+		}
+	}}
+
+	currentDone := make(chan error, 1)
+	go func() { currentDone <- reporter.reportCurrentAppliedStateHeartbeat(context.Background()) }()
+	<-snapshotLoaded
+	statusDone := make(chan error, 1)
+	go func() {
+		statusDone <- reporter.ReportPolicyStatus(context.Background(), policysync.StatusEvent{PollAt: newerPoll})
+	}()
+	<-primarySent
+	close(releaseSnapshot)
+	if err := <-currentDone; err != nil {
+		t.Fatalf("reportCurrentAppliedStateHeartbeat() error = %v", err)
+	}
+	if err := <-statusDone; err != nil {
+		t.Fatalf("ReportPolicyStatus() error = %v", err)
+	}
+	heartbeatsMu.Lock()
+	defer heartbeatsMu.Unlock()
+	if len(heartbeatPolls) != 2 {
+		t.Fatalf("heartbeat count = %d, want 2", len(heartbeatPolls))
+	}
+	if !heartbeatPolls[0].Equal(olderPoll) || !heartbeatPolls[1].Equal(newerPoll) {
+		t.Fatalf("heartbeat poll order = %v, want older %v then newer %v", heartbeatPolls, olderPoll, newerPoll)
 	}
 }
 

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -170,6 +170,36 @@ func TestAppliedStateHeartbeat_EmitsOnIdlePolicyPollWhenNegotiated(t *testing.T)
 	}
 }
 
+func TestAppliedStateHeartbeat_FailureDoesNotFailRuntimeStatus(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	statusRequests := 0
+	heartbeatRequests := 0
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case controlplane.FollowerRuntimeStatusPath:
+			statusRequests++
+			return responseWithBody(http.StatusOK, `{"status":"ok"}`), nil
+		case controlplane.AppliedStateHeartbeatPath:
+			heartbeatRequests++
+			return nil, errors.New("heartbeat unavailable")
+		default:
+			t.Fatalf("unexpected request path %s", req.URL.Path)
+			return nil, errors.New("unreachable")
+		}
+	}}
+	if err := reporter.ReportPolicyStatus(context.Background(), policysync.StatusEvent{PollAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("ReportPolicyStatus() error = %v, want nil after successful runtime status", err)
+	}
+	if statusRequests != 1 || heartbeatRequests != 1 {
+		t.Fatalf("requests = status %d, heartbeat %d; want 1 each", statusRequests, heartbeatRequests)
+	}
+}
+
 func TestAppliedStateHeartbeat_RemainsOffWithoutNegotiation(t *testing.T) {
 	reporter := newAppliedStateReporter(t)
 	_, priv, err := ed25519.GenerateKey(nil)

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -7,7 +7,10 @@ package runtime
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -16,9 +19,11 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/enrollmentclient"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/policysync"
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 func newAppliedStateReporter(t *testing.T) *conductorPolicyStatusReporter {
@@ -112,6 +117,106 @@ func TestAppliedStateProvider_SanitizesErrorMessageStaysValid(t *testing.T) {
 	}
 	if err := state.Validate(); err != nil {
 		t.Fatalf("sanitized applied-state invalid: %v", err)
+	}
+}
+
+func TestAppliedStateHeartbeat_EmitsOnIdlePolicyPollWhenNegotiated(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	var heartbeat conductor.AppliedStateHeartbeat
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case controlplane.FollowerRuntimeStatusPath:
+			return responseWithBody(http.StatusOK, `{"status":"ok"}`), nil
+		case controlplane.AppliedStateHeartbeatPath:
+			body, readErr := io.ReadAll(req.Body)
+			if readErr != nil {
+				t.Fatalf("read heartbeat body: %v", readErr)
+			}
+			if unmarshalErr := json.Unmarshal(body, &heartbeat); unmarshalErr != nil {
+				t.Fatalf("decode heartbeat: %v", unmarshalErr)
+			}
+			return responseWithBody(http.StatusAccepted, `{"status":"accepted"}`), nil
+		default:
+			t.Fatalf("unexpected request path %s", req.URL.Path)
+			return nil, errors.New("unreachable")
+		}
+	}}
+
+	pollAt := time.Now().UTC().Add(-4 * time.Minute)
+	if err := reporter.ReportPolicyStatus(context.Background(), policysync.StatusEvent{PollAt: pollAt}); err != nil {
+		t.Fatalf("ReportPolicyStatus() error = %v", err)
+	}
+	if heartbeat.HeartbeatID == "" {
+		t.Fatal("signed heartbeat was not emitted")
+	}
+	if !heartbeat.AppliedState.LastPolicyPollAt.Equal(pollAt) {
+		t.Fatalf("LastPolicyPollAt = %v, want %v", heartbeat.AppliedState.LastPolicyPollAt, pollAt)
+	}
+	if time.Since(heartbeat.AppliedState.ObservedAt) > time.Minute {
+		t.Fatalf("ObservedAt = %v, want fresh heartbeat time", heartbeat.AppliedState.ObservedAt)
+	}
+	if err := heartbeat.VerifySignaturesAt(time.Now().UTC(), func(id string) (conductor.SignatureKey, error) {
+		if id != "audit-key-main-1" {
+			return conductor.SignatureKey{}, errors.New("unknown key")
+		}
+		return conductor.SignatureKey{PublicKey: pub, KeyPurpose: signing.PurposeAuditBatchSigning}, nil
+	}); err != nil {
+		t.Fatalf("VerifySignaturesAt() error = %v", err)
+	}
+}
+
+func TestAppliedStateHeartbeat_RemainsOffWithoutNegotiation(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	// A downgrade/reload must clear a previously negotiated signer, not leave
+	// the old heartbeat capability active in memory.
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	reporter.configureAppliedStateHeartbeat(false, "audit-key-main-1", priv)
+	requests := 0
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.Path != controlplane.FollowerRuntimeStatusPath {
+			t.Fatalf("unexpected unnegotiated request path %s", req.URL.Path)
+		}
+		return responseWithBody(http.StatusOK, `{"status":"ok"}`), nil
+	}}
+	if err := reporter.ReportPolicyStatus(context.Background(), policysync.StatusEvent{PollAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("ReportPolicyStatus() error = %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want only unsigned status", requests)
+	}
+}
+
+func TestAppliedStateHeartbeat_CurrentSnapshot(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.configureAppliedStateHeartbeat(true, "audit-key-main-1", priv)
+	wantPoll := time.Now().UTC().Add(-time.Minute)
+	reporter.latest.Store(&policysync.StatusEvent{PollAt: wantPoll})
+	var got conductor.AppliedStateHeartbeat
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(req.Body).Decode(&got); err != nil {
+			t.Fatalf("decode heartbeat: %v", err)
+		}
+		return responseWithBody(http.StatusAccepted, `{"status":"accepted"}`), nil
+	}}
+	if err := reporter.reportCurrentAppliedStateHeartbeat(context.Background()); err != nil {
+		t.Fatalf("reportCurrentAppliedStateHeartbeat() error = %v", err)
+	}
+	if !got.AppliedState.LastPolicyPollAt.Equal(wantPoll) {
+		t.Fatalf("LastPolicyPollAt = %v, want %v", got.AppliedState.LastPolicyPollAt, wantPoll)
 	}
 }
 

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -67,6 +67,9 @@ type conductorPolicyStatusReporter struct {
 	heartbeatConfig atomic.Pointer[conductorHeartbeatConfig]
 	heartbeatSeq    atomic.Uint64
 	heartbeatMu     sync.Mutex
+	// afterHeartbeatSnapshot is a deterministic concurrency-test seam. It is
+	// nil in production and runs while heartbeatMu is held.
+	afterHeartbeatSnapshot func()
 }
 
 type conductorHeartbeatConfig struct {
@@ -207,6 +210,10 @@ func (r *conductorPolicyStatusReporter) configureAppliedStateHeartbeat(enabled b
 func (r *conductorPolicyStatusReporter) reportAppliedStateHeartbeat(ctx context.Context, ev policysync.StatusEvent) error {
 	r.heartbeatMu.Lock()
 	defer r.heartbeatMu.Unlock()
+	return r.reportAppliedStateHeartbeatLocked(ctx, ev)
+}
+
+func (r *conductorPolicyStatusReporter) reportAppliedStateHeartbeatLocked(ctx context.Context, ev policysync.StatusEvent) error {
 	cfg := r.heartbeatConfig.Load()
 	if cfg == nil {
 		return nil
@@ -254,11 +261,16 @@ func (r *conductorPolicyStatusReporter) reportAppliedStateHeartbeat(ctx context.
 }
 
 func (r *conductorPolicyStatusReporter) reportCurrentAppliedStateHeartbeat(ctx context.Context) error {
+	r.heartbeatMu.Lock()
+	defer r.heartbeatMu.Unlock()
 	latest := r.latest.Load()
+	if r.afterHeartbeatSnapshot != nil {
+		r.afterHeartbeatSnapshot()
+	}
 	if latest == nil {
 		return nil
 	}
-	return r.reportAppliedStateHeartbeat(ctx, *latest)
+	return r.reportAppliedStateHeartbeatLocked(ctx, *latest)
 }
 
 func (r *conductorPolicyStatusReporter) status(ev policysync.StatusEvent, identity conductorEnrollmentMarker) controlplane.FollowerRuntimeStatus {

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -253,11 +253,11 @@ func (r *conductorPolicyStatusReporter) reportAppliedStateHeartbeat(ctx context.
 }
 
 func (r *conductorPolicyStatusReporter) reportCurrentAppliedStateHeartbeat(ctx context.Context) error {
-	var ev policysync.StatusEvent
-	if latest := r.latest.Load(); latest != nil {
-		ev = *latest
+	latest := r.latest.Load()
+	if latest == nil {
+		return nil
 	}
-	return r.reportAppliedStateHeartbeat(ctx, ev)
+	return r.reportAppliedStateHeartbeat(ctx, *latest)
 }
 
 func (r *conductorPolicyStatusReporter) status(ev policysync.StatusEvent, identity conductorEnrollmentMarker) controlplane.FollowerRuntimeStatus {

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -8,6 +8,7 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode"
@@ -23,6 +25,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/applycache"
+	"github.com/luckyPipewrench/pipelock/enterprise/conductor/auditbatcher"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/controlplane"
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor/policysync"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
@@ -32,10 +35,11 @@ import (
 const conductorStatusResponseBytes = 64 * 1024
 
 type conductorPolicyStatusReporter struct {
-	client   policysync.HTTPDoer
-	endpoint string
-	cfg      config.Conductor
-	cache    *applycache.Cache
+	client            policysync.HTTPDoer
+	endpoint          string
+	heartbeatEndpoint string
+	cfg               config.Conductor
+	cache             *applycache.Cache
 	// markerPath is the follower's local enrollment marker, and identity is
 	// resolved from it lazily rather than once at construction.
 	//
@@ -57,6 +61,17 @@ type conductorPolicyStatusReporter struct {
 	// observation) can read the same poll/apply outcome the unsigned status POST
 	// reports, without coupling the producer to the poller.
 	latest atomic.Pointer[policysync.StatusEvent]
+	// heartbeatConfig is installed only after capability negotiation confirms
+	// the conductor understands recorder-independent signed state. Atomic
+	// publication keeps policy polling and startup wiring race-free.
+	heartbeatConfig atomic.Pointer[conductorHeartbeatConfig]
+	heartbeatSeq    atomic.Uint64
+	heartbeatMu     sync.Mutex
+}
+
+type conductorHeartbeatConfig struct {
+	signerKeyID string
+	privateKey  ed25519.PrivateKey
 }
 
 func newConductorPolicyStatusReporter(cfg *config.Config, client policysync.HTTPDoer, cache *applycache.Cache) (*conductorPolicyStatusReporter, error) {
@@ -71,12 +86,17 @@ func newConductorPolicyStatusReporter(cfg *config.Config, client policysync.HTTP
 	if err != nil {
 		return nil, err
 	}
+	heartbeatEndpoint, err := conductorEndpoint(cfg.Conductor.ConductorURL, controlplane.AppliedStateHeartbeatPath)
+	if err != nil {
+		return nil, err
+	}
 	r := &conductorPolicyStatusReporter{
-		client:     client,
-		endpoint:   endpoint,
-		cfg:        cfg.Conductor,
-		cache:      cache,
-		markerPath: markerPath,
+		client:            client,
+		endpoint:          endpoint,
+		heartbeatEndpoint: heartbeatEndpoint,
+		cfg:               cfg.Conductor,
+		cache:             cache,
+		markerPath:        markerPath,
 	}
 	// Resolve now when the marker already exists, so an already-enrolled follower
 	// behaves exactly as before and never pays a lookup on its first report.
@@ -105,6 +125,10 @@ func (r *conductorPolicyStatusReporter) resolveIdentity() (conductorEnrollmentMa
 }
 
 func conductorStatusEndpoint(rawBaseURL string) (string, error) {
+	return conductorEndpoint(rawBaseURL, controlplane.FollowerRuntimeStatusPath)
+}
+
+func conductorEndpoint(rawBaseURL, path string) (string, error) {
 	u, err := url.Parse(rawBaseURL)
 	if err != nil {
 		return "", fmt.Errorf("parse conductor status base URL: %w", err)
@@ -118,7 +142,7 @@ func conductorStatusEndpoint(rawBaseURL string) (string, error) {
 	if u.Path != "" && u.Path != "/" {
 		return "", fmt.Errorf("conductor status base URL must not include a path component")
 	}
-	u.Path = controlplane.FollowerRuntimeStatusPath
+	u.Path = path
 	u.RawPath = ""
 	return u.String(), nil
 }
@@ -162,7 +186,78 @@ func (r *conductorPolicyStatusReporter) ReportPolicyStatus(ctx context.Context, 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("conductor runtime status rejected HTTP %d: %s", resp.StatusCode, statusSnippet(respBody))
 	}
+	return r.reportAppliedStateHeartbeat(ctx, ev)
+}
+
+func (r *conductorPolicyStatusReporter) configureAppliedStateHeartbeat(enabled bool, signerKeyID string, privateKey ed25519.PrivateKey) {
+	if r == nil {
+		return
+	}
+	if !enabled || len(privateKey) != ed25519.PrivateKeySize || strings.TrimSpace(signerKeyID) == "" {
+		r.heartbeatConfig.Store(nil)
+		return
+	}
+	r.heartbeatConfig.Store(&conductorHeartbeatConfig{
+		signerKeyID: signerKeyID,
+		privateKey:  append(ed25519.PrivateKey(nil), privateKey...),
+	})
+}
+
+func (r *conductorPolicyStatusReporter) reportAppliedStateHeartbeat(ctx context.Context, ev policysync.StatusEvent) error {
+	r.heartbeatMu.Lock()
+	defer r.heartbeatMu.Unlock()
+	cfg := r.heartbeatConfig.Load()
+	if cfg == nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	state := r.buildAppliedState(ev)
+	// The signed heartbeat is evidence produced now. ObservedAt and
+	// ProvenanceAt therefore advance together even when the underlying bundle
+	// has not changed; the bundle/apply timestamps remain unchanged.
+	state.ObservedAt = now
+	state.ProvenanceAt = now
+	heartbeat := conductor.AppliedStateHeartbeat{
+		SchemaVersion: conductor.SchemaVersion,
+		HeartbeatID:   fmt.Sprintf("state-%020d-%06d", now.UnixNano(), r.heartbeatSeq.Add(1)),
+		OrgID:         r.cfg.OrgID,
+		FleetID:       r.cfg.FleetID,
+		InstanceID:    r.cfg.InstanceID,
+		EmittedAt:     now,
+		AppliedState:  state,
+	}
+	signed, err := auditbatcher.SignAppliedStateHeartbeat(heartbeat, cfg.signerKeyID, cfg.privateKey)
+	if err != nil {
+		return fmt.Errorf("sign conductor applied-state heartbeat: %w", err)
+	}
+	body, err := json.Marshal(signed)
+	if err != nil {
+		return fmt.Errorf("marshal conductor applied-state heartbeat: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.heartbeatEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build conductor applied-state heartbeat request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post conductor applied-state heartbeat: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, conductorStatusResponseBytes))
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("conductor applied-state heartbeat rejected HTTP %d: %s", resp.StatusCode, statusSnippet(respBody))
+	}
 	return nil
+}
+
+func (r *conductorPolicyStatusReporter) reportCurrentAppliedStateHeartbeat(ctx context.Context) error {
+	var ev policysync.StatusEvent
+	if latest := r.latest.Load(); latest != nil {
+		ev = *latest
+	}
+	return r.reportAppliedStateHeartbeat(ctx, ev)
 }
 
 func (r *conductorPolicyStatusReporter) status(ev policysync.StatusEvent, identity conductorEnrollmentMarker) controlplane.FollowerRuntimeStatus {

--- a/internal/cli/runtime/conductor_status.go
+++ b/internal/cli/runtime/conductor_status.go
@@ -186,7 +186,8 @@ func (r *conductorPolicyStatusReporter) ReportPolicyStatus(ctx context.Context, 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("conductor runtime status rejected HTTP %d: %s", resp.StatusCode, statusSnippet(respBody))
 	}
-	return r.reportAppliedStateHeartbeat(ctx, ev)
+	_ = r.reportAppliedStateHeartbeat(ctx, ev)
+	return nil
 }
 
 func (r *conductorPolicyStatusReporter) configureAppliedStateHeartbeat(enabled bool, signerKeyID string, privateKey ed25519.PrivateKey) {


### PR DESCRIPTION
## What changed
- Add a signed, recorder-independent applied-state heartbeat for idle followers when the conductor negotiates audit schema v3.
- Reject replayed or mismatched statements and keep fleet health stale when policy polling stops, so liveness can't present as current policy state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed applied-state heartbeats at configurable intervals to report current follower state.
  * Added capability negotiation and control-plane support for receiving, validating, and storing heartbeats.
  * Added replay protection, duplicate detection, signature verification, timestamp validation, and canonical hashing.
  * Added stale policy-poll detection to fleet health classification.
* **Style**
  * Updated dashboard labels from “batch” and “envelope” to “evidence” and “statement.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->