### PR TITLE
feat(rules): export the reader schema contract

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -221,6 +221,20 @@ the `pattern.validator` field.
 | Injection pattern | `injection` | `response_scanning.patterns` |
 | Tool poison pattern | `tool-poison` | `mcp_tool_scanning` descriptions |
 
+### Machine-readable reader contract
+
+A release-stamped Pipelock binary can export the rule-bundle contract it enforces:
+
+```bash
+pipelock rules schema > pipelock-rule-schema.json
+```
+
+The JSON records the exact Pipelock version and source revision, accepted bundle formats, YAML fields,
+enum values, rule types, type-specific pattern fields, merge targets, and bundle action semantics. The
+command refuses to produce an unversioned contract when the build can't report its source revision.
+Consumers should pin output from an exact Pipelock artifact by digest instead of fetching a moving
+release during ordinary pull-request checks.
+
 ### Signing your bundle
 
 ```bash

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -152,6 +152,7 @@ func Cmd() *cobra.Command {
 		Long:  "Install, update, list, verify, diff, remove, and inspect rule bundles.",
 	}
 	cmd.AddCommand(
+		rulesSchemaCmd(),
 		rulesStatusCmd(),
 		rulesInstallCmd(),
 		rulesUpdateCmd(),

--- a/internal/cli/rules/schema.go
+++ b/internal/cli/rules/schema.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+func rulesSchemaCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "schema",
+		Short: "Export the rule-bundle reader contract as JSON",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !cliutil.HasExactBuildIdentity() {
+				return fmt.Errorf("export rule schema: exact build version and source revision are unavailable")
+			}
+			contract, err := domrules.BuildRuleSchemaContract(cliutil.Version, cliutil.GitCommit)
+			if err != nil {
+				return fmt.Errorf("export rule schema: %w", err)
+			}
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(contract); err != nil {
+				return fmt.Errorf("encode rule schema: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/rules/schema_test.go
+++ b/internal/cli/rules/schema_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
+)
+
+func TestRulesSchemaCommand(t *testing.T) {
+	originalVersion, originalCommit := cliutil.Version, cliutil.GitCommit
+	cliutil.Version = "3.5.0"
+	cliutil.GitCommit = "abcdef0123456789"
+	t.Cleanup(func() {
+		cliutil.Version = originalVersion
+		cliutil.GitCommit = originalCommit
+	})
+
+	root := testRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"rules", "schema"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("rules schema: %v", err)
+	}
+
+	var contract domrules.RuleSchemaContract
+	decoder := json.NewDecoder(&stdout)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&contract); err != nil {
+		t.Fatalf("decode schema output: %v", err)
+	}
+	if contract.Producer.Version != "3.5.0" || contract.Producer.SourceRevision != "abcdef0123456789" {
+		t.Fatalf("producer = %+v", contract.Producer)
+	}
+	if len(contract.Rule.Types) != 3 {
+		t.Fatalf("rule types = %d, want 3", len(contract.Rule.Types))
+	}
+}
+
+func TestRulesSchemaCommandRefusesUnknownRevision(t *testing.T) {
+	originalVersion, originalCommit := cliutil.Version, cliutil.GitCommit
+	cliutil.Version = "3.5.0"
+	cliutil.GitCommit = "unknown"
+	t.Cleanup(func() {
+		cliutil.Version = originalVersion
+		cliutil.GitCommit = originalCommit
+	})
+
+	root := testRootCmd()
+	root.SetArgs([]string{"rules", "schema"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "source revision are unavailable") {
+		t.Fatalf("rules schema error = %v", err)
+	}
+}
+
+func TestRulesSchemaCommandRefusesPartialBuildStamps(t *testing.T) {
+	originalVersion, originalCommit := cliutil.Version, cliutil.GitCommit
+	cliutil.Version = "0.0.0-dev.unknown"
+	cliutil.GitCommit = "abcdef0123456789"
+	t.Cleanup(func() {
+		cliutil.Version = originalVersion
+		cliutil.GitCommit = originalCommit
+	})
+
+	root := testRootCmd()
+	root.SetArgs([]string{"rules", "schema"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "exact build version") {
+		t.Fatalf("rules schema partial-stamp error = %v", err)
+	}
+}
+
+func TestRulesSchemaCommandReportsOutputFailure(t *testing.T) {
+	originalVersion, originalCommit := cliutil.Version, cliutil.GitCommit
+	cliutil.Version = "3.5.0"
+	cliutil.GitCommit = "abcdef0123456789"
+	t.Cleanup(func() {
+		cliutil.Version = originalVersion
+		cliutil.GitCommit = originalCommit
+	})
+
+	root := testRootCmd()
+	root.SetOut(schemaErrorWriter{})
+	root.SetArgs([]string{"rules", "schema"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "encode rule schema") {
+		t.Fatalf("rules schema output error = %v", err)
+	}
+}
+
+type schemaErrorWriter struct{}
+
+func (schemaErrorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("forced schema output failure")
+}

--- a/internal/cliutil/version.go
+++ b/internal/cliutil/version.go
@@ -37,6 +37,21 @@ func IsProductReleaseTag(tag string) bool {
 	return len(tag) <= MaxProductReleaseVersionLength+1 && productReleaseTagRE.MatchString(tag)
 }
 
+// HasExactBuildIdentity reports whether the running binary has both a
+// deliberately stamped version and source revision. Build-derived display
+// versions are useful for diagnostics, but they are not an artifact identity
+// contract when either build stamp is unavailable.
+func HasExactBuildIdentity() bool {
+	version := strings.TrimSpace(Version)
+	revision := strings.TrimSpace(GitCommit)
+	return version != "" &&
+		version != "unknown" &&
+		version != defaultVersion &&
+		!strings.HasPrefix(version, defaultVersion+".") &&
+		revision != "" &&
+		revision != "unknown"
+}
+
 // Build metadata, set at build time via ldflags. Defaults are used when
 // building with plain "go build" (without the Makefile).
 var (

--- a/internal/cliutil/version_test.go
+++ b/internal/cliutil/version_test.go
@@ -340,6 +340,41 @@ func TestIsProductReleaseTag(t *testing.T) {
 	}
 }
 
+func TestHasExactBuildIdentity(t *testing.T) {
+	originalVersion, originalCommit := Version, GitCommit
+	t.Cleanup(func() {
+		Version = originalVersion
+		GitCommit = originalCommit
+	})
+
+	tests := []struct {
+		name     string
+		version  string
+		commit   string
+		expected bool
+	}{
+		{name: "release stamps", version: "3.5.0", commit: "abcdef012345", expected: true},
+		{name: "described source stamps", version: "3.5.0-101-gabcdef0", commit: "abcdef0", expected: true},
+		{name: "missing version", commit: "abcdef012345"},
+		{name: "unknown version", version: "unknown", commit: "abcdef012345"},
+		{name: "default version", version: defaultVersion, commit: "abcdef012345"},
+		{name: "dirty default version", version: defaultVersion + ".dirty", commit: "abcdef012345"},
+		{name: "missing revision", version: "3.5.0"},
+		{name: "unknown revision", version: "3.5.0", commit: "unknown"},
+		{name: "whitespace unknown revision", version: "3.5.0", commit: " unknown "},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Version = test.version
+			GitCommit = test.commit
+			if got := HasExactBuildIdentity(); got != test.expected {
+				t.Fatalf("HasExactBuildIdentity() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
 // TestProductReleaseTag_PrereleaseAccepted guards the release-policy decision
 // that prerelease tags are valid product releases.
 func TestProductReleaseTag_PrereleaseAccepted(t *testing.T) {

--- a/internal/rules/bundle.go
+++ b/internal/rules/bundle.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/luckyPipewrench/pipelock/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -167,12 +167,6 @@ var bundleNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$`)
 var ruleIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,94}[a-z0-9]$`)
 
 // Valid enum sets for quick membership checks.
-var validRuleTypes = map[string]bool{
-	RuleTypeDLP:        true,
-	RuleTypeInjection:  true,
-	RuleTypeToolPoison: true,
-}
-
 var validStatuses = map[string]bool{
 	StatusExperimental: true,
 	StatusStable:       true,
@@ -190,11 +184,6 @@ var validConfidences = map[string]bool{
 	confidenceHigh:   true,
 	confidenceMedium: true,
 	confidenceLow:    true,
-}
-
-var validScanFields = map[string]bool{
-	scanFieldDescription: true,
-	scanFieldName:        true,
 }
 
 // ParseBundle unmarshals YAML data into a Bundle and validates it.
@@ -319,7 +308,8 @@ func validateRule(r *Rule, seen map[string]bool) error {
 	}
 	seen[r.ID] = true
 
-	if !validRuleTypes[r.Type] {
+	definition, ok := ruleTypeDefinitionFor(r.Type)
+	if !ok {
 		return fmt.Errorf("invalid type %q for rule %q", r.Type, r.ID)
 	}
 
@@ -343,7 +333,7 @@ func validateRule(r *Rule, seen map[string]bool) error {
 		return fmt.Errorf("invalid confidence %q for rule %q", r.Confidence, r.ID)
 	}
 
-	if err := validatePattern(&r.Pattern, r.Type, r.ID); err != nil {
+	if err := validatePattern(&r.Pattern, definition, r.ID); err != nil {
 		return err
 	}
 
@@ -351,7 +341,7 @@ func validateRule(r *Rule, seen map[string]bool) error {
 }
 
 // validatePattern validates a rule's pattern fields based on rule type.
-func validatePattern(p *RulePattern, ruleType, ruleID string) error {
+func validatePattern(p *RulePattern, definition ruleTypeDefinition, ruleID string) error {
 	if p.Regex == "" {
 		return fmt.Errorf("regex must not be empty for rule %q", ruleID)
 	}
@@ -365,22 +355,19 @@ func validatePattern(p *RulePattern, ruleType, ruleID string) error {
 	}
 
 	if p.Validator != "" {
-		if ruleType != RuleTypeDLP {
+		if len(definition.ValidatorValues) == 0 {
 			return fmt.Errorf("validator is only valid for %s rules (rule %q)", RuleTypeDLP, ruleID)
 		}
-		switch p.Validator {
-		case config.ValidatorLuhn, config.ValidatorMod97, config.ValidatorABA, config.ValidatorWIF:
-		default:
+		if !slices.Contains(definition.ValidatorValues, p.Validator) {
 			return fmt.Errorf("invalid validator %q for rule %q", p.Validator, ruleID)
 		}
 	}
 
 	// scan_field validation for tool-poison rules.
-	if ruleType == RuleTypeToolPoison {
+	if len(definition.ScanFieldValues) > 0 {
 		if p.ScanField == "" {
-			// Default to "description" if empty.
-			p.ScanField = scanFieldDescription
-		} else if !validScanFields[p.ScanField] {
+			p.ScanField = definition.DefaultScanField
+		} else if !slices.Contains(definition.ScanFieldValues, p.ScanField) {
 			return fmt.Errorf("invalid scan_field %q for rule %q (must be %q or %q)", p.ScanField, ruleID, scanFieldDescription, scanFieldName)
 		}
 	} else if p.ScanField != "" {

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -539,7 +539,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			return
 		}
 		if err := definition.Load(stagedCtx, bundle, r, patternName, nsID, &loaded); err != nil {
-			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassIntegrity})
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Official: official, Reason: err.Error(), Class: BundleErrorClassIntegrity})
 			return
 		}
 	}

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -121,6 +121,8 @@ type LoadedBundle struct {
 	Expired               bool // bundle is past expires_at but loaded in stale mode
 }
 
+type loadRuleFunc func(ctx *bundleExecCtx, bundle *Bundle, rule *Rule, patternName, namespacedID string, loaded *LoadedBundle) error
+
 // IntegrityErrors returns load failures that indicate installed-bundle
 // provenance or freshness integrity loss.
 func (r *LoadResult) IntegrityErrors() []BundleError {
@@ -482,49 +484,64 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 				bundle.Name, r.ID))
 		}
 
-		// Convert rule to config-compatible type.
-		switch r.Type {
-		case RuleTypeDLP:
-			ctx.Result.DLP = append(ctx.Result.DLP, config.DLPPattern{
-				Name:          patternName,
-				Regex:         r.Pattern.Regex,
-				Severity:      r.Severity,
-				Validator:     r.Pattern.Validator,
-				Bundle:        bundle.Name,
-				BundleVersion: bundle.Version,
+		definition, ok := ruleTypeDefinitionFor(r.Type)
+		if !ok || definition.Load == nil {
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{
+				Name:   dirName,
+				Reason: fmt.Sprintf("rule type %q has no runtime loader", r.Type),
+				Class:  BundleErrorClassIntegrity,
 			})
-			loaded.DLP++
-
-		case RuleTypeInjection:
-			ctx.Result.Injection = append(ctx.Result.Injection, config.ResponseScanPattern{
-				Name:          patternName,
-				Regex:         r.Pattern.Regex,
-				Bundle:        bundle.Name,
-				BundleVersion: bundle.Version,
-			})
-			loaded.Injection++
-
-		case RuleTypeToolPoison:
-			// Tool-poison regexes use case-insensitive matching.
-			compiled, err := regexp.Compile("(?i)" + r.Pattern.Regex)
-			if err != nil {
-				// Pattern was already validated by ParseBundle, but guard anyway.
-				continue
-			}
-			ctx.Result.ToolPoison = append(ctx.Result.ToolPoison, CompiledToolPoisonRule{
-				Name:          nsID,
-				RuleID:        nsID,
-				Re:            compiled,
-				ScanField:     r.Pattern.ScanField,
-				Bundle:        bundle.Name,
-				BundleVersion: bundle.Version,
-			})
-			loaded.ToolPoison++
+			return
+		}
+		if err := definition.Load(ctx, bundle, r, patternName, nsID, &loaded); err != nil {
+			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassIntegrity})
+			return
 		}
 	}
 
 	loaded.Rules = loaded.DLP + loaded.Injection + loaded.ToolPoison
 	ctx.Result.Loaded = append(ctx.Result.Loaded, loaded)
+}
+
+func loadDLPRule(ctx *bundleExecCtx, bundle *Bundle, rule *Rule, patternName, _ string, loaded *LoadedBundle) error {
+	ctx.Result.DLP = append(ctx.Result.DLP, config.DLPPattern{
+		Name:          patternName,
+		Regex:         rule.Pattern.Regex,
+		Severity:      rule.Severity,
+		Validator:     rule.Pattern.Validator,
+		Bundle:        bundle.Name,
+		BundleVersion: bundle.Version,
+	})
+	loaded.DLP++
+	return nil
+}
+
+func loadInjectionRule(ctx *bundleExecCtx, bundle *Bundle, rule *Rule, patternName, _ string, loaded *LoadedBundle) error {
+	ctx.Result.Injection = append(ctx.Result.Injection, config.ResponseScanPattern{
+		Name:          patternName,
+		Regex:         rule.Pattern.Regex,
+		Bundle:        bundle.Name,
+		BundleVersion: bundle.Version,
+	})
+	loaded.Injection++
+	return nil
+}
+
+func loadToolPoisonRule(ctx *bundleExecCtx, bundle *Bundle, rule *Rule, _ string, namespacedID string, loaded *LoadedBundle) error {
+	compiled, err := regexp.Compile("(?i)" + rule.Pattern.Regex)
+	if err != nil {
+		return fmt.Errorf("compile tool-poison rule %q after validation: %w", rule.ID, err)
+	}
+	ctx.Result.ToolPoison = append(ctx.Result.ToolPoison, CompiledToolPoisonRule{
+		Name:          namespacedID,
+		RuleID:        namespacedID,
+		Re:            compiled,
+		ScanField:     rule.Pattern.ScanField,
+		Bundle:        bundle.Name,
+		BundleVersion: bundle.Version,
+	})
+	loaded.ToolPoison++
+	return nil
 }
 
 // ReadBundleFile reads a bundle artifact with a stat-first size check.

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -390,6 +390,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: fmt.Sprintf("parse error: %v", err), Class: BundleErrorClassIntegrity})
 		return
 	}
+	bundleWarnings := make([]string, 0, 1)
 
 	// Check min_pipelock version requirement.
 	if err := CheckMinPipelock(bundle.MinPipelock, opts.PipelockVersion, opts.AllowUnversionedLoad); err != nil {
@@ -400,7 +401,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 		ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassIntegrity})
 		return
 	} else if warning != "" {
-		ctx.Result.Warnings = append(ctx.Result.Warnings, fmt.Sprintf("bundle %q: %s", bundle.Name, warning))
+		bundleWarnings = append(bundleWarnings, fmt.Sprintf("bundle %q: %s", bundle.Name, warning))
 	}
 
 	// Check pipelock-* name reservation: only official signers allowed.
@@ -460,7 +461,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			return
 		}
 		if fr.Expired {
-			ctx.Result.Warnings = append(ctx.Result.Warnings, fr.Message)
+			bundleWarnings = append(bundleWarnings, fr.Message)
 		}
 
 	}
@@ -469,7 +470,7 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 	// leak part of this bundle into the shared result or persisted state.
 	stagedCtx := &bundleExecCtx{
 		MinRank:        ctx.MinRank,
-		Result:         &LoadResult{},
+		Result:         &LoadResult{Warnings: bundleWarnings},
 		FreshnessState: cloneFreshnessState(ctx.FreshnessState),
 		Now:            ctx.Now,
 		Definitions:    ctx.Definitions,

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -41,6 +41,7 @@ type LoadOptions struct {
 	AllowStale           bool                // accept expired bundles with warning
 	TierKeyMapping       map[string]string   // tier → expected signing key fingerprint
 	saveFreshnessState   func(string, *FreshnessState) error
+	definitions          []ruleTypeDefinition
 }
 
 // StandardBundleName is the reserved name for the official standard pack.
@@ -257,6 +258,7 @@ func LoadBundles(rulesDir string, opts LoadOptions) *LoadResult {
 			Result:         result,
 			FreshnessState: freshnessState,
 			Now:            now,
+			Definitions:    opts.definitions,
 		}
 		for _, d := range dirs {
 			bundleDir := filepath.Join(rulesDir, d.Name())
@@ -322,6 +324,38 @@ type bundleExecCtx struct {
 	Result         *LoadResult
 	FreshnessState *FreshnessState
 	Now            time.Time
+	Definitions    []ruleTypeDefinition
+}
+
+func cloneFreshnessState(state *FreshnessState) *FreshnessState {
+	cloned := &FreshnessState{
+		HighestSeen: make(map[string]uint64),
+		FormatFloor: make(map[string]int),
+	}
+	if state == nil {
+		return cloned
+	}
+	cloned.Context = state.Context
+	cloned.Digest = state.Digest
+	for key, version := range state.HighestSeen {
+		cloned.HighestSeen[key] = version
+	}
+	for name, format := range state.FormatFloor {
+		cloned.FormatFloor[name] = format
+	}
+	return cloned
+}
+
+func (ctx *bundleExecCtx) ruleTypeDefinitionFor(ruleType string) (ruleTypeDefinition, bool) {
+	if ctx.Definitions == nil {
+		return ruleTypeDefinitionFor(ruleType)
+	}
+	for _, definition := range ctx.Definitions {
+		if definition.ID == ruleType {
+			return definition, true
+		}
+	}
+	return ruleTypeDefinition{}, false
 }
 
 // loadOneBundle loads a single bundle directory and appends results or errors.
@@ -429,10 +463,21 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			ctx.Result.Warnings = append(ctx.Result.Warnings, fr.Message)
 		}
 
-		// Record version for future rollback prevention.
-		RecordVersion(ctx.FreshnessState, bundle.Tier, bundle.Name, bundle.MonotonicVersion)
 	}
-	RecordFormat(ctx.FreshnessState, bundle.Name, bundle.FormatVersion)
+
+	// Stage every rule and freshness mutation so a later loader failure cannot
+	// leak part of this bundle into the shared result or persisted state.
+	stagedCtx := &bundleExecCtx{
+		MinRank:        ctx.MinRank,
+		Result:         &LoadResult{},
+		FreshnessState: cloneFreshnessState(ctx.FreshnessState),
+		Now:            ctx.Now,
+		Definitions:    ctx.Definitions,
+	}
+	if bundle.FormatVersion >= 2 {
+		RecordVersion(stagedCtx.FreshnessState, bundle.Tier, bundle.Name, bundle.MonotonicVersion)
+	}
+	RecordFormat(stagedCtx.FreshnessState, bundle.Name, bundle.FormatVersion)
 
 	// Filter and convert rules.
 	loaded := LoadedBundle{
@@ -479,12 +524,12 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 		}
 
 		if len(r.Pattern.ExemptDomains) > 0 {
-			ctx.Result.Warnings = append(ctx.Result.Warnings, fmt.Sprintf(
+			stagedCtx.Result.Warnings = append(stagedCtx.Result.Warnings, fmt.Sprintf(
 				"bundle %q rule %q sets pattern.exempt_domains, which is ignored; exemptions belong in the local pipelock config, not in a deny-only bundle",
 				bundle.Name, r.ID))
 		}
 
-		definition, ok := ruleTypeDefinitionFor(r.Type)
+		definition, ok := stagedCtx.ruleTypeDefinitionFor(r.Type)
 		if !ok || definition.Load == nil {
 			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{
 				Name:   dirName,
@@ -493,13 +538,18 @@ func loadOneBundle(bundleDir, dirName string, opts LoadOptions, ctx *bundleExecC
 			})
 			return
 		}
-		if err := definition.Load(ctx, bundle, r, patternName, nsID, &loaded); err != nil {
+		if err := definition.Load(stagedCtx, bundle, r, patternName, nsID, &loaded); err != nil {
 			ctx.Result.Errors = append(ctx.Result.Errors, BundleError{Name: dirName, Reason: err.Error(), Class: BundleErrorClassIntegrity})
 			return
 		}
 	}
 
 	loaded.Rules = loaded.DLP + loaded.Injection + loaded.ToolPoison
+	ctx.Result.DLP = append(ctx.Result.DLP, stagedCtx.Result.DLP...)
+	ctx.Result.Injection = append(ctx.Result.Injection, stagedCtx.Result.Injection...)
+	ctx.Result.ToolPoison = append(ctx.Result.ToolPoison, stagedCtx.Result.ToolPoison...)
+	ctx.Result.Warnings = append(ctx.Result.Warnings, stagedCtx.Result.Warnings...)
+	*ctx.FreshnessState = *stagedCtx.FreshnessState
 	ctx.Result.Loaded = append(ctx.Result.Loaded, loaded)
 }
 

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -277,6 +278,51 @@ func TestLoadBundlesFailedBundleIsAtomic(t *testing.T) {
 	}
 	if got := state.FormatFloor["z-success"]; got != 2 {
 		t.Fatalf("successful bundle format = %d, want 2", got)
+	}
+}
+
+func TestLoadBundlesOfficialLoaderFailureWarnsDegraded(t *testing.T) {
+	// Non-parallel: mutates keyring globals.
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	setupKeyring(t, pub)
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, StandardBundleName)
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	bundle := testBundle(StandardBundleName, []Rule{
+		testToolPoisonRule("forced-failure", confidenceHigh, StatusStable, scanFieldDescription),
+	})
+	writeSignedBundle(t, bundleDir, bundle, pub, priv)
+
+	definitions := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
+	for i := range definitions {
+		if definitions[i].ID == RuleTypeToolPoison {
+			definitions[i].Load = func(_ *bundleExecCtx, _ *Bundle, _ *Rule, _, _ string, _ *LoadedBundle) error {
+				return errors.New("forced official loader failure")
+			}
+		}
+	}
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+		definitions:     definitions,
+	})
+	if len(result.IntegrityErrors()) != 1 {
+		t.Fatalf("integrity errors = %+v, want one forced loader failure", result.IntegrityErrors())
+	}
+	if !result.IntegrityErrors()[0].Official {
+		t.Fatal("official loader failure was not classified as official")
+	}
+	if !slices.ContainsFunc(result.Warnings, func(warning string) bool {
+		return strings.Contains(warning, "DEGRADED: standard pack") && strings.Contains(warning, "forced official loader failure")
+	}) {
+		t.Fatalf("warnings = %q, want degraded standard-pack warning", result.Warnings)
 	}
 }
 

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -285,6 +285,37 @@ func TestLoadBundlesFailedBundleIsAtomic(t *testing.T) {
 	}
 }
 
+func TestLoadBundlesMissingRuntimeLoaderIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bundleDir := filepath.Join(dir, "missing-loader")
+	if err := os.MkdirAll(bundleDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	bundle := testBundle("missing-loader", []Rule{
+		testDLPRule("dlp-before-missing-loader", confidenceHigh, StatusStable),
+		testToolPoisonRule("missing-loader", scanFieldDescription),
+	})
+	writeUnsignedBundle(t, bundleDir, bundle)
+
+	definitions := slices.DeleteFunc(append([]ruleTypeDefinition(nil), ruleTypeDefinitions...), func(definition ruleTypeDefinition) bool {
+		return definition.ID == RuleTypeToolPoison
+	})
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+		definitions:     definitions,
+	})
+
+	if len(result.IntegrityErrors()) != 1 || !strings.Contains(result.IntegrityErrors()[0].Reason, "has no runtime loader") {
+		t.Fatalf("integrity errors = %+v, want missing runtime loader", result.IntegrityErrors())
+	}
+	if len(result.DLP) != 0 || len(result.Loaded) != 0 {
+		t.Fatalf("failed bundle leaked state: DLP=%+v loaded=%+v", result.DLP, result.Loaded)
+	}
+}
+
 func TestLoadBundlesOfficialLoaderFailureWarnsDegraded(t *testing.T) {
 	// Non-parallel: mutates keyring globals.
 	pub, priv, err := ed25519.GenerateKey(nil)

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -223,9 +223,10 @@ func TestLoadBundlesFailedBundleIsAtomic(t *testing.T) {
 	}
 	failing := testBundleV2("a-failing", TierCommunity, 7, []Rule{
 		testDLPRule("dlp-before-failure", confidenceHigh, StatusStable),
-		testToolPoisonRule("forced-failure", confidenceHigh, StatusStable, scanFieldDescription),
+		testToolPoisonRule("forced-failure", scanFieldDescription),
 	})
 	failing.KeyID = KeyFingerprint(pub)
+	failing.TestedThroughPipelock = "1.0.0"
 	writeSignedBundle(t, failingDir, failing, pub, priv)
 
 	successDir := filepath.Join(dir, "z-success")
@@ -262,6 +263,9 @@ func TestLoadBundlesFailedBundleIsAtomic(t *testing.T) {
 	if len(result.Loaded) != 1 || result.Loaded[0].Name != "z-success" {
 		t.Fatalf("loaded bundles = %+v, want only z-success", result.Loaded)
 	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %q, want none from failed bundle", result.Warnings)
+	}
 
 	state, err := LoadFreshnessState(dir)
 	if err != nil {
@@ -295,7 +299,7 @@ func TestLoadBundlesOfficialLoaderFailureWarnsDegraded(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	bundle := testBundle(StandardBundleName, []Rule{
-		testToolPoisonRule("forced-failure", confidenceHigh, StatusStable, scanFieldDescription),
+		testToolPoisonRule("forced-failure", scanFieldDescription),
 	})
 	writeSignedBundle(t, bundleDir, bundle, pub, priv)
 
@@ -384,15 +388,15 @@ func testInjectionRule(id, confidence string) Rule {
 }
 
 // testToolPoisonRule creates a valid tool-poison rule.
-func testToolPoisonRule(id, confidence, status, scanField string) Rule {
+func testToolPoisonRule(id, scanField string) Rule {
 	return Rule{
 		ID:          id,
 		Type:        RuleTypeToolPoison,
-		Status:      status,
+		Status:      StatusStable,
 		Name:        "Test Tool Poison Rule " + id,
 		Description: "Detects poisoned tool " + id,
 		Severity:    severityCritical,
-		Confidence:  confidence,
+		Confidence:  confidenceHigh,
 		Pattern:     RulePattern{Regex: `exec\s+curl`, ScanField: scanField},
 	}
 }
@@ -527,7 +531,7 @@ func TestLoadBundles_ValidUnsignedBundle(t *testing.T) {
 	b := testBundle(testBundleName, []Rule{
 		testDLPRule("dlp-rule-001", confidenceHigh, StatusStable),
 		testInjectionRule("inj-rule-001", confidenceMedium),
-		testToolPoisonRule("tp-rule-001", confidenceHigh, StatusStable, scanFieldDescription),
+		testToolPoisonRule("tp-rule-001", scanFieldDescription),
 	})
 	writeUnsignedBundle(t, bundleDir, b)
 
@@ -1318,7 +1322,7 @@ func TestLoadBundles_RuleTypeRouting(t *testing.T) {
 		testDLPRule("dlp-001", confidenceHigh, StatusStable),
 		testDLPRule("dlp-002", confidenceHigh, StatusStable),
 		testInjectionRule("inj-001", confidenceHigh),
-		testToolPoisonRule("tp-001", confidenceHigh, StatusStable, scanFieldName),
+		testToolPoisonRule("tp-001", scanFieldName),
 	})
 	writeUnsignedBundle(t, bundleDir, b)
 

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -207,6 +207,79 @@ func TestLoadBundlesFreshnessSaveFailureIsIntegrityError(t *testing.T) {
 	}
 }
 
+func TestLoadBundlesFailedBundleIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	failingDir := filepath.Join(dir, "a-failing")
+	if err := os.MkdirAll(failingDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll failing bundle: %v", err)
+	}
+	failing := testBundleV2("a-failing", TierCommunity, 7, []Rule{
+		testDLPRule("dlp-before-failure", confidenceHigh, StatusStable),
+		testToolPoisonRule("forced-failure", confidenceHigh, StatusStable, scanFieldDescription),
+	})
+	failing.KeyID = KeyFingerprint(pub)
+	writeSignedBundle(t, failingDir, failing, pub, priv)
+
+	successDir := filepath.Join(dir, "z-success")
+	if err := os.MkdirAll(successDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll successful bundle: %v", err)
+	}
+	success := testBundleV2("z-success", TierCommunity, 3, []Rule{
+		testDLPRule("dlp-success", confidenceHigh, StatusStable),
+	})
+	success.KeyID = KeyFingerprint(pub)
+	writeSignedBundle(t, successDir, success, pub, priv)
+
+	definitions := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
+	for i := range definitions {
+		if definitions[i].ID == RuleTypeToolPoison {
+			definitions[i].Load = func(_ *bundleExecCtx, _ *Bundle, _ *Rule, _, _ string, _ *LoadedBundle) error {
+				return errors.New("forced loader failure")
+			}
+		}
+	}
+
+	result := LoadBundles(dir, LoadOptions{
+		MinConfidence:   confidenceLow,
+		PipelockVersion: testPipelockVersion,
+		TrustedKeys:     []config.TrustedKey{{Name: "test", PublicKey: hex.EncodeToString(pub)}},
+		definitions:     definitions,
+	})
+	if len(result.IntegrityErrors()) != 1 || !strings.Contains(result.IntegrityErrors()[0].Reason, "forced loader failure") {
+		t.Fatalf("integrity errors = %+v, want forced loader failure", result.IntegrityErrors())
+	}
+	if len(result.DLP) != 1 || result.DLP[0].Bundle != "z-success" {
+		t.Fatalf("DLP patterns = %+v, want only the successful bundle", result.DLP)
+	}
+	if len(result.Loaded) != 1 || result.Loaded[0].Name != "z-success" {
+		t.Fatalf("loaded bundles = %+v, want only z-success", result.Loaded)
+	}
+
+	state, err := LoadFreshnessState(dir)
+	if err != nil {
+		t.Fatalf("LoadFreshnessState: %v", err)
+	}
+	if _, ok := state.HighestSeen[freshnessKey(TierCommunity, "a-failing")]; ok {
+		t.Fatalf("failed bundle version persisted: %+v", state.HighestSeen)
+	}
+	if _, ok := state.FormatFloor["a-failing"]; ok {
+		t.Fatalf("failed bundle format persisted: %+v", state.FormatFloor)
+	}
+	if got := state.HighestSeen[freshnessKey(TierCommunity, "z-success")]; got != 3 {
+		t.Fatalf("successful bundle version = %d, want 3", got)
+	}
+	if got := state.FormatFloor["z-success"]; got != 2 {
+		t.Fatalf("successful bundle format = %d, want 2", got)
+	}
+}
+
 func TestLoadBundlesRejectsV1AfterAcceptedV2AcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	bundleDir := filepath.Join(dir, testBundleName)

--- a/internal/rules/schema_contract.go
+++ b/internal/rules/schema_contract.go
@@ -94,6 +94,7 @@ type RuleTypeSchema struct {
 	MergeTarget           string   `json:"merge_target"`
 	RequiredPatternFields []string `json:"required_pattern_fields"`
 	OptionalPatternFields []string `json:"optional_pattern_fields"`
+	RejectedPatternFields []string `json:"rejected_pattern_fields"`
 	IgnoredPatternFields  []string `json:"ignored_pattern_fields"`
 	ScanFieldValues       []string `json:"scan_field_values,omitempty"`
 	DefaultScanField      string   `json:"default_scan_field,omitempty"`
@@ -135,6 +136,8 @@ func buildRuleSchemaContract(version, sourceRevision string, definitions []ruleT
 		formats = append(formats, BundleFormatSchema{FormatVersion: formatVersion, RequiredFields: required})
 	}
 
+	patternFields := yamlFields(reflect.TypeOf(RulePattern{}))
+	requiredPatternFields := []string{"regex"}
 	types := make([]RuleTypeSchema, 0, len(definitions))
 	seenTypes := make(map[string]struct{}, len(definitions))
 	for _, definition := range definitions {
@@ -147,11 +150,16 @@ func buildRuleSchemaContract(version, sourceRevision string, definitions []ruleT
 		seenTypes[definition.ID] = struct{}{}
 		optional := append([]string(nil), definition.OptionalPatternFields...)
 		sort.Strings(optional)
+		rejected, err := rejectedFields(patternFields, requiredPatternFields, optional)
+		if err != nil {
+			return RuleSchemaContract{}, fmt.Errorf("rule schema contract: rule type %q: %w", definition.ID, err)
+		}
 		types = append(types, RuleTypeSchema{
 			ID:                    definition.ID,
 			MergeTarget:           definition.MergeTarget,
-			RequiredPatternFields: []string{"regex"},
+			RequiredPatternFields: append([]string(nil), requiredPatternFields...),
 			OptionalPatternFields: optional,
+			RejectedPatternFields: rejected,
 			IgnoredPatternFields:  []string{"exempt_domains"},
 			ScanFieldValues:       append([]string(nil), definition.ScanFieldValues...),
 			DefaultScanField:      definition.DefaultScanField,
@@ -207,6 +215,34 @@ func yamlFields(t reflect.Type) []string {
 	}
 	sort.Strings(fields)
 	return fields
+}
+
+func rejectedFields(all, required, optional []string) ([]string, error) {
+	known := make(map[string]struct{}, len(all))
+	for _, field := range all {
+		known[field] = struct{}{}
+	}
+
+	accepted := make(map[string]struct{}, len(required)+len(optional))
+	for _, fields := range [][]string{required, optional} {
+		for _, field := range fields {
+			if _, ok := known[field]; !ok {
+				return nil, fmt.Errorf("unknown pattern field %q", field)
+			}
+			if _, duplicate := accepted[field]; duplicate {
+				return nil, fmt.Errorf("pattern field %q has multiple classifications", field)
+			}
+			accepted[field] = struct{}{}
+		}
+	}
+
+	rejected := make([]string, 0, len(all)-len(accepted))
+	for _, field := range all {
+		if _, ok := accepted[field]; !ok {
+			rejected = append(rejected, field)
+		}
+	}
+	return rejected, nil
 }
 
 func sortedTrueKeys(values map[string]bool) []string {

--- a/internal/rules/schema_contract.go
+++ b/internal/rules/schema_contract.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const RuleSchemaContractVersion = 1
+
+const (
+	mergeTargetDLP        = "dlp.patterns"
+	mergeTargetInjection  = "response_scanning.patterns"
+	mergeTargetToolPoison = "mcp_tool_scanning.descriptions"
+)
+
+type ruleTypeDefinition struct {
+	ID                    string
+	MergeTarget           string
+	OptionalPatternFields []string
+	ScanFieldValues       []string
+	DefaultScanField      string
+	ValidatorValues       []string
+	Load                  loadRuleFunc
+}
+
+var ruleTypeDefinitions = []ruleTypeDefinition{
+	{
+		ID:                    RuleTypeDLP,
+		MergeTarget:           mergeTargetDLP,
+		OptionalPatternFields: []string{"exempt_domains", "validator"},
+		ValidatorValues:       []string{config.ValidatorABA, config.ValidatorLuhn, config.ValidatorMod97, config.ValidatorWIF},
+		Load:                  loadDLPRule,
+	},
+	{ID: RuleTypeInjection, MergeTarget: mergeTargetInjection, OptionalPatternFields: []string{"exempt_domains"}, Load: loadInjectionRule},
+	{
+		ID:                    RuleTypeToolPoison,
+		MergeTarget:           mergeTargetToolPoison,
+		OptionalPatternFields: []string{"exempt_domains", "scan_field"},
+		ScanFieldValues:       []string{scanFieldDescription, scanFieldName},
+		DefaultScanField:      scanFieldDescription,
+		Load:                  loadToolPoisonRule,
+	},
+}
+
+// RuleSchemaContract is the machine-readable contract exported by the rule
+// bundle reader. Consumers can pin this output instead of copying the reader's
+// accepted formats, fields, enums, and rule types by hand.
+type RuleSchemaContract struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Producer      RuleSchemaProducer   `json:"producer"`
+	Bundle        BundleSchemaContract `json:"bundle"`
+	Rule          RuleSchema           `json:"rule"`
+	Semantics     RuleSchemaSemantics  `json:"semantics"`
+}
+
+type RuleSchemaProducer struct {
+	Name           string `json:"name"`
+	Version        string `json:"version"`
+	SourceRevision string `json:"source_revision"`
+}
+
+type BundleSchemaContract struct {
+	AcceptedFormatVersions []int                `json:"accepted_format_versions"`
+	AllowedFields          []string             `json:"allowed_fields"`
+	Formats                []BundleFormatSchema `json:"formats"`
+	UnknownFields          string               `json:"unknown_fields"`
+	KnownFeatures          []string             `json:"known_features"`
+	Tiers                  []string             `json:"tiers"`
+}
+
+type BundleFormatSchema struct {
+	FormatVersion  int      `json:"format_version"`
+	RequiredFields []string `json:"required_fields"`
+}
+
+type RuleSchema struct {
+	AllowedFields        []string         `json:"allowed_fields"`
+	CommonRequiredFields []string         `json:"common_required_fields"`
+	Statuses             []string         `json:"statuses"`
+	Severities           []string         `json:"severities"`
+	Confidences          []string         `json:"confidences"`
+	Types                []RuleTypeSchema `json:"types"`
+}
+
+type RuleTypeSchema struct {
+	ID                    string   `json:"id"`
+	MergeTarget           string   `json:"merge_target"`
+	RequiredPatternFields []string `json:"required_pattern_fields"`
+	OptionalPatternFields []string `json:"optional_pattern_fields"`
+	IgnoredPatternFields  []string `json:"ignored_pattern_fields"`
+	ScanFieldValues       []string `json:"scan_field_values,omitempty"`
+	DefaultScanField      string   `json:"default_scan_field,omitempty"`
+	ValidatorValues       []string `json:"validator_values,omitempty"`
+}
+
+type RuleSchemaSemantics struct {
+	Composition             string `json:"composition"`
+	ActionAuthority         string `json:"action_authority"`
+	BundleExemptionsAllowed bool   `json:"bundle_exemptions_allowed"`
+	UnknownTypes            string `json:"unknown_types"`
+}
+
+// BuildRuleSchemaContract builds a deterministic contract from the same
+// declarations used by YAML decoding and rule validation.
+func BuildRuleSchemaContract(version, sourceRevision string) (RuleSchemaContract, error) {
+	return buildRuleSchemaContract(version, sourceRevision, ruleTypeDefinitions)
+}
+
+func buildRuleSchemaContract(version, sourceRevision string, definitions []ruleTypeDefinition) (RuleSchemaContract, error) {
+	version = strings.TrimSpace(version)
+	sourceRevision = strings.TrimSpace(sourceRevision)
+	if version == "" || version == "unknown" {
+		return RuleSchemaContract{}, fmt.Errorf("rule schema contract: exact pipelock version is unavailable")
+	}
+	if sourceRevision == "" || sourceRevision == "unknown" {
+		return RuleSchemaContract{}, fmt.Errorf("rule schema contract: exact source revision is unavailable")
+	}
+
+	formats := make([]BundleFormatSchema, 0, MaxFormatVersion)
+	acceptedFormats := make([]int, 0, MaxFormatVersion)
+	for formatVersion := 1; formatVersion <= MaxFormatVersion; formatVersion++ {
+		required := []string{"author", "description", "format_version", "name", "version"}
+		if formatVersion >= 2 {
+			required = append(required, "expires_at", "key_id", "monotonic_version", "published_at", "tier")
+			sort.Strings(required)
+		}
+		acceptedFormats = append(acceptedFormats, formatVersion)
+		formats = append(formats, BundleFormatSchema{FormatVersion: formatVersion, RequiredFields: required})
+	}
+
+	types := make([]RuleTypeSchema, 0, len(definitions))
+	seenTypes := make(map[string]struct{}, len(definitions))
+	for _, definition := range definitions {
+		if definition.ID == "" || definition.MergeTarget == "" || definition.Load == nil {
+			return RuleSchemaContract{}, fmt.Errorf("rule schema contract: rule type id, merge target, and loader must be declared")
+		}
+		if _, exists := seenTypes[definition.ID]; exists {
+			return RuleSchemaContract{}, fmt.Errorf("rule schema contract: duplicate rule type %q", definition.ID)
+		}
+		seenTypes[definition.ID] = struct{}{}
+		optional := append([]string(nil), definition.OptionalPatternFields...)
+		sort.Strings(optional)
+		types = append(types, RuleTypeSchema{
+			ID:                    definition.ID,
+			MergeTarget:           definition.MergeTarget,
+			RequiredPatternFields: []string{"regex"},
+			OptionalPatternFields: optional,
+			IgnoredPatternFields:  []string{"exempt_domains"},
+			ScanFieldValues:       append([]string(nil), definition.ScanFieldValues...),
+			DefaultScanField:      definition.DefaultScanField,
+			ValidatorValues:       append([]string(nil), definition.ValidatorValues...),
+		})
+	}
+	sort.Slice(types, func(i, j int) bool { return types[i].ID < types[j].ID })
+
+	return RuleSchemaContract{
+		SchemaVersion: RuleSchemaContractVersion,
+		Producer:      RuleSchemaProducer{Name: "pipelock", Version: version, SourceRevision: sourceRevision},
+		Bundle: BundleSchemaContract{
+			AcceptedFormatVersions: acceptedFormats,
+			AllowedFields:          yamlFields(reflect.TypeOf(Bundle{})),
+			Formats:                formats,
+			UnknownFields:          "reject",
+			KnownFeatures:          sortedTrueKeys(KnownFeatures),
+			Tiers:                  sortedTrueKeys(validTiers),
+		},
+		Rule: RuleSchema{
+			AllowedFields:        yamlFields(reflect.TypeOf(Rule{})),
+			CommonRequiredFields: []string{"confidence", "description", "id", "name", "pattern", "severity", "status", "type"},
+			Statuses:             sortedTrueKeys(validStatuses),
+			Severities:           sortedTrueKeys(validSeverities),
+			Confidences:          sortedTrueKeys(validConfidences),
+			Types:                types,
+		},
+		Semantics: RuleSchemaSemantics{
+			Composition:             "additive",
+			ActionAuthority:         "local_pipelock_config",
+			BundleExemptionsAllowed: false,
+			UnknownTypes:            "reject",
+		},
+	}, nil
+}
+
+func ruleTypeDefinitionFor(ruleType string) (ruleTypeDefinition, bool) {
+	for _, definition := range ruleTypeDefinitions {
+		if definition.ID == ruleType {
+			return definition, true
+		}
+	}
+	return ruleTypeDefinition{}, false
+}
+
+func yamlFields(t reflect.Type) []string {
+	fields := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		name := strings.Split(t.Field(i).Tag.Get("yaml"), ",")[0]
+		if name != "" && name != "-" {
+			fields = append(fields, name)
+		}
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func sortedTrueKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for value, enabled := range values {
+		if enabled {
+			keys = append(keys, value)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/rules/schema_contract_test.go
+++ b/internal/rules/schema_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -98,12 +99,39 @@ func TestSchemaRequiredFieldsMatchValidation(t *testing.T) {
 	}
 }
 
+func TestSchemaPatternFieldsFormExactTypeContract(t *testing.T) {
+	contract, err := BuildRuleSchemaContract("3.5.0", "abcdef0123456789")
+	if err != nil {
+		t.Fatalf("BuildRuleSchemaContract: %v", err)
+	}
+
+	expectedRejected := map[string][]string{
+		RuleTypeDLP:        {"scan_field"},
+		RuleTypeInjection:  {"scan_field", "validator"},
+		RuleTypeToolPoison: {"validator"},
+	}
+	patternFields := yamlFields(reflect.TypeOf(RulePattern{}))
+	for _, schema := range contract.Rule.Types {
+		if !reflect.DeepEqual(schema.RejectedPatternFields, expectedRejected[schema.ID]) {
+			t.Fatalf("type %q rejected fields = %v, want %v", schema.ID, schema.RejectedPatternFields, expectedRejected[schema.ID])
+		}
+
+		classified := append([]string(nil), schema.RequiredPatternFields...)
+		classified = append(classified, schema.OptionalPatternFields...)
+		classified = append(classified, schema.RejectedPatternFields...)
+		sort.Strings(classified)
+		if !reflect.DeepEqual(classified, patternFields) {
+			t.Fatalf("type %q pattern field classifications = %v, want %v", schema.ID, classified, patternFields)
+		}
+	}
+}
+
 func TestBuildRuleSchemaContractSyntheticTypeCannotDisappear(t *testing.T) {
 	definitions := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
 	definitions = append(definitions, ruleTypeDefinition{
 		ID:                    "synthetic-fourth",
 		MergeTarget:           "synthetic.target",
-		OptionalPatternFields: []string{"synthetic_field"},
+		OptionalPatternFields: []string{"validator"},
 		Load: func(_ *bundleExecCtx, _ *Bundle, _ *Rule, _, _ string, _ *LoadedBundle) error {
 			return nil
 		},
@@ -114,7 +142,7 @@ func TestBuildRuleSchemaContractSyntheticTypeCannotDisappear(t *testing.T) {
 		t.Fatalf("buildRuleSchemaContract: %v", err)
 	}
 	if !slices.ContainsFunc(contract.Rule.Types, func(schema RuleTypeSchema) bool {
-		return schema.ID == "synthetic-fourth" && slices.Contains(schema.OptionalPatternFields, "synthetic_field")
+		return schema.ID == "synthetic-fourth" && slices.Contains(schema.OptionalPatternFields, "validator")
 	}) {
 		t.Fatal("synthetic reader type disappeared from the exported contract")
 	}
@@ -152,6 +180,8 @@ func TestBuildRuleSchemaContractRejectsAmbiguousTypeRegistry(t *testing.T) {
 		{name: "missing ID", definitions: []ruleTypeDefinition{{MergeTarget: "new.target", Load: loadDLPRule}}},
 		{name: "missing merge target", definitions: []ruleTypeDefinition{{ID: "new-type", Load: loadDLPRule}}},
 		{name: "missing loader", definitions: []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target"}}},
+		{name: "unknown pattern field", definitions: []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target", OptionalPatternFields: []string{"unknown"}, Load: loadDLPRule}}},
+		{name: "duplicate pattern field classification", definitions: []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target", OptionalPatternFields: []string{"regex"}, Load: loadDLPRule}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := buildRuleSchemaContract("3.5.0", "abcdef", test.definitions); err == nil {

--- a/internal/rules/schema_contract_test.go
+++ b/internal/rules/schema_contract_test.go
@@ -144,13 +144,20 @@ func TestBuildRuleSchemaContractRequiresProducerIdentity(t *testing.T) {
 func TestBuildRuleSchemaContractRejectsAmbiguousTypeRegistry(t *testing.T) {
 	duplicate := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
 	duplicate = append(duplicate, ruleTypeDefinitions[0])
-	if _, err := buildRuleSchemaContract("3.5.0", "abcdef", duplicate); err == nil {
-		t.Fatal("duplicate rule type registry produced a contract")
-	}
-
-	missingLoader := []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target"}}
-	if _, err := buildRuleSchemaContract("3.5.0", "abcdef", missingLoader); err == nil {
-		t.Fatal("rule type without a runtime loader produced a contract")
+	for _, test := range []struct {
+		name        string
+		definitions []ruleTypeDefinition
+	}{
+		{name: "duplicate ID", definitions: duplicate},
+		{name: "missing ID", definitions: []ruleTypeDefinition{{MergeTarget: "new.target", Load: loadDLPRule}}},
+		{name: "missing merge target", definitions: []ruleTypeDefinition{{ID: "new-type", Load: loadDLPRule}}},
+		{name: "missing loader", definitions: []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := buildRuleSchemaContract("3.5.0", "abcdef", test.definitions); err == nil {
+				t.Fatal("malformed rule type registry produced a contract")
+			}
+		})
 	}
 }
 

--- a/internal/rules/schema_contract_test.go
+++ b/internal/rules/schema_contract_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestBuildRuleSchemaContractUsesReaderDeclarations(t *testing.T) {
+	contract, err := BuildRuleSchemaContract("3.5.0", "abcdef0123456789")
+	if err != nil {
+		t.Fatalf("BuildRuleSchemaContract: %v", err)
+	}
+
+	if contract.SchemaVersion != RuleSchemaContractVersion {
+		t.Fatalf("schema_version = %d, want %d", contract.SchemaVersion, RuleSchemaContractVersion)
+	}
+	if contract.Producer.Version != "3.5.0" || contract.Producer.SourceRevision != "abcdef0123456789" {
+		t.Fatalf("producer = %+v", contract.Producer)
+	}
+	if !reflect.DeepEqual(contract.Bundle.AcceptedFormatVersions, []int{1, 2}) {
+		t.Fatalf("accepted format versions = %v", contract.Bundle.AcceptedFormatVersions)
+	}
+	if !reflect.DeepEqual(contract.Bundle.AllowedFields, yamlFields(reflect.TypeOf(Bundle{}))) {
+		t.Fatal("bundle allowed fields did not come from Bundle YAML tags")
+	}
+	if !reflect.DeepEqual(contract.Rule.AllowedFields, yamlFields(reflect.TypeOf(Rule{}))) {
+		t.Fatal("rule allowed fields did not come from Rule YAML tags")
+	}
+	if contract.Bundle.UnknownFields != "reject" || contract.Semantics.UnknownTypes != "reject" {
+		t.Fatalf("unknown input semantics = %+v", contract.Semantics)
+	}
+	if contract.Semantics.BundleExemptionsAllowed {
+		t.Fatal("contract says bundles can add exemptions")
+	}
+
+	for _, definition := range ruleTypeDefinitions {
+		index := slices.IndexFunc(contract.Rule.Types, func(schema RuleTypeSchema) bool {
+			return schema.ID == definition.ID
+		})
+		if index < 0 {
+			t.Fatalf("contract omitted reader rule type %q", definition.ID)
+		}
+		schema := contract.Rule.Types[index]
+		if schema.MergeTarget != definition.MergeTarget ||
+			!reflect.DeepEqual(schema.ScanFieldValues, definition.ScanFieldValues) ||
+			!reflect.DeepEqual(schema.ValidatorValues, definition.ValidatorValues) {
+			t.Fatalf("contract type %q = %+v, definition = %+v", definition.ID, schema, definition)
+		}
+	}
+}
+
+func TestSchemaRequiredFieldsMatchValidation(t *testing.T) {
+	contract, err := BuildRuleSchemaContract("3.5.0", "abcdef0123456789")
+	if err != nil {
+		t.Fatalf("BuildRuleSchemaContract: %v", err)
+	}
+
+	for _, format := range contract.Bundle.Formats {
+		t.Run("bundle-format-"+strconv.Itoa(format.FormatVersion), func(t *testing.T) {
+			var bundle *Bundle
+			if format.FormatVersion == 1 {
+				bundle = testBundle("schema-bundle", nil)
+			} else {
+				bundle = testBundleV2("schema-bundle", TierCommunity, 1, nil)
+			}
+			zeroYAMLFieldsExcept(bundle, format.RequiredFields)
+			if err := bundle.Validate(); err != nil {
+				t.Fatalf("declared minimal format %d bundle rejected: %v", format.FormatVersion, err)
+			}
+			for _, field := range format.RequiredFields {
+				candidate := *bundle
+				zeroYAMLField(&candidate, field)
+				if err := candidate.Validate(); err == nil {
+					t.Fatalf("format %d field %q is declared required but validation accepted its zero value", format.FormatVersion, field)
+				}
+			}
+		})
+	}
+
+	rule := testDLPRule("schema-rule", confidenceHigh, StatusStable)
+	zeroYAMLFieldsExcept(&rule, contract.Rule.CommonRequiredFields)
+	if err := validateRule(&rule, make(map[string]bool)); err != nil {
+		t.Fatalf("declared minimal rule rejected: %v", err)
+	}
+	for _, field := range contract.Rule.CommonRequiredFields {
+		candidate := rule
+		zeroYAMLField(&candidate, field)
+		if err := validateRule(&candidate, make(map[string]bool)); err == nil {
+			t.Fatalf("rule field %q is declared required but validation accepted its zero value", field)
+		}
+	}
+}
+
+func TestBuildRuleSchemaContractSyntheticTypeCannotDisappear(t *testing.T) {
+	definitions := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
+	definitions = append(definitions, ruleTypeDefinition{
+		ID:                    "synthetic-fourth",
+		MergeTarget:           "synthetic.target",
+		OptionalPatternFields: []string{"synthetic_field"},
+		Load: func(_ *bundleExecCtx, _ *Bundle, _ *Rule, _, _ string, _ *LoadedBundle) error {
+			return nil
+		},
+	})
+
+	contract, err := buildRuleSchemaContract("3.5.0", "abcdef0123456789", definitions)
+	if err != nil {
+		t.Fatalf("buildRuleSchemaContract: %v", err)
+	}
+	if !slices.ContainsFunc(contract.Rule.Types, func(schema RuleTypeSchema) bool {
+		return schema.ID == "synthetic-fourth" && slices.Contains(schema.OptionalPatternFields, "synthetic_field")
+	}) {
+		t.Fatal("synthetic reader type disappeared from the exported contract")
+	}
+}
+
+func TestBuildRuleSchemaContractRequiresProducerIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		version  string
+		revision string
+	}{
+		{name: "missing version", revision: "abcdef"},
+		{name: "unknown version", version: "unknown", revision: "abcdef"},
+		{name: "whitespace unknown version", version: " unknown ", revision: "abcdef"},
+		{name: "missing revision", version: "3.5.0"},
+		{name: "unknown revision", version: "3.5.0", revision: "unknown"},
+		{name: "whitespace unknown revision", version: "3.5.0", revision: " unknown "},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := BuildRuleSchemaContract(test.version, test.revision); err == nil {
+				t.Fatal("BuildRuleSchemaContract succeeded without exact producer identity")
+			}
+		})
+	}
+}
+
+func TestBuildRuleSchemaContractRejectsAmbiguousTypeRegistry(t *testing.T) {
+	duplicate := append([]ruleTypeDefinition(nil), ruleTypeDefinitions...)
+	duplicate = append(duplicate, ruleTypeDefinitions[0])
+	if _, err := buildRuleSchemaContract("3.5.0", "abcdef", duplicate); err == nil {
+		t.Fatal("duplicate rule type registry produced a contract")
+	}
+
+	missingLoader := []ruleTypeDefinition{{ID: "new-type", MergeTarget: "new.target"}}
+	if _, err := buildRuleSchemaContract("3.5.0", "abcdef", missingLoader); err == nil {
+		t.Fatal("rule type without a runtime loader produced a contract")
+	}
+}
+
+func TestBuildRuleSchemaContractJSONIsDeterministic(t *testing.T) {
+	first, err := BuildRuleSchemaContract("3.5.0", "abcdef0123456789")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := BuildRuleSchemaContract("3.5.0", "abcdef0123456789")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(firstJSON, secondJSON) {
+		t.Fatal("contract JSON changed between identical builds")
+	}
+}
+
+func zeroYAMLFieldsExcept(value any, keep []string) {
+	kept := make(map[string]struct{}, len(keep))
+	for _, name := range keep {
+		kept[name] = struct{}{}
+	}
+	structValue := reflect.ValueOf(value).Elem()
+	structType := structValue.Type()
+	for i := 0; i < structValue.NumField(); i++ {
+		name := strings.Split(structType.Field(i).Tag.Get("yaml"), ",")[0]
+		if _, ok := kept[name]; !ok {
+			structValue.Field(i).Set(reflect.Zero(structValue.Field(i).Type()))
+		}
+	}
+}
+
+func zeroYAMLField(value any, name string) {
+	structValue := reflect.ValueOf(value).Elem()
+	structType := structValue.Type()
+	for i := 0; i < structValue.NumField(); i++ {
+		if strings.Split(structType.Field(i).Tag.Get("yaml"), ",")[0] == name {
+			structValue.Field(i).Set(reflect.Zero(structValue.Field(i).Type()))
+			return
+		}
+	}
+}


### PR DESCRIPTION
## What changed

Export the rule-bundle contract enforced by an exact Pipelock build, including accepted formats, fields, enums, rule types, merge targets, and bundle semantics. Validation, loading, and export now share one rule-type registry so a new type cannot appear on one surface and disappear from another.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `rules schema` command to export the rule-bundle contract as readable JSON.
  * The contract describes supported formats, fields, values, rule types, and processing semantics.
  * Schema output requires an exact build version and source revision for reliable identification.

* **Documentation**
  * Added guidance for consuming and pinning schema output from exact build artifacts.

* **Bug Fixes**
  * Rule-loading errors, including invalid tool-poison patterns, are now reported instead of silently skipped.
  * Failed bundles no longer leave behind partial loading or freshness state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->