### PR TITLE
fix: detect current GitHub and Azure token formats

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -2336,7 +2336,8 @@ def derive_state(progress: ReviewProgress) -> str:
 # step, so the pattern has to match the reassembled form as well as the original.
 SECRET_PATTERNS: tuple[tuple[str, str], ...] = (
     ('aws-access-key', '(?:AKIA|ASIA|AROA|AIDA|AGPA|AIPA|ANPA|ANVA|A3T)[A-Z0-9]{16,}'),
-    ('github-token', 'gh[pousr]_?[A-Za-z0-9]{36,}'),
+    ('github-token', '(?:gh[pour]_?[A-Za-z0-9]{36,}|ghs_?[A-Za-z0-9.\\-_]{36,})'),
+    ('azure-sas-token', '(?i)\\bsig=(?:[A-Za-z0-9%]{43,}%3d\\b|[A-Za-z0-9+/]{43}=)'),
     ('github-pat', 'github_?pat_?[A-Za-z0-9]{22,}'),
     ('slack-token', 'xox[abprs]-[A-Za-z0-9-]{10,}'),
     ('stripe-key', '(?:sk|rk)_?(?:live|test)_?[A-Za-z0-9]{16,}'),

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -123,7 +123,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -180,7 +180,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -151,7 +151,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -208,7 +208,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -163,7 +163,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -220,7 +220,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -164,7 +164,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -221,7 +221,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -162,7 +162,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -219,7 +219,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -143,7 +143,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -200,7 +200,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -139,7 +139,7 @@ dlp:
       regex: 'whsec_[a-zA-Z0-9_\-]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'
@@ -196,7 +196,7 @@ dlp:
       regex: 'AccountKey=[A-Za-z0-9+/]{86}=='
       severity: critical
     - name: "Azure SAS Token"
-      regex: '\bsig=[A-Za-z0-9%]{43,}%3d\b'
+      regex: '\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)'
       severity: high
     - name: "Slack Token"
       regex: 'xox[bpras]-[0-9a-zA-Z-]{15,}'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -762,7 +762,7 @@ For built-in provider-key patterns, the default config already exempts the provi
 | Google OAuth Client ID | `*.apps.googleusercontent.com` | medium |
 | Stripe Key | `[sr]k_live\|test_` | critical |
 | Stripe Webhook Secret | `whsec_` | critical |
-| GitHub Token | `gh[pousr]_` | critical |
+| GitHub Token | `gh[pour]_` / `ghs_` + 36+ JWT-safe chars | critical |
 | GitHub Fine-Grained PAT | `github_pat_` | critical |
 | GitLab PAT | `glpat-` | critical |
 | GitLab Deploy Token | `gldt-` | critical |
@@ -779,7 +779,7 @@ For built-in provider-key patterns, the default config already exempts the provi
 | GCP Service Account Key (always-on core pattern, not part of the 65 default count) | `"type":"service_account"` | critical |
 | GCP Service Account Private Key ID | `"private_key_id":"<40 hex>"` | high |
 | Azure Storage Account Key | `AccountKey=<88-char base64>` | critical |
-| Azure SAS Token | `sig=<base64>%3D` | high |
+| Azure SAS Token | `sig=<base64>%3D` / decoded `sig=<base64>=` | high |
 | Slack Token | `xox[bpras]-` | critical |
 | Slack App Token | `xapp-` | critical |
 | Discord Bot Token | `[MN]*.*.*` / `mfa.*` | critical |

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -104,7 +104,7 @@ dlp:
       regex: '[sr]k[-_](live|test)[-_][a-zA-Z0-9]{20,}'
       severity: critical
     - name: "GitHub Token"
-      regex: 'gh[pousr]_[A-Za-z0-9_]{36,}'
+      regex: '(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})'
       severity: critical
     - name: "GitHub Fine-Grained PAT"
       regex: 'github_pat_[a-zA-Z0-9_]{36,}'

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -347,7 +347,9 @@ const (
 	// Re-bumped for request_body_scanning.content_entropy_warn_routes. The
 	// exact route exception changes an entropy block to a visible warning, so
 	// mixed versions must not report the same policy identity.
-	goldenHashDefaults = "4d531d9b039f54906dd5ea1a92ea66054e7a5fd6e62cdbabe1f5fa7b377af218"
+	// Re-bumped for issuer-backed GitHub stateless-token and decoded Azure SAS
+	// coverage in the default DLP pattern set.
+	goldenHashDefaults = "718ecf4871dbd1744da7a7e624c863aa6baab0b5681f66ce6ab7403723a4d82e"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -523,7 +525,9 @@ const (
 	// nil allowlist flows into ph identically to Defaults() and the hash
 	// shifts in lockstep.
 	// Re-bumped for route-scoped entropy warnings: see goldenHashDefaults.
-	goldenHashRichConfig = "d5c791b08f5cf44338f78aeb3a426ba9a839a6db3151aa4f73aa2244100f8a3f"
+	// Re-bumped for issuer-backed GitHub stateless-token and decoded Azure SAS
+	// coverage: the rich fixture inherits the default DLP pattern set.
+	goldenHashRichConfig = "1ac09f329b157f9f8c096b8e534cf6631a4ceeabc8105d632476d99d89aa0f4d"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/dlp_patterns.go
+++ b/internal/config/dlp_patterns.go
@@ -54,9 +54,12 @@ var defaultDLPPatternSet = []DLPPattern{
 	{Name: "Stripe Webhook Secret", Regex: `whsec_[a-zA-Z0-9_\-]{20,}`, Severity: SeverityCritical},
 
 	// Source control tokens
-	// GitHub tokens are base64url-ish after a short "gh?_"/"github_pat_"
-	// prefix. Keep these unanchored so glued-key exfiltration still matches.
-	{Name: "GitHub Token", Regex: `gh[pousr]_[A-Za-z0-9_]{36,}`, Severity: SeverityCritical},
+	// GitHub's classic tokens are base64url-ish after a short "gh?_" prefix.
+	// Stateless server-to-server tokens use ghs_ followed by a JWT and therefore
+	// also contain dots and hyphens. Keep the broader alphabet scoped to ghs_ so
+	// the other short prefixes do not start matching dotted prose.
+	// Source: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/
+	{Name: "GitHub Token", Regex: `(?:gh[pour]_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,})`, Severity: SeverityCritical},
 	{Name: "GitHub Fine-Grained PAT", Regex: `github_pat_[a-zA-Z0-9_]{36,}`, Severity: SeverityCritical},
 	// GitLab personal access tokens: "glpat-" prefix, 20+ chars.
 	{Name: "GitLab PAT", Regex: `glpat-[a-zA-Z0-9\-_]{20,}`, Severity: SeverityCritical},
@@ -113,11 +116,11 @@ var defaultDLPPatternSet = []DLPPattern{
 	// (86 + "==") in an AccountKey= connection-string field. Anchored
 	// on AccountKey= so arbitrary 88-char base64 does not match.
 	{Name: "Azure Storage Account Key", Regex: `AccountKey=[A-Za-z0-9+/]{86}==`, Severity: SeverityCritical},
-	// Azure SAS signature: the sig= parameter is a URL-encoded base64
-	// HMAC-SHA256 (32 bytes -> 44 base64 chars, trailing '=' as %3D).
-	// Anchored on the urlencoded padding; severity "high" reflects the
-	// generality of a "sig=" parameter name.
-	{Name: "Azure SAS Token", Regex: `\bsig=[A-Za-z0-9%]{43,}%3d\b`, Severity: SeverityHigh},
+	// Azure SAS signature: the sig= parameter is a base64 HMAC-SHA256
+	// (32 bytes -> 44 base64 chars). Match both the URI form with encoded
+	// padding and the decoded form read after a carrier is unescaped.
+	// Source: https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas
+	{Name: "Azure SAS Token", Regex: `\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)`, Severity: SeverityHigh},
 
 	// Messaging platform tokens
 	{Name: "Slack Token", Regex: `xox[bpras]-[0-9a-zA-Z-]{15,}`, Severity: SeverityCritical},

--- a/internal/config/dlp_patterns_test.go
+++ b/internal/config/dlp_patterns_test.go
@@ -24,6 +24,36 @@ func TestDefaultDLPPatternsMatchDefaults(t *testing.T) {
 	}
 }
 
+func TestDefaultDLPPatternsMatchIssuerBackedDecodedFormats(t *testing.T) {
+	t.Parallel()
+	githubJWTHeader := strings.Join([]string{"ghs_", "eyJ", "hbG", "ciOi", "JFUz", "I1Ni", "J9."}, "")
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name: "GitHub Token",
+			value: githubJWTHeader +
+				strings.Repeat("A", 48) + "." + strings.Repeat("B", 48) + "-_",
+		},
+		{
+			name:  "Azure SAS Token",
+			value: "sig=" + strings.Repeat("A", 43) + "=",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			re := regexp.MustCompile(mustDLPPatternRegex(t, test.name))
+			if got := re.FindString(test.value + "&next=1"); got != test.value {
+				t.Fatalf("%s pattern matched %q, want exact credential %q", test.name, got, test.value)
+			}
+		})
+	}
+}
+
 func TestDefaultDLPPatternsReturnsDeepCopy(t *testing.T) {
 	t.Parallel()
 
@@ -200,6 +230,7 @@ func TestDefaultDLPPatternsRedactionMirrorCoverage(t *testing.T) {
 		variant string
 		value   string
 		class   redact.Class
+		exact   bool
 	}{
 		{name: "Anthropic API Key", value: "sk-" + "ant-" + strings.Repeat("A", 20), class: redact.ClassAnthropicKey},
 		{name: "OpenAI API Key", value: "sk-" + "proj-" + strings.Repeat("A", 20), class: redact.ClassOpenAIAPIKey},
@@ -223,7 +254,8 @@ func TestDefaultDLPPatternsRedactionMirrorCoverage(t *testing.T) {
 		{name: "AWS Access ID", value: "AKIA" + strings.Repeat("A", 16), class: redact.ClassAWSAccessKey},
 		{name: "AWS Secret Key", value: "aws_secret_access_key = " + strings.Repeat("A", 40), class: redact.ClassAWSSecretKey},
 		{name: "Azure Storage Account Key", value: "AccountKey=" + strings.Repeat("A", 86) + "==", class: redact.ClassAzureStorageKey},
-		{name: "Azure SAS Token", value: "sig=" + strings.Repeat("A", 43) + "%3d", class: redact.ClassAzureSAS},
+		{name: "Azure SAS Token", value: "sig=" + strings.Repeat("A", 43) + "%3d", class: redact.ClassAzureSAS, exact: true},
+		{name: "Azure SAS Token", variant: " decoded", value: "sig=" + strings.Repeat("A", 43) + "=", class: redact.ClassAzureSAS, exact: true},
 		{name: "Slack Token", value: "xoxb-" + strings.Repeat("A", 15), class: redact.ClassSlackToken},
 		{name: "Hugging Face Token", value: "hf_" + strings.Repeat("A", 34), class: redact.ClassHuggingFaceToken},
 		{name: "Databricks Token", value: "dapi" + strings.Repeat("a", 32), class: redact.ClassDatabricksPAT},
@@ -256,12 +288,16 @@ func TestDefaultDLPPatternsRedactionMirrorCoverage(t *testing.T) {
 			if !regexpMustCompile(t, pattern.Regex).MatchString(tt.value) {
 				t.Fatalf("sample %q no longer matches canonical DLP regex %q", tt.value, pattern.Regex)
 			}
-			for _, match := range matcher.Scan(tt.value) {
-				if match.Class == tt.class && strings.Contains(tt.value, match.Original) {
+			input := tt.value
+			if tt.exact {
+				input += "&next=1"
+			}
+			for _, match := range matcher.Scan(input) {
+				if match.Class == tt.class && (!tt.exact || match.Original == tt.value) {
 					return
 				}
 			}
-			t.Fatalf("redaction mirror did not classify %q as %s; matches=%+v", tt.name, tt.class, matcher.Scan(tt.value))
+			t.Fatalf("redaction mirror did not classify %q as exact %s span; matches=%+v", tt.name, tt.class, matcher.Scan(input))
 		})
 	}
 }

--- a/internal/mcp/coverage_boost_test.go
+++ b/internal/mcp/coverage_boost_test.go
@@ -180,6 +180,26 @@ func TestScanHTTPInput_DLPBlocksSecret(t *testing.T) {
 	}
 }
 
+func TestScanHTTPInput_DLPBlocksGitHubStatelessInstallationToken(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	githubJWTHeader := strings.Join([]string{"ghs_", "eyJ", "hbG", "ciOi", "JFUz", "I1Ni", "J9."}, "")
+	token := githubJWTHeader + strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_"
+	msg := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"write","arguments":{"content":"%s"}}}`, token))
+	var logBuf bytes.Buffer
+
+	blocked := scanHTTPInput(msg, &logBuf, "session-1", "audit-1", MCPProxyOpts{
+		Scanner: sc,
+		InputCfg: &InputScanConfig{
+			Enabled:      true,
+			Action:       config.ActionBlock,
+			OnParseError: config.ActionBlock,
+		},
+	})
+	if blocked == nil {
+		t.Fatal("expected GitHub stateless token in MCP tool arguments to block")
+	}
+}
+
 func TestScanHTTPInput_DLPBlocksStackedEncodedSecret(t *testing.T) {
 	sc := testScannerForHTTP(t)
 	secret := "AKIA" + "IOSFODNN7EXAMPLE"

--- a/internal/proxy/bodyscan_redact_test.go
+++ b/internal/proxy/bodyscan_redact_test.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -54,6 +55,36 @@ func TestScanRequestBody_Redaction_BeforeDLPEarlyReturn(t *testing.T) {
 	}
 	if len(result.DLPMatches) == 0 {
 		t.Fatal("expected pre-redaction DLP evidence to survive redaction")
+	}
+}
+
+func TestScanRequestBody_RedactsGitHubStatelessInstallationToken(t *testing.T) {
+	cfg := testScannerConfig()
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	githubJWTHeader := strings.Join([]string{"ghs_", "eyJ", "hbG", "ciOi", "JFUz", "I1Ni", "J9."}, "")
+	token := githubJWTHeader + strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_"
+	body := `{"token":"` + token + `"}`
+	buf, result := scanRequestBody(context.Background(), BodyScanRequest{
+		Body:          strings.NewReader(body),
+		ContentType:   contentTypeJSON,
+		MaxBytes:      len(body) * 2,
+		Scanner:       sc,
+		RedactMatcher: redact.NewDefaultMatcher(),
+	})
+
+	var redacted struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(buf, &redacted); err != nil {
+		t.Fatalf("parse redacted body: %v", err)
+	}
+	if redacted.Token != "<pl:github-token:1>" {
+		t.Fatalf("redacted token = %q, want complete placeholder", redacted.Token)
+	}
+	if result.RedactionReport == nil || !result.RedactionReport.Applied {
+		t.Fatalf("RedactionReport missing or not applied: %+v", result.RedactionReport)
 	}
 }
 

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -181,6 +181,31 @@ func TestWebSocketClientMessageBody_ContentEntropy(t *testing.T) {
 	}
 }
 
+func TestWebSocketClientMessageBody_DetectsDecodedAzureSAS(t *testing.T) {
+	cfg := testScannerConfig()
+	cfg.WebSocketProxy.Enabled = true
+	sc := scanner.MustNew(cfg)
+	defer sc.Close()
+
+	relay := &wsRelay{
+		cfg:       cfg,
+		maxMsg:    cfg.WebSocketProxy.MaxMessageBytes,
+		scanner:   sc,
+		hostname:  "socket.vendor.example",
+		path:      "/ws",
+		targetURL: "wss://socket.vendor.example/ws",
+	}
+	msg := []byte(`{"sas":"sig=` + strings.Repeat("A", 43) + `="}`)
+
+	_, result := relay.scanClientMessageBody(context.Background(), msg)
+	for _, match := range result.DLPMatches {
+		if match.PatternName == "Azure SAS Token" {
+			return
+		}
+	}
+	t.Fatalf("decoded Azure SAS was not detected in WebSocket JSON: %+v", result.DLPMatches)
+}
+
 // wsAckServer reads one client message and replies with a clean acknowledgement.
 func wsAckServer(t *testing.T) (string, func()) {
 	t.Helper()

--- a/internal/redact/classes.go
+++ b/internal/redact/classes.go
@@ -10,8 +10,7 @@ import (
 )
 
 // A classPattern associates a secret class with a compiled regex that
-// matches instances of that class in arbitrary text. Patterns must not have
-// anchors (^ / $) because they are applied inside larger string scalars.
+// matches instances of that class in arbitrary text.
 type classPattern struct {
 	class   Class
 	pattern *regexp.Regexp
@@ -115,7 +114,7 @@ func tokenClasses() []classPattern {
 		{class: ClassAWSAccessKey, pattern: regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}\b`), priority: 100, skipTrailing: sigV4CredentialScope, skipLeading: sigV4CredentialPrefix},
 		{class: ClassAWSSecretKey, pattern: regexp.MustCompile(`(?i)\b(?:aws_secret_access_key|secret.?access.?key|SecretAccessKey)\s*["'=:\s]{1,5}\s*[A-Za-z0-9/+=]{40}\b`), priority: 100},
 		{class: ClassGoogleAPIKey, pattern: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}\b`), priority: 100},
-		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?i)(?:(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{36,})`), priority: 100},
+		{class: ClassGitHubToken, pattern: regexp.MustCompile(`(?i)(?:(?:ghp|gho|ghu|ghr)_[A-Za-z0-9_]{36,}|ghs_[A-Za-z0-9.\-_]{36,}|github_pat_[A-Za-z0-9_]{36,})`), priority: 100},
 		// All documented GitLab token prefixes (token overview: glpat-,
 		// gloas-, gldt-, glrt-/glrtr-, glcbt-, glptt-, glft-, glimt-,
 		// glagent-, glwt-, glsoat-, glffct-) share the gl<type>- + base64url
@@ -132,10 +131,10 @@ func tokenClasses() []classPattern {
 		// in an AccountKey= connection-string field. Anchored on AccountKey= to
 		// avoid matching arbitrary base64.
 		{class: ClassAzureStorageKey, pattern: regexp.MustCompile(`(?i)\bAccountKey=[A-Za-z0-9+/]{86}==`), priority: 100},
-		// Azure SAS signature: the sig= parameter is a URL-encoded base64
-		// HMAC-SHA256 (32 bytes -> 44 base64 chars, trailing '=' as %3D).
-		// Anchored on the urlencoded padding to bound the match.
-		{class: ClassAzureSAS, pattern: regexp.MustCompile(`(?i)\bsig=[A-Za-z0-9%]{43,}%3d\b`), priority: 100},
+		// Azure SAS signature: the sig= parameter is a base64 HMAC-SHA256
+		// (32 bytes -> 44 base64 chars). Match encoded or decoded padding;
+		// the padding itself terminates the value without consuming a query delimiter.
+		{class: ClassAzureSAS, pattern: regexp.MustCompile(`(?i)\bsig=(?:[A-Za-z0-9%]{43,}%3d\b|[A-Za-z0-9+/]{43}=)`), priority: 100},
 		{class: ClassSlackToken, pattern: regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}\b`), priority: 100},
 		{class: ClassFireworksAPIKey, pattern: regexp.MustCompile(`(?i)fw_[A-Za-z0-9]{22}\b`), priority: 100},
 		{class: ClassAIProviderKey, pattern: regexp.MustCompile(`(?i)(?:sk-or-v1-[A-Fa-f0-9]{20,}|pplx-[A-Za-z0-9]{20,}|tvly-[A-Za-z0-9]{20,}|pcsk_[A-Za-z0-9]{36,}|gsk_[A-Za-z0-9]{48,}|xai-[A-Za-z0-9_-]{80,})\b`), priority: 100},

--- a/internal/redact/classes_test.go
+++ b/internal/redact/classes_test.go
@@ -91,6 +91,7 @@ func TestDefaultMatcher_StructuredClasses(t *testing.T) {
 		{"azure-storage-key", "conn AccountKey=" + strings.Repeat("A", 86) + "==", ClassAzureStorageKey},
 		// Azure SAS signature parameter.
 		{"azure-sas-token", "url sig=" + strings.Repeat("A", 43) + "%3d", ClassAzureSAS},
+		{"azure-sas-token-decoded", "url sig=" + strings.Repeat("A", 43) + "=", ClassAzureSAS},
 		{"env-secret", fakeTelegramEnvSecret(), ClassEnvSecret},
 		{"seed-phrase", "mnemonic abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", ClassSeedPhrase},
 		{"ad-user", "CONTOSO\\jsmith logged in", ClassADUser},
@@ -296,6 +297,23 @@ func TestDefaultMatcher_GitHubTokenInOpaqueRunStillMatches(t *testing.T) {
 	}
 }
 
+func TestDefaultMatcher_AzureSASPreservesQueryDelimiter(t *testing.T) {
+	t.Parallel()
+
+	signature := "sig=" + strings.Repeat("A", 43) + "="
+	input := signature + "&next=value"
+	matches := NewDefaultMatcher().Scan(input)
+	for _, match := range matches {
+		if match.Class == ClassAzureSAS {
+			if match.Original != signature {
+				t.Fatalf("Azure SAS match = %q, want %q", match.Original, signature)
+			}
+			return
+		}
+	}
+	t.Fatalf("Azure SAS signature was not detected in %q", input)
+}
+
 func TestDefaultMatcher_ProviderKeyGlueParity(t *testing.T) {
 	t.Parallel()
 	m := NewDefaultMatcher()
@@ -323,6 +341,7 @@ func TestDefaultMatcher_ProviderKeyGlueParity(t *testing.T) {
 		{"sentry", "sntrys_" + strings.Repeat("A", 40), ClassSentryAuthToken},
 		// Round 2: source-control, messaging, package-registry, platform tokens
 		{"github-ghp", "ghp_" + strings.Repeat("A", 36), ClassGitHubToken},
+		{"github-ghs-stateless", "ghs_eyJhbGciOiJFUzI1NiJ9." + strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_", ClassGitHubToken},
 		{"github-pat", "github_pat_" + strings.Repeat("B", 36), ClassGitHubToken},
 		{"gitlab-pat", "glpat-" + strings.Repeat("C", 24), ClassGitLabToken},
 		{"gitlab-deploy", "gldt-" + strings.Repeat("D", 24), ClassGitLabToken},

--- a/internal/replaycapture/allowlist_test.go
+++ b/internal/replaycapture/allowlist_test.go
@@ -117,6 +117,10 @@ func TestValidateReceiptPublicSafe_Rejections(t *testing.T) {
 		{"openai service key in pattern", func(ar *receipt.ActionRecord) {
 			ar.Pattern = "leaked " + "sk-" + "svcacct-" + "AAAAAAAAAA_BBBBBBBBBB"
 		}},
+		{"github stateless installation token in target", func(ar *receipt.ActionRecord) {
+			ar.Target = "https://collector.example.com/?k=" + "ghs_eyJhbGciOiJFUzI1NiJ9." +
+				strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_"
+		}},
 		{"populated request_id", func(ar *receipt.ActionRecord) { ar.RequestID = "req-provider-9c4ad1" }},
 		{"bad run nonce", func(ar *receipt.ActionRecord) { ar.RunNonce = "not-a-nonce" }},
 		{"populated session task", func(ar *receipt.ActionRecord) { ar.SessionTaskLabel = "internal-task" }},

--- a/internal/scanner/dlp_agent_traffic_corpus_test.go
+++ b/internal/scanner/dlp_agent_traffic_corpus_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"encoding/base64"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// dlpAgentTrafficFixtures is the positive-control corpus for every pattern in
+// the shipped full preset. Values are synthetic and assembled at runtime so
+// repository secret scanners do not mistake fixtures for live credentials.
+func dlpAgentTrafficFixtures(t *testing.T) map[string]string {
+	t.Helper()
+	githubJWTHeader := strings.Join([]string{"ghs_", "eyJ", "hbG", "ciOi", "JFUz", "I1Ni", "J9."}, "")
+
+	return map[string]string{
+		"Anthropic API Key":                  "sk-" + "ant-" + strings.Repeat("A", 24),
+		"OpenAI API Key":                     "sk-" + "proj-" + strings.Repeat("B", 24),
+		"OpenAI Service Key":                 "sk-" + "svcacct-" + strings.Repeat("C", 24),
+		"Fireworks API Key":                  "fw_" + strings.Repeat("D", 22),
+		"LLM Router API Key":                 "sk-or-v1-" + strings.Repeat("a", 24),
+		"Answer Engine API Key":              "pplx-" + strings.Repeat("E", 24),
+		"Web Research API Key":               "tvly-" + strings.Repeat("F", 24),
+		"Google API Key":                     "AIza" + strings.Repeat("G", 35),
+		"Google OAuth Client Secret":         "GOCSPX-" + strings.Repeat("H", 28),
+		"Stripe Key":                         "sk_" + "live_" + strings.Repeat("I", 24),
+		"Stripe Webhook Secret":              "whsec_" + strings.Repeat("J", 24),
+		"GitHub Token":                       githubJWTHeader + strings.Repeat("K", 240) + "." + strings.Repeat("L", 220) + "-_",
+		"GitHub Fine-Grained PAT":            "github_pat_" + strings.Repeat("M", 40),
+		"GitLab PAT":                         "glpat-" + strings.Repeat("N", 24),
+		"GitLab Deploy Token":                "gldt-" + strings.Repeat("O", 24),
+		"GitLab Runner Token":                "glrt-" + strings.Repeat("P", 24),
+		"GitLab CI Job Token":                "glcbt-" + strings.Repeat("Q", 24),
+		"GitLab Pipeline Trigger Token":      "glptt-" + strings.Repeat("R", 24),
+		"GitLab OAuth Application Secret":    "gloas-" + strings.Repeat("S", 24),
+		"GitLab SCIM Token":                  "glsoat-" + strings.Repeat("T", 24),
+		"GitLab Service Token":               "glagent-" + strings.Repeat("U", 24),
+		"PostgreSQL Connection String":       "postgres://user:" + strings.Repeat("p", 12) + "@db.example/app",
+		"MySQL Connection String":            "mysql://user:" + strings.Repeat("q", 12) + "@db.example/app",
+		"MongoDB Connection String":          "mongodb://user:" + strings.Repeat("r", 12) + "@db.example/app",
+		"Redis Connection String":            "redis://:" + strings.Repeat("s", 12) + "@cache.example:6379",
+		"AWS Access ID":                      "AKIA" + strings.Repeat("V", 16),
+		"AWS Secret Key":                     "aws_secret_access_key = " + strings.Repeat("W", 40),
+		"Google OAuth Token":                 "ya29." + strings.Repeat("X", 24),
+		"GCP Service Account Private Key ID": `"private_key_id":"` + strings.Repeat("a", 40) + `"`,
+		"Azure Storage Account Key":          "AccountKey=" + strings.Repeat("Y", 86) + "==",
+		"Azure SAS Token":                    "sig=" + strings.Repeat("Z", 43) + "=",
+		"Slack Token":                        "xoxb-" + strings.Repeat("1", 16),
+		"Slack App Token":                    "xapp-1-" + strings.Repeat("A", 12) + "-2-" + strings.Repeat("b", 16),
+		"Discord Bot Token":                  "M" + strings.Repeat("A", 23) + "." + strings.Repeat("B", 6) + "." + strings.Repeat("C", 27),
+		"Twilio API Key":                     "SK" + strings.Repeat("a", 32),
+		"SendGrid API Key":                   "SG." + strings.Repeat("D", 22) + "." + strings.Repeat("E", 43),
+		"Mailgun API Key":                    "key-" + strings.Repeat("F", 32),
+		"New Relic API Key":                  "NRAK-" + strings.Repeat("G", 27),
+		"Hugging Face Token":                 "hf_" + strings.Repeat("H", 34),
+		"Databricks Token":                   "dapi" + strings.Repeat("a", 32),
+		"Replicate API Token":                "r8_" + strings.Repeat("b", 40),
+		"Together AI Key":                    "tok_" + strings.Repeat("c", 40),
+		"Pinecone API Key":                   "pcsk_" + strings.Repeat("I", 36),
+		"Groq API Key":                       "gsk_" + strings.Repeat("J", 48),
+		"xAI API Key":                        "xai-" + strings.Repeat("K", 80),
+		"DigitalOcean Token":                 "dop_v1_" + strings.Repeat("d", 64),
+		"HashiCorp Vault Token":              "hvs." + strings.Repeat("L", 24),
+		"Vercel Token":                       "vercel_" + strings.Repeat("M", 24),
+		"Supabase Service Key":               "sb_secret_" + strings.Repeat("N", 22) + "_" + strings.Repeat("O", 8),
+		"npm Token":                          "npm_" + strings.Repeat("P", 36),
+		"PyPI Token":                         "pypi-AgE" + strings.Repeat("Q", 90),
+		"Linear API Key":                     "lin_api_" + strings.Repeat("R", 40),
+		"Notion API Key":                     "ntn_" + strings.Repeat("S", 40),
+		"Sentry Auth Token":                  "sntrys_" + strings.Repeat("T", 40),
+		"Private Key Header":                 "-----BEGIN " + "PRIVATE KEY-----",
+		"JWT Token":                          "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0." + strings.Repeat("U", 32),
+		"Bitcoin WIF Private Key":            "5HueCGU8rMjx" + "EXxiPuD5BDku4MkFqe" + "Zyd4dZ1jvhTVqvbTLvyTJ",
+		"Extended Private Key":               "xprv" + strings.Repeat("A", 107),
+		"Ethereum Private Key":               "0x" + strings.Repeat("ab", 32),
+		"Social Security Number":             "123-" + "45-" + "6789",
+		"Google OAuth Client ID":             "123456-" + strings.Repeat("V", 32) + ".apps.googleusercontent.com",
+		"Credential in URL":                  "?token=" + strings.Repeat("W", 12),
+		"Environment Variable Secret":        "SERVICE_API_KEY=" + strings.Repeat("X", 12),
+		"Credit Card Number":                 "4111" + "1111" + "1111" + "1111",
+		"IBAN":                               "DE89" + "3704" + "0044" + "0532" + "0130" + "00",
+		"Ethereum Address":                   "0x" + strings.Repeat("cd", 20),
+	}
+}
+
+func TestDLPAgentTrafficCorpusCoversFullPreset(t *testing.T) {
+	patterns, err := config.PresetDLPPatterns(config.DLPPresetProfileFull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtures := dlpAgentTrafficFixtures(t)
+
+	for _, pattern := range patterns {
+		if _, ok := fixtures[pattern.Name]; !ok {
+			t.Errorf("full-preset pattern %q has no agent-traffic fixture", pattern.Name)
+		}
+	}
+	for name := range fixtures {
+		found := false
+		for _, pattern := range patterns {
+			if pattern.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("agent-traffic fixture %q has no full-preset pattern", name)
+		}
+	}
+}
+
+func TestDLPAgentTrafficCorpusAcrossCarriers(t *testing.T) {
+	patterns, err := config.PresetDLPPatterns(config.DLPPresetProfileFull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig()
+	cfg.DLP.IncludeDefaults = ptrBool(false)
+	cfg.DLP.Patterns = patterns
+	s := MustNew(cfg)
+	defer s.Close()
+
+	carriers := map[string]func(string) string{
+		"prompt":      func(secret string) string { return "Use this credential for the next tool call: " + secret },
+		"tool_args":   func(secret string) string { return `{"arguments":{"credential":"` + secret + `"}}` },
+		"form_body":   func(secret string) string { return "credential=" + url.QueryEscape(secret) },
+		"base64_blob": func(secret string) string { return base64.StdEncoding.EncodeToString([]byte(secret)) },
+	}
+
+	ctx := context.Background()
+	for patternName, secret := range dlpAgentTrafficFixtures(t) {
+		patternName, secret := patternName, secret
+		for carrierName, carry := range carriers {
+			carrierName, carry := carrierName, carry
+			t.Run(patternName+"/"+carrierName, func(t *testing.T) {
+				result := s.ScanTextForDLP(ctx, carry(secret))
+				if result.Clean {
+					t.Fatalf("%s was not detected in %s traffic", patternName, carrierName)
+				}
+				if !hasTextDLPMatch(result.Matches, patternName, "") && !hasTextDLPMatch(result.Matches, patternName, "base64") &&
+					!hasTextDLPMatch(result.Matches, patternName, "url") {
+					t.Fatalf("wanted %q in matches for %s, got %v", patternName, carrierName, result.Matches)
+				}
+			})
+		}
+	}
+}
+
+func TestDLPAgentTrafficChangedFormatNearMissesStayClean(t *testing.T) {
+	cfg := testConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+
+	tests := map[string]string{
+		"github stateless under issuer floor":  "ghs_" + strings.Repeat("A", 35),
+		"classic github does not gain hyphens": "ghp_" + strings.Repeat("B", 20) + "-" + strings.Repeat("C", 40),
+		"azure decoded signature too short":    "sig=" + strings.Repeat("D", 42) + "=",
+		"generic colon-delimited signature":    "sig=" + strings.Repeat("E", 43) + ":",
+	}
+	for name, text := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), text)
+			if !result.Clean {
+				t.Fatalf("near-miss %q matched: %+v", text, result.Matches)
+			}
+		})
+	}
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -164,7 +164,12 @@ func TestScan_BlocksBlocklistedDomains(t *testing.T) {
 }
 
 func TestScan_BlocksDLPPatterns(t *testing.T) {
-	s := MustNew(testConfig())
+	cfg := testConfig()
+	// DLP owns the assertion in this test. GitHub's stateless installation
+	// tokens are roughly 520 characters, so the generic URL-length guard must
+	// not preempt the detector under test.
+	cfg.FetchProxy.Monitoring.MaxURLLength = 2048
+	s := MustNew(cfg)
 
 	tests := []struct {
 		url     string
@@ -175,6 +180,7 @@ func TestScan_BlocksDLPPatterns(t *testing.T) {
 		{"https://example.com/path?" + "token=" + "ASIA" + "IOSFODNN7EXAMPLE", "AWS Access ID"},
 		{"https://example.com/path/ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl", "GitHub Token"},
 		{"https://example.com/path/gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl", "GitHub Token"},
+		{"https://example.com/path/ghs_eyJhbGciOiJFUzI1NiJ9." + strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_", "GitHub Token"},
 		{"https://example.com/api?k=fw_" + "aBcDeFgHiJkLmNoPqRsTuV", "Fireworks API Key"},
 		{"https://example.com/api?k=GOCSPX-" + "aBcDeFgHiJkLmNoPqRsTuVwXyZaB", "Google OAuth Client Secret"},
 		{"https://example.com/api?k=AIza" + "SyA1234567890abcdefghijklmnopqrstuv", "Google API Key"},

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1598,6 +1598,27 @@ func TestScanTextForDLP_GitHubTokensInLongOpaqueRunsStillBlock(t *testing.T) {
 	}
 }
 
+func TestScanTextForDLP_GitHubStatelessInstallationToken(t *testing.T) {
+	cfg := testConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+
+	// GitHub's stateless installation-token contract is a ghs_-prefixed JWT
+	// of roughly 520 characters. Keep the first segment below the legacy
+	// 36-character opaque-token floor: the complete token is the credential,
+	// and GitHub explicitly requires matchers to accept dots and hyphens.
+	token := "ghs_" + "eyJhbGciOiJFUzI1NiJ9" + "." +
+		strings.Repeat("A", 240) + "." + strings.Repeat("B", 220) + "-_"
+
+	result := s.ScanTextForDLP(context.Background(), "token="+token)
+	if result.Clean {
+		t.Fatal("GitHub stateless installation token was not detected")
+	}
+	if !hasTextDLPMatch(result.Matches, "GitHub Token", "") {
+		t.Fatalf("missing GitHub Token match: %v", result.Matches)
+	}
+}
+
 func TestScanTextForDLP_MultiplePatterns(t *testing.T) {
 	cfg := testConfig()
 	s := MustNew(cfg)

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2151,6 +2151,29 @@ class StructuredOutputSafetyTest(unittest.TestCase):
                 self.assertNotIn(sample, rendered)
                 self.assertIn(label, rendered)
 
+        stateless = (
+            bytes.fromhex("6768735f").decode()
+            + "eyJhbGciOiJFUzI1NiJ9."
+            + "A" * 48
+            + "."
+            + "B" * 48
+            + "-_"
+        )
+        rendered = pr_review.sanitize_public_text(
+            f"The diff contains {stateless}&next=1; remove it.", limit=600
+        )
+        self.assertNotIn(stateless, rendered)
+        self.assertIn("(redacted:github-token)&next=1", rendered)
+
+        for suffix in ("A" * 43 + "=", "B" * 43 + "%3d"):
+            with self.subTest(credential="azure-sas-token", suffix=suffix[-3:]):
+                sample = bytes.fromhex("7369673d").decode() + suffix
+                rendered = pr_review.sanitize_public_text(
+                    f"The diff contains {sample}&next=1; remove it.", limit=600
+                )
+                self.assertNotIn(sample, rendered)
+                self.assertIn("(redacted:azure-sas-token)&next=1", rendered)
+
     def test_a_separator_inside_the_body_does_not_shorten_a_token_past_its_minimum(self) -> None:
         """A length minimum cannot be rescued by an optional separator.
 


### PR DESCRIPTION
## What changed
- Detect GitHub stateless installation JWTs and decoded Azure SAS signatures across the default scanner, redactor, generated presets, and review-publication scrubber, so these issuer formats fail closed without consuming the following query delimiter.
- Add a 66-pattern agent-traffic corpus across prompt, tool-argument, form, and base64 carriers, and bump canonical policy hashes because the default enforcement semantics changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and redaction of modern GitHub server-to-server tokens, including JWT-style formats.
  * Expanded Azure SAS token detection to recognize both URL-encoded and standard Base64 signature endings.
  * Updated detection across built-in configurations and quickstart settings.

* **Documentation**
  * Updated configuration reference descriptions for the expanded token formats.

* **Tests**
  * Added coverage for blocking, redaction, WebSocket scanning, proxy requests, and near-miss secret formats.
  * Added comprehensive DLP coverage across supported input carriers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->