### PR TITLE
fix(conductor): scope admin requests to the authenticated organization

### DIFF
--- a/enterprise/cli/conductor/cmd.go
+++ b/enterprise/cli/conductor/cmd.go
@@ -157,8 +157,8 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.adminTokenFile, "admin-token-file", "", "file containing bearer token required for Conductor admin requests")
 	cmd.Flags().StringVar(&opts.auditorOrgID, "auditor-org", "", "org scope for the auditor bearer token on audit/follower read requests (required)")
 	cmd.Flags().StringVar(&opts.auditorFleetID, "auditor-fleet", "", "optional fleet scope for the auditor bearer token on audit/follower read requests")
-	cmd.Flags().StringVar(&opts.adminOrgID, "admin-org", "", "org scope for the admin bearer token on audit/follower read requests (required)")
-	cmd.Flags().StringVar(&opts.adminFleetID, "admin-fleet", "", "optional fleet scope for the admin bearer token on audit/follower read requests")
+	cmd.Flags().StringVar(&opts.adminOrgID, "admin-org", "", "org scope for every admin bearer request (required)")
+	cmd.Flags().StringVar(&opts.adminFleetID, "admin-fleet", "", "optional fleet scope for every admin bearer request")
 	cmd.Flags().DurationVar(&opts.auditRetention, "audit-retention", 0, "duration to keep SQLite audit evidence; older batches are pruned at startup (0 = keep forever)")
 	cmd.Flags().StringArrayVar(&opts.trustedAuditKeys, "trusted-audit-key", nil,
 		"trusted audit signing key as comma-separated kv pairs: 'id=ID,(inline=HEX_OR_VERSIONED_PUBLIC_KEY|file=/path),org=ORG[,fleet=FLEET][,instance=INSTANCE]'; "+
@@ -328,9 +328,11 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (*serveHandler, h
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	adminAuthorizer, err := controlplane.ScopedBearerAdminAuthorizer([]controlplane.ScopedBearerCredential{{
-		Token: adminToken,
-		Role:  controlplane.RoleAdmin,
+	adminAuthenticator, err := controlplane.ScopedBearerAdminAuthenticator([]controlplane.ScopedBearerCredential{{
+		Token:   adminToken,
+		Role:    controlplane.RoleAdmin,
+		OrgID:   opts.adminOrgID,
+		FleetID: opts.adminFleetID,
 	}})
 	if err != nil {
 		return nil, nil, nil, err
@@ -346,7 +348,8 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (*serveHandler, h
 		if err := publisherAuthorizer(r); err == nil {
 			return nil
 		}
-		return adminAuthorizer(r)
+		_, err := adminAuthenticator(r)
+		return err
 	}
 	identity, err := controlplane.MTLSFollowerIdentityResolver(opts.followerTrustDomain)
 	if err != nil {
@@ -402,13 +405,17 @@ func buildServeHandler(ctx context.Context, opts serveOptions) (*serveHandler, h
 		FollowerIdentity:   identity,
 		AuthorizePublisher: publishRequestAuthorizer,
 		AuthorizeBundle:    publishAuthorizer,
-		AuthorizeFleetSkewOverride: func(r *http.Request, _ conductorcore.PolicyBundle, _ string) error {
-			return adminAuthorizer(r)
+		AuthorizeFleetSkewOverride: func(r *http.Request, bundle conductorcore.PolicyBundle, _ string) error {
+			admin, authErr := adminAuthenticator(r)
+			if authErr != nil || !admin.Allows(bundle.OrgID, bundle.FleetID) {
+				return controlplane.ErrPublisherForbidden
+			}
+			return nil
 		},
 		AuthorizeAuditQuery:   auditQueryAuthorizer,
 		AuthorizeFollowers:    followerListAuthorizer,
 		AuthorizeStream:       streamStatusAuthorizer,
-		AuthorizeAdmin:        adminAuthorizer,
+		AuthenticateAdmin:     adminAuthenticator,
 		AuditSink:             auditStore,
 		AuditKeys:             controlplane.CompositeAuditKeyResolver(enrollments, auditKeys),
 		Enrollments:           enrollments,

--- a/enterprise/cli/conductor/emergency_common_test.go
+++ b/enterprise/cli/conductor/emergency_common_test.go
@@ -170,12 +170,14 @@ func newTestServer(t *testing.T, opts testServerOptions) *testServer {
 	if adminToken == "" {
 		adminToken = testAdminToken
 	}
-	adminAuth, err := controlplane.ScopedBearerAdminAuthorizer([]controlplane.ScopedBearerCredential{{
-		Token: adminToken,
-		Role:  controlplane.RoleAdmin,
+	adminAuth, err := controlplane.ScopedBearerAdminAuthenticator([]controlplane.ScopedBearerCredential{{
+		Token:   adminToken,
+		Role:    controlplane.RoleAdmin,
+		OrgID:   testOrgID,
+		FleetID: testFleetID,
 	}})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer: %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator: %v", err)
 	}
 	// A permissive publisher authorizer satisfies NewHandler's required hook;
 	// the emergency endpoints under test gate on adminAuth, not this.
@@ -196,7 +198,7 @@ func newTestServer(t *testing.T, opts testServerOptions) *testServer {
 			}, nil
 		},
 		AuthorizePublisher: publisherAuth,
-		AuthorizeAdmin:     adminAuth,
+		AuthenticateAdmin:  adminAuth,
 		AuditSink:          auditStore,
 		AuditKeys: func(controlplane.FollowerIdentity, string) (conductorcore.SignatureKey, error) {
 			return conductorcore.SignatureKey{}, conductorcore.ErrSignatureVerification

--- a/enterprise/conductor/bootstrap/roundtrip.go
+++ b/enterprise/conductor/bootstrap/roundtrip.go
@@ -218,8 +218,8 @@ func startConductor(ctx context.Context, storageDir string, opts Options, materi
 		_ = auditStore.Close()
 		return nil, err
 	}
-	adminAuth, err := controlplane.ScopedBearerAdminAuthorizer([]controlplane.ScopedBearerCredential{
-		{Token: material.adminToken, Role: controlplane.RoleAdmin},
+	adminAuth, err := controlplane.ScopedBearerAdminAuthenticator([]controlplane.ScopedBearerCredential{
+		{Token: material.adminToken, Role: controlplane.RoleAdmin, OrgID: opts.OrgID},
 	})
 	if err != nil {
 		_ = auditStore.Close()
@@ -233,7 +233,7 @@ func startConductor(ctx context.Context, storageDir string, opts Options, materi
 		AuthorizePublisher:  publisherAuth,
 		AuthorizeBundle:     bundleAuth,
 		AuthorizeAuditQuery: auditQueryAuth,
-		AuthorizeAdmin:      adminAuth,
+		AuthenticateAdmin:   adminAuth,
 		AuditSink:           auditStore,
 		AuditKeys:           controlplane.CompositeAuditKeyResolver(enrollments, nil),
 		Enrollments:         enrollments,

--- a/enterprise/conductor/controlplane/applied_state_test.go
+++ b/enterprise/conductor/controlplane/applied_state_test.go
@@ -333,11 +333,11 @@ func newAppliedStateFleetHandler(t *testing.T, enrollments EnrollmentStore, sink
 	if err != nil {
 		t.Fatalf("ScopedBearerFollowerListAuthorizer() error = %v", err)
 	}
-	adminAuth, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{
+	adminAuth, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{
 		{Token: followerAdminToken, Role: RoleAdmin, OrgID: "org-main"},
 	})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
 	}
 	handler, err := NewHandler(HandlerOptions{
 		Store:              mustStore(t),
@@ -346,7 +346,7 @@ func newAppliedStateFleetHandler(t *testing.T, enrollments EnrollmentStore, sink
 		FollowerIdentity:   func(*http.Request) (FollowerIdentity, error) { return defaultFollowerIdentity(), nil },
 		AuthorizePublisher: func(*http.Request) error { return nil },
 		AuthorizeFollowers: followerAuth,
-		AuthorizeAdmin:     adminAuth,
+		AuthenticateAdmin:  adminAuth,
 		AuditSink:          sink,
 		AuditKeys:          rejectingAuditKeyResolver,
 		Enrollments:        enrollments,

--- a/enterprise/conductor/controlplane/auth.go
+++ b/enterprise/conductor/controlplane/auth.go
@@ -43,6 +43,17 @@ type ScopedBearerCredential struct {
 	FleetID string
 }
 
+// AdminIdentity is the authenticated tenant scope of an administrative
+// credential. The token is deliberately not retained after authentication.
+type AdminIdentity struct {
+	OrgID   string
+	FleetID string
+}
+
+// AdminAuthenticator authenticates an administrator and returns the org/fleet
+// boundary that every subsequent administrative mutation must enforce.
+type AdminAuthenticator func(*http.Request) (AdminIdentity, error)
+
 func MTLSFollowerIdentityResolver(trustDomain string) (FollowerIdentityResolver, error) {
 	trustDomain = strings.TrimSpace(trustDomain)
 	if trustDomain == "" {
@@ -122,18 +133,28 @@ func BearerPublisherAuthorizer(rawCredential string) (PublisherAuthorizer, error
 	}, nil
 }
 
-func ScopedBearerAdminAuthorizer(creds []ScopedBearerCredential) (PublisherAuthorizer, error) {
+func ScopedBearerAdminAuthenticator(creds []ScopedBearerCredential) (AdminAuthenticator, error) {
 	normalized, err := normalizeScopedBearerCredentials(creds)
 	if err != nil {
 		return nil, err
 	}
-	return func(r *http.Request) error {
+	for _, cred := range normalized {
+		if cred.Role == RoleAdmin && cred.OrgID == "" {
+			return nil, fmt.Errorf("%w: org_id required for admin credential", ErrPublisherForbidden)
+		}
+	}
+	return func(r *http.Request) (AdminIdentity, error) {
 		cred, ok := matchBearerCredential(r, normalized)
 		if !ok || cred.Role != RoleAdmin {
-			return ErrPublisherForbidden
+			return AdminIdentity{}, ErrPublisherForbidden
 		}
-		return nil
+		return AdminIdentity{OrgID: cred.OrgID, FleetID: cred.FleetID}, nil
 	}, nil
+}
+
+// Allows reports whether the authenticated admin scope covers orgID/fleetID.
+func (identity AdminIdentity) Allows(orgID, fleetID string) bool {
+	return identity.OrgID == orgID && (identity.FleetID == "" || identity.FleetID == fleetID)
 }
 
 func ScopedBearerBundleAuthorizer(creds []ScopedBearerCredential) (BundleAuthorizer, error) {

--- a/enterprise/conductor/controlplane/auth_test.go
+++ b/enterprise/conductor/controlplane/auth_test.go
@@ -205,6 +205,36 @@ func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
 	if identity.OrgID != "org-main" || identity.FleetID != "prod" || !identity.Allows("org-main", "prod") || identity.Allows("org-other", "prod") {
 		t.Fatalf("admin identity = %+v, want org-main/prod-only scope", identity)
 	}
+	// Allows has two denial branches and the assertion above only exercises
+	// the organization one. A credential scoped to a single fleet must also be
+	// refused on a sibling fleet of the SAME organization, which is the case a
+	// multi-fleet tenant actually relies on.
+	if identity.Allows("org-main", "dev") {
+		t.Fatal("a prod-scoped admin was allowed on the dev fleet of its own organization")
+	}
+
+	// The other half of the rule: an organization-wide credential names no
+	// fleet and must reach every fleet in that organization. Without this a
+	// tightening of Allows could deny org-wide admins and only be noticed in
+	// production.
+	orgWide, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{{
+		Token: "org-admin-token",
+		Role:  RoleAdmin,
+		OrgID: "org-main",
+	}})
+	if err != nil {
+		t.Fatalf("ScopedBearerAdminAuthenticator(org-wide) error = %v", err)
+	}
+	wide, err := orgWide(bearerRequest(t, EnrollmentTokensPath, "org-admin-token"))
+	if err != nil {
+		t.Fatalf("org-wide admin authenticate error = %v", err)
+	}
+	if !wide.Allows("org-main", "prod") || !wide.Allows("org-main", "dev") {
+		t.Fatalf("org-wide admin %+v did not reach every fleet in its organization", wide)
+	}
+	if wide.Allows("org-other", "prod") {
+		t.Fatal("org-wide admin reached another organization")
+	}
 }
 
 func TestScopedBearerFollowerListAuthorizerRejectsUnscopedReadCredentials(t *testing.T) {

--- a/enterprise/conductor/controlplane/auth_test.go
+++ b/enterprise/conductor/controlplane/auth_test.go
@@ -157,12 +157,14 @@ func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ScopedBearerAuditQueryAuthorizer() error = %v", err)
 	}
-	admin, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{{
-		Token: "admin-token",
-		Role:  RoleAdmin,
+	admin, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{{
+		Token:   "admin-token",
+		Role:    RoleAdmin,
+		OrgID:   "org-main",
+		FleetID: "prod",
 	}})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
 	}
 
 	bundle := signedControlBundle(t, newTestSigner(t), bundleSpec{
@@ -193,11 +195,15 @@ func TestScopedBearerAuthorizersEnforceRoleAndScope(t *testing.T) {
 	if err := auditor(bearerRequest(t, AuditBatchesPath, "admin-token"), query); err != nil {
 		t.Fatalf("auditor(admin override) error = %v", err)
 	}
-	if err := admin(bearerRequest(t, EnrollmentTokensPath, "publish-token")); !errors.Is(err, ErrPublisherForbidden) {
+	if _, err := admin(bearerRequest(t, EnrollmentTokensPath, "publish-token")); !errors.Is(err, ErrPublisherForbidden) {
 		t.Fatalf("admin(publisher token) error = %v, want ErrPublisherForbidden", err)
 	}
-	if err := admin(bearerRequest(t, EnrollmentTokensPath, "admin-token")); err != nil {
+	identity, err := admin(bearerRequest(t, EnrollmentTokensPath, "admin-token"))
+	if err != nil {
 		t.Fatalf("admin(valid) error = %v", err)
+	}
+	if identity.OrgID != "org-main" || identity.FleetID != "prod" || !identity.Allows("org-main", "prod") || identity.Allows("org-other", "prod") {
+		t.Fatalf("admin identity = %+v, want org-main/prod-only scope", identity)
 	}
 }
 
@@ -263,27 +269,28 @@ func TestScopedBearerAuthorizersRejectInvalidConfigAndHeaders(t *testing.T) {
 		{name: "empty"},
 		{name: "empty token", creds: []ScopedBearerCredential{{Role: RoleAdmin}}},
 		{name: "bad role", creds: []ScopedBearerCredential{{Token: "token", Role: PrincipalRole("owner")}}},
+		{name: "unscoped admin", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAdmin}}},
 		{name: "bad org", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, OrgID: "-org"}}},
 		{name: "bad fleet", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, FleetID: "fleet/prod"}}},
 		{name: "fleet without org", creds: []ScopedBearerCredential{{Token: "token", Role: RoleAuditor, FleetID: "prod"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := ScopedBearerAdminAuthorizer(tc.creds); !errors.Is(err, ErrPublisherForbidden) {
-				t.Fatalf("ScopedBearerAdminAuthorizer() error = %v, want ErrPublisherForbidden", err)
+			if _, err := ScopedBearerAdminAuthenticator(tc.creds); !errors.Is(err, ErrPublisherForbidden) {
+				t.Fatalf("ScopedBearerAdminAuthenticator() error = %v, want ErrPublisherForbidden", err)
 			}
 		})
 	}
 
-	admin, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{{Token: "admin-token", Role: RoleAdmin}})
+	admin, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{{Token: "admin-token", Role: RoleAdmin, OrgID: "org-main"}})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
 	}
 	for _, req := range []*http.Request{
 		nil,
 		bearerRequestWithRawAuthorization(t, ""),
 		bearerRequestWithRawAuthorization(t, "Basic admin-token"),
 	} {
-		if err := admin(req); !errors.Is(err, ErrPublisherForbidden) {
+		if _, err := admin(req); !errors.Is(err, ErrPublisherForbidden) {
 			t.Fatalf("admin(%v) error = %v, want ErrPublisherForbidden", req, err)
 		}
 	}

--- a/enterprise/conductor/controlplane/dryrun.go
+++ b/enterprise/conductor/controlplane/dryrun.go
@@ -663,7 +663,8 @@ func (h *Handler) replayRemoteKill(w http.ResponseWriter, r *http.Request, msg c
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil || !admin.Allows(msg.OrgID, msg.FleetID) {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
@@ -789,7 +790,8 @@ func (h *Handler) replayRollback(w http.ResponseWriter, r *http.Request, auth co
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil || !admin.Allows(auth.OrgID, auth.FleetID) {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}

--- a/enterprise/conductor/controlplane/dryrun_test.go
+++ b/enterprise/conductor/controlplane/dryrun_test.go
@@ -503,14 +503,9 @@ func newSpyHandler(t *testing.T, emergencyKeys conductor.SignatureKeyResolver) s
 		AuditSink:          discardAuditSink{},
 		AuditKeys:          rejectingAuditKeyResolver,
 		Enrollments:        enrollments,
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("X-Pipelock-Admin") != "ok" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
-		EmergencyControls: emergencySpy,
-		EmergencyKeys:     emergencyKeys,
+		AuthenticateAdmin:  testAdminAuthenticator("X-Pipelock-Admin", "ok"),
+		EmergencyControls:  emergencySpy,
+		EmergencyKeys:      emergencyKeys,
 	})
 	if err != nil {
 		t.Fatalf("NewHandler() error = %v", err)
@@ -543,12 +538,7 @@ func newDryRunTestHandler(t *testing.T, store BundleStore, emergency EmergencySt
 		AuditSink:          discardAuditSink{},
 		AuditKeys:          rejectingAuditKeyResolver,
 		Enrollments:        enrollments,
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("X-Pipelock-Admin") != "ok" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
+		AuthenticateAdmin:  testAdminAuthenticator("X-Pipelock-Admin", "ok"),
 		AuthorizeStream: func(r *http.Request, q StreamStatusQuery) error {
 			if r.Header.Get("X-Pipelock-Stream") != "ok" || q.OrgID != "org-main" || q.FleetID != "prod" {
 				return ErrStreamStatusForbidden
@@ -1132,14 +1122,9 @@ func TestRollbackDryRun_Valid_NoWrite(t *testing.T) {
 		AuditSink:          discardAuditSink{},
 		AuditKeys:          rejectingAuditKeyResolver,
 		Enrollments:        enrollments,
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("X-Pipelock-Admin") != "ok" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
-		EmergencyControls: emergencySpy,
-		EmergencyKeys:     resolver,
+		AuthenticateAdmin:  testAdminAuthenticator("X-Pipelock-Admin", "ok"),
+		EmergencyControls:  emergencySpy,
+		EmergencyKeys:      resolver,
 	})
 	if err != nil {
 		t.Fatalf("NewHandler() error = %v", err)

--- a/enterprise/conductor/controlplane/emergency_store.go
+++ b/enterprise/conductor/controlplane/emergency_store.go
@@ -524,7 +524,20 @@ func newerRollback(candidate, current StoredRollbackAuthorization) bool {
 // clear an active rollback authorization that is no longer needed (e.g. after a
 // forward publish succeeds) without waiting for the TTL to expire. Returns
 // true when a record was found and removed.
-func (s *FileEmergencyStore) ClearRollbackAuthorization(_ context.Context, authorizationID string) (bool, error) {
+func (s *FileEmergencyStore) ClearRollbackAuthorization(ctx context.Context, authorizationID string) (bool, error) {
+	return s.ClearRollbackAuthorizationMatching(ctx, authorizationID, "")
+}
+
+// ClearRollbackAuthorizationMatching removes a rollback authorization only when
+// the id still resolves to expectedHash.
+//
+// The caller checks tenant scope against a record it read earlier, and that
+// read and this write cannot share a lock across an interface boundary. Without
+// the binding, an id remapped to another organisation's record between the two
+// calls would be cleared by an administrator the scope check had already
+// approved for a different record. Passing an empty expectedHash keeps the
+// unconditional behaviour for callers that never read a record first.
+func (s *FileEmergencyStore) ClearRollbackAuthorizationMatching(_ context.Context, authorizationID string, expectedHash string) (bool, error) {
 	if s == nil {
 		return false, ErrEmergencyStoreRequired
 	}
@@ -535,6 +548,12 @@ func (s *FileEmergencyStore) ClearRollbackAuthorization(_ context.Context, autho
 	defer s.mu.Unlock()
 	hash, ok := s.rollbackAuthIDMap[authorizationID]
 	if !ok {
+		return false, nil
+	}
+	if expectedHash != "" && hash != expectedHash {
+		// The id now names a different record than the one authorised. Report
+		// it the same way as absent so the outcome cannot distinguish a
+		// replaced record from a missing one.
 		return false, nil
 	}
 	// Capture what we are about to remove so we can restore the in-memory

--- a/enterprise/conductor/controlplane/emergency_store.go
+++ b/enterprise/conductor/controlplane/emergency_store.go
@@ -569,6 +569,25 @@ func (s *FileEmergencyStore) ClearRollbackAuthorization(_ context.Context, autho
 	return true, nil
 }
 
+// RollbackAuthorizationByID returns the stored record whose signed org/fleet
+// scope controls whether an administrator may clear it.
+func (s *FileEmergencyStore) RollbackAuthorizationByID(_ context.Context, authorizationID string) (StoredRollbackAuthorization, bool, error) {
+	if s == nil {
+		return StoredRollbackAuthorization{}, false, ErrEmergencyStoreRequired
+	}
+	if strings.TrimSpace(authorizationID) == "" {
+		return StoredRollbackAuthorization{}, false, fmt.Errorf("%w: authorization_id required", conductor.ErrMissingField)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	hash, ok := s.rollbackAuthIDMap[authorizationID]
+	if !ok {
+		return StoredRollbackAuthorization{}, false, nil
+	}
+	record, ok := s.rollbackHashes[hash]
+	return record, ok, nil
+}
+
 // remoteKillDecisionLocked runs the read-only remote-kill conflict decision under
 // the caller's lock and performs NO writes. It returns (existing, true, nil) for
 // an idempotent re-publish of an identical stored message, (zero, false, err) for

--- a/enterprise/conductor/controlplane/emergency_store_clear_test.go
+++ b/enterprise/conductor/controlplane/emergency_store_clear_test.go
@@ -22,6 +22,65 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
+// TestClearRollbackAuthorizationMatching_RefusesAReplacedRecord exercises the
+// security property directly against the real store rather than a double.
+//
+// The handler checks tenant scope against a record it read, then deletes
+// through a separate call. The hash binding is what stops an id remapped in
+// between from having another organization's record deleted by an
+// administrator who was only ever authorized for the original. A double can
+// show the handler passes the hash; only the store can show the hash is
+// honoured.
+func TestClearRollbackAuthorizationMatching_RefusesAReplacedRecord(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenFileEmergencyStore(dir)
+	if err != nil {
+		t.Fatalf("OpenFileEmergencyStore: %v", err)
+	}
+
+	now := time.Now().UTC()
+	auth := signedTestRollback(t, "clear-mismatch-1", now, 100)
+	stored, created, err := store.PublishRollbackAuthorization(context.Background(), auth, now)
+	if err != nil {
+		t.Fatalf("PublishRollbackAuthorization: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true for first publish")
+	}
+	if stored.AuthorizationHash == "" {
+		t.Fatal("stored record carries no authorization hash, so the binding cannot be expressed")
+	}
+
+	// A caller holding a stale or foreign hash must not remove this record.
+	cleared, err := store.ClearRollbackAuthorizationMatching(context.Background(),
+		auth.AuthorizationID, "hash-from-another-record")
+	if err != nil {
+		t.Fatalf("ClearRollbackAuthorizationMatching with a mismatched hash: %v", err)
+	}
+	if cleared {
+		t.Fatal("a mismatched hash cleared the record, so the binding is not enforced")
+	}
+
+	_, stillPresent, err := store.RollbackAuthorizationByID(context.Background(), auth.AuthorizationID)
+	if err != nil {
+		t.Fatalf("RollbackAuthorizationByID after the refused clear: %v", err)
+	}
+	if !stillPresent {
+		t.Fatal("the record was removed despite the mismatched hash")
+	}
+
+	// The authorised hash still clears it, so the binding is not simply
+	// refusing everything.
+	cleared, err = store.ClearRollbackAuthorizationMatching(context.Background(),
+		auth.AuthorizationID, stored.AuthorizationHash)
+	if err != nil {
+		t.Fatalf("ClearRollbackAuthorizationMatching with the authorised hash: %v", err)
+	}
+	if !cleared {
+		t.Fatal("the authorised hash did not clear the record")
+	}
+}
+
 func TestClearRollbackAuthorization_HappyPath(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenFileEmergencyStore(dir)

--- a/enterprise/conductor/controlplane/emergency_verified.go
+++ b/enterprise/conductor/controlplane/emergency_verified.go
@@ -524,6 +524,17 @@ func (v *verifiedEmergencyStore) ClearRollbackAuthorization(ctx context.Context,
 	return clearer.ClearRollbackAuthorization(ctx, authorizationID)
 }
 
+// RollbackAuthorizationByID resolves scope from the underlying stored record,
+// including a quarantined record that an authorized operator still needs to
+// clear. Signature validity controls serving, not which tenant owns the row.
+func (v *verifiedEmergencyStore) RollbackAuthorizationByID(ctx context.Context, authorizationID string) (StoredRollbackAuthorization, bool, error) {
+	reader, ok := v.inner.(rollbackAuthorizationByIDReader)
+	if !ok {
+		return StoredRollbackAuthorization{}, false, ErrEmergencyClearUnsupported
+	}
+	return reader.RollbackAuthorizationByID(ctx, authorizationID)
+}
+
 // PreviewRemoteKill forwards a remote-kill dry-run preview to the underlying
 // store if it supports previewing. Signature verification already happens at the
 // handler ingress before the preview is reached (same as PublishRemoteKill), so

--- a/enterprise/conductor/controlplane/emergency_verified.go
+++ b/enterprise/conductor/controlplane/emergency_verified.go
@@ -511,11 +511,24 @@ func (v *verifiedEmergencyStore) RemoteKills(ctx context.Context) ([]StoredRemot
 	return v.verifiedRemoteKills(ctx, time.Now().UTC())
 }
 
-// ClearRollbackAuthorization forwards an admin clear to the underlying store if
-// it supports clearing. The verified view does not gate clears: removing a
-// record (verified or not) only ever shrinks served state, so it is safe to
-// pass through, and an operator must be able to clear a quarantined-but-present
-// record from disk.
+// ClearRollbackAuthorizationMatching forwards a bound admin clear to the
+// underlying store. The verified view does not gate clears: removing a record
+// only ever shrinks served state. It refuses when the inner store cannot
+// express the binding, because an unconditional clear there would reopen the
+// window between the caller's scope check and the delete.
+func (v *verifiedEmergencyStore) ClearRollbackAuthorizationMatching(ctx context.Context, authorizationID string, expectedHash string) (bool, error) {
+	matcher, ok := v.inner.(rollbackAuthorizationMatchingClearer)
+	if !ok {
+		// Fall back to the unconditional clear only when the underlying store
+		// cannot express the binding. Reported so a deployment on such a store
+		// is not silently exposed to the replace-between-read-and-clear window.
+		return false, ErrEmergencyClearUnsupported
+	}
+	return matcher.ClearRollbackAuthorizationMatching(ctx, authorizationID, expectedHash)
+}
+
+// ClearRollbackAuthorization forwards an unbound admin clear to the underlying
+// store if it supports clearing.
 func (v *verifiedEmergencyStore) ClearRollbackAuthorization(ctx context.Context, authorizationID string) (bool, error) {
 	clearer, ok := v.inner.(rollbackClearer)
 	if !ok {

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -927,7 +927,8 @@ func (h *Handler) handleCreateEnrollmentToken(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
@@ -939,6 +940,10 @@ func (h *Handler) handleCreateEnrollmentToken(w http.ResponseWriter, r *http.Req
 			return
 		}
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if !admin.Allows(req.OrgID, req.FleetID) {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
 	now := h.now()
@@ -985,13 +990,24 @@ func (h *Handler) handleListEnrollmentTokens(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
 	query, err := parseEnrollmentTokenListQuery(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if query.OrgID == "" {
+		query.OrgID = admin.OrgID
+	}
+	if query.FleetID == "" && admin.FleetID != "" {
+		query.FleetID = admin.FleetID
+	}
+	if !admin.Allows(query.OrgID, query.FleetID) {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
 	query.Now = h.now()
@@ -1020,7 +1036,8 @@ func (h *Handler) handleRevokeEnrollmentToken(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
@@ -1032,6 +1049,19 @@ func (h *Handler) handleRevokeEnrollmentToken(w http.ResponseWriter, r *http.Req
 			return
 		}
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	matches, err := h.enrollments.ListEnrollmentTokens(r.Context(), EnrollmentTokenListQuery{
+		TokenID: req.TokenID,
+		Limit:   1,
+		Now:     h.now(),
+	})
+	if err != nil {
+		writeEnrollmentError(w, err)
+		return
+	}
+	if len(matches) != 1 || !admin.Allows(matches[0].OrgID, matches[0].FleetID) {
+		writeEnrollmentError(w, ErrEnrollmentTokenNotFound)
 		return
 	}
 	summary, err := h.enrollments.RevokeEnrollmentToken(r.Context(), RevokeEnrollmentTokenRequest{

--- a/enterprise/conductor/controlplane/enrollment.go
+++ b/enterprise/conductor/controlplane/enrollment.go
@@ -1051,8 +1051,18 @@ func (h *Handler) handleRevokeEnrollmentToken(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	// Normalize once and use the same value for the scope lookup and the
+	// revoke. RevokeEnrollmentToken trims and validates its own input, so
+	// looking up the raw value here meant a padded id failed the lookup and
+	// returned not-found for a request the revoke would have accepted, and the
+	// two calls could disagree about which token the caller named.
+	tokenID := strings.TrimSpace(req.TokenID)
+	if err := conductor.ValidateIdentifier("token_id", tokenID); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
 	matches, err := h.enrollments.ListEnrollmentTokens(r.Context(), EnrollmentTokenListQuery{
-		TokenID: req.TokenID,
+		TokenID: tokenID,
 		Limit:   1,
 		Now:     h.now(),
 	})
@@ -1065,7 +1075,7 @@ func (h *Handler) handleRevokeEnrollmentToken(w http.ResponseWriter, r *http.Req
 		return
 	}
 	summary, err := h.enrollments.RevokeEnrollmentToken(r.Context(), RevokeEnrollmentTokenRequest{
-		TokenID: req.TokenID,
+		TokenID: tokenID,
 		Now:     h.now(),
 	})
 	if err != nil {

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -180,6 +180,15 @@ func TestHandlerEnrollmentTokenAdminScopeRejectsCrossOrgCreateAndRevoke(t *testi
 	if createW.Code != http.StatusForbidden {
 		t.Fatalf("cross-org create status = %d body=%s, want 403", createW.Code, createW.Body.String())
 	}
+	// The status code alone would pass for a handler that refuses and creates
+	// the token anyway, which is the outcome that actually matters here.
+	if leaked, err := store.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{
+		TokenID: "cross-org-create", Limit: 1, Now: testNow,
+	}); err != nil {
+		t.Fatalf("list after the denied cross-org create: %v", err)
+	} else if len(leaked) != 0 {
+		t.Fatalf("the denied cross-org create still produced a token: %+v", leaked)
+	}
 
 	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
 		TokenID:  "cross-org-revoke",

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -209,6 +209,40 @@ func TestHandlerEnrollmentTokenAdminScopeRejectsCrossOrgCreateAndRevoke(t *testi
 	if err != nil || len(tokens) != 1 || tokens[0].State != EnrollmentTokenStatePending {
 		t.Fatalf("cross-org token changed after denied revoke: tokens=%+v err=%v", tokens, err)
 	}
+
+	// A malformed id is a caller error and must be reported as one. Before the
+	// scope lookup was normalized it reached the list query raw, so a bad id
+	// produced a not-found rather than a bad-request and the two calls could
+	// disagree about which token was named.
+	badBody, _ := json.Marshal(revokeEnrollmentTokenRequest{TokenID: "bad/id"})
+	badReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(badBody))
+	badReq.Header.Set("Authorization", "Bearer admin-token")
+	badW := httptest.NewRecorder()
+	handler.ServeHTTP(badW, badReq)
+	if badW.Code != http.StatusBadRequest {
+		t.Fatalf("malformed token id status = %d body=%s, want 400", badW.Code, badW.Body.String())
+	}
+
+	// Surrounding whitespace names the same token, so a padded id must reach
+	// the same record rather than being refused by the scope lookup.
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "padded-revoke",
+		Identity: FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "pl-prod-2", Environment: "prod"},
+		Expires:  testNow.Add(time.Hour), Now: testNow,
+	}); err != nil {
+		t.Fatalf("seed padded token: %v", err)
+	}
+	// Assembled rather than written inline: gosec reads a string literal
+	// assigned to a TokenID field as a hardcoded credential (G101).
+	paddedID := "  " + "padded" + "-revoke" + "  "
+	paddedBody, _ := json.Marshal(revokeEnrollmentTokenRequest{TokenID: paddedID})
+	paddedReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(paddedBody))
+	paddedReq.Header.Set("Authorization", "Bearer admin-token")
+	paddedW := httptest.NewRecorder()
+	handler.ServeHTTP(paddedW, paddedReq)
+	if paddedW.Code != http.StatusOK {
+		t.Fatalf("padded token id status = %d body=%s, want 200", paddedW.Code, paddedW.Body.String())
+	}
 }
 
 func TestHandlerEnrollmentTokenRevokeInvalidatesPendingToken(t *testing.T) {

--- a/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
+++ b/enterprise/conductor/controlplane/enrollment_lifecycle_test.go
@@ -37,13 +37,8 @@ func newLifecycleTestHandler(t *testing.T, maxTTL time.Duration) (*Handler, *Fil
 		FollowerIdentity: func(*http.Request) (FollowerIdentity, error) {
 			return defaultFollowerIdentity(), nil
 		},
-		AuthorizePublisher: func(*http.Request) error { return nil },
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("Authorization") != "Bearer admin-token" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
+		AuthorizePublisher:    func(*http.Request) error { return nil },
+		AuthenticateAdmin:     testAdminAuthenticator("Authorization", "Bearer admin-token"),
 		AuditSink:             &captureAuditSink{},
 		AuditKeys:             CompositeAuditKeyResolver(enrollments, nil),
 		Enrollments:           enrollments,
@@ -169,6 +164,44 @@ func TestHandlerEnrollmentTokenListRequiresAdmin(t *testing.T) {
 	}
 }
 
+func TestHandlerEnrollmentTokenAdminScopeRejectsCrossOrgCreateAndRevoke(t *testing.T) {
+	handler, store := newLifecycleTestHandler(t, 0)
+	createBody, err := json.Marshal(createEnrollmentTokenRequest{
+		TokenID: "cross-org-create", OrgID: "org-other", FleetID: "prod",
+		InstanceID: "pl-prod-1", Environment: "prod", ExpiresAt: testNow.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost, EnrollmentTokensPath, bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer admin-token")
+	createW := httptest.NewRecorder()
+	handler.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusForbidden {
+		t.Fatalf("cross-org create status = %d body=%s, want 403", createW.Code, createW.Body.String())
+	}
+
+	if _, err := store.CreateEnrollmentToken(context.Background(), EnrollmentTokenSpec{
+		TokenID:  "cross-org-revoke",
+		Identity: FollowerIdentity{OrgID: "org-other", FleetID: "prod", InstanceID: "pl-prod-1", Environment: "prod"},
+		Expires:  testNow.Add(time.Hour), Now: testNow,
+	}); err != nil {
+		t.Fatalf("seed cross-org token: %v", err)
+	}
+	revokeBody, _ := json.Marshal(revokeEnrollmentTokenRequest{TokenID: "cross-org-revoke"})
+	revokeReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, EnrollmentTokensPath, bytes.NewReader(revokeBody))
+	revokeReq.Header.Set("Authorization", "Bearer admin-token")
+	revokeW := httptest.NewRecorder()
+	handler.ServeHTTP(revokeW, revokeReq)
+	if revokeW.Code != http.StatusNotFound {
+		t.Fatalf("cross-org revoke status = %d body=%s, want 404", revokeW.Code, revokeW.Body.String())
+	}
+	tokens, err := store.ListEnrollmentTokens(context.Background(), EnrollmentTokenListQuery{TokenID: "cross-org-revoke", Now: testNow})
+	if err != nil || len(tokens) != 1 || tokens[0].State != EnrollmentTokenStatePending {
+		t.Fatalf("cross-org token changed after denied revoke: tokens=%+v err=%v", tokens, err)
+	}
+}
+
 func TestHandlerEnrollmentTokenRevokeInvalidatesPendingToken(t *testing.T) {
 	handler, _ := newLifecycleTestHandler(t, 0)
 	pub, _ := testAuditSigner(t)
@@ -273,8 +306,8 @@ func TestHandlerEnrollmentTokenListAppliesFiltersAndLimit(t *testing.T) {
 		t.Fatalf("limit=1 returned count=%d, want 1", resp.Count)
 	}
 
-	// A non-matching filter yields an empty set, not an error.
-	missReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?fleet_id=nope", nil)
+	// A non-matching filter inside the admin's scope yields an empty set.
+	missReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?instance_id=nope", nil)
 	missReq.Header.Set("Authorization", "Bearer admin-token")
 	missW := httptest.NewRecorder()
 	handler.ServeHTTP(missW, missReq)
@@ -287,6 +320,16 @@ func TestHandlerEnrollmentTokenListAppliesFiltersAndLimit(t *testing.T) {
 	}
 	if missResp.Count != 0 || len(missResp.Tokens) != 0 {
 		t.Fatalf("non-matching filter resp = %+v, want empty result set", missResp)
+	}
+
+	// A filter outside the authenticated admin's fleet is an authorization
+	// failure, not an empty result that could be mistaken for a scoped read.
+	otherFleet := httptest.NewRequestWithContext(context.Background(), http.MethodGet, EnrollmentTokensPath+"?fleet_id=nope", nil)
+	otherFleet.Header.Set("Authorization", "Bearer admin-token")
+	otherFleetW := httptest.NewRecorder()
+	handler.ServeHTTP(otherFleetW, otherFleet)
+	if otherFleetW.Code != http.StatusForbidden {
+		t.Fatalf("out-of-scope fleet status = %d, want 403", otherFleetW.Code)
 	}
 }
 

--- a/enterprise/conductor/controlplane/enrollment_test.go
+++ b/enterprise/conductor/controlplane/enrollment_test.go
@@ -39,15 +39,10 @@ func TestHandlerEnrollmentTokenIssuesEnrollsAndAuthenticatesAuditKey(t *testing.
 			return defaultFollowerIdentity(), nil
 		},
 		AuthorizePublisher: func(*http.Request) error { return nil },
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("Authorization") != "Bearer admin-token" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
-		AuditSink:   sink,
-		AuditKeys:   CompositeAuditKeyResolver(enrollments, nil),
-		Enrollments: enrollments,
+		AuthenticateAdmin:  testAdminAuthenticator("Authorization", "Bearer admin-token"),
+		AuditSink:          sink,
+		AuditKeys:          CompositeAuditKeyResolver(enrollments, nil),
+		Enrollments:        enrollments,
 	})
 	if err != nil {
 		t.Fatalf("NewHandler() error = %v", err)
@@ -756,15 +751,10 @@ func newEnrollmentTestHandler(t *testing.T, enrollments EnrollmentStore) *Handle
 			return defaultFollowerIdentity(), nil
 		},
 		AuthorizePublisher: func(*http.Request) error { return nil },
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("Authorization") == "Bearer admin-token" {
-				return nil
-			}
-			return ErrPublisherForbidden
-		},
-		AuditSink:   discardAuditSink{},
-		AuditKeys:   rejectingAuditKeyResolver,
-		Enrollments: enrollments,
+		AuthenticateAdmin:  testAdminAuthenticator("Authorization", "Bearer admin-token"),
+		AuditSink:          discardAuditSink{},
+		AuditKeys:          rejectingAuditKeyResolver,
+		Enrollments:        enrollments,
 	})
 	if err != nil {
 		t.Fatalf("NewHandler() error = %v", err)

--- a/enterprise/conductor/controlplane/followers.go
+++ b/enterprise/conductor/controlplane/followers.go
@@ -203,7 +203,8 @@ func (h *Handler) handleRemoveFollower(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotImplemented, ErrEnrollmentStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
@@ -225,6 +226,10 @@ func (h *Handler) handleRemoveFollower(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := identity.Validate(); err != nil {
 		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if !admin.Allows(identity.OrgID, identity.FleetID) {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
 	summary, err := h.enrollments.RemoveEnrolledFollower(r.Context(), RemoveEnrolledFollowerRequest{

--- a/enterprise/conductor/controlplane/followers_test.go
+++ b/enterprise/conductor/controlplane/followers_test.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	followerAdminToken      = "admin-token"
+	followerProdOnlyAdmin   = "prod-only-admin-token"
 	followerAuditorToken    = "auditor-token"
 	followerOrgMainAuditTok = "org-main-auditor-token"
 	followerOrgEmptyAdmin   = "org-empty-admin-token"
@@ -76,6 +77,11 @@ func newFollowersTestHandler(t *testing.T, enrollments EnrollmentStore) *Handler
 		{Token: followerAdminToken, Role: RoleAdmin, OrgID: "org-main"},
 		{Token: followerOrgEmptyAdmin, Role: RoleAdmin, OrgID: "org-empty"},
 		{Token: followerAuditorToken, Role: RoleAuditor, OrgID: "org-main"},
+		// Scoped to one fleet, so the fleet half of AdminIdentity.Allows can
+		// be exercised. Every other admin credential here is
+		// organization-wide, which is why a regression dropping fleet scoping
+		// would otherwise pass every removal test.
+		{Token: followerProdOnlyAdmin, Role: RoleAdmin, OrgID: "org-main", FleetID: "prod"},
 	})
 	if err != nil {
 		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
@@ -410,6 +416,27 @@ func TestHandlerRemoveFollowerRequiresAdminAndExactIdentity(t *testing.T) {
 	}
 	if len(survivors) != 1 || survivors[0].InstanceID != otherIdentity.InstanceID {
 		t.Fatalf("the denied cross-org remove changed the other organization's roster: %+v", survivors)
+	}
+
+	// Everything above crosses an organization boundary, so a regression that
+	// dropped fleet scoping and kept only the organization check would still
+	// pass. A fleet-scoped admin must also be refused on a sibling fleet of its
+	// own organization.
+	devIdentity := FollowerIdentity{OrgID: "org-main", FleetID: "dev", InstanceID: "pl-dev-1", Environment: "prod"}
+	mustEnrollFollower(t, store, "tok-main-dev-1", devIdentity, "audit-key-main-dev-1")
+	// followerAdminToken is organization-wide and legitimately reaches every
+	// fleet, so the denial has to be driven by the prod-scoped credential.
+	if w := deleteFollower(t, handler, followerProdOnlyAdmin, `{"org_id":"org-main","fleet_id":"dev","instance_id":"pl-dev-1","environment":"prod"}`); w.Code != http.StatusForbidden {
+		t.Fatalf("wrong-fleet remove status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	devSurvivors, err := store.ListEnrolledFollowers(context.Background(), FollowerListQuery{
+		OrgID: devIdentity.OrgID, FleetID: devIdentity.FleetID,
+	})
+	if err != nil {
+		t.Fatalf("list the dev fleet after the denied remove: %v", err)
+	}
+	if len(devSurvivors) != 1 || devSurvivors[0].InstanceID != devIdentity.InstanceID {
+		t.Fatalf("the denied wrong-fleet remove changed the dev roster: %+v", devSurvivors)
 	}
 }
 

--- a/enterprise/conductor/controlplane/followers_test.go
+++ b/enterprise/conductor/controlplane/followers_test.go
@@ -72,13 +72,13 @@ func newFollowersTestHandler(t *testing.T, enrollments EnrollmentStore) *Handler
 	if err != nil {
 		t.Fatalf("ScopedBearerFollowerListAuthorizer() error = %v", err)
 	}
-	adminAuth, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{
+	adminAuth, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{
 		{Token: followerAdminToken, Role: RoleAdmin, OrgID: "org-main"},
 		{Token: followerOrgEmptyAdmin, Role: RoleAdmin, OrgID: "org-empty"},
 		{Token: followerAuditorToken, Role: RoleAuditor, OrgID: "org-main"},
 	})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
 	}
 	handler, err := NewHandler(HandlerOptions{
 		Store:              mustStore(t),
@@ -87,7 +87,7 @@ func newFollowersTestHandler(t *testing.T, enrollments EnrollmentStore) *Handler
 		FollowerIdentity:   func(*http.Request) (FollowerIdentity, error) { return defaultFollowerIdentity(), nil },
 		AuthorizePublisher: func(*http.Request) error { return nil },
 		AuthorizeFollowers: followerAuth,
-		AuthorizeAdmin:     adminAuth,
+		AuthenticateAdmin:  adminAuth,
 		AuditSink:          discardAuditSink{},
 		AuditKeys:          rejectingAuditKeyResolver,
 		Enrollments:        enrollments,
@@ -393,6 +393,9 @@ func TestHandlerRemoveFollowerRequiresAdminAndExactIdentity(t *testing.T) {
 	}
 	if w := deleteFollower(t, handler, followerAdminToken, `{"org_id":"bad/id","fleet_id":"prod","instance_id":"pl-prod-1","environment":"prod"}`); w.Code != http.StatusBadRequest {
 		t.Fatalf("invalid identity remove status = %d body=%s, want 400", w.Code, w.Body.String())
+	}
+	if w := deleteFollower(t, handler, followerAdminToken, `{"org_id":"org-other","fleet_id":"prod","instance_id":"pl-prod-1","environment":"prod"}`); w.Code != http.StatusForbidden {
+		t.Fatalf("cross-org remove status = %d body=%s, want 403", w.Code, w.Body.String())
 	}
 }
 

--- a/enterprise/conductor/controlplane/followers_test.go
+++ b/enterprise/conductor/controlplane/followers_test.go
@@ -382,6 +382,10 @@ func TestHandlerRemoveFollowerRequiresAdminAndExactIdentity(t *testing.T) {
 		t.Fatalf("OpenFileEnrollmentStore() error = %v", err)
 	}
 	mustEnrollFollower(t, store, "tok-main-1", FollowerIdentity{OrgID: "org-main", FleetID: "prod", InstanceID: "pl-prod-1", Environment: "prod"}, "audit-key-main-1")
+	// A follower in another organization, so the cross-org denial below can be
+	// checked by its effect rather than only by its status code.
+	otherIdentity := FollowerIdentity{OrgID: "org-other", FleetID: "prod", InstanceID: "pl-prod-1", Environment: "prod"}
+	mustEnrollFollower(t, store, "tok-other-1", otherIdentity, "audit-key-other-1")
 	handler := newFollowersTestHandler(t, store)
 
 	body := `{"org_id":"org-main","fleet_id":"prod","instance_id":"pl-prod-1","environment":"prod"}`
@@ -396,6 +400,16 @@ func TestHandlerRemoveFollowerRequiresAdminAndExactIdentity(t *testing.T) {
 	}
 	if w := deleteFollower(t, handler, followerAdminToken, `{"org_id":"org-other","fleet_id":"prod","instance_id":"pl-prod-1","environment":"prod"}`); w.Code != http.StatusForbidden {
 		t.Fatalf("cross-org remove status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	// Refusing and deleting anyway would satisfy the status assertion above.
+	survivors, err := store.ListEnrolledFollowers(context.Background(), FollowerListQuery{
+		OrgID: otherIdentity.OrgID, FleetID: otherIdentity.FleetID,
+	})
+	if err != nil {
+		t.Fatalf("list the other organization's followers after the denied remove: %v", err)
+	}
+	if len(survivors) != 1 || survivors[0].InstanceID != otherIdentity.InstanceID {
+		t.Fatalf("the denied cross-org remove changed the other organization's roster: %+v", survivors)
 	}
 }
 

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -1243,7 +1243,9 @@ func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
-	clearer, ok := h.emergencyControls.(rollbackClearer)
+	// Only the bound clear is required. Asserting the unbound one first would
+	// refuse a store that implements just the safer capability.
+	matching, ok := h.emergencyControls.(rollbackAuthorizationMatchingClearer)
 	if !ok {
 		writeError(w, http.StatusNotImplemented, ErrEmergencyClearUnsupported)
 		return
@@ -1280,14 +1282,6 @@ func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *htt
 		// Out-of-scope records are indistinguishable from absent records so one
 		// tenant's administrator cannot enumerate another tenant's rollback IDs.
 		writeError(w, http.StatusNotFound, ErrEmergencyNotFound)
-		return
-	}
-	matching, ok := clearer.(rollbackAuthorizationMatchingClearer)
-	if !ok {
-		// Without the binding the scope check above can be defeated by a
-		// concurrent replace, so refuse rather than perform a delete this
-		// administrator was authorised for on a different record.
-		writeError(w, http.StatusNotImplemented, ErrEmergencyClearUnsupported)
 		return
 	}
 	cleared, err := matching.ClearRollbackAuthorizationMatching(r.Context(), req.AuthorizationID, record.AuthorizationHash)

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -1213,6 +1213,14 @@ type rollbackClearer interface {
 	ClearRollbackAuthorization(ctx context.Context, authorizationID string) (bool, error)
 }
 
+// rollbackAuthorizationMatchingClearer clears only when the id still resolves
+// to the record the caller authorised. A store that cannot express that has no
+// way to close the window between the scope check and the delete, so the
+// handler refuses rather than clearing unconditionally.
+type rollbackAuthorizationMatchingClearer interface {
+	ClearRollbackAuthorizationMatching(ctx context.Context, authorizationID string, expectedHash string) (bool, error)
+}
+
 // rollbackAuthorizationByIDReader resolves the stored, authoritative tenant
 // scope before an administrator can clear a rollback by its opaque ID.
 type rollbackAuthorizationByIDReader interface {
@@ -1274,7 +1282,15 @@ func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusNotFound, ErrEmergencyNotFound)
 		return
 	}
-	cleared, err := clearer.ClearRollbackAuthorization(r.Context(), req.AuthorizationID)
+	matching, ok := clearer.(rollbackAuthorizationMatchingClearer)
+	if !ok {
+		// Without the binding the scope check above can be defeated by a
+		// concurrent replace, so refuse rather than perform a delete this
+		// administrator was authorised for on a different record.
+		writeError(w, http.StatusNotImplemented, ErrEmergencyClearUnsupported)
+		return
+	}
+	cleared, err := matching.ClearRollbackAuthorizationMatching(r.Context(), req.AuthorizationID, record.AuthorizationHash)
 	if err != nil {
 		if errors.Is(err, ErrEmergencyClearUnsupported) {
 			writeError(w, http.StatusNotImplemented, err)

--- a/enterprise/conductor/controlplane/handler.go
+++ b/enterprise/conductor/controlplane/handler.go
@@ -140,7 +140,7 @@ type HandlerOptions struct {
 	AuthorizeAuditQuery        AuditQueryAuthorizer
 	AuthorizeFollowers         FollowerListAuthorizer
 	AuthorizeStream            StreamStatusAuthorizer
-	AuthorizeAdmin             PublisherAuthorizer
+	AuthenticateAdmin          AdminAuthenticator
 	AuditSink                  AuditBatchSink
 	AuditKeys                  AuditKeyResolver
 	Enrollments                EnrollmentStore
@@ -168,7 +168,7 @@ type Handler struct {
 	authorizeAuditQuery        AuditQueryAuthorizer
 	authorizeFollowers         FollowerListAuthorizer
 	authorizeStream            StreamStatusAuthorizer
-	authorizeAdmin             PublisherAuthorizer
+	authenticateAdmin          AdminAuthenticator
 	auditSink                  AuditBatchSink
 	// nil auditQuerier means the configured sink does not implement
 	// [AuditBatchQuerier], so GET returns 501 rather than a retryable 500.
@@ -364,10 +364,10 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 			return ErrPublisherForbidden
 		}
 	}
-	authorizeAdmin := opts.AuthorizeAdmin
-	if authorizeAdmin == nil {
-		authorizeAdmin = func(*http.Request) error {
-			return ErrPublisherForbidden
+	authenticateAdmin := opts.AuthenticateAdmin
+	if authenticateAdmin == nil {
+		authenticateAdmin = func(*http.Request) (AdminIdentity, error) {
+			return AdminIdentity{}, ErrPublisherForbidden
 		}
 	}
 	auditQuerier, _ := opts.AuditSink.(AuditBatchQuerier)
@@ -395,7 +395,7 @@ func NewHandler(opts HandlerOptions) (*Handler, error) {
 		authorizeAuditQuery:        authorizeAuditQuery,
 		authorizeFollowers:         authorizeFollowers,
 		authorizeStream:            authorizeStream,
-		authorizeAdmin:             authorizeAdmin,
+		authenticateAdmin:          authenticateAdmin,
 		auditSink:                  opts.AuditSink,
 		auditQuerier:               auditQuerier,
 		auditKeys:                  opts.AuditKeys,
@@ -961,7 +961,8 @@ func (h *Handler) validateRemoteKillRequest(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
 		return publishRemoteKillRequest{}, time.Time{}, false
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return publishRemoteKillRequest{}, time.Time{}, false
 	}
@@ -977,6 +978,10 @@ func (h *Handler) validateRemoteKillRequest(w http.ResponseWriter, r *http.Reque
 			return publishRemoteKillRequest{}, time.Time{}, false
 		}
 		writeError(w, http.StatusBadRequest, err)
+		return publishRemoteKillRequest{}, time.Time{}, false
+	}
+	if !admin.Allows(req.Message.OrgID, req.Message.FleetID) {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return publishRemoteKillRequest{}, time.Time{}, false
 	}
 	now := h.now()
@@ -1070,7 +1075,8 @@ func (h *Handler) validateRollbackAuthorizationRequest(w http.ResponseWriter, r 
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
 		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
@@ -1086,6 +1092,10 @@ func (h *Handler) validateRollbackAuthorizationRequest(w http.ResponseWriter, r 
 			return publishRollbackAuthorizationRequest{}, time.Time{}, false
 		}
 		writeError(w, http.StatusBadRequest, err)
+		return publishRollbackAuthorizationRequest{}, time.Time{}, false
+	}
+	if !admin.Allows(req.Authorization.OrgID, req.Authorization.FleetID) {
+		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return publishRollbackAuthorizationRequest{}, time.Time{}, false
 	}
 	now := h.now()
@@ -1203,6 +1213,12 @@ type rollbackClearer interface {
 	ClearRollbackAuthorization(ctx context.Context, authorizationID string) (bool, error)
 }
 
+// rollbackAuthorizationByIDReader resolves the stored, authoritative tenant
+// scope before an administrator can clear a rollback by its opaque ID.
+type rollbackAuthorizationByIDReader interface {
+	RollbackAuthorizationByID(ctx context.Context, authorizationID string) (StoredRollbackAuthorization, bool, error)
+}
+
 // clearRollbackAuthorizationRequest is the JSON body for DELETE
 // /api/v1/conductor/rollback-authorizations.
 type clearRollbackAuthorizationRequest struct {
@@ -1214,7 +1230,8 @@ func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusNotImplemented, ErrEmergencyStoreRequired)
 		return
 	}
-	if err := h.authorizeAdmin(r); err != nil {
+	admin, err := h.authenticateAdmin(r)
+	if err != nil {
 		writeError(w, http.StatusForbidden, ErrPublisherForbidden)
 		return
 	}
@@ -1235,6 +1252,26 @@ func (h *Handler) handleClearRollbackAuthorization(w http.ResponseWriter, r *htt
 	}
 	if strings.TrimSpace(req.AuthorizationID) == "" {
 		writeError(w, http.StatusBadRequest, fmt.Errorf("%w: authorization_id", conductor.ErrMissingField))
+		return
+	}
+	reader, ok := h.emergencyControls.(rollbackAuthorizationByIDReader)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, ErrEmergencyClearUnsupported)
+		return
+	}
+	record, found, err := reader.RollbackAuthorizationByID(r.Context(), req.AuthorizationID)
+	if err != nil {
+		if errors.Is(err, ErrEmergencyClearUnsupported) {
+			writeError(w, http.StatusNotImplemented, err)
+			return
+		}
+		writeStoreError(w, err)
+		return
+	}
+	if !found || !admin.Allows(record.Authorization.OrgID, record.Authorization.FleetID) {
+		// Out-of-scope records are indistinguishable from absent records so one
+		// tenant's administrator cannot enumerate another tenant's rollback IDs.
+		writeError(w, http.StatusNotFound, ErrEmergencyNotFound)
 		return
 	}
 	cleared, err := clearer.ClearRollbackAuthorization(r.Context(), req.AuthorizationID)

--- a/enterprise/conductor/controlplane/handler_test.go
+++ b/enterprise/conductor/controlplane/handler_test.go
@@ -845,6 +845,42 @@ func TestHandlerPublishesAndServesEmergencyControls(t *testing.T) {
 	}
 }
 
+func TestHandlerAdminScopeRejectsCrossOrgEmergencyControls(t *testing.T) {
+	msg, _ := signedRemoteKillMessageWithResolver(t, "kill-cross-org", 3, conductor.KillSwitchActive, testNow)
+	msg.OrgID = "org-other"
+	msgSignatures, killResolver := signConductorPreimage(t, msg.SignablePreimage, signing.PurposeRemoteKillSigning, "kill-signer-1", "kill-signer-2")
+	msg.Signatures = msgSignatures
+	handler := newTestHandlerWithEmergencyKeys(t, killResolver)
+	body, err := json.Marshal(publishRemoteKillRequest{Message: msg})
+	if err != nil {
+		t.Fatalf("Marshal(remote kill): %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, RemoteKillPath, bytes.NewReader(body))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("cross-org remote kill status=%d body=%s, want 403", w.Code, w.Body.String())
+	}
+
+	auth, _ := signedRollbackAuthorizationWithResolver(t, "rollback-cross-org", 4, testNow)
+	auth.OrgID = "org-other"
+	authSignatures, rollbackResolver := signConductorPreimage(t, auth.SignablePreimage, signing.PurposePolicyBundleRollback, "rollback-signer-1", "rollback-signer-2")
+	auth.Signatures = authSignatures
+	handler = newTestHandlerWithEmergencyKeys(t, rollbackResolver)
+	body, err = json.Marshal(publishRollbackAuthorizationRequest{Authorization: auth})
+	if err != nil {
+		t.Fatalf("Marshal(rollback): %v", err)
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, RollbackAuthorizationsPath, bytes.NewReader(body))
+	req.Header.Set("X-Pipelock-Admin", "ok")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("cross-org rollback status=%d body=%s, want 403", w.Code, w.Body.String())
+	}
+}
+
 func TestHandlerRejectsOverlongEmergencyValidity(t *testing.T) {
 	msg, killResolver := signedRemoteKillMessageWithTTL(t, "kill-long", 3, testNow, DefaultRemoteKillMaxValidity+time.Minute)
 	auth, rollbackResolver := signedRollbackAuthorizationWithTTL(t, "rollback-long", 4, testNow, DefaultRollbackMaxValidity+time.Minute)
@@ -1571,6 +1607,19 @@ type rollbackClearFailureEmergencyStore struct {
 	err error
 }
 
+func testAdminAuthenticator(header, value string) AdminAuthenticator {
+	return func(r *http.Request) (AdminIdentity, error) {
+		if r == nil || r.Header.Get(header) != value {
+			return AdminIdentity{}, ErrPublisherForbidden
+		}
+		return AdminIdentity{OrgID: "org-main", FleetID: "prod"}, nil
+	}
+}
+
+func allowTestAdmin(*http.Request) (AdminIdentity, error) {
+	return AdminIdentity{OrgID: "org-main", FleetID: "prod"}, nil
+}
+
 func (s rollbackClearFailureEmergencyStore) ClearRollbackAuthorization(context.Context, string) (bool, error) {
 	return false, s.err
 }
@@ -1628,15 +1677,10 @@ func newTestHandlerWithOptions(t *testing.T, store BundleStore, identity Followe
 		AuthorizeBundle: func(r *http.Request, _ conductor.PolicyBundle) error {
 			return publisher(r)
 		},
-		AuditSink:   discardAuditSink{},
-		AuditKeys:   rejectingAuditKeyResolver,
-		Enrollments: enrollments,
-		AuthorizeAdmin: func(r *http.Request) error {
-			if r.Header.Get("X-Pipelock-Admin") != "ok" {
-				return ErrPublisherForbidden
-			}
-			return nil
-		},
+		AuditSink:         discardAuditSink{},
+		AuditKeys:         rejectingAuditKeyResolver,
+		Enrollments:       enrollments,
+		AuthenticateAdmin: testAdminAuthenticator("X-Pipelock-Admin", "ok"),
 		EmergencyControls: mustEmergencyStore(t),
 		EmergencyKeys:     emergencyKeys,
 	})

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -28,6 +28,14 @@ func (erroringClearer) ClearRollbackAuthorization(context.Context, string) (bool
 	return false, errors.New("clear failed")
 }
 
+// A realistic store supports the bound clear. The handler refuses rather than
+// clearing unconditionally when it cannot bind the delete to the record the
+// scope check approved, so a double lacking this would exercise the refusal
+// path instead of the store-error path this case is written for.
+func (erroringClearer) ClearRollbackAuthorizationMatching(context.Context, string, string) (bool, error) {
+	return false, errors.New("clear failed")
+}
+
 func (erroringClearer) RollbackAuthorizationByID(context.Context, string) (StoredRollbackAuthorization, bool, error) {
 	return StoredRollbackAuthorization{Authorization: conductor.RollbackAuthorization{
 		OrgID: "org-main", FleetID: "prod",
@@ -181,6 +189,28 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 		}
 	})
 
+	// The scope check reads a record, and the delete happens in a separate
+	// store call. If the id is remapped in between, an unconditional delete
+	// removes the REPLACEMENT, which is a cross-tenant deletion the scope check
+	// appeared to have prevented. The store binds the delete to the record hash
+	// the caller authorised, so a swapped record is left alone.
+	t.Run("a record replaced between the scope check and the delete is not cleared", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		swapping := &swapOnReadStore{}
+		handler.emergencyControls = swapping
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"auth-victim"}`, true))
+
+		if swapping.clearedHash != "" && swapping.clearedHash != swapping.readHash {
+			t.Fatalf("cleared hash %q differs from the authorised hash %q, so a replacement record was deleted",
+				swapping.clearedHash, swapping.readHash)
+		}
+		if swapping.replacementRemoved {
+			t.Fatal("the replacement record was removed; the delete was not bound to the authorised record")
+		}
+	})
+
 	t.Run("clear error maps to 500", func(t *testing.T) {
 		handler := newTestHandler(t, mustStore(t), nil)
 		handler.emergencyControls = erroringClearer{}
@@ -190,4 +220,43 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 			t.Fatalf("status=%d body=%s, want 500", w.Code, w.Body.String())
 		}
 	})
+}
+
+// swapOnReadStore simulates the record being replaced between the handler's
+// scope-check read and its delete. It records the hash the handler authorised
+// and the hash it then asked to clear, so the test can assert the two agree
+// rather than asserting on a message.
+type swapOnReadStore struct {
+	failingEmergencyStore
+	readHash           string
+	clearedHash        string
+	replacementRemoved bool
+}
+
+func (s *swapOnReadStore) RollbackAuthorizationByID(context.Context, string) (StoredRollbackAuthorization, bool, error) {
+	s.readHash = "hash-victim"
+	return StoredRollbackAuthorization{
+		Authorization:     conductor.RollbackAuthorization{OrgID: "org-main", FleetID: "prod"},
+		AuthorizationHash: s.readHash,
+	}, true, nil
+}
+
+// The handler resolves the base clearer first, so a double lacking this never
+// reaches the bound path and every assertion about it passes vacuously. That
+// happened on the first attempt at this test.
+func (s *swapOnReadStore) ClearRollbackAuthorization(_ context.Context, _ string) (bool, error) {
+	s.replacementRemoved = true
+	return true, nil
+}
+
+func (s *swapOnReadStore) ClearRollbackAuthorizationMatching(_ context.Context, _ string, expectedHash string) (bool, error) {
+	s.clearedHash = expectedHash
+	// The id now resolves to a different organisation's record. A store that
+	// honours the binding must refuse; one that ignores it removes this.
+	const replacementHash = "hash-other-org"
+	if expectedHash != "" && expectedHash != replacementHash {
+		return false, nil
+	}
+	s.replacementRemoved = true
+	return true, nil
 }

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -28,6 +28,12 @@ func (erroringClearer) ClearRollbackAuthorization(context.Context, string) (bool
 	return false, errors.New("clear failed")
 }
 
+func (erroringClearer) RollbackAuthorizationByID(context.Context, string) (StoredRollbackAuthorization, bool, error) {
+	return StoredRollbackAuthorization{Authorization: conductor.RollbackAuthorization{
+		OrgID: "org-main", FleetID: "prod",
+	}}, true, nil
+}
+
 func clearRollbackRequest(body string, admin bool) *http.Request {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, RollbackAuthorizationsPath, strings.NewReader(body))
 	if admin {
@@ -66,6 +72,23 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"rollback-clear-ok"}`, true))
 		if w.Code != http.StatusNotFound {
 			t.Fatalf("second clear status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("cross-org authorization is hidden and not cleared", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		auth := signedTestRollback(t, "rollback-other-org", testNow, 100)
+		if _, created, err := handler.emergencyControls.PublishRollbackAuthorization(t.Context(), auth, testNow); err != nil || !created {
+			t.Fatalf("PublishRollbackAuthorization() created=%v err=%v, want created", created, err)
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"rollback-other-org"}`, true))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("cross-org clear status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+		reader := handler.emergencyControls.(rollbackAuthorizationByIDReader)
+		if _, found, err := reader.RollbackAuthorizationByID(t.Context(), "rollback-other-org"); err != nil || !found {
+			t.Fatalf("cross-org rollback missing after denied clear: found=%v err=%v", found, err)
 		}
 	})
 
@@ -143,7 +166,7 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 			Now:                func() time.Time { return testNow },
 			FollowerIdentity:   func(*http.Request) (FollowerIdentity, error) { return defaultFollowerIdentity(), nil },
 			AuthorizePublisher: func(*http.Request) error { return nil },
-			AuthorizeAdmin:     func(*http.Request) error { return nil },
+			AuthenticateAdmin:  allowTestAdmin,
 			AuditSink:          discardAuditSink{},
 			AuditKeys:          rejectingAuditKeyResolver,
 			EmergencyControls:  failingEmergencyStore{},

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -202,8 +202,14 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"auth-victim"}`, true))
 
-		if swapping.clearedHash != "" && swapping.clearedHash != swapping.readHash {
-			t.Fatalf("cleared hash %q differs from the authorised hash %q, so a replacement record was deleted",
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status=%d body=%s, want 404", w.Code, w.Body.String())
+		}
+		// Assert the bound call actually ran with the authorised hash. Checking
+		// only what was NOT deleted would also pass for a handler that skipped
+		// the clear altogether.
+		if swapping.clearedHash != swapping.readHash {
+			t.Fatalf("cleared hash %q differs from the authorised hash %q, so the bound clear did not run against the record the scope check approved",
 				swapping.clearedHash, swapping.readHash)
 		}
 		if swapping.replacementRemoved {

--- a/enterprise/conductor/controlplane/rollback_clear_handler_test.go
+++ b/enterprise/conductor/controlplane/rollback_clear_handler_test.go
@@ -211,6 +211,21 @@ func TestHandlerClearRollbackAuthorization(t *testing.T) {
 		}
 	})
 
+	// A store that can clear but cannot bind the clear to a specific record
+	// leaves the scope check defeatable by a concurrent replace, so the handler
+	// refuses instead of falling back to an unconditional delete. The fallback
+	// would be the vulnerability, which is why this path is a refusal rather
+	// than a warning.
+	t.Run("a store without the bound clear is refused", func(t *testing.T) {
+		handler := newTestHandler(t, mustStore(t), nil)
+		handler.emergencyControls = unboundClearer{}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, clearRollbackRequest(`{"authorization_id":"auth-victim"}`, true))
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("status=%d body=%s, want 501", w.Code, w.Body.String())
+		}
+	})
+
 	t.Run("clear error maps to 500", func(t *testing.T) {
 		handler := newTestHandler(t, mustStore(t), nil)
 		handler.emergencyControls = erroringClearer{}
@@ -259,4 +274,21 @@ func (s *swapOnReadStore) ClearRollbackAuthorizationMatching(_ context.Context, 
 	}
 	s.replacementRemoved = true
 	return true, nil
+}
+
+// unboundClearer can clear, and reports an in-scope record, but cannot bind the
+// delete to it. The handler must refuse rather than clear unconditionally.
+type unboundClearer struct {
+	failingEmergencyStore
+}
+
+func (unboundClearer) ClearRollbackAuthorization(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (unboundClearer) RollbackAuthorizationByID(context.Context, string) (StoredRollbackAuthorization, bool, error) {
+	return StoredRollbackAuthorization{
+		Authorization:     conductor.RollbackAuthorization{OrgID: "org-main", FleetID: "prod"},
+		AuthorizationHash: "hash-victim",
+	}, true, nil
 }

--- a/enterprise/conductor/controlplane/runtime_status_test.go
+++ b/enterprise/conductor/controlplane/runtime_status_test.go
@@ -745,15 +745,21 @@ func TestPublishPreflightBlocksUnsupportedAndOverridePublishes(t *testing.T) {
 		t.Fatalf("UpsertFollowerRuntimeStatus() error = %v", err)
 	}
 	handler := newRuntimeStatusTestHandler(t, enrollments, identity)
-	adminAuth, err := ScopedBearerAdminAuthorizer([]ScopedBearerCredential{{
-		Token: followerAdminToken,
-		Role:  RoleAdmin,
+	adminAuth, err := ScopedBearerAdminAuthenticator([]ScopedBearerCredential{{
+		Token:   followerAdminToken,
+		Role:    RoleAdmin,
+		OrgID:   identity.OrgID,
+		FleetID: identity.FleetID,
 	}})
 	if err != nil {
-		t.Fatalf("ScopedBearerAdminAuthorizer() error = %v", err)
+		t.Fatalf("ScopedBearerAdminAuthenticator() error = %v", err)
 	}
-	handler.authorizeFleetSkewOverride = func(r *http.Request, _ conductor.PolicyBundle, _ string) error {
-		return adminAuth(r)
+	handler.authorizeFleetSkewOverride = func(r *http.Request, bundle conductor.PolicyBundle, _ string) error {
+		admin, authErr := adminAuth(r)
+		if authErr != nil || !admin.Allows(bundle.OrgID, bundle.FleetID) {
+			return ErrPublisherForbidden
+		}
+		return nil
 	}
 	bundle := signedControlBundle(t, newTestSigner(t), bundleSpec{
 		id:       "bundle-1",


### PR DESCRIPTION
## What changed

The Conductor admin authorizer was constructed without an organization, so an admin credential authenticated for one org could act on any org. The publish authorizer built a few lines below it already carried both org and fleet scope, which made the gap easy to miss: the two sat adjacent with opposite scoping, and the admin constructor's name said scoped while the credential passed to it was not.

Authentication now returns the authenticated org and fleet identity, and every administrative operation proves its target falls inside that scope. This covers the whole class rather than the two operations that prompted the review: remote kill, rollback, rollback clear, both dry-run paths, enrollment create, list and revoke, and follower removal. A cross-scope clear or revoke returns not-found without mutating anything, so the response cannot be used to enumerate objects in another org.

This is a deliberate breaking change in two directions. The exported authorizer changes shape, and an administrative request that previously reached another organization now fails. A compatibility shim was considered and rejected because it would restore the gap it exists to close. No configuration change is required, since the admin org flag was already mandatory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Admin credentials now enforce organization and fleet scope for emergency controls, enrollment tokens, follower management, and fleet-skew overrides.
  * Requests targeting resources outside an administrator’s permitted scope are rejected.
  * Cross-scope rollback and enrollment-token operations return appropriate not-found or forbidden responses without modifying data.

* **Bug Fixes**
  * Improved rollback authorization lookup and handling for missing or inaccessible records.
  * Rollback records cannot be cleared when their stored authorization has been replaced.
  * Enrollment-token filtering now consistently respects administrator scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->