### PR TITLE
fix(ci): fail closed when docs searches cannot run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -702,6 +702,9 @@ jobs:
       - name: Config example startability policy
         run: bash scripts/check-config-examples.sh
 
+      - name: Install documentation search dependency
+        run: bash scripts/ci-apt-install.sh ripgrep
+
       - name: Documentation accuracy and local links
         run: make docs-check
 

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -10,6 +10,11 @@ cd "$repo_root"
 
 scope=(README.md CLAUDE.md CONTRIBUTING.md GOVERNANCE.md SECURITY.md docs examples)
 
+if ! command -v rg >/dev/null 2>&1; then
+	echo "docs-check: failed: rg is required" >&2
+	exit 1
+fi
+
 check_no_match() {
 	local pattern="$1"
 	local label="$2"
@@ -18,6 +23,12 @@ check_no_match() {
 		echo
 		echo "docs-check: failed: found stale ${label}"
 		exit 1
+	else
+		local status=$?
+		if ((status != 1)); then
+			echo "docs-check: failed: rg could not check ${label} (exit ${status})" >&2
+			exit "$status"
+		fi
 	fi
 }
 

--- a/scripts/test_docs_check.py
+++ b/scripts/test_docs_check.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -28,14 +29,19 @@ def write_command(directory: Path, name: str, body: str) -> None:
 class DocsCheckTest(unittest.TestCase):
     def run_with_path(self, commands: dict[str, str]) -> subprocess.CompletedProcess[str]:
         """Run the real docs check with only the named commands available."""
+        bash = shutil.which("bash")
+        dirname = shutil.which("dirname")
+        if bash is None or dirname is None:
+            self.skipTest("bash and dirname are required to run docs-check.sh")
+
         with tempfile.TemporaryDirectory() as temp_dir:
             command_dir = Path(temp_dir)
-            os.symlink("/usr/bin/bash", command_dir / "bash")
-            os.symlink("/usr/bin/dirname", command_dir / "dirname")
+            os.symlink(bash, command_dir / "bash")
+            os.symlink(dirname, command_dir / "dirname")
             for name, body in commands.items():
                 write_command(command_dir, name, body)
             return subprocess.run(
-                ["/usr/bin/bash", str(DOCS_CHECK)],
+                [bash, str(DOCS_CHECK)],
                 cwd=ROOT,
                 env=os.environ | {"PATH": str(command_dir)},
                 check=False,

--- a/scripts/test_docs_check.py
+++ b/scripts/test_docs_check.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for fail-closed documentation checks."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_CHECK = ROOT / "scripts" / "docs-check.sh"
+
+
+def write_command(directory: Path, name: str, body: str) -> None:
+    """Create one executable test command in an isolated PATH."""
+    path = directory / name
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class DocsCheckTest(unittest.TestCase):
+    def run_with_path(self, commands: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        """Run the real docs check with only the named commands available."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            command_dir = Path(temp_dir)
+            os.symlink("/usr/bin/bash", command_dir / "bash")
+            os.symlink("/usr/bin/dirname", command_dir / "dirname")
+            for name, body in commands.items():
+                write_command(command_dir, name, body)
+            return subprocess.run(
+                ["/usr/bin/bash", str(DOCS_CHECK)],
+                cwd=ROOT,
+                env=os.environ | {"PATH": str(command_dir)},
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+    def test_missing_rg_fails_before_reporting_success(self):
+        result = self.run_with_path({})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("docs-check: failed: rg is required", result.stderr)
+        self.assertNotIn("docs-check: ok", result.stdout)
+
+    def test_rg_operational_error_fails_instead_of_meaning_no_match(self):
+        result = self.run_with_path({"python3": "exit 0", "rg": "exit 2"})
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("docs-check: failed: rg could not check gauntlet corpus count (exit 2)", result.stderr)
+        self.assertNotIn("docs-check: ok", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Fail the documentation audit when ripgrep is missing or returns an operational error instead of treating an incomplete search as clean.
- Run the real script against missing-command and exit-2 cases so either path can't regress to a green check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation checks now clearly report when the required search tool is unavailable.
  * Operational errors during documentation scans are no longer mistaken for successful checks.
  * Documentation validation now provides more accurate pass/fail results.

* **Tests**
  * Added regression coverage for missing-tool and scan-error scenarios.
  * Improved validation of documentation-check behavior in automated quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->