### PR TITLE
fix(release): keep Pipelock out of PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ ARG LICENSE_PUBLIC_KEY=""
 ARG RULES_KEYRING_HEX=""
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags enterprise \
+RUN apk add --no-cache tini-static=0.19.0-r3 && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags enterprise \
     -ldflags "-s -w \
       -X github.com/luckyPipewrench/pipelock/internal/cliutil.Version=${VERSION} \
       -X github.com/luckyPipewrench/pipelock/internal/cliutil.BuildDate=${BUILD_DATE} \
@@ -50,6 +51,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags enterpris
 FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /sbin/tini-static /sbin/tini-static
 COPY --from=builder /pipelock /pipelock
 
 EXPOSE 8888
@@ -57,5 +59,5 @@ EXPOSE 8888
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
   CMD ["/pipelock", "healthcheck"]
 
-ENTRYPOINT ["/pipelock"]
+ENTRYPOINT ["/sbin/tini-static", "--", "/pipelock"]
 CMD ["run", "--listen", "0.0.0.0:8888"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,10 +4,11 @@
 # Used by GoReleaser — copies the pre-built binary instead of building from source.
 # For local/manual builds, use the main Dockerfile instead.
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS certs
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tini-static=0.19.0-r3
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=certs /sbin/tini-static /sbin/tini-static
 COPY pipelock /pipelock
 
 EXPOSE 8888
@@ -15,5 +16,5 @@ EXPOSE 8888
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
   CMD ["/pipelock", "healthcheck"]
 
-ENTRYPOINT ["/pipelock"]
+ENTRYPOINT ["/sbin/tini-static", "--", "/pipelock"]
 CMD ["run", "--listen", "0.0.0.0:8888"]

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -107,11 +107,15 @@ def load_workflow(path: Path) -> object:
 class TestReleaseArtifacts(unittest.TestCase):
     def test_scratch_images_use_a_non_go_init(self) -> None:
         """Keep the published binary out of PID 1 in a new PID namespace."""
+        expected_tini_copies = {
+            "Dockerfile": "COPY --from=builder /sbin/tini-static /sbin/tini-static",
+            "Dockerfile.goreleaser": "COPY --from=certs /sbin/tini-static /sbin/tini-static",
+        }
         for dockerfile in RUNTIME_DOCKERFILES:
             with self.subTest(dockerfile=dockerfile.name):
                 source = dockerfile.read_text(encoding="utf-8")
                 self.assertIn("tini-static=0.19.0-r3", source)
-                self.assertIn("COPY --from=", source)
+                self.assertIn(expected_tini_copies[dockerfile.name], source)
                 self.assertIn("/sbin/tini-static", source)
                 self.assertIn(
                     'ENTRYPOINT ["/sbin/tini-static", "--", "/pipelock"]', source

--- a/scripts/test_release_artifacts.py
+++ b/scripts/test_release_artifacts.py
@@ -23,6 +23,7 @@ from scripts.chart_changes_version import changes_appversion
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/release.yaml"
 GORELEASER = ROOT / ".goreleaser.yaml"
+RUNTIME_DOCKERFILES = (ROOT / "Dockerfile", ROOT / "Dockerfile.goreleaser")
 CHART = ROOT / "charts/pipelock/Chart.yaml"
 MANUAL_CHART_WORKFLOW = ROOT / ".github/workflows/publish-chart.yaml"
 WORKFLOWS_DIR = ROOT / ".github/workflows"
@@ -104,6 +105,18 @@ def load_workflow(path: Path) -> object:
 
 
 class TestReleaseArtifacts(unittest.TestCase):
+    def test_scratch_images_use_a_non_go_init(self) -> None:
+        """Keep the published binary out of PID 1 in a new PID namespace."""
+        for dockerfile in RUNTIME_DOCKERFILES:
+            with self.subTest(dockerfile=dockerfile.name):
+                source = dockerfile.read_text(encoding="utf-8")
+                self.assertIn("tini-static=0.19.0-r3", source)
+                self.assertIn("COPY --from=", source)
+                self.assertIn("/sbin/tini-static", source)
+                self.assertIn(
+                    'ENTRYPOINT ["/sbin/tini-static", "--", "/pipelock"]', source
+                )
+
     def test_chart_has_no_branch_selectable_manual_publisher(self) -> None:
         self.assertFalse(
             MANUAL_CHART_WORKFLOW.exists(),


### PR DESCRIPTION
## What changed

- Starts the scratch images through a static init process so Pipelock runs as a child in a new PID namespace.
- Pins that entrypoint contract in the release-artifact tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container process handling by launching the application through a lightweight init process.
  * Ensured consistent startup behavior across standard and release container images.

* **Tests**
  * Added automated checks to verify init-process installation, inclusion, version pinning, and container entrypoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->