### PR TITLE
fix: let PR review judge retrieve missing evidence

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -93,6 +93,17 @@ DEEP_MAX_UNITS_PER_CHUNK = 60
 # Each judge context fetch allows 30 seconds, so an unbounded candidate set
 # could spend longer on requests than the whole job is permitted to run.
 MAX_JUDGE_CONTEXT_FETCHES = 20
+# One file window used to consume most of the default judge payload and leave
+# later candidates entirely unjudged. A focused actual-line window is enough
+# for the first pass; the judge can request a specific path or literal search
+# for its one bounded repair pass when the deciding code lives elsewhere.
+MAX_JUDGE_CONTEXT_TOKENS = 1_200
+MAX_JUDGE_EVIDENCE_REQUESTS = 8
+MAX_REQUESTS_PER_CANDIDATE = 3
+MAX_REQUESTED_EVIDENCE_TOKENS = 2_000
+# Evidence retrieval shares one wall-clock allowance. Per-command timeouts alone
+# let several model-authored requests consume their full timeout serially.
+MAX_REQUESTED_EVIDENCE_SECONDS = 10
 # Each git-grep is itself time-bounded. This is how many we are willing to start
 # for one judge pass; without it, twenty candidates times four terms can spend
 # minutes rescanning HEAD before a partial review is even published.
@@ -103,7 +114,7 @@ REPO_PATTERN = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
 # @@ -old_start,old_count +new_start,new_count @@ optional section heading.
 # Counts are optional in unified diff when they are 1.
 HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$")
-RUBRIC_VERSION = "2026-08-30.1"
+RUBRIC_VERSION = "2026-08-30.2"
 STATUS_MARKER = "pr-review-status:v1"
 # A separate marker so the compact record of published findings never has to
 # fit on the status line, and so a parser for one cannot be confused by the
@@ -219,6 +230,19 @@ class Finding:
     why: str
     fix: str
     needs_verification: bool = False
+
+
+@dataclass(frozen=True)
+class EvidenceRequest:
+    path: str | None = None
+    line: int | None = None
+    search: str | None = None
+
+
+@dataclass(frozen=True)
+class JudgeDecision:
+    verdict: str
+    requests: tuple[EvidenceRequest, ...] = ()
 
 
 @dataclass
@@ -722,8 +746,11 @@ def build_judge_prompt(
         + recheck
         + "Choose keep or drop whenever checked-out repository code can decide the premise. "
         "Use unresolved only when the decisive fact is outside the repository or the prompt explicitly says required evidence was omitted or unavailable. "
+        "On the first pass, if repository evidence could decide the premise but was not supplied, return unresolved and request the missing evidence. "
+        "Each request must contain either a repository-relative path (plus an optional positive line) or one literal search string. Do not request commands or tests. "
+        "On the final targeted recheck, requests must be empty: decide from the expanded evidence or name the genuinely external fact still required. "
         "An unresolved reason must name that missing external or omitted evidence. Unresolved candidates are withheld and require human verification rather than becoming actionable findings. "
-        "Return JSON only: {\"findings\":[{\"index\":integer,\"verdict\":\"keep|drop|unresolved\",\"reason\":\"short\"}]}. "
+        "Return JSON only: {\"findings\":[{\"index\":integer,\"verdict\":\"keep|drop|unresolved\",\"reason\":\"short\",\"requests\":[{\"path\":\"relative/path\",\"line\":integer|null}|{\"search\":\"literal\"}]}]}. "
         "Return exactly one result for every candidate and no extra keys."
     )
     user = json.dumps(
@@ -749,11 +776,42 @@ def build_judge_prompt(
     return system, user
 
 
-def _parse_judge_decisions(payload: object, candidate_count: int) -> dict[int, str]:
+def _parse_evidence_requests(value: object) -> tuple[EvidenceRequest, ...]:
+    if not isinstance(value, list):
+        return ()
+    requests_out: list[EvidenceRequest] = []
+    for raw in value[:MAX_REQUESTS_PER_CANDIDATE]:
+        if not isinstance(raw, dict):
+            continue
+        path = raw.get("path")
+        search = raw.get("search")
+        line = raw.get("line")
+        if (
+            isinstance(path, str)
+            and 0 < len(path) <= 300
+            and not path.startswith("/")
+            and ".." not in Path(path).parts
+            and not any(unicodedata.category(char) in {"Cc", "Cs"} for char in path)
+        ):
+            if line is not None and (type(line) is not int or line <= 0):
+                continue
+            requests_out.append(EvidenceRequest(path=path, line=line))
+        elif (
+            isinstance(search, str)
+            and 3 <= len(search) <= 160
+            and not any(unicodedata.category(char) in {"Cc", "Cs"} for char in search)
+        ):
+            requests_out.append(EvidenceRequest(search=search))
+    return tuple(requests_out)
+
+
+def _parse_judge_decisions(
+    payload: object, candidate_count: int, *, allow_requests: bool = True
+) -> dict[int, JudgeDecision]:
     """Return only schema-valid decisions; the caller owns bounded repair."""
     if not isinstance(payload, dict) or not isinstance(payload.get("findings"), list):
         raise ModelOutputError("judge response violated its schema")
-    decisions: dict[int, str] = {}
+    decisions: dict[int, JudgeDecision] = {}
     for item in payload["findings"]:
         if not isinstance(item, dict) or not {"index", "verdict", "reason"} <= set(item):
             continue
@@ -767,7 +825,11 @@ def _parse_judge_decisions(payload: object, candidate_count: int) -> dict[int, s
             _required_string(item["reason"], "judge reason", limit=300)
         except ModelOutputError:
             continue
-        decisions[index] = verdict
+        raw_requests = item.get("requests")
+        if raw_requests not in (None, []) and (not allow_requests or verdict != "unresolved"):
+            continue
+        requests = _parse_evidence_requests(raw_requests)
+        decisions[index] = JudgeDecision(verdict, requests)
     return decisions
 
 
@@ -1773,19 +1835,26 @@ def find_running_comment(repo: str, pr_number: str, token: str, correlation: str
     return found, False
 
 
-def _local_review_root(head_sha: str, correlation: str) -> Path | None:
+def _local_review_root(head_sha: str, correlation: str, deadline: float | None = None) -> Path | None:
     """Return the immutable target checkout only when it is the reviewed head."""
     configured = os.environ.get("REVIEWED_REPOSITORY_PATH", "")
     if not configured:
         return None
     root = Path(configured).resolve()
+    timeout = 10.0
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            log_phase("judge-checkout", status="deadline-exhausted", correlation=correlation)
+            return None
+        timeout = min(timeout, remaining)
     try:
         completed = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "HEAD"],
             text=True,
             capture_output=True,
             check=False,
-            timeout=10,
+            timeout=timeout,
         )
     except (OSError, subprocess.TimeoutExpired):
         log_phase("judge-checkout", status="unreadable", correlation=correlation)
@@ -1808,6 +1877,47 @@ def _read_local_file(root: Path, path: str) -> str | None:
         return candidate.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
+
+
+def _read_commit_file(root: Path, head_sha: str, path: str, deadline: float) -> str | None:
+    """Read one bounded tracked blob from the immutable reviewed commit."""
+    object_name = f"{head_sha}:{path}"
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return None
+    try:
+        size = subprocess.run(
+            ["git", "-C", str(root), "cat-file", "-s", object_name],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=min(10, remaining),
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError, UnicodeError):
+        return None
+    if size.returncode:
+        return None
+    try:
+        blob_size = int(size.stdout.strip())
+    except ValueError:
+        return None
+    if blob_size < 0 or blob_size > 2_000_000:
+        return None
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return None
+    try:
+        blob = subprocess.run(
+            ["git", "-C", str(root), "cat-file", "blob", object_name],
+            capture_output=True,
+            check=False,
+            timeout=min(10, remaining),
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError, UnicodeError):
+        return None
+    if blob.returncode or len(blob.stdout) != blob_size:
+        return None
+    return blob.stdout.decode("utf-8", errors="replace")
 
 
 def fetch_file_context(repo: str, path: str, head_sha: str, token: str, correlation: str) -> str | None:
@@ -1845,14 +1955,39 @@ def fetch_file_context(repo: str, path: str, head_sha: str, token: str, correlat
         return None
 
 
-def _line_context(content: str, line: int | None) -> str:
+def _line_context(content: str, line: int | None, max_tokens: int = MAX_JUDGE_CONTEXT_TOKENS) -> str:
     lines = content.splitlines()
+    if line is not None and (line < 1 or line > len(lines)):
+        return "<file-context-unavailable: requested line is outside the file>"
     if not lines:
         return "<empty file>"
     center = (line - 1) if line is not None else 0
     start = max(0, center - 60)
     end = min(len(lines), center + 60)
-    return "\n".join(f"{number + 1}: {value}" for number, value in enumerate(lines[start:end], start=start))
+    rendered = [
+        f"{number + 1}: {value}"[: max_tokens * 4]
+        for number, value in enumerate(lines[start:end], start=start)
+    ]
+    if estimate_tokens("\n".join(rendered)) <= max_tokens:
+        return "\n".join(rendered)
+    local_center = min(max(center - start, 0), len(rendered) - 1)
+    selected: list[int] = []
+    used = 0
+    for distance in range(len(rendered)):
+        for index in (local_center - distance, local_center + distance):
+            if index < 0 or index >= len(rendered) or index in selected:
+                continue
+            addition = estimate_tokens(rendered[index])
+            if selected and used + addition > max_tokens:
+                continue
+            selected.append(index)
+            used += addition
+        if used >= max_tokens:
+            break
+    selected.sort()
+    output = [rendered[index] for index in selected]
+    output.append("<file-context-truncated: request a path or literal search if more repository evidence is needed>")
+    return "\n".join(output)
 
 
 _EVIDENCE_STOP_WORDS = frozenset(
@@ -1960,12 +2095,14 @@ def cross_file_evidence(
                 break
             searched_terms.add(term)
             searches += 1
-            lines, search_truncated, search_failed = _bounded_git_grep(root, term)
+            lines, search_truncated, search_failed = _bounded_git_grep(
+                root, term, binding.head_sha
+            )
             if search_failed:
                 return "", True
             search_output_truncated = search_output_truncated or search_truncated
             for raw in lines:
-                match = re.match(r"HEAD:([^:]+):(\d+):(.*)", raw)
+                match = re.match(rf"{re.escape(binding.head_sha)}:([^:]+):(\d+):(.*)", raw)
                 if not match:
                     continue
                 path, line_text, text = match.groups()
@@ -2031,11 +2168,13 @@ def _reap_process(process: subprocess.Popen[Any]) -> None:
         process.wait()
 
 
-def _bounded_git_grep(root: Path, term: str) -> tuple[list[str], bool, bool]:
+def _bounded_git_grep(
+    root: Path, term: str, treeish: str, deadline: float | None = None
+) -> tuple[list[str], bool, bool]:
     """Read repository search output with hard time and byte bounds."""
     try:
         process = subprocess.Popen(  # noqa: S603
-            ["git", "-C", str(root), "grep", "-n", "-I", "-i", "-F", "-m", "3", "-e", term, "HEAD", "--"],
+            ["git", "-C", str(root), "grep", "-n", "-I", "-i", "-F", "-m", "3", "-e", term, treeish, "--"],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
         )
@@ -2047,14 +2186,16 @@ def _bounded_git_grep(root: Path, term: str) -> tuple[list[str], bool, bool]:
         return [], False, True
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ)
-    deadline = time.monotonic() + 10
+    command_deadline = time.monotonic() + 10
+    if deadline is not None:
+        command_deadline = min(command_deadline, deadline)
     data = bytearray()
     truncated = False
     try:
         # Drain stdout until EOF. poll() is only a deadline/exit check; a child
         # that already exited can still have unread output in the pipe.
         while True:
-            remaining = deadline - time.monotonic()
+            remaining = command_deadline - time.monotonic()
             if remaining <= 0:
                 process.kill()
                 _reap_process(process)
@@ -2108,6 +2249,79 @@ def _bounded_change_summaries(
         retained.append(summary)
         used += addition
     return retained, False
+
+
+def requested_repository_evidence(
+    binding: PullBinding,
+    decisions: dict[int, JudgeDecision],
+    max_tokens: int = MAX_REQUESTED_EVIDENCE_TOKENS,
+    deadline: float | None = None,
+) -> tuple[str, bool]:
+    """Fetch only the repository evidence the first judge says it lacked."""
+    requested: list[EvidenceRequest] = []
+    seen: set[EvidenceRequest] = set()
+    for decision in decisions.values():
+        if decision.verdict != "unresolved":
+            continue
+        for request in decision.requests:
+            if request in seen:
+                continue
+            seen.add(request)
+            requested.append(request)
+            if len(requested) == MAX_JUDGE_EVIDENCE_REQUESTS:
+                break
+        if len(requested) == MAX_JUDGE_EVIDENCE_REQUESTS:
+            break
+    if not requested:
+        return "", False
+    evidence_deadline = time.monotonic() + MAX_REQUESTED_EVIDENCE_SECONDS
+    if deadline is not None:
+        evidence_deadline = min(evidence_deadline, deadline)
+    root = _local_review_root(binding.head_sha, binding.correlation, evidence_deadline)
+    if root is None:
+        return "<requested-repository-evidence-unavailable>", True
+    rendered: list[str] = []
+    used = 0
+    unavailable = False
+    for request in requested:
+        remaining = evidence_deadline - time.monotonic()
+        if remaining <= 0:
+            rendered.append("<requested-repository-evidence-deadline-exhausted>")
+            unavailable = True
+            break
+        if request.path is not None:
+            content = _read_commit_file(root, binding.head_sha, request.path, evidence_deadline)
+            if content is None:
+                piece = f"<requested-path-unavailable: {request.path}>"
+                unavailable = True
+            else:
+                context = _line_context(content, request.line, 700)
+                piece = f"REQUESTED PATH {request.path}\n{context}"
+                if context.startswith("<file-context-unavailable:"):
+                    unavailable = True
+        else:
+            lines, truncated, failed = _bounded_git_grep(
+                root,
+                request.search or "",
+                treeish=binding.head_sha,
+                deadline=evidence_deadline,
+            )
+            if failed:
+                piece = f"<requested-search-unavailable: {request.search}>"
+                unavailable = True
+            else:
+                hits = lines[:12]
+                piece = f"REQUESTED LITERAL SEARCH {request.search!r}\n" + ("\n".join(hits) or "<no matches>")
+                if truncated or len(lines) > len(hits):
+                    piece += "\n<requested-search-truncated>"
+        addition = estimate_tokens(piece)
+        if used + addition > max_tokens:
+            rendered.append("<requested-repository-evidence-truncated>")
+            unavailable = True
+            break
+        rendered.append(piece)
+        used += addition
+    return "\n\n".join(rendered), unavailable
 
 
 def judge_findings(
@@ -2184,7 +2398,10 @@ def judge_findings(
             }
         )
     summary_tokens = estimate_tokens(json.dumps(judge_summaries, separators=(",", ":")))
-    evidence_budget = budget - used - summary_tokens - 1_000
+    # The first pass may ask for evidence that the repair must add. Reserve
+    # that allowance now; otherwise a valid first prompt can leave the repair
+    # above the same provider input limit merely by using its advertised path.
+    evidence_budget = budget - used - summary_tokens - 1_000 - MAX_REQUESTED_EVIDENCE_TOKENS
     if evidence_budget < 1_000:
         return [], False, over_budget, over_files, [], candidates
     evidence, evidence_unavailable = cross_file_evidence(
@@ -2204,40 +2421,59 @@ def judge_findings(
     # review. It gets only candidates the first pass omitted or explicitly
     # marked unresolved, and it cannot recurse.
     pending_indices = [
-        index for index in range(len(candidates)) if decisions.get(index) in {None, "unresolved"}
+        index
+        for index in range(len(candidates))
+        if decisions.get(index) is None or decisions[index].verdict == "unresolved"
     ]
     repair_failed = False
     if pending_indices and (deadline is None or budget_allows(deadline, mode, "judge-repair")):
         pending = [candidates[index] for index in pending_indices]
+        evidence_deadline = None
+        if deadline is not None:
+            # Keep the repair model's advertised connection-and-call budget
+            # intact instead of spending it on model-authored repository reads.
+            evidence_deadline = deadline - llm_call_budget_for(mode, "judge-repair")
+        requested_evidence, requested_unavailable = requested_repository_evidence(
+            binding, decisions, deadline=evidence_deadline
+        )
+        expanded_evidence = evidence
+        if requested_evidence:
+            expanded_evidence += "\n\nFIRST-PASS REQUESTED REPOSITORY EVIDENCE\n" + requested_evidence
+        if requested_unavailable:
+            expanded_evidence += "\n<some-requested-repository-evidence-was-unavailable-or-omitted>"
         recheck_system, recheck_user = build_judge_prompt(
             pending,
             {path: context for path, context in contexts.items() if path in {item.path for item in pending}},
             judge_summaries,
-            evidence,
+            expanded_evidence,
             targeted_recheck=True,
         )
-        try:
-            recheck_payload = call_model(
-                recheck_system, recheck_user, mode, "judge-repair", binding.correlation
-            )
-            recheck = _parse_judge_decisions(recheck_payload, len(pending))
-        except ReviewError:
-            recheck = {}
-            repair_failed = True
-        for recheck_index, original_index in enumerate(pending_indices):
-            if recheck_index in recheck:
-                decisions[original_index] = recheck[recheck_index]
-            else:
-                # Provider failure says nothing about where the decisive fact
-                # lives, and an omitted repair decision violates the repair
-                # contract. Neither may preserve a first-pass unresolved
-                # verdict as outside-evidence uncertainty.
-                decisions.pop(original_index, None)
+        repair_budget_available = deadline is None or budget_allows(deadline, mode, "judge-repair")
+        if repair_budget_available:
+            try:
+                recheck_payload = call_model(
+                    recheck_system, recheck_user, mode, "judge-repair", binding.correlation
+                )
+                recheck = _parse_judge_decisions(
+                    recheck_payload, len(pending), allow_requests=False
+                )
+            except ReviewError:
+                recheck = {}
+                repair_failed = True
+            for recheck_index, original_index in enumerate(pending_indices):
+                if recheck_index in recheck:
+                    decisions[original_index] = recheck[recheck_index]
+                else:
+                    # Provider failure says nothing about where the decisive fact
+                    # lives, and an omitted repair decision violates the repair
+                    # contract. Neither may preserve a first-pass unresolved
+                    # verdict as outside-evidence uncertainty.
+                    decisions.pop(original_index, None)
 
     unresolved = [
         candidates[index]
         for index in range(len(candidates))
-        if decisions.get(index) == "unresolved"
+        if decisions.get(index) is not None and decisions[index].verdict == "unresolved"
     ]
     invalid = [
         candidates[index]
@@ -2248,8 +2484,8 @@ def judge_findings(
         raise ModelOutputError("judge decided no candidate after targeted recheck")
     verified: list[Finding] = []
     for index, finding in enumerate(candidates):
-        verdict = decisions.get(index)
-        if verdict == "keep":
+        decision = decisions.get(index)
+        if decision is not None and decision.verdict == "keep":
             verified.append(finding)
     return verified, True, over_budget, over_files, unresolved, invalid
 
@@ -2518,7 +2754,8 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
         lines.extend(
             [
                 "",
-                "### Candidates requiring manual verification",
+                "<details>",
+                f"<summary>Unverified candidates ({len(all_candidates)}; not findings)</summary>",
                 "",
                 "The actual-code judge couldn't settle these candidates. They aren't verified findings.",
             ]
@@ -2531,6 +2768,7 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
             )
         if remaining := len(all_candidates) - len(candidates):
             lines.append(f"- and {remaining} more")
+        lines.extend(["", "</details>"])
     lines.extend(
         [
             "",

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -55,10 +55,10 @@ final comment includes an omission manifest. If the reviewer omits a unit, can't
 parse it, or gets unusable provider output, it reports `partial` instead of
 `clean`.
 
-The judge gets one bounded follow-up with only the candidates it didn't settle.
+The judge gets one bounded follow-up with only the candidates it didn't settle. The first pass can request a specific repository path or literal search; the runner fetches that evidence from the immutable reviewed checkout before the follow-up. The review job never executes pull-request code to settle a candidate.
 When a candidate depends on external evidence or evidence the run couldn't
-include, the comment reports `inconclusive` and shows the candidate under a
-manual-verification heading. The candidate doesn't count as an actionable
+include, the comment reports `inconclusive` and keeps the candidate in a
+collapsed unverified-candidates section. The candidate doesn't count as an actionable
 finding, and the completeness check stays red until the review reaches `clean`
 or `findings`.
 A finding the judge does keep can still show `(needs verification)` when the

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1357,12 +1357,13 @@ class JudgeFetchCapTest(unittest.TestCase):
             _, judged, over_budget, over_files, _unresolved, _invalid = pr_review.judge_findings(
                 "owner/repo", "token", binding, "deep", candidates
             )
-        self.assertFalse(judged)
+        self.assertTrue(judged)
         self.assertEqual(fetch.call_count, pr_review.MAX_JUDGE_CONTEXT_FETCHES)
-        # The two limits are now reported apart, because naming the wrong one
-        # sends an operator to shrink the wrong thing. The total held back is
-        # unchanged, which is what this test has always been about.
-        self.assertEqual(len(over_budget) + len(over_files), len(candidates))
+        # The context window is now bounded, so the first twenty paths still
+        # reach the judge instead of one giant source line excluding all of
+        # them. Only the candidates beyond the file-fetch cap are held back.
+        self.assertEqual(over_budget, [])
+        self.assertEqual(len(over_files), len(candidates) - pr_review.MAX_JUDGE_CONTEXT_FETCHES)
         self.assertTrue(over_files, "the file cap is what bites with 60 distinct paths")
 
 
@@ -1407,6 +1408,266 @@ class JudgeEvidenceTest(unittest.TestCase):
         self.assertEqual(invalid, [])
         self.assertEqual([call.args[3] for call in model.call_args_list], ["judge", "judge-repair"])
         self.assertIn("final targeted recheck", model.call_args_list[1].args[0])
+
+    def test_targeted_recheck_fetches_the_repository_evidence_the_judge_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            init_git_fixture(root)
+            (root / "go.mod").write_text("module example.test/reviewer\n\ngo 1.25\n")
+            subprocess.run(["git", "-C", str(root), "add", "go.mod"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
+            head = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True
+            ).stdout.strip()
+            binding = pr_review.PullBinding("a" * 40, head, "c" * 40, pr_review.RUBRIC_VERSION)
+            candidate = pr_review.Finding("medium", "config.yaml", 12, "syntax may fail", "runtime unclear", "fix")
+            first = {
+                "findings": [{
+                    "index": 0,
+                    "verdict": "unresolved",
+                    "reason": "language version is missing",
+                    "requests": [{"path": "go.mod", "line": 3}],
+                }]
+            }
+            repaired = {"findings": [{"index": 0, "verdict": "drop", "reason": "supported", "requests": []}]}
+            with mock.patch.dict(pr_review.os.environ, {"REVIEWED_REPOSITORY_PATH": str(root)}, clear=False), mock.patch.object(
+                pr_review, "fetch_file_context", return_value="12: regex"
+            ), mock.patch.object(pr_review, "cross_file_evidence", return_value=("", False)), mock.patch.object(
+                pr_review, "call_model", side_effect=[first, repaired]
+            ) as model:
+                verified, judged, over_budget, over_files, unresolved, invalid = pr_review.judge_findings(
+                    "owner/repo", "token", binding, "default", [candidate]
+                )
+        self.assertTrue(judged)
+        self.assertEqual((verified, over_budget, over_files, unresolved, invalid), ([], [], [], [], []))
+        repair_prompt = json.loads(model.call_args_list[1].args[1])
+        self.assertIn("REQUESTED PATH go.mod", repair_prompt["cross_file_repository_evidence"])
+        self.assertIn("go 1.25", repair_prompt["cross_file_repository_evidence"])
+
+    def test_requested_path_reads_the_reviewed_commit_not_dirty_worktree_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            init_git_fixture(root)
+            (root / "contract.txt").write_text("committed contract\n")
+            subprocess.run(["git", "-C", str(root), "add", "contract.txt"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "-qm", "fixture"], check=True)
+            head = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True
+            ).stdout.strip()
+            (root / "contract.txt").write_text("dirty replacement\n")
+            binding = pr_review.PullBinding("a" * 40, head, "c" * 40, pr_review.RUBRIC_VERSION)
+            decisions = {
+                0: pr_review.JudgeDecision(
+                    "unresolved", (pr_review.EvidenceRequest(path="contract.txt"),)
+                )
+            }
+            with mock.patch.dict(
+                pr_review.os.environ, {"REVIEWED_REPOSITORY_PATH": str(root)}, clear=False
+            ):
+                evidence, unavailable = pr_review.requested_repository_evidence(binding, decisions)
+        self.assertFalse(unavailable)
+        self.assertIn("committed contract", evidence)
+        self.assertNotIn("dirty replacement", evidence)
+
+    def test_requested_search_reads_the_reviewed_commit_not_later_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            init_git_fixture(root)
+            (root / "contract.txt").write_text("reviewed needle\n")
+            subprocess.run(["git", "-C", str(root), "add", "contract.txt"], check=True)
+            subprocess.run(["git", "-C", str(root), "commit", "-qm", "reviewed"], check=True)
+            reviewed_head = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True
+            ).stdout.strip()
+            (root / "contract.txt").write_text("later replacement\n")
+            subprocess.run(["git", "-C", str(root), "commit", "-am", "later", "-q"], check=True)
+            binding = pr_review.PullBinding("a" * 40, reviewed_head, "c" * 40, pr_review.RUBRIC_VERSION)
+            decisions = {
+                0: pr_review.JudgeDecision(
+                    "unresolved", (pr_review.EvidenceRequest(search="reviewed needle"),)
+                )
+            }
+            with mock.patch.object(pr_review, "_local_review_root", return_value=root):
+                evidence, unavailable = pr_review.requested_repository_evidence(binding, decisions)
+        self.assertFalse(unavailable)
+        self.assertIn("reviewed needle", evidence)
+        self.assertNotIn("later replacement", evidence)
+
+    def test_requested_line_outside_file_is_unavailable(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        decisions = {
+            0: pr_review.JudgeDecision(
+                "unresolved", (pr_review.EvidenceRequest(path="contract.txt", line=99),)
+            )
+        }
+        with mock.patch.object(pr_review, "_local_review_root", return_value=pathlib.Path(".")), mock.patch.object(
+            pr_review, "_read_commit_file", return_value="one line\n"
+        ):
+            evidence, unavailable = pr_review.requested_repository_evidence(binding, decisions)
+        self.assertTrue(unavailable)
+        self.assertIn("<file-context-unavailable:", evidence)
+
+    def test_requested_repository_evidence_shares_one_aggregate_deadline(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        decisions = {
+            0: pr_review.JudgeDecision(
+                "unresolved",
+                (
+                    pr_review.EvidenceRequest(search="first"),
+                    pr_review.EvidenceRequest(search="second"),
+                ),
+            )
+        }
+        with mock.patch.object(pr_review.time, "monotonic", return_value=100.0), mock.patch.object(
+            pr_review, "_local_review_root", return_value=pathlib.Path(".")
+        ), mock.patch.object(pr_review, "_bounded_git_grep", return_value=([], False, False)) as grep:
+            evidence, unavailable = pr_review.requested_repository_evidence(
+                binding, decisions, deadline=105.0
+            )
+        self.assertFalse(unavailable)
+        self.assertIn("first", evidence)
+        self.assertIn("second", evidence)
+        self.assertEqual([call.kwargs["deadline"] for call in grep.call_args_list], [105.0, 105.0])
+        self.assertEqual([call.kwargs["treeish"] for call in grep.call_args_list], [binding.head_sha] * 2)
+
+    def test_requested_repository_evidence_caps_its_own_aggregate_time(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        decisions = {
+            0: pr_review.JudgeDecision(
+                "unresolved", (pr_review.EvidenceRequest(search="needle"),)
+            )
+        }
+        with mock.patch.object(pr_review.time, "monotonic", return_value=100.0), mock.patch.object(
+            pr_review, "_local_review_root", return_value=pathlib.Path(".")
+        ), mock.patch.object(pr_review, "_bounded_git_grep", return_value=([], False, False)) as grep:
+            pr_review.requested_repository_evidence(binding, decisions, deadline=500.0)
+        self.assertEqual(grep.call_args.kwargs["deadline"], 110.0)
+
+    def test_requested_repository_evidence_skips_checkout_at_the_deadline_boundary(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        now = 100.0
+        job_deadline = now + pr_review.llm_call_budget_for("deep", "judge-repair")
+        evidence_deadline = job_deadline - pr_review.llm_call_budget_for("deep", "judge-repair")
+        decisions = {
+            0: pr_review.JudgeDecision(
+                "unresolved", (pr_review.EvidenceRequest(search="needle"),)
+            )
+        }
+        with mock.patch.dict(
+            pr_review.os.environ, {"REVIEWED_REPOSITORY_PATH": "/reviewed"}, clear=False
+        ), mock.patch.object(pr_review.time, "monotonic", return_value=now), mock.patch.object(
+            pr_review.subprocess, "run"
+        ) as run:
+            evidence, unavailable = pr_review.requested_repository_evidence(
+                binding, decisions, deadline=evidence_deadline
+            )
+        self.assertTrue(unavailable)
+        self.assertEqual(evidence, "<requested-repository-evidence-unavailable>")
+        run.assert_not_called()
+
+    def test_requested_repository_evidence_caps_checkout_validation_to_remaining_time(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        decisions = {
+            0: pr_review.JudgeDecision(
+                "unresolved", (pr_review.EvidenceRequest(search="needle"),)
+            )
+        }
+        completed = subprocess.CompletedProcess([], 0, stdout=binding.head_sha + "\n", stderr="")
+        with mock.patch.dict(
+            pr_review.os.environ, {"REVIEWED_REPOSITORY_PATH": "/reviewed"}, clear=False
+        ), mock.patch.object(pr_review.time, "monotonic", return_value=100.0), mock.patch.object(
+            pr_review.subprocess, "run", return_value=completed
+        ) as run, mock.patch.object(
+            pr_review, "_bounded_git_grep", return_value=([], False, False)
+        ):
+            evidence, unavailable = pr_review.requested_repository_evidence(
+                binding, decisions, deadline=102.0
+            )
+        self.assertFalse(unavailable)
+        self.assertIn("needle", evidence)
+        self.assertEqual(run.call_args.kwargs["timeout"], 2.0)
+
+    def test_judge_context_is_shared_instead_of_one_large_file_crowding_out_later_candidates(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        candidates = [pr_review.Finding("low", f"docs/{index}.md", 80, "title", "why", "fix") for index in range(5)]
+        payload = {
+            "findings": [
+                {"index": index, "verdict": "drop", "reason": "not a defect", "requests": []}
+                for index in range(len(candidates))
+            ]
+        }
+        with mock.patch.object(pr_review, "fetch_file_context", return_value=("long documentation line\n" * 500)), mock.patch.object(
+            pr_review, "cross_file_evidence", return_value=("", False)
+        ), mock.patch.object(pr_review, "call_model", return_value=payload):
+            verified, judged, over_budget, over_files, unresolved, invalid = pr_review.judge_findings(
+                "owner/repo", "token", binding, "default", candidates
+            )
+        self.assertTrue(judged)
+        self.assertEqual((verified, over_budget, over_files, unresolved, invalid), ([], [], [], [], []))
+
+    def test_evidence_requests_reject_paths_outside_the_review_checkout(self) -> None:
+        parsed = pr_review._parse_judge_decisions(
+            {
+                "findings": [{
+                    "index": 0,
+                    "verdict": "unresolved",
+                    "reason": "need file",
+                    "requests": [{"path": "../../etc/passwd", "line": 1}],
+                }]
+            },
+            1,
+        )
+        self.assertEqual(parsed[0].requests, ())
+
+    def test_evidence_requests_reject_nul_path_without_failing_the_judge_parse(self) -> None:
+        parsed = pr_review._parse_judge_decisions(
+            {
+                "findings": [{
+                    "index": 0,
+                    "verdict": "unresolved",
+                    "reason": "need file",
+                    "requests": [{"path": "docs/bad\x00name.md", "line": 1}],
+                }]
+            },
+            1,
+        )
+        self.assertEqual(parsed[0].requests, ())
+
+    def test_judge_rejects_keep_or_drop_with_an_evidence_request(self) -> None:
+        for verdict in ("keep", "drop"):
+            with self.subTest(verdict=verdict):
+                payload = {
+                    "findings": [{
+                        "index": 0,
+                        "verdict": verdict,
+                        "reason": "another file might confirm this",
+                        "requests": [{"path": "internal/consumer.go", "line": 12}],
+                    }]
+                }
+                self.assertEqual(pr_review._parse_judge_decisions(payload, 1), {})
+                self.assertEqual(
+                    pr_review._parse_judge_decisions(payload, 1, allow_requests=False),
+                    {},
+                )
+
+    def test_evidence_requests_reject_control_characters_for_paths_and_searches(self) -> None:
+        for request in (
+            {"path": "docs/bad\nname.md"},
+            {"path": "docs/bad\x7fname.md"},
+            {"path": "docs/bad\x85name.md"},
+            {"search": "bad\x7fsearch"},
+            {"search": "bad\x85search"},
+        ):
+            with self.subTest(request=request):
+                self.assertEqual(pr_review._parse_evidence_requests([request]), ())
+
+    def test_evidence_requests_reject_lone_surrogates_for_paths_and_searches(self) -> None:
+        for request in (
+            {"path": "docs/bad\ud800name.md"},
+            {"search": "bad\ud800search"},
+        ):
+            with self.subTest(request=request):
+                self.assertEqual(pr_review._parse_evidence_requests([request]), ())
 
     def test_failed_targeted_recheck_marks_pending_candidate_invalid(self) -> None:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
@@ -1472,6 +1733,38 @@ class JudgeEvidenceTest(unittest.TestCase):
         budget.assert_called_once_with(1.0, "deep", "judge-repair")
         model.assert_called_once()
 
+    def test_targeted_recheck_rechecks_budget_after_repository_evidence(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        candidate = pr_review.Finding("medium", "a.go", 12, "guard may skip", "caller unclear", "deny")
+        first = {
+            "findings": [{
+                "index": 0,
+                "verdict": "unresolved",
+                "reason": "outside state required",
+                "requests": [{"path": "consumer.go"}],
+            }]
+        }
+        with mock.patch.object(pr_review, "fetch_file_context", return_value="12: return nil"), mock.patch.object(
+            pr_review, "cross_file_evidence", return_value=("", False)
+        ), mock.patch.object(
+            pr_review, "requested_repository_evidence", return_value=("", True)
+        ) as requested, mock.patch.object(
+            pr_review, "budget_allows", side_effect=[True, False]
+        ) as budget, mock.patch.object(pr_review, "call_model", return_value=first) as model:
+            verified, judged, _payload, _files, unresolved, invalid = pr_review.judge_findings(
+                "owner/repo", "token", binding, "deep", [candidate], deadline=1_000.0
+            )
+        self.assertTrue(judged)
+        self.assertEqual(verified, [])
+        self.assertEqual(unresolved, [candidate])
+        self.assertEqual(invalid, [])
+        requested.assert_called_once_with(binding, mock.ANY, deadline=mock.ANY)
+        self.assertEqual(budget.call_args_list, [
+            mock.call(1_000.0, "deep", "judge-repair"),
+            mock.call(1_000.0, "deep", "judge-repair"),
+        ])
+        model.assert_called_once()
+
     def test_deep_recheck_uses_its_real_phase_budget_at_the_call_site(self) -> None:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         candidate = pr_review.Finding("medium", "a.go", 12, "guard may skip", "caller unclear", "deny")
@@ -1481,6 +1774,8 @@ class JudgeEvidenceTest(unittest.TestCase):
         with mock.patch.object(pr_review, "fetch_file_context", return_value="12: return nil"), mock.patch.object(
             pr_review, "cross_file_evidence", return_value=("", False)
         ), mock.patch.object(pr_review.time, "monotonic", return_value=1_000.0), mock.patch.object(
+            pr_review, "requested_repository_evidence", return_value=("", False)
+        ) as requested, mock.patch.object(
             pr_review, "call_model", side_effect=[first, repaired]
         ) as model:
             verified, judged, _payload, _files, unresolved, invalid = pr_review.judge_findings(
@@ -1491,6 +1786,7 @@ class JudgeEvidenceTest(unittest.TestCase):
         self.assertEqual(unresolved, [])
         self.assertEqual(invalid, [])
         self.assertEqual([call.args[3] for call in model.call_args_list], ["judge", "judge-repair"])
+        requested.assert_called_once_with(binding, mock.ANY, deadline=1_000.0)
 
     def test_judge_repair_has_small_output_and_timeout_bounds(self) -> None:
         payload = pr_review.build_llm_payload("gpt-5.6-terra", "system", "user", "deep", "judge-repair")
@@ -1543,7 +1839,7 @@ class JudgeEvidenceTest(unittest.TestCase):
                 return None
 
         with mock.patch.object(pr_review.subprocess, "Popen", return_value=Finished()):
-            lines, truncated, failed = pr_review._bounded_git_grep(pathlib.Path("."), "match")
+            lines, truncated, failed = pr_review._bounded_git_grep(pathlib.Path("."), "match", "HEAD")
         self.assertFalse(failed)
         self.assertFalse(truncated)
         self.assertEqual(lines, ["HEAD:a.go:1:match"])
@@ -1582,7 +1878,7 @@ class JudgeEvidenceTest(unittest.TestCase):
         with mock.patch.object(pr_review.time, "monotonic", side_effect=monotonic), mock.patch.object(
             pr_review.subprocess, "Popen", return_value=child
         ):
-            _lines, _truncated, failed = pr_review._bounded_git_grep(pathlib.Path("."), "match")
+            _lines, _truncated, failed = pr_review._bounded_git_grep(pathlib.Path("."), "match", "HEAD")
         self.assertTrue(failed)
         self.assertTrue(child.killed)
         self.assertTrue(child.waited)
@@ -2462,7 +2758,7 @@ class StatusPresentationTest(unittest.TestCase):
         self.assertIn("Verdict:** `inconclusive`", status)
         self.assertIn("whole diff was reviewed", status)
         self.assertIn("Findings:** high 0, medium 0, low 0.", status)
-        self.assertIn("### Candidates requiring manual verification", status)
+        self.assertIn("<summary>Unverified candidates (1; not findings)</summary>", status)
         self.assertIn("`internal/enforce.go:42`: error path may allow", status)
         self.assertIn("They aren't verified findings.", status)
         self.assertIn("Why manual verification is required", status)


### PR DESCRIPTION
## What changed
- Let unresolved review candidates request bounded repository paths or literal searches before the final judge pass.
- Limit per-file context and collapse unverified candidates so one large file or unproven claim doesn't dominate the review output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review judgments can request targeted repository files or literal searches before a final recheck.
  * Unverified candidates now appear in a collapsible status section.

* **Bug Fixes**
  * Improved review context handling so large files do not crowd out other candidates.
  * Bounded evidence collection by request, token, and time limits.
  * Evidence requests are limited to the reviewed checkout and never execute pull-request code.
  * Improved handling of deletion hunks and inconclusive review results.

* **Documentation**
  * Updated the review guide to explain targeted evidence requests and revised candidate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->