### PR TITLE
fix: retry heartbeat capability negotiation

### DIFF
--- a/enterprise/conductor/auditbatcher/producer.go
+++ b/enterprise/conductor/auditbatcher/producer.go
@@ -100,8 +100,10 @@ type ProducerConfig struct {
 	// false so the wire form is byte-identical to v1 and passes the conductor's
 	// strict unknown-field decoder. Default false = do not emit (fail-safe).
 	EmitAppliedState bool
-	// EmitAppliedStateHeartbeat gates the recorder-independent heartbeat. It
-	// must only be true when capability negotiation confirmed audit schema v3.
+	// EmitAppliedStateHeartbeat enables the recorder-independent heartbeat
+	// scheduler. The callback remains responsible for capability negotiation
+	// before it emits any v3 request, allowing a failed startup handshake to be
+	// retried without weakening wire compatibility with older conductors.
 	EmitAppliedStateHeartbeat bool
 	// AppliedStateProvider supplies the current applied-state snapshot when
 	// EmitAppliedState is true. It is a callback so the producer stays decoupled
@@ -109,8 +111,9 @@ type ProducerConfig struct {
 	// the batch (best-effort) while the batch itself still flows.
 	AppliedStateProvider func() (conductor.FollowerAppliedState, bool)
 	// AppliedStateHeartbeat sends a recorder-independent signed state update.
-	// It runs periodically only when EmitAppliedStateHeartbeat was negotiated. Failures
-	// are best-effort: the next interval retries with a fresh statement.
+	// It runs periodically only when EmitAppliedStateHeartbeat is enabled. Failures
+	// are best-effort: the next interval retries negotiation or emission with a
+	// fresh statement.
 	AppliedStateHeartbeat func(context.Context) error
 	HeartbeatInterval     time.Duration
 }

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -760,7 +760,7 @@ func (s *Server) initConductorProducer(cfg *config.Config, m *metrics.Metrics, r
 	if reporter, ok := s.conductorStatusReporter.(*conductorPolicyStatusReporter); ok && reporter != nil {
 		appliedProvider = reporter.appliedStateProvider()
 		var initialHeartbeat bool
-		emitApplied, initialHeartbeat = conductorNegotiateAppliedState(cfg.Conductor, stderr)
+		emitApplied, initialHeartbeat = conductorNegotiateAppliedState(context.Background(), cfg.Conductor, stderr)
 		reporter.configureAppliedStateHeartbeat(initialHeartbeat, cfg.Conductor.AuditSigningKeyID, recPrivKey)
 		// Keep the periodic callback alive even when the startup handshake fails.
 		// The callback repeats capability negotiation before emitting, so an old
@@ -816,7 +816,7 @@ func conductorRecorderPublicKey(priv ed25519.PrivateKey) (ed25519.PublicKey, err
 // an older v1-only conductor, returns false so the producer omits applied-state
 // and its batches stay byte-identical to v1 past the conductor's strict
 // unknown-field decoder.
-func conductorNegotiateAppliedState(cfg config.Conductor, stderr io.Writer) (bool, bool) {
+func conductorNegotiateAppliedState(parent context.Context, cfg config.Conductor, stderr io.Writer) (bool, bool) {
 	client, err := newConductorMTLSClient(cfg)
 	if err != nil {
 		return false, false
@@ -825,7 +825,7 @@ func conductorNegotiateAppliedState(cfg config.Conductor, stderr io.Writer) (boo
 	if err != nil {
 		return false, false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), conductorAppliedStateHandshakeTimeout)
+	ctx, cancel := context.WithTimeout(parent, conductorAppliedStateHandshakeTimeout)
 	defer cancel()
 	negotiated, err := capClient.Handshake(ctx)
 	if err != nil {
@@ -837,7 +837,7 @@ func conductorNegotiateAppliedState(cfg config.Conductor, stderr io.Writer) (boo
 	return negotiated.AuditSchemaVersion >= conductor.AuditEnvelopeSchemaVersion, negotiated.AppliedStateHeartbeat
 }
 
-type conductorAppliedStateNegotiator func(config.Conductor, io.Writer) (bool, bool)
+type conductorAppliedStateNegotiator func(context.Context, config.Conductor, io.Writer) (bool, bool)
 
 func conductorAppliedStateHeartbeatCallback(
 	reporter *conductorPolicyStatusReporter,
@@ -851,7 +851,7 @@ func conductorAppliedStateHeartbeatCallback(
 	}
 	return func(ctx context.Context) error {
 		if reporter.heartbeatConfig.Load() == nil {
-			_, heartbeat := negotiate(cfg, nil)
+			_, heartbeat := negotiate(ctx, cfg, nil)
 			reporter.configureAppliedStateHeartbeat(heartbeat, signerKeyID, privateKey)
 			if !heartbeat {
 				return nil

--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -754,12 +754,26 @@ func (s *Server) initConductorProducer(cfg *config.Config, m *metrics.Metrics, r
 	// fail-safe — any handshake failure (or an old v1 conductor) leaves it off,
 	// so batches still flow without applied-state and stay v1-wire-compatible.
 	emitApplied := false
-	emitHeartbeat := false
+	scheduleHeartbeat := false
 	var appliedProvider func() (conductor.FollowerAppliedState, bool)
+	var appliedHeartbeat func(context.Context) error
 	if reporter, ok := s.conductorStatusReporter.(*conductorPolicyStatusReporter); ok && reporter != nil {
 		appliedProvider = reporter.appliedStateProvider()
-		emitApplied, emitHeartbeat = conductorNegotiateAppliedState(cfg.Conductor, stderr)
-		reporter.configureAppliedStateHeartbeat(emitHeartbeat, cfg.Conductor.AuditSigningKeyID, recPrivKey)
+		var initialHeartbeat bool
+		emitApplied, initialHeartbeat = conductorNegotiateAppliedState(cfg.Conductor, stderr)
+		reporter.configureAppliedStateHeartbeat(initialHeartbeat, cfg.Conductor.AuditSigningKeyID, recPrivKey)
+		// Keep the periodic callback alive even when the startup handshake fails.
+		// The callback repeats capability negotiation before emitting, so an old
+		// conductor still receives no v3 request while a temporarily unavailable
+		// upgraded conductor recovers without an operator restart.
+		scheduleHeartbeat = true
+		appliedHeartbeat = conductorAppliedStateHeartbeatCallback(
+			reporter,
+			cfg.Conductor,
+			cfg.Conductor.AuditSigningKeyID,
+			recPrivKey,
+			conductorNegotiateAppliedState,
+		)
 	}
 	producer, err := auditbatcher.NewProducer(auditbatcher.ProducerConfig{
 		Queue:                     queue,
@@ -772,14 +786,9 @@ func (s *Server) initConductorProducer(cfg *config.Config, m *metrics.Metrics, r
 		AuditSigner:               recPrivKey,
 		RecorderPublicKey:         recPubKey,
 		EmitAppliedState:          emitApplied,
-		EmitAppliedStateHeartbeat: emitHeartbeat,
+		EmitAppliedStateHeartbeat: scheduleHeartbeat,
 		AppliedStateProvider:      appliedProvider,
-		AppliedStateHeartbeat: func(ctx context.Context) error {
-			if reporter, ok := s.conductorStatusReporter.(*conductorPolicyStatusReporter); ok && reporter != nil {
-				return reporter.reportCurrentAppliedStateHeartbeat(ctx)
-			}
-			return nil
-		},
+		AppliedStateHeartbeat:     appliedHeartbeat,
 	})
 	if err != nil {
 		return fmt.Errorf("creating conductor audit producer: %w", err)
@@ -826,4 +835,28 @@ func conductorNegotiateAppliedState(cfg config.Conductor, stderr io.Writer) (boo
 		return false, false
 	}
 	return negotiated.AuditSchemaVersion >= conductor.AuditEnvelopeSchemaVersion, negotiated.AppliedStateHeartbeat
+}
+
+type conductorAppliedStateNegotiator func(config.Conductor, io.Writer) (bool, bool)
+
+func conductorAppliedStateHeartbeatCallback(
+	reporter *conductorPolicyStatusReporter,
+	cfg config.Conductor,
+	signerKeyID string,
+	privateKey ed25519.PrivateKey,
+	negotiate conductorAppliedStateNegotiator,
+) func(context.Context) error {
+	if reporter == nil || negotiate == nil {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		if reporter.heartbeatConfig.Load() == nil {
+			_, heartbeat := negotiate(cfg, nil)
+			reporter.configureAppliedStateHeartbeat(heartbeat, signerKeyID, privateKey)
+			if !heartbeat {
+				return nil
+			}
+		}
+		return reporter.reportCurrentAppliedStateHeartbeat(ctx)
+	}
 }

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -246,6 +246,49 @@ func TestAppliedStateHeartbeat_RemainsOffWithoutNegotiation(t *testing.T) {
 	}
 }
 
+func TestAppliedStateHeartbeat_RetriesNegotiationAfterStartupOutage(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	reporter.latest.Store(&policysync.StatusEvent{PollAt: time.Now().UTC()})
+	heartbeatRequests := 0
+	reporter.client = statusReporterDoer{fn: func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != controlplane.AppliedStateHeartbeatPath {
+			t.Fatalf("request path = %s, want %s", req.URL.Path, controlplane.AppliedStateHeartbeatPath)
+		}
+		heartbeatRequests++
+		return responseWithBody(http.StatusAccepted, `{"status":"accepted"}`), nil
+	}}
+	negotiations := 0
+	callback := conductorAppliedStateHeartbeatCallback(
+		reporter,
+		reporter.cfg,
+		"audit-key-main-1",
+		priv,
+		func(config.Conductor, io.Writer) (bool, bool) {
+			negotiations++
+			return true, negotiations > 1
+		},
+	)
+	if callback == nil {
+		t.Fatal("callback = nil")
+	}
+	if err := callback(context.Background()); err != nil {
+		t.Fatalf("first callback error = %v", err)
+	}
+	if heartbeatRequests != 0 {
+		t.Fatalf("heartbeat requests after failed negotiation = %d, want 0", heartbeatRequests)
+	}
+	if err := callback(context.Background()); err != nil {
+		t.Fatalf("second callback error = %v", err)
+	}
+	if negotiations != 2 || heartbeatRequests != 1 {
+		t.Fatalf("negotiations = %d, heartbeat requests = %d; want 2, 1", negotiations, heartbeatRequests)
+	}
+}
+
 func TestAppliedStateHeartbeat_CurrentSnapshot(t *testing.T) {
 	reporter := newAppliedStateReporter(t)
 	_, priv, err := ed25519.GenerateKey(nil)

--- a/internal/cli/runtime/conductor_applied_state_test.go
+++ b/internal/cli/runtime/conductor_applied_state_test.go
@@ -267,7 +267,7 @@ func TestAppliedStateHeartbeat_RetriesNegotiationAfterStartupOutage(t *testing.T
 		reporter.cfg,
 		"audit-key-main-1",
 		priv,
-		func(config.Conductor, io.Writer) (bool, bool) {
+		func(context.Context, config.Conductor, io.Writer) (bool, bool) {
 			negotiations++
 			return true, negotiations > 1
 		},
@@ -286,6 +286,41 @@ func TestAppliedStateHeartbeat_RetriesNegotiationAfterStartupOutage(t *testing.T
 	}
 	if negotiations != 2 || heartbeatRequests != 1 {
 		t.Fatalf("negotiations = %d, heartbeat requests = %d; want 2, 1", negotiations, heartbeatRequests)
+	}
+}
+
+func TestAppliedStateHeartbeat_CancelsBlockedNegotiation(t *testing.T) {
+	reporter := newAppliedStateReporter(t)
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	started := make(chan struct{})
+	callback := conductorAppliedStateHeartbeatCallback(
+		reporter,
+		reporter.cfg,
+		"audit-key-main-1",
+		priv,
+		func(ctx context.Context, _ config.Conductor, _ io.Writer) (bool, bool) {
+			close(started)
+			<-ctx.Done()
+			return false, false
+		},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- callback(ctx)
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("callback error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("callback did not return after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What changed

- Retry heartbeat capability negotiation after a startup failure so followers recover when the Conductor becomes available.
- Keep v3 heartbeat emission disabled until negotiation succeeds, preserving compatibility with older Conductors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved applied-state heartbeat reliability when capability negotiation is temporarily unavailable during startup.
  - Capability negotiation now retries automatically on subsequent heartbeat intervals.
  - Heartbeats are withheld until support is confirmed, then resume with the current applied state.
  - Heartbeat failures remain non-blocking and do not interrupt normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->