### PR TITLE
fix(receipts): stop an unreadable posture proof from killing startup

### DIFF
--- a/internal/cli/runtime/guard.go
+++ b/internal/cli/runtime/guard.go
@@ -337,7 +337,10 @@ func newGuardEvidence(ctx context.Context, cfg *config.Config, sc *scanner.Scann
 	evidence.recorder = rec
 	evidence.proxyOptions = append(evidence.proxyOptions, proxy.WithRecorder(rec))
 
-	binding, err := posturebinding.LoadRuntime()
+	binding, err := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+		ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
+		Stderr:                stderr,
+	})
 	if err != nil {
 		evidence.close()
 		return nil, fmt.Errorf("loading Guard posture binding: %w", err)

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1121,7 +1121,10 @@ Key-free evidence capture:
 					retentionCancel()
 					retentionWG.Wait()
 				}()
-				postureBinding, bindErr := posturebinding.LoadRuntime()
+				postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+					ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
+					Stderr:                cmd.ErrOrStderr(),
+				})
 				if bindErr != nil {
 					return fmt.Errorf("loading posture binding: %w", bindErr)
 				}

--- a/internal/cli/runtime/server.go
+++ b/internal/cli/runtime/server.go
@@ -561,7 +561,10 @@ func NewServer(opts ServerOpts) (*Server, error) {
 		runFlightRecorderExpiryOnce(rec, opts.Stderr, opts.expiry())
 		s.recorder = rec
 		proxyOpts = append(proxyOpts, proxy.WithRecorder(rec))
-		postureBinding, bindErr := posturebinding.LoadRuntime()
+		postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+			ReceiptSigningEnabled: cfg.FlightRecorder.SigningKeyPath != "",
+			Stderr:                opts.Stderr,
+		})
 		if bindErr != nil {
 			s.cleanup()
 			return nil, fmt.Errorf("loading posture binding: %w", bindErr)

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -158,7 +158,8 @@ func (s *Server) Reload(newCfg *config.Config) (err error) {
 		// changes would leave the live config disagreeing with the running
 		// recorder. require_receipts is the exception: it changes only whether
 		// an emit failure escalates an otherwise-allowed request to a block, so
-		// it is safe and intentionally reloadable.
+		// it is safe and intentionally reloadable. Containment evidence is read
+		// while the emitter starts, so its requirement remains restart-only.
 		//
 		// This also keeps Conductor policy-bundle apply working: a signed bundle
 		// carries enforcement-only config (flight_recorder is not an allowlisted

--- a/internal/posturebinding/binding.go
+++ b/internal/posturebinding/binding.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,43 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/securefile"
 )
+
+// Availability describes whether this process could obtain containment posture
+// evidence for its receipt session_open record.
+type Availability string
+
+const (
+	// AvailabilityAttested means a proof file was read and verified. Its binding
+	// can be empty when the verified capsule carries no containment evidence.
+	AvailabilityAttested Availability = "attested"
+	// AvailabilityAbsent means the configured proof path does not exist.
+	AvailabilityAbsent Availability = "absent"
+	// AvailabilityUnreadable means reading the proof or traversing one of its
+	// parents was denied. It does not establish whether a proof exists.
+	AvailabilityUnreadable Availability = "unreadable"
+	// AvailabilityInvalid means a present proof was malformed, unverifiable, or
+	// expired. Invalid proofs always return an error and are never bound.
+	AvailabilityInvalid Availability = "invalid"
+)
+
+// Result is the typed outcome of loading a runtime posture proof. Invalid
+// outcomes carry AvailabilityInvalid together with a non-nil error.
+type Result struct {
+	Binding      receipt.PostureBinding
+	Availability Availability
+	Path         string
+	Cause        error
+}
+
+// RuntimeReceiptOptions controls the shared receipt-runtime policy applied to
+// every caller that opens a receipt emitter.
+type RuntimeReceiptOptions struct {
+	// ReceiptSigningEnabled reports whether this runtime will create signed
+	// action receipts. Posture binding is not loaded for a recorder-only
+	// runtime, which has no session_open record to bind.
+	ReceiptSigningEnabled bool
+	Stderr                io.Writer
+}
 
 const (
 	// RuntimeProofEnv overrides the posture proof path used for receipt
@@ -32,28 +70,70 @@ const (
 	maxRuntimeProofBytes       = 4 << 20
 )
 
-// LoadRuntime returns the posture binding for the configured runtime proof
-// path. Missing proof files mean no attested containment is available and return
-// the zero binding; malformed present proof files return an error so callers do
-// not sign a misleading empty binding by accident.
+// LoadRuntime returns the typed outcome for the configured runtime proof path.
+// Missing proof files are absent. A permission denial is unreadable, which
+// means this process cannot determine whether containment evidence exists.
+// Malformed present proof files are invalid and return an error.
 //
 // A non-empty PIPELOCK_POSTURE_PROOF override must be an ABSOLUTE path. A
 // relative value would resolve against the runtime process cwd and could
 // silently read the wrong file, so it is rejected outright rather than
 // filepath.Abs-resolved (resolving would hide the operator's mistake against an
 // ambiguous cwd). The default DefaultContainRunProofPath is already absolute.
-func LoadRuntime() (receipt.PostureBinding, error) {
+func LoadRuntime() (Result, error) {
 	path := strings.TrimSpace(os.Getenv(RuntimeProofEnv))
 	switch {
 	case path == "":
 		path = DefaultContainRunProofPath
 	case !filepath.IsAbs(path):
-		return receipt.PostureBinding{}, fmt.Errorf("%s must be an absolute path, got %q", RuntimeProofEnv, path)
+		err := fmt.Errorf("%s must be an absolute path, got %q", RuntimeProofEnv, path)
+		result := resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, err
 	}
 	return LoadFile(path)
 }
 
-// LoadFile derives a receipt posture binding from a signed posture proof file.
+// LoadRuntimeForReceipts applies the one shared availability policy used by
+// every receipt-enabled runtime. An unreadable proof records an actionable
+// warning and binds nothing, so the runtime starts without claiming
+// containment it could not confirm. A malformed present proof still fails.
+func LoadRuntimeForReceipts(opts RuntimeReceiptOptions) (receipt.PostureBinding, error) {
+	if !opts.ReceiptSigningEnabled {
+		return receipt.PostureBinding{}, nil
+	}
+	result, err := LoadRuntime()
+	if err != nil {
+		return receipt.PostureBinding{}, err
+	}
+	if result.Availability == AvailabilityUnreadable && opts.Stderr != nil {
+		_, _ = fmt.Fprint(opts.Stderr, unreadableProofWarning(result))
+	}
+	return result.Binding, nil
+}
+
+func resultWithAvailability(path string, availability Availability) Result {
+	return Result{
+		Availability: availability,
+		Path:         path,
+	}
+}
+
+func unreadableProofWarning(result Result) string {
+	owner, group, known := proofOwnerGroup(result.Path)
+	ownerGroup := "owner/group could not be inspected because directory traversal was denied"
+	if known {
+		ownerGroup = fmt.Sprintf("owner %s, group %s", owner, group)
+	}
+	return fmt.Sprintf(
+		"WARNING: containment posture proof %q is unreadable: %v\n"+
+			"         %s. Containment-run proofs are only readable by the containment user.\n"+
+			"         Run this runtime as that user, or grant this runtime user read access to the proof and traverse access to each parent directory.\n",
+		result.Path, result.Cause, ownerGroup)
+}
+
+// LoadFile derives a typed receipt posture result from a signed posture proof
+// file.
 //
 // A present capsule with containment evidence is signature-verified before its
 // fields are bound. This is a defense-in-depth SELF-CONSISTENCY check: it
@@ -66,33 +146,56 @@ func LoadRuntime() (receipt.PostureBinding, error) {
 // or tampered capsule body at emit time, rejecting it fail-closed instead of
 // recording misleading fields.
 //
-// A missing proof file still returns the zero binding (no attested containment).
-// A present-but-invalid capsule now returns an error where it previously bound
-// silently; callers already fail emitter setup on that error.
-func LoadFile(path string) (receipt.PostureBinding, error) {
+// A missing proof file is absent. A present proof that this principal cannot
+// read is unreadable, not absent: it does not establish that containment exists.
+// A present-but-invalid capsule returns AvailabilityInvalid and an error so it
+// never binds misleading fields.
+func LoadFile(path string) (Result, error) {
+	result := resultWithAvailability(path, AvailabilityAbsent)
 	if strings.TrimSpace(path) == "" {
-		return receipt.PostureBinding{}, nil
+		return result, nil
 	}
 	data, err := securefile.Read(path, securefile.Options{MaxBytes: maxRuntimeProofBytes, DisallowedPerms: 0o022})
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return receipt.PostureBinding{}, nil
+			return result, nil
 		}
-		return receipt.PostureBinding{}, fmt.Errorf("read posture proof: %w", err)
+		if errors.Is(err, os.ErrPermission) {
+			result = resultWithAvailability(path, AvailabilityUnreadable)
+			result.Cause = err
+			return result, nil
+		}
+		result = resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, fmt.Errorf("read posture proof: %w", err)
 	}
 	var capsule posture.Capsule
 	if err := json.Unmarshal(data, &capsule); err != nil {
-		return receipt.PostureBinding{}, fmt.Errorf("parse posture proof: %w", err)
-	}
-	if capsule.Evidence.Containment == nil {
-		return receipt.PostureBinding{}, nil
+		result = resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, fmt.Errorf("parse posture proof: %w", err)
 	}
 	pub, err := hex.DecodeString(capsule.SignerKeyID)
 	if err != nil {
-		return receipt.PostureBinding{}, fmt.Errorf("decode posture proof signer key: %w", err)
+		result = resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, fmt.Errorf("decode posture proof signer key: %w", err)
 	}
 	if err := posture.VerifyAt(&capsule, ed25519.PublicKey(pub), time.Now().UTC()); err != nil {
-		return receipt.PostureBinding{}, fmt.Errorf("verify posture proof: %w", err)
+		result = resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, fmt.Errorf("verify posture proof: %w", err)
+	}
+	// Only AFTER verification may a no-containment capsule report attested.
+	// This branch used to sit before VerifyAt, so any readable JSON without
+	// containment evidence, including a bare {}, was labeled attested in the
+	// signed session_open. Assessment never granted containment from it, but
+	// the signed availability value violated its own documented contract:
+	// attested means read AND verified. An unverifiable capsule is invalid
+	// and stays fatal, like every other malformed present proof.
+	if capsule.Evidence.Containment == nil {
+		result = resultWithAvailability(path, AvailabilityAttested)
+		return result, nil
 	}
 	// CapsuleSHA256 binds the canonical posture capsule, not the raw proof.json
 	// bytes. That matches contain-run proofs and verifier-side canonical capsule
@@ -102,13 +205,17 @@ func LoadFile(path string) (receipt.PostureBinding, error) {
 	// canonicalize the file first.
 	canonical, err := json.Marshal(&capsule)
 	if err != nil {
-		return receipt.PostureBinding{}, fmt.Errorf("marshal posture proof: %w", err)
+		result = resultWithAvailability(path, AvailabilityInvalid)
+		result.Cause = err
+		return result, fmt.Errorf("marshal posture proof: %w", err)
 	}
 	sum := sha256.Sum256(canonical)
-	return receipt.PostureBinding{
+	result = resultWithAvailability(path, AvailabilityAttested)
+	result.Binding = receipt.PostureBinding{
 		CapsuleSHA256:    hex.EncodeToString(sum[:]),
 		SignerKeyID:      capsule.SignerKeyID,
 		ContainmentNonce: capsule.Signature,
 		ContainedUID:     capsule.Evidence.Containment.TargetUID,
-	}, nil
+	}
+	return result, nil
 }

--- a/internal/posturebinding/binding_owner_unix.go
+++ b/internal/posturebinding/binding_owner_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posturebinding
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// proofOwnerGroup returns numeric ownership where the calling principal can
+// inspect the proof or its direct parent. A denied parent deliberately remains
+// unknown: guessing ownership would turn an unreadable state into a false claim.
+func proofOwnerGroup(path string) (string, string, bool) {
+	for _, candidate := range []string{path, filepath.Dir(path)} {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return "", "", false
+		}
+		return strconv.FormatUint(uint64(stat.Uid), 10), strconv.FormatUint(uint64(stat.Gid), 10), true
+	}
+	return "", "", false
+}

--- a/internal/posturebinding/binding_owner_windows.go
+++ b/internal/posturebinding/binding_owner_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posturebinding
+
+// proofOwnerGroup cannot derive POSIX ownership from Windows file metadata.
+func proofOwnerGroup(string) (string, string, bool) {
+	return "", "", false
+}

--- a/internal/posturebinding/binding_permission_linux_test.go
+++ b/internal/posturebinding/binding_permission_linux_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posturebinding
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+)
+
+const (
+	unreadableCaseEnv = "PIPELOCK_POSTUREBINDING_UNREADABLE_CASE"
+	unreadablePathEnv = "PIPELOCK_POSTUREBINDING_UNREADABLE_PATH"
+)
+
+func TestLoadFileUnreadableFile(t *testing.T) {
+	testUnreadableProof(t, "file")
+}
+
+func TestLoadFileUnreadableParent(t *testing.T) {
+	testUnreadableProof(t, "parent")
+}
+
+func testUnreadableProof(t *testing.T, wantCase string) {
+	t.Helper()
+	if childCase := os.Getenv(unreadableCaseEnv); childCase != "" {
+		if childCase != wantCase {
+			t.Fatalf("child case = %q, want %q", childCase, wantCase)
+		}
+		assertUnreadableProof(t, os.Getenv(unreadablePathEnv))
+		return
+	}
+
+	path, cleanup := makeUnreadableProof(t, wantCase)
+	t.Cleanup(cleanup)
+	if os.Geteuid() == 0 {
+		testName := "^TestLoadFileUnreadableFile$"
+		if wantCase == "parent" {
+			testName = "^TestLoadFileUnreadableParent$"
+		}
+		// #nosec G204,G702 -- this only re-executes the current test binary with a fixed test name.
+		cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run="+testName, "-test.v")
+		cmd.Env = append(os.Environ(), unreadableCaseEnv+"="+wantCase, unreadablePathEnv+"="+path)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: 65534, Gid: 65534}}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unprivileged child: %v\n%s", err, output)
+		}
+		return
+	}
+	assertUnreadableProof(t, path)
+}
+
+func makeUnreadableProof(t *testing.T, wantCase string) (string, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "pipelock-posturebinding-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	cleanup := func() {
+		if wantCase == "parent" {
+			// #nosec G302 -- restore a private test directory before test cleanup.
+			_ = os.Chmod(filepath.Join(dir, "denied"), 0o700)
+		}
+		_ = os.Chmod(filepath.Join(dir, "proof.json"), 0o600)
+		_ = os.RemoveAll(dir)
+	}
+	// #nosec G302 -- the unprivileged child must traverse this isolated test directory.
+	if err := os.Chmod(dir, 0o755); err != nil {
+		cleanup()
+		t.Fatalf("Chmod temp dir: %v", err)
+	}
+	_, data := mintContainmentCapsule(t)
+	path := filepath.Join(dir, "proof.json")
+	if wantCase == "parent" {
+		denied := filepath.Join(dir, "denied")
+		if err := os.Mkdir(denied, 0o700); err != nil {
+			cleanup()
+			t.Fatalf("Mkdir denied parent: %v", err)
+		}
+		path = filepath.Join(denied, "proof.json")
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		cleanup()
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if wantCase == "parent" {
+		if err := os.Chmod(filepath.Dir(path), 0o000); err != nil {
+			cleanup()
+			t.Fatalf("Chmod parent: %v", err)
+		}
+	} else if err := os.Chmod(path, 0o000); err != nil {
+		cleanup()
+		t.Fatalf("Chmod proof: %v", err)
+	}
+	return path, cleanup
+}
+
+func assertUnreadableProof(t *testing.T, path string) {
+	t.Helper()
+	result, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q): %v", path, err)
+	}
+	requireAvailability(t, result, AvailabilityUnreadable)
+	if !errors.Is(result.Cause, os.ErrPermission) {
+		t.Fatalf("unreadable cause = %v, want permission denial", result.Cause)
+	}
+
+	t.Setenv(RuntimeProofEnv, path)
+	var warning bytes.Buffer
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true, Stderr: &warning})
+	if err != nil {
+		t.Fatalf("ordinary receipt policy: %v", err)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("unreadable proof binding = %+v, want zero: an unreadable proof must claim nothing", binding)
+	}
+	result, loadErr := LoadRuntime()
+	if loadErr != nil {
+		t.Fatalf("LoadRuntime on an unreadable proof returned an error: %v", loadErr)
+	}
+	if result.Availability != AvailabilityUnreadable {
+		t.Fatalf("availability = %q, want %q", result.Availability, AvailabilityUnreadable)
+	}
+	message := warning.String()
+	for _, want := range []string{path, "containment user", "grant this runtime user read access"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("warning %q does not contain %q", message, want)
+		}
+	}
+	if !strings.Contains(message, "owner ") || !strings.Contains(message, "group ") {
+		t.Fatalf("file warning %q does not name the proof owner and group", message)
+	}
+}

--- a/internal/posturebinding/binding_test.go
+++ b/internal/posturebinding/binding_test.go
@@ -10,12 +10,11 @@
 package posturebinding
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/posture"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 )
 
 // mintContainmentCapsule emits a valid, signed posture capsule carrying
@@ -52,6 +52,13 @@ func mintContainmentCapsule(t *testing.T) (*posture.Capsule, []byte) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	return capsule, data
+}
+
+func requireAvailability(t *testing.T, got Result, want Availability) {
+	t.Helper()
+	if got.Availability != want {
+		t.Fatalf("availability = %q, want %q (result = %+v)", got.Availability, want, got)
+	}
 }
 
 // writeMutatedCapsule rewrites one or more top-level capsule fields in the
@@ -90,9 +97,11 @@ func TestLoadFileTamperedBodyRejected(t *testing.T) {
 	path := writeMutatedCapsule(t, data, map[string]string{
 		"config_hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 	})
-	if _, err := LoadFile(path); err == nil {
+	got, err := LoadFile(path)
+	if err == nil {
 		t.Fatal("LoadFile error = nil, want signature verification failure on tampered body")
 	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadFileExpiredCapsuleRejected(t *testing.T) {
@@ -105,7 +114,7 @@ func TestLoadFileExpiredCapsuleRejected(t *testing.T) {
 		"generated_at": now.Add(-48 * time.Hour).Format(time.RFC3339Nano),
 		"expires_at":   now.Add(-24 * time.Hour).Format(time.RFC3339Nano),
 	})
-	_, err := LoadFile(path)
+	got, err := LoadFile(path)
 	if err == nil {
 		t.Fatal("LoadFile error = nil, want expiry rejection")
 	}
@@ -115,6 +124,7 @@ func TestLoadFileExpiredCapsuleRejected(t *testing.T) {
 	if !strings.Contains(err.Error(), "expired") {
 		t.Fatalf("LoadFile error = %v, want an expiry rejection", err)
 	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadFileNonHexSignerKeyRejected(t *testing.T) {
@@ -122,9 +132,11 @@ func TestLoadFileNonHexSignerKeyRejected(t *testing.T) {
 	// A signer_key_id that is not valid hex must fail closed at the key-decode
 	// step, before any signature verification.
 	path := writeMutatedCapsule(t, data, map[string]string{"signer_key_id": "not-hex-zz"})
-	if _, err := LoadFile(path); err == nil {
+	got, err := LoadFile(path)
+	if err == nil {
 		t.Fatal("LoadFile error = nil, want signer-key decode rejection")
 	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadFileValidContainmentCapsuleStillBinds(t *testing.T) {
@@ -133,10 +145,12 @@ func TestLoadFileValidContainmentCapsuleStillBinds(t *testing.T) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	got, err := LoadFile(path)
+	result, err := LoadFile(path)
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
+	requireAvailability(t, result, AvailabilityAttested)
+	got := result.Binding
 	sum := sha256.Sum256(data)
 	if got.CapsuleSHA256 != hex.EncodeToString(sum[:]) ||
 		got.SignerKeyID != capsule.SignerKeyID ||
@@ -157,9 +171,11 @@ func TestLoadFileRejectsGroupWritableProof(t *testing.T) {
 		t.Fatalf("Chmod() error = %v", err)
 	}
 
-	if _, err := LoadFile(path); err == nil || !strings.Contains(err.Error(), "permissions") {
+	got, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "permissions") {
 		t.Fatalf("LoadFile(group-writable proof) error = %v, want permission rejection", err)
 	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadRuntimeRelativeOverrideRejected(t *testing.T) {
@@ -176,57 +192,27 @@ func TestLoadRuntimeAbsoluteOverrideWorks(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	t.Setenv(RuntimeProofEnv, path)
-	got, err := LoadRuntime()
+	result, err := LoadRuntime()
 	if err != nil {
 		t.Fatalf("LoadRuntime: %v", err)
 	}
+	requireAvailability(t, result, AvailabilityAttested)
+	got := result.Binding
 	if got.SignerKeyID != capsule.SignerKeyID || got.ContainedUID != "966" {
 		t.Fatalf("binding = %+v, want fields from capsule at absolute override", got)
 	}
 }
 
-func TestLoadRuntimeUnsetUsesDefaultPath(t *testing.T) {
-	// With no override, LoadRuntime reads DefaultContainRunProofPath, so this
-	// assertion is only meaningful when that path is provably absent.
-	//
-	// Skipping on `err == nil` alone was not that check. It treats every error
-	// as absence, and the error a containment host actually returns is
-	// permission denied: `pipelock contain install` creates the posture
-	// directory 0o750 owned by pipelock-proxy, so an ordinary user's stat fails
-	// without the file being missing. The guard then declined to skip,
-	// LoadRuntime surfaced that refusal, and the test failed for a reason that
-	// has nothing to do with the missing-default behavior it asserts.
-	//
-	// A machine with containment installed is a production state, not an exotic
-	// one, so this must distinguish absence from refusal rather than collapse
-	// them.
-	_, statErr := os.Stat(DefaultContainRunProofPath)
-	switch {
-	case statErr == nil:
-		t.Skipf("default proof path %s exists; skipping missing-default assertion",
-			DefaultContainRunProofPath)
-	case errors.Is(statErr, fs.ErrNotExist):
-		// Provably absent, which is the state this assertion is about.
-	case errors.Is(statErr, fs.ErrPermission):
-		// `pipelock contain install` creates the posture directory 0o750 owned
-		// by pipelock-proxy, so an ordinary user cannot tell whether the proof
-		// is there. Absence is unprovable, so the assertion is skipped rather
-		// than failed: a machine with containment installed is a production
-		// state, and failing here would be the defect this test was fixed for.
-		t.Skipf("default proof path %s is unreadable (%v); absence cannot be established",
-			DefaultContainRunProofPath, statErr)
-	default:
-		// Anything else is a genuine filesystem fault and must not be hidden
-		// behind a skip.
-		t.Fatalf("stat default proof path %s: %v", DefaultContainRunProofPath, statErr)
-	}
-	t.Setenv(RuntimeProofEnv, "")
+func TestLoadRuntimeAbsentOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-proof.json")
+	t.Setenv(RuntimeProofEnv, path)
 	got, err := LoadRuntime()
 	if err != nil {
 		t.Fatalf("LoadRuntime: %v", err)
 	}
-	if got.CapsuleSHA256 != "" || got.SignerKeyID != "" || got.ContainmentNonce != "" || got.ContainedUID != "" {
-		t.Fatalf("binding = %+v, want zero from missing default proof", got)
+	requireAvailability(t, got, AvailabilityAbsent)
+	if got.Binding.CapsuleSHA256 != "" || got.Binding.SignerKeyID != "" || got.Binding.ContainmentNonce != "" || got.Binding.ContainedUID != "" {
+		t.Fatalf("binding = %+v, want zero from missing proof", got.Binding)
 	}
 }
 
@@ -235,8 +221,81 @@ func TestLoadFileMissingReturnsZeroBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
-	if got.CapsuleSHA256 != "" || got.SignerKeyID != "" || got.ContainmentNonce != "" || got.ContainedUID != "" {
+	requireAvailability(t, got, AvailabilityAbsent)
+	if got.Binding.CapsuleSHA256 != "" || got.Binding.SignerKeyID != "" || got.Binding.ContainmentNonce != "" || got.Binding.ContainedUID != "" {
 		t.Fatalf("binding = %+v, want zero", got)
+	}
+}
+
+func TestLoadRuntimeForReceiptsAbsentPolicy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-proof.json")
+	t.Setenv(RuntimeProofEnv, path)
+
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+	if err != nil {
+		t.Fatalf("ordinary receipt policy: %v", err)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("absent proof binding = %+v, want zero", binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsSkipsProofWithoutSigning(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid-proof.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{})
+	if err != nil {
+		t.Fatalf("recorder-only runtime loaded posture proof: %v", err)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("recorder-only posture binding = %+v, want zero", binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsBindsAttestedContainment(t *testing.T) {
+	_, data := mintContainmentCapsule(t)
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+	if err != nil {
+		t.Fatalf("ordinary receipt policy: %v", err)
+	}
+	if binding.CapsuleSHA256 == "" || binding.ContainmentNonce == "" {
+		t.Fatalf("attested binding = %+v, want containment fields", binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsBindsNothingWithoutContainment(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	capsule, err := posture.Emit(config.Defaults(), posture.Options{SigningKey: priv})
+	if err != nil {
+		t.Fatalf("posture.Emit: %v", err)
+	}
+	data, err := json.Marshal(capsule)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true})
+	if err != nil {
+		t.Fatalf("proof without containment: %v", err)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("binding without containment evidence = %+v, want zero", binding)
 	}
 }
 
@@ -247,10 +306,12 @@ func TestLoadFileDerivesContainmentBinding(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	got, err := LoadFile(path)
+	result, err := LoadFile(path)
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
+	requireAvailability(t, result, AvailabilityAttested)
+	got := result.Binding
 	canonicalSum := sha256.Sum256(data)
 	if got.CapsuleSHA256 != hex.EncodeToString(canonicalSum[:]) {
 		t.Fatalf("CapsuleSHA256 = %q, want canonical capsule hash", got.CapsuleSHA256)
@@ -292,9 +353,26 @@ func TestLoadFileNoContainmentReturnsZeroBinding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFile: %v", err)
 	}
-	if got.CapsuleSHA256 != "" || got.SignerKeyID != "" || got.ContainmentNonce != "" || got.ContainedUID != "" {
+	requireAvailability(t, got, AvailabilityAttested)
+	if got.Binding.CapsuleSHA256 != "" || got.Binding.SignerKeyID != "" || got.Binding.ContainmentNonce != "" || got.Binding.ContainedUID != "" {
 		t.Fatalf("binding = %+v, want zero (no containment evidence)", got)
 	}
+}
+
+func TestLoadFileUnsignedNoContainmentIsInvalid(t *testing.T) {
+	// A readable capsule that carries no containment evidence AND cannot be
+	// verified must be invalid, not attested. Before the fix, this exact file
+	// produced posture_availability "attested" in a signed session_open.
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := LoadFile(path)
+	if err == nil {
+		t.Fatalf("LoadFile: want error for unverifiable capsule, got nil (availability=%q)", got.Availability)
+	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadFileMalformedReturnsError(t *testing.T) {
@@ -302,9 +380,11 @@ func TestLoadFileMalformedReturnsError(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if _, err := LoadFile(path); err == nil {
+	got, err := LoadFile(path)
+	if err == nil {
 		t.Fatal("LoadFile error = nil, want parse error")
 	}
+	requireAvailability(t, got, AvailabilityInvalid)
 }
 
 func TestLoadFileRejectsOversizedAndEscapingSymlink(t *testing.T) {
@@ -331,4 +411,35 @@ func TestLoadFileRejectsOversizedAndEscapingSymlink(t *testing.T) {
 			t.Fatal("LoadFile accepted symlink escaping the proof directory")
 		}
 	})
+}
+
+func TestLoadFileEmptyPathIsAbsent(t *testing.T) {
+	got, err := LoadFile("   ")
+	if err != nil {
+		t.Fatalf("LoadFile with a blank path: %v", err)
+	}
+	requireAvailability(t, got, AvailabilityAbsent)
+	if got.Binding != (receipt.PostureBinding{}) {
+		t.Fatalf("blank-path binding = %+v, want zero", got.Binding)
+	}
+}
+
+func TestLoadRuntimeForReceiptsPropagatesInvalidProof(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proof.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(RuntimeProofEnv, path)
+
+	var warning bytes.Buffer
+	binding, err := LoadRuntimeForReceipts(RuntimeReceiptOptions{ReceiptSigningEnabled: true, Stderr: &warning})
+	if err == nil || !strings.Contains(err.Error(), "parse posture proof") {
+		t.Fatalf("malformed proof error = %v, want a parse failure", err)
+	}
+	if binding != (receipt.PostureBinding{}) {
+		t.Fatalf("malformed proof binding = %+v, want zero", binding)
+	}
+	if warning.Len() != 0 {
+		t.Fatalf("malformed proof wrote an unreadable warning: %q", warning.String())
+	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1529,7 +1529,10 @@ func (p *Proxy) buildReceiptEmitter(cfg *config.Config) (receiptEmitterStage, er
 		}, nil
 	}
 
-	postureBinding, bindErr := posturebinding.LoadRuntime()
+	postureBinding, bindErr := posturebinding.LoadRuntimeForReceipts(posturebinding.RuntimeReceiptOptions{
+		ReceiptSigningEnabled: keyPath != "",
+		Stderr:                os.Stderr,
+	})
 	if bindErr != nil {
 		return receiptEmitterStage{}, fmt.Errorf("loading posture binding: %w", bindErr)
 	}

--- a/internal/testposture/testposture_test.go
+++ b/internal/testposture/testposture_test.go
@@ -43,12 +43,15 @@ func TestPinAbsentIsolatesFromHostPosture(t *testing.T) {
 
 	// An absent proof yields the zero binding rather than an error, which is what
 	// makes callers take their no-attested-containment path.
-	binding, loadErr := posturebinding.LoadRuntime()
+	result, loadErr := posturebinding.LoadRuntime()
 	if loadErr != nil {
 		t.Fatalf("LoadRuntime with an absent pinned proof: %v", loadErr)
 	}
-	if binding != (receipt.PostureBinding{}) {
-		t.Fatalf("expected the zero binding, got %+v", binding)
+	if result.Availability != posturebinding.AvailabilityAbsent {
+		t.Fatalf("availability = %q, want %q", result.Availability, posturebinding.AvailabilityAbsent)
+	}
+	if result.Binding != (receipt.PostureBinding{}) {
+		t.Fatalf("expected the zero binding, got %+v", result.Binding)
 	}
 
 	dir := filepath.Dir(got)


### PR DESCRIPTION
## What changed

A permission-denied read at the containment posture proof path no longer aborts startup. Only a nonexistent proof counted as no proof, so a proof written by a contained agent that the runtime user cannot read took down every receipt-enabled MCP proxy, server, guard and proxy start alike.

An unreadable proof now binds nothing and warns with the path, its owner and group, and the remedy. A missing proof was already non-fatal, so this opens no gap: it makes one unreadable error class behave like the other rather than introducing a new tolerance. A malformed or unverifiable present proof still fails and never binds.

The meaningful failure direction is that a runtime which cannot read its proof makes no containment claim at all, rather than claiming containment it could not confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, inaccessible, malformed, expired, and unverifiable posture proofs.
  * Unreadable proof files now report clearer diagnostics, including relevant file ownership details where available.
  * Unverifiable proofs are no longer treated as valid no-containment attestations.
  * Receipt and flight recorder configuration now applies the correct posture evidence and signing behavior.

* **Documentation**
  * Clarified that containment evidence changes require a restart, while receipt requirements can be reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->