### PR TITLE
ci: run every published target natively

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -449,6 +449,44 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Verify native target is darwin/arm64
+        run: |
+          set -euo pipefail
+          echo "runner architecture: $RUNNER_ARCH"
+          go_target="$(go env GOOS)/$(go env GOARCH)"
+          echo "Go target: $go_target"
+          test "$RUNNER_ARCH" = "ARM64"
+          test "$go_target" = "darwin/arm64"
+
+      - name: Run sandbox tests (macOS seatbelt)
+        run: go test -race -count=1 ./internal/sandbox/...
+
+      - name: Verify cross-platform build
+        run: go build ./...
+
+  test-macos-intel:
+    needs: [security-scan]
+    runs-on: macos-15-intel
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+
+      - name: Verify native target is darwin/amd64
+        run: |
+          set -euo pipefail
+          echo "runner architecture: $RUNNER_ARCH"
+          go_target="$(go env GOOS)/$(go env GOARCH)"
+          echo "Go target: $go_target"
+          test "$RUNNER_ARCH" = "X64"
+          test "$go_target" = "darwin/amd64"
+
       - name: Run sandbox tests (macOS seatbelt)
         run: go test -race -count=1 ./internal/sandbox/...
 
@@ -482,6 +520,15 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Verify native target is windows/amd64
+        shell: pwsh
+        run: |
+          Write-Output "runner architecture: $env:RUNNER_ARCH"
+          $goTarget = "$(go env GOOS)/$(go env GOARCH)"
+          Write-Output "Go target: $goTarget"
+          if ($env:RUNNER_ARCH -ne "X64") { throw "expected X64 runner, got $env:RUNNER_ARCH" }
+          if ($goTarget -ne "windows/amd64") { throw "expected windows/amd64 Go target, got $goTarget" }
+
       - name: Verify Windows build (OSS + enterprise)
         run: |
           go build ./...
@@ -504,6 +551,51 @@ jobs:
         run: go test -count=1 -run "TestWindows" ./internal/proxy/baseline/...
 
       # Compiling this package is the point: it guards the Mkfifo-class break.
+      - name: internal/config test package builds on Windows
+        run: go test -count=1 -run "TestWindows" ./internal/config/...
+
+  test-windows-arm64:
+    needs: [security-scan]
+    runs-on: windows-11-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+
+      - name: Verify native target is windows/arm64
+        shell: pwsh
+        run: |
+          Write-Output "runner architecture: $env:RUNNER_ARCH"
+          $goTarget = "$(go env GOOS)/$(go env GOARCH)"
+          Write-Output "Go target: $goTarget"
+          if ($env:RUNNER_ARCH -ne "ARM64") { throw "expected ARM64 runner, got $env:RUNNER_ARCH" }
+          if ($goTarget -ne "windows/arm64") { throw "expected windows/arm64 Go target, got $goTarget" }
+
+      - name: Verify Windows build (OSS + enterprise)
+        run: |
+          go build ./...
+          go build -tags enterprise ./...
+
+      # Keep this paired with test-windows. These targeted packages avoid the
+      # Unix permission assertions that make a full Windows suite misleading.
+      - name: secperm OS split (mode checks skipped on Windows)
+        run: go test -count=1 ./internal/secperm/...
+
+      - name: Signing key / salt / header-file load at any reported mode (#695)
+        run: go test -count=1 -run "TestWindows" ./internal/signing/... ./internal/contract/privacy/... ./internal/cli/runtime/... ./internal/recorder/...
+
+      - name: Key-free MCP capture writer smoke (#696)
+        run: go test -count=1 -run "TestBuildCaptureWriter|TestParseCaptureEscrowKey" ./internal/cli/runtime/...
+
+      - name: Baseline no-follow reads work on Windows
+        run: go test -count=1 -run "TestWindows" ./internal/proxy/baseline/...
+
       - name: internal/config test package builds on Windows
         run: go test -count=1 -run "TestWindows" ./internal/config/...
 
@@ -538,6 +630,15 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.26'
+
+      - name: Verify native target is linux/arm64
+        run: |
+          set -euo pipefail
+          echo "runner architecture: $RUNNER_ARCH"
+          go_target="$(go env GOOS)/$(go env GOARCH)"
+          echo "Go target: $go_target"
+          test "$RUNNER_ARCH" = "ARM64"
+          test "$go_target" = "linux/arm64"
 
       # A published target that has never been compiled natively can break in
       # ways cross-compilation catches and ways it does not, and `go build` never

--- a/scripts/test_ci_native_targets.py
+++ b/scripts/test_ci_native_targets.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression contract for native CI target evidence."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
+NATIVE_TARGETS = {
+    "test-macos": ("macos-latest", "ARM64", "darwin/arm64", "bash"),
+    "test-macos-intel": ("macos-15-intel", "X64", "darwin/amd64", "bash"),
+    "test-windows": ("windows-latest", "X64", "windows/amd64", "pwsh"),
+    "test-windows-arm64": ("windows-11-arm", "ARM64", "windows/arm64", "pwsh"),
+    "test-linux-arm64": ("ubuntu-24.04-arm", "ARM64", "linux/arm64", "bash"),
+}
+
+
+def workflow_jobs() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def native_target_errors(jobs: dict) -> list[str]:
+    """Return violations of the native target and architecture contract."""
+    errors = []
+    for job_name, (runner, runner_arch, go_target, shell) in NATIVE_TARGETS.items():
+        job = jobs.get(job_name)
+        if job is None:
+            errors.append(f"missing {job_name}")
+            continue
+        if job.get("runs-on") != runner:
+            errors.append(f"{job_name} does not use {runner}")
+        steps = job.get("steps", [])
+        proof_steps = [
+            step
+            for step in steps
+            if step.get("name") == f"Verify native target is {go_target}"
+        ]
+        if len(proof_steps) != 1:
+            errors.append(f"{job_name} does not have one architecture proof step")
+            continue
+        proof = proof_steps[0].get("run", "")
+        if shell == "pwsh":
+            runner_predicate = f'if ($env:RUNNER_ARCH -ne "{runner_arch}")'
+            target_predicate = f'if ($goTarget -ne "{go_target}")'
+        else:
+            runner_predicate = f'test "$RUNNER_ARCH" = "{runner_arch}"'
+            target_predicate = f'test "$go_target" = "{go_target}"'
+        if runner_predicate not in proof:
+            errors.append(f"{job_name} does not verify runner architecture {runner_arch}")
+        if (
+            "go env GOOS" not in proof
+            or "go env GOARCH" not in proof
+            or target_predicate not in proof
+        ):
+            errors.append(f"{job_name} does not verify native Go target {go_target}")
+    return errors
+
+
+class NativeTargetWorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.jobs = workflow_jobs()
+
+    def test_native_targets_have_pinned_architecture_evidence(self):
+        self.assertEqual(native_target_errors(self.jobs), [])
+
+    def test_runner_label_drift_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        broken["test-macos-intel"]["runs-on"] = "macos-latest"
+        self.assertIn(
+            "test-macos-intel does not use macos-15-intel",
+            native_target_errors(broken),
+        )
+
+    def test_missing_runtime_architecture_check_fails_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        proof = next(
+            step
+            for step in broken["test-windows-arm64"]["steps"]
+            if step.get("name") == "Verify native target is windows/arm64"
+        )
+        proof["run"] = 'Write-Output "windows/arm64"'
+        self.assertIn(
+            "test-windows-arm64 does not verify runner architecture ARM64",
+            native_target_errors(broken),
+        )
+
+    def test_inverted_predicates_fail_the_contract(self):
+        broken = copy.deepcopy(self.jobs)
+        mac_proof = next(
+            step
+            for step in broken["test-macos-intel"]["steps"]
+            if step.get("name") == "Verify native target is darwin/amd64"
+        )
+        mac_proof["run"] = mac_proof["run"].replace(
+            'test "$RUNNER_ARCH" = "X64"',
+            'test "$RUNNER_ARCH" != "X64"',
+        )
+        windows_proof = next(
+            step
+            for step in broken["test-windows-arm64"]["steps"]
+            if step.get("name") == "Verify native target is windows/arm64"
+        )
+        windows_proof["run"] = windows_proof["run"].replace(
+            'if ($goTarget -ne "windows/arm64")',
+            'if ($goTarget -eq "windows/arm64")',
+        )
+        errors = native_target_errors(broken)
+        self.assertIn(
+            "test-macos-intel does not verify runner architecture X64",
+            errors,
+        )
+        self.assertIn(
+            "test-windows-arm64 does not verify native Go target windows/arm64",
+            errors,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_native_targets.py
+++ b/scripts/test_ci_native_targets.py
@@ -25,7 +25,39 @@ NATIVE_TARGETS = {
 
 
 def workflow_jobs() -> dict:
+    """Load CI jobs from the public workflow."""
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def executable_lines(proof: str) -> list[str]:
+    """Return non-comment shell lines with indentation removed."""
+    return [
+        stripped
+        for line in proof.splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    ]
+
+
+def expected_proof_lines(shell: str, runner_arch: str, go_target: str) -> list[str]:
+    """Return the exact straight-line proof required for one native lane."""
+    if shell == "pwsh":
+        return [
+            'Write-Output "runner architecture: $env:RUNNER_ARCH"',
+            '$goTarget = "$(go env GOOS)/$(go env GOARCH)"',
+            'Write-Output "Go target: $goTarget"',
+            f'if ($env:RUNNER_ARCH -ne "{runner_arch}") '
+            f'{{ throw "expected {runner_arch} runner, got $env:RUNNER_ARCH" }}',
+            f'if ($goTarget -ne "{go_target}") '
+            f'{{ throw "expected {go_target} Go target, got $goTarget" }}',
+        ]
+    return [
+        "set -euo pipefail",
+        'echo "runner architecture: $RUNNER_ARCH"',
+        'go_target="$(go env GOOS)/$(go env GOARCH)"',
+        'echo "Go target: $go_target"',
+        f'test "$RUNNER_ARCH" = "{runner_arch}"',
+        f'test "$go_target" = "{go_target}"',
+    ]
 
 
 def native_target_errors(jobs: dict) -> list[str]:
@@ -48,31 +80,40 @@ def native_target_errors(jobs: dict) -> list[str]:
             errors.append(f"{job_name} does not have one architecture proof step")
             continue
         proof = proof_steps[0].get("run", "")
+        actual_lines = executable_lines(proof)
+        expected_lines = expected_proof_lines(shell, runner_arch, go_target)
         if shell == "pwsh":
             runner_predicate = f'if ($env:RUNNER_ARCH -ne "{runner_arch}")'
             target_predicate = f'if ($goTarget -ne "{go_target}")'
+            target_source = '$goTarget = "$(go env GOOS)/$(go env GOARCH)"'
         else:
             runner_predicate = f'test "$RUNNER_ARCH" = "{runner_arch}"'
             target_predicate = f'test "$go_target" = "{go_target}"'
-        if runner_predicate not in proof:
+            target_source = 'go_target="$(go env GOOS)/$(go env GOARCH)"'
+        if not any(line.startswith(runner_predicate) for line in actual_lines):
             errors.append(f"{job_name} does not verify runner architecture {runner_arch}")
-        if (
-            "go env GOOS" not in proof
-            or "go env GOARCH" not in proof
-            or target_predicate not in proof
+        if target_source not in actual_lines or not any(
+            line.startswith(target_predicate) for line in actual_lines
         ):
             errors.append(f"{job_name} does not verify native Go target {go_target}")
+        if actual_lines != expected_lines:
+            errors.append(f"{job_name} does not use the straight-line architecture proof")
     return errors
 
 
 class NativeTargetWorkflowTest(unittest.TestCase):
+    """Protect native job labels and their runtime architecture assertions."""
+
     def setUp(self):
+        """Load a fresh workflow model for each mutation test."""
         self.jobs = workflow_jobs()
 
     def test_native_targets_have_pinned_architecture_evidence(self):
+        """Accept the checked-in native target contract."""
         self.assertEqual(native_target_errors(self.jobs), [])
 
     def test_runner_label_drift_fails_the_contract(self):
+        """Reject a runner label that no longer proves the claimed pair."""
         broken = copy.deepcopy(self.jobs)
         broken["test-macos-intel"]["runs-on"] = "macos-latest"
         self.assertIn(
@@ -81,6 +122,7 @@ class NativeTargetWorkflowTest(unittest.TestCase):
         )
 
     def test_missing_runtime_architecture_check_fails_the_contract(self):
+        """Reject a proof step replaced with inert output."""
         broken = copy.deepcopy(self.jobs)
         proof = next(
             step
@@ -94,6 +136,7 @@ class NativeTargetWorkflowTest(unittest.TestCase):
         )
 
     def test_inverted_predicates_fail_the_contract(self):
+        """Reject success predicates whose direction is reversed."""
         broken = copy.deepcopy(self.jobs)
         mac_proof = next(
             step
@@ -121,6 +164,51 @@ class NativeTargetWorkflowTest(unittest.TestCase):
         self.assertIn(
             "test-windows-arm64 does not verify native Go target windows/arm64",
             errors,
+        )
+
+    def test_commented_and_echoed_predicates_fail_the_contract(self):
+        """Reject predicates that exist only as comments or log text."""
+        broken = copy.deepcopy(self.jobs)
+        mac_proof = next(
+            step
+            for step in broken["test-macos-intel"]["steps"]
+            if step.get("name") == "Verify native target is darwin/amd64"
+        )
+        mac_proof["run"] = mac_proof["run"].replace(
+            'test "$RUNNER_ARCH" = "X64"',
+            '# test "$RUNNER_ARCH" = "X64"',
+        )
+        windows_proof = next(
+            step
+            for step in broken["test-windows-arm64"]["steps"]
+            if step.get("name") == "Verify native target is windows/arm64"
+        )
+        windows_proof["run"] = windows_proof["run"].replace(
+            'if ($goTarget -ne "windows/arm64")',
+            'Write-Output \'if ($goTarget -ne "windows/arm64")\'; if ($false)',
+        )
+        errors = native_target_errors(broken)
+        self.assertIn(
+            "test-macos-intel does not verify runner architecture X64",
+            errors,
+        )
+        self.assertIn(
+            "test-windows-arm64 does not use the straight-line architecture proof",
+            errors,
+        )
+
+    def test_dead_control_flow_fails_the_contract(self):
+        """Reject valid predicates wrapped in unreachable shell control flow."""
+        broken = copy.deepcopy(self.jobs)
+        proof = next(
+            step
+            for step in broken["test-linux-arm64"]["steps"]
+            if step.get("name") == "Verify native target is linux/arm64"
+        )
+        proof["run"] = f"if false; then\n{proof['run']}fi\n"
+        self.assertIn(
+            "test-linux-arm64 does not use the straight-line architecture proof",
+            native_target_errors(broken),
         )
 
 

--- a/scripts/test_ci_native_targets.py
+++ b/scripts/test_ci_native_targets.py
@@ -45,10 +45,14 @@ def expected_proof_lines(shell: str, runner_arch: str, go_target: str) -> list[s
             'Write-Output "runner architecture: $env:RUNNER_ARCH"',
             '$goTarget = "$(go env GOOS)/$(go env GOARCH)"',
             'Write-Output "Go target: $goTarget"',
-            f'if ($env:RUNNER_ARCH -ne "{runner_arch}") '
-            f'{{ throw "expected {runner_arch} runner, got $env:RUNNER_ARCH" }}',
-            f'if ($goTarget -ne "{go_target}") '
-            f'{{ throw "expected {go_target} Go target, got $goTarget" }}',
+            (
+                f'if ($env:RUNNER_ARCH -ne "{runner_arch}") '
+                f'{{ throw "expected {runner_arch} runner, got $env:RUNNER_ARCH" }}'
+            ),
+            (
+                f'if ($goTarget -ne "{go_target}") '
+                f'{{ throw "expected {go_target} Go target, got $goTarget" }}'
+            ),
         ]
     return [
         "set -euo pipefail",


### PR DESCRIPTION
## What changed
- Add native macOS Intel and Windows ARM jobs for the two published target pairs without execution coverage.
- Fail each platform lane if GitHub's runner architecture or Go's native target differs from what the job claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded continuous integration coverage across macOS, Windows, and Linux ARM64 environments.
  * Added macOS Intel and Windows ARM64 build and sandbox test coverage.
  * Added validation to ensure builds and sandbox tests run against the expected native architectures.
  * Added automated checks to detect configuration drift, incorrect targets, or missing architecture verification steps.
  * Improved confidence that platform-specific builds and tests run correctly across supported hardware architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->