### PR TITLE
docs(manifest): say the proof field is a source reference, not proof

### DIFF
--- a/internal/capabilitymanifest/manifest.go
+++ b/internal/capabilitymanifest/manifest.go
@@ -88,24 +88,16 @@ type Gate struct {
 // GateFeature points at the enforcement selector and at a declaration that
 // names the feature constant.
 //
-// The Proof field is NOT proof. It is a source reference an auditor can follow,
-// and the name is a historical one this comment exists to contradict until the
-// field is renamed. Four review rounds tightened the check behind it and each
-// found the next way through, because the check reads the SHAPE of the code and
-// the field name promises something about its MEANING.
+// Proof is a source reference for an auditor to follow, not a proof of gating.
 //
-// What the check establishes: the referenced declaration exists, and it passes
-// something spelled like the feature constant to some call. What it cannot
-// establish, and must not be read as establishing: that the identifier resolves
-// to the license package's constant rather than a local of the same spelling,
-// that the call does anything with it, that the result is tested, or that the
-// enforcement selector in the OTHER reference is bound to this feature. The two
-// references are checked independently and nothing connects them.
-//
-// Closing that gap needs binding resolution through go/types, not a stricter
-// spelling rule. Until someone decides that is worth a package load inside a
-// parity test, treat a passing check as evidence the reference is live, and
-// nothing more.
+// A passing check establishes that the referenced declaration exists and passes
+// something spelled like the feature constant to a call. It does not establish
+// that the identifier resolves to the license package's constant rather than a
+// local of the same spelling, that the call uses the value, that any result is
+// tested, or that the separately-checked enforcement selector names the same
+// feature. The two references are validated independently and nothing connects
+// them. Establishing any of that requires binding resolution through go/types
+// rather than a stricter spelling rule.
 //
 // Proof is often a dedicated license helper such as VerifyAgentsWithOptions,
 // but it does NOT have to be a separate declaration, and a feature whose

--- a/internal/capabilitymanifest/manifest.go
+++ b/internal/capabilitymanifest/manifest.go
@@ -88,12 +88,24 @@ type Gate struct {
 // GateFeature points at the enforcement selector and at a declaration that
 // names the feature constant.
 //
-// The two references are checked INDEPENDENTLY: the parity test looks for the
-// enforcement selector in one declaration and the feature constant in the
-// other, and nothing connects them. So proof shows the feature constant is
-// passed to a call in the referenced declaration; it does not establish that
-// this selector is bound to that feature, or that the declaration verifies
-// anything.
+// The Proof field is NOT proof. It is a source reference an auditor can follow,
+// and the name is a historical one this comment exists to contradict until the
+// field is renamed. Four review rounds tightened the check behind it and each
+// found the next way through, because the check reads the SHAPE of the code and
+// the field name promises something about its MEANING.
+//
+// What the check establishes: the referenced declaration exists, and it passes
+// something spelled like the feature constant to some call. What it cannot
+// establish, and must not be read as establishing: that the identifier resolves
+// to the license package's constant rather than a local of the same spelling,
+// that the call does anything with it, that the result is tested, or that the
+// enforcement selector in the OTHER reference is bound to this feature. The two
+// references are checked independently and nothing connects them.
+//
+// Closing that gap needs binding resolution through go/types, not a stricter
+// spelling rule. Until someone decides that is worth a package load inside a
+// parity test, treat a passing check as evidence the reference is live, and
+// nothing more.
 //
 // Proof is often a dedicated license helper such as VerifyAgentsWithOptions,
 // but it does NOT have to be a separate declaration, and a feature whose


### PR DESCRIPTION
## What changed

The capability manifest's `proof` field is a source reference an auditor can follow, and its name promises more than the check behind it can deliver. Four review rounds tightened that check and each found the next way through: it accepted the feature constant mentioned anywhere in a declaration, then passed to any call, then spelled with the license qualifier, and a local variable named `license` carrying a matching field still satisfies the last of those. In the other direction it began refusing truthful code that imports the license package under an alias or assigns the constant to a variable before using it.

Being wrong in both directions is the sign that the shape is wrong rather than the details. The check reads the syntax of the code while the field name makes a claim about its meaning, so each round closed one spelling and left the gap between the two untouched.

The comment now states what a passing check does establish, that the reference is live and passes something spelled like the feature constant to some call, and what it does not: that the identifier resolves to the license package rather than a local of the same spelling, that the call uses it, that any result is tested, or that the separately-checked enforcement reference names the same feature. Closing that needs binding resolution through the type checker rather than a stricter spelling rule, and the comment says so rather than leaving a reader to assume the current check already does it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how feature proof references should be interpreted.
  * Documented the limitations of shape-based checks and the need for independent enforcement validation.
  * Added guidance on binding resolution for establishing stronger guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->