### PR TITLE
fix(proxy): verify signed rule artifacts before release

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -891,6 +891,10 @@ response_scanning:
       reason: "opaque signed archive"
       added: "2026-07-04"
       expires: "2099-12-31"
+  authenticated_artifacts:      # exact signed rules artifacts verified by the proxy
+    - host: "pipelab.org"
+      path: "/rules/pipelock-community/bundle.yaml"
+      bundle_name: "pipelock-community"
   mcp_servers:                  # MCP response trust classes; default is untrusted/block
     - server: "analysis-server"
       trust: "reasoning"        # reasoning permits warn when action is warn; untrusted => block
@@ -910,6 +914,7 @@ response_scanning:
 | `size_exempt_scan_max_bytes` | `67108864` | Maximum bytes read into memory for one over-cap response from a `size_exempt_domains` host before the existing response scanners run. Exceeding this ceiling blocks fail-closed with no upstream bytes delivered. |
 | `size_exempt_scan_max_inflight_bytes` | `268435456` | Per-proxy-instance memory reservation budget for concurrent over-cap size-exempt scans. If a scan cannot reserve its ceiling immediately, the response blocks fail-closed instead of waiting. |
 | `unscannable_passthrough` | `[]` | Structured allowlist for deliberately unscannable opaque artifact responses. Matching entries stream unscanned and emit an audit warning plus an allow receipt on every use. Requires `host`, exact `paths`, non-textual `content_types`, `reason`, and non-expired `expires`; optional `added` documents the entry. The host must also match `size_exempt_domains`, the response must exceed the normal scan cap, include a positive `Content-Length`, and declare `Content-Disposition: attachment`. |
+| `authenticated_artifacts` | `[]` | Exact official signed rules artifacts which the forward proxy and decrypted CONNECT interceptor buffer and verify before bypassing only response prompt-injection matching. Each entry requires exact `host`, canonical non-root `path`, and signed `bundle_name`; no wildcard, prefix, query, userinfo, or non-default port matches. The proxy fetches the sidecar signature without forwarding caller credentials, refuses every redirect, verifies an embedded official Ed25519 key and the bundle identity, then records an audit event and artifact-labelled allow receipt. Any mismatch, redirect, oversized body, invalid signer/signature, or wrong bundle name blocks before upstream bytes reach the client. Request DLP, authority, SSRF, budgets, Browser Shield, and media policy remain active. Upgrade binaries before adding this field: older binaries reject unknown config fields. |
 | `mcp_servers` | `[]` | Per-MCP-server response trust classes keyed by `pipelock mcp proxy --server-name`. A server that is omitted, missing, or does not match an entry is treated as `untrusted` and blocks response-injection findings. A malformed entry is not a fallback: an unknown trust value, an invalid server name, or a duplicate entry fails config validation, so the configuration does not load. `reasoning` permits warn-and-forward only when `response_scanning.action` is `warn`; a stricter section action still applies. |
 | `patterns` | 33 built-in | Injection and state/control poisoning patterns |
 

--- a/docs/guides/siem-integration.md
+++ b/docs/guides/siem-integration.md
@@ -216,8 +216,9 @@ Operator lifecycle:
   skip). Preserve the corrupt pair for investigation first.
 - Revoke: remove `emit.forwarder.url` and restart Pipelock. The stopped worker
   leaves its state files for operator-controlled retention or deletion.
-- Approve changes: destination and state-path changes require a restart. Pipelock
-  validates them before the new worker starts.
+- Approve changes: all `emit` settings require a restart, including filters,
+  `instance_id`, webhook, syslog, OTLP, forwarder destinations, and state paths.
+  Pipelock validates the new settings before the replacement workers start.
 
 **Severity filtering:** Events below `min_severity` are silently dropped before
 reaching the sink. Set to `warn` for all security events (recommended), or

--- a/internal/config/authenticated_artifact_parity_test.go
+++ b/internal/config/authenticated_artifact_parity_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+func TestAuthenticatedArtifactBundleNameMatchesRulesContract(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"", "a", "ab", "abc", "a-b", "-abc", "abc-", "Abc", "a_b",
+		"a" + strings.Repeat("b", 62) + "c",
+		"a" + strings.Repeat("b", 63) + "c",
+	}
+	for _, name := range names {
+		cfg := config.Defaults()
+		cfg.ResponseScanning.AuthenticatedArtifacts = []config.AuthenticatedArtifactEntry{{
+			Host:       "rules.example",
+			Path:       "/rules/example/bundle.yaml",
+			BundleName: name,
+		}}
+		configAccepts := cfg.Validate() == nil
+		rulesAccepts := rules.ValidateBundleName(name) == nil
+		if configAccepts != rulesAccepts {
+			t.Errorf("bundle name %q: config accepts=%t, rules accepts=%t", name, configAccepts, rulesAccepts)
+		}
+	}
+}

--- a/internal/config/authenticated_artifact_test.go
+++ b/internal/config/authenticated_artifact_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAuthenticatedArtifactsConfigContract(t *testing.T) {
+	valid := AuthenticatedArtifactEntry{Host: "rules.example", Path: "/rules/pipelock-community/bundle.yaml", BundleName: "pipelock-community"}
+	for _, tc := range []struct {
+		name    string
+		entries []AuthenticatedArtifactEntry
+		want    string
+	}{
+		{"omitted", nil, ""}, {"valid", []AuthenticatedArtifactEntry{valid}, ""},
+		{"duplicate", []AuthenticatedArtifactEntry{valid, valid}, "duplicates"},
+		{"wildcard host", []AuthenticatedArtifactEntry{{Host: "*.example", Path: valid.Path, BundleName: valid.BundleName}}, "exact DNS"},
+		{"root path", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/", BundleName: valid.BundleName}}, "canonical non-root"},
+		{"encoded topology", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/rules/%2e%2e/x", BundleName: valid.BundleName}}, "canonical non-root"},
+		{"missing name", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path}}, "bundle_name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.ResponseScanning.AuthenticatedArtifacts = tc.entries
+			err := cfg.Validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("err=%v want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthenticatedArtifactsCloneAndCanonicalOrder(t *testing.T) {
+	a := AuthenticatedArtifactEntry{Host: "a.example", Path: "/rules/a/bundle.yaml", BundleName: "a"}
+	b := AuthenticatedArtifactEntry{Host: "b.example", Path: "/rules/b/bundle.yaml", BundleName: "b"}
+	cfg := Defaults()
+	cfg.ResponseScanning.AuthenticatedArtifacts = []AuthenticatedArtifactEntry{b, a}
+	clone := cfg.Clone()
+	clone.ResponseScanning.AuthenticatedArtifacts[0].Host = "changed.example"
+	if cfg.ResponseScanning.AuthenticatedArtifacts[0].Host != "b.example" {
+		t.Fatal("Clone aliased authenticated artifacts")
+	}
+	other := Defaults()
+	other.ResponseScanning.AuthenticatedArtifacts = []AuthenticatedArtifactEntry{a, b}
+	if cfg.CanonicalPolicyHash() != other.CanonicalPolicyHash() {
+		t.Fatal("entry order changed canonical policy hash")
+	}
+}

--- a/internal/config/authenticated_artifact_test.go
+++ b/internal/config/authenticated_artifact_test.go
@@ -45,6 +45,21 @@ func TestAuthenticatedArtifactsConfigContract(t *testing.T) {
 	}
 }
 
+func TestAuthenticatedArtifactsConfigNormalizesHost(t *testing.T) {
+	cfg := Defaults()
+	cfg.ResponseScanning.AuthenticatedArtifacts = []AuthenticatedArtifactEntry{{
+		Host:       "RULES.EXAMPLE.",
+		Path:       "/rules/pipelock-community/bundle.yaml",
+		BundleName: "pipelock-community",
+	}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.ResponseScanning.AuthenticatedArtifacts[0].Host; got != "rules.example" {
+		t.Fatalf("normalized host=%q want %q", got, "rules.example")
+	}
+}
+
 func TestAuthenticatedArtifactsCloneAndCanonicalOrder(t *testing.T) {
 	a := AuthenticatedArtifactEntry{Host: "a.example", Path: "/rules/a/bundle.yaml", BundleName: "aaa"}
 	b := AuthenticatedArtifactEntry{Host: "b.example", Path: "/rules/b/bundle.yaml", BundleName: "bbb"}

--- a/internal/config/authenticated_artifact_test.go
+++ b/internal/config/authenticated_artifact_test.go
@@ -60,4 +60,23 @@ func TestAuthenticatedArtifactsCloneAndCanonicalOrder(t *testing.T) {
 	if cfg.CanonicalPolicyHash() != other.CanonicalPolicyHash() {
 		t.Fatal("entry order changed canonical policy hash")
 	}
+	pathA := AuthenticatedArtifactEntry{Host: "rules.example", Path: "/rules/a/bundle.yaml", BundleName: "bundle-a"}
+	pathB := AuthenticatedArtifactEntry{Host: "rules.example", Path: "/rules/b/bundle.yaml", BundleName: "bundle-b"}
+	nameA := AuthenticatedArtifactEntry{Host: "same.example", Path: "/rules/bundle.yaml", BundleName: "bundle-a"}
+	nameB := AuthenticatedArtifactEntry{Host: "same.example", Path: "/rules/bundle.yaml", BundleName: "bundle-b"}
+	for _, tc := range []struct {
+		name    string
+		entries []AuthenticatedArtifactEntry
+		want    []AuthenticatedArtifactEntry
+	}{
+		{name: "path", entries: []AuthenticatedArtifactEntry{pathB, pathA}, want: []AuthenticatedArtifactEntry{pathA, pathB}},
+		{name: "bundle name", entries: []AuthenticatedArtifactEntry{nameB, nameA}, want: []AuthenticatedArtifactEntry{nameA, nameB}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := canonicalAuthenticatedArtifacts(tc.entries)
+			if got[0] != tc.want[0] || got[1] != tc.want[1] {
+				t.Fatalf("canonical order=%v want=%v", got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/config/authenticated_artifact_test.go
+++ b/internal/config/authenticated_artifact_test.go
@@ -15,12 +15,19 @@ func TestAuthenticatedArtifactsConfigContract(t *testing.T) {
 		entries []AuthenticatedArtifactEntry
 		want    string
 	}{
-		{"omitted", nil, ""}, {"valid", []AuthenticatedArtifactEntry{valid}, ""},
+		{"omitted", nil, ""},
+		{"valid", []AuthenticatedArtifactEntry{valid}, ""},
 		{"duplicate", []AuthenticatedArtifactEntry{valid, valid}, "duplicates"},
 		{"wildcard host", []AuthenticatedArtifactEntry{{Host: "*.example", Path: valid.Path, BundleName: valid.BundleName}}, "exact DNS"},
+		{"bad DNS label", []AuthenticatedArtifactEntry{{Host: "-rules.example", Path: valid.Path, BundleName: valid.BundleName}}, "host"},
+		{"non ASCII host", []AuthenticatedArtifactEntry{{Host: "rulés.example", Path: valid.Path, BundleName: valid.BundleName}}, "host"},
+		{"trailing DNS dot normalizes", []AuthenticatedArtifactEntry{{Host: "RULES.EXAMPLE.", Path: valid.Path, BundleName: valid.BundleName}}, ""},
 		{"root path", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/", BundleName: valid.BundleName}}, "canonical non-root"},
 		{"encoded topology", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/rules/%2e%2e/x", BundleName: valid.BundleName}}, "canonical non-root"},
+		{"encoded slash", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/rules%2fbundle.yaml", BundleName: valid.BundleName}}, "canonical non-root"},
 		{"missing name", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path}}, "bundle_name"},
+		{"invalid name uppercase", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "Pipelock-Community"}}, "bundle_name"},
+		{"invalid name edge hyphen", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "-pipelock"}}, "bundle_name"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := Defaults()

--- a/internal/config/authenticated_artifact_test.go
+++ b/internal/config/authenticated_artifact_test.go
@@ -26,6 +26,8 @@ func TestAuthenticatedArtifactsConfigContract(t *testing.T) {
 		{"encoded topology", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/rules/%2e%2e/x", BundleName: valid.BundleName}}, "canonical non-root"},
 		{"encoded slash", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: "/rules%2fbundle.yaml", BundleName: valid.BundleName}}, "canonical non-root"},
 		{"missing name", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path}}, "bundle_name"},
+		{"invalid name one character", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "a"}}, "bundle_name"},
+		{"invalid name two characters", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "ab"}}, "bundle_name"},
 		{"invalid name uppercase", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "Pipelock-Community"}}, "bundle_name"},
 		{"invalid name edge hyphen", []AuthenticatedArtifactEntry{{Host: valid.Host, Path: valid.Path, BundleName: "-pipelock"}}, "bundle_name"},
 	} {
@@ -44,8 +46,8 @@ func TestAuthenticatedArtifactsConfigContract(t *testing.T) {
 }
 
 func TestAuthenticatedArtifactsCloneAndCanonicalOrder(t *testing.T) {
-	a := AuthenticatedArtifactEntry{Host: "a.example", Path: "/rules/a/bundle.yaml", BundleName: "a"}
-	b := AuthenticatedArtifactEntry{Host: "b.example", Path: "/rules/b/bundle.yaml", BundleName: "b"}
+	a := AuthenticatedArtifactEntry{Host: "a.example", Path: "/rules/a/bundle.yaml", BundleName: "aaa"}
+	b := AuthenticatedArtifactEntry{Host: "b.example", Path: "/rules/b/bundle.yaml", BundleName: "bbb"}
 	cfg := Defaults()
 	cfg.ResponseScanning.AuthenticatedArtifacts = []AuthenticatedArtifactEntry{b, a}
 	clone := cfg.Clone()

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -230,6 +230,7 @@ func (c *Config) policySemanticView() canonicalPolicyView {
 	view.A2AScanning.TrustedAgentCardKeys = canonicalA2ATrustedCardKeys(view.A2AScanning.TrustedAgentCardKeys)
 	view.ResponseScanning.SizeExemptDomains = sortedCopy(view.ResponseScanning.SizeExemptDomains)
 	view.ResponseScanning.UnscannablePassthrough = canonicalUnscannablePassthrough(view.ResponseScanning.UnscannablePassthrough)
+	view.ResponseScanning.AuthenticatedArtifacts = canonicalAuthenticatedArtifacts(view.ResponseScanning.AuthenticatedArtifacts)
 	view.ResponseScanning.MCPServers = canonicalMCPResponseServers(view.ResponseScanning.MCPServers)
 	view.FetchProxy.Monitoring.QueryEntropyParamExclusions = canonicalQueryEntropyParamExclusions(view.FetchProxy.Monitoring.QueryEntropyParamExclusions)
 	view.RequestBodyScanning.ContentEntropyExclusions = sortedCopy(view.RequestBodyScanning.ContentEntropyExclusions)
@@ -263,6 +264,23 @@ func (c *Config) policySemanticView() canonicalPolicyView {
 		guardView = &guard
 	}
 	return canonicalPolicyView{Config: view, Guard: guardView}
+}
+
+func canonicalAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) []AuthenticatedArtifactEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := append([]AuthenticatedArtifactEntry(nil), entries...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Host != out[j].Host {
+			return out[i].Host < out[j].Host
+		}
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].BundleName < out[j].BundleName
+	})
+	return out
 }
 
 func canonicalGuard(g Guard) Guard {

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -339,7 +339,12 @@ const (
 	// Re-bumped for provider-key left-boundary precision. The change prevents
 	// ordinary prose from being redacted or blocked, while deliberately losing
 	// detection for a key glued to a preceding token-alphabet character.
-	goldenHashDefaults = "372a8ac8fc647317f2878b78e019c94021dcaf30359d9149691d51a1083b4ff2"
+	// Re-bumped for response_scanning.authenticated_artifacts: the canonical
+	// view now carries the exact signed-artifact allowlist. It is
+	// policy-relevant because an entry lets the proxy release a verified
+	// official rules bundle with response injection matching skipped, so
+	// verifiers must observe the schema change through ph.
+	goldenHashDefaults = "975c1fc1b7554dd04fd7aea3df8cd421159c0c50fa0f89aa666660cd2e445a90"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -510,7 +515,11 @@ const (
 	// which the ops-field invariance test confirms by landing on this same
 	// hash.
 	// Re-bumped for provider-key left-boundary precision; see goldenHashDefaults.
-	goldenHashRichConfig = "ccc3ae30a36df4a01fb355913a60e438937edb693694d4e393836bccebab0128"
+	// Re-bumped for response_scanning.authenticated_artifacts: see
+	// goldenHashDefaults note above. The rich fixture omits the field, so the
+	// nil allowlist flows into ph identically to Defaults() and the hash
+	// shifts in lockstep.
+	goldenHashRichConfig = "e2e76982713a955b7275fff84ab4420fc23441706ccfb2fe26b50470230135fb"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -278,6 +278,9 @@ func (c *Config) Clone() *Config {
 	if c.ResponseScanning.UnscannablePassthrough != nil {
 		clone.ResponseScanning.UnscannablePassthrough = cloneUnscannablePassthrough(c.ResponseScanning.UnscannablePassthrough)
 	}
+	if c.ResponseScanning.AuthenticatedArtifacts != nil {
+		clone.ResponseScanning.AuthenticatedArtifacts = append([]AuthenticatedArtifactEntry(nil), c.ResponseScanning.AuthenticatedArtifacts...)
+	}
 	if c.Taint.TrustedMCPServers != nil {
 		clone.Taint.TrustedMCPServers = append([]string(nil), c.Taint.TrustedMCPServers...)
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -774,13 +774,22 @@ type ResponseScanning struct {
 	AskTimeoutSeconds              int                           `yaml:"ask_timeout_seconds"` // timeout for HITL prompt (default 30)
 	IncludeDefaults                *bool                         `yaml:"include_defaults"`    // nil/true: merge user patterns with defaults; false: user patterns only
 	Patterns                       []ResponseScanPattern         `yaml:"patterns"`
-	ExemptDomains                  []string                      `yaml:"exempt_domains"`                      // responses from these hosts skip injection scanning (DLP still applies)
-	SizeExemptDomains              []string                      `yaml:"size_exempt_domains"`                 // trusted hosts whose oversized responses get a larger bounded whole-buffer scan
-	SizeExemptScanMaxBytes         int                           `yaml:"size_exempt_scan_max_bytes"`          // per-response in-memory ceiling for over-cap size-exempt responses
-	SizeExemptScanMaxInflightBytes int                           `yaml:"size_exempt_scan_max_inflight_bytes"` // per-proxy-instance in-flight memory budget for size-exempt response scans
-	UnscannablePassthrough         []UnscannablePassthroughEntry `yaml:"unscannable_passthrough"`             // explicit audited stream-unscanned allowlist for opaque responses
-	SSEStreaming                   GenericSSEScanning            `yaml:"sse_streaming"`                       // generic text/event-stream inline scanning (LLM SSE)
-	MCPServers                     []MCPResponseServerTrust      `yaml:"mcp_servers"`                         // per-server MCP response trust overrides
+	ExemptDomains                  []string                      `yaml:"exempt_domains"`                                                   // responses from these hosts skip injection scanning (DLP still applies)
+	SizeExemptDomains              []string                      `yaml:"size_exempt_domains"`                                              // trusted hosts whose oversized responses get a larger bounded whole-buffer scan
+	SizeExemptScanMaxBytes         int                           `yaml:"size_exempt_scan_max_bytes"`                                       // per-response in-memory ceiling for over-cap size-exempt responses
+	SizeExemptScanMaxInflightBytes int                           `yaml:"size_exempt_scan_max_inflight_bytes"`                              // per-proxy-instance in-flight memory budget for size-exempt response scans
+	UnscannablePassthrough         []UnscannablePassthroughEntry `yaml:"unscannable_passthrough"`                                          // explicit audited stream-unscanned allowlist for opaque responses
+	AuthenticatedArtifacts         []AuthenticatedArtifactEntry  `yaml:"authenticated_artifacts" json:"authenticated_artifacts,omitempty"` // exact signed artifacts the proxy may release after its own verification
+	SSEStreaming                   GenericSSEScanning            `yaml:"sse_streaming"`                                                    // generic text/event-stream inline scanning (LLM SSE)
+	MCPServers                     []MCPResponseServerTrust      `yaml:"mcp_servers"`                                                      // per-server MCP response trust overrides
+}
+
+// AuthenticatedArtifactEntry identifies one official signed rule artifact.
+// It is deliberately an exact identity rather than a host or path prefix.
+type AuthenticatedArtifactEntry struct {
+	Host       string `yaml:"host"`
+	Path       string `yaml:"path"`
+	BundleName string `yaml:"bundle_name"`
 }
 
 type UnscannablePassthroughEntry struct {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -774,14 +774,14 @@ type ResponseScanning struct {
 	AskTimeoutSeconds              int                           `yaml:"ask_timeout_seconds"` // timeout for HITL prompt (default 30)
 	IncludeDefaults                *bool                         `yaml:"include_defaults"`    // nil/true: merge user patterns with defaults; false: user patterns only
 	Patterns                       []ResponseScanPattern         `yaml:"patterns"`
-	ExemptDomains                  []string                      `yaml:"exempt_domains"`                                                   // responses from these hosts skip injection scanning (DLP still applies)
-	SizeExemptDomains              []string                      `yaml:"size_exempt_domains"`                                              // trusted hosts whose oversized responses get a larger bounded whole-buffer scan
-	SizeExemptScanMaxBytes         int                           `yaml:"size_exempt_scan_max_bytes"`                                       // per-response in-memory ceiling for over-cap size-exempt responses
-	SizeExemptScanMaxInflightBytes int                           `yaml:"size_exempt_scan_max_inflight_bytes"`                              // per-proxy-instance in-flight memory budget for size-exempt response scans
-	UnscannablePassthrough         []UnscannablePassthroughEntry `yaml:"unscannable_passthrough"`                                          // explicit audited stream-unscanned allowlist for opaque responses
-	AuthenticatedArtifacts         []AuthenticatedArtifactEntry  `yaml:"authenticated_artifacts" json:"authenticated_artifacts,omitempty"` // exact signed artifacts the proxy may release after its own verification
-	SSEStreaming                   GenericSSEScanning            `yaml:"sse_streaming"`                                                    // generic text/event-stream inline scanning (LLM SSE)
-	MCPServers                     []MCPResponseServerTrust      `yaml:"mcp_servers"`                                                      // per-server MCP response trust overrides
+	ExemptDomains                  []string                      `yaml:"exempt_domains"`                      // responses from these hosts skip injection scanning (DLP still applies)
+	SizeExemptDomains              []string                      `yaml:"size_exempt_domains"`                 // trusted hosts whose oversized responses get a larger bounded whole-buffer scan
+	SizeExemptScanMaxBytes         int                           `yaml:"size_exempt_scan_max_bytes"`          // per-response in-memory ceiling for over-cap size-exempt responses
+	SizeExemptScanMaxInflightBytes int                           `yaml:"size_exempt_scan_max_inflight_bytes"` // per-proxy-instance in-flight memory budget for size-exempt response scans
+	UnscannablePassthrough         []UnscannablePassthroughEntry `yaml:"unscannable_passthrough"`             // explicit audited stream-unscanned allowlist for opaque responses
+	AuthenticatedArtifacts         []AuthenticatedArtifactEntry  `yaml:"authenticated_artifacts"`             // exact signed artifacts the proxy may release after its own verification
+	SSEStreaming                   GenericSSEScanning            `yaml:"sse_streaming"`                       // generic text/event-stream inline scanning (LLM SSE)
+	MCPServers                     []MCPResponseServerTrust      `yaml:"mcp_servers"`                         // per-server MCP response trust overrides
 }
 
 // AuthenticatedArtifactEntry identifies one official signed rule artifact.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1285,7 +1285,7 @@ func validateAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) error 
 		if entry.Host == "" || strings.ContainsAny(entry.Host, ":/*@") || net.ParseIP(entry.Host) != nil {
 			return fmt.Errorf("%s.host must be one exact DNS host without port or wildcard", field)
 		}
-		if entry.Path == "" || entry.Path == "/" || !strings.HasPrefix(entry.Path, "/") || path.Clean(entry.Path) != entry.Path || strings.Contains(entry.Path, "?") || strings.Contains(entry.Path, "#") {
+		if entry.Path == "" || entry.Path == "/" || !strings.HasPrefix(entry.Path, "/") || path.Clean(entry.Path) != entry.Path || strings.ContainsAny(entry.Path, "%?#;") || strings.ContainsAny(entry.Path, "\r\n\t") {
 			return fmt.Errorf("%s.path must be one canonical non-root path", field)
 		}
 		if entry.BundleName == "" || strings.TrimSpace(entry.BundleName) != entry.BundleName {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1225,6 +1225,9 @@ func (c *Config) validateResponseScanning(warnings *[]Warning) error {
 			return fmt.Errorf("response_scanning.unscannable_passthrough[%d].host %q must match response_scanning.size_exempt_domains", i, entry.Host)
 		}
 	}
+	if err := validateAuthenticatedArtifacts(c.ResponseScanning.AuthenticatedArtifacts); err != nil {
+		return err
+	}
 	if !c.ResponseScanning.Enabled && len(c.ResponseScanning.ExemptDomains) > 0 {
 		*warnings = append(*warnings, Warning{
 			Field:   "response_scanning.exempt_domains",
@@ -1269,6 +1272,30 @@ func (c *Config) validateResponseScanning(warnings *[]Warning) error {
 		if sse.MaxEventBytes < 0 {
 			return fmt.Errorf("response_scanning.sse_streaming.max_event_bytes must be >= 0 (0 means use default), got %d", sse.MaxEventBytes)
 		}
+	}
+	return nil
+}
+
+func validateAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) error {
+	seen := make(map[string]struct{}, len(entries))
+	for i := range entries {
+		entry := &entries[i]
+		field := fmt.Sprintf("response_scanning.authenticated_artifacts[%d]", i)
+		entry.Host = strings.ToLower(strings.TrimSpace(entry.Host))
+		if entry.Host == "" || strings.ContainsAny(entry.Host, ":/*@") || net.ParseIP(entry.Host) != nil {
+			return fmt.Errorf("%s.host must be one exact DNS host without port or wildcard", field)
+		}
+		if entry.Path == "" || entry.Path == "/" || !strings.HasPrefix(entry.Path, "/") || path.Clean(entry.Path) != entry.Path || strings.Contains(entry.Path, "?") || strings.Contains(entry.Path, "#") {
+			return fmt.Errorf("%s.path must be one canonical non-root path", field)
+		}
+		if entry.BundleName == "" || strings.TrimSpace(entry.BundleName) != entry.BundleName {
+			return fmt.Errorf("%s.bundle_name is required", field)
+		}
+		key := entry.Host + "\x00" + entry.Path
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%s duplicates an earlier authenticated artifact", field)
+		}
+		seen[key] = struct{}{}
 	}
 	return nil
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1281,16 +1281,18 @@ func validateAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) error 
 	for i := range entries {
 		entry := &entries[i]
 		field := fmt.Sprintf("response_scanning.authenticated_artifacts[%d]", i)
-		entry.Host = strings.ToLower(strings.TrimSpace(entry.Host))
-		if entry.Host == "" || strings.ContainsAny(entry.Host, ":/*@") || net.ParseIP(entry.Host) != nil {
-			return fmt.Errorf("%s.host must be one exact DNS host without port or wildcard", field)
+		host, err := normalizeQueryEntropyParamHost(entry.Host)
+		if err != nil {
+			return fmt.Errorf("%s.host must be one exact registrable DNS host: %w", field, err)
 		}
-		if entry.Path == "" || entry.Path == "/" || !strings.HasPrefix(entry.Path, "/") || path.Clean(entry.Path) != entry.Path || strings.ContainsAny(entry.Path, "%?#;") || strings.ContainsAny(entry.Path, "\r\n\t") {
-			return fmt.Errorf("%s.path must be one canonical non-root path", field)
+		pathValue, err := normalizeQueryEntropyParamPath(entry.Path)
+		if err != nil {
+			return fmt.Errorf("%s.path must be one canonical non-root path: %w", field, err)
 		}
-		if entry.BundleName == "" || strings.TrimSpace(entry.BundleName) != entry.BundleName {
-			return fmt.Errorf("%s.bundle_name is required", field)
+		if !authenticatedArtifactBundleNameRE.MatchString(entry.BundleName) {
+			return fmt.Errorf("%s.bundle_name must be 3-64 lowercase alphanumeric characters or hyphens without edge hyphens", field)
 		}
+		entry.Host, entry.Path = host, pathValue
 		key := entry.Host + "\x00" + entry.Path
 		if _, ok := seen[key]; ok {
 			return fmt.Errorf("%s duplicates an earlier authenticated artifact", field)
@@ -1299,6 +1301,8 @@ func validateAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) error 
 	}
 	return nil
 }
+
+var authenticatedArtifactBundleNameRE = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{1,62}[a-z0-9])?$`)
 
 func hostMatchesResponseSizeExemptDomain(host string, domains []string) bool {
 	return hostMatchesPassthrough(host, domains)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1302,7 +1302,10 @@ func validateAuthenticatedArtifacts(entries []AuthenticatedArtifactEntry) error 
 	return nil
 }
 
-var authenticatedArtifactBundleNameRE = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{1,62}[a-z0-9])?$`)
+// Keep this syntax identical to the authoritative bundle-name contract in
+// internal/rules. Config cannot import that package because rules imports
+// config, so an external-package parity test pins the contract boundaries.
+var authenticatedArtifactBundleNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$`)
 
 func hostMatchesResponseSizeExemptDomain(host string, domains []string) bool {
 	return hostMatchesPassthrough(host, domains)

--- a/internal/proxy/authenticated_artifact.go
+++ b/internal/proxy/authenticated_artifact.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+type authenticatedArtifactResponse struct {
+	body []byte
+}
+
+func matchingAuthenticatedArtifact(req *http.Request, entries []config.AuthenticatedArtifactEntry) (config.AuthenticatedArtifactEntry, bool) {
+	if req == nil || req.Method != http.MethodGet || req.URL == nil || req.URL.Scheme != "https" || req.URL.User != nil || req.URL.RawQuery != "" || req.URL.Fragment != "" || req.URL.Port() != "" {
+		return config.AuthenticatedArtifactEntry{}, false
+	}
+	for _, entry := range entries {
+		if strings.EqualFold(req.URL.Hostname(), entry.Host) && req.URL.EscapedPath() == entry.Path {
+			return entry, true
+		}
+	}
+	return config.AuthenticatedArtifactEntry{}, false
+}
+
+// verifyAuthenticatedArtifact releases only exact operator-configured rule
+// artifacts which the proxy itself has verified against the embedded keyring.
+func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *http.Response, rt http.RoundTripper, entries []config.AuthenticatedArtifactEntry) (*authenticatedArtifactResponse, error) {
+	entry, ok := matchingAuthenticatedArtifact(req, entries)
+	if !ok {
+		return nil, nil
+	}
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil || resp.Request.URL.String() != req.URL.String() {
+		return nil, fmt.Errorf("authenticated artifact refused: redirect")
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("authenticated artifact refused: upstream status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, domrules.MaxBundleFileSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact read: %w", err)
+	}
+	if len(body) > domrules.MaxBundleFileSize {
+		return nil, fmt.Errorf("authenticated artifact refused: bundle exceeds %d bytes", domrules.MaxBundleFileSize)
+	}
+	sigURL := *req.URL
+	sigURL.Path += signing.SigExtension
+	sigURL.RawPath = ""
+	sigReq := req.Clone(ctx)
+	sigReq.URL, sigReq.RequestURI, sigReq.Body, sigReq.GetBody = &sigURL, "", nil, nil
+	sigReq.Host = ""
+	sigReq.Header = make(http.Header)
+	sigResp, err := rt.RoundTrip(sigReq)
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact signature fetch: %w", err)
+	}
+	defer sigResp.Body.Close() //nolint:errcheck // best effort
+	if sigResp.Request == nil || sigResp.Request.URL == nil || sigResp.Request.URL.String() != sigURL.String() || sigResp.StatusCode < http.StatusOK || sigResp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("authenticated artifact refused: signature redirect or status")
+	}
+	sigData, err := io.ReadAll(io.LimitReader(sigResp.Body, 4097))
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact signature read: %w", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigData)))
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact signature decode: %w", err)
+	}
+	result, err := domrules.VerifyBundleSignatureBytes(body, sig, domrules.TrustPolicy{TrustEmbeddedKeys: true})
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact signature verification: %w", err)
+	}
+	if result.Tier != domrules.TrustTierOfficial {
+		return nil, fmt.Errorf("authenticated artifact signature verification: signer is not official")
+	}
+	bundle, err := domrules.ParseBundle(body)
+	if err != nil {
+		return nil, fmt.Errorf("authenticated artifact parse: %w", err)
+	}
+	if bundle.Name != entry.BundleName {
+		return nil, fmt.Errorf("authenticated artifact identity mismatch: got %q, want %q", bundle.Name, entry.BundleName)
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return &authenticatedArtifactResponse{body: body}, nil
+}

--- a/internal/proxy/authenticated_artifact.go
+++ b/internal/proxy/authenticated_artifact.go
@@ -75,6 +75,9 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	if err != nil {
 		return nil, fmt.Errorf("authenticated artifact signature read: %w", err)
 	}
+	if len(sigData) > 4096 {
+		return nil, fmt.Errorf("authenticated artifact refused: signature exceeds 4096 bytes")
+	}
 	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigData)))
 	if err != nil {
 		return nil, fmt.Errorf("authenticated artifact signature decode: %w", err)
@@ -92,6 +95,9 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	}
 	if bundle.Name != entry.BundleName {
 		return nil, fmt.Errorf("authenticated artifact identity mismatch: got %q, want %q", bundle.Name, entry.BundleName)
+	}
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("authenticated artifact close upstream body: %w", err)
 	}
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 	return &authenticatedArtifactResponse{body: body}, nil

--- a/internal/proxy/authenticated_artifact.go
+++ b/internal/proxy/authenticated_artifact.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
@@ -35,11 +36,13 @@ func matchingAuthenticatedArtifact(req *http.Request, entries []config.Authentic
 
 // verifyAuthenticatedArtifact releases only exact operator-configured rule
 // artifacts which the proxy itself has verified against the embedded keyring.
-func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *http.Response, rt http.RoundTripper, entries []config.AuthenticatedArtifactEntry) (*authenticatedArtifactResponse, error) {
+func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *http.Response, rt http.RoundTripper, verificationTimeout time.Duration, entries []config.AuthenticatedArtifactEntry) (*authenticatedArtifactResponse, error) {
 	entry, ok := matchingAuthenticatedArtifact(req, entries)
 	if !ok {
 		return nil, nil
 	}
+	verifyCtx, cancel := context.WithTimeout(ctx, verificationTimeout)
+	defer cancel()
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
@@ -49,7 +52,7 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("authenticated artifact refused: upstream status %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, domrules.MaxBundleFileSize+1))
+	body, err := readAuthenticatedArtifactBody(verifyCtx, resp.Body, domrules.MaxBundleFileSize+1)
 	if err != nil {
 		return nil, fmt.Errorf("authenticated artifact read: %w", err)
 	}
@@ -59,7 +62,7 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	sigURL := *req.URL
 	sigURL.Path += signing.SigExtension
 	sigURL.RawPath = ""
-	sigReq := req.Clone(ctx)
+	sigReq := req.Clone(verifyCtx)
 	sigReq.URL, sigReq.RequestURI, sigReq.Body, sigReq.GetBody = &sigURL, "", nil, nil
 	sigReq.Host = ""
 	sigReq.Header = make(http.Header)
@@ -71,7 +74,7 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	if sigResp.Request == nil || sigResp.Request.URL == nil || sigResp.Request.URL.String() != sigURL.String() || sigResp.StatusCode < http.StatusOK || sigResp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("authenticated artifact refused: signature redirect or status")
 	}
-	sigData, err := io.ReadAll(io.LimitReader(sigResp.Body, 4097))
+	sigData, err := readAuthenticatedArtifactBody(verifyCtx, sigResp.Body, 4097)
 	if err != nil {
 		return nil, fmt.Errorf("authenticated artifact signature read: %w", err)
 	}
@@ -101,4 +104,17 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	}
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 	return &authenticatedArtifactResponse{body: body}, nil
+}
+
+func readAuthenticatedArtifactBody(ctx context.Context, body io.ReadCloser, limit int64) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stopClose := context.AfterFunc(ctx, func() { _ = body.Close() })
+	defer stopClose()
+	data, err := io.ReadAll(io.LimitReader(body, limit))
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	return data, err
 }

--- a/internal/proxy/authenticated_artifact.go
+++ b/internal/proxy/authenticated_artifact.go
@@ -22,7 +22,7 @@ type authenticatedArtifactResponse struct {
 }
 
 func matchingAuthenticatedArtifact(req *http.Request, entries []config.AuthenticatedArtifactEntry) (config.AuthenticatedArtifactEntry, bool) {
-	if req == nil || req.Method != http.MethodGet || req.URL == nil || req.URL.Scheme != "https" || req.URL.User != nil || req.URL.RawQuery != "" || req.URL.Fragment != "" || req.URL.Port() != "" {
+	if req == nil || req.Method != http.MethodGet || req.URL == nil || req.URL.Scheme != "https" || req.URL.User != nil || req.URL.RawQuery != "" || req.URL.Fragment != "" || (req.URL.Port() != "" && req.URL.Port() != "443") {
 		return config.AuthenticatedArtifactEntry{}, false
 	}
 	for _, entry := range entries {

--- a/internal/proxy/authenticated_artifact.go
+++ b/internal/proxy/authenticated_artifact.go
@@ -67,7 +67,7 @@ func verifyAuthenticatedArtifact(ctx context.Context, req *http.Request, resp *h
 	if err != nil {
 		return nil, fmt.Errorf("authenticated artifact signature fetch: %w", err)
 	}
-	defer sigResp.Body.Close() //nolint:errcheck // best effort
+	defer func() { _ = sigResp.Body.Close() }()
 	if sigResp.Request == nil || sigResp.Request.URL == nil || sigResp.Request.URL.String() != sigURL.String() || sigResp.StatusCode < http.StatusOK || sigResp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("authenticated artifact refused: signature redirect or status")
 	}

--- a/internal/proxy/authenticated_artifact_integration_test.go
+++ b/internal/proxy/authenticated_artifact_integration_test.go
@@ -89,6 +89,8 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 	priv := installArtifactOfficialKey(t)
 	goodBody := artifactBundle(testInjectionPayload)
 	goodSig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, goodBody)))
+	oversizedSSEBody := artifactBundle(strings.Repeat("a", 65*1024))
+	oversizedSSESig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, oversizedSSEBody)))
 
 	for _, tc := range []struct {
 		name        string
@@ -98,12 +100,16 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 		sigStatus   int
 		sigRedirect bool
 		contentType string
+		encoding    string
+		bodyLimit   int64
 		want        int
 		wantReason  blockreason.Reason
 	}{
 		{name: "no matching policy retains response scan", body: []byte(testInjectionPayload), want: http.StatusForbidden, wantReason: blockreason.PromptInjection},
 		{name: "valid official artifact bypasses only injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
 		{name: "valid official artifact bypasses SSE injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", want: http.StatusOK},
+		{name: "valid official SSE artifact keeps response size gate", policy: true, body: oversizedSSEBody, signature: oversizedSSESig, sigStatus: http.StatusOK, contentType: "text/event-stream", bodyLimit: 64 * 1024, want: http.StatusForbidden, wantReason: blockreason.ResponseSize},
+		{name: "valid official SSE artifact keeps compressed response gate", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", encoding: "gzip", want: http.StatusForbidden, wantReason: blockreason.CompressedResponse},
 		{name: "tampered body is blocked", policy: true, body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
 		{name: "invalid signature is blocked", policy: true, body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
 		{name: "missing signature is blocked", policy: true, body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
@@ -133,10 +139,15 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 				if contentType == "" {
 					contentType = "text/plain"
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{headerContentType: {contentType}}, Body: originalBody, Request: req}, nil
+				header := http.Header{headerContentType: {contentType}}
+				if tc.encoding != "" {
+					header.Set("Content-Encoding", tc.encoding)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: header, Body: originalBody, Request: req}, nil
 			})
 			logger := audit.NewNop()
 			p := newArtifactIntegrationProxy(t, cfg, logger, rt)
+			p.responseBodyLimit = tc.bodyLimit
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
 			w := httptest.NewRecorder()
 			p.handleForwardHTTP(w, req)

--- a/internal/proxy/authenticated_artifact_integration_test.go
+++ b/internal/proxy/authenticated_artifact_integration_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+	"github.com/luckyPipewrench/pipelock/internal/session"
+)
+
+const artifactIntegrationPath = "/rules/pipelock-community/bundle.yaml"
+
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func artifactBundle(bodySuffix string) []byte {
+	return []byte("format_version: 1\nname: pipelock-community\nversion: 2026.08.0\nauthor: test\ndescription: " + bodySuffix + "\nrules: []\n")
+}
+
+func installArtifactOfficialKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origDefault, origKeyring := domrules.DefaultKeyringHex, domrules.KeyringHex
+	domrules.DefaultKeyringHex, domrules.KeyringHex = hex.EncodeToString(pub), ""
+	t.Cleanup(func() { domrules.DefaultKeyringHex, domrules.KeyringHex = origDefault, origKeyring })
+	return priv
+}
+
+func artifactConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = nil
+	cfg.ResponseScanning.Enabled = true
+	cfg.ResponseScanning.Action = config.ActionBlock
+	cfg.ResponseScanning.AuthenticatedArtifacts = []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: artifactIntegrationPath, BundleName: "pipelock-community"}}
+	return cfg
+}
+
+func newArtifactIntegrationProxy(t *testing.T, cfg *config.Config, logger *audit.Logger, rt http.RoundTripper) *Proxy {
+	t.Helper()
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.client = &http.Client{Transport: rt}
+	t.Cleanup(p.Close)
+	return p
+}
+
+func artifactResponse(req *http.Request, status int, body []byte) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": {"text/plain"}}, Body: io.NopCloser(bytes.NewReader(body)), Request: req}
+}
+
+// TestForwardHTTPAuthenticatedArtifact_HandlerPath covers the actual forward
+// handler, including its response scanner and pre-release artifact verifier.
+func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
+	priv := installArtifactOfficialKey(t)
+	goodBody := artifactBundle(testInjectionPayload)
+	goodSig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, goodBody)))
+
+	for _, tc := range []struct {
+		name        string
+		policy      bool
+		body        []byte
+		signature   []byte
+		sigStatus   int
+		sigRedirect bool
+		want        int
+	}{
+		{name: "no matching policy retains response scan", body: []byte(testInjectionPayload), want: http.StatusForbidden},
+		{name: "valid official artifact bypasses only injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
+		{name: "tampered body is blocked", policy: true, body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "invalid signature is blocked", policy: true, body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "missing signature is blocked", policy: true, body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
+		{name: "signature redirect is blocked", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden},
+		{name: "oversized signature is blocked", policy: true, body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := artifactConfig()
+			if !tc.policy {
+				cfg.ResponseScanning.AuthenticatedArtifacts = nil
+			}
+			originalBody := &closeTrackingBody{Reader: bytes.NewReader(tc.body)}
+			rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if strings.HasSuffix(req.URL.Path, ".sig") {
+					responseReq := req
+					if tc.sigRedirect {
+						redirected := req.Clone(context.Background())
+						redirected.URL = &url.URL{Scheme: "https", Host: "rules.example", Path: "/other.sig"}
+						responseReq = redirected
+					}
+					return artifactResponse(responseReq, tc.sigStatus, tc.signature), nil
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/plain"}}, Body: originalBody, Request: req}, nil
+			})
+			logger := audit.NewNop()
+			p := newArtifactIntegrationProxy(t, cfg, logger, rt)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
+			w := httptest.NewRecorder()
+			p.handleForwardHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("status=%d want=%d body=%q", w.Code, tc.want, w.Body.String())
+			}
+			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
+				t.Fatal("blocked artifact bytes reached the client")
+			}
+			if tc.policy && !originalBody.closed {
+				t.Fatal("verified handler path did not close the upstream body")
+			}
+		})
+	}
+}
+
+// TestInterceptAuthenticatedArtifact_HandlerPath drives the decrypted CONNECT
+// handler itself rather than the verifier helper.
+func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
+	priv := installArtifactOfficialKey(t)
+	goodBody := artifactBundle(testInjectionPayload)
+	goodSig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, goodBody)))
+	for _, tc := range []struct {
+		name        string
+		body        []byte
+		signature   []byte
+		sigStatus   int
+		sigRedirect bool
+		want        int
+	}{
+		{name: "valid official artifact", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
+		{name: "tampered body", body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "invalid signature", body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "missing signature", body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
+		{name: "signature path mismatch", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden},
+		{name: "oversized signature", body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := artifactConfig()
+			cfg.AdaptiveEnforcement.Enabled = true
+			sc := scanner.MustNew(cfg)
+			t.Cleanup(sc.Close)
+			originalBody := &closeTrackingBody{Reader: bytes.NewReader(tc.body)}
+			rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if strings.HasSuffix(req.URL.Path, ".sig") {
+					responseReq := req
+					if tc.sigRedirect {
+						redirected := req.Clone(context.Background())
+						redirected.URL = &url.URL{Scheme: "https", Host: "rules.example", Path: "/other.sig"}
+						responseReq = redirected
+					}
+					return artifactResponse(responseReq, tc.sigStatus, tc.signature), nil
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/plain"}}, Body: originalBody, Request: req}, nil
+			})
+			rec := &artifactCleanRecorder{}
+			handler := newInterceptHandler(&InterceptContext{TargetHost: "rules.example", TargetPort: "443", Config: cfg, Scanner: sc, Logger: audit.NewNop(), Metrics: metrics.New(), ClientIP: testLoopbackIP, RequestID: "artifact-intercept", Agent: "test-agent", Recorder: rec}, rt)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("status=%d want=%d body=%q", w.Code, tc.want, w.Body.String())
+			}
+			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
+				t.Fatal("blocked artifact bytes reached the client")
+			}
+			if !originalBody.closed {
+				t.Fatal("intercept handler did not close the upstream body")
+			}
+			if tc.want == http.StatusOK && rec.cleanCalls != 0 {
+				t.Fatalf("verified artifact recorded %d clean adaptive events despite skipped injection scan", rec.cleanCalls)
+			}
+		})
+	}
+}
+
+type artifactCleanRecorder struct{ cleanCalls int }
+
+func (*artifactCleanRecorder) RecordSignal(session.SignalType, float64) (bool, string, string) {
+	return false, "", ""
+}
+func (r *artifactCleanRecorder) RecordClean(float64) { r.cleanCalls++ }
+func (*artifactCleanRecorder) EscalationLevel() int  { return 0 }
+func (*artifactCleanRecorder) ThreatScore() float64  { return 0 }
+
+func TestForwardHTTPAuthenticatedArtifact_EmitsLabelledAuditEvidence(t *testing.T) {
+	priv := installArtifactOfficialKey(t)
+	body := artifactBundle(testInjectionPayload)
+	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", logPath, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := newArtifactIntegrationProxy(t, artifactConfig(), logger, roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, ".sig") {
+			return artifactResponse(req, http.StatusOK, sig), nil
+		}
+		return artifactResponse(req, http.StatusOK, body), nil
+	}))
+	w := httptest.NewRecorder()
+	p.handleForwardHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	logger.Close()
+	logData, err := os.ReadFile(filepath.Clean(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "authenticated_artifact") {
+		t.Fatalf("artifact verification did not emit labelled audit evidence: %s", logData)
+	}
+}
+
+func TestForwardHTTPAuthenticatedArtifact_DoesNotDecayAdaptiveScore(t *testing.T) {
+	priv := installArtifactOfficialKey(t)
+	body := artifactBundle(testInjectionPayload)
+	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))
+	cfg := artifactConfig()
+	cfg.SessionProfiling.Enabled = true
+	cfg.AdaptiveEnforcement.Enabled = true
+	cfg.AdaptiveEnforcement.EscalationThreshold = 100
+	cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
+	p := newArtifactIntegrationProxy(t, cfg, audit.NewNop(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.HasSuffix(req.URL.Path, ".sig") {
+			return artifactResponse(req, http.StatusOK, sig), nil
+		}
+		return artifactResponse(req, http.StatusOK, body), nil
+	}))
+	sm := p.sessionMgrPtr.Load()
+	if sm == nil {
+		t.Fatal("session manager not initialized")
+	}
+	rec := sm.GetOrCreate("192.0.2.1")
+	rec.RecordSignal(session.SignalBlock, cfg.AdaptiveEnforcement.EscalationThreshold)
+	before := rec.ThreatScore()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	w := httptest.NewRecorder()
+	p.handleForwardHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if got := rec.ThreatScore(); got != before {
+		t.Fatalf("verified artifact decayed adaptive score from %v to %v despite skipped injection scan", before, got)
+	}
+}

--- a/internal/proxy/authenticated_artifact_integration_test.go
+++ b/internal/proxy/authenticated_artifact_integration_test.go
@@ -96,10 +96,12 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 		signature   []byte
 		sigStatus   int
 		sigRedirect bool
+		contentType string
 		want        int
 	}{
 		{name: "no matching policy retains response scan", body: []byte(testInjectionPayload), want: http.StatusForbidden},
 		{name: "valid official artifact bypasses only injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
+		{name: "valid official artifact bypasses SSE injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", want: http.StatusOK},
 		{name: "tampered body is blocked", policy: true, body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
 		{name: "invalid signature is blocked", policy: true, body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
 		{name: "missing signature is blocked", policy: true, body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
@@ -122,7 +124,11 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 					}
 					return artifactResponse(responseReq, tc.sigStatus, tc.signature), nil
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/plain"}}, Body: originalBody, Request: req}, nil
+				contentType := tc.contentType
+				if contentType == "" {
+					contentType = "text/plain"
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: originalBody, Request: req}, nil
 			})
 			logger := audit.NewNop()
 			p := newArtifactIntegrationProxy(t, cfg, logger, rt)
@@ -134,6 +140,9 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 			}
 			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
 				t.Fatal("blocked artifact bytes reached the client")
+			}
+			if tc.want == http.StatusOK && !bytes.Equal(w.Body.Bytes(), tc.body) {
+				t.Fatalf("released body=%q want exact verified body=%q", w.Body.Bytes(), tc.body)
 			}
 			if tc.policy && !originalBody.closed {
 				t.Fatal("verified handler path did not close the upstream body")
@@ -154,9 +163,11 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 		signature   []byte
 		sigStatus   int
 		sigRedirect bool
+		contentType string
 		want        int
 	}{
 		{name: "valid official artifact", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
+		{name: "valid official artifact with SSE content type", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", want: http.StatusOK},
 		{name: "tampered body", body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
 		{name: "invalid signature", body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
 		{name: "missing signature", body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
@@ -179,7 +190,11 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 					}
 					return artifactResponse(responseReq, tc.sigStatus, tc.signature), nil
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/plain"}}, Body: originalBody, Request: req}, nil
+				contentType := tc.contentType
+				if contentType == "" {
+					contentType = "text/plain"
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: originalBody, Request: req}, nil
 			})
 			rec := &artifactCleanRecorder{}
 			handler := newInterceptHandler(&InterceptContext{TargetHost: "rules.example", TargetPort: "443", Config: cfg, Scanner: sc, Logger: audit.NewNop(), Metrics: metrics.New(), ClientIP: testLoopbackIP, RequestID: "artifact-intercept", Agent: "test-agent", Recorder: rec}, rt)
@@ -191,6 +206,9 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 			}
 			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
 				t.Fatal("blocked artifact bytes reached the client")
+			}
+			if tc.want == http.StatusOK && !bytes.Equal(w.Body.Bytes(), tc.body) {
+				t.Fatalf("released body=%q want exact verified body=%q", w.Body.Bytes(), tc.body)
 			}
 			if !originalBody.closed {
 				t.Fatal("intercept handler did not close the upstream body")

--- a/internal/proxy/authenticated_artifact_integration_test.go
+++ b/internal/proxy/authenticated_artifact_integration_test.go
@@ -79,7 +79,7 @@ func newArtifactIntegrationProxy(t *testing.T, cfg *config.Config, logger *audit
 }
 
 func artifactResponse(req *http.Request, status int, body []byte) *http.Response {
-	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": {"text/plain"}}, Body: io.NopCloser(bytes.NewReader(body)), Request: req}
+	return &http.Response{StatusCode: status, Header: http.Header{headerContentType: {"text/plain"}}, Body: io.NopCloser(bytes.NewReader(body)), Request: req}
 }
 
 // TestForwardHTTPAuthenticatedArtifact_HandlerPath covers the actual forward
@@ -128,7 +128,7 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 				if contentType == "" {
 					contentType = "text/plain"
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: originalBody, Request: req}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{headerContentType: {contentType}}, Body: originalBody, Request: req}, nil
 			})
 			logger := audit.NewNop()
 			p := newArtifactIntegrationProxy(t, cfg, logger, rt)
@@ -194,7 +194,7 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 				if contentType == "" {
 					contentType = "text/plain"
 				}
-				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: originalBody, Request: req}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{headerContentType: {contentType}}, Body: originalBody, Request: req}, nil
 			})
 			rec := &artifactCleanRecorder{}
 			handler := newInterceptHandler(&InterceptContext{TargetHost: "rules.example", TargetPort: "443", Config: cfg, Scanner: sc, Logger: audit.NewNop(), Metrics: metrics.New(), ClientIP: testLoopbackIP, RequestID: "artifact-intercept", Agent: "test-agent", Recorder: rec}, rt)
@@ -290,5 +290,47 @@ func TestForwardHTTPAuthenticatedArtifact_DoesNotDecayAdaptiveScore(t *testing.T
 	}
 	if got := rec.ThreatScore(); got != before {
 		t.Fatalf("verified artifact decayed adaptive score from %v to %v despite skipped injection scan", before, got)
+	}
+}
+
+func TestForwardHTTPAdaptiveCleanRecordsOnlyScannedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        []byte
+	}{
+		{name: "buffered response", contentType: "text/plain", body: []byte("clean response")},
+		{name: "SSE response", contentType: "text/event-stream", body: []byte("data: clean response\n\n")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := artifactConfig()
+			cfg.ResponseScanning.AuthenticatedArtifacts = nil
+			cfg.SessionProfiling.Enabled = true
+			cfg.AdaptiveEnforcement.Enabled = true
+			cfg.AdaptiveEnforcement.EscalationThreshold = 100
+			cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
+			p := newArtifactIntegrationProxy(t, cfg, audit.NewNop(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{headerContentType: {tc.contentType}}, Body: io.NopCloser(bytes.NewReader(tc.body)), Request: req}, nil
+			}))
+			sm := p.sessionMgrPtr.Load()
+			if sm == nil {
+				t.Fatal("session manager not initialized")
+			}
+			clientIP := "192.0.2.1"
+			rec := sm.GetOrCreate(clientIP)
+			rec.RecordSignal(session.SignalBlock, cfg.AdaptiveEnforcement.EscalationThreshold)
+			before := rec.ThreatScore()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://clean.example/response", nil)
+			req.RemoteAddr = clientIP + ":1234"
+			w := httptest.NewRecorder()
+			p.handleForwardHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+			}
+			if got := rec.ThreatScore(); got >= before {
+				t.Fatalf("clean scanned response did not reduce adaptive score: before=%v after=%v", before, got)
+			}
+		})
 	}
 }

--- a/internal/proxy/authenticated_artifact_integration_test.go
+++ b/internal/proxy/authenticated_artifact_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
@@ -98,15 +99,16 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 		sigRedirect bool
 		contentType string
 		want        int
+		wantReason  blockreason.Reason
 	}{
-		{name: "no matching policy retains response scan", body: []byte(testInjectionPayload), want: http.StatusForbidden},
+		{name: "no matching policy retains response scan", body: []byte(testInjectionPayload), want: http.StatusForbidden, wantReason: blockreason.PromptInjection},
 		{name: "valid official artifact bypasses only injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
 		{name: "valid official artifact bypasses SSE injection scan", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", want: http.StatusOK},
-		{name: "tampered body is blocked", policy: true, body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
-		{name: "invalid signature is blocked", policy: true, body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
-		{name: "missing signature is blocked", policy: true, body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
-		{name: "signature redirect is blocked", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden},
-		{name: "oversized signature is blocked", policy: true, body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "tampered body is blocked", policy: true, body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "invalid signature is blocked", policy: true, body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "missing signature is blocked", policy: true, body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "signature redirect is blocked", policy: true, body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "oversized signature is blocked", policy: true, body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := artifactConfig()
@@ -116,6 +118,9 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 			originalBody := &closeTrackingBody{Reader: bytes.NewReader(tc.body)}
 			rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				if strings.HasSuffix(req.URL.Path, ".sig") {
+					if req.Context().Value(ctxKeyAgentConfig) != cfg {
+						t.Fatal("signature fetch lost the scanned outbound request context")
+					}
 					responseReq := req
 					if tc.sigRedirect {
 						redirected := req.Clone(context.Background())
@@ -137,6 +142,12 @@ func TestForwardHTTPAuthenticatedArtifact_HandlerPath(t *testing.T) {
 			p.handleForwardHTTP(w, req)
 			if w.Code != tc.want {
 				t.Fatalf("status=%d want=%d body=%q", w.Code, tc.want, w.Body.String())
+			}
+			if tc.wantReason != "" && w.Header().Get(blockreason.HeaderReason) != string(tc.wantReason) {
+				t.Fatalf("%s=%q want=%q", blockreason.HeaderReason, w.Header().Get(blockreason.HeaderReason), tc.wantReason)
+			}
+			if tc.wantReason == blockreason.EnvelopeVerifyFailed && w.Header().Get(blockreason.HeaderLayer) != "authenticated_artifact" {
+				t.Fatalf("%s=%q want authenticated_artifact", blockreason.HeaderLayer, w.Header().Get(blockreason.HeaderLayer))
 			}
 			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
 				t.Fatal("blocked artifact bytes reached the client")
@@ -165,14 +176,15 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 		sigRedirect bool
 		contentType string
 		want        int
+		wantReason  blockreason.Reason
 	}{
 		{name: "valid official artifact", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, want: http.StatusOK},
 		{name: "valid official artifact with SSE content type", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, contentType: "text/event-stream", want: http.StatusOK},
-		{name: "tampered body", body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden},
-		{name: "invalid signature", body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden},
-		{name: "missing signature", body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden},
-		{name: "signature path mismatch", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden},
-		{name: "oversized signature", body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden},
+		{name: "tampered body", body: artifactBundle("NEVER_RELEASE tampered"), signature: goodSig, sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "invalid signature", body: goodBody, signature: []byte("not-base64"), sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "missing signature", body: goodBody, sigStatus: http.StatusNotFound, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "signature path mismatch", body: goodBody, signature: goodSig, sigStatus: http.StatusOK, sigRedirect: true, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
+		{name: "oversized signature", body: goodBody, signature: bytes.Repeat([]byte("A"), 4097), sigStatus: http.StatusOK, want: http.StatusForbidden, wantReason: blockreason.EnvelopeVerifyFailed},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := artifactConfig()
@@ -203,6 +215,12 @@ func TestInterceptAuthenticatedArtifact_HandlerPath(t *testing.T) {
 			handler.ServeHTTP(w, req)
 			if w.Code != tc.want {
 				t.Fatalf("status=%d want=%d body=%q", w.Code, tc.want, w.Body.String())
+			}
+			if tc.wantReason != "" && w.Header().Get(blockreason.HeaderReason) != string(tc.wantReason) {
+				t.Fatalf("%s=%q want=%q", blockreason.HeaderReason, w.Header().Get(blockreason.HeaderReason), tc.wantReason)
+			}
+			if tc.wantReason == blockreason.EnvelopeVerifyFailed && w.Header().Get(blockreason.HeaderLayer) != "authenticated_artifact" {
+				t.Fatalf("%s=%q want authenticated_artifact", blockreason.HeaderLayer, w.Header().Get(blockreason.HeaderLayer))
 			}
 			if tc.want == http.StatusForbidden && strings.Contains(w.Body.String(), "NEVER_RELEASE") {
 				t.Fatal("blocked artifact bytes reached the client")
@@ -263,33 +281,39 @@ func TestForwardHTTPAuthenticatedArtifact_DoesNotDecayAdaptiveScore(t *testing.T
 	priv := installArtifactOfficialKey(t)
 	body := artifactBundle(testInjectionPayload)
 	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))
-	cfg := artifactConfig()
-	cfg.SessionProfiling.Enabled = true
-	cfg.AdaptiveEnforcement.Enabled = true
-	cfg.AdaptiveEnforcement.EscalationThreshold = 100
-	cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
-	p := newArtifactIntegrationProxy(t, cfg, audit.NewNop(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if strings.HasSuffix(req.URL.Path, ".sig") {
-			return artifactResponse(req, http.StatusOK, sig), nil
-		}
-		return artifactResponse(req, http.StatusOK, body), nil
-	}))
-	sm := p.sessionMgrPtr.Load()
-	if sm == nil {
-		t.Fatal("session manager not initialized")
-	}
-	rec := sm.GetOrCreate("192.0.2.1")
-	rec.RecordSignal(session.SignalBlock, cfg.AdaptiveEnforcement.EscalationThreshold)
-	before := rec.ThreatScore()
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
-	req.RemoteAddr = "192.0.2.1:1234"
-	w := httptest.NewRecorder()
-	p.handleForwardHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
-	}
-	if got := rec.ThreatScore(); got != before {
-		t.Fatalf("verified artifact decayed adaptive score from %v to %v despite skipped injection scan", before, got)
+	for _, contentType := range []string{"text/plain", "text/event-stream"} {
+		t.Run(contentType, func(t *testing.T) {
+			cfg := artifactConfig()
+			cfg.SessionProfiling.Enabled = true
+			cfg.AdaptiveEnforcement.Enabled = true
+			cfg.AdaptiveEnforcement.EscalationThreshold = 100
+			cfg.AdaptiveEnforcement.DecayPerCleanRequest = 0.5
+			p := newArtifactIntegrationProxy(t, cfg, audit.NewNop(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if strings.HasSuffix(req.URL.Path, ".sig") {
+					return artifactResponse(req, http.StatusOK, sig), nil
+				}
+				resp := artifactResponse(req, http.StatusOK, body)
+				resp.Header.Set(headerContentType, contentType)
+				return resp, nil
+			}))
+			sm := p.sessionMgrPtr.Load()
+			if sm == nil {
+				t.Fatal("session manager not initialized")
+			}
+			rec := sm.GetOrCreate("192.0.2.1")
+			rec.RecordSignal(session.SignalBlock, cfg.AdaptiveEnforcement.EscalationThreshold)
+			before := rec.ThreatScore()
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://rules.example"+artifactIntegrationPath, nil)
+			req.RemoteAddr = "192.0.2.1:1234"
+			w := httptest.NewRecorder()
+			p.handleForwardHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+			}
+			if got := rec.ThreatScore(); got != before {
+				t.Fatalf("verified artifact decayed adaptive score from %v to %v despite skipped injection scan", before, got)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/authenticated_artifact_test.go
+++ b/internal/proxy/authenticated_artifact_test.go
@@ -14,7 +14,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
@@ -24,7 +26,29 @@ type artifactRoundTripper func(*http.Request) (*http.Response, error)
 
 func (f artifactRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
+type blockingArtifactBody struct {
+	started chan struct{}
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingArtifactBody) Read([]byte) (int, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.closed
+	return 0, errors.New("body closed")
+}
+
+func (b *blockingArtifactBody) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
 func TestVerifyAuthenticatedArtifact_VerifiesBeforeReleaseAndStripsCallerHeaders(t *testing.T) {
+	const verificationTimeout = 30 * time.Second
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -35,20 +59,69 @@ func TestVerifyAuthenticatedArtifact_VerifiesBeforeReleaseAndStripsCallerHeaders
 	body := []byte("format_version: 1\nname: pipelock-community\nversion: 2026.08.0\nauthor: test\ndescription: test bundle\nrules: []\n")
 	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))
 	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
-	req := &http.Request{Method: http.MethodGet, URL: u, Header: http.Header{"Authorization": {"Bearer caller"}, "Cookie": {"session=caller"}}}
+	req := &http.Request{Method: http.MethodGet, URL: u, Header: http.Header{"Authorization": {"Bearer caller"}, "Cookie": {"session=caller"}, "Proxy-Authorization": {"Basic caller"}, "X-Api-Key": {"caller"}, "X-Custom": {"caller"}}}
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body)), Request: req}
 	rt := artifactRoundTripper(func(got *http.Request) (*http.Response, error) {
-		if got.Header.Get("Authorization") != "" || got.Header.Get("Cookie") != "" {
-			t.Fatalf("sidecar copied caller credentials: %v", got.Header)
+		if got.Method != http.MethodGet || got.URL.String() != u.String()+".sig" || got.URL.Scheme != "https" || got.URL.Host != "rules.example" || got.URL.Path != u.Path+".sig" || got.URL.Port() != "" || got.URL.User != nil || got.URL.RawQuery != "" || got.URL.Fragment != "" {
+			t.Fatalf("sidecar request = %s %v, want exact HTTPS GET %s.sig", got.Method, got.URL, u)
+		}
+		if got.Host != "" || got.RequestURI != "" || got.Body != nil || got.GetBody != nil || len(got.Header) != 0 {
+			t.Fatalf("sidecar retained caller request state: host=%q requestURI=%q body=%v getBodySet=%t headers=%v", got.Host, got.RequestURI, got.Body, got.GetBody != nil, got.Header)
+		}
+		deadline, ok := got.Context().Deadline()
+		if !ok {
+			t.Fatal("sidecar request has no verification deadline")
+		}
+		if remaining := time.Until(deadline); remaining <= 0 || remaining > verificationTimeout {
+			t.Fatalf("sidecar verification deadline remaining=%v", remaining)
 		}
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(sig)), Request: got}, nil
 	})
-	artifact, err := verifyAuthenticatedArtifact(context.Background(), req, resp, rt, []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: "/rules/pipelock-community/bundle.yaml", BundleName: "pipelock-community"}})
+	artifact, err := verifyAuthenticatedArtifact(context.Background(), req, resp, rt, verificationTimeout, []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: "/rules/pipelock-community/bundle.yaml", BundleName: "pipelock-community"}})
 	if err != nil {
 		t.Fatalf("verifyAuthenticatedArtifact() error: %v", err)
 	}
 	if artifact == nil || !bytes.Equal(artifact.body, body) {
 		t.Fatalf("verified artifact = %#v, want original bytes", artifact)
+	}
+}
+
+func TestVerifyAuthenticatedArtifact_HonorsEarlierCancellation(t *testing.T) {
+	u, err := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(artifactBundle("test"))), Request: req}
+	artifact, err := verifyAuthenticatedArtifact(ctx, req, resp, nil, 30*time.Second, []config.AuthenticatedArtifactEntry{{Host: u.Host, Path: u.Path, BundleName: "pipelock-community"}})
+	if !errors.Is(err, context.Canceled) || artifact != nil {
+		t.Fatalf("artifact=%v err=%v, want context cancellation", artifact, err)
+	}
+}
+
+func TestReadAuthenticatedArtifactBody_DeadlineClosesBlockedRead(t *testing.T) {
+	body := &blockingArtifactBody{started: make(chan struct{}), closed: make(chan struct{})}
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := readAuthenticatedArtifactBody(ctx, body, 4097)
+		result <- err
+	}()
+	select {
+	case <-body.started:
+	case <-time.After(time.Second):
+		t.Fatal("body read did not start")
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("read error=%v, want deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deadline did not close blocked artifact body")
 	}
 }
 
@@ -66,7 +139,7 @@ func TestVerifyAuthenticatedArtifact_FailsClosedForTamperAndRedirect(t *testing.
 		t.Run(tc.name, func(t *testing.T) {
 			artifact, err := verifyAuthenticatedArtifact(context.Background(), req, tc.resp, artifactRoundTripper(func(got *http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("bad"))), Request: got}, nil
-			}), entries)
+			}), 30*time.Second, entries)
 			if err == nil || artifact != nil {
 				t.Fatalf("artifact=%v err=%v, want fail closed", artifact, err)
 			}
@@ -194,7 +267,7 @@ func TestVerifyAuthenticatedArtifact_FailsClosedForVerifierErrors(t *testing.T) 
 			if tc.rt == nil && !tc.noSigFetch {
 				t.Fatal("test setup omitted a signature transport")
 			}
-			artifact, err := verifyAuthenticatedArtifact(t.Context(), req, tc.resp, tc.rt, entries)
+			artifact, err := verifyAuthenticatedArtifact(t.Context(), req, tc.resp, tc.rt, 30*time.Second, entries)
 			if err == nil || artifact != nil {
 				t.Fatalf("artifact=%v err=%v, want fail closed", artifact, err)
 			}

--- a/internal/proxy/authenticated_artifact_test.go
+++ b/internal/proxy/authenticated_artifact_test.go
@@ -140,17 +140,19 @@ func TestVerifyAuthenticatedArtifact_FailsClosedForVerifierErrors(t *testing.T) 
 		})
 	}
 	for _, tc := range []struct {
-		name string
-		resp *http.Response
-		rt   http.RoundTripper
+		name       string
+		resp       *http.Response
+		rt         http.RoundTripper
+		noSigFetch bool
 	}{
 		{
-			name: "default transport still rejects redirect",
-			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Request: &http.Request{URL: &url.URL{Scheme: "https", Host: u.Host, Path: "/other"}}},
+			name:       "default transport still rejects redirect",
+			resp:       &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Request: &http.Request{URL: &url.URL{Scheme: "https", Host: u.Host, Path: "/other"}}},
+			noSigFetch: true,
 		},
-		{name: "upstream status", resp: &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(bytes.NewReader(nil)), Request: req}},
-		{name: "bundle read", resp: &http.Response{StatusCode: http.StatusOK, Body: artifactErrorBody{readErr: errors.New("bundle read failed")}, Request: req}},
-		{name: "bundle too large", resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("x"), domrules.MaxBundleFileSize+1))), Request: req}},
+		{name: "upstream status", resp: &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(bytes.NewReader(nil)), Request: req}, noSigFetch: true},
+		{name: "bundle read", resp: &http.Response{StatusCode: http.StatusOK, Body: artifactErrorBody{readErr: errors.New("bundle read failed")}, Request: req}, noSigFetch: true},
+		{name: "bundle too large", resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("x"), domrules.MaxBundleFileSize+1))), Request: req}, noSigFetch: true},
 		{
 			name: "signature transport",
 			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(validBody)), Request: req},
@@ -189,7 +191,7 @@ func TestVerifyAuthenticatedArtifact_FailsClosedForVerifierErrors(t *testing.T) 
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() { _ = tc.resp.Body.Close() }()
-			if tc.rt == nil && tc.name != "default transport still rejects redirect" && tc.name != "upstream status" && tc.name != "bundle read" && tc.name != "bundle too large" {
+			if tc.rt == nil && !tc.noSigFetch {
 				t.Fatal("test setup omitted a signature transport")
 			}
 			artifact, err := verifyAuthenticatedArtifact(t.Context(), req, tc.resp, tc.rt, entries)

--- a/internal/proxy/authenticated_artifact_test.go
+++ b/internal/proxy/authenticated_artifact_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -92,5 +93,109 @@ func TestMatchingAuthenticatedArtifact_RejectsMethodQueryAndNonDefaultPort(t *te
 	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
 	if _, ok := matchingAuthenticatedArtifact(&http.Request{Method: http.MethodPost, URL: u}, entries); ok {
 		t.Fatal("matched non-GET request")
+	}
+}
+
+type artifactErrorBody struct {
+	readErr  error
+	closeErr error
+}
+
+func (b artifactErrorBody) Read([]byte) (int, error) { return 0, b.readErr }
+func (b artifactErrorBody) Close() error             { return b.closeErr }
+
+type artifactCloseErrorBody struct {
+	io.Reader
+	closeErr error
+}
+
+func (b artifactCloseErrorBody) Close() error { return b.closeErr }
+
+func TestVerifyAuthenticatedArtifact_FailsClosedForVerifierErrors(t *testing.T) {
+	priv := installArtifactOfficialKey(t)
+	validBody := artifactBundle("test")
+	validSig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, validBody)))
+	_, unofficialPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongNameBody := bytes.Replace(validBody, []byte("name: pipelock-community"), []byte("name: other-bundle"), 1)
+	u, err := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	entries := []config.AuthenticatedArtifactEntry{{Host: u.Host, Path: u.Path, BundleName: "pipelock-community"}}
+
+	signatureResponse := func(body io.ReadCloser) *http.Response {
+		sigURL := *u
+		sigURL.Path += ".sig"
+		sigReq := req.Clone(t.Context())
+		sigReq.URL = &sigURL
+		return &http.Response{StatusCode: http.StatusOK, Body: body, Request: sigReq}
+	}
+	signedTransport := func(sig []byte) http.RoundTripper {
+		return artifactRoundTripper(func(*http.Request) (*http.Response, error) {
+			return signatureResponse(io.NopCloser(bytes.NewReader(sig))), nil
+		})
+	}
+	for _, tc := range []struct {
+		name string
+		resp *http.Response
+		rt   http.RoundTripper
+	}{
+		{
+			name: "default transport still rejects redirect",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Request: &http.Request{URL: &url.URL{Scheme: "https", Host: u.Host, Path: "/other"}}},
+		},
+		{name: "upstream status", resp: &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(bytes.NewReader(nil)), Request: req}},
+		{name: "bundle read", resp: &http.Response{StatusCode: http.StatusOK, Body: artifactErrorBody{readErr: errors.New("bundle read failed")}, Request: req}},
+		{name: "bundle too large", resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("x"), domrules.MaxBundleFileSize+1))), Request: req}},
+		{
+			name: "signature transport",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(validBody)), Request: req},
+			rt:   artifactRoundTripper(func(*http.Request) (*http.Response, error) { return nil, errors.New("signature transport failed") }),
+		},
+		{
+			name: "signature read",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(validBody)), Request: req},
+			rt: artifactRoundTripper(func(*http.Request) (*http.Response, error) {
+				return signatureResponse(artifactErrorBody{readErr: errors.New("signature read failed")}), nil
+			}),
+		},
+		{
+			name: "untrusted signer",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(validBody)), Request: req},
+			rt:   signedTransport([]byte(base64.StdEncoding.EncodeToString(ed25519.Sign(unofficialPriv, validBody)))),
+		},
+		{
+			name: "bundle parse",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("not a bundle"))), Request: req},
+			rt: artifactRoundTripper(func(*http.Request) (*http.Response, error) {
+				body := []byte("not a bundle")
+				return signatureResponse(io.NopCloser(bytes.NewReader([]byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))))), nil
+			}),
+		},
+		{
+			name: "bundle identity",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(wrongNameBody)), Request: req},
+			rt:   signedTransport([]byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, wrongNameBody)))),
+		},
+		{
+			name: "upstream close",
+			resp: &http.Response{StatusCode: http.StatusOK, Body: artifactCloseErrorBody{Reader: bytes.NewReader(validBody), closeErr: errors.New("close failed")}, Request: req},
+			rt:   signedTransport(validSig),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() { _ = tc.resp.Body.Close() }()
+			if tc.rt == nil && tc.name != "default transport still rejects redirect" && tc.name != "upstream status" && tc.name != "bundle read" && tc.name != "bundle too large" {
+				t.Fatal("test setup omitted a signature transport")
+			}
+			artifact, err := verifyAuthenticatedArtifact(t.Context(), req, tc.resp, tc.rt, entries)
+			if err == nil || artifact != nil {
+				t.Fatalf("artifact=%v err=%v, want fail closed", artifact, err)
+			}
+		})
 	}
 }

--- a/internal/proxy/authenticated_artifact_test.go
+++ b/internal/proxy/authenticated_artifact_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+type artifactRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f artifactRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestVerifyAuthenticatedArtifact_VerifiesBeforeReleaseAndStripsCallerHeaders(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origDefault, origKeyring := domrules.DefaultKeyringHex, domrules.KeyringHex
+	domrules.DefaultKeyringHex, domrules.KeyringHex = hex.EncodeToString(pub), ""
+	t.Cleanup(func() { domrules.DefaultKeyringHex, domrules.KeyringHex = origDefault, origKeyring })
+	body := []byte("format_version: 1\nname: pipelock-community\nversion: 2026.08.0\nauthor: test\ndescription: test bundle\nrules: []\n")
+	sig := []byte(base64.StdEncoding.EncodeToString(ed25519.Sign(priv, body)))
+	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
+	req := &http.Request{Method: http.MethodGet, URL: u, Header: http.Header{"Authorization": {"Bearer caller"}, "Cookie": {"session=caller"}}}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body)), Request: req}
+	rt := artifactRoundTripper(func(got *http.Request) (*http.Response, error) {
+		if got.Header.Get("Authorization") != "" || got.Header.Get("Cookie") != "" {
+			t.Fatalf("sidecar copied caller credentials: %v", got.Header)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(sig)), Request: got}, nil
+	})
+	artifact, err := verifyAuthenticatedArtifact(context.Background(), req, resp, rt, []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: "/rules/pipelock-community/bundle.yaml", BundleName: "pipelock-community"}})
+	if err != nil {
+		t.Fatalf("verifyAuthenticatedArtifact() error: %v", err)
+	}
+	if artifact == nil || !bytes.Equal(artifact.body, body) {
+		t.Fatalf("verified artifact = %#v, want original bytes", artifact)
+	}
+}
+
+func TestVerifyAuthenticatedArtifact_FailsClosedForTamperAndRedirect(t *testing.T) {
+	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	entries := []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: u.Path, BundleName: "pipelock-community"}}
+	for _, tc := range []struct {
+		name string
+		resp *http.Response
+	}{
+		{name: "redirect", resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(nil)), Request: &http.Request{URL: &url.URL{Scheme: "https", Host: "rules.example", Path: "/other"}}}},
+		{name: "tamper", resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("not a bundle"))), Request: req}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, err := verifyAuthenticatedArtifact(context.Background(), req, tc.resp, artifactRoundTripper(func(got *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader([]byte("bad"))), Request: got}, nil
+			}), entries)
+			if err == nil || artifact != nil {
+				t.Fatalf("artifact=%v err=%v, want fail closed", artifact, err)
+			}
+		})
+	}
+}
+
+func TestMatchingAuthenticatedArtifact_RejectsMethodQueryAndNonDefaultPort(t *testing.T) {
+	entries := []config.AuthenticatedArtifactEntry{{Host: "rules.example", Path: "/rules/pipelock-community/bundle.yaml", BundleName: "pipelock-community"}}
+	for _, raw := range []string{
+		"https://rules.example/rules/pipelock-community/bundle.yaml?next=x",
+		"https://rules.example:444/rules/pipelock-community/bundle.yaml",
+		"https://rules.example/rules/pipelock-community/bundle.yaml/extra",
+	} {
+		u, _ := url.Parse(raw)
+		if _, ok := matchingAuthenticatedArtifact(&http.Request{Method: http.MethodGet, URL: u}, entries); ok {
+			t.Fatalf("matched unsafe URL %q", raw)
+		}
+	}
+	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
+	if _, ok := matchingAuthenticatedArtifact(&http.Request{Method: http.MethodPost, URL: u}, entries); ok {
+		t.Fatal("matched non-GET request")
+	}
+}

--- a/internal/proxy/authenticated_artifact_test.go
+++ b/internal/proxy/authenticated_artifact_test.go
@@ -85,6 +85,10 @@ func TestMatchingAuthenticatedArtifact_RejectsMethodQueryAndNonDefaultPort(t *te
 			t.Fatalf("matched unsafe URL %q", raw)
 		}
 	}
+	defaultPort, _ := url.Parse("https://rules.example:443/rules/pipelock-community/bundle.yaml")
+	if _, ok := matchingAuthenticatedArtifact(&http.Request{Method: http.MethodGet, URL: defaultPort}, entries); !ok {
+		t.Fatal("explicit HTTPS default port did not match")
+	}
 	u, _ := url.Parse("https://rules.example/rules/pipelock-community/bundle.yaml")
 	if _, ok := matchingAuthenticatedArtifact(&http.Request{Method: http.MethodPost, URL: u}, entries); ok {
 		t.Fatal("matched non-GET request")

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2096,7 +2096,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// buffers and verifies this exact response before allowing only injection
 	// matching to be skipped; all other response controls remain below.
 	fwdAuthenticatedArtifact := false
-	if artifact, artifactErr := verifyAuthenticatedArtifact(outReq.Context(), outReq, resp, p.client.Transport, cfg.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
+	if artifact, artifactErr := verifyAuthenticatedArtifact(outReq.Context(), outReq, resp, p.client.Transport, time.Duration(cfg.FetchProxy.TimeoutSeconds)*time.Second, cfg.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
 		p.logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
 		p.metrics.RecordBlocked(r.URL.Hostname(), "authenticated_artifact", time.Since(start), agentLabel)
 		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "forward", Method: r.Method, Target: targetURL, RequestID: requestID, Agent: agent}))
@@ -2359,13 +2359,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// lose image metadata stripping, audio/video blocks, and exposure
 	// events.
 	//
-	// SSE responses are excluded: the streaming branch above is the
-	// authoritative path for text/event-stream, and the exclusion here
-	// is defense-in-depth that protects SSE TTFB if future refactors
-	// reorder the blocks. MediaPolicy/BrowserShield have no work to do on
-	// text/event-stream payloads - both target images/audio/video/HTML
-	// content types.
-	if !fwdRespIsSSE &&
+	// Ordinary SSE responses are excluded: the streaming branch above is the
+	// authoritative path for text/event-stream. A verified artifact is already
+	// buffered, so it stays on this path for response-size and encoding controls;
+	// only its injection matching is skipped below.
+	if (!fwdRespIsSSE || fwdAuthenticatedArtifact) &&
 		(sc.ResponseScanningEnabled() || cfg.BrowserShield.Enabled || cfg.MediaPolicy.IsEnabled()) {
 		// Fail-closed on compressed responses: regex can't match compressed content.
 		if hasNonIdentityEncoding(resp.Header.Get("Content-Encoding")) {

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2269,9 +2269,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			outcomeStatus = strconv.Itoa(resp.StatusCode)
 			outcomeBytes = 0
 			outcomeReason = "complete"
-			if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
+			if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding && !fwdAuthenticatedArtifact {
 				forwardScope := adaptiveScopeForHost(r.URL.Hostname())
-				recordCleanForAdaptiveScope(forwardRec, forwardScope, &cfg.AdaptiveEnforcement, !fwdRespExempt, adaptiveRecoveryContext{
+				recordCleanForAdaptiveScope(forwardRec, forwardScope, &cfg.AdaptiveEnforcement, !fwdRespExempt && !fwdAuthenticatedArtifact, adaptiveRecoveryContext{
 					sessionKey: sessionKeyFor(agent, clientIP),
 					scope:      forwardScope,
 					reason:     adaptiveRecoveryClean,
@@ -2341,7 +2341,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		outcomeStatus = strconv.Itoa(resp.StatusCode)
 		outcomeBytes = written
 		outcomeReason = "complete"
-		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
+		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding && !fwdAuthenticatedArtifact {
 			recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), &cfg.AdaptiveEnforcement, false, adaptiveRecoveryContext{})
 		}
 		return
@@ -2825,9 +2825,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		if responseBudgetTruncated {
 			outcomeReason = "budget_truncated"
 		}
-		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
+		if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding && !fwdAuthenticatedArtifact {
 			forwardScope := adaptiveScopeForHost(r.URL.Hostname())
-			recordCleanForAdaptiveScope(forwardRec, forwardScope, &cfg.AdaptiveEnforcement, sc.ResponseScanningEnabled() && !responseBudgetTruncated && !fwdRespExempt, adaptiveRecoveryContext{
+			recordCleanForAdaptiveScope(forwardRec, forwardScope, &cfg.AdaptiveEnforcement, sc.ResponseScanningEnabled() && !responseBudgetTruncated && !fwdRespExempt && !fwdAuthenticatedArtifact, adaptiveRecoveryContext{
 				sessionKey: sessionKeyFor(agent, clientIP),
 				scope:      forwardScope,
 				reason:     adaptiveRecoveryClean,

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2106,6 +2106,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if artifact != nil {
 		fwdAuthenticatedArtifact = true
 		p.logger.LogAnomaly(actx, "authenticated_artifact", "official signed artifact verified before response release", 0)
+		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionAllow, Layer: "authenticated_artifact", Pattern: "official signed artifact verified before response release", Transport: "forward", Method: r.Method, Target: targetURL, RequestID: requestID, Agent: agent}))
 	}
 
 	responsePromptHit := false

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2096,11 +2096,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// buffers and verifies this exact response before allowing only injection
 	// matching to be skipped; all other response controls remain below.
 	fwdAuthenticatedArtifact := false
-	if artifact, artifactErr := verifyAuthenticatedArtifact(r.Context(), outReq, resp, p.client.Transport, cfg.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
+	if artifact, artifactErr := verifyAuthenticatedArtifact(outReq.Context(), outReq, resp, p.client.Transport, cfg.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
 		p.logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
 		p.metrics.RecordBlocked(r.URL.Hostname(), "authenticated_artifact", time.Since(start), agentLabel)
 		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "forward", Method: r.Method, Target: targetURL, RequestID: requestID, Agent: agent}))
-		writeBlockedError(w, blockInfoFor(blockreason.PromptInjection, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
+		writeBlockedError(w, blockInfoFor(blockreason.EnvelopeVerifyFailed, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
 		outcomeStatus, outcomeReason = strconv.Itoa(http.StatusForbidden), "authenticated_artifact"
 		return
 	} else if artifact != nil {
@@ -2874,7 +2874,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if responseBudgetTruncated {
 		outcomeReason = "budget_truncated"
 	}
-	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding {
+	if forwardRec != nil && cfg.AdaptiveEnforcement.Enabled && !hasFinding && !fwdAuthenticatedArtifact {
 		recordCleanForAdaptiveScope(forwardRec, adaptiveScopeForHost(r.URL.Hostname()), &cfg.AdaptiveEnforcement, false, adaptiveRecoveryContext{})
 	}
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2092,6 +2092,21 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer safeClose(resp.Body, "resp.Body", p.logger)
+	// An authenticated artifact is not a destination exemption. The proxy
+	// buffers and verifies this exact response before allowing only injection
+	// matching to be skipped; all other response controls remain below.
+	fwdAuthenticatedArtifact := false
+	if artifact, artifactErr := verifyAuthenticatedArtifact(r.Context(), outReq, resp, p.client.Transport, cfg.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
+		p.logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
+		p.metrics.RecordBlocked(r.URL.Hostname(), "authenticated_artifact", time.Since(start), agentLabel)
+		emitForwardReceipt(withForwardRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "forward", Method: r.Method, Target: targetURL, RequestID: requestID, Agent: agent}))
+		writeBlockedError(w, blockInfoFor(blockreason.PromptInjection, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
+		outcomeStatus, outcomeReason = strconv.Itoa(http.StatusForbidden), "authenticated_artifact"
+		return
+	} else if artifact != nil {
+		fwdAuthenticatedArtifact = true
+		p.logger.LogAnomaly(actx, "authenticated_artifact", "official signed artifact verified before response release", 0)
+	}
 
 	responsePromptHit := false
 	defer func() {
@@ -2650,7 +2665,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		// Response injection scanning: only runs when the scanner feature
 		// is enabled. Media policy above always runs when MediaPolicy
 		// is enabled, even if response scanning is off.
-		if sc.ResponseScanningEnabled() {
+		if sc.ResponseScanningEnabled() && !fwdAuthenticatedArtifact {
 			scanResult := sc.ScanResponseBodyWithSuppress(r.Context(), respBody, resp.Request.URL.String(), cfg.Suppress)
 			recordSuppressedResponseScanExempts(p.metrics, scanResult.SuppressedMatches, TransportForward)
 			if !scanResult.Clean {

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -2148,7 +2148,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// pipelock must never forward inspection-resistant bytes through a
 	// security boundary.
 	fwdRespIsSSE := HasSingleSSEContentType(resp.Header)
-	if fwdRespIsSSE {
+	if fwdRespIsSSE && !fwdAuthenticatedArtifact {
 		if sc.ResponseScanningEnabled() && fwdRespExempt {
 			p.logger.LogResponseScanExempt(actx, fwdRespHost)
 			p.metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportForward)

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1699,6 +1699,20 @@ func newInterceptHandler(
 			return
 		}
 		defer resp.Body.Close() //nolint:errcheck // response body
+		// The authenticated-artifact exception is verified at the proxy before
+		// bytes reach the client; it is not a route-level response exemption.
+		interceptAuthenticatedArtifact := false
+		if artifact, artifactErr := verifyAuthenticatedArtifact(r.Context(), r, resp, upstream, ic.Config.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
+			ic.Logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
+			ic.Metrics.RecordTLSResponseBlocked("authenticated_artifact")
+			_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "intercept", Method: r.Method, Target: targetURL, RequestID: ic.RequestID, Agent: ic.Agent}))
+			writeBlockedError(w, blockInfoFor(blockreason.PromptInjection, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
+			emitBlockedPostRoundTripOutcome(http.StatusForbidden, "authenticated_artifact")
+			return
+		} else if artifact != nil {
+			interceptAuthenticatedArtifact = true
+			ic.Logger.LogAnomaly(actx, "authenticated_artifact", "official signed artifact verified before response release", 0)
+		}
 
 		// Fail-closed on compressed responses: DLP regex can't match
 		// compressed content. Block rather than forward unscanned data.
@@ -2204,7 +2218,7 @@ func newInterceptHandler(
 			ic.Logger.LogResponseScanExempt(actx, r.URL.Hostname())
 			ic.Metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportConnect)
 		}
-		if ic.Scanner.ResponseScanningEnabled() {
+		if ic.Scanner.ResponseScanningEnabled() && !interceptAuthenticatedArtifact {
 			scanResult := ic.Scanner.ScanResponseBodyWithSuppress(r.Context(), respBody, r.URL.String(), ic.Config.Suppress)
 			recordSuppressedResponseScanExempts(ic.Metrics, scanResult.SuppressedMatches, TransportConnect)
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1702,7 +1702,7 @@ func newInterceptHandler(
 		// The authenticated-artifact exception is verified at the proxy before
 		// bytes reach the client; it is not a route-level response exemption.
 		interceptAuthenticatedArtifact := false
-		if artifact, artifactErr := verifyAuthenticatedArtifact(r.Context(), r, resp, upstream, ic.Config.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
+		if artifact, artifactErr := verifyAuthenticatedArtifact(r.Context(), r, resp, upstream, time.Duration(ic.Config.FetchProxy.TimeoutSeconds)*time.Second, ic.Config.ResponseScanning.AuthenticatedArtifacts); artifactErr != nil {
 			ic.Logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
 			ic.Metrics.RecordTLSResponseBlocked("authenticated_artifact")
 			_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "intercept", Method: r.Method, Target: targetURL, RequestID: ic.RequestID, Agent: ic.Agent}))

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -2330,7 +2330,7 @@ func newInterceptHandler(
 		// Record clean request for adaptive score decay. Only apply decay when no
 		// finding was detected; warn/strip paths indicate suspicious traffic and
 		// must not contribute to score decay.
-		if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding {
+		if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding && !interceptAuthenticatedArtifact {
 			ic.Recorder.RecordClean(ic.Config.AdaptiveEnforcement.DecayPerCleanRequest)
 		}
 

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1750,7 +1750,7 @@ func newInterceptHandler(
 		// scanning state, because pipelock must never forward
 		// inspection-resistant bytes through a security boundary.
 		interceptRespExempt := isResponseScanExempt(r.URL.Hostname(), ic.Config.ResponseScanning.ExemptDomains)
-		if HasSingleSSEContentType(resp.Header) {
+		if HasSingleSSEContentType(resp.Header) && !interceptAuthenticatedArtifact {
 			if ic.Scanner.ResponseScanningEnabled() && interceptRespExempt {
 				ic.Logger.LogResponseScanExempt(actx, r.URL.Hostname())
 				ic.Metrics.RecordResponseScanExempt(ExemptReasonDomain, TransportConnect)
@@ -1913,7 +1913,7 @@ func newInterceptHandler(
 					Outcome:           captureOutcome(config.ActionAllow, true),
 				})
 			}
-			if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding {
+			if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding && !interceptAuthenticatedArtifact {
 				ic.Recorder.RecordClean(ic.Config.AdaptiveEnforcement.DecayPerCleanRequest)
 			}
 			ic.Metrics.RecordAllowed(time.Since(reqStart), agentAnonymous)
@@ -1997,7 +1997,7 @@ func newInterceptHandler(
 						})
 					}
 					ic.Metrics.RecordAllowed(time.Since(reqStart), agentAnonymous)
-					if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding {
+					if ic.Recorder != nil && ic.Config.AdaptiveEnforcement.Enabled && !hasFinding && !interceptAuthenticatedArtifact {
 						ic.Recorder.RecordClean(ic.Config.AdaptiveEnforcement.DecayPerCleanRequest)
 					}
 					return

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1706,7 +1706,7 @@ func newInterceptHandler(
 			ic.Logger.LogBlocked(actx, "authenticated_artifact", artifactErr.Error())
 			ic.Metrics.RecordTLSResponseBlocked("authenticated_artifact")
 			_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionBlock, Layer: "authenticated_artifact", Pattern: artifactErr.Error(), Transport: "intercept", Method: r.Method, Target: targetURL, RequestID: ic.RequestID, Agent: ic.Agent}))
-			writeBlockedError(w, blockInfoFor(blockreason.PromptInjection, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
+			writeBlockedError(w, blockInfoFor(blockreason.EnvelopeVerifyFailed, "authenticated_artifact"), "blocked: authenticated artifact verification failed", http.StatusForbidden)
 			emitBlockedPostRoundTripOutcome(http.StatusForbidden, "authenticated_artifact")
 			return
 		} else if artifact != nil {

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -1712,6 +1712,7 @@ func newInterceptHandler(
 		} else if artifact != nil {
 			interceptAuthenticatedArtifact = true
 			ic.Logger.LogAnomaly(actx, "authenticated_artifact", "official signed artifact verified before response release", 0)
+			_ = interceptEmitReceipt(ic, withInterceptRedaction(receipt.EmitOpts{ActionID: actionID, Verdict: config.ActionAllow, Layer: "authenticated_artifact", Pattern: "official signed artifact verified before response release", Transport: "intercept", Method: r.Method, Target: targetURL, RequestID: ic.RequestID, Agent: ic.Agent}))
 		}
 
 		// Fail-closed on compressed responses: DLP regex can't match


### PR DESCRIPTION
## What changed

- Adds `response_scanning.authenticated_artifacts` for exact Rules bundle URLs. Pipelock verifies each detached signature with the embedded official key before the forward proxy or decrypted CONNECT path releases the body.
- Verification failures block before any artifact bytes reach the client. A verified artifact skips only response injection matching; it doesn't bypass request controls or other response checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration for trusted, signed response artifacts identified by host, path, and bundle name.
  - Verified official artifacts bypass response prompt-injection scanning after signature and identity checks.
  - Invalid, tampered, oversized, redirected, or untrusted artifacts are blocked with audit evidence.

- **Documentation**
  - Clarified that all emission settings and external sinks require a restart.
  - Documented startup-only sanitizer behavior and authenticated artifact configuration.

- **Bug Fixes**
  - Improved configuration validation, normalization, and consistent policy hashing for authenticated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->