### PR TITLE
ci: compile tests for every published target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -683,6 +683,7 @@ jobs:
           for target in linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
             printf '==> %s\n' "$target"
             GOOS="${target%%/*}" GOARCH="${target##*/}" go vet ./...
+            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet -tags enterprise ./...
           done
 
       - name: Python pin policy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -677,15 +677,10 @@ jobs:
       # this amd64 runner without needing hardware for every target. It runs here
       # rather than in each native lane so a target with no lane is still covered.
       #
-      # windows/amd64 and windows/arm64 are deliberately NOT in this list yet:
-      # internal/cli/contain and internal/emit have test files with this exact
-      # defect on Windows today, tracked separately. Adding them here before that
-      # is fixed would land a knowingly-red required check, and a check people
-      # expect to be red stops being read. Add both the moment that lands.
-      - name: Test code compiles for every published non-Windows target
+      - name: Test code compiles for every published target
         run: |
           set -euo pipefail
-          for target in linux/arm64 darwin/amd64 darwin/arm64; do
+          for target in linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
             printf '==> %s\n' "$target"
             GOOS="${target%%/*}" GOARCH="${target##*/}" go vet ./...
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -663,29 +663,6 @@ jobs:
       - name: golangci-lint (enterprise)
         run: golangci-lint run --build-tags enterprise ./...
 
-      # Test files are compiled by `go test`, never by `go build`, so a test file
-      # that references a symbol guarded to one architecture makes an entire test
-      # package uncompilable there while every build job stays green. That is not
-      # hypothetical: internal/sandbox's test package could not compile on
-      # linux/arm64 at all, because coverage_deep_test.go was tagged plain linux
-      # while the seccomp filter builder and BPF helpers it calls exist only under
-      # linux && amd64. A published target therefore had zero sandbox test
-      # coverage and nothing said so. The same shape hit internal/config on
-      # Windows previously via syscall.Mkfifo.
-      #
-      # `go vet` compiles test files, so cross-targeting it catches the class on
-      # this amd64 runner without needing hardware for every target. It runs here
-      # rather than in each native lane so a target with no lane is still covered.
-      #
-      - name: Test code compiles for every published target
-        run: |
-          set -euo pipefail
-          for target in linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
-            printf '==> %s\n' "$target"
-            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet ./...
-            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet -tags enterprise ./...
-          done
-
       - name: Python pin policy
         run: bash scripts/check-python-pins.sh
 
@@ -725,6 +702,43 @@ jobs:
 
       - name: Reproducible OSS build
         run: make reproducible-build-check
+
+  # Test files are compiled by `go test`, never by `go build`, so a test file
+  # that references a symbol guarded to one architecture makes an entire test
+  # package uncompilable there while every build job stays green. That is not
+  # hypothetical: internal/sandbox's test package could not compile on
+  # linux/arm64 at all, because coverage_deep_test.go was tagged plain linux
+  # while the seccomp filter builder and BPF helpers it calls exist only under
+  # linux && amd64. A published target therefore had zero sandbox test coverage
+  # and nothing said so. The same shape hit internal/config on Windows via
+  # syscall.Mkfifo.
+  #
+  # `go vet` compiles test files, so cross-targeting it catches the class on this
+  # amd64 runner without needing hardware for every target. Keep the expensive
+  # cross-target pass separate from lint so neither job consumes the other's
+  # timeout budget.
+  test-cross-target:
+    needs: [security-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.25'
+
+      - name: Test code compiles for every published target
+        run: |
+          set -euo pipefail
+          for target in linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+            printf '==> %s\n' "$target"
+            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet ./...
+            GOOS="${target%%/*}" GOARCH="${target##*/}" go vet -tags enterprise ./...
+          done
 
   helm:
     needs: [security-scan]
@@ -862,10 +876,10 @@ jobs:
   # Helm remains a separate diagnostic job, but the required `build` context
   # intentionally carries its result through `needs`. Keep that dependency
   # until a separately approved ruleset change makes `helm` required itself.
-  # The parallel build-binaries producer also flows through this gate, so a
-  # compilation failure cannot present as a successful required build check.
+  # The parallel binary and cross-target producers also flow through this gate,
+  # so a compilation failure cannot present as a successful required build check.
   build:
-    needs: [security-scan, test-go125, test-go126, lint, helm, build-binaries]
+    needs: [security-scan, test-go125, test-go126, lint, test-cross-target, helm, build-binaries]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -876,6 +890,7 @@ jobs:
           TEST_GO125_RESULT: ${{ needs.test-go125.result }}
           TEST_GO126_RESULT: ${{ needs.test-go126.result }}
           LINT_RESULT: ${{ needs.lint.result }}
+          CROSS_TARGET_RESULT: ${{ needs.test-cross-target.result }}
           HELM_RESULT: ${{ needs.helm.result }}
           BUILD_BINARIES_RESULT: ${{ needs.build-binaries.result }}
         run: |
@@ -885,6 +900,7 @@ jobs:
             "$TEST_GO125_RESULT" \
             "$TEST_GO126_RESULT" \
             "$LINT_RESULT" \
+            "$CROSS_TARGET_RESULT" \
             "$HELM_RESULT" \
             "$BUILD_BINARIES_RESULT"; do
             if [ "$result" != success ]; then

--- a/internal/cli/contain/selfmanaged_verify_test.go
+++ b/internal/cli/contain/selfmanaged_verify_test.go
@@ -5,28 +5,9 @@ package contain
 
 import (
 	"context"
-	"errors"
-	"io/fs"
-	"os"
 	"strings"
-	"syscall"
 	"testing"
-	"time"
 )
-
-type rootFileInfo struct{ mode fs.FileMode }
-
-func (rootFileInfo) Name() string { return "nft" }
-func (rootFileInfo) Size() int64  { return 1 }
-func (f rootFileInfo) Mode() fs.FileMode {
-	if f.mode == 0 {
-		return 0o755
-	}
-	return f.mode
-}
-func (rootFileInfo) ModTime() time.Time { return time.Time{} }
-func (rootFileInfo) IsDir() bool        { return false }
-func (rootFileInfo) Sys() any           { return &syscall.Stat_t{Uid: 0} }
 
 func TestValidateSelfManagedNFTRules(t *testing.T) {
 	t.Parallel()
@@ -73,91 +54,6 @@ func TestValidateSelfManagedNFTRules(t *testing.T) {
 			t.Fatal("IPv4-only table accepted")
 		}
 	})
-}
-
-func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
-	t.Parallel()
-	canonical := renderNFTRules(1000, 1001, 10001, 8888, defaultNFTTable, defaultNFTChain)
-	statSecondPath := func(path string) (fs.FileInfo, error) {
-		if path == "/usr/sbin/nft" {
-			return nil, os.ErrNotExist
-		}
-		return rootFileInfo{}, nil
-	}
-
-	var gotPath string
-	run := func(ctx context.Context, path string, args ...string) ([]byte, error) {
-		gotPath = path
-		if err := context.Cause(ctx); err != nil {
-			return nil, err
-		}
-		if strings.Join(args, " ") != "-n -a list chain inet pipelock_containment output_filter" {
-			t.Fatalf("args = %q", args)
-		}
-		return []byte(canonical), nil
-	}
-	baseOpts := selfManagedNFTVerifyOptions{
-		ctx: context.Background(), operatorUID: 1000, proxyUID: 1001,
-		agentUID: 10001, proxyPort: 8888, statFn: statSecondPath, run: run,
-	}
-	if err := verifySelfManagedNFTRules(baseOpts); err != nil {
-		t.Fatalf("verify: %v", err)
-	}
-	if gotPath != "/usr/bin/nft" {
-		t.Fatalf("nft path = %q", gotPath)
-	}
-
-	t.Run("command failure includes output", func(t *testing.T) {
-		runErr := func(context.Context, string, ...string) ([]byte, error) {
-			return []byte("permission denied\n"), errors.New("exit 1")
-		}
-		opts := baseOpts
-		opts.run = runErr
-		err := verifySelfManagedNFTRules(opts)
-		if err == nil || !strings.Contains(err.Error(), "permission denied") {
-			t.Fatalf("error = %v", err)
-		}
-	})
-
-	t.Run("trusted executable absent", func(t *testing.T) {
-		missing := func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist }
-		opts := baseOpts
-		opts.statFn = missing
-		if err := verifySelfManagedNFTRules(opts); err == nil {
-			t.Fatal("missing nft executable accepted")
-		}
-	})
-
-	t.Run("untrusted executable rejected", func(t *testing.T) {
-		writable := func(string) (fs.FileInfo, error) { return rootFileInfo{mode: 0o777}, nil }
-		opts := baseOpts
-		opts.statFn = writable
-		if err := verifySelfManagedNFTRules(opts); err == nil {
-			t.Fatal("world-writable nft executable accepted")
-		}
-	})
-
-	t.Run("command receives bounded context", func(t *testing.T) {
-		opts := baseOpts
-		opts.run = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
-			deadline, ok := ctx.Deadline()
-			if !ok || time.Until(deadline) > selfManagedNFTTimeout {
-				t.Fatalf("bounded deadline missing or too long: %v, %v", deadline, ok)
-			}
-			return []byte(canonical), nil
-		}
-		if err := verifySelfManagedNFTRules(opts); err != nil {
-			t.Fatalf("verify with bounded context: %v", err)
-		}
-	})
-}
-
-func TestRunNFTCommand(t *testing.T) {
-	t.Parallel()
-	out, err := runNFTCommand(context.Background(), "/bin/sh", "-c", "printf nft-ok")
-	if err != nil || string(out) != "nft-ok" {
-		t.Fatalf("runNFTCommand output=%q err=%v", out, err)
-	}
 }
 
 func TestVerifySelfManagedNFTRules_CanceledContextFailsClosed(t *testing.T) {

--- a/internal/cli/contain/selfmanaged_verify_unix_test.go
+++ b/internal/cli/contain/selfmanaged_verify_unix_test.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Josh Waldrep
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows
+//go:build unix
 
 package contain
 

--- a/internal/cli/contain/selfmanaged_verify_unix_test.go
+++ b/internal/cli/contain/selfmanaged_verify_unix_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package contain
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type rootFileInfo struct{ mode fs.FileMode }
+
+func (rootFileInfo) Name() string { return "nft" }
+func (rootFileInfo) Size() int64  { return 1 }
+func (f rootFileInfo) Mode() fs.FileMode {
+	if f.mode == 0 {
+		return 0o755
+	}
+	return f.mode
+}
+func (rootFileInfo) ModTime() time.Time { return time.Time{} }
+func (rootFileInfo) IsDir() bool        { return false }
+func (rootFileInfo) Sys() any           { return fakeFileSysWithUID(0) }
+
+func TestVerifySelfManagedNFTRulesWithDependencies(t *testing.T) {
+	t.Parallel()
+	canonical := renderNFTRules(1000, 1001, 10001, 8888, defaultNFTTable, defaultNFTChain)
+	statSecondPath := func(path string) (fs.FileInfo, error) {
+		if path == "/usr/sbin/nft" {
+			return nil, os.ErrNotExist
+		}
+		return rootFileInfo{}, nil
+	}
+
+	var gotPath string
+	run := func(ctx context.Context, path string, args ...string) ([]byte, error) {
+		gotPath = path
+		if err := context.Cause(ctx); err != nil {
+			return nil, err
+		}
+		if strings.Join(args, " ") != "-n -a list chain inet pipelock_containment output_filter" {
+			t.Fatalf("args = %q", args)
+		}
+		return []byte(canonical), nil
+	}
+	baseOpts := selfManagedNFTVerifyOptions{
+		ctx: context.Background(), operatorUID: 1000, proxyUID: 1001,
+		agentUID: 10001, proxyPort: 8888, statFn: statSecondPath, run: run,
+	}
+	if err := verifySelfManagedNFTRules(baseOpts); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if gotPath != "/usr/bin/nft" {
+		t.Fatalf("nft path = %q", gotPath)
+	}
+
+	t.Run("command failure includes output", func(t *testing.T) {
+		runErr := func(context.Context, string, ...string) ([]byte, error) {
+			return []byte("permission denied\n"), errors.New("exit 1")
+		}
+		opts := baseOpts
+		opts.run = runErr
+		err := verifySelfManagedNFTRules(opts)
+		if err == nil || !strings.Contains(err.Error(), "permission denied") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("trusted executable absent", func(t *testing.T) {
+		missing := func(string) (fs.FileInfo, error) { return nil, os.ErrNotExist }
+		opts := baseOpts
+		opts.statFn = missing
+		if err := verifySelfManagedNFTRules(opts); err == nil {
+			t.Fatal("missing nft executable accepted")
+		}
+	})
+
+	t.Run("untrusted executable rejected", func(t *testing.T) {
+		writable := func(string) (fs.FileInfo, error) { return rootFileInfo{mode: 0o777}, nil }
+		opts := baseOpts
+		opts.statFn = writable
+		if err := verifySelfManagedNFTRules(opts); err == nil {
+			t.Fatal("world-writable nft executable accepted")
+		}
+	})
+
+	t.Run("command receives bounded context", func(t *testing.T) {
+		opts := baseOpts
+		opts.run = func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+			deadline, ok := ctx.Deadline()
+			if !ok || time.Until(deadline) > selfManagedNFTTimeout {
+				t.Fatalf("bounded deadline missing or too long: %v, %v", deadline, ok)
+			}
+			return []byte(canonical), nil
+		}
+		if err := verifySelfManagedNFTRules(opts); err != nil {
+			t.Fatalf("verify with bounded context: %v", err)
+		}
+	})
+}
+
+func TestRunNFTCommand(t *testing.T) {
+	t.Parallel()
+	out, err := runNFTCommand(context.Background(), "/bin/sh", "-c", "printf nft-ok")
+	if err != nil || string(out) != "nft-ok" {
+		t.Fatalf("runNFTCommand output=%q err=%v", out, err)
+	}
+}

--- a/internal/emit/health_syslog_unix_test.go
+++ b/internal/emit/health_syslog_unix_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package emit
+
+func syslogHealthTestSink() (*SyslogSink, SinkHealth) {
+	sink := &SyslogSink{queue: make(chan syslogMessage, 5)}
+	sink.dropped.Store(3)
+	sink.degraded.Store(true)
+	sink.lastErr = "queue_full"
+	return sink, SinkHealth{
+		Sink:             SinkSyslog,
+		Dropped:          3,
+		QueueCap:         5,
+		Degraded:         true,
+		LastErrorPresent: true,
+	}
+}

--- a/internal/emit/health_syslog_windows_test.go
+++ b/internal/emit/health_syslog_windows_test.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package emit
+
+func syslogHealthTestSink() (*SyslogSink, SinkHealth) {
+	return &SyslogSink{}, SinkHealth{Sink: SinkSyslog}
+}

--- a/internal/emit/health_test.go
+++ b/internal/emit/health_test.go
@@ -17,10 +17,7 @@ func TestEmitterSinkHealthIncludesAllBuiltInSinks(t *testing.T) {
 	webhook.degraded.Store(true)
 	webhook.lastErr = "HTTP 500"
 
-	syslog := &SyslogSink{queue: make(chan syslogMessage, 5)}
-	syslog.dropped.Store(3)
-	syslog.degraded.Store(true)
-	syslog.lastErr = "queue_full"
+	syslog, wantSyslog := syslogHealthTestSink()
 
 	otlp := &OTLPSink{queue: make(chan Event, 7)}
 	otlp.abandoned.Store(4)
@@ -40,7 +37,7 @@ func TestEmitterSinkHealthIncludesAllBuiltInSinks(t *testing.T) {
 	if health := byName[SinkWebhook]; health.Delivered != 2 || health.Failed != 1 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 3 {
 		t.Errorf("webhook health = %+v", health)
 	}
-	if health := byName[SinkSyslog]; health.Dropped != 3 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 5 {
+	if health := byName[SinkSyslog]; health != wantSyslog {
 		t.Errorf("syslog health = %+v", health)
 	}
 	if health := byName[SinkOTLP]; health.Abandoned != 4 || !health.Degraded || !health.LastErrorPresent || health.QueueCap != 7 {

--- a/scripts/test_ci_security_workflow.py
+++ b/scripts/test_ci_security_workflow.py
@@ -46,6 +46,7 @@ class CISecurityWorkflowTest(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = WORKFLOW.read_text(encoding="utf-8")
         self.govulncheck = job_block(self.workflow, "govulncheck")
+        self.cross_target = job_block(self.workflow, "test-cross-target")
         self.build_binaries = job_block(self.workflow, "build-binaries")
         self.build = job_block(self.workflow, "build")
 
@@ -149,7 +150,15 @@ exit "$DEFAULT_STATUS"
         gate_needs = re.search(r"(?m)^\s+needs:\s*\[([^]]+)\]$", self.build)
         self.assertIsNotNone(gate_needs, "build needs list not found")
         self.assertEqual(
-            {"security-scan", "test-go125", "test-go126", "lint", "helm", "build-binaries"},
+            {
+                "security-scan",
+                "test-go125",
+                "test-go126",
+                "lint",
+                "test-cross-target",
+                "helm",
+                "build-binaries",
+            },
             {dependency.strip() for dependency in gate_needs.group(1).split(",")},
         )
         self.assertIn("if: ${{ always() }}", self.build)
@@ -158,6 +167,7 @@ exit "$DEFAULT_STATUS"
             "TEST_GO125_RESULT",
             "TEST_GO126_RESULT",
             "LINT_RESULT",
+            "CROSS_TARGET_RESULT",
             "HELM_RESULT",
             "BUILD_BINARIES_RESULT",
         ):
@@ -170,6 +180,7 @@ exit "$DEFAULT_STATUS"
             "TEST_GO125_RESULT",
             "TEST_GO126_RESULT",
             "LINT_RESULT",
+            "CROSS_TARGET_RESULT",
             "HELM_RESULT",
             "BUILD_BINARIES_RESULT",
         )
@@ -197,6 +208,16 @@ exit "$DEFAULT_STATUS"
                         capture_output=True,
                     )
                     self.assertNotEqual(0, result.returncode)
+
+    def test_cross_target_compile_has_an_independent_timeout_and_required_gate(self) -> None:
+        self.assertIn("timeout-minutes: 15", self.cross_target)
+        self.assertIn(
+            "linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64",
+            self.cross_target,
+        )
+        self.assertIn('go vet ./...', self.cross_target)
+        self.assertIn('go vet -tags enterprise ./...', self.cross_target)
+        self.assertNotIn("Test code compiles for every published target", job_block(self.workflow, "lint"))
 
     def test_helm_transitive_gate_contract_rejects_removed_dependency(self) -> None:
         needs_match = re.search(r"(?m)^(\s+needs:\s*\[)([^]]+)(\])$", self.build)


### PR DESCRIPTION
## What changed
- Keep portable containment and emitter health tests compiling on Windows without treating Unix-only fixtures as cross-platform.
- Add windows/amd64 and windows/arm64 to the required cross-target test compilation gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded cross-platform validation to include Windows AMD64 and ARM64 targets.
  - Added Unix coverage for self-managed NFT rule verification, command failures, executable validation, context limits, and successful validation.
  - Improved cross-platform syslog health testing for consistent sink reporting.
  - Strengthened CI checks to ensure all supported targets are validated before builds are accepted.
  - Removed redundant test coverage and simplified test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->