### PR TITLE
Pin official rules-registry fetches to the official origin

### DIFF
--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -443,9 +443,19 @@ func fetchOfficialRegistryBundle(ctx context.Context, bundleURL string) ([]byte,
 // policy the install used; otherwise the pin covers only the one-time install
 // and not the commands an operator runs repeatedly afterwards.
 //
-// Routing on the RECORDED source preserves the separation that matters: an
-// operator-supplied --source that happens to spell the official URL stays on
-// the general client and never acquires official-path handling.
+// Routing keys on the RECORDED source string, not on install provenance.
+// LockFile carries no field saying whether the install used the official name
+// (internal/rules/lock.go), so a --source install that spelled the official URL
+// is pinned on later update and diff even though its install was not. That
+// direction is fail-closed, and the reverse is not possible: an official-name
+// install can never fall back to the general client. The cost is narrow and
+// worth stating, because update has no --source override: an operator who
+// installed from an official-looking URL that later redirects off-origin has no
+// in-command way to accept that redirect on update.
+//
+// Install itself does keep the separation. installRemote selects the client
+// from the official-name branch, not from the URL, so a --source install is
+// never pinned at install time however it is spelled.
 func fetchBundleForRecordedSource(ctx context.Context, source string) ([]byte, []byte, error) {
 	if isOfficialRegistryURL(source) {
 		return fetchOfficialRegistryBundle(ctx, source)

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -436,6 +436,23 @@ func fetchOfficialRegistryBundle(ctx context.Context, bundleURL string) ([]byte,
 	return fetchRemoteBundleWithClient(ctx, bundleURL, officialRegistryClient)
 }
 
+// fetchBundleForRecordedSource fetches a bundle whose URL came from an
+// installed bundle's lock file rather than from the operator's --source flag.
+// A bundle installed by official name records the official registry URL as its
+// source, so update and diff must re-fetch it under the same pinned redirect
+// policy the install used; otherwise the pin covers only the one-time install
+// and not the commands an operator runs repeatedly afterwards.
+//
+// Routing on the RECORDED source preserves the separation that matters: an
+// operator-supplied --source that happens to spell the official URL stays on
+// the general client and never acquires official-path handling.
+func fetchBundleForRecordedSource(ctx context.Context, source string) ([]byte, []byte, error) {
+	if isOfficialRegistryURL(source) {
+		return fetchOfficialRegistryBundle(ctx, source)
+	}
+	return fetchRemoteBundle(ctx, source)
+}
+
 func fetchRemoteBundleWithClient(ctx context.Context, bundleURL string, client *http.Client) ([]byte, []byte, error) {
 	if !strings.HasPrefix(bundleURL, "https://") {
 		return nil, nil, fmt.Errorf("remote source must use HTTPS: %s", bundleURL)
@@ -455,10 +472,20 @@ func fetchRemoteBundleWithClient(ctx context.Context, bundleURL string, client *
 	return bundleData, sigData, nil
 }
 
+// maxBundleRedirects bounds a redirect chain. Setting CheckRedirect at all
+// replaces net/http's default callback, and the ten-hop cap lives IN that
+// default, so a custom callback that never inspects via silently removes the
+// bound. Without this, a redirect loop spins until the request context expires
+// instead of failing fast.
+const maxBundleRedirects = 10
+
 // httpsOnlyClient is a shared HTTP client that rejects HTTPS-to-HTTP
 // redirect downgrades. Bundle fetches must stay on HTTPS.
 var httpsOnlyClient = &http.Client{
-	CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxBundleRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxBundleRedirects)
+		}
 		if req.URL.Scheme != schemeHTTPS {
 			return fmt.Errorf("refusing redirect to non-HTTPS URL: %s", req.URL)
 		}
@@ -469,9 +496,12 @@ var httpsOnlyClient = &http.Client{
 // officialRegistryClient allows redirects only when they stay on the exact
 // official registry origin. User-supplied --source URLs never use this client.
 var officialRegistryClient = &http.Client{
-	CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxBundleRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxBundleRedirects)
+		}
 		if !isOfficialRegistryURL(req.URL.String()) {
-			return fmt.Errorf("%w: redirects must stay on %s (got %s)", errOfficialRegistryRedirect, officialRegistryURL, req.URL)
+			return fmt.Errorf("%w: redirects must stay on %s (got %s); if the registry moved, install explicitly with --source <url>", errOfficialRegistryRedirect, officialRegistryURL, req.URL)
 		}
 		return nil
 	},
@@ -1382,7 +1412,7 @@ func updateBundle(opts updateBundleOpts) error {
 
 	// Fetch latest from source.
 	ctx := context.Background()
-	bundleData, sigData, err := fetchRemoteBundle(ctx, lf.Source)
+	bundleData, sigData, err := fetchBundleForRecordedSource(ctx, lf.Source)
 	if err != nil {
 		return fmt.Errorf("fetching update for %s: %w", opts.Name, err)
 	}
@@ -1623,7 +1653,15 @@ func rulesDiffCmd() *cobra.Command {
 
 			// Fetch remote bundle.
 			ctx := context.Background()
-			remoteData, _, err := fetchRemoteBundle(ctx, fetchURL)
+			// Only a RECORDED official source gets the pinned client. An
+			// explicit --source override stays on the general path, so it
+			// cannot acquire official-path handling by spelling the URL.
+			var remoteData []byte
+			if sourceURL == "" {
+				remoteData, _, err = fetchBundleForRecordedSource(ctx, fetchURL)
+			} else {
+				remoteData, _, err = fetchRemoteBundle(ctx, fetchURL)
+			}
 			if err != nil {
 				return fmt.Errorf("fetching remote bundle: %w", err)
 			}

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,11 @@ import (
 // Official bundle registry base URL. Bundles are served as static files
 // from the pipelab.org Hugo site via Cloudflare Pages.
 const officialRegistryURL = "https://pipelab.org/rules"
+
+var (
+	errOfficialRegistryOrigin   = errors.New("official rules registry origin refused")
+	errOfficialRegistryRedirect = errors.New("official rules registry redirect refused")
+)
 
 var discoverRulesConfigPath = cliutil.DiscoverConfigPathStrict
 
@@ -418,17 +424,30 @@ func validateBundlePath(rulesDir, name string) (string, error) {
 // fetchRemoteBundle fetches bundle.yaml and bundle.yaml.sig from a remote URL.
 // Requires HTTPS. Returns the bundle data and signature data.
 func fetchRemoteBundle(ctx context.Context, bundleURL string) ([]byte, []byte, error) {
+	return fetchRemoteBundleWithClient(ctx, bundleURL, httpsOnlyClient)
+}
+
+// fetchOfficialRegistryBundle fetches a bundle from the built-in registry URL.
+// It pins both the initial URL and every redirect to the official HTTPS origin.
+func fetchOfficialRegistryBundle(ctx context.Context, bundleURL string) ([]byte, []byte, error) {
+	if !isOfficialRegistryURL(bundleURL) {
+		return nil, nil, fmt.Errorf("%w: expected %s, got %s", errOfficialRegistryOrigin, officialRegistryURL, bundleURL)
+	}
+	return fetchRemoteBundleWithClient(ctx, bundleURL, officialRegistryClient)
+}
+
+func fetchRemoteBundleWithClient(ctx context.Context, bundleURL string, client *http.Client) ([]byte, []byte, error) {
 	if !strings.HasPrefix(bundleURL, "https://") {
 		return nil, nil, fmt.Errorf("remote source must use HTTPS: %s", bundleURL)
 	}
 
-	bundleData, err := httpGet(ctx, bundleURL)
+	bundleData, err := httpGetWithClient(ctx, bundleURL, client)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetching bundle: %w", err)
 	}
 
 	sigURL := bundleURL + signing.SigExtension
-	sigData, err := httpGet(ctx, sigURL)
+	sigData, err := httpGetWithClient(ctx, sigURL, client)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetching signature: %w", err)
 	}
@@ -447,8 +466,35 @@ var httpsOnlyClient = &http.Client{
 	},
 }
 
+// officialRegistryClient allows redirects only when they stay on the exact
+// official registry origin. User-supplied --source URLs never use this client.
+var officialRegistryClient = &http.Client{
+	CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+		if !isOfficialRegistryURL(req.URL.String()) {
+			return fmt.Errorf("%w: redirects must stay on %s (got %s)", errOfficialRegistryRedirect, officialRegistryURL, req.URL)
+		}
+		return nil
+	},
+}
+
+func isOfficialRegistryURL(rawURL string) bool {
+	got, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	want, err := url.Parse(officialRegistryURL)
+	if err != nil {
+		return false
+	}
+	return got.Scheme == want.Scheme && got.Host == want.Host && got.User == nil
+}
+
 // httpGet performs an HTTP GET with context and timeout.
 func httpGet(ctx context.Context, url string) ([]byte, error) {
+	return httpGetWithClient(ctx, url, httpsOnlyClient)
+}
+
+func httpGetWithClient(ctx context.Context, url string, client *http.Client) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, httpFetchTimeout)
 	defer cancel()
 
@@ -457,7 +503,7 @@ func httpGet(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	resp, err := httpsOnlyClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP GET %s: %w", url, err)
 	}
@@ -693,6 +739,7 @@ Examples:
 					bundleURL:    url,
 					configFile:   configFile,
 					expectedName: name,
+					official:     true,
 				})
 			default:
 				return fmt.Errorf("specify a bundle name, --source URL, or --path DIR")
@@ -813,6 +860,7 @@ type installRemoteOptions struct {
 	bundleURL    string
 	configFile   string
 	expectedName string
+	official     bool
 }
 
 // installRemote installs a bundle from a remote URL.
@@ -845,7 +893,12 @@ func installRemote(opts installRemoteOptions) error {
 		return err
 	}
 
-	bundleData, sigData, err := fetchRemoteBundle(ctx, opts.bundleURL)
+	var bundleData, sigData []byte
+	if opts.official {
+		bundleData, sigData, err = fetchOfficialRegistryBundle(ctx, opts.bundleURL)
+	} else {
+		bundleData, sigData, err = fetchRemoteBundle(ctx, opts.bundleURL)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cli/rules/rules_redirect_guards_test.go
+++ b/internal/cli/rules/rules_redirect_guards_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
 package rules
 
 import (

--- a/internal/cli/rules/rules_redirect_guards_test.go
+++ b/internal/cli/rules/rules_redirect_guards_test.go
@@ -1,0 +1,78 @@
+package rules
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestBundleClients_StopAfterRedirectLoop proves the hop cap on BOTH clients.
+// Setting CheckRedirect at all replaces net/http's default callback, and the
+// ten-hop bound lives inside that default, so a custom callback that never
+// inspects via silently removes it. Without the cap a redirect loop spins until
+// the request context expires instead of failing fast.
+func TestBundleClients_StopAfterRedirectLoop(t *testing.T) {
+	// NOT parallel: mutates the shared clients.
+	originalOfficial := officialRegistryClient
+	originalHTTPS := httpsOnlyClient
+	t.Cleanup(func() {
+		officialRegistryClient = originalOfficial
+		httpsOnlyClient = originalHTTPS
+	})
+
+	// Each client redirects to itself forever. Only the hop cap can end it.
+	loop := func(host string) rulesRoundTripper {
+		return func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"https://" + host + req.URL.Path}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+	}
+	officialRegistryClient = &http.Client{
+		Transport:     loop("pipelab.org"),
+		CheckRedirect: originalOfficial.CheckRedirect,
+	}
+	httpsOnlyClient = &http.Client{
+		Transport:     loop("source.example"),
+		CheckRedirect: originalHTTPS.CheckRedirect,
+	}
+
+	if _, _, err := fetchOfficialRegistryBundle(t.Context(), officialRegistryURL+testBundlePath); err == nil ||
+		!strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("official client error = %v, want the redirect hop cap to stop the loop", err)
+	}
+	if _, _, err := fetchRemoteBundle(t.Context(), "https://source.example/bundle.yaml"); err == nil ||
+		!strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("general client error = %v, want the redirect hop cap to stop the loop", err)
+	}
+}
+
+// TestIsOfficialRegistryURL_EdgesFailClosed locks in the origin comparison.
+// Every deviation must refuse rather than match, including an unparseable
+// target, embedded credentials, and a lookalike host that merely contains or
+// extends the official one.
+func TestIsOfficialRegistryURL_EdgesFailClosed(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"exact official path", officialRegistryURL + testBundlePath, true},
+		{"unparseable", "https://pipelab.org/%zz", false},
+		{"empty", "", false},
+		{"userinfo smuggled", "https://user:pass@pipelab.org/rules/x/bundle.yaml", false},
+		{"suffix lookalike host", "https://pipelab.org.rules-attacker.example/rules/x", false},
+		{"prefix lookalike host", "https://evilpipelab.org/rules/x", false},
+		{"subdomain", "https://cdn.pipelab.org/rules/x", false},
+		{"scheme downgrade", "http://pipelab.org/rules/x", false},
+		{"explicit port", "https://pipelab.org:443/rules/x", false},
+	} {
+		if got := isOfficialRegistryURL(tc.url); got != tc.want {
+			t.Errorf("%s: isOfficialRegistryURL(%q) = %v, want %v", tc.name, tc.url, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -3097,3 +3097,137 @@ func TestRulesStatus_IncludeDefaultsFalse(t *testing.T) {
 		t.Error("expected 'disabled' when include_defaults: false")
 	}
 }
+
+// TestFetchBundleForRecordedSource_PinsOfficialSource proves the routing that
+// update and diff depend on. A bundle installed by official name records the
+// official registry URL as its source, so re-fetching that recorded source must
+// use the pinned client. Before this routing existed the pin covered only the
+// one-time install, leaving update and diff, the commands an operator runs
+// repeatedly, on the client that accepts a redirect to any HTTPS host.
+func TestFetchBundleForRecordedSource_PinsOfficialSource(t *testing.T) {
+	// NOT parallel: mutates the shared clients.
+	originalOfficial := officialRegistryClient
+	originalHTTPS := httpsOnlyClient
+	t.Cleanup(func() {
+		officialRegistryClient = originalOfficial
+		httpsOnlyClient = originalHTTPS
+	})
+
+	// The general client must never be reached for a recorded official source.
+	httpsOnlyClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("recorded official source was fetched with the unpinned client: %s", req.URL)
+		}),
+		CheckRedirect: originalHTTPS.CheckRedirect,
+	}
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "pipelab.org":
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://rules-attacker.example/bundle.yaml"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			default:
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("redirected response")),
+				}, nil
+			}
+		}),
+		CheckRedirect: originalOfficial.CheckRedirect,
+	}
+
+	_, _, err := fetchBundleForRecordedSource(t.Context(), officialRegistryURL+testBundlePath)
+	if !errors.Is(err, errOfficialRegistryRedirect) {
+		t.Fatalf("error = %v, want the recorded official source to be fetched under the pinned redirect policy", err)
+	}
+}
+
+// TestFetchBundleForRecordedSource_LeavesThirdPartySourceUnpinned is the other
+// direction: a recorded third-party source must stay on the general client, so
+// the pin does not quietly become a global redirect policy.
+func TestFetchBundleForRecordedSource_LeavesThirdPartySourceUnpinned(t *testing.T) {
+	// NOT parallel: mutates the shared clients.
+	originalOfficial := officialRegistryClient
+	originalHTTPS := httpsOnlyClient
+	t.Cleanup(func() {
+		officialRegistryClient = originalOfficial
+		httpsOnlyClient = originalHTTPS
+	})
+
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("third-party source was fetched with the pinned client: %s", req.URL)
+		}),
+		CheckRedirect: originalOfficial.CheckRedirect,
+	}
+	reached := false
+	httpsOnlyClient = &http.Client{
+		Transport: rulesRoundTripper(func(*http.Request) (*http.Response, error) {
+			reached = true
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+		CheckRedirect: originalHTTPS.CheckRedirect,
+	}
+
+	_, _, _ = fetchBundleForRecordedSource(t.Context(), "https://source.example/bundle.yaml")
+	if !reached {
+		t.Fatal("third-party recorded source did not use the general client")
+	}
+}
+
+// TestFetchOfficialRegistryBundle_AllowsSameOriginRedirect covers the
+// AVAILABILITY half of the design. Same-origin redirects are permitted on
+// purpose so a future registry path move does not break the documented install
+// command. Without this test, a later tightening that refused every redirect
+// would keep all the refusal tests green while breaking that command in
+// production.
+func TestFetchOfficialRegistryBundle_AllowsSameOriginRedirect(t *testing.T) {
+	// NOT parallel: mutates officialRegistryClient.
+	originalClient := officialRegistryClient
+	moved := "/rules-moved/community-rules/bundle.yaml"
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "pipelab.org" {
+				return nil, fmt.Errorf("left the official origin: %s", req.URL)
+			}
+			if !strings.HasPrefix(req.URL.Path, "/rules-moved/") {
+				target := moved
+				if strings.HasSuffix(req.URL.Path, signing.SigExtension) {
+					target += signing.SigExtension
+				}
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://pipelab.org" + target}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}
+			body := "moved-bundle"
+			if strings.HasSuffix(req.URL.Path, signing.SigExtension) {
+				body = "moved-signature"
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+		CheckRedirect: originalClient.CheckRedirect,
+	}
+	t.Cleanup(func() { officialRegistryClient = originalClient })
+
+	bundleData, sigData, err := fetchOfficialRegistryBundle(t.Context(), officialRegistryURL+testBundlePath)
+	if err != nil {
+		t.Fatalf("same-origin redirect refused: %v; a registry path move must not break the documented install", err)
+	}
+	if string(bundleData) != "moved-bundle" || string(sigData) != "moved-signature" {
+		t.Fatalf("bundle=%q sig=%q, want the redirected artifacts", bundleData, sigData)
+	}
+}

--- a/internal/cli/rules/rules_test.go
+++ b/internal/cli/rules/rules_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +26,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // Test-scoped constants for repeated string literals.
@@ -605,6 +608,118 @@ func TestRulesInstall_RemoteSigned(t *testing.T) {
 	}
 	if !strings.Contains(output, "official") {
 		t.Errorf("expected 'official' tier in output, got %q", output)
+	}
+}
+
+func TestFetchOfficialRegistryBundle_RejectsOffOriginRedirect(t *testing.T) {
+	// NOT parallel: mutates officialRegistryClient.
+	originalClient := officialRegistryClient
+	offOrigin := "https://rules-attacker.example/bundle.yaml"
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "pipelab.org":
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{offOrigin}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			case "rules-attacker.example":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("redirected response")),
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected request %s", req.URL)
+			}
+		}),
+		CheckRedirect: originalClient.CheckRedirect,
+	}
+	t.Cleanup(func() { officialRegistryClient = originalClient })
+
+	_, _, err := fetchOfficialRegistryBundle(t.Context(), officialRegistryURL+testBundlePath)
+	if !errors.Is(err, errOfficialRegistryRedirect) {
+		t.Fatalf("error = %v, want typed official registry redirect refusal", err)
+	}
+	if !strings.Contains(err.Error(), "redirects must stay on "+officialRegistryURL) {
+		t.Fatalf("error = %v, want operator-legible registry redirect error", err)
+	}
+}
+
+func TestFetchOfficialRegistryBundle_RejectsNonRegistryOrigin(t *testing.T) {
+	// NOT parallel: mutates officialRegistryClient.
+	originalClient := officialRegistryClient
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("bundle")),
+			}, nil
+		}),
+		CheckRedirect: originalClient.CheckRedirect,
+	}
+	t.Cleanup(func() { officialRegistryClient = originalClient })
+
+	_, _, err := fetchOfficialRegistryBundle(t.Context(), "https://source.example/bundle.yaml")
+	if !errors.Is(err, errOfficialRegistryOrigin) {
+		t.Fatalf("error = %v, want typed official registry origin refusal", err)
+	}
+}
+
+func TestRulesInstall_SourceOfficialURLAllowsHTTPSRedirect(t *testing.T) {
+	// NOT parallel: mutates the HTTP clients and the keyring globals.
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	setRulesKeyringHexForTest(t, hex.EncodeToString(pub))
+
+	bundleData := []byte(validBundleYAML)
+	sigData := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, bundleData)) + "\n")
+	originalHTTPSClient := httpsOnlyClient
+	httpsOnlyClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Host {
+			case "pipelab.org":
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://source.example" + req.URL.Path}},
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			case "source.example":
+				body := bundleData
+				if strings.HasSuffix(req.URL.Path, signing.SigExtension) {
+					body = sigData
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected source request %s", req.URL)
+			}
+		}),
+		CheckRedirect: originalHTTPSClient.CheckRedirect,
+	}
+	t.Cleanup(func() { httpsOnlyClient = originalHTTPSClient })
+
+	originalOfficialClient := officialRegistryClient
+	officialRegistryClient = &http.Client{
+		Transport: rulesRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("official registry client must not fetch --source URL %s", req.URL)
+		}),
+		CheckRedirect: originalOfficialClient.CheckRedirect,
+	}
+	t.Cleanup(func() { officialRegistryClient = originalOfficialClient })
+
+	cmd := testRootCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{"rules", "install", "--source", officialRegistryURL + testBundlePath, "--rules-dir", t.TempDir()})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--source using the official URL should retain generic HTTPS redirect behavior: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

A rules-registry fetch followed a redirect to any HTTPS host. The shared client rejected only an HTTPS-to-HTTP downgrade, so a response could steer a fetch of the official artifact to an arbitrary origin. Signature verification against the embedded key still gated staging, so this was never a path to installing an unsigned bundle, but it defeated any expectation that the official path talks only to the official origin.

Installs by official name now use a client that pins both the initial URL and every redirect to the exact official origin, comparing scheme, host and port on the parsed URL and refusing embedded credentials. Same-origin redirects stay allowed on purpose so a future registry path move does not break the documented first-run command, and the refusal names `--source` so an operator whose registry moved has a next step rather than a bare failure.

Update and diff route through the same pinned path when the bundle's recorded source is the official registry. The first version keyed that on a flag set only by the install path, which left update and diff, the commands an operator runs repeatedly, still following a redirect anywhere. Routing now derives from the recorded lock-file source instead of a flag a future caller can forget to set.

A `--source` URL that spells the official registry address stays on the general client and never acquires official-path handling. That separation is deliberate and has its own test in both directions, because a fetch path selectable by user input would be a worse problem than the one being fixed.

Both clients regained a redirect hop limit. Setting a redirect callback at all replaces the standard library's default, and the ten-hop bound lives inside that default, so supplying a custom callback silently removed it and a redirect loop ran until the request deadline instead of failing fast.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when downloading official rule bundles by validating sources and redirects.
  * Prevented redirect loops from stalling installations, updates, or comparisons.
  * Rejected unsafe redirects, including lookalike domains, downgraded connections, and unexpected ports.
* **Reliability**
  * Official registry downloads support valid same-origin redirects while rejecting off-origin destinations.
  * Updates and comparisons preserve the recorded source type.
  * Third-party sources continue using their configured download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->