### PR TITLE
fix: refuse unsafe installs and anchor posture evidence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2666,6 +2666,8 @@ flight_recorder:
   retention_days: 90
   redact: true
   require_receipts: false
+  require_containment_evidence: false
+  posture_signer_key: "/path/to/posture-signer.pub"
   sign_checkpoints: true
   signing_key_path: "/path/to/signing-key"
   max_entries_per_file: 10000
@@ -2701,6 +2703,8 @@ dashboard_snapshot:
 | `retention_days` | `0` | Auto-expire raw-escrow sidecars after N days. JSONL receipt-chain shards are preserved for offline verification. 0 = keep forever. |
 | `redact` | `true` | DLP-redact evidence content before writing. Receipt entries get field-level redaction (target/pattern scrubbed, signature preserved). |
 | `require_receipts` | `false` | Require allow-path receipt emission before forwarding traffic. When true, signing/recorder failures block with `receipt_emission_failed`; this includes TLS-intercepted CONNECT inner HTTP requests before their upstream request. Block-path receipts remain best-effort because the action is already denied. |
+| `require_containment_evidence` | `false` | Require a readable containment proof signed by the pinned `posture_signer_key` before signed receipts start. `absent`, `unreadable`, a proof without containment evidence, and a proof signed by another key refuse startup when this is true. Requires `enabled: true`, `dir`, `signing_key_path`, and `posture_signer_key`. It is startup-only; reload changes are ignored until restart. |
+| `posture_signer_key` | (empty) | Pinned Ed25519 public key, as 64 hex characters or a public-key file, used to verify containment proofs when `require_containment_evidence: true`. The runtime reads and pins the key at startup; it is not needed for ordinary receipt operation. `PIPELOCK_POSTURE_PROOF` can select an absolute proof path, but in required mode that proof must verify with this pinned key. |
 | `sign_checkpoints` | `true` | Ed25519 sign checkpoint entries |
 | `signing_key_path` | (empty) | Ed25519 private key for signed action receipts. When set, blocks produce signed receipts; allow receipts also require `require_receipts: true`, and clean stream frames are summarized. Without a key, the flight recorder can still write non-receipt evidence entries. Generate a key with `pipelock keygen <name>`. Verify receipts with `pipelock verify-receipt <file> --key <signer.pub>` (pin the signer key — an unpinned run is structural-only and exits non-zero unless you pass `--allow-unpinned`). In `pipelock run`, changing the configured path requires restart; reload re-reads updated key bytes only when the same path stays configured. |
 | `max_entries_per_file` | `10000` | Rotate to a new file after this many entries |

--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -57,6 +57,8 @@ flight_recorder:
   retention_days: 90             # auto-expire raw-escrow sidecars older than 90 days (0 = forever)
   redact: true                   # DLP redaction before commit (recommended)
   require_receipts: false        # fail closed before forwarding when allow receipts cannot be emitted
+  require_containment_evidence: false # set true to refuse startup unless a verified containment proof is available
+  posture_signer_key: /etc/pipelock/keys/flight-recorder-signing.key.pub # required when containment evidence is required
   sign_checkpoints: true         # Ed25519 signed checkpoints
   signing_key_path: /etc/pipelock/keys/flight-recorder-signing.key   # `pipelock init` writes this next to your config
   max_entries_per_file: 10000    # rotate to a new file after this many entries
@@ -72,6 +74,8 @@ flight_recorder:
 | `retention_days` | 0 | Auto-expire raw-escrow sidecars after N days. JSONL receipt-chain shards are preserved. 0 = never expire. |
 | `redact` | true | DLP scan each entry before writing. Replaces matched content with a redaction marker. |
 | `require_receipts` | false | Require receipt emission before allow-path traffic is forwarded. When true, missing or failed receipt emission blocks the action with `receipt_emission_failed`; block-path receipts remain best-effort because the action is already denied. |
+| `require_containment_evidence` | false | Refuse signed-receipt startup unless the process can read a containment proof that verifies with `posture_signer_key`. This setting is startup-only. |
+| `posture_signer_key` | (empty) | Pinned Ed25519 public key, as 64 hex characters or a public-key file. Required with `require_containment_evidence: true`; the key is read and pinned at startup. |
 | `sign_checkpoints` | true | Sign each checkpoint with the agent's Ed25519 private key. |
 | `max_entries_per_file` | 10000 | Rotate to a new JSONL file after this many entries. |
 | `raw_escrow` | false | Write an encrypted sidecar with the unredacted detail for each entry. |
@@ -135,6 +139,38 @@ Two operational notes:
   `action_id`**. Under `require_receipts` you will therefore see an allow
   followed by a block for one action — the request did egress, and the response
   was blocked separately.
+
+### Posture proof availability
+
+When a signed receipt session starts, it records `posture_proof_availability`
+in the unsigned top-level `ext` bag of its `session_open` receipt. The field is
+advisory diagnosis for a human reader, not verifier input or containment proof.
+It may be modified or removed without invalidating the individual receipt
+signature, but it is part of the full receipt envelope hash: changing a
+persisted `session_open` extension causes chain verification to fail once a
+successor receipt links to it.
+
+| Status | Runtime behavior | Meaning in the receipt |
+|--------|------------------|------------------------|
+| `attested` | Starts. | The proof was read and verified. A verified proof can still lack containment evidence. |
+| `absent` | Starts by default. | No proof file was present at the configured path. |
+| `unreadable` | Starts by default and writes a warning to stderr. | The process could not read the proof or traverse a parent directory. This does not establish that a proof exists. The warning names the path, filesystem cause, visible owner and group, and the access remedy. |
+| `invalid` | Refuses to start. | A present proof was malformed, unverifiable, or expired. No receipt is emitted from that startup. |
+
+Set `require_containment_evidence: true` when signed receipts must begin only
+with containment evidence signed by an operator-pinned key. Configure
+`posture_signer_key` with the key that signs the capsule; for containment runs
+that use the recorder signing key, its `<signing_key_path>.pub` sidecar is the
+natural value. In that mode `absent`, `unreadable`, an `attested` proof without
+containment evidence, and a proof signed by another key refuse startup.
+`invalid` always refuses startup. The setting requires `enabled`, `dir`,
+`signing_key_path`, and `posture_signer_key`, and changing any of them through a
+reload has no effect until restart.
+
+`PIPELOCK_POSTURE_PROOF` may select an absolute proof path for a process. In
+required mode the selected file still must verify with the pinned
+`posture_signer_key`; setting the variable cannot make a self-signed capsule
+satisfy containment evidence.
 
 ### Default-on footguns (handled)
 

--- a/internal/cli/contain/host_linux.go
+++ b/internal/cli/contain/host_linux.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package contain
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// requireContainHost rejects environments that cannot own the host lifecycle
+// containment installs. In particular, an init image can be root but cannot
+// create host users, install a host systemd service, or persist nftables rules.
+func requireContainHost() error {
+	return requireContainHostWith(os.Stat, os.ReadFile)
+}
+
+func requireContainHostWith(
+	stat func(string) (os.FileInfo, error),
+	readFile func(string) ([]byte, error),
+) error {
+	for _, marker := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := stat(marker); err == nil {
+			return unsupportedContainHostError("container marker " + marker + " is present")
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return unsupportedContainHostError(fmt.Sprintf("cannot inspect container marker %s: %v", marker, err))
+		}
+	}
+
+	pidOne, err := readFile("/proc/1/comm")
+	if err != nil {
+		return unsupportedContainHostError(fmt.Sprintf("cannot inspect host init process: %v", err))
+	}
+	if init := strings.TrimSpace(string(pidOne)); init != "systemd" {
+		return unsupportedContainHostError(fmt.Sprintf("PID 1 is %q, not systemd", init))
+	}
+	cgroup, err := readFile("/proc/1/cgroup")
+	if err != nil {
+		return unsupportedContainHostError(fmt.Sprintf("cannot inspect host cgroup: %v", err))
+	}
+	if containerCgroup(string(cgroup)) {
+		return unsupportedContainHostError("PID 1 cgroup identifies a container runtime")
+	}
+	return nil
+}
+
+var containerCgroupPath = regexp.MustCompile(`(?m):[^\n]*(?:/(?:docker(?:/|$)|kubepods(?:\.slice)?(?:/|$)|(?:docker|cri-containerd|crio|libpod)-[^/]+\.scope(?:/|$)))`)
+
+// containerCgroup recognizes the common cgroup path forms emitted by Docker,
+// Kubernetes runtimes, and Podman. It is deliberately not a claim of complete
+// container detection.
+func containerCgroup(cgroup string) bool {
+	return containerCgroupPath.MatchString(cgroup)
+}
+
+func unsupportedContainHostError(reason string) error {
+	return fmt.Errorf(
+		"pipelock contain install requires a supported Linux host with systemd as PID 1; %s. "+
+			"Container and init-image environments cannot install host users, systemd units, or nftables rules. "+
+			"Run this command on the host instead",
+		reason,
+	)
+}

--- a/internal/cli/contain/host_linux_test.go
+++ b/internal/cli/contain/host_linux_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package contain
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRequireContainHostWith(t *testing.T) {
+	tests := []struct {
+		name    string
+		markers map[string]bool
+		pidOne  string
+		want    string
+	}{
+		{name: "supported host", pidOne: "systemd\n"},
+		{name: "docker container", markers: map[string]bool{"/.dockerenv": true}, pidOne: "systemd\n", want: "container marker /.dockerenv is present"},
+		{name: "init image", pidOne: "pipelock\n", want: `PID 1 is "pipelock", not systemd`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stat := func(path string) (os.FileInfo, error) {
+				if tt.markers[path] {
+					return containFileInfo{name: path}, nil
+				}
+				return nil, os.ErrNotExist
+			}
+			err := requireContainHostWith(stat, func(path string) ([]byte, error) {
+				if path == "/proc/1/cgroup" {
+					return []byte("0::/\n"), nil
+				}
+				return []byte(tt.pidOne), nil
+			})
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("requireContainHostWith: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+			if !strings.Contains(err.Error(), "Run this command on the host instead") {
+				t.Fatalf("operator remedy missing from %q", err)
+			}
+		})
+	}
+}
+
+func TestContainerCgroup(t *testing.T) {
+	for _, tt := range []struct {
+		cgroup string
+		want   bool
+	}{
+		{cgroup: "0::/", want: false},
+		{cgroup: "0::/kubepods.slice/pod-id", want: true},
+		{cgroup: "0::/docker/012345", want: true},
+		{cgroup: "0::/system.slice/docker-012345.scope", want: true},
+		{cgroup: "0::/system.slice/cri-containerd-012345.scope", want: true},
+		{cgroup: "0::/system.slice/crio-012345.scope", want: true},
+		{cgroup: "0::/machine.slice/libpod-deadbeef.scope", want: true},
+	} {
+		if got := containerCgroup(tt.cgroup); got != tt.want {
+			t.Errorf("containerCgroup(%q) = %v, want %v", tt.cgroup, got, tt.want)
+		}
+	}
+}
+
+func TestRequireContainHostWithRefusesUnreadableMarker(t *testing.T) {
+	err := requireContainHostWith(
+		func(path string) (os.FileInfo, error) {
+			if path == "/.dockerenv" {
+				return nil, errors.New("permission denied")
+			}
+			return nil, os.ErrNotExist
+		},
+		func(string) ([]byte, error) { return []byte("systemd\n"), nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot inspect container marker /.dockerenv") || !strings.Contains(err.Error(), "Run this command on the host instead") {
+		t.Fatalf("error = %v, want fail-closed marker refusal with remedy", err)
+	}
+}
+
+func TestRequireContainHostWithRefusesUnreadableInit(t *testing.T) {
+	err := requireContainHostWith(
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		func(string) ([]byte, error) { return nil, errors.New("denied") },
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot inspect host init process") || !strings.Contains(err.Error(), "Run this command on the host instead") {
+		t.Fatalf("error = %v, want actionable unreadable init refusal", err)
+	}
+}
+
+func TestRequireContainHostWithRefusesUnreadableCgroup(t *testing.T) {
+	err := requireContainHostWith(
+		func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		func(path string) ([]byte, error) {
+			if path == "/proc/1/cgroup" {
+				return nil, errors.New("permission denied")
+			}
+			return []byte("systemd\n"), nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "cannot inspect host cgroup") || !strings.Contains(err.Error(), "Run this command on the host instead") {
+		t.Fatalf("error = %v, want actionable unreadable cgroup refusal", err)
+	}
+}

--- a/internal/cli/contain/host_other.go
+++ b/internal/cli/contain/host_other.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package contain
+
+import "errors"
+
+func requireContainHost() error {
+	return errors.New("pipelock contain install requires a supported Linux host with systemd and nftables")
+}

--- a/internal/cli/contain/install.go
+++ b/internal/cli/contain/install.go
@@ -37,6 +37,14 @@ type installOpts struct {
 
 var containUsernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
 
+// Test seams keep the command-level host preflight load-bearing: an
+// unsupported host must fail before an install environment is constructed.
+var (
+	requireContainInstallPrivilege = requireContainPrivilege
+	requireContainInstallHost      = requireContainHost
+	newContainInstallEnv           = defaultInstallEnv
+)
+
 // containToolNameRegex is the shared regex that both plk-launch and the plk
 // meta-wrapper enforce on operator-supplied tool names. Keeping a single
 // source of truth prevents the two wrappers from drifting and letting a name
@@ -81,11 +89,14 @@ Exit codes:
 				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 			}
 			if !opts.dryRun {
-				if err := requireContainPrivilege("install"); err != nil {
+				if err := requireContainInstallPrivilege("install"); err != nil {
+					return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+				}
+				if err := requireContainInstallHost(); err != nil {
 					return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 				}
 			}
-			env := defaultInstallEnv(cmd.OutOrStdout())
+			env := newContainInstallEnv(cmd.OutOrStdout())
 			if opts.operatorUser != "" {
 				env.operatorUser = opts.operatorUser
 			}

--- a/internal/cli/contain/install_test.go
+++ b/internal/cli/contain/install_test.go
@@ -2176,6 +2176,58 @@ func TestInstallCmdRejectsInvalidPortBeforeRootCheck(t *testing.T) {
 	}
 }
 
+func TestInstallCmdUnsupportedHostStopsBeforeInstallEnvironment(t *testing.T) {
+	origPrivilege := requireContainInstallPrivilege
+	origHost := requireContainInstallHost
+	origEnv := newContainInstallEnv
+	t.Cleanup(func() {
+		requireContainInstallPrivilege = origPrivilege
+		requireContainInstallHost = origHost
+		newContainInstallEnv = origEnv
+	})
+
+	requireContainInstallPrivilege = func(string) error { return nil }
+	requireContainInstallHost = func() error { return errors.New("unsupported test host") }
+	newContainInstallEnv = func(io.Writer) *installEnv {
+		t.Fatal("unsupported host reached install environment construction")
+		return nil
+	}
+
+	cmd := installCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil || cliutil.ExitCodeOf(err) != cliutil.ExitConfig || !strings.Contains(err.Error(), "unsupported test host") {
+		t.Fatalf("error = %v, want unsupported-host precondition failure", err)
+	}
+}
+
+func TestInstallCmdDryRunSkipsHostPreflightAndPrintsPlan(t *testing.T) {
+	origHost := requireContainInstallHost
+	origEnv := newContainInstallEnv
+	t.Cleanup(func() {
+		requireContainInstallHost = origHost
+		newContainInstallEnv = origEnv
+	})
+	requireContainInstallHost = func() error {
+		t.Fatal("dry-run must not run host preflight")
+		return nil
+	}
+	env, _, out := newFakeEnv(t)
+	newContainInstallEnv = func(io.Writer) *installEnv { return env }
+	src := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(src, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := installCmd()
+	cmd.SetArgs([]string{"--dry-run", "--operator-user", containInstallOperatorUser, "--pipelock-binary", env.pipelockBinary, "--config", src})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "planned steps") {
+		t.Fatalf("dry-run output = %q, want plan", out.String())
+	}
+}
+
 func TestWalkAndChown_NoOpEnvCallsForEveryFile(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	chownCalls := 0

--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -337,9 +337,11 @@ func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scann
 	evidence.recorder = rec
 	evidence.proxyOptions = append(evidence.proxyOptions, proxy.WithRecorder(rec))
 
-	binding, err := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
-		ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
-		Stderr:                stderr,
+	postureResult, err := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      cfg.FlightRecorder.SigningKeyPath != "",
+		RequireContainmentEvidence: cfg.FlightRecorder.RequireContainmentEvidence,
+		PinnedPostureSignerKey:     cfg.FlightRecorder.PostureSignerPublicKey,
+		Stderr:                     stderr,
 	})
 	if err != nil {
 		evidence.close()
@@ -347,8 +349,9 @@ func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scann
 	}
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
 		Recorder: rec, PrivKey: privateKey, ConfigHash: cfg.CanonicalPolicyHash(),
-		Principal: "local", Actor: "pipelock", Metrics: m, PostureBinding: binding,
-		HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
+		Principal: "local", Actor: "pipelock", Metrics: m, PostureBinding: postureResult.Binding,
+		PostureAvailability: string(postureResult.Availability),
+		HeartbeatSeconds:    cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 	})
 	if !receiptEmitterReady(emitter) {
 		if cfg.FlightRecorder.RequireReceipts {

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1121,9 +1121,11 @@ Key-free evidence capture:
 					retentionCancel()
 					retentionWG.Wait()
 				}()
-				postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
-					ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
-					Stderr:                cmd.ErrOrStderr(),
+				postureResult, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+					ReceiptSigningEnabled:      cfg.FlightRecorder.SigningKeyPath != "",
+					RequireContainmentEvidence: cfg.FlightRecorder.RequireContainmentEvidence,
+					PinnedPostureSignerKey:     cfg.FlightRecorder.PostureSignerPublicKey,
+					Stderr:                     cmd.ErrOrStderr(),
 				})
 				if bindErr != nil {
 					return fmt.Errorf("loading posture binding: %w", bindErr)
@@ -1140,14 +1142,15 @@ Key-free evidence capture:
 				// bundle merge and auto-enable.
 				// The shared MCP registry also captures receipt emission failures.
 				receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
-					Recorder:         rec,
-					PrivKey:          recPrivKey,
-					ConfigHash:       cfg.Hash(),
-					Principal:        "local",
-					Actor:            "pipelock",
-					Metrics:          mcpMetrics,
-					PostureBinding:   postureBinding,
-					HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
+					Recorder:            rec,
+					PrivKey:             recPrivKey,
+					ConfigHash:          cfg.Hash(),
+					Principal:           "local",
+					Actor:               "pipelock",
+					Metrics:             mcpMetrics,
+					PostureBinding:      postureResult.Binding,
+					PostureAvailability: string(postureResult.Availability),
+					HeartbeatSeconds:    cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 				})
 
 				cmd.PrintErrf("  Recorder: %s (flight recorder enabled)\n", cfg.FlightRecorder.Dir)

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -561,9 +561,11 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		runFlightRecorderExpiryOnce(rec, opts.Stderr, opts.expiry())
 		s.recorder = rec
 		proxyOpts = append(proxyOpts, proxy.WithRecorder(rec))
-		postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
-			ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
-			Stderr:                opts.Stderr,
+		postureResult, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+			ReceiptSigningEnabled:      cfg.FlightRecorder.SigningKeyPath != "",
+			RequireContainmentEvidence: cfg.FlightRecorder.RequireContainmentEvidence,
+			PinnedPostureSignerKey:     cfg.FlightRecorder.PostureSignerPublicKey,
+			Stderr:                     opts.Stderr,
 		})
 		if bindErr != nil {
 			s.cleanup()
@@ -580,14 +582,15 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		// effective policy should produce identical envelope ph
 		// regardless of YAML formatting.
 		s.receiptEmitter = receipt.NewEmitter(receipt.EmitterConfig{
-			Recorder:         rec,
-			PrivKey:          recPrivKey,
-			ConfigHash:       cfg.Hash(),
-			Principal:        "local",
-			Actor:            "pipelock",
-			Metrics:          m,
-			PostureBinding:   postureBinding,
-			HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
+			Recorder:            rec,
+			PrivKey:             recPrivKey,
+			ConfigHash:          cfg.Hash(),
+			Principal:           "local",
+			Actor:               "pipelock",
+			Metrics:             m,
+			PostureBinding:      postureResult.Binding,
+			PostureAvailability: string(postureResult.Availability),
+			HeartbeatSeconds:    cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 		})
 		if s.receiptEmitter != nil {
 			// Loud, one-time startup signal when the chain could not be

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -173,7 +173,9 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		oldFR.EvidenceHealth.MaxAnchorLag = newFR.EvidenceHealth.MaxAnchorLag
 		oldFR.Anchor = newFR.Anchor
 		if !reflect.DeepEqual(oldFR, newFR) {
-			if oldCfg.FlightRecorder.SigningKeyPath != newCfg.FlightRecorder.SigningKeyPath {
+			if oldCfg.FlightRecorder.RequireContainmentEvidence != newCfg.FlightRecorder.RequireContainmentEvidence {
+				_, _ = fmt.Fprintln(s.opts.Stderr, "WARNING: config reload: flight_recorder.require_containment_evidence changed, but posture evidence is checked when signed receipts start. Ignoring the change until restart.")
+			} else if oldCfg.FlightRecorder.SigningKeyPath != newCfg.FlightRecorder.SigningKeyPath {
 				_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: flight_recorder.signing_key_path changed from %q to %q — receipt chain cannot rotate at runtime, ignoring (restart required)\n",
 					oldCfg.FlightRecorder.SigningKeyPath, newCfg.FlightRecorder.SigningKeyPath)
 			} else if !boolPtrEqual(oldCfg.FlightRecorder.EvidenceHealth.Enabled, newCfg.FlightRecorder.EvidenceHealth.Enabled) {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/filesentry"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/posture"
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
 	"github.com/luckyPipewrench/pipelock/internal/proxy"
 	"github.com/luckyPipewrench/pipelock/internal/rules"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
@@ -3415,6 +3417,119 @@ func TestServer_Reload_IgnoresFlightRecorderHeartbeatIntervalChange(t *testing.T
 	}
 	if !buf.contains("flight_recorder settings changed") {
 		t.Fatalf("stderr missing flight_recorder restart-only warning:\n%s", buf.String())
+	}
+}
+
+func newContainmentEvidenceReloadServer(t *testing.T, require bool) (*Server, *syncBuffer) {
+	t.Helper()
+	dir := t.TempDir()
+	_, receiptKey, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair receipt: %v", err)
+	}
+	receiptKeyPath := filepath.Join(dir, "receipt.key")
+	if err := signing.SavePrivateKey(receiptKey, receiptKeyPath); err != nil {
+		t.Fatalf("SavePrivateKey receipt: %v", err)
+	}
+	posturePublicKey, postureKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey posture: %v", err)
+	}
+	capsule, err := posture.Emit(config.Defaults(), posture.Options{
+		SigningKey: postureKey,
+		Containment: &posture.ContainmentEvidence{
+			Mode:                     posture.ContainmentModeKernelNFTOwnerMatch,
+			BoundaryVerified:         true,
+			ProbeRefusedDirectEgress: true,
+			KernelRuleHash:           strings.Repeat("a", 64),
+			TargetUID:                "966",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emit posture capsule: %v", err)
+	}
+	proof, err := json.Marshal(capsule)
+	if err != nil {
+		t.Fatalf("Marshal posture capsule: %v", err)
+	}
+	proofPath := filepath.Join(dir, "proof.json")
+	if err := os.WriteFile(proofPath, proof, 0o600); err != nil {
+		t.Fatalf("Write posture capsule: %v", err)
+	}
+	t.Setenv(posturebinding.RuntimeProofEnv, proofPath)
+
+	cfgPath := writeServerTestConfig(t, strings.Join([]string{
+		"mode: balanced",
+		"flight_recorder:",
+		"  enabled: true",
+		"  dir: " + strconv.Quote(filepath.Join(dir, "receipts")),
+		"  signing_key_path: " + strconv.Quote(receiptKeyPath),
+		"  posture_signer_key: " + strconv.Quote(hex.EncodeToString(posturePublicKey)),
+		"  require_containment_evidence: " + strconv.FormatBool(require),
+		"",
+	}, "\n"))
+	return newTestServer(t, func(opts *ServerOpts) { opts.ConfigFile = cfgPath })
+}
+
+func TestServer_Reload_ContainmentEvidenceRequirementIsRestartOnly(t *testing.T) {
+	s, buf := newContainmentEvidenceReloadServer(t, true)
+	oldLive := s.proxy.CurrentConfig()
+	if !oldLive.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("server did not start with required containment evidence")
+	}
+
+	changed := oldLive.Clone()
+	changed.FlightRecorder.RequireContainmentEvidence = false
+	if err := s.Reload(changed); err != nil {
+		t.Fatalf("Reload changed requirement: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if !live.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("containment evidence requirement was removed by reload")
+	}
+	s.stateMu.RLock()
+	runtimeRequire := s.cfg.FlightRecorder.RequireContainmentEvidence
+	s.stateMu.RUnlock()
+	if !runtimeRequire {
+		t.Fatal("server runtime state applied the restart-only containment evidence change")
+	}
+	if !buf.contains("flight_recorder.require_containment_evidence changed") {
+		t.Fatalf("stderr missing restart-only requirement warning:\n%s", buf.String())
+	}
+
+	buf.reset()
+	if err := s.Reload(live.Clone()); err != nil {
+		t.Fatalf("Reload unchanged requirement: %v", err)
+	}
+	if buf.contains("flight_recorder.require_containment_evidence changed") {
+		t.Fatalf("unchanged requirement produced a restart-only warning:\n%s", buf.String())
+	}
+}
+
+func TestServer_Reload_ContainmentEvidenceRequirementEnableIsRestartOnly(t *testing.T) {
+	s, buf := newContainmentEvidenceReloadServer(t, false)
+	oldLive := s.proxy.CurrentConfig()
+	if oldLive.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("server unexpectedly started with required containment evidence")
+	}
+
+	changed := oldLive.Clone()
+	changed.FlightRecorder.RequireContainmentEvidence = true
+	if err := s.Reload(changed); err != nil {
+		t.Fatalf("Reload enabled requirement: %v", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("reload silently enabled containment evidence requirement without a restart")
+	}
+	s.stateMu.RLock()
+	runtimeRequire := s.cfg.FlightRecorder.RequireContainmentEvidence
+	s.stateMu.RUnlock()
+	if runtimeRequire {
+		t.Fatal("server runtime state applied the restart-only containment evidence change")
+	}
+	if !buf.contains("flight_recorder.require_containment_evidence changed") {
+		t.Fatalf("stderr missing restart-only requirement warning:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -3471,6 +3471,92 @@ func newContainmentEvidenceReloadServer(t *testing.T, require bool) (*Server, *s
 	return newTestServer(t, func(opts *ServerOpts) { opts.ConfigFile = cfgPath })
 }
 
+func TestNewServer_RequiredContainmentEvidenceFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		proofKind string
+	}{
+		{name: "missing proof", proofKind: "missing"},
+		{name: "different signer", proofKind: "different-signer"},
+		{name: "no containment evidence", proofKind: "no-containment"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, receiptKey, err := signing.GenerateKeyPair()
+			if err != nil {
+				t.Fatalf("GenerateKeyPair receipt: %v", err)
+			}
+			receiptKeyPath := filepath.Join(dir, "receipt.key")
+			if err := signing.SavePrivateKey(receiptKey, receiptKeyPath); err != nil {
+				t.Fatalf("SavePrivateKey receipt: %v", err)
+			}
+
+			posturePublicKey, postureKey, err := ed25519.GenerateKey(nil)
+			if err != nil {
+				t.Fatalf("GenerateKey posture: %v", err)
+			}
+			proofPath := filepath.Join(dir, "proof.json")
+			if tc.proofKind != "missing" {
+				proofKey := postureKey
+				containment := (*posture.ContainmentEvidence)(nil)
+				if tc.proofKind == "different-signer" {
+					_, proofKey, err = ed25519.GenerateKey(nil)
+					if err != nil {
+						t.Fatalf("GenerateKey mismatched posture: %v", err)
+					}
+					containment = &posture.ContainmentEvidence{
+						Mode:                     posture.ContainmentModeKernelNFTOwnerMatch,
+						BoundaryVerified:         true,
+						ProbeRefusedDirectEgress: true,
+						KernelRuleHash:           strings.Repeat("a", 64),
+						TargetUID:                "966",
+					}
+				}
+				capsule, emitErr := posture.Emit(config.Defaults(), posture.Options{
+					SigningKey:  proofKey,
+					Containment: containment,
+				})
+				if emitErr != nil {
+					t.Fatalf("Emit posture capsule: %v", emitErr)
+				}
+				proof, marshalErr := json.Marshal(capsule)
+				if marshalErr != nil {
+					t.Fatalf("Marshal posture capsule: %v", marshalErr)
+				}
+				if err := os.WriteFile(proofPath, proof, 0o600); err != nil {
+					t.Fatalf("Write posture capsule: %v", err)
+				}
+			}
+			t.Setenv(posturebinding.RuntimeProofEnv, proofPath)
+
+			cfgPath := writeServerTestConfig(t, strings.Join([]string{
+				"mode: balanced",
+				"flight_recorder:",
+				"  enabled: true",
+				"  dir: " + strconv.Quote(filepath.Join(dir, "receipts")),
+				"  signing_key_path: " + strconv.Quote(receiptKeyPath),
+				"  posture_signer_key: " + strconv.Quote(hex.EncodeToString(posturePublicKey)),
+				"  require_containment_evidence: true",
+				"",
+			}, "\n"))
+			buf := &syncBuffer{}
+			s, err := NewServer(ServerOpts{
+				ConfigFile:                        cfgPath,
+				Stdout:                            buf,
+				Stderr:                            buf,
+				allowEphemeralListenersForTesting: true,
+			})
+			if s != nil {
+				s.cleanup()
+				t.Fatal("NewServer returned a server for invalid containment evidence")
+			}
+			if err == nil || !strings.Contains(err.Error(), "loading posture binding") {
+				t.Fatalf("NewServer error = %v, want fail-closed posture binding error", err)
+			}
+		})
+	}
+}
+
 func TestServer_Reload_ContainmentEvidenceRequirementIsRestartOnly(t *testing.T) {
 	s, buf := newContainmentEvidenceReloadServer(t, true)
 	oldLive := s.proxy.CurrentConfig()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11705,6 +11705,97 @@ func TestLoad_FlightRecorderRequireReceiptsReloadStates(t *testing.T) {
 	}
 }
 
+func TestLoad_FlightRecorderRequireContainmentEvidenceStates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		section string
+		want    bool
+	}{
+		{name: "omitted_whole_section", section: "", want: false},
+		{name: "key_null", section: "flight_recorder:\n  require_containment_evidence:\n", want: false},
+		{name: "key_blank", section: "flight_recorder:\n  require_containment_evidence: \n", want: false},
+		{name: "explicit_false", section: "flight_recorder:\n  require_containment_evidence: false\n", want: false},
+		{name: "explicit_true", section: "flight_recorder:\n  enabled: true\n  dir: /tmp/recorder\n  signing_key_path: /tmp/recorder.key\n  posture_signer_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  require_containment_evidence: true\n", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfgPath := filepath.Join(t.TempDir(), "fr-require-containment.yaml")
+			if err := os.WriteFile(cfgPath, []byte("mode: balanced\n"+tt.section), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+			if cfg.FlightRecorder.RequireContainmentEvidence != tt.want {
+				t.Errorf("FlightRecorder.RequireContainmentEvidence = %v, want %v", cfg.FlightRecorder.RequireContainmentEvidence, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_FlightRecorderRequireContainmentEvidenceReloadStates(t *testing.T) {
+	t.Parallel()
+	cfgPath := filepath.Join(t.TempDir(), "fr-require-containment-reload.yaml")
+	firstContent := "mode: balanced\nflight_recorder:\n  require_containment_evidence: false\n"
+	if err := os.WriteFile(cfgPath, []byte(firstContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #1: %v", err)
+	}
+	if first.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("first load RequireContainmentEvidence = true, want false")
+	}
+
+	changedContent := "mode: balanced\nflight_recorder:\n  enabled: true\n  dir: /tmp/recorder\n  signing_key_path: /tmp/recorder.key\n  posture_signer_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  require_containment_evidence: true\n"
+	if err := os.WriteFile(cfgPath, []byte(changedContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #2: %v", err)
+	}
+	if !second.FlightRecorder.RequireContainmentEvidence {
+		t.Fatal("reload with change RequireContainmentEvidence = false, want true")
+	}
+
+	third, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load #3: %v", err)
+	}
+	if third.FlightRecorder.RequireContainmentEvidence != second.FlightRecorder.RequireContainmentEvidence {
+		t.Fatalf("reload without change RequireContainmentEvidence = %v, want %v",
+			third.FlightRecorder.RequireContainmentEvidence, second.FlightRecorder.RequireContainmentEvidence)
+	}
+}
+
+func TestValidate_FlightRecorderContainmentPinsPostureSignerKey(t *testing.T) {
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	cfg := Defaults()
+	cfg.FlightRecorder.RequireContainmentEvidence = true
+	cfg.FlightRecorder.Dir = testRecorderDir
+	cfg.FlightRecorder.SigningKeyPath = "/tmp/recorder.key"
+	cfg.FlightRecorder.PostureSignerKey = hex.EncodeToString(publicKey)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !bytes.Equal(cfg.FlightRecorder.PostureSignerPublicKey, publicKey) {
+		t.Fatal("validated posture signer key did not match configured pin")
+	}
+	clone := cfg.Clone()
+	clone.FlightRecorder.PostureSignerPublicKey[0] ^= 0xff
+	if bytes.Equal(clone.FlightRecorder.PostureSignerPublicKey, cfg.FlightRecorder.PostureSignerPublicKey) {
+		t.Fatal("cloned posture signer key aliases the validated config")
+	}
+}
+
 func TestLoad_MCPToolProvenanceDefaults(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "prov.yaml")
@@ -15223,6 +15314,63 @@ func TestValidate_FlightRecorder(t *testing.T) {
 				return c
 			},
 			wantErr: "require_receipts requires flight_recorder.signing_key_path",
+		},
+		{
+			name: "require_containment_evidence_requires_enabled",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.Enabled = false
+				c.FlightRecorder.RequireContainmentEvidence = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.SigningKeyPath = "/tmp/recorder.key"
+				return c
+			},
+			wantErr: "require_containment_evidence requires flight_recorder.enabled",
+		},
+		{
+			name: "require_containment_evidence_requires_dir",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.RequireContainmentEvidence = true
+				c.FlightRecorder.Dir = ""
+				c.FlightRecorder.SigningKeyPath = "/tmp/recorder.key"
+				return c
+			},
+			wantErr: "require_containment_evidence requires flight_recorder.dir",
+		},
+		{
+			name: "require_containment_evidence_requires_signing_key_path",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.RequireContainmentEvidence = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.SigningKeyPath = ""
+				return c
+			},
+			wantErr: "require_containment_evidence requires flight_recorder.signing_key_path",
+		},
+		{
+			name: "require_containment_evidence_requires_posture_signer_key",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.RequireContainmentEvidence = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.SigningKeyPath = "/tmp/recorder.key"
+				return c
+			},
+			wantErr: "require_containment_evidence requires flight_recorder.posture_signer_key",
+		},
+		{
+			name: "require_containment_evidence_rejects_invalid_posture_signer_key",
+			cfg: func() *Config {
+				c := Defaults()
+				c.FlightRecorder.RequireContainmentEvidence = true
+				c.FlightRecorder.Dir = testRecorderDir
+				c.FlightRecorder.SigningKeyPath = "/tmp/recorder.key"
+				c.FlightRecorder.PostureSignerKey = "not-a-public-key"
+				return c
+			},
+			wantErr: "load flight_recorder.posture_signer_key",
 		},
 		{
 			// Enabled is on by default; without a dir the recorder is inert

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -552,12 +552,13 @@ func Defaults() *Config {
 			// silently fill the disk or leak. Evidence, not enforcement by default:
 			// a recorder failure never blocks traffic unless RequireReceipts is
 			// explicitly enabled by the operator.
-			Enabled:            true,
-			RequireReceipts:    false,
-			CheckpointInterval: 1000,  // entries between signed checkpoints
-			Redact:             true,  // DLP-scrub evidence before commit
-			SignCheckpoints:    true,  // Ed25519 sign checkpoints
-			MaxEntriesPerFile:  10000, // rotate files at this count
+			Enabled:                    true,
+			RequireReceipts:            false,
+			RequireContainmentEvidence: false,
+			CheckpointInterval:         1000,  // entries between signed checkpoints
+			Redact:                     true,  // DLP-scrub evidence before commit
+			SignCheckpoints:            true,  // Ed25519 sign checkpoints
+			MaxEntriesPerFile:          10000, // rotate files at this count
 			Completeness: FlightRecorderCompleteness{
 				HeartbeatInterval: "60s",
 			},

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -257,6 +257,9 @@ func (c *Config) Clone() *Config {
 	if c.MCPToolScanning.ListenerDriftResetAuthorityPublicKey != nil {
 		clone.MCPToolScanning.ListenerDriftResetAuthorityPublicKey = append([]byte(nil), c.MCPToolScanning.ListenerDriftResetAuthorityPublicKey...)
 	}
+	if c.FlightRecorder.PostureSignerPublicKey != nil {
+		clone.FlightRecorder.PostureSignerPublicKey = append([]byte(nil), c.FlightRecorder.PostureSignerPublicKey...)
+	}
 
 	clone.DLP.Patterns = cloneDLPPatterns(c.DLP.Patterns)
 	clone.ResponseScanning.Patterns = cloneResponseScanPatterns(c.ResponseScanning.Patterns)

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1590,21 +1590,24 @@ type BudgetConfig struct {
 
 // FlightRecorder configures the tamper-evident evidence recording system.
 type FlightRecorder struct {
-	Enabled            bool                         `yaml:"enabled"`
-	Dir                string                       `yaml:"dir"`
-	CheckpointInterval int                          `yaml:"checkpoint_interval"`      // entries between signed checkpoints (default 1000)
-	RetentionDays      int                          `yaml:"retention_days"`           // auto-expire raw sidecars after N days (0=forever)
-	Redact             bool                         `yaml:"redact"`                   // DLP on evidence before commit (default true)
-	SignCheckpoints    bool                         `yaml:"sign_checkpoints"`         // Ed25519 sign checkpoints (default true)
-	MaxEntriesPerFile  int                          `yaml:"max_entries_per_file"`     // rotate files (default 10000)
-	FileMode           os.FileMode                  `yaml:"file_mode" json:"-"`       // evidence file permissions: 0600, 0640, or 0660 (default 0600)
-	RawEscrow          bool                         `yaml:"raw_escrow"`               // encrypted raw detail sidecar (default false)
-	EscrowPublicKey    string                       `yaml:"escrow_public_key"`        // X25519 public key for raw escrow encryption
-	SigningKeyPath     string                       `yaml:"signing_key_path"`         // Ed25519 private key for checkpoint signing and action receipts
-	RequireReceipts    bool                         `yaml:"require_receipts"`         // fail closed when a required receipt cannot be emitted (default false)
-	Completeness       FlightRecorderCompleteness   `yaml:"completeness" json:"-"`    // restart-only evidence completeness knobs
-	EvidenceHealth     FlightRecorderEvidenceHealth `yaml:"evidence_health" json:"-"` // process-local evidence health monitoring
-	Anchor             FlightRecorderAnchor         `yaml:"anchor" json:"-"`          // optional runtime receipt-chain anchoring
+	Enabled                    bool                         `yaml:"enabled"`
+	Dir                        string                       `yaml:"dir"`
+	CheckpointInterval         int                          `yaml:"checkpoint_interval"`                   // entries between signed checkpoints (default 1000)
+	RetentionDays              int                          `yaml:"retention_days"`                        // auto-expire raw sidecars after N days (0=forever)
+	Redact                     bool                         `yaml:"redact"`                                // DLP on evidence before commit (default true)
+	SignCheckpoints            bool                         `yaml:"sign_checkpoints"`                      // Ed25519 sign checkpoints (default true)
+	MaxEntriesPerFile          int                          `yaml:"max_entries_per_file"`                  // rotate files (default 10000)
+	FileMode                   os.FileMode                  `yaml:"file_mode" json:"-"`                    // evidence file permissions: 0600, 0640, or 0660 (default 0600)
+	RawEscrow                  bool                         `yaml:"raw_escrow"`                            // encrypted raw detail sidecar (default false)
+	EscrowPublicKey            string                       `yaml:"escrow_public_key"`                     // X25519 public key for raw escrow encryption
+	SigningKeyPath             string                       `yaml:"signing_key_path"`                      // Ed25519 private key for checkpoint signing and action receipts
+	RequireReceipts            bool                         `yaml:"require_receipts"`                      // fail closed when a required receipt cannot be emitted (default false)
+	RequireContainmentEvidence bool                         `yaml:"require_containment_evidence" json:"-"` // require a verified containment posture binding before signed receipts start (default false; restart-only)
+	PostureSignerKey           string                       `yaml:"posture_signer_key" json:"-"`           // pinned Ed25519 public key or public-key file for required containment evidence
+	PostureSignerPublicKey     ed25519.PublicKey            `yaml:"-" json:"-"`                            // parsed at validation; runtime must not reopen PostureSignerKey
+	Completeness               FlightRecorderCompleteness   `yaml:"completeness" json:"-"`                 // restart-only evidence completeness knobs
+	EvidenceHealth             FlightRecorderEvidenceHealth `yaml:"evidence_health" json:"-"`              // process-local evidence health monitoring
+	Anchor                     FlightRecorderAnchor         `yaml:"anchor" json:"-"`                       // optional runtime receipt-chain anchoring
 }
 
 // EvidenceProvenance configures the private operator-owned material needed to

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3493,18 +3493,33 @@ func (c *Config) validateSandbox() error {
 }
 
 func (c *Config) validateFlightRecorder(warnings *[]Warning) error {
+	c.FlightRecorder.PostureSignerPublicKey = nil
 	if err := c.validateFlightRecorderAnchor(warnings); err != nil {
 		return err
 	}
-	if c.FlightRecorder.RequireReceipts {
+	if c.FlightRecorder.RequireReceipts || c.FlightRecorder.RequireContainmentEvidence {
+		requirement := "flight_recorder.require_receipts"
+		if c.FlightRecorder.RequireContainmentEvidence {
+			requirement = "flight_recorder.require_containment_evidence"
+		}
 		switch {
 		case !c.FlightRecorder.Enabled:
-			return fmt.Errorf("flight_recorder.require_receipts requires flight_recorder.enabled")
+			return fmt.Errorf("%s requires flight_recorder.enabled", requirement)
 		case c.FlightRecorder.Dir == "":
-			return fmt.Errorf("flight_recorder.require_receipts requires flight_recorder.dir")
+			return fmt.Errorf("%s requires flight_recorder.dir", requirement)
 		case c.FlightRecorder.SigningKeyPath == "":
-			return fmt.Errorf("flight_recorder.require_receipts requires flight_recorder.signing_key_path")
+			return fmt.Errorf("%s requires flight_recorder.signing_key_path", requirement)
 		}
+	}
+	if c.FlightRecorder.RequireContainmentEvidence {
+		if strings.TrimSpace(c.FlightRecorder.PostureSignerKey) == "" {
+			return errors.New("flight_recorder.require_containment_evidence requires flight_recorder.posture_signer_key")
+		}
+		publicKey, err := signing.LoadPublicKey(c.FlightRecorder.PostureSignerKey)
+		if err != nil {
+			return fmt.Errorf("load flight_recorder.posture_signer_key: %w", err)
+		}
+		c.FlightRecorder.PostureSignerPublicKey = append([]byte(nil), publicKey...)
 	}
 	if !c.FlightRecorder.Enabled {
 		return nil

--- a/internal/posturebinding/binding.go
+++ b/internal/posturebinding/binding.go
@@ -48,6 +48,25 @@ type Result struct {
 	Availability Availability
 	Path         string
 	Cause        error
+	anchored     bool
+}
+
+// HasContainmentAttestation reports whether this result carries a verified
+// containment binding, rather than merely a verified posture capsule.
+func (r Result) HasContainmentAttestation() bool {
+	return r.Availability == AvailabilityAttested &&
+		strings.TrimSpace(r.Binding.CapsuleSHA256) != "" &&
+		strings.TrimSpace(r.Binding.SignerKeyID) != "" &&
+		strings.TrimSpace(r.Binding.ContainmentNonce) != "" &&
+		strings.TrimSpace(r.Binding.ContainedUID) != ""
+}
+
+// HasAnchoredContainmentAttestation reports whether this result carries a
+// containment binding that was verified with an operator-configured signer.
+// It is deliberately distinct from HasContainmentAttestation, which also
+// describes the ordinary self-consistency-only loading path.
+func (r Result) HasAnchoredContainmentAttestation() bool {
+	return r.anchored && r.HasContainmentAttestation()
 }
 
 // RuntimeReceiptOptions controls the shared receipt-runtime policy applied to
@@ -56,8 +75,13 @@ type RuntimeReceiptOptions struct {
 	// ReceiptSigningEnabled reports whether this runtime will create signed
 	// action receipts. Posture binding is not loaded for a recorder-only
 	// runtime, which has no session_open record to bind.
-	ReceiptSigningEnabled bool
-	Stderr                io.Writer
+	ReceiptSigningEnabled      bool
+	RequireContainmentEvidence bool
+	// PinnedPostureSignerKey is the operator-configured trust anchor used only
+	// when containment evidence is required. It must come from validated config,
+	// never from the proof capsule or environment.
+	PinnedPostureSignerKey ed25519.PublicKey
+	Stderr                 io.Writer
 }
 
 const (
@@ -81,6 +105,10 @@ const (
 // filepath.Abs-resolved (resolving would hide the operator's mistake against an
 // ambiguous cwd). The default DefaultContainRunProofPath is already absolute.
 func LoadRuntime() (Result, error) {
+	return loadRuntime(nil)
+}
+
+func loadRuntime(pinnedSignerKey ed25519.PublicKey) (Result, error) {
 	path := strings.TrimSpace(os.Getenv(RuntimeProofEnv))
 	switch {
 	case path == "":
@@ -91,25 +119,37 @@ func LoadRuntime() (Result, error) {
 		result.Cause = err
 		return result, err
 	}
-	return LoadFile(path)
+	return loadFile(path, pinnedSignerKey)
 }
 
-// LoadRuntimeForReceipts applies the one shared availability policy used by
-// every receipt-enabled runtime. An unreadable proof records an actionable
-// warning and binds nothing, so the runtime starts without claiming
-// containment it could not confirm. A malformed present proof still fails.
-func LoadRuntimeForReceipts(opts RuntimeReceiptOptions) (receipt.PostureBinding, error) {
+// LoadRuntimeForReceipts applies the one shared availability and required-
+// containment policy used by every receipt-enabled runtime. It records an
+// actionable warning for an unreadable proof in ordinary operation. Required
+// containment refuses both absent and unreadable outcomes.
+func LoadRuntimeForReceipts(opts RuntimeReceiptOptions) (Result, error) {
 	if !opts.ReceiptSigningEnabled {
-		return receipt.PostureBinding{}, nil
+		if opts.RequireContainmentEvidence {
+			return Result{}, errors.New("containment evidence requires signed receipts")
+		}
+		return Result{}, nil
 	}
-	result, err := LoadRuntime()
+	if opts.RequireContainmentEvidence && len(opts.PinnedPostureSignerKey) != ed25519.PublicKeySize {
+		return Result{}, errors.New("containment evidence requires a pinned posture signer key; set flight_recorder.posture_signer_key")
+	}
+	result, err := loadRuntime(opts.PinnedPostureSignerKey)
 	if err != nil {
-		return receipt.PostureBinding{}, err
+		if opts.RequireContainmentEvidence {
+			return Result{}, fmt.Errorf("verify containment posture proof against pinned signer key: %w", err)
+		}
+		return Result{}, err
 	}
 	if result.Availability == AvailabilityUnreadable && opts.Stderr != nil {
 		_, _ = fmt.Fprint(opts.Stderr, unreadableProofWarning(result))
 	}
-	return result.Binding, nil
+	if opts.RequireContainmentEvidence && !result.HasAnchoredContainmentAttestation() {
+		return Result{}, fmt.Errorf("containment evidence is required but posture proof %q is %s; set flight_recorder.posture_signer_key and provide a matching signed proof at that path", result.Path, result.Availability)
+	}
+	return result, nil
 }
 
 func resultWithAvailability(path string, availability Availability) Result {
@@ -151,6 +191,10 @@ func unreadableProofWarning(result Result) string {
 // A present-but-invalid capsule returns AvailabilityInvalid and an error so it
 // never binds misleading fields.
 func LoadFile(path string) (Result, error) {
+	return loadFile(path, nil)
+}
+
+func loadFile(path string, pinnedSignerKey ed25519.PublicKey) (Result, error) {
 	result := resultWithAvailability(path, AvailabilityAbsent)
 	if strings.TrimSpace(path) == "" {
 		return result, nil
@@ -175,13 +219,17 @@ func LoadFile(path string) (Result, error) {
 		result.Cause = err
 		return result, fmt.Errorf("parse posture proof: %w", err)
 	}
-	pub, err := hex.DecodeString(capsule.SignerKeyID)
-	if err != nil {
-		result = resultWithAvailability(path, AvailabilityInvalid)
-		result.Cause = err
-		return result, fmt.Errorf("decode posture proof signer key: %w", err)
+	trustedKey := pinnedSignerKey
+	if len(trustedKey) == 0 {
+		pub, err := hex.DecodeString(capsule.SignerKeyID)
+		if err != nil {
+			result = resultWithAvailability(path, AvailabilityInvalid)
+			result.Cause = err
+			return result, fmt.Errorf("decode posture proof signer key: %w", err)
+		}
+		trustedKey = ed25519.PublicKey(pub)
 	}
-	if err := posture.VerifyAt(&capsule, ed25519.PublicKey(pub), time.Now().UTC()); err != nil {
+	if err := posture.VerifyAt(&capsule, trustedKey, time.Now().UTC()); err != nil {
 		result = resultWithAvailability(path, AvailabilityInvalid)
 		result.Cause = err
 		return result, fmt.Errorf("verify posture proof: %w", err)
@@ -189,8 +237,8 @@ func LoadFile(path string) (Result, error) {
 	// Only AFTER verification may a no-containment capsule report attested.
 	// This branch used to sit before VerifyAt, so any readable JSON without
 	// containment evidence, including a bare {}, was labeled attested in the
-	// signed session_open. Assessment never granted containment from it, but
-	// the signed availability value violated its own documented contract:
+	// advisory session_open extension. Assessment never granted containment
+	// from it, but the emitted availability value violated its own contract:
 	// attested means read AND verified. An unverifiable capsule is invalid
 	// and stays fatal, like every other malformed present proof.
 	if capsule.Evidence.Containment == nil {
@@ -217,5 +265,6 @@ func LoadFile(path string) (Result, error) {
 		ContainmentNonce: capsule.Signature,
 		ContainedUID:     capsule.Evidence.Containment.TargetUID,
 	}
+	result.anchored = len(pinnedSignerKey) == ed25519.PublicKeySize
 	return result, nil
 }

--- a/internal/posturebinding/binding_permission_linux_test.go
+++ b/internal/posturebinding/binding_permission_linux_test.go
@@ -7,6 +7,7 @@ package posturebinding
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"os"
 	"os/exec"
@@ -14,13 +15,12 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-
-	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 const (
 	unreadableCaseEnv = "PIPELOCK_POSTUREBINDING_UNREADABLE_CASE"
 	unreadablePathEnv = "PIPELOCK_POSTUREBINDING_UNREADABLE_PATH"
+	unreadableKeyEnv  = "PIPELOCK_POSTUREBINDING_UNREADABLE_KEY"
 )
 
 func TestLoadFileUnreadableFile(t *testing.T) {
@@ -37,11 +37,11 @@ func testUnreadableProof(t *testing.T, wantCase string) {
 		if childCase != wantCase {
 			t.Fatalf("child case = %q, want %q", childCase, wantCase)
 		}
-		assertUnreadableProof(t, os.Getenv(unreadablePathEnv))
+		assertUnreadableProof(t, os.Getenv(unreadablePathEnv), os.Getenv(unreadableKeyEnv))
 		return
 	}
 
-	path, cleanup := makeUnreadableProof(t, wantCase)
+	path, keyHex, cleanup := makeUnreadableProof(t, wantCase)
 	t.Cleanup(cleanup)
 	if os.Geteuid() == 0 {
 		testName := "^TestLoadFileUnreadableFile$"
@@ -50,7 +50,7 @@ func testUnreadableProof(t *testing.T, wantCase string) {
 		}
 		// #nosec G204,G702 -- this only re-executes the current test binary with a fixed test name.
 		cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run="+testName, "-test.v")
-		cmd.Env = append(os.Environ(), unreadableCaseEnv+"="+wantCase, unreadablePathEnv+"="+path)
+		cmd.Env = append(os.Environ(), unreadableCaseEnv+"="+wantCase, unreadablePathEnv+"="+path, unreadableKeyEnv+"="+keyHex)
 		cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: 65534, Gid: 65534}}
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -58,10 +58,10 @@ func testUnreadableProof(t *testing.T, wantCase string) {
 		}
 		return
 	}
-	assertUnreadableProof(t, path)
+	assertUnreadableProof(t, path, keyHex)
 }
 
-func makeUnreadableProof(t *testing.T, wantCase string) (string, func()) {
+func makeUnreadableProof(t *testing.T, wantCase string) (string, string, func()) {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "pipelock-posturebinding-")
 	if err != nil {
@@ -80,7 +80,7 @@ func makeUnreadableProof(t *testing.T, wantCase string) (string, func()) {
 		cleanup()
 		t.Fatalf("Chmod temp dir: %v", err)
 	}
-	_, data := mintContainmentCapsule(t)
+	capsule, data := mintContainmentCapsule(t)
 	path := filepath.Join(dir, "proof.json")
 	if wantCase == "parent" {
 		denied := filepath.Join(dir, "denied")
@@ -103,10 +103,10 @@ func makeUnreadableProof(t *testing.T, wantCase string) (string, func()) {
 		cleanup()
 		t.Fatalf("Chmod proof: %v", err)
 	}
-	return path, cleanup
+	return path, capsule.SignerKeyID, cleanup
 }
 
-func assertUnreadableProof(t *testing.T, path string) {
+func assertUnreadableProof(t *testing.T, path, keyHex string) {
 	t.Helper()
 	result, err := LoadFile(path)
 	if err != nil {
@@ -123,15 +123,8 @@ func assertUnreadableProof(t *testing.T, path string) {
 	if err != nil {
 		t.Fatalf("ordinary receipt policy: %v", err)
 	}
-	if binding != (receipt.PostureBinding{}) {
-		t.Fatalf("unreadable proof binding = %+v, want zero: an unreadable proof must claim nothing", binding)
-	}
-	result, loadErr := LoadRuntime()
-	if loadErr != nil {
-		t.Fatalf("LoadRuntime on an unreadable proof returned an error: %v", loadErr)
-	}
-	if result.Availability != AvailabilityUnreadable {
-		t.Fatalf("availability = %q, want %q", result.Availability, AvailabilityUnreadable)
+	if binding.Availability != AvailabilityUnreadable {
+		t.Fatalf("ordinary receipt availability = %q, want %q", binding.Availability, AvailabilityUnreadable)
 	}
 	message := warning.String()
 	for _, want := range []string{path, "containment user", "grant this runtime user read access"} {
@@ -141,5 +134,19 @@ func assertUnreadableProof(t *testing.T, path string) {
 	}
 	if !strings.Contains(message, "owner ") || !strings.Contains(message, "group ") {
 		t.Fatalf("file warning %q does not name the proof owner and group", message)
+	}
+
+	pinnedKey, decodeErr := hex.DecodeString(keyHex)
+	if decodeErr != nil {
+		t.Fatalf("decode pinned signer key: %v", decodeErr)
+	}
+	_, err = LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     pinnedKey,
+		Stderr:                     &warning,
+	})
+	if err == nil || !strings.Contains(err.Error(), "containment evidence is required") || !strings.Contains(err.Error(), "unreadable") {
+		t.Fatalf("required receipt policy error = %v, want unreadable containment requirement", err)
 	}
 }

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -10,7 +10,6 @@
 package posturebinding
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
@@ -23,7 +22,6 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/posture"
-	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 // mintContainmentCapsule emits a valid, signed posture capsule carrying
@@ -52,6 +50,27 @@ func mintContainmentCapsule(t *testing.T) (*posture.Capsule, []byte) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	return capsule, data
+}
+
+func capsuleSignerKey(t *testing.T, capsule *posture.Capsule) ed25519.PublicKey {
+	t.Helper()
+	key, err := hex.DecodeString(capsule.SignerKeyID)
+	if err != nil {
+		t.Fatalf("decode capsule signer key: %v", err)
+	}
+	if len(key) != ed25519.PublicKeySize {
+		t.Fatalf("capsule signer key length = %d, want %d", len(key), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(key)
+}
+
+func newPublicKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	key, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return key
 }
 
 func requireAvailability(t *testing.T, got Result, want Availability) {
@@ -158,6 +177,16 @@ func TestLoadFileValidContainmentCapsuleStillBinds(t *testing.T) {
 		got.ContainedUID != "966" {
 		t.Fatalf("binding = %+v, want fields from valid capsule", got)
 	}
+	if result.HasAnchoredContainmentAttestation() {
+		t.Fatal("ordinary LoadFile result reported an anchored containment attestation")
+	}
+	anchored, err := loadFile(path, capsuleSignerKey(t, capsule))
+	if err != nil {
+		t.Fatalf("loadFile with pinned signer: %v", err)
+	}
+	if !anchored.HasAnchoredContainmentAttestation() {
+		t.Fatal("pinned load did not report an anchored containment attestation")
+	}
 }
 
 func TestLoadFileRejectsGroupWritableProof(t *testing.T) {
@@ -235,9 +264,57 @@ func TestLoadRuntimeForReceiptsAbsentPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ordinary receipt policy: %v", err)
 	}
-	if binding != (receipt.PostureBinding{}) {
-		t.Fatalf("absent proof binding = %+v, want zero", binding)
+	if binding.Availability != AvailabilityAbsent {
+		t.Fatalf("ordinary receipt availability = %q, want %q", binding.Availability, AvailabilityAbsent)
 	}
+	_, err = LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     newPublicKey(t),
+	})
+	if err == nil || !strings.Contains(err.Error(), "containment evidence is required") || !strings.Contains(err.Error(), "absent") {
+		t.Fatalf("required receipt policy error = %v, want absent containment requirement", err)
+	}
+}
+
+func TestLoadRuntimeForReceiptsOrdinaryAvailabilityStates(t *testing.T) {
+	t.Run("attested", func(t *testing.T) {
+		_, data := mintContainmentCapsule(t)
+		path := filepath.Join(t.TempDir(), "proof.json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		t.Setenv(RuntimeProofEnv, path)
+		binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+		if err != nil {
+			t.Fatalf("ordinary attested proof: %v", err)
+		}
+		if binding.Availability != AvailabilityAttested {
+			t.Fatalf("ordinary attested availability = %q, want %q", binding.Availability, AvailabilityAttested)
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing-proof.json")
+		t.Setenv(RuntimeProofEnv, path)
+		binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+		if err != nil {
+			t.Fatalf("ordinary absent proof: %v", err)
+		}
+		if binding.Availability != AvailabilityAbsent {
+			t.Fatalf("ordinary absent availability = %q, want %q", binding.Availability, AvailabilityAbsent)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "proof.json")
+		if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		t.Setenv(RuntimeProofEnv, path)
+		_, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+		if err == nil || !strings.Contains(err.Error(), "parse posture proof") {
+			t.Fatalf("ordinary invalid proof error = %v, want parse failure", err)
+		}
+	})
 }
 
 func TestLoadRuntimeForReceiptsSkipsProofWithoutSigning(t *testing.T) {
@@ -251,28 +328,94 @@ func TestLoadRuntimeForReceiptsSkipsProofWithoutSigning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recorder-only runtime loaded posture proof: %v", err)
 	}
-	if binding != (receipt.PostureBinding{}) {
+	if binding != (Result{}) {
 		t.Fatalf("recorder-only posture binding = %+v, want zero", binding)
+	}
+
+	_, err = LoadRuntimeForReceipts(RuntimeReceiptOptions{RequireContainmentEvidence: true})
+	if err == nil || !strings.Contains(err.Error(), "requires signed receipts") {
+		t.Fatalf("required containment without receipts error = %v", err)
 	}
 }
 
-func TestLoadRuntimeForReceiptsBindsAttestedContainment(t *testing.T) {
+func TestLoadRuntimeForReceiptsRequiresAttestedContainment(t *testing.T) {
+	capsule, data := mintContainmentCapsule(t)
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     capsuleSignerKey(t, capsule),
+	})
+	if err != nil {
+		t.Fatalf("required receipt policy: %v", err)
+	}
+	if binding.Availability != AvailabilityAttested || binding.Binding.CapsuleSHA256 == "" {
+		t.Fatalf("required receipt binding = %+v, want attested containment", binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsRejectsProofFromDifferentSigner(t *testing.T) {
+	pinnedCapsule, _ := mintContainmentCapsule(t)
+	_, attackerProof := mintContainmentCapsule(t)
+	path := filepath.Join(t.TempDir(), "caller-selected-proof.json")
+	if err := os.WriteFile(path, attackerProof, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+
+	_, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     capsuleSignerKey(t, pinnedCapsule),
+	})
+	if err == nil || !strings.Contains(err.Error(), "pinned signer key") || !strings.Contains(err.Error(), "does not match trusted key") {
+		t.Fatalf("different signer error = %v, want pinned-key rejection", err)
+	}
+}
+
+func TestLoadRuntimeForReceiptsRequiresPinnedSigner(t *testing.T) {
 	_, data := mintContainmentCapsule(t)
 	path := filepath.Join(t.TempDir(), "proof.json")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	t.Setenv(RuntimeProofEnv, path)
-	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
-	if err != nil {
-		t.Fatalf("ordinary receipt policy: %v", err)
-	}
-	if binding.CapsuleSHA256 == "" || binding.ContainmentNonce == "" {
-		t.Fatalf("attested binding = %+v, want containment fields", binding)
+
+	_, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "flight_recorder.posture_signer_key") {
+		t.Fatalf("missing pinned signer error = %v, want actionable rejection", err)
 	}
 }
 
-func TestLoadRuntimeForReceiptsBindsNothingWithoutContainment(t *testing.T) {
+func TestLoadRuntimeForReceiptsVerifiesOverrideAgainstPinnedSigner(t *testing.T) {
+	capsule, data := mintContainmentCapsule(t)
+	path := filepath.Join(t.TempDir(), "caller-selected-proof.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     capsuleSignerKey(t, capsule),
+	})
+	if err != nil {
+		t.Fatalf("required override with matching pinned signer: %v", err)
+	}
+	if binding.Availability != AvailabilityAttested || binding.Binding.CapsuleSHA256 == "" {
+		t.Fatalf("required override binding = %+v, want attested containment", binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsRejectsAttestedProofWithoutContainment(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("GenerateKey: %v", err)
@@ -290,12 +433,13 @@ func TestLoadRuntimeForReceiptsBindsNothingWithoutContainment(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	t.Setenv(RuntimeProofEnv, path)
-	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
-	if err != nil {
-		t.Fatalf("proof without containment: %v", err)
-	}
-	if binding != (receipt.PostureBinding{}) {
-		t.Fatalf("binding without containment evidence = %+v, want zero", binding)
+	_, err = LoadRuntimeForReceipts(RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      true,
+		RequireContainmentEvidence: true,
+		PinnedPostureSignerKey:     capsuleSignerKey(t, capsule),
+	})
+	if err == nil || !strings.Contains(err.Error(), "containment evidence is required") || !strings.Contains(err.Error(), "attested") {
+		t.Fatalf("required receipt policy error = %v, want rejected proof without containment", err)
 	}
 }
 
@@ -362,7 +506,7 @@ func TestLoadFileNoContainmentReturnsZeroBinding(t *testing.T) {
 func TestLoadFileUnsignedNoContainmentIsInvalid(t *testing.T) {
 	// A readable capsule that carries no containment evidence AND cannot be
 	// verified must be invalid, not attested. Before the fix, this exact file
-	// produced posture_availability "attested" in a signed session_open.
+	// produced an "attested" advisory posture-availability value.
 	path := filepath.Join(t.TempDir(), "proof.json")
 	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -411,35 +555,4 @@ func TestLoadFileRejectsOversizedAndEscapingSymlink(t *testing.T) {
 			t.Fatal("LoadFile accepted symlink escaping the proof directory")
 		}
 	})
-}
-
-func TestLoadFileEmptyPathIsAbsent(t *testing.T) {
-	got, err := LoadFile("   ")
-	if err != nil {
-		t.Fatalf("LoadFile with a blank path: %v", err)
-	}
-	requireAvailability(t, got, AvailabilityAbsent)
-	if got.Binding != (receipt.PostureBinding{}) {
-		t.Fatalf("blank-path binding = %+v, want zero", got.Binding)
-	}
-}
-
-func TestLoadRuntimeForReceiptsPropagatesInvalidProof(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "proof.json")
-	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	t.Setenv(RuntimeProofEnv, path)
-
-	var warning bytes.Buffer
-	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true, Stderr: &warning})
-	if err == nil || !strings.Contains(err.Error(), "parse posture proof") {
-		t.Fatalf("malformed proof error = %v, want a parse failure", err)
-	}
-	if binding != (receipt.PostureBinding{}) {
-		t.Fatalf("malformed proof binding = %+v, want zero", binding)
-	}
-	if warning.Len() != 0 {
-		t.Fatalf("malformed proof wrote an unreadable warning: %q", warning.String())
-	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1529,22 +1529,25 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 		}, nil
 	}
 
-	postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
-		ReceiptSigningEnabled: keyPath != "",
-		Stderr:                os.Stderr,
+	postureResult, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+		ReceiptSigningEnabled:      keyPath != "",
+		RequireContainmentEvidence: cfg.FlightRecorder.RequireContainmentEvidence,
+		PinnedPostureSignerKey:     cfg.FlightRecorder.PostureSignerPublicKey,
+		Stderr:                     os.Stderr,
 	})
 	if bindErr != nil {
 		return receiptEmitterStage{}, fmt.Errorf("loading posture binding: %w", bindErr)
 	}
 	emitter := receipt.NewEmitter(receipt.EmitterConfig{
-		Recorder:         p.recorder,
-		PrivKey:          privKey,
-		ConfigHash:       cfg.Hash(),
-		Principal:        "local",
-		Actor:            "pipelock",
-		Metrics:          p.metrics,
-		PostureBinding:   postureBinding,
-		HeartbeatSeconds: cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
+		Recorder:            p.recorder,
+		PrivKey:             privKey,
+		ConfigHash:          cfg.Hash(),
+		Principal:           "local",
+		Actor:               "pipelock",
+		Metrics:             p.metrics,
+		PostureBinding:      postureResult.Binding,
+		PostureAvailability: string(postureResult.Availability),
+		HeartbeatSeconds:    cfg.FlightRecorder.HeartbeatIntervalSecondsForReceipt(),
 	})
 	if emitter != nil {
 		if initErr := emitter.InitError(); initErr != nil {

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -122,6 +122,10 @@ type Emitter struct {
 	heartbeatSeconds int
 
 	postureBinding PostureBinding
+	// postureAvailability is advisory runtime diagnosis, recorded only in the
+	// unsigned top-level ext bag of session_open. It must never be used by
+	// containment assessment or signature verification.
+	postureAvailability string
 
 	// pendingTransition is set by resumeChain when the on-disk tail was
 	// signed by a DIFFERENT (but self-valid) key, meaning a legitimate key
@@ -164,6 +168,9 @@ type EmitterConfig struct {
 	// containment assessment can bind a receipt chain to a signed posture
 	// capsule and contained UID.
 	PostureBinding PostureBinding
+	// PostureAvailability is an advisory reason attached to the unsigned ext
+	// bag of session_open. Unlike PostureBinding, it is not signed evidence.
+	PostureAvailability string
 	// HeartbeatSeconds is the configured heartbeat cadence in seconds. It is
 	// recorded verbatim in the session_open record so a consumer can read the
 	// expected liveness interval off the run anchor. 0 (the default) means the
@@ -191,17 +198,18 @@ func NewEmitter(cfg EmitterConfig) *Emitter {
 	}
 	runNonce, nonceErr := newRunNonce()
 	e := &Emitter{
-		recorder:         cfg.Recorder,
-		privKey:          cfg.PrivKey,
-		principal:        cfg.Principal,
-		actor:            cfg.Actor,
-		metrics:          cfg.Metrics,
-		onReceipt:        cfg.OnReceipt,
-		now:              time.Now,
-		runNonce:         runNonce,
-		chainPrevHash:    GenesisHash,
-		postureBinding:   cfg.PostureBinding,
-		heartbeatSeconds: cfg.HeartbeatSeconds,
+		recorder:            cfg.Recorder,
+		privKey:             cfg.PrivKey,
+		principal:           cfg.Principal,
+		actor:               cfg.Actor,
+		metrics:             cfg.Metrics,
+		onReceipt:           cfg.OnReceipt,
+		now:                 time.Now,
+		runNonce:            runNonce,
+		chainPrevHash:       GenesisHash,
+		postureBinding:      cfg.PostureBinding,
+		postureAvailability: cfg.PostureAvailability,
+		heartbeatSeconds:    cfg.HeartbeatSeconds,
 	}
 	e.configHash.Store(cfg.ConfigHash)
 	if nonceErr != nil {
@@ -640,6 +648,13 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	if err != nil {
 		e.recordFailure(FailReasonSign)
 		return fmt.Errorf("signing receipt: %w", err)
+	}
+	if isSessionOpenControl(sessionControl) && e.postureAvailability != "" {
+		rcpt.Ext, err = json.Marshal(map[string]string{"posture_proof_availability": e.postureAvailability})
+		if err != nil {
+			e.recordFailure(FailReasonMarshal)
+			return fmt.Errorf("marshaling posture availability extension: %w", err)
+		}
 	}
 
 	receiptHash, err := ReceiptHash(rcpt)

--- a/internal/receipt/emitter.go
+++ b/internal/receipt/emitter.go
@@ -4,6 +4,7 @@
 package receipt
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -23,13 +24,17 @@ import (
 	aelpkg "github.com/luckyPipewrench/pipelock/internal/ael"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/evidencename"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/redact"
 	"github.com/luckyPipewrench/pipelock/internal/session"
 )
 
 // recorderEntryType is the recorder entry type for action receipts.
-const recorderEntryType = "action_receipt"
+const (
+	recorderEntryType               = "action_receipt"
+	postureAvailabilityExtensionKey = "posture_proof_availability"
+)
 
 // recorderSessionID is the session ID used for all recorder entries from the emitter.
 // The recorder pins to the first session ID it sees, so all entries must use the same value.
@@ -650,7 +655,7 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 		return fmt.Errorf("signing receipt: %w", err)
 	}
 	if isSessionOpenControl(sessionControl) && e.postureAvailability != "" {
-		rcpt.Ext, err = json.Marshal(map[string]string{"posture_proof_availability": e.postureAvailability})
+		rcpt.Ext, err = mergePostureAvailabilityExtension(rcpt.Ext, e.postureAvailability)
 		if err != nil {
 			e.recordFailure(FailReasonMarshal)
 			return fmt.Errorf("marshaling posture availability extension: %w", err)
@@ -771,6 +776,43 @@ func (e *Emitter) emitWithControl(opts EmitOpts, durable bool, buildControl lock
 	}
 
 	return nil
+}
+
+func mergePostureAvailabilityExtension(ext json.RawMessage, value string) (json.RawMessage, error) {
+	fields := make(map[string]json.RawMessage)
+	if len(bytes.TrimSpace(ext)) != 0 {
+		if err := jsonscan.RejectDuplicateKeys(ext); err != nil {
+			return nil, fmt.Errorf("invalid existing extension: %w", err)
+		}
+		if err := json.Unmarshal(ext, &fields); err != nil {
+			return nil, fmt.Errorf("decode existing extension: %w", err)
+		}
+		if fields == nil {
+			return nil, errors.New("existing extension must be a JSON object")
+		}
+	}
+
+	if current, ok := fields[postureAvailabilityExtensionKey]; ok {
+		var currentValue string
+		if err := json.Unmarshal(current, &currentValue); err != nil {
+			return nil, fmt.Errorf("existing extension key %q must be a string: %w", postureAvailabilityExtensionKey, err)
+		}
+		if currentValue != value {
+			return nil, fmt.Errorf("existing extension key %q conflicts with value %q", postureAvailabilityExtensionKey, value)
+		}
+		return ext, nil
+	}
+
+	encodedValue, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode extension value: %w", err)
+	}
+	fields[postureAvailabilityExtensionKey] = encodedValue
+	merged, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("encode merged extension: %w", err)
+	}
+	return merged, nil
 }
 
 func (e *Emitter) emitNativeAEL(ar ActionRecord, control *SessionControl, durable bool) error {

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/crypto/nacl/box"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
 	"github.com/luckyPipewrench/pipelock/internal/recorder"
 )
 
@@ -378,6 +379,47 @@ func TestEmitter_PostureAvailabilityExtMutationBreaksSuccessorChain(t *testing.T
 	if res := VerifyChain(receipts, hex.EncodeToString(pub)); res.Valid {
 		t.Fatal("mutated session_open extension left successor chain valid")
 	}
+}
+
+func TestMergePostureAvailabilityExtension(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves existing metadata", func(t *testing.T) {
+		got, err := mergePostureAvailabilityExtension(
+			json.RawMessage(`{"vendor":"acme"}`),
+			"unreadable",
+		)
+		if err != nil {
+			t.Fatalf("mergePostureAvailabilityExtension: %v", err)
+		}
+		var fields map[string]string
+		if err := json.Unmarshal(got, &fields); err != nil {
+			t.Fatalf("decode merged extension: %v", err)
+		}
+		if fields["vendor"] != "acme" || fields["posture_proof_availability"] != "unreadable" {
+			t.Fatalf("merged extension = %#v", fields)
+		}
+	})
+
+	t.Run("rejects conflicting value", func(t *testing.T) {
+		_, err := mergePostureAvailabilityExtension(
+			json.RawMessage(`{"posture_proof_availability":"attested"}`),
+			"unreadable",
+		)
+		if err == nil || !strings.Contains(err.Error(), "conflicts") {
+			t.Fatalf("error = %v, want conflicting extension error", err)
+		}
+	})
+
+	t.Run("rejects duplicate keys", func(t *testing.T) {
+		_, err := mergePostureAvailabilityExtension(
+			json.RawMessage(`{"vendor":"a","vendor":"b"}`),
+			"unreadable",
+		)
+		if !errors.Is(err, jsonscan.ErrDuplicateKey) {
+			t.Fatalf("error = %v, want duplicate-key error", err)
+		}
+	})
 }
 
 func TestEmitter_EmitSessionCloseFinalReceiptAndRoot(t *testing.T) {

--- a/internal/receipt/session_control_emit_test.go
+++ b/internal/receipt/session_control_emit_test.go
@@ -289,12 +289,13 @@ func TestEmitter_EmitSessionOpenPopulatesPostureBinding(t *testing.T) {
 		ContainedUID:     "966",
 	}
 	e := NewEmitter(EmitterConfig{
-		Recorder:       rec,
-		PrivKey:        priv,
-		ConfigHash:     testConfigHash,
-		Principal:      testPrincipal,
-		Actor:          testActor,
-		PostureBinding: binding,
+		Recorder:            rec,
+		PrivKey:             priv,
+		ConfigHash:          testConfigHash,
+		Principal:           testPrincipal,
+		Actor:               testActor,
+		PostureBinding:      binding,
+		PostureAvailability: "unreadable",
 	})
 
 	if err := e.EmitSessionOpen(); err != nil {
@@ -318,8 +319,64 @@ func TestEmitter_EmitSessionOpenPopulatesPostureBinding(t *testing.T) {
 		open.ContainedUID != binding.ContainedUID {
 		t.Fatalf("posture binding = %+v, want %+v", open, binding)
 	}
+	var ext map[string]string
+	if err := json.Unmarshal(receipts[0].Ext, &ext); err != nil {
+		t.Fatalf("decode unsigned posture extension: %v", err)
+	}
+	if got := ext["posture_proof_availability"]; got != "unreadable" {
+		t.Fatalf("posture availability extension = %q, want unreadable", got)
+	}
+	// ext is intentionally outside the signature: changing its advisory value
+	// must not turn it into a verified containment claim.
+	receipts[0].Ext = json.RawMessage(`{"posture_proof_availability":"attested"}`)
+	if err := VerifyWithKey(receipts[0], hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("signature unexpectedly covers advisory extension: %v", err)
+	}
 	if res := VerifyChain(receipts, hex.EncodeToString(pub)); !res.Valid {
 		t.Fatalf("VerifyChain: %s", res.Error)
+	}
+}
+
+func TestEmitter_PostureAvailabilityExtMutationBreaksSuccessorChain(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	e := NewEmitter(EmitterConfig{
+		Recorder:            rec,
+		PrivKey:             priv,
+		ConfigHash:          testConfigHash,
+		Principal:           testPrincipal,
+		Actor:               testActor,
+		PostureAvailability: "unreadable",
+	})
+	if err := e.EmitSessionOpen(); err != nil {
+		t.Fatalf("EmitSessionOpen: %v", err)
+	}
+	if err := e.Emit(EmitOpts{
+		ActionID:  NewActionID(),
+		Verdict:   config.ActionAllow,
+		Transport: testTransport,
+		Target:    testTarget,
+		Method:    http.MethodGet,
+	}); err != nil {
+		t.Fatalf("Emit successor: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	receipts := readAllReceiptsFromDir(t, dir, pub)
+	if len(receipts) != 2 {
+		t.Fatalf("receipts = %d, want 2", len(receipts))
+	}
+	receipts[0].Ext = json.RawMessage(`{"posture_proof_availability":"attested"}`)
+	if err := VerifyWithKey(receipts[0], hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("individual signature unexpectedly covers advisory extension: %v", err)
+	}
+	if res := VerifyChain(receipts, hex.EncodeToString(pub)); res.Valid {
+		t.Fatal("mutated session_open extension left successor chain valid")
 	}
 }
 

--- a/internal/testposture/testposture_test.go
+++ b/internal/testposture/testposture_test.go
@@ -51,7 +51,7 @@ func TestPinAbsentIsolatesFromHostPosture(t *testing.T) {
 		t.Fatalf("availability = %q, want %q", result.Availability, posturebinding.AvailabilityAbsent)
 	}
 	if result.Binding != (receipt.PostureBinding{}) {
-		t.Fatalf("expected the zero binding, got %+v", result.Binding)
+		t.Fatalf("expected an absent binding, got %+v", result.Binding)
 	}
 
 	dir := filepath.Dir(got)

--- a/scripts/check-config-consumption.sh
+++ b/scripts/check-config-consumption.sh
@@ -19,6 +19,9 @@ set -euo pipefail
 # uniquely-named fields with ZERO references, which is exactly how dead knobs
 # look. Deliberately-reserved fields go in config-consumption-allowlist.txt
 # with a comment explaining what future slice they reserve.
+# Fields decoded once into a runtime-only field go in
+# config-consumption-derived-fields.txt. A mapping counts only when the source
+# is read inside internal/config and the derived field is consumed outside it.
 #
 # Fails CLOSED: if the schema or corpus cannot be scanned, error loudly.
 
@@ -26,15 +29,19 @@ cd "$(dirname "$0")/.."
 
 SCHEMA="internal/config/schema.go"
 ALLOWLIST="scripts/config-consumption-allowlist.txt"
+DERIVED_FIELDS="scripts/config-consumption-derived-fields.txt"
 
 [ -r "$SCHEMA" ] || { echo "ERROR: cannot read $SCHEMA" >&2; exit 2; }
 
 # Corpus: every non-test Go file outside internal/config (enterprise included).
 CORPUS="$(mktemp)"
-trap 'rm -f "$CORPUS"' EXIT
+CONFIG_CORPUS="$(mktemp)"
+trap 'rm -f "$CORPUS" "$CONFIG_CORPUS"' EXIT
 find . -name '*.go' ! -name '*_test.go' ! -path './internal/config/*' \
   ! -path './vendor/*' -exec cat {} + > "$CORPUS"
 [ -s "$CORPUS" ] || { echo "ERROR: empty scan corpus" >&2; exit 2; }
+find internal/config -name '*.go' ! -name '*_test.go' -exec cat {} + > "$CONFIG_CORPUS"
+[ -s "$CONFIG_CORPUS" ] || { echo "ERROR: empty internal/config scan corpus" >&2; exit 2; }
 
 # Field names: tab-indented exported identifiers carrying a yaml tag in schema.go.
 FIELDS="$(grep -P '^\t[A-Z][A-Za-z0-9]*\s+\S+.*yaml:"' "$SCHEMA" \
@@ -44,6 +51,23 @@ FIELDS="$(grep -P '^\t[A-Z][A-Za-z0-9]*\s+\S+.*yaml:"' "$SCHEMA" \
 fail=0
 while IFS= read -r field; do
   if ! grep -qE "\.${field}\b" "$CORPUS" && ! grep -qE "\.${field}Enabled\(" "$CORPUS"; then
+    derived=""
+    if [ -f "$DERIVED_FIELDS" ]; then
+      derived="$(awk -v source="$field" '$1 == source { print $2; exit }' "$DERIVED_FIELDS")"
+    fi
+    if [ -n "$derived" ]; then
+      if ! grep -qE "\.${field}\b" "$CONFIG_CORPUS"; then
+        echo "INVALID derived config mapping: ${field} -> ${derived} (source is not read inside internal/config)"
+        fail=1
+        continue
+      fi
+      if ! grep -qE "\.${derived}\b" "$CORPUS"; then
+        echo "UNCONSUMED derived config field: ${field} -> ${derived} (no non-test runtime reference outside internal/config)"
+        fail=1
+        continue
+      fi
+      continue
+    fi
     if [ -f "$ALLOWLIST" ] && grep -qE "^${field}([[:space:]]|$)" "$ALLOWLIST"; then
       continue
     fi

--- a/scripts/config-consumption-derived-fields.txt
+++ b/scripts/config-consumption-derived-fields.txt
@@ -1,0 +1,5 @@
+# YAMLField RuntimeField
+# Source fields listed here are decoded or normalized once during validation.
+# The consumption gate verifies that validation reads the source and production
+# code outside internal/config consumes the derived field.
+PostureSignerKey PostureSignerPublicKey # decoded Ed25519 trust anchor; runtime must not reopen the configured path


### PR DESCRIPTION
## What changed

- Receipt-enabled runtimes record missing or unreadable posture proofs in unsigned `session_open.ext` metadata. Required containment still refuses startup unless a pinned signer and verified capsule prove containment.
- Real `contain install` runs stop before host setup in recognized container or init-image environments and on non-Linux systems. `--dry-run` still prints the plan.

The advisory field doesn't change signed v1 canonical data. Receipt-chain hashes cover the full envelope, so changing the field after recording breaks the next chain link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flight recorder options to require verified containment evidence and configure a trusted posture signer key.
  - Signed session receipts now report posture proof availability (`attested`, `absent`, `unreadable`, or `invalid`).
  - Containment installation now validates the host environment and prevents unsupported installations.

- **Bug Fixes**
  - Invalid or insufficient containment evidence now fails closed when required.
  - Dry-run installations continue without host preflight checks.

- **Documentation**
  - Documented configuration prerequisites, evidence statuses, startup behavior, and restart-only reload changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->