### PR TITLE
fix(ci): fail closed on release-audit search errors

### DIFF
--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -205,16 +205,28 @@ done
 note "release audit: checking secret-bearing comment workflows"
 
 while IFS= read -r workflow; do
-	if ! rg -q '^[[:space:]]*issue_comment:' "$workflow"; then
+	if ! rg_search -n '^[[:space:]]*issue_comment:' "$workflow"; then
 		continue
 	fi
-	if ! rg -q 'secrets\.' "$workflow"; then
+	if [[ -z "$rg_output" ]]; then
 		continue
 	fi
-	if ! rg -q 'author_association' "$workflow"; then
+	if ! rg_search -n 'secrets\.' "$workflow"; then
+		continue
+	fi
+	if [[ -z "$rg_output" ]]; then
+		continue
+	fi
+	if ! rg_search -n 'author_association' "$workflow"; then
+		continue
+	fi
+	if [[ -z "$rg_output" ]]; then
 		fail "${workflow} uses secrets on issue_comment without an author_association gate"
 	fi
-	if rg -q 'refs/pull/\$\{\{[[:space:]]*github\.event\.issue\.number[[:space:]]*\}\}/head' "$workflow"; then
+	if ! rg_search -n 'refs/pull/\$\{\{[[:space:]]*github\.event\.issue\.number[[:space:]]*\}\}/head' "$workflow"; then
+		continue
+	fi
+	if [[ -n "$rg_output" ]]; then
 		fail "${workflow} checks out the PR head ref in a secret-bearing comment workflow; use the merge ref instead"
 	fi
 done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)

--- a/scripts/test_release_audit_rg_errors.py
+++ b/scripts/test_release_audit_rg_errors.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for fail-closed release-audit searches."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_AUDIT = ROOT / "scripts" / "release-audit.sh"
+
+
+class ReleaseAuditRipgrepErrorTest(unittest.TestCase):
+    def test_issue_comment_search_error_cannot_report_ok(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_rg = Path(temp_dir) / "rg"
+            fake_rg.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"$*\" == *issue_comment:* ]]; then\n"
+                "  exit 2\n"
+                "fi\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            fake_rg.chmod(fake_rg.stat().st_mode | stat.S_IXUSR)
+            result = subprocess.run(
+                ["/usr/bin/bash", str(RELEASE_AUDIT)],
+                cwd=ROOT,
+                env=os.environ | {"PATH": f"{temp_dir}:/usr/bin:/bin"},
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ripgrep exited with 2", result.stderr)
+        self.assertNotIn("release audit: OK", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Route secret-bearing comment-workflow searches through the release audit's existing fail-closed ripgrep wrapper.
- Run the real audit with an injected search error so an incomplete scan can't report success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release audits now fail safely when searches encounter errors, preventing false success reports.
  * Improved handling of search results during secret-bearing comment checks.

* **Tests**
  * Added regression coverage verifying that search failures produce an error and a nonzero audit result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->