### PR TITLE
chore: close release-readiness gate gaps

### DIFF
--- a/.github/workflows/publish-verifiers.yaml
+++ b/.github/workflows/publish-verifiers.yaml
@@ -58,6 +58,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Assert tag matches verifier package versions
+        if: ${{ startsWith(github.ref, 'refs/tags/verifier-v') }}
+        env:
+          VERIFIER_TAG: ${{ github.ref_name }}
+        run: scripts/check-verifier-publish-tag.sh "$VERIFIER_TAG"
+
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/release/verifier-installers.json
+++ b/release/verifier-installers.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_blocked": false,
+  "release_blocked": true,
   "verifiers": [
     {
       "language": "Go",
@@ -19,29 +19,29 @@
     {
       "language": "TypeScript",
       "package": "@pipelock/verifier-ts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "install_source": "npm",
-      "artifact_digest": "sha512-toSGcJXUjXWmEpFcByA+Q8PGP/WatIAqWYIvhR4WjAz3IbcURAWyc32k0Ev+tknUbNdyaykRwkxNKhwKS+2rFg==",
+      "artifact_digest": "REPLACE_WITH_NPM_DIST_INTEGRITY",
       "publisher": {
         "repository": "luckyPipewrench/pipelock",
         "workflow": ".github/workflows/publish-verifiers.yaml",
         "environment": "verifier-release",
-        "source_ref": "verifier-v0.3.0",
-        "source_commit": "a2bc6cb18d728841b0edd7f714aca67d234f2e52"
+        "source_ref": "verifier-v0.3.1",
+        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_1_TAG_COMMIT"
       }
     },
     {
       "language": "Rust",
       "package": "pipelock-verifier-rs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "install_source": "crates.io",
-      "artifact_digest": "381ed98d8b945e05f06b98d1c432ab5f9920b7932e5381458224511864ce2c0e",
+      "artifact_digest": "REPLACE_WITH_CRATES_IO_SHA256",
       "publisher": {
         "repository": "luckyPipewrench/pipelock",
         "workflow": ".github/workflows/publish-verifiers.yaml",
         "environment": "verifier-release",
-        "source_ref": "verifier-v0.3.0",
-        "source_commit": "a2bc6cb18d728841b0edd7f714aca67d234f2e52"
+        "source_ref": "verifier-v0.3.1",
+        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_1_TAG_COMMIT"
       }
     },
     {

--- a/scripts/check-config-examples.sh
+++ b/scripts/check-config-examples.sh
@@ -69,17 +69,19 @@ fi
 # Fixture a real recorder signing key. Without this the check is CIRCULAR: a snippet
 # that correctly sets signing_key_path names a file this host does not have, gets
 # skipped as environment-dependent, and is never booted — so the policy would not
-# exercise the very examples it exists to protect. A signing key is trivially
-# fixture-creatable (init generates one), so it must be fixtured, not skipped. Skips
-# are reserved for dependencies that cannot reasonably be created here (a real signed
-# license, an operator's CA). `init` writes keys/ next to the config it generates.
-FIXTURE_KEY=""
-if "$BIN" init --output "$WORK/keygen/pipelock.yaml" --skip-canary --skip-validate >/dev/null 2>&1 \
-    && [ -s "$WORK/keygen/keys/flight-recorder-signing.key" ]; then
-    FIXTURE_KEY="$WORK/keygen/keys/flight-recorder-signing.key"
-else
-    echo "config-examples: WARNING - could not fixture a recorder signing key;" >&2
-    echo "  snippets naming signing_key_path will be skipped instead of booted." >&2
+# exercise the very examples it exists to protect. Generate only the required key
+# through its dedicated shipped lifecycle command. `init` performs unrelated host
+# setup after writing the key, so using its overall exit status makes this gate skip
+# recorder examples when that later setup is unavailable.
+FIXTURE_KEY="$WORK/keygen/flight-recorder-signing.key"
+mkdir -p "$(dirname "$FIXTURE_KEY")"
+KEYGEN_OUT="$WORK/recorder-key-generate.txt"
+if ! HOME="$PROBE_HOME" "$BIN" signing key generate \
+    --purpose receipt-signing --out "$FIXTURE_KEY" >"$KEYGEN_OUT" 2>&1 \
+    || [ ! -s "$FIXTURE_KEY" ]; then
+    echo "config-examples: could not fixture a recorder signing key" >&2
+    grep -vE '^[[:space:]]*$' "$KEYGEN_OUT" | tail -3 >&2 || true
+    exit 1
 fi
 
 # Top-level keys of config.Config. A yaml block is a pipelock config only if every

--- a/scripts/check-verifier-publish-tag.sh
+++ b/scripts/check-verifier-publish-tag.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/check-verifier-publish-tag.sh
+++ b/scripts/check-verifier-publish-tag.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "${1:-}" == "--root" ]]; then
+	ROOT_DIR="${2:-}"
+	shift 2
+fi
+TAG="${1:-}"
+if [[ -z "$TAG" ]]; then
+	printf 'usage: %s [--root DIR] verifier-vX.Y.Z\n' "$0" >&2
+	exit 2
+fi
+
+ts_version="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["version"])' "$ROOT_DIR/sdk/verifiers/ts/package.json")"
+rust_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT_DIR/sdk/verifiers/rust/Cargo.toml" | head -n 1)"
+
+if [[ -z "$ts_version" || -z "$rust_version" ]]; then
+	printf 'verifier publish tag check: could not read both package versions\n' >&2
+	exit 2
+fi
+if [[ "$ts_version" != "$rust_version" ]]; then
+	printf 'verifier publish tag check: TypeScript %s does not match Rust %s\n' "$ts_version" "$rust_version" >&2
+	exit 1
+fi
+if [[ "$TAG" != "verifier-v$ts_version" ]]; then
+	printf 'verifier publish tag check: tag %s does not match package version %s\n' "$TAG" "$ts_version" >&2
+	exit 1
+fi
+
+printf 'verifier publish tag check: %s matches both package manifests\n' "$TAG"

--- a/scripts/release-verifier-fixture_test.go
+++ b/scripts/release-verifier-fixture_test.go
@@ -406,6 +406,36 @@ func setStagedVerifierSourceCommits(t *testing.T, inventory map[string]interface
 	}
 }
 
+func stagedVerifierSourceRef(t *testing.T, root, language string) string {
+	t.Helper()
+	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
+	raw, err := os.ReadFile(inventoryPath) // #nosec G304 -- fixed inventory path under t.TempDir.
+	if err != nil {
+		t.Fatalf("read staged inventory: %v", err)
+	}
+	var inventory struct {
+		Verifiers []struct {
+			Language  string `json:"language"`
+			Publisher struct {
+				SourceRef string `json:"source_ref"`
+			} `json:"publisher"`
+		} `json:"verifiers"`
+	}
+	if err := json.Unmarshal(raw, &inventory); err != nil {
+		t.Fatalf("decode staged inventory: %v", err)
+	}
+	for _, verifier := range inventory.Verifiers {
+		if verifier.Language == language {
+			if verifier.Publisher.SourceRef == "" {
+				t.Fatalf("staged %s verifier has no publisher source_ref", language)
+			}
+			return verifier.Publisher.SourceRef
+		}
+	}
+	t.Fatalf("staged inventory has no %s verifier entry", language)
+	return ""
+}
+
 func TestReleaseVerifierInstallGateRejectsMissingVerifierTag(t *testing.T) {
 	root := stageReleaseVerifierInventoryTest(t)
 	inventoryPath := filepath.Join(root, "release", "verifier-installers.json")
@@ -481,7 +511,7 @@ func TestReleaseVerifierInstallGateRejectsPostTagSourceDrift(t *testing.T) {
 	}
 
 	tagCommit := runGit("rev-parse", "HEAD")
-	runGit("tag", "verifier-v0.3.0")
+	runGit("tag", stagedVerifierSourceRef(t, root, "TypeScript"))
 	// Point the inventory at this fixture's own tag commit and unblock it, so the
 	// gate reaches the source-drift check. These were find-and-replace edits
 	// against REPLACE_WITH_* and `"release_blocked": true`; both silently became

--- a/scripts/release-verifier-install-gate.sh
+++ b/scripts/release-verifier-install-gate.sh
@@ -234,7 +234,7 @@ fi
 
 release_blocked="$(python3 -c 'import json, sys; print(str(json.load(open(sys.argv[1], encoding="utf-8"))["release_blocked"]).lower())' "$INVENTORY")"
 if [[ "$release_blocked" == "true" ]]; then
-	printf 'release verifier install gate: release is explicitly blocked until verifier-v0.3.0 is published and its immutable registry digests replace the inventory placeholders\n' >&2
+	printf 'release verifier install gate: release is explicitly blocked until verifier-v%s is published and its immutable registry digests replace the inventory placeholders\n' "$ts_version" >&2
 	exit 2
 fi
 

--- a/scripts/test_config_examples.py
+++ b/scripts/test_config_examples.py
@@ -1,7 +1,10 @@
 # Copyright 2026 Pipelock contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pathlib
+import subprocess
+import tempfile
 import unittest
 
 
@@ -10,6 +13,37 @@ SCRIPT = ROOT / "scripts" / "check-config-examples.sh"
 
 
 class ConfigExampleFixtureContractTests(unittest.TestCase):
+    def run_fixture_gate(self, keygen_mode: str) -> subprocess.CompletedProcess[str]:
+        temp = pathlib.Path(self.enterContext(tempfile.TemporaryDirectory()))
+        fake = temp / "pipelock"
+        fake.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = tls ] && [ "${2:-}" = init ]; then
+    mkdir -p "$4"
+    exit 0
+fi
+if [ "${1:-}" = signing ] && [ "${2:-}" = key ] && [ "${3:-}" = generate ]; then
+    [ "$FAKE_KEYGEN_MODE" != fail ] || exit 9
+    exit 0
+fi
+exit 97
+""",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        env = os.environ.copy()
+        env["HOME"] = str(temp / "home")
+        env["FAKE_KEYGEN_MODE"] = keygen_mode
+        return subprocess.run(
+            ["bash", str(SCRIPT), str(fake)],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
     def test_recorder_key_uses_dedicated_lifecycle_command(self) -> None:
         source = SCRIPT.read_text(encoding="utf-8")
         self.assertIn("signing key generate", source)
@@ -21,6 +55,16 @@ class ConfigExampleFixtureContractTests(unittest.TestCase):
         failure = 'echo "config-examples: could not fixture a recorder signing key" >&2'
         start = source.index(failure)
         self.assertIn("exit 1", source[start : start + 160])
+
+    def test_key_generation_failure_fails_the_gate(self) -> None:
+        result = self.run_fixture_gate("fail")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not fixture a recorder signing key", result.stderr)
+
+    def test_empty_generated_key_fails_the_gate(self) -> None:
+        result = self.run_fixture_gate("empty")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not fixture a recorder signing key", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test_config_examples.py
+++ b/scripts/test_config_examples.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-config-examples.sh"
+
+
+class ConfigExampleFixtureContractTests(unittest.TestCase):
+    def test_recorder_key_uses_dedicated_lifecycle_command(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("signing key generate", source)
+        self.assertIn("--purpose receipt-signing", source)
+        self.assertNotIn('"$BIN" init --output "$WORK/keygen/', source)
+
+    def test_missing_recorder_key_fails_the_gate(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        failure = 'echo "config-examples: could not fixture a recorder signing key" >&2'
+        start = source.index(failure)
+        self.assertIn("exit 1", source[start : start + 160])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verifier_publish_tag.py
+++ b/scripts/test_verifier_publish_tag.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "scripts" / "check-verifier-publish-tag.sh"
+
+
+class VerifierPublishTagTests(unittest.TestCase):
+    def fixture(self, ts_version: str = "0.3.1", rust_version: str = "0.3.1") -> Path:
+        temp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        ts = temp / "sdk" / "verifiers" / "ts"
+        rust = temp / "sdk" / "verifiers" / "rust"
+        ts.mkdir(parents=True)
+        rust.mkdir(parents=True)
+        (ts / "package.json").write_text(json.dumps({"version": ts_version}), encoding="utf-8")
+        (rust / "Cargo.toml").write_text(
+            f'[package]\nname = "pipelock-verifier-rs"\nversion = "{rust_version}"\n',
+            encoding="utf-8",
+        )
+        return temp
+
+    def run_check(self, root: Path, tag: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(CHECK), "--root", str(root), tag],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_matching_tag_and_manifests_pass(self) -> None:
+        result = self.run_check(self.fixture(), "verifier-v0.3.1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_wrong_tag_fails_before_publish(self) -> None:
+        result = self.run_check(self.fixture(), "verifier-v0.3.2")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not match package version", result.stderr)
+
+    def test_manifest_version_drift_fails_before_publish(self) -> None:
+        result = self.run_check(self.fixture(rust_version="0.3.2"), "verifier-v0.3.1")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("TypeScript 0.3.1 does not match Rust 0.3.2", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verifier_publish_tag.py
+++ b/scripts/test_verifier_publish_tag.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import subprocess
 import tempfile

--- a/sdk/verifiers/rust/Cargo.lock
+++ b/sdk/verifiers/rust/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipelock-verifier-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "data-encoding",

--- a/sdk/verifiers/rust/Cargo.toml
+++ b/sdk/verifiers/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipelock-verifier-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.95"
 license = "Apache-2.0"

--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipelock/verifier-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipelock/verifier-ts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "3.1.0",

--- a/sdk/verifiers/ts/package.json
+++ b/sdk/verifiers/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipelock/verifier-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript reference verifier for Pipelock signed agent-egress receipts (Audit Packet v0, ActionReceipt v1, EvidenceReceipt v2).",
   "license": "Apache-2.0",
   "author": "Pipelab",


### PR DESCRIPTION
## What changed

- Stage the TypeScript and Rust verifiers at 0.3.1 while the product release stays blocked until their published digests and source commit are recorded.
- Refuse mismatched verifier tags and make config-example validation generate the receipt-signing key it requires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the TypeScript and Rust verifier packages to version 0.3.1.
  * Added release safeguards to ensure verifier package versions and tags remain aligned.

* **Bug Fixes**
  * Configuration checks now fail clearly when recorder signing keys cannot be generated.
  * Release validation messages now report the current verifier version.

* **Tests**
  * Added coverage for version mismatches, signing-key failures, and release safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->