### PR TITLE
test: keep preflight capability checks consistent

### DIFF
--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -1238,13 +1238,13 @@ func TestPreflight_InvalidPolicy(t *testing.T) {
 
 func TestPreflight_AllLayersAvailable(t *testing.T) {
 	workspace := t.TempDir()
-	caps := Detect()
-
-	if caps.LandlockABI <= 0 || !caps.UserNamespaces || !caps.Seccomp {
-		t.Skip("not all layers available on this system")
-	}
-
 	result := Preflight(workspace, []string{echoCmd}, nil, false)
+	requireExpectedPreflightLayers(t, result.Layers)
+	for _, layer := range result.Layers {
+		if !layer.Available {
+			t.Skipf("layer %s unavailable on this system: %s", layer.Name, layer.Reason)
+		}
+	}
 	if result.Status != StatusReady {
 		t.Errorf("status = %q, want %q with all layers available", result.Status, StatusReady)
 	}
@@ -1252,15 +1252,37 @@ func TestPreflight_AllLayersAvailable(t *testing.T) {
 
 func TestPreflight_StrictAllAvailable(t *testing.T) {
 	workspace := t.TempDir()
-	caps := Detect()
-
-	if caps.LandlockABI <= 0 || !caps.UserNamespaces || !caps.Seccomp {
-		t.Skip("not all layers available on this system")
-	}
-
 	result := Preflight(workspace, []string{echoCmd}, nil, true)
+	requireExpectedPreflightLayers(t, result.Layers)
+	for _, layer := range result.Layers {
+		if !layer.Available {
+			t.Skipf("layer %s unavailable on this system: %s", layer.Name, layer.Reason)
+		}
+	}
 	if result.Status != StatusReady {
 		t.Errorf("strict with all layers: status = %q, want %q", result.Status, StatusReady)
+	}
+}
+
+func requireExpectedPreflightLayers(t *testing.T, layers []LayerProbe) {
+	t.Helper()
+
+	expected := map[LayerName]struct{}{
+		LayerLandlock: {},
+		LayerNetNS:    {},
+		LayerSeccomp:  {},
+	}
+	if len(layers) != len(expected) {
+		t.Fatalf("preflight layers = %d, want %d", len(layers), len(expected))
+	}
+	for _, layer := range layers {
+		if _, ok := expected[layer.Name]; !ok {
+			t.Fatalf("unexpected or duplicate preflight layer %q", layer.Name)
+		}
+		delete(expected, layer.Name)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("preflight omitted layers: %#v", expected)
 	}
 }
 
@@ -1274,9 +1296,18 @@ func TestPreflight_PrivateShm(t *testing.T) {
 		t.Error("best-effort should not have private SHM")
 	}
 
-	caps := Detect()
-	if caps.UserNamespaces && !strict.PrivateShm {
-		t.Error("strict with user namespaces should have private SHM")
+	var netNS *LayerProbe
+	for i := range strict.Layers {
+		if strict.Layers[i].Name == LayerNetNS {
+			netNS = &strict.Layers[i]
+			break
+		}
+	}
+	if netNS == nil {
+		t.Fatal("strict preflight omitted network namespace layer")
+	}
+	if strict.PrivateShm != netNS.Available {
+		t.Errorf("strict private SHM = %v, want network namespace availability %v", strict.PrivateShm, netNS.Available)
 	}
 }
 

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -360,8 +360,10 @@ func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *test
 	}
 
 	required := make(map[LayerName]bool, len(result.Layers))
+	available := make(map[LayerName]bool, len(result.Layers))
 	for _, layer := range result.Layers {
 		required[layer.Name] = layer.Required
+		available[layer.Name] = layer.Available
 	}
 	if !required[LayerNetNS] {
 		t.Fatal("network namespace was not reported as required")
@@ -369,7 +371,7 @@ func TestPreflightWithRequirements_IndependentlyReportsNetworkAndHandler(t *test
 	if required[LayerLandlock] || required[LayerSeccomp] {
 		t.Fatalf("optional layers reported as required: %#v", required)
 	}
-	if !Detect().UserNamespaces && result.Status != StatusError {
+	if !available[LayerNetNS] && result.Status != StatusError {
 		t.Fatalf("required unavailable network namespace status = %q, want error", result.Status)
 	}
 }


### PR DESCRIPTION
## What changed

Preflight tests now compare private shared-memory and required-layer results against the capability snapshot from the same call, so repeated runtime probes can't produce contradictory outcomes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved sandbox preflight tests to evaluate network namespace and handler availability independently.
  * Tests now skip only unavailable layers instead of relying on an aggregate capability check.
  * Added validation that preflight results include the expected security layers.
  * Strengthened validation for strict private shared-memory settings based on network namespace availability.
  * Updated error assertions to reflect each layer’s actual availability status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->