### PR TITLE
Report seccomp unavailable where the filter is not built

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -548,14 +548,17 @@ jobs:
           go build ./...
           go build -tags enterprise ./...
 
-      - name: Sandbox behavior on an architecture without seccomp
+      - name: Sandbox behavior without Pipelock's seccomp filter
         run: go test -race -count=1 ./internal/sandbox/...
 
-      # Preflight is what tells an operator which layers they are actually
-      # getting. On arm64 it must report seccomp as unavailable rather than
-      # claiming it, and it must do so without erroring.
+      # Preflight and diagnose are what tell an operator which layers they are
+      # actually getting. On arm64 they must report seccomp as unavailable
+      # rather than claiming it.
       - name: Preflight reports the real arm64 layer set
         run: go test -race -count=1 -run "TestPreflight|TestDetect" ./internal/sandbox/...
+
+      - name: Diagnose reports the real arm64 layer set
+        run: go test -race -count=1 -run TestDiagnoseReportsSeccompUnavailableWithoutFilter ./internal/cli/diag/...
 
   # Exercise the browser target's concrete fail-closed filesystem fallbacks,
   # then compile the same contracts for WASI and AIX so build-tag gaps cannot

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -554,11 +554,24 @@ jobs:
       # Preflight and diagnose are what tell an operator which layers they are
       # actually getting. On arm64 they must report seccomp as unavailable
       # rather than claiming it.
+      # `go test -run NAME` exits 0 when the filter matches NOTHING, including
+      # when a build tag excludes the file entirely. Both guards below are tagged
+      # `linux && !amd64`, so a tag drift, a rename, or a package move would leave
+      # this lane green while proving nothing: the exact failure this job exists to
+      # catch, relocated into the check. Assert the named test actually ran.
       - name: Preflight reports the real arm64 layer set
-        run: go test -race -count=1 -run "TestPreflight|TestDetect" ./internal/sandbox/...
+        run: |
+          set -euo pipefail
+          go test -race -count=1 -v -run TestDetectAndPreflightReportSeccompUnavailableWithoutFilter \
+            ./internal/sandbox/... | tee /tmp/arm64-preflight.log
+          grep -q '^--- PASS: TestDetectAndPreflightReportSeccompUnavailableWithoutFilter' /tmp/arm64-preflight.log
 
       - name: Diagnose reports the real arm64 layer set
-        run: go test -race -count=1 -run TestDiagnoseReportsSeccompUnavailableWithoutFilter ./internal/cli/diag/...
+        run: |
+          set -euo pipefail
+          go test -race -count=1 -v -run TestDiagnoseReportsSeccompUnavailableWithoutFilter \
+            ./internal/cli/diag/... | tee /tmp/arm64-diagnose.log
+          grep -q '^--- PASS: TestDiagnoseReportsSeccompUnavailableWithoutFilter' /tmp/arm64-diagnose.log
 
   # Exercise the browser target's concrete fail-closed filesystem fallbacks,
   # then compile the same contracts for WASI and AIX so build-tag gaps cannot

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2572,11 +2572,14 @@ pipelock sandbox --dry-run --json -- python agent.py
 
 | Environment | Layers | Notes |
 |-------------|--------|-------|
-| Bare metal / VM (Linux) | 3/3 | Full containment: Landlock + seccomp + network namespace |
+| Bare metal / VM (Linux, amd64) | 3/3 | Full containment: Landlock + seccomp + network namespace |
+| Bare metal / VM (Linux, non-amd64) | 2/3 | Landlock + network namespace. Seccomp reports unavailable; see below. |
 | Containers (`--best-effort`) | 2/3 | Landlock + seccomp. Network via HTTP_PROXY + NetworkPolicy. |
 | macOS | sandbox-exec | Apple SBPL profiles for filesystem + network restriction |
 
 **Requirements:** Linux 5.13+ (Landlock ABI v1). Unprivileged on bare metal. macOS 13+ for sandbox-exec. Containers may need `--best-effort` if default seccomp blocks `CLONE_NEWUSER`.
+
+**Seccomp is built for `linux/amd64` only.** On other Linux architectures, including the published `linux/arm64` binaries, Pipelock does not contain a seccomp filter to install, so the layer reports unavailable and containment is 2/3 rather than 3/3. This is reported rather than silently absent: `pipelock diagnose` shows the seccomp check as `FAIL … unavailable`, and under `--strict`, preflight refuses the launch instead of starting with fewer layers than strict promises. Landlock and the network namespace, which carry the filesystem and egress guarantees, are unaffected.
 
 **`--best-effort` is a degraded mode with a known bypass vector.** When user namespaces are unavailable — either the container runtime's seccomp profile blocks `CLONE_NEWUSER` or the host has `kernel.unprivileged_userns_clone=0` (default on some Debian-derivative kernels) — pipelock cannot create a network namespace for the child, so outbound traffic is enforced only by `HTTP_PROXY` / `HTTPS_PROXY` environment variables. A process inside the sandbox that explicitly `unset`s those vars, or makes a raw socket call without consulting the proxy env, will connect directly to the network and bypass pipelock's scanning pipeline. Pipelock emits a loud startup `WARNING` line alongside the `DEGRADED` status whenever this path is taken, on both `pipelock sandbox` and `pipelock mcp proxy --sandbox-best-effort`. For deployments that need kernel-level enforcement, either (1) make `CLONE_NEWUSER` available (adjust the runtime's seccomp profile or set `kernel.unprivileged_userns_clone=1`) so pipelock can run full 3/3 containment, or (2) use the companion-proxy topology from `pipelock init sidecar` — putting pipelock in a separate pod with a NetworkPolicy that restricts the agent pod's egress to the pipelock Service IP is the kernel-enforced equivalent of a network namespace. That equivalence depends on your CNI enforcing the policy, so verify it rather than assuming it; see [NetworkPolicy Semantics](cli/init-sidecar.md#networkpolicy-semantics).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2574,7 +2574,8 @@ pipelock sandbox --dry-run --json -- python agent.py
 |-------------|--------|-------|
 | Bare metal / VM (Linux, amd64) | 3/3 | Full containment: Landlock + seccomp + network namespace |
 | Bare metal / VM (Linux, non-amd64) | 2/3 | Landlock + network namespace. Seccomp reports unavailable; see below. |
-| Containers (`--best-effort`) | 2/3 | Landlock + seccomp. Network via HTTP_PROXY + NetworkPolicy. |
+| Containers, amd64 (`--best-effort`) | 2/3 | Landlock + seccomp. Network via HTTP_PROXY + NetworkPolicy. |
+| Containers, non-amd64 (`--best-effort`) | 1/3 | Landlock only. Seccomp reports unavailable; network via HTTP_PROXY + NetworkPolicy. |
 | macOS | sandbox-exec | Apple SBPL profiles for filesystem + network restriction |
 
 **Requirements:** Linux 5.13+ (Landlock ABI v1). Unprivileged on bare metal. macOS 13+ for sandbox-exec. Containers may need `--best-effort` if default seccomp blocks `CLONE_NEWUSER`.

--- a/internal/cli/diag/diagnose_seccomp_unavailable_linux_test.go
+++ b/internal/cli/diag/diagnose_seccomp_unavailable_linux_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && !amd64
+
+package diag
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+func TestDiagnoseReportsSeccompUnavailableWithoutFilter(t *testing.T) {
+	cmd := &cobra.Command{}
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+
+	err := runDiagnoseSandbox(cmd, false, false)
+	if err == nil {
+		t.Fatal("diagnose succeeded despite unavailable seccomp")
+	}
+	var exitErr *cliutil.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("diagnose error = %v, want exit code 1", err)
+	}
+
+	const want = "sandbox_seccomp      FAIL  unavailable"
+	if got := output.String(); !bytes.Contains([]byte(got), []byte(want)) {
+		t.Fatalf("diagnose output missing %q:\n%s", want, got)
+	}
+}

--- a/internal/sandbox/detect_linux.go
+++ b/internal/sandbox/detect_linux.go
@@ -46,14 +46,17 @@ func Detect() Capabilities {
 		}
 	}
 
-	// Seccomp: check /proc/self/status for Seccomp line.
-	if data, err := os.ReadFile("/proc/self/status"); err == nil {
-		for _, line := range strings.Split(string(data), "\n") {
-			if strings.HasPrefix(line, "Seccomp:") {
-				// Value 0 = disabled, 1 = strict, 2 = filter
-				// If the field exists at all, seccomp is supported.
-				c.Seccomp = true
-				break
+	// Seccomp is available only when this binary includes Pipelock's filter
+	// and the kernel exposes seccomp support.
+	if seccompFilterSupportedByBuild() {
+		if data, err := os.ReadFile("/proc/self/status"); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.HasPrefix(line, "Seccomp:") {
+					// Value 0 = disabled, 1 = strict, 2 = filter. The field
+					// existing means the kernel supports seccomp.
+					c.Seccomp = true
+					break
+				}
 			}
 		}
 	}

--- a/internal/sandbox/detect_seccomp_unavailable_linux_test.go
+++ b/internal/sandbox/detect_seccomp_unavailable_linux_test.go
@@ -40,8 +40,31 @@ func TestDetectAndPreflightReportSeccompUnavailableWithoutFilter(t *testing.T) {
 	// operator actually feels, and it is the one behaviour change in this
 	// commit, so it gets its own assertion rather than riding on the layer
 	// report.
-	if strict := Preflight(t.TempDir(), []string{"true"}, nil, true); strict.Status != StatusError {
+	//
+	// StatusError alone would NOT prove that, because a runner missing Landlock
+	// or user namespaces produces the same status for an unrelated reason. So
+	// assert the seccomp layer specifically: present, required, and unavailable.
+	// Otherwise this test could pass on a host where strict mode never rejected
+	// the missing seccomp layer at all.
+	strict := Preflight(t.TempDir(), []string{"true"}, nil, true)
+	if strict.Status != StatusError {
 		t.Fatalf("strict preflight status = %q, want %q when the build cannot apply seccomp",
 			strict.Status, StatusError)
+	}
+	found := false
+	for _, layer := range strict.Layers {
+		if layer.Name != LayerSeccomp {
+			continue
+		}
+		found = true
+		if !layer.Required {
+			t.Error("strict preflight did not mark seccomp required, so StatusError cannot be attributed to it")
+		}
+		if layer.Available {
+			t.Error("strict preflight reported seccomp available without Pipelock's filter")
+		}
+	}
+	if !found {
+		t.Fatal("strict preflight did not report a seccomp layer")
 	}
 }

--- a/internal/sandbox/detect_seccomp_unavailable_linux_test.go
+++ b/internal/sandbox/detect_seccomp_unavailable_linux_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && !amd64
+
+package sandbox
+
+import "testing"
+
+func TestDetectAndPreflightReportSeccompUnavailableWithoutFilter(t *testing.T) {
+	if seccompFilterSupportedByBuild() {
+		t.Fatal("build without the seccomp filter reported support")
+	}
+
+	if caps := Detect(); caps.Seccomp {
+		t.Fatal("Detect reported seccomp available without Pipelock's filter")
+	}
+
+	result := Preflight(t.TempDir(), []string{"true"}, nil, false)
+	for _, layer := range result.Layers {
+		if layer.Name != LayerSeccomp {
+			continue
+		}
+		if layer.Available {
+			t.Fatal("preflight reported seccomp available without Pipelock's filter")
+		}
+		if layer.Reason != "seccomp unavailable" {
+			t.Fatalf("preflight seccomp reason = %q, want seccomp unavailable", layer.Reason)
+		}
+		return
+	}
+
+	t.Fatal("preflight did not report a seccomp layer")
+}

--- a/internal/sandbox/detect_seccomp_unavailable_linux_test.go
+++ b/internal/sandbox/detect_seccomp_unavailable_linux_test.go
@@ -17,18 +17,31 @@ func TestDetectAndPreflightReportSeccompUnavailableWithoutFilter(t *testing.T) {
 	}
 
 	result := Preflight(t.TempDir(), []string{"true"}, nil, false)
+	seen := false
 	for _, layer := range result.Layers {
 		if layer.Name != LayerSeccomp {
 			continue
 		}
+		seen = true
 		if layer.Available {
 			t.Fatal("preflight reported seccomp available without Pipelock's filter")
 		}
 		if layer.Reason != "seccomp unavailable" {
 			t.Fatalf("preflight seccomp reason = %q, want seccomp unavailable", layer.Reason)
 		}
-		return
+	}
+	if !seen {
+		t.Fatal("preflight did not report a seccomp layer")
 	}
 
-	t.Fatal("preflight did not report a seccomp layer")
+	// Strict mode promises every layer, so on a build that cannot apply the
+	// filter it must REFUSE rather than report ready and launch without it.
+	// Reporting the layer honestly is only half the fix; this is the half an
+	// operator actually feels, and it is the one behaviour change in this
+	// commit, so it gets its own assertion rather than riding on the layer
+	// report.
+	if strict := Preflight(t.TempDir(), []string{"true"}, nil, true); strict.Status != StatusError {
+		t.Fatalf("strict preflight status = %q, want %q when the build cannot apply seccomp",
+			strict.Status, StatusError)
+	}
 }

--- a/internal/sandbox/seccomp_darwin_capability.go
+++ b/internal/sandbox/seccomp_darwin_capability.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package sandbox
+
+// seccompFilterSupportedByBuild reports whether this binary contains
+// Pipelock's seccomp filter implementation. seccomp is a Linux facility, so a
+// darwin build never carries one.
+//
+// This definition exists for build-tag symmetry rather than for a current
+// caller: today the only caller is Detect in detect_linux.go. Without it,
+// darwin is the one target that gets neither the linux/amd64 nor the
+// seccomp_other.go definition, so the first cross-platform caller would break
+// the darwin build rather than get an honest answer.
+func seccompFilterSupportedByBuild() bool {
+	return false
+}

--- a/internal/sandbox/seccomp_darwin_capability.go
+++ b/internal/sandbox/seccomp_darwin_capability.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build darwin
 
 package sandbox

--- a/internal/sandbox/seccomp_linux.go
+++ b/internal/sandbox/seccomp_linux.go
@@ -27,6 +27,12 @@ const cloneNewMask = 0x7E020000 // CLONE_NEWNS|CLONE_NEWCGROUP|CLONE_NEWUTS|CLON
 // communication. Blocked because it could bypass network namespace isolation.
 const afVSOCK = 40
 
+// seccompFilterSupportedByBuild reports whether this binary contains
+// Pipelock's seccomp filter implementation.
+func seccompFilterSupportedByBuild() bool {
+	return true
+}
+
 // ApplySeccomp installs a seccomp BPF filter that restricts the calling
 // process to a safe set of syscalls. Dangerous syscalls (ptrace, mount,
 // io_uring, kernel module loading, etc.) are blocked.

--- a/internal/sandbox/seccomp_other.go
+++ b/internal/sandbox/seccomp_other.go
@@ -7,6 +7,12 @@ package sandbox
 
 import "fmt"
 
+// seccompFilterSupportedByBuild reports whether this binary contains
+// Pipelock's seccomp filter implementation.
+func seccompFilterSupportedByBuild() bool {
+	return false
+}
+
 // ApplySeccomp is a no-op on non-Linux/amd64 platforms.
 func ApplySeccomp(_ ...bool) (LayerStatus, error) {
 	return LayerStatus{


### PR DESCRIPTION
## What changed

Seccomp detection reported the layer available on any Linux kernel exposing a `Seccomp:` field in `/proc/self/status`, while the filter implementation is built only for `linux/amd64`. A published `linux/arm64` binary therefore reported a protection it could not apply, and preflight and `diagnose` carried that through to the operator.

Detection now requires both that this binary contains the filter and that the kernel supports seccomp. On `linux/amd64` nothing changes. On other Linux architectures the layer reports unavailable, containment is 2 of 3 rather than 3 of 3, and the containment table in the configuration guide now states that limit instead of leaving an operator to discover it.

One behavior change worth calling out. Under `--strict` on a non-amd64 Linux build, preflight now refuses the launch rather than reporting ready and then starting without the layer, because applying the filter was already failing at that point and only being printed. Refusal is the honest direction, and it replaces a ready verdict for containment that was not being delivered.

The architecture lane now asserts its guards actually ran. `go test -run NAME` exits zero when the filter matches nothing, including when a build tag excludes the file entirely, so a rename, a package move, or a tag drift would have left that lane green while proving nothing, which is the same class of defect this change exists to remove.

Landlock was checked in the same pass and is unaffected: it uses the same ABI syscall for detection and for application, so there is no equivalent gap between what is probed and what can be applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved sandbox capability detection across supported platforms.
  - Diagnostics now clearly report when seccomp protection is unavailable.

- **Bug Fixes**
  - Prevented unsupported platforms from being incorrectly reported as having seccomp protection.
  - Strict sandbox mode now correctly refuses launches when seccomp is unavailable.

- **Documentation**
  - Clarified that seccomp is available on Linux amd64 only; other Linux architectures provide reduced containment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->