### PR TITLE
fix(sandbox): enforce the containment layers a launch actually applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ pipelock run --config pipelock.yaml --mcp-listen 127.0.0.1:8889 --mcp-upstream h
 
 ### Containment
 
-Unprivileged process containment uses OS-native primitives. Linux uses Landlock and network namespaces; `linux/amd64` also applies seccomp. Other Linux builds label the launch partial, and `--strict` refuses them. macOS uses `sandbox-exec` profiles. In containers, `--best-effort` keeps Landlock and, on `linux/amd64`, seccomp when namespace creation is restricted. Network scanning then uses proxy-based routing and may be bypassed by direct egress.
+Unprivileged process containment uses OS-native primitives. Linux uses Landlock and network namespaces; `linux/amd64` also applies seccomp. Other Linux builds label the launch partial while the network namespace is active, and `--strict` refuses them. macOS uses `sandbox-exec` profiles. In containers, `--best-effort` keeps Landlock and, on `linux/amd64`, seccomp when namespace creation is restricted. A launch without the namespace is labelled advisory-override regardless of architecture, because the missing namespace is the more serious gap: network scanning then uses proxy-based routing and may be bypassed by direct egress.
 
 ```bash
 pipelock sandbox --config pipelock.yaml -- python agent.py

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ pipelock run --config pipelock.yaml --mcp-listen 127.0.0.1:8889 --mcp-upstream h
 
 ### Containment
 
-Unprivileged process containment uses OS-native primitives. Linux uses Landlock, seccomp, and network namespaces. macOS uses `sandbox-exec` profiles. In containers, `--best-effort` keeps Landlock and seccomp when namespace creation is restricted, while network scanning uses proxy-based routing.
+Unprivileged process containment uses OS-native primitives. Linux uses Landlock and network namespaces; `linux/amd64` also applies seccomp. Other Linux builds label the launch partial, and `--strict` refuses them. macOS uses `sandbox-exec` profiles. In containers, `--best-effort` keeps Landlock and, on `linux/amd64`, seccomp when namespace creation is restricted. Network scanning then uses proxy-based routing and may be bypassed by direct egress.
 
 ```bash
 pipelock sandbox --config pipelock.yaml -- python agent.py

--- a/internal/cli/runtime/sandbox.go
+++ b/internal/cli/runtime/sandbox.go
@@ -40,18 +40,19 @@ func SandboxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sandbox [flags] -- COMMAND [ARGS...]",
 		Short: "Run a command in an unprivileged sandbox (Linux only)",
-		Long: `Runs a command with three layers of unprivileged containment:
+		Long: `Runs a command with up to three layers of unprivileged containment:
 
   - Landlock: restricts filesystem access (read, write, exec)
-  - seccomp: blocks dangerous syscalls (ptrace, mount, io_uring)
+  - seccomp (linux/amd64): blocks dangerous syscalls (ptrace, mount, io_uring)
   - Network namespace: isolates network (traffic routed through pipelock scanner)
 
 Agent HTTP/HTTPS traffic is routed through pipelock's full scanner pipeline
 (DLP, SSRF, blocklist, rate limiting, entropy analysis) via a bridge proxy.
 
 Use --best-effort inside containers where user namespace creation is blocked
-(e.g. Kubernetes with default seccomp). Landlock and seccomp are still applied;
-network scanning uses proxy-based routing instead of kernel-enforced isolation.
+(e.g. Kubernetes with default seccomp). Landlock remains mandatory. On
+linux/amd64, seccomp is also applied. Network scanning uses proxy-based routing
+instead of kernel-enforced isolation and may be bypassed by direct egress.
 
 Examples:
   pipelock sandbox -- python agent.py

--- a/internal/sandbox/child_init.go
+++ b/internal/sandbox/child_init.go
@@ -151,11 +151,12 @@ func RunInit() {
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] containment: %d/%d layers active\n", active, totalLayers)
 
-	// Strict mode: fail-closed if any layer is inactive.
-	if strict && active < totalLayers {
-		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] FATAL: strict mode requires all %d layers active, got %d\n", totalLayers, active)
+	outcome, outcomeErr := appliedLaunchOutcome(strict, noNetNS, seccompFilterSupportedByBuild(), llStatus, scStatus)
+	if outcomeErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] launch outcome: REFUSED: %v\n", outcomeErr)
 		exitSandboxProcess(1)
 	}
+	reportAppliedLaunchOutcome(os.Stderr, outcome)
 
 	// Mapped launches remain here until the parent has made itself
 	// non-dumpable. This gate covers both the direct exec below and bridge-mode

--- a/internal/sandbox/child_standalone_init.go
+++ b/internal/sandbox/child_standalone_init.go
@@ -236,11 +236,12 @@ func RunStandaloneInit() {
 	}
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] containment: %d/%d layers active\n", active, totalLayers)
 
-	// Strict mode: fail-closed if any layer is inactive.
-	if strict && active < totalLayers {
-		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] FATAL: strict mode requires all %d layers active, got %d\n", totalLayers, active)
+	outcome, outcomeErr := appliedLaunchOutcome(strict, noNetNS, seccompFilterSupportedByBuild(), llStatus, scStatus)
+	if outcomeErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "[sandbox] launch outcome: REFUSED: %v\n", outcomeErr)
 		exitSandboxProcess(1)
 	}
+	reportAppliedLaunchOutcome(os.Stderr, outcome)
 	_, _ = fmt.Fprintf(os.Stderr, "[sandbox] bridge proxy: %s → %s\n", bridge.Addr(), socketPath)
 
 	if useDeveloperEnvironment {

--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -1181,9 +1181,28 @@ func TestPreflight_ValidBestEffort(t *testing.T) {
 	if len(result.Layers) != 3 {
 		t.Errorf("expected 3 layers, got %d", len(result.Layers))
 	}
+	// The loop this replaces would have passed if Landlock were absent from
+	// the result entirely, because it only inspected layers that were present.
+	// Assert each flag by name, and assert the two that must stay optional as
+	// well, so a change that made everything required would also be caught.
+	required := map[LayerName]bool{}
 	for _, layer := range result.Layers {
-		if layer.Name == LayerLandlock && !layer.Required {
-			t.Error("normal sandbox preflight did not mark Landlock required")
+		required[layer.Name] = layer.Required
+	}
+	landlock, ok := required[LayerLandlock]
+	if !ok {
+		t.Fatalf("preflight result has no %s layer at all, so its required flag proves nothing", LayerLandlock)
+	}
+	if !landlock {
+		t.Errorf("normal sandbox preflight did not mark %s required", LayerLandlock)
+	}
+	for _, optional := range []LayerName{LayerNetNS, LayerSeccomp} {
+		flag, present := required[optional]
+		if !present {
+			t.Fatalf("preflight result has no %s layer", optional)
+		}
+		if flag {
+			t.Errorf("non-strict preflight marked %s required; only Landlock is mandatory outside strict mode", optional)
 		}
 	}
 }

--- a/internal/sandbox/coverage_deep_test.go
+++ b/internal/sandbox/coverage_deep_test.go
@@ -1175,11 +1175,16 @@ func TestPreflight_ValidBestEffort(t *testing.T) {
 	if result.Workspace != workspace {
 		t.Errorf("workspace = %q, want %q", result.Workspace, workspace)
 	}
-	if result.Mode != "best-effort" {
-		t.Errorf("mode = %q, want best-effort", result.Mode)
+	if result.Mode != "required" {
+		t.Errorf("mode = %q, want required", result.Mode)
 	}
 	if len(result.Layers) != 3 {
 		t.Errorf("expected 3 layers, got %d", len(result.Layers))
+	}
+	for _, layer := range result.Layers {
+		if layer.Name == LayerLandlock && !layer.Required {
+			t.Error("normal sandbox preflight did not mark Landlock required")
+		}
 	}
 }
 

--- a/internal/sandbox/helpers.go
+++ b/internal/sandbox/helpers.go
@@ -38,6 +38,15 @@ const noNetNSEnvKey = "__PIPELOCK_SANDBOX_NO_NETNS"
 // gate. sandbox-init consumes one byte before it can exec or start its target.
 const sandboxReadinessFDEnv = "__PIPELOCK_SANDBOX_READINESS_FD"
 
+type AppliedLaunchOutcome string
+
+const (
+	LaunchOutcomeFull             AppliedLaunchOutcome = "full"
+	LaunchOutcomePartial          AppliedLaunchOutcome = "partial"
+	LaunchOutcomeAdvisoryOverride AppliedLaunchOutcome = "advisory_override"
+	LaunchOutcomeRefused          AppliedLaunchOutcome = "refused"
+)
+
 // IsStrictMode returns true if the child process should enforce strict
 // sandbox containment (error on missing layers, private /dev/shm, etc.).
 func IsStrictMode() bool {
@@ -114,6 +123,38 @@ func countActive(layers ...LayerStatus) int {
 		}
 	}
 	return n
+}
+
+// appliedLaunchOutcome classifies only layers the child actually applied.
+// Capability probes are deliberately excluded: they cannot prove the launch.
+func appliedLaunchOutcome(strict, noNetNS, seccompSupported bool, landlock, seccomp LayerStatus) (AppliedLaunchOutcome, error) {
+	if !landlock.Active {
+		return LaunchOutcomeRefused, fmt.Errorf("landlock is required for sandbox filesystem containment; use a kernel with Landlock support or a separately labelled `pipelock contain` host boundary")
+	}
+	if !seccomp.Active && (strict || seccompSupported) {
+		return LaunchOutcomeRefused, fmt.Errorf("seccomp was not applied; refusing a launch whose build supports the filter")
+	}
+	if strict && noNetNS {
+		return LaunchOutcomeRefused, fmt.Errorf("strict mode requires a network namespace")
+	}
+	if noNetNS {
+		return LaunchOutcomeAdvisoryOverride, nil
+	}
+	if !seccomp.Active {
+		return LaunchOutcomePartial, nil
+	}
+	return LaunchOutcomeFull, nil
+}
+
+func reportAppliedLaunchOutcome(w io.Writer, outcome AppliedLaunchOutcome) {
+	switch outcome {
+	case LaunchOutcomeFull:
+		_, _ = fmt.Fprintln(w, "[sandbox] launch outcome: FULL (Landlock + seccomp + network namespace applied)")
+	case LaunchOutcomePartial:
+		_, _ = fmt.Fprintln(w, "[sandbox] launch outcome: PARTIAL (Landlock + network namespace applied; seccomp filter unavailable in this build)")
+	case LaunchOutcomeAdvisoryOverride:
+		_, _ = fmt.Fprintln(w, "[sandbox] launch outcome: ADVISORY-OVERRIDE (no network namespace; direct egress may bypass Pipelock)")
+	}
 }
 
 // removeEnvKey removes all entries with the given key from an env slice.

--- a/internal/sandbox/helpers_mode_test.go
+++ b/internal/sandbox/helpers_mode_test.go
@@ -222,3 +222,60 @@ func TestReportLayer_UnavailableNoErrorNoReason(t *testing.T) {
 		t.Errorf("got %q, want %q", got, expected)
 	}
 }
+
+func TestAppliedLaunchOutcome(t *testing.T) {
+	activeLandlock := LayerStatus{Name: LayerLandlock, Active: true}
+	activeSeccomp := LayerStatus{Name: LayerSeccomp, Active: true}
+	inactiveLandlock := LayerStatus{Name: LayerLandlock, Reason: "unavailable"}
+	inactiveSeccomp := LayerStatus{Name: LayerSeccomp, Reason: "unavailable"}
+
+	tests := []struct {
+		name             string
+		strict           bool
+		noNetNS          bool
+		seccompSupported bool
+		landlock         LayerStatus
+		seccomp          LayerStatus
+		want             AppliedLaunchOutcome
+		wantErr          bool
+	}{
+		{name: "full", landlock: activeLandlock, seccomp: activeSeccomp, seccompSupported: true, want: LaunchOutcomeFull},
+		{name: "arm64 partial", landlock: activeLandlock, seccomp: inactiveSeccomp, want: LaunchOutcomePartial},
+		{name: "network advisory override", noNetNS: true, landlock: activeLandlock, seccomp: activeSeccomp, seccompSupported: true, want: LaunchOutcomeAdvisoryOverride},
+		{name: "missing landlock refuses", landlock: inactiveLandlock, seccomp: activeSeccomp, seccompSupported: true, want: LaunchOutcomeRefused, wantErr: true},
+		{name: "unexpected seccomp failure refuses", landlock: activeLandlock, seccomp: inactiveSeccomp, seccompSupported: true, want: LaunchOutcomeRefused, wantErr: true},
+		{name: "strict arm64 refuses", strict: true, landlock: activeLandlock, seccomp: inactiveSeccomp, want: LaunchOutcomeRefused, wantErr: true},
+		{name: "strict network degrade refuses", strict: true, noNetNS: true, landlock: activeLandlock, seccomp: activeSeccomp, seccompSupported: true, want: LaunchOutcomeRefused, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := appliedLaunchOutcome(tt.strict, tt.noNetNS, tt.seccompSupported, tt.landlock, tt.seccomp)
+			if got != tt.want || (err != nil) != tt.wantErr {
+				t.Fatalf("appliedLaunchOutcome() = %q, %v; want %q, error=%v", got, err, tt.want, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReportAppliedLaunchOutcome(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		outcome AppliedLaunchOutcome
+		want    []string
+	}{
+		{name: "full", outcome: LaunchOutcomeFull, want: []string{"FULL", "Landlock + seccomp + network namespace applied"}},
+		{name: "partial", outcome: LaunchOutcomePartial, want: []string{"PARTIAL", "seccomp filter unavailable in this build"}},
+		{name: "advisory override", outcome: LaunchOutcomeAdvisoryOverride, want: []string{"ADVISORY-OVERRIDE", "direct egress may bypass Pipelock"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			reportAppliedLaunchOutcome(&buf, tt.outcome)
+			for _, want := range tt.want {
+				if got := buf.String(); !strings.Contains(got, want) {
+					t.Fatalf("outcome output = %q, want substring %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/sandbox/preflight.go
+++ b/internal/sandbox/preflight.go
@@ -53,7 +53,7 @@ type LayerProbe struct {
 func Preflight(workspace string, argv []string, policy *Policy, strict bool) PreflightResult {
 	return preflight(workspace, argv, policy, PreflightRequirements{
 		RequireNetNS:    strict,
-		RequireLandlock: strict,
+		RequireLandlock: true,
 		RequireSeccomp:  strict,
 	}, strict, false)
 }

--- a/internal/sandbox/standalone_test.go
+++ b/internal/sandbox/standalone_test.go
@@ -381,8 +381,8 @@ func TestPreflight_BackwardCompatibleStrictWrapper(t *testing.T) {
 	if result.Requirements != nil {
 		t.Fatalf("legacy Preflight exposed requirements = %#v", result.Requirements)
 	}
-	if result.Mode != "best-effort" {
-		t.Fatalf("legacy Preflight mode = %q, want best-effort", result.Mode)
+	if result.Mode != "required" {
+		t.Fatalf("legacy Preflight mode = %q, want required", result.Mode)
 	}
 }
 


### PR DESCRIPTION
## What changed

A sandbox launch reported which containment layers failed and then carried on. Only strict mode counted the layers and refused, so a normal launch could proceed after warning that the filesystem or syscall layer was missing, and the operator kept a sandbox that had lost a guarantee its name implies.

The child now classifies what it actually applied into four outcomes: full, partial, an explicit advisory override, and refused. Landlock must succeed for the normal Linux sandbox, because without it the process reads host files the sandbox claims to fence off, and a kernel too old to provide it gets a clear refusal rather than a warning. Strict mode requires all three layers. Explicit best-effort remains the availability valve for containers without user namespaces, and still says plainly that direct egress may bypass Pipelock.

The one architecture-shaped exception is `linux/arm64`, which this build has no seccomp implementation for. Refusing those launches would break a published target over a defence-in-depth gap, and calling them fully contained would be false, so they run in a state that is labelled partial. Preflight, command help and the README now describe the same behaviour the launcher enforces, and a preflight probe is never treated as evidence that the child applied anything.

Two additions were considered and left out. A reason and expiry on the best-effort override have no consumer today and add clock and configuration failure modes without adding containment. Writing child-applied outcomes into the signed receipt would need a versioned child-to-parent evidence channel first, because the parent emits receipt state before the child has proven which layers took effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sandbox launches now clearly report whether containment is **FULL**, **PARTIAL**, or **ADVISORY-OVERRIDE**.
  - Strict mode refuses to launch when required containment protections are unavailable.
  - Landlock remains required, while seccomp is applied on supported Linux `amd64` builds.
  - Best-effort launches retain available protections and clarify network-routing limitations.

- **Documentation**
  - Updated sandbox help and README guidance to explain platform-specific containment behavior and launch outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->