### PR TITLE
docs(manifest): scope two field comments to what the checks prove

### DIFF
--- a/internal/capabilitymanifest/manifest.go
+++ b/internal/capabilitymanifest/manifest.go
@@ -85,14 +85,15 @@ type Gate struct {
 	Features []GateFeature `json:"features,omitempty"`
 }
 
-// GateFeature points at the enforcing call and at a declaration that names the
-// feature constant.
+// GateFeature points at the enforcement selector and at a declaration that
+// names the feature constant.
 //
 // The two references are checked INDEPENDENTLY: the parity test looks for the
 // enforcement selector in one declaration and the feature constant in the
-// other, and nothing connects them. So proof shows the feature is named in real
-// verification code; it does not establish that this enforcement call is bound
-// to that feature.
+// other, and nothing connects them. So proof shows the feature constant is
+// passed to a call in the referenced declaration; it does not establish that
+// this selector is bound to that feature, or that the declaration verifies
+// anything.
 //
 // Proof is often a dedicated license helper such as VerifyAgentsWithOptions,
 // but it does NOT have to be a separate declaration, and a feature whose

--- a/internal/capabilitymanifest/manifest.go
+++ b/internal/capabilitymanifest/manifest.go
@@ -85,8 +85,27 @@ type Gate struct {
 	Features []GateFeature `json:"features,omitempty"`
 }
 
-// GateFeature points both at the enforcing call and the license helper that
-// binds that call to a concrete feature constant.
+// GateFeature points at the enforcing call and at a declaration that names the
+// feature constant.
+//
+// The two references are checked INDEPENDENTLY: the parity test looks for the
+// enforcement selector in one declaration and the feature constant in the
+// other, and nothing connects them. So proof shows the feature is named in real
+// verification code; it does not establish that this enforcement call is bound
+// to that feature.
+//
+// Proof is often a dedicated license helper such as VerifyAgentsWithOptions,
+// but it does NOT have to be a separate declaration, and a feature whose
+// enforcing function names the constant directly is correctly recorded with the
+// same reference in both fields. Those helpers exist so require-intermediate
+// mode is honoured in env-only commands that take no config file, which a
+// config-driven gate resolving those options for itself does not need. A
+// wrapper could still be wanted for other reasons, such as centralising
+// feature-gate behaviour; it is simply not required to preserve those options.
+// Reading this field as "there must be a helper" is what makes a same-reference
+// row look like a defect, and the remedy then looks like adding a wrapper whose
+// stated purpose would be false of its only caller. Record the asymmetry
+// instead of writing code to erase it.
 type GateFeature struct {
 	Name        string           `json:"name"`
 	Enforcement EnforcementCheck `json:"enforcement"`
@@ -113,7 +132,16 @@ type GateExclusion struct {
 	Reason  string `json:"reason"`
 }
 
-// EnforcementCheck identifies the concrete call that denies the feature.
+// EnforcementCheck identifies the gating selector inside the enforcing
+// declaration.
+//
+// Call is a selector that must APPEAR in that declaration, and the parity check
+// proves presence, not invocation. It cannot show the selector is reached, that
+// its result is tested, or that the guarded work is refused when it fails, so a
+// row here is a pointer for an auditor rather than proof of enforcement. Some
+// rows name a constant rather than a function for that reason. Treating a
+// present selector as a verified deny is the over-reading this field invites,
+// and it is why the value is described as a selector and not as a call.
 type EnforcementCheck struct {
 	Source SourceReference `json:"source"`
 	Call   string          `json:"call"`

--- a/internal/capabilitymanifest/manifest_test.go
+++ b/internal/capabilitymanifest/manifest_test.go
@@ -52,7 +52,7 @@ func TestManifestParity(t *testing.T) {
 					enforcement := declaration(t, root, feature.Enforcement.Source)
 					assertSelector(t, enforcement, feature.Enforcement.Call)
 					proof := declaration(t, root, feature.Proof)
-					assertFeatureConstant(t, proof, feature.Name)
+					assertFeatureConstant(t, proof, feature.Name, packageNameOf(t, root, feature.Proof.File))
 				}
 			default:
 				t.Fatalf("unsupported gate kind %q", capability.Gate.Kind)
@@ -549,12 +549,46 @@ func assertSelector(t *testing.T, declaration ast.Node, want string) {
 // verifyFeatureWithOptions(FeatureAgents, ...) inside the license package. This
 // still does not prove the RESULT is acted on, which no AST check can establish
 // cheaply; it does rule out a declaration that only happens to contain the name.
-func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string) {
+// packageNameOf reports the package clause of a parsed source file. The
+// constant may be written bare inside the license package and qualified
+// everywhere else, so the accepted spelling depends on where the proof lives.
+func packageNameOf(t *testing.T, root string, file string) string {
+	t.Helper()
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, filepath.Join(root, filepath.FromSlash(file)), nil, parser.PackageClauseOnly)
+	if err != nil {
+		t.Fatalf("parse package clause of %q: %v", file, err)
+	}
+	return parsed.Name.Name
+}
+
+// namesFeatureConstant reports whether an expression is the license package's
+// feature constant, written the way that file is entitled to write it.
+//
+// Matching a bare identifier name anywhere was not enough: a local parameter
+// called FeatureAssess, or an unrelated package's other.FeatureAssess, would
+// both satisfy it while gating on nothing. Requiring the license qualifier
+// outside that package, and a bare identifier only inside it, rejects both
+// without loading a type checker. It is a spelling check rather than a binding
+// resolution, so a parameter shadowing the constant INSIDE the license package
+// would still pass; resolving that needs go/types and is tracked separately.
+func namesFeatureConstant(expr ast.Expr, want string, pkg string) bool {
+	switch value := expr.(type) {
+	case *ast.SelectorExpr:
+		qualifier, ok := value.X.(*ast.Ident)
+		return ok && qualifier.Name == "license" && value.Sel.Name == want
+	case *ast.Ident:
+		return pkg == "license" && value.Name == want
+	}
+	return false
+}
+
+func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string, pkg string) {
 	t.Helper()
 	want := featureConstant(feature)
 	var mentioned, passed bool
 	ast.Inspect(declaration, func(node ast.Node) bool {
-		if ident, ok := node.(*ast.Ident); ok && ident.Name == want {
+		if expr, ok := node.(ast.Expr); ok && namesFeatureConstant(expr, want, pkg) {
 			mentioned = true
 		}
 		call, ok := node.(*ast.CallExpr)
@@ -563,7 +597,7 @@ func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string) {
 		}
 		for _, arg := range call.Args {
 			ast.Inspect(arg, func(inner ast.Node) bool {
-				if ident, ok := inner.(*ast.Ident); ok && ident.Name == want {
+				if expr, ok := inner.(ast.Expr); ok && namesFeatureConstant(expr, want, pkg) {
 					passed = true
 				}
 				return true

--- a/internal/capabilitymanifest/manifest_test.go
+++ b/internal/capabilitymanifest/manifest_test.go
@@ -583,10 +583,10 @@ func namesFeatureConstant(expr ast.Expr, want string, pkg string) bool {
 	return false
 }
 
-func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string, pkg string) {
-	t.Helper()
-	want := featureConstant(feature)
-	var mentioned, passed bool
+// featureConstantUsage reports how a declaration uses the feature constant.
+// Kept separate from the assertion because t.Fatalf cannot be exercised from a
+// test, and the rejection paths are the ones worth covering.
+func featureConstantUsage(declaration ast.Node, want string, pkg string) (mentioned, passed bool) {
 	ast.Inspect(declaration, func(node ast.Node) bool {
 		if expr, ok := node.(ast.Expr); ok && namesFeatureConstant(expr, want, pkg) {
 			mentioned = true
@@ -605,11 +605,62 @@ func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string, p
 		}
 		return true
 	})
+	return mentioned, passed
+}
+
+func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string, pkg string) {
+	t.Helper()
+	want := featureConstant(feature)
+	mentioned, passed := featureConstantUsage(declaration, want, pkg)
 	if !mentioned {
 		t.Fatalf("proof declaration does not reference license.%s", want)
 	}
 	if !passed {
 		t.Fatalf("proof declaration mentions license.%s but never passes it to a call, so it does not gate on that feature", want)
+	}
+}
+
+// parseFuncBody parses a single function into an AST node for the usage tests.
+func parseFuncBody(t *testing.T, body string) ast.Node {
+	t.Helper()
+	src := "package p\nfunc subject(FeatureAssess string) {\n" + body + "\n}\n"
+	parsed, err := parser.ParseFile(token.NewFileSet(), "subject.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse subject: %v", err)
+	}
+	return parsed.Decls[0]
+}
+
+// TestFeatureConstantUsage covers the paths a manifest proof reference can take
+// wrong. Each rejection here was a real hole at some point in this file's
+// history: mentioning the constant without passing it, and matching an
+// identifier by name so an unrelated qualifier or a local parameter satisfied
+// it. The subject function deliberately declares a PARAMETER named
+// FeatureAssess so the shadowing case is exercised rather than described.
+func TestFeatureConstantUsage(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		body          string
+		pkg           string
+		wantMentioned bool
+		wantPassed    bool
+	}{
+		{"qualified constant passed to a call", `gate(license.FeatureAssess)`, "assess", true, true},
+		{"qualified constant only mentioned", `var x = license.FeatureAssess; _ = x`, "assess", true, false},
+		{"bare constant inside the license package", `gate(FeatureAssess)`, "license", true, true},
+		{"bare constant outside the license package is the parameter", `gate(FeatureAssess)`, "assess", false, false},
+		{"unrelated qualifier", `gate(other.FeatureAssess)`, "assess", false, false},
+		{"different constant", `gate(license.FeatureFleet)`, "assess", false, false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			mentioned, passed := featureConstantUsage(parseFuncBody(t, testCase.body), "FeatureAssess", testCase.pkg)
+			if mentioned != testCase.wantMentioned {
+				t.Errorf("mentioned = %v, want %v", mentioned, testCase.wantMentioned)
+			}
+			if passed != testCase.wantPassed {
+				t.Errorf("passed = %v, want %v", passed, testCase.wantPassed)
+			}
+		})
 	}
 }
 

--- a/internal/capabilitymanifest/manifest_test.go
+++ b/internal/capabilitymanifest/manifest_test.go
@@ -539,19 +539,43 @@ func assertSelector(t *testing.T, declaration ast.Node, want string) {
 	}
 }
 
+// assertFeatureConstant requires the proof declaration to PASS the feature
+// constant to a call, not merely to mention it somewhere.
+//
+// Mentioning it anywhere was the earlier bar, and it let a proof reference point
+// at a declaration that names the constant incidentally, in an unrelated switch
+// arm or a neighbouring branch, while gating on nothing. Both real shapes pass
+// the constant as an argument: lic.HasFeature(license.FeatureAssess), and
+// verifyFeatureWithOptions(FeatureAgents, ...) inside the license package. This
+// still does not prove the RESULT is acted on, which no AST check can establish
+// cheaply; it does rule out a declaration that only happens to contain the name.
 func assertFeatureConstant(t *testing.T, declaration ast.Node, feature string) {
 	t.Helper()
 	want := featureConstant(feature)
-	var found bool
+	var mentioned, passed bool
 	ast.Inspect(declaration, func(node ast.Node) bool {
-		ident, ok := node.(*ast.Ident)
-		if ok && ident.Name == want {
-			found = true
+		if ident, ok := node.(*ast.Ident); ok && ident.Name == want {
+			mentioned = true
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		for _, arg := range call.Args {
+			ast.Inspect(arg, func(inner ast.Node) bool {
+				if ident, ok := inner.(*ast.Ident); ok && ident.Name == want {
+					passed = true
+				}
+				return true
+			})
 		}
 		return true
 	})
-	if !found {
+	if !mentioned {
 		t.Fatalf("proof declaration does not reference license.%s", want)
+	}
+	if !passed {
+		t.Fatalf("proof declaration mentions license.%s but never passes it to a call, so it does not gate on that feature", want)
 	}
 }
 

--- a/internal/capabilitymanifest/manifest_test.go
+++ b/internal/capabilitymanifest/manifest_test.go
@@ -631,6 +631,32 @@ func parseFuncBody(t *testing.T, body string) ast.Node {
 	return parsed.Decls[0]
 }
 
+// TestPackageNameOfDerivesTheProofPackage covers the input to the usage check
+// rather than the check itself.
+//
+// TestFeatureConstantUsage supplies the package name directly, so it cannot
+// notice packageNameOf deriving the wrong one. That matters in a single
+// direction: deriving "license" for a proof that lives elsewhere would accept a
+// bare identifier outside the package that declares the constants, which is one
+// of the holes the qualifier rule exists to close. These read the two real
+// files a proof reference actually points at.
+func TestPackageNameOfDerivesTheProofPackage(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, testCase := range []struct {
+		file string
+		want string
+	}{
+		{"internal/license/license.go", "license"},
+		{"internal/cli/assess/finalize.go", "assess"},
+	} {
+		t.Run(testCase.file, func(t *testing.T) {
+			if got := packageNameOf(t, root, testCase.file); got != testCase.want {
+				t.Fatalf("packageNameOf(%q) = %q, want %q", testCase.file, got, testCase.want)
+			}
+		})
+	}
+}
+
 // TestFeatureConstantUsage covers the paths a manifest proof reference can take
 // wrong. Each rejection here was a real hole at some point in this file's
 // history: mentioning the constant without passing it, and matching an


### PR DESCRIPTION
## What changed

Two doc comments on the capability-manifest schema described more than the fields and their parity checks establish, and one of them had already produced a proposal to change a licensing path.

`proof` was documented as the license helper binding the enforcement call to a feature constant. The parity test checks the two references independently, looking for the enforcement selector in one declaration and the feature constant in the other, and never connects them. It also does not require proof to be a separate declaration, so a capability whose enforcing function names its constant directly is correctly recorded with the same reference in both fields. Read as written, that row looked like a defect, and the remedy looked like adding a verification wrapper for it.

`enforcement` was documented as identifying the concrete call that denies the feature. The check proves the selector appears in the declaration. It cannot show the selector is reached, that its result is tested, or that the guarded work is refused, and some rows name a constant rather than a function. A present selector is a stable pointer for an auditor and catches drift; it is not proof that enforcement happened.

Comments only. No behaviour, schema fields, manifest data, or generated output change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that enforcement and proof references are evaluated independently.
  * Documented that proof may use the same reference as enforcement.
  * Clarified that selectors identify what is proven and do not represent an invocation or verified enforcement.

* **Tests**
  * Improved validation to require feature constants as call arguments.
  * Added package-aware validation for qualified and unqualified feature constant references.
  * Added coverage for accepted and rejected constant-reference formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->