### PR TITLE
fail closed on MCP whitespace batches and sink redirects

### DIFF
--- a/examples/ci-workflow-advanced.yaml
+++ b/examples/ci-workflow-advanced.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write  # for future SARIF upload
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 

--- a/examples/ci-workflow.yaml
+++ b/examples/ci-workflow.yaml
@@ -18,7 +18,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0  # needed for PR diff scanning
 

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -53,6 +53,20 @@ const (
 	DefaultRekorHashAlgorithm = rekorDefaultSubmitHashAlgorithm
 )
 
+// clientWithoutRedirects copies base (or http.DefaultClient) and refuses
+// later hops. Submit validates only the configured Rekor URL; following a
+// redirect would POST the checkpoint to a host that never passed that check.
+func clientWithoutRedirects(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	cloned := *base
+	cloned.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &cloned
+}
+
 // RekorLog submits receipt-chain checkpoints to Rekor and stores the returned
 // submission metadata. Verify requires a pinned Rekor log public key and checks
 // the SET, signed checkpoint, and inclusion proof offline.
@@ -195,11 +209,7 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 		return Proof{}, fmt.Errorf("build rekor request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := r.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-	resp, err := client.Do(req)
+	resp, err := clientWithoutRedirects(r.HTTPClient).Do(req)
 	if err != nil {
 		return Proof{}, fmt.Errorf("submit rekor entry: %w", err)
 	}

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -1098,6 +1098,52 @@ func TestRekorLogSubmitRejectsRequestFailures(t *testing.T) {
 	}
 }
 
+func TestRekorLogSubmitDoesNotFollowRedirect(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		client *http.Client
+	}{
+		{name: "default client"},
+		{name: "configured client", client: &http.Client{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reached := make(chan struct{}, 1)
+			private := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				select {
+				case reached <- struct{}{}:
+				default:
+				}
+			}))
+			defer private.Close()
+
+			front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, private.URL, http.StatusFound)
+			}))
+			defer front.Close()
+
+			_, submitErr := (RekorLog{URL: front.URL, HTTPClient: tt.client, Signer: priv}).Submit(checkpoint)
+			if submitErr == nil {
+				t.Fatal("Submit followed or accepted a redirect")
+			}
+			select {
+			case <-reached:
+				t.Fatal("rekor client followed a redirect to an unvalidated destination")
+			default:
+			}
+		})
+	}
+}
+
 func TestDecodeRekorEntryAcceptsRealisticUnknownFields(t *testing.T) {
 	body := base64.StdEncoding.EncodeToString([]byte(`{"kind":"hashedrekord"}`))
 	data := []byte(`{

--- a/internal/emit/httpclient.go
+++ b/internal/emit/httpclient.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"net/http"
+	"time"
+)
+
+// newNoRedirectHTTPClient builds a client that never follows later hops.
+// Webhook, OTLP, and sibling sinks validate the configured URL only; a
+// redirect would send the POST (and for 307/308 its body) to a destination
+// that never passed that check. http.ErrUseLastResponse keeps the 3xx as
+// the final response so existing status handling fails closed without
+// turning the hop into a retried network error.
+func newNoRedirectHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/internal/emit/otlp.go
+++ b/internal/emit/otlp.go
@@ -148,7 +148,7 @@ func NewOTLPSink(endpoint, version string, minSev Severity, headers map[string]s
 		minSev:   minSev,
 		useGzip:  useGzip,
 		version:  version,
-		client:   &http.Client{Timeout: timeout},
+		client:   newNoRedirectHTTPClient(timeout),
 		resource: resource,
 		queue:    make(chan Event, queueSize),
 		done:     make(chan struct{}),

--- a/internal/emit/otlp_test.go
+++ b/internal/emit/otlp_test.go
@@ -25,6 +25,51 @@ import (
 
 const otlpLogsPath = "/v1/logs"
 
+func TestOTLPSink_DoesNotFollowRedirect(t *testing.T) {
+	reached := make(chan struct{}, 1)
+	private := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		select {
+		case reached <- struct{}{}:
+		default:
+		}
+	}))
+	defer private.Close()
+
+	frontHit := make(chan struct{})
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(frontHit)
+		http.Redirect(w, r, private.URL, http.StatusFound)
+	}))
+	defer front.Close()
+
+	sink, err := NewOTLPSink(front.URL, "1.0.0", SeverityInfo, nil, 5*time.Second, 64, false)
+	if err != nil {
+		t.Fatalf("NewOTLPSink: %v", err)
+	}
+	defer func() { _ = sink.Close() }()
+
+	if err := sink.Emit(context.Background(), Event{
+		Severity:   SeverityWarn,
+		Type:       testEventBlocked,
+		Timestamp:  time.Now(),
+		InstanceID: testInstanceName,
+		Fields:     map[string]any{testFieldURL: testEvilURL},
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	select {
+	case <-frontHit:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for configured OTLP URL")
+	}
+	select {
+	case <-reached:
+		t.Fatal("OTLP client followed a redirect to an unvalidated destination")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestOTLPSink_EmitEvent(t *testing.T) {
 	bodyCh := make(chan []byte, 1)
 

--- a/internal/emit/otlp_test.go
+++ b/internal/emit/otlp_test.go
@@ -46,7 +46,6 @@ func TestOTLPSink_DoesNotFollowRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOTLPSink: %v", err)
 	}
-	defer func() { _ = sink.Close() }()
 
 	if err := sink.Emit(context.Background(), Event{
 		Severity:   SeverityWarn,
@@ -63,10 +62,13 @@ func TestOTLPSink_DoesNotFollowRedirect(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for configured OTLP URL")
 	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 	select {
 	case <-reached:
 		t.Fatal("OTLP client followed a redirect to an unvalidated destination")
-	case <-time.After(200 * time.Millisecond):
+	default:
 	}
 }
 

--- a/internal/emit/webhook.go
+++ b/internal/emit/webhook.go
@@ -119,7 +119,7 @@ func NewWebhookSink(url string, opts ...WebhookOption) *WebhookSink {
 	w := &WebhookSink{
 		url:    url,
 		format: FormatJSON,
-		client: &http.Client{Timeout: DefaultWebhookTimeout},
+		client: newNoRedirectHTTPClient(DefaultWebhookTimeout),
 		queue:  make(chan Event, DefaultQueueSize),
 		done:   make(chan struct{}),
 	}

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -66,7 +66,6 @@ func TestWebhookSink_DoesNotFollowRedirect(t *testing.T) {
 	defer front.Close()
 
 	sink := NewWebhookSink(front.URL)
-	defer func() { _ = sink.Close() }()
 
 	if err := sink.Emit(context.Background(), Event{
 		Severity:  SeverityWarn,
@@ -81,10 +80,13 @@ func TestWebhookSink_DoesNotFollowRedirect(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for configured webhook URL")
 	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
 	select {
 	case <-reached:
 		t.Fatal("webhook client followed a redirect to an unvalidated destination")
-	case <-time.After(200 * time.Millisecond):
+	default:
 	}
 }
 

--- a/internal/emit/webhook_test.go
+++ b/internal/emit/webhook_test.go
@@ -48,6 +48,46 @@ func TestWebhookSink_BelowMinSeverity(t *testing.T) {
 	}
 }
 
+func TestWebhookSink_DoesNotFollowRedirect(t *testing.T) {
+	reached := make(chan struct{}, 1)
+	private := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		select {
+		case reached <- struct{}{}:
+		default:
+		}
+	}))
+	defer private.Close()
+
+	frontHit := make(chan struct{})
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(frontHit)
+		http.Redirect(w, r, private.URL, http.StatusFound)
+	}))
+	defer front.Close()
+
+	sink := NewWebhookSink(front.URL)
+	defer func() { _ = sink.Close() }()
+
+	if err := sink.Emit(context.Background(), Event{
+		Severity:  SeverityWarn,
+		Type:      testEventBlocked,
+		Timestamp: time.Date(2026, 2, 25, 12, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	select {
+	case <-frontHit:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for configured webhook URL")
+	}
+	select {
+	case <-reached:
+		t.Fatal("webhook client followed a redirect to an unvalidated destination")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestWebhookSink_SuccessfulPost(t *testing.T) {
 	var received webhookPayload
 	done := make(chan struct{})

--- a/internal/mcp/proxy.go
+++ b/internal/mcp/proxy.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"encoding/json"
@@ -301,8 +302,10 @@ func ForwardScanned(reader transport.MessageReader, writer transport.MessageWrit
 
 		// MCP does not use JSON-RPC batch messages (top-level arrays).
 		// A batch from the server is either malformed or an attempt to
-		// bypass per-message ID validation. Fail closed.
-		if len(line) > 0 && line[0] == '[' {
+		// bypass per-message ID validation. Fail closed. Use the parsed
+		// frame: WebSocket and SSE can preserve leading whitespace that
+		// a raw first-byte check would miss.
+		if frame.IsBatch {
 			_, _ = fmt.Fprintf(logW, "pipelock: line %d: blocked batch JSON-RPC message (not supported by MCP)\n", lineNum)
 			continue
 		}
@@ -1220,12 +1223,13 @@ func stripResponse(line []byte, sc *scanner.Scanner) ([]byte, error) {
 }
 
 func stripResponseDepth(line []byte, sc *scanner.Scanner, depth int) ([]byte, error) {
-	// Handle batch responses (JSON array).
-	if len(line) > 0 && line[0] == '[' {
+	// Handle batch responses (JSON array). Trim so a leading-whitespace
+	// array is classified the same way ParseMCPFrame sets IsBatch.
+	if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 && trimmed[0] == '[' {
 		if depth >= maxStripDepth {
 			return nil, fmt.Errorf("batch nesting too deep (max %d)", maxStripDepth)
 		}
-		return stripBatchDepth(line, sc, depth+1)
+		return stripBatchDepth(trimmed, sc, depth+1)
 	}
 
 	var rpc stripRPCResponse

--- a/internal/mcp/proxy_test.go
+++ b/internal/mcp/proxy_test.go
@@ -2762,6 +2762,19 @@ func TestStripResponse_Batch(t *testing.T) {
 	}
 }
 
+func TestStripResponse_WhitespacePrefixedBatch(t *testing.T) {
+	sc := testScannerWithAction(t, "strip")
+	batch := " \t" + `[` + injectionResponse + `]`
+
+	stripped, err := stripResponse([]byte(batch), sc)
+	if err != nil {
+		t.Fatalf("stripResponse whitespace-prefixed batch: %v", err)
+	}
+	if !bytes.Contains(stripped, []byte("[REDACTED:")) {
+		t.Fatalf("whitespace-prefixed batch was not stripped: %s", stripped)
+	}
+}
+
 func TestStripResponse_BatchInvalidJSON(t *testing.T) {
 	sc := testScannerWithAction(t, "strip")
 	_, err := stripResponse([]byte(`[not valid`), sc)
@@ -4439,6 +4452,42 @@ func TestForwardScanned_BatchJSONRPCBlocked(t *testing.T) {
 	if outBuf.Len() > 0 {
 		t.Errorf("expected no output for blocked batch, got: %s", outBuf.String())
 	}
+}
+
+func TestForwardScanned_BlocksWhitespacePrefixedBatchJSONRPC(t *testing.T) {
+	// Stdio trims, so this uses a raw reader matching WebSocket/SSE payloads.
+	batch := []byte("  \t" + `[{"jsonrpc":"2.0","id":1,"result":"ok"},{"jsonrpc":"2.0","id":999,"result":"injected"}]`)
+
+	sc := testScannerWithAction(t, config.ActionWarn)
+	var outBuf bytes.Buffer
+	logBuf := &syncBuffer{}
+	opts := MCPProxyOpts{Scanner: sc}
+
+	_, err := ForwardScanned(&oneShotMessageReader{msg: batch}, transport.NewStdioWriter(&outBuf), logBuf, nil, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outBuf.Len() != 0 {
+		t.Errorf("expected no output for whitespace-prefixed batch, got: %s", outBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "blocked batch JSON-RPC") {
+		t.Errorf("expected batch block log, got: %s", logBuf.String())
+	}
+}
+
+type oneShotMessageReader struct {
+	msg  []byte
+	done bool
+}
+
+func (r *oneShotMessageReader) ReadMessage() ([]byte, error) {
+	if r.done {
+		return nil, io.EOF
+	}
+	r.done = true
+	out := make([]byte, len(r.msg))
+	copy(out, r.msg)
+	return out, nil
 }
 
 // TestForwardScanned_MidStreamBlockAllEscalation verifies that when

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -1873,8 +1873,10 @@ func ScanTools(line []byte, sc *scanner.Scanner, cfg *ToolScanConfig) ToolScanRe
 	}
 
 	// Detect batch response (JSON-RPC 2.0 batch = JSON array).
-	if len(line) > 0 && line[0] == '[' {
-		return scanToolsBatch(line, sc, cfg)
+	// Trim so a leading-whitespace array is not treated as an unparseable
+	// single object, which would return Clean and skip per-element scanning.
+	if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 && trimmed[0] == '[' {
+		return scanToolsBatch(trimmed, sc, cfg)
 	}
 
 	return scanToolsSingle(line, sc, cfg)

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -2248,6 +2248,22 @@ func TestScanTools_BatchInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestScanTools_WhitespacePrefixedBatchIsScanned(t *testing.T) {
+	sc := testScanner(t)
+	cfg := &ToolScanConfig{Action: "block"}
+
+	resp := `{"jsonrpc":"2.0","id":42,"result":{"tools":[{"name":"evil","description":"<IMPORTANT>Bad</IMPORTANT>"}]}}`
+	line := append([]byte("  \t"), makeBatchToolsResponse(resp)...)
+
+	result := ScanTools(line, sc, cfg)
+	if result.Clean {
+		t.Fatal("whitespace-prefixed poisoned batch returned clean")
+	}
+	if !result.IsToolsList {
+		t.Fatal("whitespace-prefixed batch was not classified as tools/list")
+	}
+}
+
 func TestScanTools_BatchPreservesRPCID(t *testing.T) {
 	sc := testScanner(t)
 	cfg := &ToolScanConfig{Action: "block"}

--- a/scripts/release-audit.sh
+++ b/scripts/release-audit.sh
@@ -92,7 +92,7 @@ while IFS= read -r match; do
 	if [[ ! "$version" =~ ^[0-9a-f]{40}$ ]]; then
 		fail "${file}:${line} action is not pinned to a full commit SHA (${ref})"
 	fi
-done < <(rg -n '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*[^[:space:]]+' .github/workflows/*.y*ml || true)
+done < <(rg -n --glob '*.y*ml' '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*[^[:space:]]+' .github/workflows examples || true)
 
 note "release audit: checking pull_request workflows stay secret-light"
 


### PR DESCRIPTION
## What changed
MCP batch deny now uses the parsed frame flag so a JSON-RPC array with leading whitespace on WebSocket or SSE is dropped instead of forwarded.
Webhook, OTLP, and Rekor clients treat a 3xx from the configured URL as the final response and don't POST to the next hop. Example CI workflows pin actions/checkout to the same commit SHA as the repository workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Prevented Rekor, OTLP, and webhook requests from following redirects to unvalidated destinations.
  * Improved detection, blocking, and scanning of whitespace-prefixed JSON-RPC batch responses.

* **Maintenance**
  * Pinned workflow checkout actions to a specific commit.
  * Expanded release audits to recursively include workflow examples.

* **Tests**
  * Added coverage for redirect prevention and whitespace-prefixed batch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->