### PR TITLE
fix(contain): recognize established reply rules

### DIFF
--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1327,6 +1327,9 @@ func chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines []string, uids containment
 		if lineHasAgentProxyLoopbackAllow(line, uids.agentUID, proxyPort) {
 			return false
 		}
+		if lineHasAgentEstablishedReplyAllow(line, uids.agentUID) {
+			return false
+		}
 		if lineHasSkuidProtocolDPortVerdict(line, uids.agentUID, "udp", 53, "drop") ||
 			lineHasSkuidProtocolDPortVerdict(line, uids.agentUID, "tcp", 53, "drop") {
 			return false
@@ -1338,6 +1341,46 @@ func chainLinesHaveUnsafeVerdictBeforeAgentDrop(lines []string, uids containment
 		}
 		return true
 	})
+}
+
+// lineHasAgentEstablishedReplyAllow recognizes a narrow server reply path.
+// Established TCP replies cannot admit the NEW outbound connection used by the
+// direct-egress canary. The explicit conntrack direction prevents an
+// established original-direction flow from being mistaken for a reply.
+func lineHasAgentEstablishedReplyAllow(line string, agentUID int) bool {
+	fields := nftLineFields(line)
+	const predicatesLen = 17
+	if len(fields) <= predicatesLen {
+		return false
+	}
+	interfaceOK := fields[3] == "oifname" && isQuotedNFTName(fields[4]) ||
+		fields[3] == "oif" && isPositiveInteger(fields[4])
+	if fields[0] != "meta" || fields[1] != "skuid" || fields[2] != strconv.Itoa(agentUID) ||
+		!interfaceOK ||
+		fields[5] != "ip" || (fields[6] != "saddr" && fields[6] != "daddr") || net.ParseIP(fields[7]).To4() == nil ||
+		fields[8] != "tcp" || fields[9] != "sport" || !isTCPPort(fields[10]) ||
+		fields[11] != "ct" || fields[12] != "state" || (fields[13] != "established" && fields[13] != "0x2") ||
+		fields[14] != "ct" || fields[15] != "direction" || (fields[16] != "reply" && fields[16] != "1") {
+		return false
+	}
+	acceptAt := indexTokenAfter(fields, "accept", predicatesLen)
+	return acceptAt != -1 &&
+		fieldsAreNFTBookkeeping(fields[predicatesLen:acceptAt]) &&
+		nftRuleTailIsCommentOnly(fields[acceptAt+1:])
+}
+
+func isQuotedNFTName(value string) bool {
+	return len(value) >= 3 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
+}
+
+func isTCPPort(value string) bool {
+	port, err := strconv.Atoi(value)
+	return err == nil && port >= 1 && port <= 65535
+}
+
+func isPositiveInteger(value string) bool {
+	n, err := strconv.Atoi(value)
+	return err == nil && n > 0
 }
 
 // terminalSkuidUIDVerdict extracts the UID from an exact skuid verdict rule.

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -574,6 +574,25 @@ func TestProbeNFTContainment(t *testing.T) {
 			wantDetail: "skuid drop rule",
 		},
 		{
+			name: "established server reply remains compatible",
+			stdout: `table inet pipelock_containment {
+		chain output_filter {
+			type filter hook output priority filter; policy accept;
+			meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state 0x2 ct direction reply counter packets 3 bytes 180 accept
+			meta skuid 1000 accept
+			meta skuid 988 accept
+			meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+			meta skuid 987 udp dport 53 counter packets 0 bytes 0 drop
+			meta skuid 987 tcp dport 53 counter packets 0 bytes 0 drop
+			meta skuid 987 counter packets 9 bytes 540 drop
+		}
+	}
+`,
+			code:       0,
+			wantStatus: statusPass,
+			wantDetail: "skuid drop rule",
+		},
+		{
 			name: "otherwise canonical regular chain is not containment",
 			stdout: `table inet pipelock_containment {
 		chain output_filter {
@@ -1122,6 +1141,38 @@ func TestProbeNFTContainment(t *testing.T) {
 			}
 			if !strings.Contains(gotDetail, tc.wantDetail) {
 				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestLineHasAgentEstablishedReplyAllow(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "loopback numeric state", line: `meta skuid 987 oifname "lo" ip daddr 127.0.0.1 tcp sport 9119 ct state 0x2 ct direction reply accept # handle 18`, want: true},
+		{name: "numeric state and direction", line: `meta skuid 987 oifname "lo" ip daddr 127.0.0.1 tcp sport 9119 ct state 0x2 ct direction 1 accept # handle 18`, want: true},
+		{name: "tailnet named state", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state established ct direction reply accept`, want: true},
+		{name: "bookkeeping", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state 0x2 ct direction reply counter packets 3 bytes 180 log prefix "reply path " accept`, want: true},
+		{name: "interface index", line: `meta skuid 987 oif 7 ip saddr 100.100.47.101 tcp sport 8642 ct state established ct direction reply accept`, want: true},
+		{name: "missing reply direction", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state established accept`},
+		{name: "original direction", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state established ct direction original accept`},
+		{name: "numeric original direction", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state 0x2 ct direction 0 accept`},
+		{name: "new connection", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state new ct direction reply accept`},
+		{name: "state set includes new", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp sport 8642 ct state { established, new } ct direction reply accept`},
+		{name: "destination port", line: `meta skuid 987 oifname "tailscale0" ip saddr 100.100.47.101 tcp dport 8642 ct state established ct direction reply accept`},
+		{name: "missing interface", line: `meta skuid 987 ip saddr 100.100.47.101 tcp sport 8642 ct state established ct direction reply accept`},
+		{name: "wrong uid", line: `meta skuid 986 oifname "lo" ip daddr 127.0.0.1 tcp sport 9119 ct state established ct direction reply accept`},
+		{name: "port zero", line: `meta skuid 987 oifname "lo" ip daddr 127.0.0.1 tcp sport 0 ct state established ct direction reply accept`},
+		{name: "IPv6 under IPv4 family", line: `meta skuid 987 oifname "lo" ip daddr ::1 tcp sport 9119 ct state established ct direction reply accept`},
+		{name: "extra verdict", line: `meta skuid 987 oifname "lo" ip daddr 127.0.0.1 tcp sport 9119 ct state established ct direction reply accept return`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lineHasAgentEstablishedReplyAllow(tt.line, 987); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed
Containment verification now accepts narrowly scoped established-reply rules ahead of the managed agent drop while continuing to reject rules that can initiate new outbound connections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container network rule verification for narrowly defined established TCP reply permissions.
  * Prevented valid established-reply configurations from being incorrectly flagged as unsafe.
  * Added stricter validation to reject malformed, overly broad, or unintended network rules.

* **Tests**
  * Added coverage for compatible established-reply configurations and invalid rule variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->