### PR TITLE
feat: add route-scoped entropy warnings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,6 +346,14 @@ request_body_scanning:
   content_entropy_threshold: 4.5      # Shannon bits/char above which a body/frame value is flagged
   content_entropy_min_length: 32      # ignore values shorter than this (limits false positives on short opaque IDs)
   content_entropy_exclusions: []      # destination hosts whose bodies legitimately carry opaque content
+  content_entropy_warn_routes:        # optional exact HTTPS exceptions; valid only when the global action is block
+    - host: upload.vendor.example
+      path: /v1/files
+      content_types: [application/octet-stream]
+      methods: [POST]                  # optional; omit to match every HTTP method
+      reason: encrypted customer archives
+      owner: storage team
+      expires: 2099-12-31
 ```
 
 | Field | Default | Description |
@@ -364,6 +372,7 @@ request_body_scanning:
 | `content_entropy_threshold` | `4.5` | Shannon entropy (bits/char) above which a value is flagged. A long all-hex value below this is still flagged as opaque-hex content. |
 | `content_entropy_min_length` | `32` | Minimum value length considered; shorter values are ignored to limit false positives on short opaque identifiers. |
 | `content_entropy_exclusions` | `[]` | Destination hosts exempt from per-message content entropy only (not from DLP). Use for endpoints that legitimately carry opaque content (content-addressed uploads, encrypted payloads). WebSocket has a parallel `websocket_proxy.content_entropy_exclusions`. |
+| `content_entropy_warn_routes` | `[]` | Exact, expiring HTTPS routes where request-body entropy findings warn instead of block. Each entry requires one exact host and canonical non-root path, one or more non-text content types, a reason, owner, and expiry; methods are optional. Other body findings and size/redirect checks still block normally. |
 
 **Content-type dispatch:** JSON bodies have string values and object keys extracted recursively. Form-urlencoded bodies are parsed as ordered key-value pairs so split instruction phrases preserve wire order. Multipart form data scans all part headers plus all part bodies regardless of declared `Content-Type` (max 100 parts), and decodes `Content-Transfer-Encoding: base64` / `quoted-printable` before scanning. Text/* and XML bodies are scanned as raw text. Unknown content types get a fallback raw-text scan (never skipped, preventing `Content-Type` spoofing bypass).
 
@@ -384,10 +393,15 @@ request_body_scanning:
 
 **Adaptive enforcement interaction:** A body/header DLP action of `warn`, including a per-pattern `pattern_actions` downgrade, still enters the existing adaptive enforcement path and can be upgraded to `block` unless the destination is adaptive-exempt. `disable_patterns` removes only the named DLP finding from this request-body/header surface; it does not create a destination exemption and does not affect URL, response, MCP, or file DLP scanning.
 
+An entropy warning produced by `content_entropy_warn_routes` is not promoted back to block and does not add an adaptive signal. It remains a visible finding, so that request does not count as a clean recovery/decay event. Logs and receipts include the configured reason, owner, and expiry. A 307/308 body replay is allowed only while the redirected request still matches the same exact route; leaving that route fails closed.
+
+Deploy binaries that understand this field across the fleet before publishing shared configuration that uses it. Config parsing rejects unknown fields, so an older process will refuse the new configuration instead of silently ignoring the exception.
+
 **Opaque content entropy (`content_entropy_*`):** DLP catches secrets that match a known pattern. A stolen canary-file value, an opaque token, or a hex-encoded blob has no signature, so a pattern scanner misses it. Content entropy closes that gap: a high-entropy value leaving in a request body, a WebSocket client-to-server frame, or an A2A message body to a destination that is not trusted is flagged, regardless of pattern. Destination trust comes from the parsed upstream authority (not a request-supplied `Host` header), and hosts in `trusted_domains` or `content_entropy_exclusions` are skipped. Entropy suppression never suppresses a DLP match in the same body. The shipped default is `warn` so the detector observes before it enforces; `strict` and `hostile-model` presets use `block`.
 
 Known limits, by design:
-- **Content-addressed uploads look like exfil.** A SHA-256 hash and a hex-encoded 32-byte secret are the same shape, so length alone cannot separate them. In `warn` mode this is a low-cost audit line; in `block` mode (strict/hostile presets), add legitimate upload/hash endpoints to `content_entropy_exclusions` or `trusted_domains`.
+- **Content-addressed uploads look like exfil.** A SHA-256 hash and a hex-encoded 32-byte secret are the same shape, so length alone cannot separate them. In `block` mode (strict/hostile presets), prefer an exact `content_entropy_warn_routes` entry for a known HTTPS upload endpoint. Host-wide `content_entropy_exclusions` and `trusted_domains` are broader exemptions.
+- **Route warning exceptions are HTTP-only.** They apply to forward proxy HTTPS requests, intercepted HTTPS requests, and HTTPS reverse-proxy upstreams. They do not change WebSocket frame entropy or A2A's separate field-aware entropy checks. `Content-Type` narrows operator intent but is supplied by the sender and is not treated as proof that the body is safe.
 - **WebSocket detection is per-message.** A blob split across separate WebSocket messages, each under `content_entropy_min_length`, is not aggregated here; the cross-request data budget (`cross_request_detection`) is the net for sustained multi-message exfiltration.
 - **MCP-transport A2A** (stdio/HTTP MCP gateways) does not yet apply content entropy; those paths lack a parsed upstream authority to gate destination trust on. HTTP/CONNECT-proxied A2A message bodies are covered.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,7 +342,7 @@ request_body_scanning:
     - Proxy-Authorization
     - X-Goog-Api-Key
   content_entropy_enabled: true       # detect opaque high-entropy body content (exfil with no credential signature)
-  content_entropy_action: warn        # warn or block; general presets default warn, strict/hostile default block
+  content_entropy_action: block       # required for the exact route warning example below; general presets default warn
   content_entropy_threshold: 4.5      # Shannon bits/char above which a body/frame value is flagged
   content_entropy_min_length: 32      # ignore values shorter than this (limits false positives on short opaque IDs)
   content_entropy_exclusions: []      # destination hosts whose bodies legitimately carry opaque content
@@ -372,7 +372,7 @@ request_body_scanning:
 | `content_entropy_threshold` | `4.5` | Shannon entropy (bits/char) above which a value is flagged. A long all-hex value below this is still flagged as opaque-hex content. |
 | `content_entropy_min_length` | `32` | Minimum value length considered; shorter values are ignored to limit false positives on short opaque identifiers. |
 | `content_entropy_exclusions` | `[]` | Destination hosts exempt from per-message content entropy only (not from DLP). Use for endpoints that legitimately carry opaque content (content-addressed uploads, encrypted payloads). WebSocket has a parallel `websocket_proxy.content_entropy_exclusions`. |
-| `content_entropy_warn_routes` | `[]` | Exact, expiring HTTPS routes where request-body entropy findings warn instead of block. Each entry requires one exact host and canonical non-root path, one or more non-text content types, a reason, owner, and expiry; methods are optional. Other body findings and size/redirect checks still block normally. |
+| `content_entropy_warn_routes` | `[]` | Exact, expiring HTTPS routes where request-body entropy findings warn instead of block. Each entry requires one exact host and canonical non-root path, one or more non-text content types, a reason, owner, and expiry; methods are optional. Other findings retain their configured actions; size and redirect limits remain fail-closed. |
 
 **Content-type dispatch:** JSON bodies have string values and object keys extracted recursively. Form-urlencoded bodies are parsed as ordered key-value pairs so split instruction phrases preserve wire order. Multipart form data scans all part headers plus all part bodies regardless of declared `Content-Type` (max 100 parts), and decodes `Content-Transfer-Encoding: base64` / `quoted-printable` before scanning. Text/* and XML bodies are scanned as raw text. Unknown content types get a fallback raw-text scan (never skipped, preventing `Content-Type` spoofing bypass).
 

--- a/docs/guides/false-positive-tuning.md
+++ b/docs/guides/false-positive-tuning.md
@@ -121,16 +121,21 @@ positive is an audit line, not a block. Tune before setting
 `request_body_scanning.content_entropy_action: block` for the deployment or
 selecting a blocking preset (strict/hostile presets already block):
 
-- **Narrowest first:** add the specific upload or hash endpoint host to
-  `request_body_scanning.content_entropy_exclusions` (or
-  `websocket_proxy.content_entropy_exclusions` for a WebSocket-only endpoint).
-  This lifts only the entropy check for that host; DLP still applies.
-- **Broader:** if the host is fully trusted, `trusted_domains` covers it for
+- **Narrowest first:** for an HTTPS request-body endpoint, add an exact,
+  expiring `request_body_scanning.content_entropy_warn_routes` entry. The
+  entropy finding remains visible while DLP, prompt injection, address, body
+  size, and redirect checks keep their normal actions.
+- **WebSocket:** use `websocket_proxy.content_entropy_exclusions` for a
+  WebSocket-only endpoint. Route warning entries do not affect WebSocket or
+  A2A entropy scanning.
+- **Broader:** a host in `request_body_scanning.content_entropy_exclusions`
+  skips request-body entropy across every path on that host. If the host is
+  fully trusted, `trusted_domains` covers it for
   entropy and other destination-trust checks at once.
 - **Global (last resort):** raising `request_body_scanning.content_entropy_threshold`
-  lowers sensitivity for every destination. Prefer a per-host exclusion.
+  lowers sensitivity for every destination. Prefer an exact route warning.
 
 `content_entropy_min_length` applies to both individual leaves and their stable
 aggregate views. Raising it can reduce flags for one short identifier, but a
-collection of short identifiers may still exceed the aggregate floor. Prefer a
-per-host exclusion when opaque identifiers are a normal part of that protocol.
+collection of short identifiers may still exceed the aggregate floor. Prefer
+an exact route warning when opaque identifiers are normal at one HTTPS endpoint.

--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -234,6 +234,7 @@ func (c *Config) policySemanticView() canonicalPolicyView {
 	view.ResponseScanning.MCPServers = canonicalMCPResponseServers(view.ResponseScanning.MCPServers)
 	view.FetchProxy.Monitoring.QueryEntropyParamExclusions = canonicalQueryEntropyParamExclusions(view.FetchProxy.Monitoring.QueryEntropyParamExclusions)
 	view.RequestBodyScanning.ContentEntropyExclusions = sortedCopy(view.RequestBodyScanning.ContentEntropyExclusions)
+	view.RequestBodyScanning.ContentEntropyWarnRoutes = canonicalRequestBodyEntropyWarnRoutes(view.RequestBodyScanning.ContentEntropyWarnRoutes)
 	view.WebSocketProxy.ContentEntropyExclusions = sortedCopy(view.WebSocketProxy.ContentEntropyExclusions)
 	if view.Redaction.Enabled {
 		view.Redaction.AllowlistUnparseable = sortedCopy(view.Redaction.AllowlistUnparseable)
@@ -373,6 +374,24 @@ func canonicalUnscannablePassthrough(entries []UnscannablePassthroughEntry) []Un
 			return a.Added < b.Added
 		}
 		return a.Expires < b.Expires
+	})
+	return out
+}
+
+func canonicalRequestBodyEntropyWarnRoutes(entries []RequestBodyEntropyWarnRoute) []RequestBodyEntropyWarnRoute {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]RequestBodyEntropyWarnRoute, len(entries))
+	for i, entry := range entries {
+		out[i] = entry
+		out[i].ContentTypes = sortedCopy(entry.ContentTypes)
+		out[i].Methods = sortedCopy(entry.Methods)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		return a.Host+"\x00"+a.Path+"\x00"+strings.Join(a.Methods, "\x00")+"\x00"+strings.Join(a.ContentTypes, "\x00")+"\x00"+a.Owner+"\x00"+a.Reason+"\x00"+a.Expires <
+			b.Host+"\x00"+b.Path+"\x00"+strings.Join(b.Methods, "\x00")+"\x00"+strings.Join(b.ContentTypes, "\x00")+"\x00"+b.Owner+"\x00"+b.Reason+"\x00"+b.Expires
 	})
 	return out
 }

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -344,7 +344,10 @@ const (
 	// policy-relevant because an entry lets the proxy release a verified
 	// official rules bundle with response injection matching skipped, so
 	// verifiers must observe the schema change through ph.
-	goldenHashDefaults = "975c1fc1b7554dd04fd7aea3df8cd421159c0c50fa0f89aa666660cd2e445a90"
+	// Re-bumped for request_body_scanning.content_entropy_warn_routes. The
+	// exact route exception changes an entropy block to a visible warning, so
+	// mixed versions must not report the same policy identity.
+	goldenHashDefaults = "4d531d9b039f54906dd5ea1a92ea66054e7a5fd6e62cdbabe1f5fa7b377af218"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -519,7 +522,8 @@ const (
 	// goldenHashDefaults note above. The rich fixture omits the field, so the
 	// nil allowlist flows into ph identically to Defaults() and the hash
 	// shifts in lockstep.
-	goldenHashRichConfig = "e2e76982713a955b7275fff84ab4420fc23441706ccfb2fe26b50470230135fb"
+	// Re-bumped for route-scoped entropy warnings: see goldenHashDefaults.
+	goldenHashRichConfig = "d5c791b08f5cf44338f78aeb3a426ba9a839a6db3151aa4f73aa2244100f8a3f"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -497,6 +497,12 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: fmt.Sprintf("request body content entropy exclusions added: %s — per-message body/frame entropy bypassed for these hosts", strings.Join(added, ", ")),
 		})
 	}
+	if added := entropyWarnRoutesAdded(old.RequestBodyScanning.ContentEntropyWarnRoutes, updated.RequestBodyScanning.ContentEntropyWarnRoutes); len(added) > 0 {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "request_body_scanning.content_entropy_warn_routes",
+			Message: fmt.Sprintf("request body entropy warning routes added or materially changed: %s — matching entropy findings now warn instead of block", strings.Join(added, ", ")),
+		})
+	}
 	if added := passthroughDomainsAdded(old.WebSocketProxy.ContentEntropyExclusions, updated.WebSocketProxy.ContentEntropyExclusions); len(added) > 0 {
 		warnings = append(warnings, ReloadWarning{
 			Field:   "websocket_proxy.content_entropy_exclusions",
@@ -1324,6 +1330,24 @@ func passthroughDomainsAdded(old, updated []string) []string {
 			added = append(added, d)
 		}
 	}
+	return added
+}
+
+func entropyWarnRoutesAdded(old, updated []RequestBodyEntropyWarnRoute) []string {
+	key := func(entry RequestBodyEntropyWarnRoute) string {
+		return strings.ToLower(entry.Host) + entry.Path + " [" + strings.Join(entry.Methods, ",") + "] [" + strings.Join(entry.ContentTypes, ",") + "] " + entry.Owner + " " + entry.Reason + " " + entry.Expires
+	}
+	oldSet := make(map[string]struct{}, len(old))
+	for _, entry := range old {
+		oldSet[key(entry)] = struct{}{}
+	}
+	var added []string
+	for _, entry := range updated {
+		if _, ok := oldSet[key(entry)]; !ok {
+			added = append(added, entry.Host+entry.Path)
+		}
+	}
+	sort.Strings(added)
 	return added
 }
 

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -1334,21 +1334,24 @@ func passthroughDomainsAdded(old, updated []string) []string {
 }
 
 func entropyWarnRoutesAdded(old, updated []RequestBodyEntropyWarnRoute) []string {
-	key := func(entry RequestBodyEntropyWarnRoute) string {
-		return strings.ToLower(entry.Host) + entry.Path + " [" + strings.Join(entry.Methods, ",") + "] [" + strings.Join(entry.ContentTypes, ",") + "] " + entry.Owner + " " + entry.Reason + " " + entry.Expires
-	}
 	oldSet := make(map[string]struct{}, len(old))
 	for _, entry := range old {
-		oldSet[key(entry)] = struct{}{}
+		oldSet[entropyWarnRouteIdentity(entry)] = struct{}{}
 	}
 	var added []string
 	for _, entry := range updated {
-		if _, ok := oldSet[key(entry)]; !ok {
-			added = append(added, entry.Host+entry.Path)
+		identity := entropyWarnRouteIdentity(entry)
+		if _, ok := oldSet[identity]; !ok {
+			added = append(added, identity)
 		}
 	}
 	sort.Strings(added)
 	return added
+}
+
+func entropyWarnRouteIdentity(entry RequestBodyEntropyWarnRoute) string {
+	return fmt.Sprintf("host=%q path=%q methods=%q content_types=%q owner=%q reason=%q expires=%q",
+		strings.TrimSuffix(strings.ToLower(entry.Host), "."), entry.Path, entry.Methods, entry.ContentTypes, entry.Owner, entry.Reason, entry.Expires)
 }
 
 // forwarderDestinationsAdded compares exact DNS hosts using the same

--- a/internal/config/request_body_entropy_warn_routes_test.go
+++ b/internal/config/request_body_entropy_warn_routes_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func validEntropyWarnRouteConfig() *Config {
+	cfg := Defaults()
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.ContentEntropyEnabled = true
+	cfg.RequestBodyScanning.ContentEntropyAction = ActionBlock
+	cfg.RequestBodyScanning.ContentEntropyWarnRoutes = []RequestBodyEntropyWarnRoute{{
+		Host: "UPLOAD.VENDOR.EXAMPLE.", Path: "/v1/files", ContentTypes: []string{"application/octet-stream; charset=binary"},
+		Methods: []string{"post"}, Reason: "encrypted customer archive", Owner: "storage team", Expires: "2099-12-31",
+	}}
+	return cfg
+}
+
+func TestValidateRequestBodyEntropyWarnRoutesNormalizesExactScope(t *testing.T) {
+	cfg := validEntropyWarnRouteConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	got := cfg.RequestBodyScanning.ContentEntropyWarnRoutes[0]
+	if got.Host != "upload.vendor.example" || got.Path != "/v1/files" || got.ContentTypes[0] != "application/octet-stream" || got.Methods[0] != "POST" {
+		t.Fatalf("route was not normalized: %+v", got)
+	}
+}
+
+func TestLoadStrictYAMLRecognizesEntropyWarnRoutes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	yaml := `mode: balanced
+request_body_scanning:
+  content_entropy_action: block
+  content_entropy_warn_routes:
+    - host: upload.vendor.example
+      path: /v1/files
+      content_types: [application/octet-stream]
+      methods: [POST]
+      reason: encrypted customer archive
+      owner: storage team
+      expires: 2099-12-31
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("strict Load rejected new route field: %v", err)
+	}
+	if len(cfg.RequestBodyScanning.ContentEntropyWarnRoutes) != 1 {
+		t.Fatalf("loaded routes = %+v", cfg.RequestBodyScanning.ContentEntropyWarnRoutes)
+	}
+}
+
+func TestValidateRequestBodyEntropyWarnRoutesRejectsUnsafeOrInertEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*Config)
+		want string
+	}{
+		{"global entropy is not block", func(c *Config) { c.RequestBodyScanning.ContentEntropyAction = ActionWarn }, "requires enabled request body scanning"},
+		{"wildcard host", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Host = "*.vendor.example" }, "exact host"},
+		{"root path", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Path = "/" }, "exact non-root canonical path"},
+		{"encoded topology", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Path = "/v1%2ffiles" }, "exact non-root canonical path"},
+		{"text content type", func(c *Config) {
+			c.RequestBodyScanning.ContentEntropyWarnRoutes[0].ContentTypes = []string{"application/json"}
+		}, "textual/scannable"},
+		{"invalid method", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Methods = []string{"UPLOAD"} }, "supported HTTP method"},
+		{"missing reason", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Reason = "" }, "reason is required"},
+		{"missing owner", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Owner = "" }, "owner is required"},
+		{"expired", func(c *Config) { c.RequestBodyScanning.ContentEntropyWarnRoutes[0].Expires = "2020-01-01" }, "already expired"},
+		{"overlapping owner", func(c *Config) {
+			duplicate := c.RequestBodyScanning.ContentEntropyWarnRoutes[0]
+			duplicate.Methods = nil
+			duplicate.Owner = "other team"
+			c.RequestBodyScanning.ContentEntropyWarnRoutes = append(c.RequestBodyScanning.ContentEntropyWarnRoutes, duplicate)
+		}, "overlaps content_entropy_warn_routes[0]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validEntropyWarnRouteConfig()
+			tt.edit(cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Validate error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeCloneDeepCopiesEntropyWarnRoutes(t *testing.T) {
+	cfg := validEntropyWarnRouteConfig()
+	clone := cfg.Clone()
+	clone.RequestBodyScanning.ContentEntropyWarnRoutes[0].Methods[0] = "PUT"
+	clone.RequestBodyScanning.ContentEntropyWarnRoutes[0].ContentTypes[0] = "image/png"
+	if cfg.RequestBodyScanning.ContentEntropyWarnRoutes[0].Methods[0] != "post" || cfg.RequestBodyScanning.ContentEntropyWarnRoutes[0].ContentTypes[0] != "application/octet-stream; charset=binary" {
+		t.Fatal("runtime clone aliases entropy warning route slices")
+	}
+}
+
+func TestEntropyWarnRoutesSurfaceLoadAndReloadDowngradeWarnings(t *testing.T) {
+	old := validEntropyWarnRouteConfig()
+	old.RequestBodyScanning.ContentEntropyWarnRoutes = nil
+	updated := validEntropyWarnRouteConfig()
+
+	warnings, err := updated.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings: %v", err)
+	}
+	if !hasConfigWarningField(warnings, "request_body_scanning.content_entropy_warn_routes") {
+		t.Fatalf("load warnings do not surface entropy route downgrade: %+v", warnings)
+	}
+	if !hasReloadWarning(ValidateReload(old, updated), "request_body_scanning.content_entropy_warn_routes") {
+		t.Fatalf("reload warnings do not surface added entropy route: %+v", ValidateReload(old, updated))
+	}
+	if hasReloadWarning(ValidateReload(updated, old), "request_body_scanning.content_entropy_warn_routes") {
+		t.Fatal("removing an entropy warning route was incorrectly reported as a downgrade")
+	}
+
+	beforeExtension := validEntropyWarnRouteConfig()
+	beforeExtension.RequestBodyScanning.ContentEntropyWarnRoutes[0].Expires = "2098-12-31"
+	afterExtension := validEntropyWarnRouteConfig()
+	if !hasReloadWarning(ValidateReload(beforeExtension, afterExtension), "request_body_scanning.content_entropy_warn_routes") {
+		t.Fatal("extending an entropy warning route expiry did not surface a reload downgrade warning")
+	}
+}
+
+func hasConfigWarningField(warnings []Warning, field string) bool {
+	for _, warning := range warnings {
+		if warning.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/request_body_entropy_warn_routes_test.go
+++ b/internal/config/request_body_entropy_warn_routes_test.go
@@ -132,6 +132,35 @@ func TestEntropyWarnRoutesSurfaceLoadAndReloadDowngradeWarnings(t *testing.T) {
 	}
 }
 
+func TestEntropyWarnRoutesReloadIdentitySeparatesOwnerAndReason(t *testing.T) {
+	old := validEntropyWarnRouteConfig()
+	old.RequestBodyScanning.ContentEntropyWarnRoutes[0].Owner = "storage team"
+	old.RequestBodyScanning.ContentEntropyWarnRoutes[0].Reason = "encrypted upload"
+	updated := validEntropyWarnRouteConfig()
+	updated.RequestBodyScanning.ContentEntropyWarnRoutes[0].Owner = "storage"
+	updated.RequestBodyScanning.ContentEntropyWarnRoutes[0].Reason = "team encrypted upload"
+
+	var message string
+	for _, warning := range ValidateReload(old, updated) {
+		if warning.Field == "request_body_scanning.content_entropy_warn_routes" {
+			message = warning.Message
+			break
+		}
+	}
+	if message == "" {
+		t.Fatal("colliding owner/reason change did not surface a reload warning")
+	}
+	for _, want := range []string{
+		`host="upload.vendor.example"`, `path="/v1/files"`, `methods=["post"]`,
+		`content_types=["application/octet-stream; charset=binary"]`, `owner="storage"`,
+		`reason="team encrypted upload"`, `expires="2099-12-31"`,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("reload warning %q does not contain %q", message, want)
+		}
+	}
+}
+
 func hasConfigWarningField(warnings []Warning, field string) bool {
 	for _, warning := range warnings {
 		if warning.Field == field {

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -281,6 +281,9 @@ func (c *Config) Clone() *Config {
 	if c.ResponseScanning.AuthenticatedArtifacts != nil {
 		clone.ResponseScanning.AuthenticatedArtifacts = append([]AuthenticatedArtifactEntry(nil), c.ResponseScanning.AuthenticatedArtifacts...)
 	}
+	if c.RequestBodyScanning.ContentEntropyWarnRoutes != nil {
+		clone.RequestBodyScanning.ContentEntropyWarnRoutes = cloneRequestBodyEntropyWarnRoutes(c.RequestBodyScanning.ContentEntropyWarnRoutes)
+	}
 	if c.Taint.TrustedMCPServers != nil {
 		clone.Taint.TrustedMCPServers = append([]string(nil), c.Taint.TrustedMCPServers...)
 	}
@@ -337,6 +340,15 @@ func cloneUnscannablePassthrough(src []UnscannablePassthroughEntry) []Unscannabl
 		if src[i].ContentTypes != nil {
 			dst[i].ContentTypes = append([]string(nil), src[i].ContentTypes...)
 		}
+	}
+	return dst
+}
+
+func cloneRequestBodyEntropyWarnRoutes(src []RequestBodyEntropyWarnRoute) []RequestBodyEntropyWarnRoute {
+	dst := append([]RequestBodyEntropyWarnRoute(nil), src...)
+	for i := range src {
+		dst[i].ContentTypes = append([]string(nil), src[i].ContentTypes...)
+		dst[i].Methods = append([]string(nil), src[i].Methods...)
 	}
 	return dst
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1296,20 +1296,35 @@ type A2ATrustedCardKey struct {
 // smuggled in Authorization/Cookie headers. CONNECT tunnels are out of scope
 // (TLS-encrypted, can't scan without MITM).
 type RequestBodyScanning struct {
-	Enabled                  bool              `yaml:"enabled"`
-	Action                   string            `yaml:"action"`                    // warn, block (no strip for bodies)
-	PatternActions           map[string]string `yaml:"pattern_actions"`           // per-DLP-pattern action override: warn or block; cannot downgrade core DLP
-	DisablePatterns          []string          `yaml:"disable_patterns"`          // non-core DLP pattern names skipped by request body/header scanning
-	MaxBodyBytes             int               `yaml:"max_body_bytes"`            // fail-closed above this limit
-	ScanHeaders              bool              `yaml:"scan_headers"`              // scan request headers for DLP
-	HeaderMode               string            `yaml:"header_mode"`               // "sensitive" (listed headers) or "all" (everything except ignore list)
-	SensitiveHeaders         []string          `yaml:"sensitive_headers"`         // headers to scan in sensitive mode
-	IgnoreHeaders            []string          `yaml:"ignore_headers"`            // headers to skip in all mode
-	ContentEntropyEnabled    bool              `yaml:"content_entropy_enabled"`   // per-message opaque high-entropy body/frame detection
-	ContentEntropyAction     string            `yaml:"content_entropy_action"`    // warn, block
-	ContentEntropyThreshold  float64           `yaml:"content_entropy_threshold"` // Shannon entropy bits per character (0,8]; non-positive fails validation while enabled
-	ContentEntropyMinLength  int               `yaml:"content_entropy_min_length"`
-	ContentEntropyExclusions []string          `yaml:"content_entropy_exclusions"` // host patterns exempt from per-message content entropy only
+	Enabled                  bool                          `yaml:"enabled"`
+	Action                   string                        `yaml:"action"`                    // warn, block (no strip for bodies)
+	PatternActions           map[string]string             `yaml:"pattern_actions"`           // per-DLP-pattern action override: warn or block; cannot downgrade core DLP
+	DisablePatterns          []string                      `yaml:"disable_patterns"`          // non-core DLP pattern names skipped by request body/header scanning
+	MaxBodyBytes             int                           `yaml:"max_body_bytes"`            // fail-closed above this limit
+	ScanHeaders              bool                          `yaml:"scan_headers"`              // scan request headers for DLP
+	HeaderMode               string                        `yaml:"header_mode"`               // "sensitive" (listed headers) or "all" (everything except ignore list)
+	SensitiveHeaders         []string                      `yaml:"sensitive_headers"`         // headers to scan in sensitive mode
+	IgnoreHeaders            []string                      `yaml:"ignore_headers"`            // headers to skip in all mode
+	ContentEntropyEnabled    bool                          `yaml:"content_entropy_enabled"`   // per-message opaque high-entropy body/frame detection
+	ContentEntropyAction     string                        `yaml:"content_entropy_action"`    // warn, block
+	ContentEntropyThreshold  float64                       `yaml:"content_entropy_threshold"` // Shannon entropy bits per character (0,8]; non-positive fails validation while enabled
+	ContentEntropyMinLength  int                           `yaml:"content_entropy_min_length"`
+	ContentEntropyExclusions []string                      `yaml:"content_entropy_exclusions"`  // host patterns exempt from per-message content entropy only
+	ContentEntropyWarnRoutes []RequestBodyEntropyWarnRoute `yaml:"content_entropy_warn_routes"` // exact HTTPS routes where entropy findings warn; all other scanners remain enforced
+}
+
+// RequestBodyEntropyWarnRoute is a narrow, expiring operator exception for
+// legitimate opaque uploads. It changes only request-body entropy findings
+// from block to warn on one exact HTTPS destination. Content-Type is an
+// operator-intent constraint, not proof that attacker-controlled bytes are safe.
+type RequestBodyEntropyWarnRoute struct {
+	Host         string   `yaml:"host"`
+	Path         string   `yaml:"path"`
+	ContentTypes []string `yaml:"content_types"`
+	Methods      []string `yaml:"methods,omitempty"`
+	Reason       string   `yaml:"reason"`
+	Owner        string   `yaml:"owner"`
+	Expires      string   `yaml:"expires"`
 }
 
 // CrossRequestDetection configures cross-request exfiltration detection.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -152,6 +153,110 @@ func validateUnscannablePassthrough(entries []UnscannablePassthroughEntry) error
 		entries[i].Expires = strings.TrimSpace(entries[i].Expires)
 	}
 	return nil
+}
+
+func validateRequestBodyEntropyWarnRoutes(cfg *RequestBodyScanning) error {
+	if len(cfg.ContentEntropyWarnRoutes) == 0 {
+		return nil
+	}
+	if !cfg.Enabled || !cfg.ContentEntropyEnabled || cfg.ContentEntropyAction != ActionBlock {
+		return fmt.Errorf("request_body_scanning.content_entropy_warn_routes requires enabled request body scanning with content entropy action block")
+	}
+
+	for i := range cfg.ContentEntropyWarnRoutes {
+		entry := &cfg.ContentEntropyWarnRoutes[i]
+		field := fmt.Sprintf("request_body_scanning.content_entropy_warn_routes[%d]", i)
+		host := []string{entry.Host}
+		if err := ValidateTrustedDomains(host, field+".host"); err != nil {
+			return err
+		}
+		if strings.ContainsAny(host[0], "*?[]") {
+			return fmt.Errorf("%s.host must be one exact host without wildcards", field)
+		}
+		entry.Host = host[0]
+
+		path, ok := CanonicalUnscannablePassthroughPath(strings.TrimSpace(entry.Path))
+		if !ok {
+			return fmt.Errorf("%s.path %q must be an exact non-root canonical path without traversal, encoded topology changes, controls, or path parameters", field, entry.Path)
+		}
+		entry.Path = path
+
+		if len(entry.ContentTypes) == 0 {
+			return fmt.Errorf("%s.content_types must contain at least one non-textual media type", field)
+		}
+		for j, raw := range entry.ContentTypes {
+			mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(strings.ToLower(raw)))
+			if err != nil || mediaType == "" {
+				return fmt.Errorf("%s.content_types[%d] %q is invalid", field, j, raw)
+			}
+			if isTextualUnscannablePassthroughType(mediaType) {
+				return fmt.Errorf("%s.content_types[%d] %q is textual/scannable and cannot downgrade entropy enforcement", field, j, raw)
+			}
+			entry.ContentTypes[j] = mediaType
+		}
+
+		for j, raw := range entry.Methods {
+			method := strings.ToUpper(strings.TrimSpace(raw))
+			if !validHTTPMethod(method) {
+				return fmt.Errorf("%s.methods[%d] %q is not a supported HTTP method", field, j, raw)
+			}
+			entry.Methods[j] = method
+		}
+
+		entry.Reason = strings.TrimSpace(entry.Reason)
+		entry.Owner = strings.TrimSpace(entry.Owner)
+		for _, textField := range []struct {
+			name  string
+			value string
+			max   int
+		}{{"reason", entry.Reason, 200}, {"owner", entry.Owner, 100}} {
+			if textField.value == "" {
+				return fmt.Errorf("%s.%s is required", field, textField.name)
+			}
+			if len(textField.value) > textField.max {
+				return fmt.Errorf("%s.%s must be %d characters or fewer", field, textField.name, textField.max)
+			}
+			if strings.IndexFunc(textField.value, unicode.IsControl) >= 0 {
+				return fmt.Errorf("%s.%s must not contain control characters", field, textField.name)
+			}
+		}
+
+		entry.Expires = strings.TrimSpace(entry.Expires)
+		expires, err := time.Parse("2006-01-02", entry.Expires)
+		if err != nil {
+			return fmt.Errorf("%s.expires %q must be YYYY-MM-DD: %w", field, entry.Expires, err)
+		}
+		if expires.Before(todayUTC()) {
+			return fmt.Errorf("%s.expires %q is already expired", field, entry.Expires)
+		}
+
+		slices.Sort(entry.ContentTypes)
+		entry.ContentTypes = slices.Compact(entry.ContentTypes)
+		slices.Sort(entry.Methods)
+		entry.Methods = slices.Compact(entry.Methods)
+		for j := range i {
+			previous := cfg.ContentEntropyWarnRoutes[j]
+			methodsOverlap := len(previous.Methods) == 0 || len(entry.Methods) == 0 || sortedStringsOverlap(previous.Methods, entry.Methods)
+			if previous.Host == entry.Host && previous.Path == entry.Path && methodsOverlap && sortedStringsOverlap(previous.ContentTypes, entry.ContentTypes) {
+				return fmt.Errorf("%s overlaps content_entropy_warn_routes[%d]; exact route exceptions must have one unambiguous owner and reason", field, j)
+			}
+		}
+	}
+	return nil
+}
+
+func sortedStringsOverlap(left, right []string) bool {
+	for i, j := 0, 0; i < len(left) && j < len(right); {
+		switch {
+		case left[i] == right[j]:
+			return true
+		case left[i] < right[j]:
+			i++
+		default:
+			j++
+		}
+	}
+	return false
 }
 
 func todayUTC() time.Time {
@@ -322,6 +427,12 @@ func (c *Config) ValidateWithWarnings() ([]Warning, error) {
 	}
 	if err := c.validateRequestBodyScanning(); err != nil {
 		return warnings, err
+	}
+	if len(c.RequestBodyScanning.ContentEntropyWarnRoutes) > 0 {
+		warnings = append(warnings, Warning{
+			Field:   "request_body_scanning.content_entropy_warn_routes",
+			Message: fmt.Sprintf("%d exact HTTPS route(s) downgrade request-body entropy findings from block to warn; DLP, injection, address, size, and redirect controls remain enforced", len(c.RequestBodyScanning.ContentEntropyWarnRoutes)),
+		})
 	}
 	if err := c.validateRequestPolicy(&warnings); err != nil {
 		return warnings, err
@@ -2363,6 +2474,9 @@ func (c *Config) validateRequestBodyScanning() error {
 		return fmt.Errorf("request_body_scanning.content_entropy_min_length must be non-negative")
 	}
 	if err := validateHostnamePatternList("request_body_scanning.content_entropy_exclusions", c.RequestBodyScanning.ContentEntropyExclusions); err != nil {
+		return err
+	}
+	if err := validateRequestBodyEntropyWarnRoutes(&c.RequestBodyScanning); err != nil {
 		return err
 	}
 	if !c.RequestBodyScanning.Enabled {

--- a/internal/proxy/body_entropy_warn_route_test.go
+++ b/internal/proxy/body_entropy_warn_route_test.go
@@ -5,10 +5,12 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -192,5 +194,75 @@ func TestWebSocketContentEntropyConfigExplicitlyDropsHTTPWarnRoutes(t *testing.T
 	}
 	if !stringListContains(req.ContentEntropyExclusions, "stream.vendor.example") {
 		t.Fatalf("WebSocket entropy exclusions were not applied: %+v", req.ContentEntropyExclusions)
+	}
+}
+
+func TestInterceptEntropyWarnReceiptPreservesProvenanceAndDoesNotFollowRedirect(t *testing.T) {
+	for _, requireReceipts := range []bool{false, true} {
+		t.Run(fmt.Sprintf("require_receipts_%t", requireReceipts), func(t *testing.T) {
+			cache, pool, cfg, _, logger, m := testInterceptSetup(t)
+			cfg.RequestBodyScanning.ContentEntropyEnabled = true
+			cfg.RequestBodyScanning.ContentEntropyAction = config.ActionBlock
+			cfg.RequestBodyScanning.ContentEntropyThreshold = 4.5
+			cfg.RequestBodyScanning.ContentEntropyMinLength = 32
+			cfg.RequestBodyScanning.ContentEntropyWarnRoutes = []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()}
+			cfg.FlightRecorder.RequireReceipts = requireReceipts
+			sc := scanner.MustNew(cfg)
+			t.Cleanup(func() { sc.Close() })
+			p, err := New(cfg, logger, sc, m)
+			if err != nil {
+				t.Fatalf("proxy.New: %v", err)
+			}
+			rph := newReceiptProxyHelperWithMetrics(t, p.metrics)
+			p.receiptEmitterPtr.Store(rph.emitter)
+
+			var calls atomic.Int32
+			rt := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusTemporaryRedirect,
+					Header: http.Header{
+						headerContentType: {"text/plain"},
+						"Location":        {"https://other.vendor.example/v1/files"},
+					},
+					Body: http.NoBody,
+				}, nil
+			})
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+				"https://upload.vendor.example/v1/files", strings.NewReader(opaqueHighEntropyBodyValue()))
+			if err != nil {
+				t.Fatalf("NewRequestWithContext: %v", err)
+			}
+			req.Header.Set(headerContentType, "application/octet-stream")
+			resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+				&InterceptContext{Proxy: p, TargetHost: "upload.vendor.example", TargetPort: "443"}, req)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			if resp.StatusCode != http.StatusTemporaryRedirect {
+				t.Fatalf("status = %d, want 307 returned to the agent", resp.StatusCode)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("intercept RoundTrip calls = %d, want 1 (redirects are not followed internally)", got)
+			}
+
+			var warningReceiptFound bool
+			for _, rcpt := range rph.findReceipts(t) {
+				ar := rcpt.ActionRecord
+				if ar.Transport != "intercept" || ar.Layer != scannerLabelBodyEntropy {
+					continue
+				}
+				warningReceiptFound = true
+				if ar.Verdict != config.ActionWarn {
+					t.Fatalf("entropy receipt verdict = %q, want warn", ar.Verdict)
+				}
+				for _, want := range []string{"encrypted customer archive", "storage team", "2099-12-31"} {
+					if !strings.Contains(ar.Pattern, want) {
+						t.Fatalf("entropy receipt pattern %q does not contain %q", ar.Pattern, want)
+					}
+				}
+			}
+			if !warningReceiptFound {
+				t.Fatal("intercept entropy warning receipt was not emitted")
+			}
+		})
 	}
 }

--- a/internal/proxy/body_entropy_warn_route_test.go
+++ b/internal/proxy/body_entropy_warn_route_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func entropyWarnRoute() config.RequestBodyEntropyWarnRoute {
+	return config.RequestBodyEntropyWarnRoute{
+		Host: "upload.vendor.example", Path: "/v1/files", ContentTypes: []string{"application/octet-stream"},
+		Methods: []string{"POST"}, Reason: "encrypted customer archive", Owner: "storage team", Expires: "2099-12-31",
+	}
+}
+
+func TestMatchBodyEntropyWarnRouteIsExactHTTPSAndExpiresAtRuntime(t *testing.T) {
+	base := BodyScanRequest{
+		Scheme: "https", Host: "upload.vendor.example", Path: "/v1/files", EntropyRoutePath: "/v1/files", Method: "POST",
+		ContentType: "application/octet-stream; version=1", ContentEntropyAction: config.ActionBlock,
+		ContentEntropyWarnRoutes: []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()},
+	}
+	if got := matchBodyEntropyWarnRoute(base, time.Date(2099, 12, 31, 12, 0, 0, 0, time.UTC)); got == nil {
+		t.Fatal("exact route did not match on its expiry date")
+	}
+	for _, mutate := range []func(*BodyScanRequest){
+		func(r *BodyScanRequest) { r.Scheme = "http" },
+		func(r *BodyScanRequest) { r.Host = "other.vendor.example" },
+		func(r *BodyScanRequest) { r.EntropyRoutePath = "/v1/files/child" },
+		func(r *BodyScanRequest) { r.EntropyRoutePath = "/v1%2ffiles" },
+		func(r *BodyScanRequest) { r.EntropyRoutePath = "" },
+		func(r *BodyScanRequest) { r.Method = "PUT" },
+		func(r *BodyScanRequest) { r.ContentType = "image/png" },
+		func(r *BodyScanRequest) { r.ContentType = "" },
+	} {
+		req := base
+		mutate(&req)
+		if got := matchBodyEntropyWarnRoute(req, time.Date(2099, 12, 31, 12, 0, 0, 0, time.UTC)); got != nil {
+			t.Fatalf("nearby route unexpectedly matched: %+v", req)
+		}
+	}
+	if got := matchBodyEntropyWarnRoute(base, time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)); got != nil {
+		t.Fatal("expired route still matched in a long-running process")
+	}
+}
+
+func TestMatchBodyEntropyWarnRouteRejectsEncodedTopologyBeforeDecode(t *testing.T) {
+	u, err := url.Parse("https://upload.vendor.example/v1%2ffiles")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	if u.Path != "/v1/files" || u.EscapedPath() != "/v1%2ffiles" {
+		t.Fatalf("unexpected URL parser precondition: Path=%q EscapedPath=%q", u.Path, u.EscapedPath())
+	}
+	req := BodyScanRequest{
+		Scheme: u.Scheme, Host: u.Hostname(), Path: u.Path, EntropyRoutePath: u.EscapedPath(), Method: http.MethodPost,
+		ContentType: "application/octet-stream", ContentEntropyAction: config.ActionBlock,
+		ContentEntropyWarnRoutes: []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()},
+	}
+	if got := matchBodyEntropyWarnRoute(req, time.Date(2099, 12, 31, 12, 0, 0, 0, time.UTC)); got != nil {
+		t.Fatalf("encoded topology change matched decoded exact route: %+v", got)
+	}
+}
+
+func TestScanRequestBodyEntropyWarnRoutePreservesFindingAndProvenance(t *testing.T) {
+	cfg := testScannerConfig()
+	cfg.RequestBodyScanning.ContentEntropyEnabled = true
+	cfg.RequestBodyScanning.ContentEntropyAction = config.ActionBlock
+	cfg.RequestBodyScanning.ContentEntropyThreshold = 4.5
+	cfg.RequestBodyScanning.ContentEntropyMinLength = 32
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	req := BodyScanRequest{
+		Body: strings.NewReader(opaqueHighEntropyBodyValue()), Scheme: "https", Method: "POST",
+		ContentType: "application/octet-stream", MaxBytes: cfg.RequestBodyScanning.MaxBodyBytes, Scanner: sc,
+		Host: "upload.vendor.example", Path: "/v1/files", Target: "https://upload.vendor.example/v1/files",
+		EntropyRoutePath: "/v1/files",
+		Action:           config.ActionBlock, ContentEntropyEnabled: true, ContentEntropyAction: config.ActionBlock,
+		ContentEntropyThreshold: 4.5, ContentEntropyMinLength: 32,
+		ContentEntropyWarnRoutes: []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()},
+	}
+	_, result := scanRequestBody(context.Background(), req)
+	if result.Clean || result.EntropyFinding == nil || result.EntropyWarnRoute == nil {
+		t.Fatalf("expected visible entropy warning with route provenance, got %+v", result)
+	}
+	if result.Action != config.ActionWarn || result.EntropyAction != config.ActionWarn {
+		t.Fatalf("actions = %q/%q, want warn/warn", result.Action, result.EntropyAction)
+	}
+	for _, want := range []string{"encrypted customer archive", "storage team", "2099-12-31"} {
+		if !strings.Contains(result.Reason, want) {
+			t.Fatalf("reason %q does not contain %q", result.Reason, want)
+		}
+	}
+
+	req.EntropyRoutePath = "/v1/other"
+	req.Body = strings.NewReader(opaqueHighEntropyBodyValue())
+	_, blocked := scanRequestBody(context.Background(), req)
+	if blocked.Action != config.ActionBlock || blocked.EntropyWarnRoute != nil {
+		t.Fatalf("non-matching route did not retain entropy block: %+v", blocked)
+	}
+
+	req.EntropyRoutePath = "/v1/files"
+	req.Body = strings.NewReader(fakeAPIKey() + opaqueHighEntropyBodyValue())
+	_, withDLP := scanRequestBody(context.Background(), req)
+	if len(withDLP.DLPMatches) == 0 || withDLP.Action != config.ActionBlock {
+		t.Fatalf("route warning hid a stronger DLP finding: %+v", withDLP)
+	}
+}
+
+func TestBodyEntropyReasonIncludesRouteProvenance(t *testing.T) {
+	result := BodyScanResult{
+		EntropyFinding: &ContentEntropyFinding{Entropy: 7.5, Threshold: 4.5},
+		EntropyWarnRoute: &BodyEntropyWarnRouteMatch{
+			Reason:  "encrypted customer archive",
+			Owner:   "storage team",
+			Expires: "2099-12-31",
+		},
+	}
+	got := bodyEntropyReason(result)
+	for _, want := range []string{"route warning override", "encrypted customer archive", "storage team", "2099-12-31"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reason %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestCheckRedirectBindsEntropyWarningToAdmittedRoute(t *testing.T) {
+	p, cfg, sc := redirectPolicyTestProxy(t)
+	cfg.RequestBodyScanning.ContentEntropyAction = config.ActionBlock
+	cfg.RequestBodyScanning.ContentEntropyWarnRoutes = []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()}
+	admitted := &BodyEntropyWarnRouteMatch{Host: "upload.vendor.example", Path: "/v1/files", Reason: "encrypted customer archive", Owner: "storage team", Expires: "2099-12-31"}
+
+	ctx := context.WithValue(t.Context(), ctxKeyAgentConfig, cfg)
+	ctx = context.WithValue(ctx, ctxKeyAgentScanner, sc)
+	ctx = context.WithValue(ctx, ctxKeyEntropyWarnRoute, admitted)
+	original := httptest.NewRequestWithContext(ctx, http.MethodPost, "https://upload.vendor.example/v1/files", nil)
+	original.Header.Set(headerContentType, "application/octet-stream")
+
+	for _, tt := range []struct {
+		name    string
+		target  string
+		blocked bool
+	}{
+		{"same exact route", "https://upload.vendor.example/v1/files?part=2", false},
+		{"different path", "https://upload.vendor.example/v1/other", true},
+		{"different host", "https://other.vendor.example/v1/files", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			redirect := httptest.NewRequestWithContext(ctx, http.MethodPost, tt.target, nil)
+			redirect.Header.Set(headerContentType, "application/octet-stream")
+			err := p.client.CheckRedirect(redirect, []*http.Request{original})
+			if tt.blocked && err == nil {
+				t.Fatal("redirect replay outside admitted route was allowed")
+			}
+			if !tt.blocked && err != nil {
+				t.Fatalf("same-route redirect was blocked: %v", err)
+			}
+		})
+	}
+}
+
+func TestEntropyWarnRouteIsAdaptiveExemptButOrdinaryEntropyIsNot(t *testing.T) {
+	cfg := config.Defaults()
+	matched := BodyScanResult{EntropyFinding: &ContentEntropyFinding{}, EntropyWarnRoute: &BodyEntropyWarnRouteMatch{Host: "upload.vendor.example", Path: "/v1/files"}}
+	if !isBodyAdaptiveExempt(scannerLabelBodyEntropy, matched, "upload.vendor.example", cfg) {
+		t.Fatal("authorized entropy warning would be re-promoted by adaptive enforcement")
+	}
+	ordinary := BodyScanResult{EntropyFinding: &ContentEntropyFinding{}}
+	if isBodyAdaptiveExempt(scannerLabelBodyEntropy, ordinary, "upload.vendor.example", cfg) {
+		t.Fatal("ordinary entropy finding was incorrectly exempted from adaptive enforcement")
+	}
+}
+
+func TestWebSocketContentEntropyConfigExplicitlyDropsHTTPWarnRoutes(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.RequestBodyScanning.ContentEntropyWarnRoutes = []config.RequestBodyEntropyWarnRoute{entropyWarnRoute()}
+	cfg.WebSocketProxy.ContentEntropyExclusions = []string{"stream.vendor.example"}
+	req := BodyScanRequest{Scheme: "https"}
+	applyWebSocketContentEntropyConfig(&req, cfg)
+	if req.ContentEntropyWarnRoutes != nil {
+		t.Fatalf("HTTP entropy warning routes leaked into WebSocket scan: %+v", req.ContentEntropyWarnRoutes)
+	}
+	if !stringListContains(req.ContentEntropyExclusions, "stream.vendor.example") {
+		t.Fatalf("WebSocket entropy exclusions were not applied: %+v", req.ContentEntropyExclusions)
+	}
+}

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -446,6 +446,14 @@ func shouldHardBlockBodyCriticalDLP(result BodyScanResult, hostname string, cfg 
 	return true
 }
 
+func isBodyAdaptiveExempt(scannerLabel string, result BodyScanResult, hostname string, cfg *config.Config) bool {
+	if scannerLabel == scannerLabelBodyEntropy && result.EntropyWarnRoute != nil {
+		return true
+	}
+	return scannerLabel == scannerLabelBodyDLP && len(result.DLPMatches) > 0 && cfg != nil &&
+		isAdaptiveExempt(hostname, cfg.AdaptiveEnforcement.ExemptDomains)
+}
+
 // BodyScanResult describes the outcome of scanning a request body or headers.
 type BodyScanResult struct {
 	Clean            bool
@@ -455,6 +463,7 @@ type BodyScanResult struct {
 	AddressFindings  []addressprotect.Finding // crypto address poisoning findings
 	EntropyFinding   *ContentEntropyFinding
 	EntropyAction    string
+	EntropyWarnRoute *BodyEntropyWarnRouteMatch
 	// RedactedDLPOnly is true when DLP matched the original body but the
 	// post-redaction body scanned clean. Callers can use this to distinguish
 	// "raw residual secret remains" from "secret was removed before forward".
@@ -474,10 +483,22 @@ type BodyScanResult struct {
 // ContentEntropyFinding describes an opaque high-entropy body/frame value.
 type ContentEntropyFinding = contententropy.Finding
 
+// BodyEntropyWarnRouteMatch records the exact operator exception that changed
+// an entropy finding from block to warn. It is kept on the result so audit and
+// receipt surfaces can show why the warning was allowed through.
+type BodyEntropyWarnRouteMatch struct {
+	Host    string
+	Path    string
+	Reason  string
+	Owner   string
+	Expires string
+}
+
 // BodyScanRequest groups the parameters for scanRequestBody, keeping the
 // function signature under the 6-parameter guideline (ctx is passed separately).
 type BodyScanRequest struct {
 	Body            io.Reader
+	Scheme          string
 	Method          string
 	ContentType     string
 	ContentEncoding string
@@ -513,6 +534,10 @@ type BodyScanRequest struct {
 	Host string
 	// Path is the upstream request path, used for provider parser selection.
 	Path string
+	// EntropyRoutePath is the escaped upstream path used only for exact entropy
+	// warning route matching. It must retain encoded topology changes that the
+	// decoded Path intentionally hides from provider and redaction dispatch.
+	EntropyRoutePath string
 	// TrustedProviderOpaqueRequest overrides provider-opaque request recognition.
 	// Nil uses the production OpenAI/ChatGPT host and path allowlist.
 	TrustedProviderOpaqueRequest func(host, path string) bool
@@ -536,6 +561,7 @@ type BodyScanRequest struct {
 	ContentEntropyMinLength  int
 	ContentEntropyTrusted    []string
 	ContentEntropyExclusions []string
+	ContentEntropyWarnRoutes []config.RequestBodyEntropyWarnRoute
 }
 
 // scanRequestBody reads, buffers, and scans an HTTP request body for
@@ -682,7 +708,11 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 	if finding := scanBodyTextsForContentEntropy(texts, req); finding != nil {
 		result.EntropyFinding = finding
 		result.EntropyAction = req.ContentEntropyAction
-		action = config.StrongestAction(action, req.ContentEntropyAction)
+		if matched := matchBodyEntropyWarnRoute(req, time.Now().UTC()); matched != nil {
+			result.EntropyAction = config.ActionWarn
+			result.EntropyWarnRoute = matched
+		}
+		action = config.StrongestAction(action, result.EntropyAction)
 	}
 	for _, text := range texts {
 		injectionResult := req.Scanner.ScanResponse(ctx, text)
@@ -730,7 +760,7 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 			result.Reason = fmt.Sprintf("address poisoning detected: %s", result.AddressFindings[0].Explanation)
 		}
 		if result.EntropyFinding != nil && len(result.DLPMatches) == 0 && len(result.InjectionMatches) == 0 && len(result.AddressFindings) == 0 {
-			result.Reason = contentEntropyReason(result.EntropyFinding)
+			result.Reason = bodyEntropyReason(result)
 		}
 		return buf, result
 	}
@@ -1018,6 +1048,50 @@ func contentEntropyReason(f *ContentEntropyFinding) string {
 	return contententropy.Reason(f)
 }
 
+func bodyEntropyReason(result BodyScanResult) string {
+	reason := contentEntropyReason(result.EntropyFinding)
+	if result.EntropyWarnRoute == nil {
+		return reason
+	}
+	return fmt.Sprintf("%s; route warning override: %s (owner %s, expires %s)", reason, result.EntropyWarnRoute.Reason, result.EntropyWarnRoute.Owner, result.EntropyWarnRoute.Expires)
+}
+
+func matchBodyEntropyWarnRoute(req BodyScanRequest, now time.Time) *BodyEntropyWarnRouteMatch {
+	if !strings.EqualFold(req.Scheme, "https") || req.ContentEntropyAction != config.ActionBlock {
+		return nil
+	}
+	path, ok := config.CanonicalUnscannablePassthroughPath(req.EntropyRoutePath)
+	if !ok {
+		return nil
+	}
+	mediaType, _, err := mime.ParseMediaType(strings.ToLower(strings.TrimSpace(req.ContentType)))
+	if err != nil || mediaType == "" {
+		return nil
+	}
+	method := strings.ToUpper(req.Method)
+	host := strings.ToLower(strings.TrimSuffix(req.Host, "."))
+	today := now.UTC().Format("2006-01-02")
+	for _, entry := range req.ContentEntropyWarnRoutes {
+		if entry.Host != host || entry.Path != path || entry.Expires < today || !stringListContains(entry.ContentTypes, mediaType) {
+			continue
+		}
+		if len(entry.Methods) > 0 && !stringListContains(entry.Methods, method) {
+			continue
+		}
+		return &BodyEntropyWarnRouteMatch{Host: entry.Host, Path: entry.Path, Reason: entry.Reason, Owner: entry.Owner, Expires: entry.Expires}
+	}
+	return nil
+}
+
+func stringListContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func applyContentEntropyConfig(req *BodyScanRequest, cfg *config.Config, extraExclusions ...[]string) {
 	if req == nil || cfg == nil {
 		return
@@ -1028,6 +1102,7 @@ func applyContentEntropyConfig(req *BodyScanRequest, cfg *config.Config, extraEx
 	req.ContentEntropyMinLength = cfg.RequestBodyScanning.ContentEntropyMinLength
 	req.ContentEntropyTrusted = cfg.TrustedDomains
 	req.ContentEntropyExclusions = append([]string(nil), cfg.RequestBodyScanning.ContentEntropyExclusions...)
+	req.ContentEntropyWarnRoutes = cfg.RequestBodyScanning.ContentEntropyWarnRoutes
 	for _, exclusions := range extraExclusions {
 		req.ContentEntropyExclusions = append(req.ContentEntropyExclusions, exclusions...)
 	}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1261,6 +1261,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	// the signer would have to re-drain req.Body itself and the caller
 	// would lose deterministic bookkeeping about byte counts.
 	var forwardBodyBytes []byte
+	var forwardEntropyWarnRoute *BodyEntropyWarnRouteMatch
 	scanA2AForwardBody := func(buf []byte) bool {
 		a2aBodyResult := mcp.ScanA2ARequestBody(r.Context(), buf, sc, &cfg.A2AScanning, a2aContentEntropyOptions(r.URL.Hostname(), cfg))
 		if a2aBodyResult.Clean {
@@ -1354,20 +1355,22 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if cfg.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
 		bodyReq := BodyScanRequest{
-			Body:            r.Body,
-			Method:          r.Method,
-			ContentType:     r.Header.Get("Content-Type"),
-			ContentEncoding: r.Header.Get("Content-Encoding"),
-			MaxBytes:        cfg.RequestBodyScanning.MaxBodyBytes,
-			Scanner:         sc,
-			AgentID:         agent,
-			Host:            r.URL.Hostname(),
-			Path:            r.URL.Path,
-			Target:          targetURL,
-			Suppress:        cfg.Suppress,
-			Action:          cfg.RequestBodyScanning.Action,
-			DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
-			PatternActions:  cfg.RequestBodyScanning.PatternActions,
+			Body:             r.Body,
+			Scheme:           r.URL.Scheme,
+			Method:           r.Method,
+			ContentType:      r.Header.Get("Content-Type"),
+			ContentEncoding:  r.Header.Get("Content-Encoding"),
+			MaxBytes:         cfg.RequestBodyScanning.MaxBodyBytes,
+			Scanner:          sc,
+			AgentID:          agent,
+			Host:             r.URL.Hostname(),
+			Path:             r.URL.Path,
+			EntropyRoutePath: r.URL.EscapedPath(),
+			Target:           targetURL,
+			Suppress:         cfg.Suppress,
+			Action:           cfg.RequestBodyScanning.Action,
+			DisablePatterns:  cfg.RequestBodyScanning.DisablePatterns,
+			PatternActions:   cfg.RequestBodyScanning.PatternActions,
 		}
 		applyContentEntropyConfig(&bodyReq, cfg)
 		if isA2A {
@@ -1375,6 +1378,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		applyBodyScanRedaction(&bodyReq, p.currentRedactionRuntimeFor(cfg))
 		buf, bodyResult := scanRequestBody(r.Context(), bodyReq)
+		forwardEntropyWarnRoute = bodyResult.EntropyWarnRoute
 
 		// Capture observer: record forward body DLP verdict for policy replay.
 		{
@@ -1411,6 +1415,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		recordBodyRedactionMetrics(p.metrics, "forward", agentLabel, bodyResult.RedactionReport)
 
 		if !bodyResult.Clean {
+			// An authorized entropy warning remains a finding for receipts and
+			// does not count as a clean adaptive-recovery event. Its exemption
+			// below prevents score signals and action re-promotion only.
 			hasFinding = true
 			action := bodyResult.Action
 			if action == "" {
@@ -1443,13 +1450,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				case len(patternNames) > 0:
 					reason = fmt.Sprintf("request body contains secret: %s", strings.Join(patternNames, ", "))
 				case bodyResult.EntropyFinding != nil:
-					reason = contentEntropyReason(bodyResult.EntropyFinding)
+					reason = bodyEntropyReason(bodyResult)
 				}
 			}
 			promptInjectionHardBlock := shouldHardBlockBodyPromptInjection(bodyResult, r.URL.Hostname(), cfg)
-			fwdBodyExempt := scannerLabel == scannerLabelBodyDLP &&
-				len(bodyResult.DLPMatches) > 0 &&
-				isAdaptiveExempt(r.URL.Hostname(), cfg.AdaptiveEnforcement.ExemptDomains)
+			bodyAdaptiveExempt := isBodyAdaptiveExempt(scannerLabel, bodyResult, r.URL.Hostname(), cfg)
 			dlpHardBlock := shouldHardBlockBodyCriticalDLP(bodyResult, r.URL.Hostname(), cfg)
 			if promptInjectionHardBlock || dlpHardBlock {
 				action = config.ActionBlock
@@ -1481,7 +1486,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			if bodyResult.EntropyFinding != nil {
 				p.metrics.RecordBodyEntropy(action, agentLabel)
-				p.logger.LogBodyScan(actx, scanner.AuditBodyEntropy, action, 1, []string{contentEntropyReason(bodyResult.EntropyFinding)})
+				p.logger.LogBodyScan(actx, scanner.AuditBodyEntropy, action, 1, []string{bodyEntropyReason(bodyResult)})
 			}
 
 			// Fail-closed: if the body cannot be replayed or redaction explicitly
@@ -1516,12 +1521,11 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// Adaptive enforcement: upgrade the body action.
-			// DLP-only exemption: skip upgrade for DLP pattern findings on
-			// adaptive-exempt destinations. Address protection findings and
-			// fail-closed body errors are NOT exempted.
+			// Adaptive enforcement: upgrade the body action except for the
+			// existing DLP destination exemption and an exact entropy warning
+			// route. Address, injection, and fail-closed errors remain eligible.
 			originalBodyAction := action
-			if !fwdBodyExempt {
+			if !bodyAdaptiveExempt {
 				action = decide.UpgradeAction(action, sr.Level, &cfg.AdaptiveEnforcement)
 			}
 			if action != originalBodyAction {
@@ -1900,6 +1904,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, ctxKeyAgentContractLoader, snapshotContractLoader)
 	ctx = context.WithValue(ctx, ctxKeyRedirectTransport, TransportForward)
 	ctx = context.WithValue(ctx, ctxKeyRedirectSessionRecorder, forwardRec)
+	if forwardEntropyWarnRoute != nil {
+		ctx = context.WithValue(ctx, ctxKeyEntropyWarnRoute, forwardEntropyWarnRoute)
+	}
 	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), effectiveURLPort(r.URL), result)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -900,6 +900,7 @@ func newInterceptHandler(
 		// hand the already-buffered bytes to InjectAndSign for
 		// content-digest computation without a second drain pass.
 		var interceptBodyBytes []byte
+		var interceptEntropyWarningPattern string
 		if !ic.Config.RequestBodyScanning.Enabled && isA2A && ic.Config.A2AScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
 			bodyBytes, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), ic.Config.RequestBodyScanning.MaxBodyBytes)
 			if err != nil {
@@ -1177,6 +1178,9 @@ func newInterceptHandler(
 					writeBlockedError(w, blockInfo(scannerLabel),
 						"blocked: "+reason+" (escalated)", http.StatusForbidden)
 					return
+				}
+				if action == config.ActionWarn && result.EntropyWarnRoute != nil {
+					interceptEntropyWarningPattern = bodyEntropyReason(result)
 				}
 				// Audit/warn mode: log finding but forward the request.
 				ic.Logger.LogAnomaly(actx, scannerLabel, reason, 0.8)
@@ -1652,9 +1656,19 @@ func newInterceptHandler(
 		// fail closed BEFORE the inner request leaves the intercepted tunnel.
 		// Every field here is request-side, so response allow paths reuse this
 		// action and skip duplicate required intents after the durable gate.
+		receiptVerdict := config.ActionAllow
+		receiptLayer := ""
+		receiptPattern := ""
+		if interceptEntropyWarningPattern != "" {
+			receiptVerdict = config.ActionWarn
+			receiptLayer = scannerLabelBodyEntropy
+			receiptPattern = interceptEntropyWarningPattern
+		}
 		allowReceipt := withInterceptRedaction(receipt.EmitOpts{
 			ActionID:  actionID,
-			Verdict:   config.ActionAllow,
+			Verdict:   receiptVerdict,
+			Layer:     receiptLayer,
+			Pattern:   receiptPattern,
 			Transport: "intercept",
 			Method:    r.Method,
 			Target:    targetURL,

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -985,20 +985,22 @@ func newInterceptHandler(
 				}
 			}
 			bodyReq := BodyScanRequest{
-				Body:            r.Body,
-				Method:          r.Method,
-				ContentType:     r.Header.Get("Content-Type"),
-				ContentEncoding: r.Header.Get("Content-Encoding"),
-				MaxBytes:        ic.Config.RequestBodyScanning.MaxBodyBytes,
-				Scanner:         ic.Scanner,
-				AgentID:         ic.Agent,
-				Host:            r.URL.Hostname(),
-				Path:            r.URL.Path,
-				Target:          targetURL,
-				Suppress:        ic.Config.Suppress,
-				Action:          ic.Config.RequestBodyScanning.Action,
-				DisablePatterns: ic.Config.RequestBodyScanning.DisablePatterns,
-				PatternActions:  ic.Config.RequestBodyScanning.PatternActions,
+				Body:             r.Body,
+				Scheme:           "https",
+				Method:           r.Method,
+				ContentType:      r.Header.Get("Content-Type"),
+				ContentEncoding:  r.Header.Get("Content-Encoding"),
+				MaxBytes:         ic.Config.RequestBodyScanning.MaxBodyBytes,
+				Scanner:          ic.Scanner,
+				AgentID:          ic.Agent,
+				Host:             r.URL.Hostname(),
+				Path:             r.URL.Path,
+				EntropyRoutePath: r.URL.EscapedPath(),
+				Target:           targetURL,
+				Suppress:         ic.Config.Suppress,
+				Action:           ic.Config.RequestBodyScanning.Action,
+				DisablePatterns:  ic.Config.RequestBodyScanning.DisablePatterns,
+				PatternActions:   ic.Config.RequestBodyScanning.PatternActions,
 			}
 			applyContentEntropyConfig(&bodyReq, ic.Config)
 			if isA2A {
@@ -1055,6 +1057,9 @@ func newInterceptHandler(
 			}
 
 			if !result.Clean {
+				// An authorized entropy warning remains a finding for receipts and
+				// does not count as a clean adaptive-recovery event. Its exemption
+				// below prevents score signals and action re-promotion only.
 				hasFinding = true
 				action := result.Action
 				if action == "" {
@@ -1080,7 +1085,7 @@ func newInterceptHandler(
 					case len(injectionNames) > 0:
 						reason = fmt.Sprintf("request body contains prompt injection: %s", strings.Join(injectionNames, ", "))
 					case result.EntropyFinding != nil:
-						reason = contentEntropyReason(result.EntropyFinding)
+						reason = bodyEntropyReason(result)
 					default:
 						patternNames := dlpMatchNames(result.DLPMatches)
 						reason = fmt.Sprintf("request body contains secret: %s", strings.Join(patternNames, ", "))
@@ -1093,9 +1098,7 @@ func newInterceptHandler(
 				// weakening scoring on general allowlisted hosts like github.com.
 				// Address protection findings and fail-closed body errors are NOT
 				// exempted - only DLP pattern matches.
-				dlpExempt := scannerLabel == scannerLabelBodyDLP &&
-					len(result.DLPMatches) > 0 &&
-					isAdaptiveExempt(r.URL.Hostname(), ic.Config.AdaptiveEnforcement.ExemptDomains)
+				bodyAdaptiveExempt := isBodyAdaptiveExempt(scannerLabel, result, r.URL.Hostname(), ic.Config)
 				promptInjectionHardBlock := shouldHardBlockBodyPromptInjection(result, r.URL.Hostname(), ic.Config)
 				dlpHardBlock := shouldHardBlockBodyCriticalDLP(result, r.URL.Hostname(), ic.Config)
 				if promptInjectionHardBlock || dlpHardBlock {
@@ -1107,7 +1110,7 @@ func newInterceptHandler(
 				// legitimate LLM traffic from cascading into session blocks.
 				originalBodyAction := action
 				level := interceptEscalationLevel(ic)
-				if !dlpExempt {
+				if !bodyAdaptiveExempt {
 					action = decide.UpgradeAction(action, level, &ic.Config.AdaptiveEnforcement)
 				}
 				if action != originalBodyAction {
@@ -1127,7 +1130,7 @@ func newInterceptHandler(
 				// mode. ActionAsk also has no HITL terminal in intercepted
 				// tunnels, so it fails closed here.
 				if promptInjectionHardBlock || dlpHardBlock || isFailClosedBodyResult(result, bodyBytes) || action == config.ActionAsk || (action == config.ActionBlock && ic.Config.EnforceEnabled()) {
-					if !dlpExempt {
+					if !bodyAdaptiveExempt {
 						interceptRecordSignal(ic, session.SignalBlock)
 					}
 					ic.Logger.LogBlocked(actx, scannerLabel, reason)
@@ -1154,7 +1157,7 @@ func newInterceptHandler(
 				// a base action that was already "block" would fire here even
 				// without any escalation, which is not the intent.
 				if action == config.ActionBlock && action != originalBodyAction && !ic.Config.EnforceEnabled() {
-					if !dlpExempt {
+					if !bodyAdaptiveExempt {
 						interceptRecordSignal(ic, session.SignalBlock)
 					}
 					ic.Logger.LogBlocked(actx, scannerLabel, reason+" (escalated)")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -126,6 +126,10 @@ const (
 	// recorder into CheckRedirect so policy is re-evaluated against the same
 	// identity and state on every hop.
 	ctxKeyRedirectSessionRecorder
+	// ctxKeyEntropyWarnRoute binds a request-body entropy warning exception to
+	// its exact admitted HTTPS destination. CheckRedirect refuses a replay to
+	// any other route because 307/308 preserve the already-scanned body.
+	ctxKeyEntropyWarnRoute
 
 	// ctxKeySSRFDialScanSnapshot carries the DNS answers from an allowed
 	// scanner SSRF pass into the later dial-time re-resolution. The safe
@@ -787,6 +791,16 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			currentScanner, _ := req.Context().Value(ctxKeyAgentScanner).(*scanner.Scanner)
 			if currentScanner == nil {
 				currentScanner = p.scannerPtr.Load()
+			}
+			if admitted, ok := req.Context().Value(ctxKeyEntropyWarnRoute).(*BodyEntropyWarnRouteMatch); ok && admitted != nil {
+				matched := matchBodyEntropyWarnRoute(BodyScanRequest{
+					Scheme: req.URL.Scheme, Method: req.Method, ContentType: req.Header.Get(headerContentType),
+					Host: req.URL.Hostname(), EntropyRoutePath: req.URL.EscapedPath(), ContentEntropyAction: config.ActionBlock,
+					ContentEntropyWarnRoutes: currentCfg.RequestBodyScanning.ContentEntropyWarnRoutes,
+				}, time.Now().UTC())
+				if matched == nil || *matched != *admitted {
+					return newRedirectBlockedRequest(scannerLabelBodyEntropy, "redirect replay left the admitted entropy warning route")
+				}
 			}
 			redirectWarnCtx := scanner.DLPWarnContextFromCtx(req.Context())
 			redirectWarnCtx.Method = req.Method

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -1292,19 +1292,21 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 	maxBytes := reverseRequestScanMaxBytes(cfg)
 
 	bodyReq := BodyScanRequest{
-		Body:            r.Body,
-		Method:          r.Method,
-		ContentType:     r.Header.Get("Content-Type"),
-		ContentEncoding: r.Header.Get("Content-Encoding"),
-		MaxBytes:        maxBytes,
-		Scanner:         sc,
-		Host:            rp.upstream.Hostname(),
-		Path:            r.URL.Path,
-		Target:          receiptInput.Target,
-		Suppress:        cfg.Suppress,
-		Action:          cfg.RequestBodyScanning.Action,
-		DisablePatterns: cfg.RequestBodyScanning.DisablePatterns,
-		PatternActions:  cfg.RequestBodyScanning.PatternActions,
+		Body:             r.Body,
+		Scheme:           rp.upstream.Scheme,
+		Method:           r.Method,
+		ContentType:      r.Header.Get("Content-Type"),
+		ContentEncoding:  r.Header.Get("Content-Encoding"),
+		MaxBytes:         maxBytes,
+		Scanner:          sc,
+		Host:             rp.upstream.Hostname(),
+		Path:             r.URL.Path,
+		EntropyRoutePath: r.URL.EscapedPath(),
+		Target:           receiptInput.Target,
+		Suppress:         cfg.Suppress,
+		Action:           cfg.RequestBodyScanning.Action,
+		DisablePatterns:  cfg.RequestBodyScanning.DisablePatterns,
+		PatternActions:   cfg.RequestBodyScanning.PatternActions,
 	}
 	applyContentEntropyConfig(&bodyReq, cfg)
 	applyBodyScanRedaction(&bodyReq, redaction)
@@ -1381,7 +1383,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 		reason = fmt.Sprintf("DLP: %s", strings.Join(patternNames, ", "))
 	}
 	if reason == "" && result.EntropyFinding != nil {
-		reason = contentEntropyReason(result.EntropyFinding)
+		reason = bodyEntropyReason(result)
 	}
 	if reason == "" {
 		reason = "request body contains secret patterns"
@@ -1398,7 +1400,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 	}
 	if result.EntropyFinding != nil {
 		rp.metrics.RecordBodyEntropy(action, "")
-		rp.logger.LogBodyScan(actx, scanner.AuditBodyEntropy, action, 1, []string{contentEntropyReason(result.EntropyFinding)})
+		rp.logger.LogBodyScan(actx, scanner.AuditBodyEntropy, action, 1, []string{bodyEntropyReason(result)})
 	}
 
 	// Fail-closed transport errors (consumed-but-unreplayable body) and

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -1367,9 +1367,16 @@ func (r *wsRelay) scanClientMessageBody(ctx context.Context, msg []byte) ([]byte
 		DisablePatterns: r.cfg.RequestBodyScanning.DisablePatterns,
 		PatternActions:  r.cfg.RequestBodyScanning.PatternActions,
 	}
-	applyContentEntropyConfig(&bodyReq, r.cfg, r.cfg.WebSocketProxy.ContentEntropyExclusions)
+	applyWebSocketContentEntropyConfig(&bodyReq, r.cfg)
 	applyBodyScanRedaction(&bodyReq, r.redaction)
 	return scanRequestBody(ctx, bodyReq)
+}
+
+func applyWebSocketContentEntropyConfig(req *BodyScanRequest, cfg *config.Config) {
+	applyContentEntropyConfig(req, cfg, cfg.WebSocketProxy.ContentEntropyExclusions)
+	// HTTP route exceptions must never become WebSocket frame exceptions if a
+	// future caller starts supplying a ws/wss or normalized HTTPS scheme.
+	req.ContentEntropyWarnRoutes = nil
 }
 
 // enforceClientControlPayload scans Ping and Pong application data without

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -69,8 +69,8 @@ const (
 
 const (
 	bodyDLPOperatorKnob        = "Request body DLP matched. For a non-core false positive, add a top-level `suppress:` entry with `rule:` set to the matched rule name and `path:` scoped to the request path. Core DLP matches cannot be suppressed; fix the core pattern's precision."
-	bodyEntropyOperatorKnob    = "If this destination is trusted to receive opaque body or WebSocket-frame content, add only that host to `request_body_scanning.content_entropy_exclusions`; for a WebSocket-only endpoint, prefer `websocket_proxy.content_entropy_exclusions`. `trusted_domains` is broader because it also affects SSRF trust."
-	bodyEntropyOperatorBroader = "Raising `request_body_scanning.content_entropy_threshold` or setting `request_body_scanning.content_entropy_action: warn` affects opaque body/frame entropy for every destination; prefer a per-host exclusion first."
+	bodyEntropyOperatorKnob    = "For a known HTTPS upload endpoint, prefer an exact, expiring `request_body_scanning.content_entropy_warn_routes` entry so the finding remains visible. For a WebSocket-only endpoint, use `websocket_proxy.content_entropy_exclusions`."
+	bodyEntropyOperatorBroader = "Host-wide `request_body_scanning.content_entropy_exclusions`, `trusted_domains`, a higher entropy threshold, or a global warn action affect more traffic than one exact route; use them only when that broader scope is intended."
 	denialOfWalletOperatorKnob = "Correct the denial-of-wallet condition named by the reason. `runaway expansion` and alternating `cycle detected` use fixed detector thresholds and have no per-detector limit knob. " +
 		"To audit instead of block, set the matched `agents._default.budget.dow_action` (or `agents.<name>.budget.dow_action`) to `warn`; this changes enforcement for every denial-of-wallet finding."
 	denialOfWalletToolCallsOperatorKnob = "Raise `agents._default.budget.max_tool_calls_per_session` (or the matched `agents.<name>.budget.max_tool_calls_per_session`) if the DoW subject's per-window tool-call budget is intentionally higher."


### PR DESCRIPTION
## What changed
- Add exact, expiring HTTPS route exceptions that keep request-body entropy findings visible as warnings while DLP, injection, address, size, and adaptive controls retain their behavior.
- Bind each exception to canonical request and redirect destinations, fail closed on invalid or expired scope, and surface its owner, reason, and expiry through validation and audit output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added exact, expiring HTTPS route exceptions that downgrade request-body entropy blocks to warnings.
  - Warnings remain visible without triggering adaptive enforcement signals.
  - Redirected request bodies are protected from replay to non-matching routes.
  - WebSocket and A2A scanning remain unaffected by HTTP route exceptions.
  - Added validation and reload warnings for invalid or newly changed routes.

- **Documentation**
  - Added configuration examples, deployment notes, and false-positive tuning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->