### PR TITLE
fail closed on missed request, media, and receipt identity

### DIFF
--- a/cmd/pipelock-verifier/evidence.go
+++ b/cmd/pipelock-verifier/evidence.go
@@ -153,7 +153,7 @@ func verifyEvidenceReceipt(r contractreceipt.EvidenceReceipt, keyHex string, opt
 		}
 		return false, nil
 	}
-	if err := contractreceipt.VerifyWithKey(r, chainOpts.PinnedKey, r.Signature.SignerKeyID); err != nil {
+	if err := contractreceipt.VerifyWithKey(r, chainOpts.PinnedKey, contractreceipt.SignerKeyID(chainOpts.PinnedKey)); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -36,7 +36,6 @@ const (
 	tHTTPS         = "https"
 	tNotPipelock   = "not-pipelock"
 	verdictAllowed = "allow"
-	v2SignerID     = "receipt-signing-v2-test"
 	v2ContractHash = "sha256:v2-contract"
 )
 
@@ -55,6 +54,26 @@ type evidenceFixture struct {
 	priv     ed25519.PrivateKey
 	receipts []contractreceipt.EvidenceReceipt
 	keyHex   string
+}
+
+func writePinnedV2ReceiptFixture(t *testing.T, source, destination, keyHex string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(source))
+	if err != nil {
+		t.Fatalf("read v2 fixture: %v", err)
+	}
+	r, err := decodeEvidenceReceipt(data)
+	if err != nil {
+		t.Fatalf("decode v2 fixture: %v", err)
+	}
+	r.Signature.SignerKeyID = keyHex
+	data, err = json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal v2 fixture: %v", err)
+	}
+	if err := os.WriteFile(destination, data, 0o600); err != nil {
+		t.Fatalf("write v2 fixture: %v", err)
+	}
 }
 
 func newEvidenceFixture(t *testing.T, n int) *evidenceFixture {
@@ -105,7 +124,7 @@ func newEvidenceFixture(t *testing.T, n int) *evidenceFixture {
 			t.Fatalf("preimage: %v", err)
 		}
 		r.Signature = contractreceipt.SignatureProof{
-			SignerKeyID: v2SignerID,
+			SignerKeyID: hex.EncodeToString(pub),
 			KeyPurpose:  "receipt-signing",
 			Algorithm:   "ed25519",
 			Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
@@ -1539,13 +1558,15 @@ func TestReceipt_EvidenceV2RecheckSourceSpan(t *testing.T) {
 	if err := os.WriteFile(sourcePath, []byte("https://example.com/[redacted-value]"), 0o600); err != nil {
 		t.Fatalf("write recheck source: %v", err)
 	}
-	receiptPath := filepath.Clean(filepath.Join("..", "..", "internal", "contract", "testdata", "golden", "valid_evidence_receipt_proxy_decision_with_spans.json"))
 	keyHex := strings.Join([]string{
 		"d75a980182b10ab7",
 		"d54bfed3c964073a",
 		"0ee172f3daa62325",
 		"af021a68f707511a",
 	}, "")
+	fixturePath := filepath.Clean(filepath.Join("..", "..", "internal", "contract", "testdata", "golden", "valid_evidence_receipt_proxy_decision_with_spans.json"))
+	receiptPath := filepath.Join(dir, "receipt.json")
+	writePinnedV2ReceiptFixture(t, fixturePath, receiptPath, keyHex)
 	stdout, stderr, code := runRoot(t,
 		"receipt",
 		"--json",
@@ -1585,13 +1606,15 @@ func TestReceipt_EvidenceV2RecheckSourceSpanMismatchReportsInvalid(t *testing.T)
 	if err := os.WriteFile(sourcePath, []byte("https://example.com/xxxxxxxxxxxxxxxx"), 0o600); err != nil {
 		t.Fatalf("write recheck source: %v", err)
 	}
-	receiptPath := filepath.Clean(filepath.Join("..", "..", "internal", "contract", "testdata", "golden", "valid_evidence_receipt_proxy_decision_with_spans.json"))
 	keyHex := strings.Join([]string{
 		"d75a980182b10ab7",
 		"d54bfed3c964073a",
 		"0ee172f3daa62325",
 		"af021a68f707511a",
 	}, "")
+	fixturePath := filepath.Clean(filepath.Join("..", "..", "internal", "contract", "testdata", "golden", "valid_evidence_receipt_proxy_decision_with_spans.json"))
+	receiptPath := filepath.Join(dir, "receipt.json")
+	writePinnedV2ReceiptFixture(t, fixturePath, receiptPath, keyHex)
 	stdout, stderr, code := runRoot(t,
 		"receipt",
 		"--json",
@@ -2018,7 +2041,7 @@ func TestChain_EvidenceV2PinnedKey(t *testing.T) {
 	stdout, stderr, code := runRoot(t,
 		"chain",
 		"--key", fix.keyHex,
-		"--expect-signer-id", v2SignerID,
+		"--expect-signer-id", fix.keyHex,
 		"--expect-payload-kind", string(contractreceipt.PayloadShadowDelta),
 		"--expect-contract", v2ContractHash,
 		evidence,
@@ -2421,7 +2444,7 @@ func TestChain_EvidenceV2DirHappyPath(t *testing.T) {
 	stdout, stderr, code := runRoot(t,
 		"chain", "--dir",
 		"--key", fix.keyHex,
-		"--expect-signer-id", v2SignerID,
+		"--expect-signer-id", fix.keyHex,
 		dir,
 	)
 	if code != cliutil.ExitOK {
@@ -2447,7 +2470,7 @@ func TestChain_EvidenceV2DirLocationSelector(t *testing.T) {
 		"chain", "--dir",
 		"--location", filepath.ToSlash(locationID),
 		"--key", fix.keyHex,
-		"--expect-signer-id", v2SignerID,
+		"--expect-signer-id", fix.keyHex,
 		root,
 	)
 	if code != cliutil.ExitOK {
@@ -2629,6 +2652,18 @@ func TestVerifyEvidenceReceipt_ManifestMismatch(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "active_manifest_hash") {
 		t.Errorf("expected manifest error, got %v", err)
+	}
+}
+
+func TestVerifyEvidenceReceipt_PinnedKeyBindsSignerKeyID(t *testing.T) {
+	t.Parallel()
+	fix := newEvidenceFixture(t, 1)
+	relabeled := fix.receipts[0]
+	relabeled.Signature.SignerKeyID = "attacker-label"
+
+	_, err := verifyEvidenceReceipt(relabeled, fix.keyHex, evidenceBindingOptions{})
+	if err == nil || !strings.Contains(err.Error(), "signer_key_id") {
+		t.Fatalf("relabeled pinned receipt error = %v, want signer_key_id rejection", err)
 	}
 }
 

--- a/internal/cli/evidence/compact_test.go
+++ b/internal/cli/evidence/compact_test.go
@@ -1730,7 +1730,7 @@ func compactSignedReceipt(t *testing.T, priv ed25519.PrivateKey, seq uint64, pre
 		Crit:    contractreceipt.CritForPayloadKind(contractreceipt.PayloadShadowDelta),
 		EventID: fmt.Sprintf("01900000-0000-7000-8000-%012d", seq), Timestamp: time.Unix(1, 0).UTC(), Actor: "test",
 		ChainSeq: seq, ChainPrevHash: prev, ContractHash: "sha256:test-contract", ActiveManifestHash: "sha256:test-manifest", Payload: payload,
-		Signature: contractreceipt.SignatureProof{SignerKeyID: "test-key", KeyPurpose: "receipt-signing", Algorithm: "ed25519"},
+		Signature: contractreceipt.SignatureProof{SignerKeyID: contractreceipt.SignerKeyID(priv.Public().(ed25519.PublicKey)), KeyPurpose: "receipt-signing", Algorithm: "ed25519"},
 	}
 	preimage, err := r.SignablePreimage()
 	if err != nil {

--- a/internal/cli/runtime/daybreak_finding_repro_test.go
+++ b/internal/cli/runtime/daybreak_finding_repro_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+func TestDaybreak_StrictReloadRejectsListenerStateTokenDowngrade(t *testing.T) {
+	oldCfg := config.Defaults()
+	oldCfg.Mode = config.ModeStrict
+	required := true
+	oldCfg.MCPSessionBinding.Enabled = true
+	oldCfg.MCPSessionBinding.ListenerRequireStateToken = &required
+
+	newCfg := oldCfg.Clone()
+	compat := false
+	newCfg.MCPSessionBinding.ListenerRequireStateToken = &compat
+
+	warnings := config.ValidateReload(oldCfg, newCfg)
+	foundWarning := false
+	for _, w := range warnings {
+		if w.Field == "mcp_session_binding.listener_require_state_token" {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatal("strict listener_require_state_token teardown emitted no reload warning")
+	}
+	if torn := requiredModeTeardowns(oldCfg, newCfg); len(torn) != 1 || torn[0] != "mcp_session_binding.listener_require_state_token" {
+		t.Fatalf("requiredModeTeardowns = %v, want exactly mcp_session_binding.listener_require_state_token", torn)
+	}
+	reason := reloadDowngradeRejectReason(oldCfg, newCfg, warnings)
+	if !strings.Contains(reason, "mcp_session_binding.listener_require_state_token") {
+		t.Fatalf("strict reload rejection = %q, want listener state-token teardown", reason)
+	}
+}

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -733,6 +733,13 @@ func requiredModeTeardowns(oldCfg, newCfg *config.Config) []string {
 	tornDown("mcp_binary_integrity.require_signature",
 		oldCfg.MCPBinaryIntegrity.Enabled && oldCfg.MCPBinaryIntegrity.RequireSignature,
 		newCfg.MCPBinaryIntegrity.Enabled && newCfg.MCPBinaryIntegrity.RequireSignature)
+	// Listener state tokens are optional in balanced and audit modes for
+	// compatibility, but a strict-mode listener that was requiring one cannot
+	// silently stop doing so. Session binding is the parent that makes the
+	// setting effective, so turning that parent off is a teardown too.
+	tornDown("mcp_session_binding.listener_require_state_token",
+		oldCfg.Mode == config.ModeStrict && oldCfg.MCPSessionBinding.Enabled && oldCfg.MCPSessionBinding.RequiresListenerStateToken(),
+		newCfg.MCPSessionBinding.Enabled && newCfg.MCPSessionBinding.RequiresListenerStateToken())
 	tornDown("mediation_envelope.verify_inbound.enabled",
 		oldCfg.MediationEnvelope.VerifyInbound.Enabled, newCfg.MediationEnvelope.VerifyInbound.Enabled)
 	// sni_require_tls refuses to splice an opaque CONNECT tunnel when the

--- a/internal/cli/runtime/server_required_mode_test.go
+++ b/internal/cli/runtime/server_required_mode_test.go
@@ -56,6 +56,16 @@ func TestReloadDowngradeRejectReason_RequiredTeardownWithoutWarnings(t *testing.
 			wantIn: "mcp_binary_integrity.require_signature",
 		},
 		{
+			name: "mcp_session_binding_listener_require_state_token_in_strict_mode",
+			on: func(c *config.Config) {
+				required := true
+				c.Mode = config.ModeStrict
+				c.MCPSessionBinding.Enabled = true
+				c.MCPSessionBinding.ListenerRequireStateToken = &required
+			},
+			wantIn: "mcp_session_binding.listener_require_state_token",
+		},
+		{
 			name:   "mediation_envelope_verify_inbound",
 			on:     func(c *config.Config) { c.MediationEnvelope.VerifyInbound.Enabled = true },
 			wantIn: "mediation_envelope.verify_inbound.enabled",
@@ -187,5 +197,57 @@ func TestRequiredModeTeardowns_SNIRequireTLSParentGating(t *testing.T) {
 	staleNew.ForwardProxy.SNIRequireTLS = &no
 	if torn := requiredModeTeardowns(staleOld, staleNew); len(torn) > 0 {
 		t.Fatalf("clearing sni_require_tls under disabled verification reported a teardown: %v", torn)
+	}
+}
+
+func TestRequiredModeTeardowns_ListenerStateTokenParentGating(t *testing.T) {
+	t.Parallel()
+	yes, no := true, false
+
+	inForce := config.Defaults()
+	inForce.Mode = config.ModeStrict
+	inForce.MCPSessionBinding.Enabled = true
+	inForce.MCPSessionBinding.ListenerRequireStateToken = &yes
+
+	flagOff := inForce.Clone()
+	flagOff.MCPSessionBinding.ListenerRequireStateToken = &no
+	if torn := requiredModeTeardowns(inForce, flagOff); len(torn) != 1 || torn[0] != "mcp_session_binding.listener_require_state_token" {
+		t.Fatalf("clearing listener_require_state_token reported %v, want exactly mcp_session_binding.listener_require_state_token", torn)
+	}
+	if torn := requiredModeTeardowns(flagOff, inForce); len(torn) > 0 {
+		t.Fatalf("enabling listener_require_state_token reported a teardown: %v", torn)
+	}
+	if reason := reloadDowngradeRejectReason(flagOff, inForce, nil); reason != "" {
+		t.Fatalf("enabling listener_require_state_token rejected as a downgrade: %q", reason)
+	}
+
+	parentOff := inForce.Clone()
+	parentOff.MCPSessionBinding.Enabled = false
+	if torn := requiredModeTeardowns(inForce, parentOff); len(torn) == 0 {
+		t.Fatal("disabling MCP session binding while listener_require_state_token stayed true reported no teardown")
+	}
+
+	staleOld := config.Defaults()
+	staleOld.Mode = config.ModeStrict
+	staleOld.MCPSessionBinding.ListenerRequireStateToken = &yes
+	staleNew := staleOld.Clone()
+	staleNew.MCPSessionBinding.ListenerRequireStateToken = &no
+	if torn := requiredModeTeardowns(staleOld, staleNew); len(torn) > 0 {
+		t.Fatalf("clearing listener_require_state_token under disabled session binding reported a teardown: %v", torn)
+	}
+
+	for _, mode := range []string{config.ModeBalanced, config.ModeAudit} {
+		t.Run(mode, func(t *testing.T) {
+			compatibleOld := inForce.Clone()
+			compatibleOld.Mode = mode
+			compatibleNew := compatibleOld.Clone()
+			compatibleNew.MCPSessionBinding.ListenerRequireStateToken = &no
+			if torn := requiredModeTeardowns(compatibleOld, compatibleNew); len(torn) > 0 {
+				t.Fatalf("%s listener_require_state_token disable reported a required teardown: %v", mode, torn)
+			}
+			if reason := reloadDowngradeRejectReason(compatibleOld, compatibleNew, config.ValidateReload(compatibleOld, compatibleNew)); reason != "" {
+				t.Fatalf("%s listener_require_state_token disable rejected: %q", mode, reason)
+			}
+		})
 	}
 }

--- a/internal/config/mcp_session_binding_token_test.go
+++ b/internal/config/mcp_session_binding_token_test.go
@@ -12,81 +12,107 @@ import (
 func TestMCPSessionBinding_RequiresListenerStateTokenYAMLStates(t *testing.T) {
 	t.Parallel()
 
-	t.Run("omitted", func(t *testing.T) {
-		var binding MCPSessionBinding
-		if err := yaml.Unmarshal([]byte("{}\n"), &binding); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if binding.RequiresListenerStateToken() {
-			t.Fatal("omitted listener_require_state_token defaulted on")
-		}
-	})
-
-	t.Run("null", func(t *testing.T) {
-		var binding MCPSessionBinding
-		if err := yaml.Unmarshal([]byte("listener_require_state_token: ~\n"), &binding); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if binding.RequiresListenerStateToken() {
-			t.Fatal("YAML null listener_require_state_token defaulted on")
-		}
-	})
-
-	t.Run("blank", func(t *testing.T) {
-		var binding MCPSessionBinding
-		if err := yaml.Unmarshal([]byte("listener_require_state_token:\n"), &binding); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if binding.RequiresListenerStateToken() {
-			t.Fatal("YAML blank listener_require_state_token defaulted on")
-		}
-	})
-
-	t.Run("explicit_false", func(t *testing.T) {
-		var binding MCPSessionBinding
-		if err := yaml.Unmarshal([]byte("listener_require_state_token: false\n"), &binding); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if binding.RequiresListenerStateToken() {
-			t.Fatal("explicit false was treated as required")
-		}
-	})
-
-	t.Run("explicit_true", func(t *testing.T) {
-		var binding MCPSessionBinding
-		if err := yaml.Unmarshal([]byte("listener_require_state_token: true\n"), &binding); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if !binding.RequiresListenerStateToken() {
-			t.Fatal("explicit true was ignored")
-		}
-	})
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{name: "omitted", yaml: "{}\n", want: false},
+		{name: "null", yaml: "listener_require_state_token: ~\n", want: false},
+		{name: "blank", yaml: "listener_require_state_token:\n", want: false},
+		{name: "explicit_false", yaml: "listener_require_state_token: false\n", want: false},
+		{name: "explicit_true", yaml: "listener_require_state_token: true\n", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var binding MCPSessionBinding
+			if err := yaml.Unmarshal([]byte(tc.yaml), &binding); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := binding.RequiresListenerStateToken(); got != tc.want {
+				t.Fatalf("RequiresListenerStateToken() = %t, want %t", got, tc.want)
+			}
+		})
+	}
 }
 
 func TestMCPSessionBinding_RequiresListenerStateTokenReload(t *testing.T) {
 	t.Parallel()
 
-	var initial MCPSessionBinding
-	if err := yaml.Unmarshal([]byte("listener_require_state_token: false\n"), &initial); err != nil {
-		t.Fatalf("initial unmarshal: %v", err)
+	for _, tc := range []struct {
+		name        string
+		initialYAML string
+		updatedYAML string
+		wantInitial bool
+		wantUpdated bool
+	}{
+		{name: "omitted_to_false", initialYAML: "{}\n", updatedYAML: "listener_require_state_token: false\n", wantInitial: false, wantUpdated: false},
+		{name: "null_to_false", initialYAML: "listener_require_state_token: ~\n", updatedYAML: "listener_require_state_token: false\n", wantInitial: false, wantUpdated: false},
+		{name: "false_to_true", initialYAML: "listener_require_state_token: false\n", updatedYAML: "listener_require_state_token: true\n", wantInitial: false, wantUpdated: true},
+		{name: "true_to_false", initialYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: false\n", wantInitial: true, wantUpdated: false},
+		{name: "true_to_true", initialYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: true\n", wantInitial: true, wantUpdated: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var initial, updated MCPSessionBinding
+			if err := yaml.Unmarshal([]byte(tc.initialYAML), &initial); err != nil {
+				t.Fatalf("initial unmarshal: %v", err)
+			}
+			if err := yaml.Unmarshal([]byte(tc.updatedYAML), &updated); err != nil {
+				t.Fatalf("updated unmarshal: %v", err)
+			}
+			if got := initial.RequiresListenerStateToken(); got != tc.wantInitial {
+				t.Fatalf("initial token requirement = %t, want %t", got, tc.wantInitial)
+			}
+			if got := updated.RequiresListenerStateToken(); got != tc.wantUpdated {
+				t.Fatalf("reload token requirement = %t, want %t", got, tc.wantUpdated)
+			}
+		})
 	}
-	if initial.RequiresListenerStateToken() {
-		t.Fatal("initial load required a listener token")
-	}
+}
 
-	var changed MCPSessionBinding
-	if err := yaml.Unmarshal([]byte("listener_require_state_token: true\n"), &changed); err != nil {
-		t.Fatalf("reload-with-change: %v", err)
-	}
-	if !changed.RequiresListenerStateToken() {
-		t.Fatal("reload-with-change did not enable the requirement")
-	}
+func TestValidateReload_MCPSessionBindingListenerRequireStateToken(t *testing.T) {
+	t.Parallel()
 
-	var unchanged MCPSessionBinding
-	if err := yaml.Unmarshal([]byte("listener_require_state_token: true\n"), &unchanged); err != nil {
-		t.Fatalf("reload-without-change: %v", err)
-	}
-	if !unchanged.RequiresListenerStateToken() {
-		t.Fatal("reload-without-change dropped the requirement")
+	for _, tc := range []struct {
+		name          string
+		oldYAML       string
+		updatedYAML   string
+		oldParent     bool
+		updatedParent bool
+		wantWarning   bool
+	}{
+		{name: "omitted_to_true", oldYAML: "{}\n", updatedYAML: "listener_require_state_token: true\n", oldParent: true, updatedParent: true},
+		{name: "null_to_true", oldYAML: "listener_require_state_token: ~\n", updatedYAML: "listener_require_state_token: true\n", oldParent: true, updatedParent: true},
+		{name: "false_to_true", oldYAML: "listener_require_state_token: false\n", updatedYAML: "listener_require_state_token: true\n", oldParent: true, updatedParent: true},
+		{name: "true_to_false", oldYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: false\n", oldParent: true, updatedParent: true, wantWarning: true},
+		{name: "true_to_null", oldYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: ~\n", oldParent: true, updatedParent: true, wantWarning: true},
+		{name: "true_to_omitted", oldYAML: "listener_require_state_token: true\n", updatedYAML: "{}\n", oldParent: true, updatedParent: true, wantWarning: true},
+		{name: "true_to_true", oldYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: true\n", oldParent: true, updatedParent: true},
+		{name: "disabled_parent", oldYAML: "listener_require_state_token: true\n", updatedYAML: "listener_require_state_token: false\n", oldParent: false, updatedParent: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var oldBinding, updatedBinding MCPSessionBinding
+			if err := yaml.Unmarshal([]byte(tc.oldYAML), &oldBinding); err != nil {
+				t.Fatalf("old unmarshal: %v", err)
+			}
+			if err := yaml.Unmarshal([]byte(tc.updatedYAML), &updatedBinding); err != nil {
+				t.Fatalf("updated unmarshal: %v", err)
+			}
+
+			old, updated := Defaults(), Defaults()
+			old.MCPSessionBinding = oldBinding
+			updated.MCPSessionBinding = updatedBinding
+			old.MCPSessionBinding.Enabled = tc.oldParent
+			updated.MCPSessionBinding.Enabled = tc.updatedParent
+
+			gotWarning := false
+			for _, warning := range ValidateReload(old, updated) {
+				if warning.Field == "mcp_session_binding.listener_require_state_token" {
+					gotWarning = true
+				}
+			}
+			if gotWarning != tc.wantWarning {
+				t.Fatalf("state-token downgrade warning = %t, want %t", gotWarning, tc.wantWarning)
+			}
+		})
 	}
 }

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -302,6 +302,13 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 			Message: "MCP session binding disabled",
 		})
 	}
+	if old.MCPSessionBinding.Enabled && updated.MCPSessionBinding.Enabled &&
+		old.MCPSessionBinding.RequiresListenerStateToken() && !updated.MCPSessionBinding.RequiresListenerStateToken() {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "mcp_session_binding.listener_require_state_token",
+			Message: "MCP listener state-token requirement disabled",
+		})
+	}
 
 	// A2A scanning disabled or downgraded
 	if old.A2AScanning.Enabled && !updated.A2AScanning.Enabled {

--- a/internal/contract/receipt/chain.go
+++ b/internal/contract/receipt/chain.go
@@ -155,6 +155,7 @@ func VerifyChain(receipts []EvidenceReceipt, opts ChainVerifyOptions) ChainResul
 	}
 
 	signerID := receipts[0].Signature.SignerKeyID
+	pinnedSignerKeyID := SignerKeyID(opts.PinnedKey)
 	prevHash := GenesisHash
 	var tipHash string
 
@@ -200,7 +201,7 @@ func VerifyChain(receipts []EvidenceReceipt, opts ChainVerifyOptions) ChainResul
 		}
 
 		if opts.PinnedKey != nil {
-			if err := VerifyWithKey(r, opts.PinnedKey, r.Signature.SignerKeyID); err != nil {
+			if err := VerifyWithKey(r, opts.PinnedKey, pinnedSignerKeyID); err != nil {
 				return brokenChain(seq, "receipt %d signature: %v", seq, err)
 			}
 		}
@@ -269,7 +270,7 @@ func (v *StreamingVerifier) AddRaw(raw []byte) error {
 		return v.latch(brokenChain(v.count, "receipt %d decode: %v", v.count, err))
 	}
 	seq := v.count
-	if err := VerifyWithKey(r, v.key, r.Signature.SignerKeyID); err != nil {
+	if err := VerifyWithKey(r, v.key, SignerKeyID(v.key)); err != nil {
 		return v.latch(brokenChain(seq, "receipt %d signature: %v", seq, err))
 	}
 	if v.count == 0 {

--- a/internal/contract/receipt/chain_test.go
+++ b/internal/contract/receipt/chain_test.go
@@ -88,10 +88,11 @@ func signReceipt(t *testing.T, r receipt.EvidenceReceipt, priv ed25519.PrivateKe
 // by priv under the test signer id.
 func buildChain(t *testing.T, priv ed25519.PrivateKey, n int) []receipt.EvidenceReceipt {
 	t.Helper()
+	signerID := hex.EncodeToString(priv.Public().(ed25519.PublicKey))
 	var chain []receipt.EvidenceReceipt
 	prev := receipt.GenesisHash
 	for i := 0; i < n; i++ {
-		r := signReceipt(t, unsignedReceipt(t, testSignerID, uint64(i), prev), priv)
+		r := signReceipt(t, unsignedReceipt(t, signerID, uint64(i), prev), priv)
 		h, err := receipt.ReceiptHash(r)
 		if err != nil {
 			t.Fatalf("hash receipt %d: %v", i, err)
@@ -145,7 +146,7 @@ func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
 		}
 	})
 	t.Run("invalid input latches independently", func(t *testing.T) {
-		badSignature := unsignedReceipt(t, testSignerID, 0, receipt.GenesisHash)
+		badSignature := unsignedReceipt(t, receipt.SignerKeyID(pub), 0, receipt.GenesisHash)
 		badSignature = signReceipt(t, badSignature, priv)
 		badSignature.Actor = "tampered"
 		valid := buildChain(t, priv, 1)[0]
@@ -187,7 +188,7 @@ func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
 	})
 	t.Run("signature signer and chain disagreement deny", func(t *testing.T) {
 		v, _ := receipt.NewPinnedStreamingVerifier(pub)
-		badSig := unsignedReceipt(t, testSignerID, 0, receipt.GenesisHash)
+		badSig := unsignedReceipt(t, receipt.SignerKeyID(pub), 0, receipt.GenesisHash)
 		badSig = signReceipt(t, badSig, priv)
 		badSig.Actor = "tampered"
 		if err := v.AddRaw(marshal(t, badSig)); err == nil || !strings.Contains(err.Error(), "signature") {
@@ -207,7 +208,7 @@ func TestPinnedStreamingVerifierFailsClosedAndLatches(t *testing.T) {
 			t.Fatalf("signer error=%v", err)
 		}
 		v, _ = receipt.NewPinnedStreamingVerifier(pub)
-		wrongSeq := signReceipt(t, unsignedReceipt(t, testSignerID, 1, receipt.GenesisHash), priv)
+		wrongSeq := signReceipt(t, unsignedReceipt(t, receipt.SignerKeyID(pub), 1, receipt.GenesisHash), priv)
 		if err := v.AddRaw(marshal(t, wrongSeq)); err == nil || !strings.Contains(err.Error(), "sequence") {
 			t.Fatalf("sequence error=%v", err)
 		}
@@ -295,8 +296,8 @@ func TestVerifyChain_ValidPinnedKey(t *testing.T) {
 	if res.ReceiptCount != 3 || res.FinalSeq != 2 {
 		t.Errorf("count=%d finalSeq=%d, want 3/2", res.ReceiptCount, res.FinalSeq)
 	}
-	if res.SignerKeyID != testSignerID {
-		t.Errorf("signer=%q, want %q", res.SignerKeyID, testSignerID)
+	if res.SignerKeyID != receipt.SignerKeyID(pub) {
+		t.Errorf("signer=%q, want %q", res.SignerKeyID, receipt.SignerKeyID(pub))
 	}
 }
 

--- a/internal/contract/receipt/daybreak_finding_repro_test.go
+++ b/internal/contract/receipt/daybreak_finding_repro_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	receipt "github.com/luckyPipewrench/pipelock/internal/contract/receipt"
+)
+
+func TestDaybreak_RelabeledSignerFailsWhenPinnedKeyBindsSignerKeyID(t *testing.T) {
+	r, pub := signedReceipt(t)
+	expectedSignerKeyID := hex.EncodeToString(pub)
+	r.Signature.SignerKeyID = "attacker-label"
+	if err := receipt.VerifyWithKey(r, pub, expectedSignerKeyID); err == nil {
+		t.Fatal("pinned verify accepted a signer_key_id relabeled away from the pinned public key")
+	}
+}

--- a/internal/contract/receipt/golden_vectors_test.go
+++ b/internal/contract/receipt/golden_vectors_test.go
@@ -58,7 +58,7 @@ func TestGolden_EvidenceReceiptProxyDecision(t *testing.T) {
 		t.Fatalf("preimage: %v", err)
 	}
 	r.Signature = SignatureProof{
-		SignerKeyID: "receipt-signing-test",
+		SignerKeyID: SignerKeyID(priv.Public().(ed25519.PublicKey)),
 		KeyPurpose:  "receipt-signing",
 		Algorithm:   "ed25519",
 		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
@@ -126,7 +126,7 @@ func TestGolden_EvidenceReceiptProxyDecisionWithSpans(t *testing.T) {
 		t.Fatalf("preimage: %v", err)
 	}
 	r.Signature = SignatureProof{
-		SignerKeyID: "receipt-signing-test",
+		SignerKeyID: SignerKeyID(priv.Public().(ed25519.PublicKey)),
 		KeyPurpose:  "receipt-signing",
 		Algorithm:   "ed25519",
 		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
@@ -190,7 +190,7 @@ func TestGolden_EvidenceReceiptPromoteCommitted(t *testing.T) {
 		t.Fatalf("preimage: %v", err)
 	}
 	r.Signature = SignatureProof{
-		SignerKeyID: "receipt-signing-test",
+		SignerKeyID: SignerKeyID(priv.Public().(ed25519.PublicKey)),
 		KeyPurpose:  "receipt-signing",
 		Algorithm:   "ed25519",
 		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),
@@ -260,7 +260,7 @@ func TestGolden_EvidenceReceiptShadowDelta(t *testing.T) {
 		t.Fatalf("preimage: %v", err)
 	}
 	r.Signature = SignatureProof{
-		SignerKeyID: "receipt-signing-test",
+		SignerKeyID: SignerKeyID(priv.Public().(ed25519.PublicKey)),
 		KeyPurpose:  "receipt-signing",
 		Algorithm:   "ed25519",
 		Signature:   "ed25519:" + hex.EncodeToString(ed25519.Sign(priv, preimage)),

--- a/internal/contract/receipt/receipt.go
+++ b/internal/contract/receipt/receipt.go
@@ -333,6 +333,13 @@ func ReceiptHash(r EvidenceReceipt) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
+// SignerKeyID returns the canonical signer_key_id for a pinned Ed25519 public
+// key. KeyedSigner emits this lowercase hexadecimal form when producing v2
+// receipts, so pinned verification can bind the receipt label to its key.
+func SignerKeyID(pubKey ed25519.PublicKey) string {
+	return hex.EncodeToString(pubKey)
+}
+
 // VerifyWithKey verifies the detached Ed25519 signature against pubKey and
 // confirms that the receipt declares the expected signer key id.
 func VerifyWithKey(r EvidenceReceipt, pubKey ed25519.PublicKey, expectedSignerKeyID string) error {

--- a/internal/contract/testdata/golden/valid_evidence_receipt_promote_committed.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_promote_committed.json
@@ -17,7 +17,7 @@
   "event_id": "01F8MECHZX3TBDSZ7XRADM79XX",
   "timestamp": "2026-04-25T22:00:00Z",
   "signature": {
-    "signer_key_id": "receipt-signing-test",
+    "signer_key_id": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
     "key_purpose": "receipt-signing",
     "algorithm": "ed25519",
     "signature": "ed25519:a153f18d3e43f03670e45f9bbe77e6d9ea874ceebb654aa33abba1f51c57479c7ed0681b5ade54e10ddbc74631caf3d661d1673f5ff56ae8f245ca593ae65907"

--- a/internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json
@@ -17,7 +17,7 @@
   "event_id": "01F8MECHZX3TBDSZ7XRADM79XV",
   "timestamp": "2026-04-25T22:00:00Z",
   "signature": {
-    "signer_key_id": "receipt-signing-test",
+    "signer_key_id": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
     "key_purpose": "receipt-signing",
     "algorithm": "ed25519",
     "signature": "ed25519:6cd1df06549a9532218d60aa556d52755a525d084ce0ca766591cad98722d21297b09d01e218b2d515c185867ff2fb861a7e8699b3072cb5864760fb50f86e0b"

--- a/internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision_with_spans.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision_with_spans.json
@@ -18,7 +18,7 @@
   "event_id": "01F8MECHZX3TBDSZ7XRADM79ZS",
   "timestamp": "2026-06-06T18:00:00Z",
   "signature": {
-    "signer_key_id": "receipt-signing-test",
+    "signer_key_id": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
     "key_purpose": "receipt-signing",
     "algorithm": "ed25519",
     "signature": "ed25519:90074ed8ff23e8b3692ee7358dfe9d4a38a49b13007214133c4939f38abfed3cad4154b9d5b59b7c750490e68208f90e4158ead5dff88925e3ba9d2a052e5e0a"

--- a/internal/contract/testdata/golden/valid_evidence_receipt_shadow_delta.json
+++ b/internal/contract/testdata/golden/valid_evidence_receipt_shadow_delta.json
@@ -17,7 +17,7 @@
   "event_id": "01F8MECHZX3TBDSZ7XRADM79YC",
   "timestamp": "2026-04-25T22:00:00Z",
   "signature": {
-    "signer_key_id": "receipt-signing-test",
+    "signer_key_id": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
     "key_purpose": "receipt-signing",
     "algorithm": "ed25519",
     "signature": "ed25519:fdcec0993f0486ff08ba2ef89e03bb88af68b435fb553b99f8b01d9ae49869b739b3a819860425d4b5e9977fe51e5289430b8c521ec066c258f1d40e80227809"

--- a/internal/mcp/daybreak_finding_repro_test.go
+++ b/internal/mcp/daybreak_finding_repro_test.go
@@ -55,11 +55,14 @@ func mcpLineMediaBlocked(t *testing.T, sc *scanner.Scanner, cfg *config.Config, 
 		t.Fatalf("ForwardScanned: %v", err)
 	}
 	if found {
-		return true
+		t.Fatalf("injection finding, want a media-policy JSON-RPC error; out=%s", bytes.TrimSpace(out.Bytes()))
 	}
 	var resp rpcError
 	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
-		return false
+		t.Fatalf("unmarshal media-policy block: %v; out=%s", err, bytes.TrimSpace(out.Bytes()))
 	}
-	return resp.Error.Message != ""
+	if resp.Error.Code != -32002 || !strings.Contains(resp.Error.Message, "media policy") {
+		t.Fatalf("block response = (%d, %q), want media-policy error", resp.Error.Code, resp.Error.Message)
+	}
+	return true
 }

--- a/internal/mcp/daybreak_finding_repro_test.go
+++ b/internal/mcp/daybreak_finding_repro_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/mcp/transport"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+func TestDaybreak_EmbeddedResourceVideoBypassesMediaPolicy(t *testing.T) {
+	sc, cfg := newMCPScannerWithMediaPolicy(t)
+	payload := base64.StdEncoding.EncodeToString([]byte("fake video bytes"))
+
+	topLevel := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"video","mimeType":"video/mp4","data":"%s"}]}}`,
+		payload,
+	)
+	embedded := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"resource","resource":{"uri":"file:///clip.mp4","mimeType":"video/mp4","blob":"%s"}}]}}`,
+		payload,
+	)
+
+	if !mcpLineMediaBlocked(t, sc, cfg, topLevel) {
+		t.Fatal("control: top-level video/mp4 was not blocked")
+	}
+	if !mcpLineMediaBlocked(t, sc, cfg, embedded) {
+		t.Fatal("embedded resource.blob video/mp4 was forwarded; media policy did not see nested mimeType/blob")
+	}
+}
+
+func mcpLineMediaBlocked(t *testing.T, sc *scanner.Scanner, cfg *config.Config, line string) bool {
+	t.Helper()
+	var out, log bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(line+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		nil,
+		MCPProxyOpts{
+			Scanner:     sc,
+			MediaPolicy: &cfg.MediaPolicy,
+			Transport:   testMCPMediaTransport,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		return true
+	}
+	var resp rpcError
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+		return false
+	}
+	return resp.Error.Message != ""
+}

--- a/internal/mcp/jsonrpc/jsonrpc.go
+++ b/internal/mcp/jsonrpc/jsonrpc.go
@@ -37,11 +37,15 @@ type ContentBlock struct {
 	MediaType   string            `json:"mediaType,omitempty"`
 }
 
-// ResourceContents is the text-bearing portion of an embedded MCP resource.
+// ResourceContents is the content carried by an embedded MCP resource.
 // Blob data intentionally stays out of prompt scanning: it is opaque binary
-// content, while Text is rendered directly to the agent.
+// content, while Text is rendered directly to the agent. Media policy handles
+// the Blob with its declared MimeType separately.
 type ResourceContents struct {
-	Text string `json:"text,omitempty"`
+	URI      string `json:"uri,omitempty"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
 }
 
 // ToolResult represents the result field of an MCP tool response.

--- a/internal/mcp/jsonrpc/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc/jsonrpc_test.go
@@ -76,9 +76,53 @@ func TestExtractText_MixedBlockTypes(t *testing.T) {
 }
 
 func TestExtractText_EmbeddedResourceText(t *testing.T) {
-	raw := json.RawMessage(`{"content":[{"type":"resource","resource":{"uri":"file:///workspace/report.txt","mimeType":"text/plain","text":"embedded resource text"}}]}`)
+	raw := json.RawMessage(`{"content":[{"type":"resource","resource":{"uri":"file:///workspace/report.txt","mimeType":"text/plain","text":"embedded resource text","blob":"opaque-base64-payload"}}]}`)
 	if got, want := ExtractText(raw), "embedded resource text"; got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResourceContentsPreservesEmbeddedMediaFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      json.RawMessage
+		wantURI  string
+		wantMime string
+		wantBlob string
+	}{
+		{
+			name:     "video_blob",
+			raw:      json.RawMessage(`{"content":[{"type":"resource","resource":{"uri":"file:///clip.mp4","mimeType":"video/mp4","blob":"ZmFrZS12aWRlby1ieXRlcw=="}}]}`),
+			wantURI:  "file:///clip.mp4",
+			wantMime: "video/mp4",
+			wantBlob: "ZmFrZS12aWRlby1ieXRlcw==",
+		},
+		{
+			name:     "text_and_blob",
+			raw:      json.RawMessage(`{"content":[{"type":"resource","resource":{"uri":"file:///report.txt","mimeType":"text/plain","text":"visible text","blob":"b3BhcXVl"}}]}`),
+			wantURI:  "file:///report.txt",
+			wantMime: "text/plain",
+			wantBlob: "b3BhcXVl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var result ToolResult
+			if err := json.Unmarshal(tt.raw, &result); err != nil {
+				t.Fatalf("unmarshal tool result: %v", err)
+			}
+			if len(result.Content) != 1 || result.Content[0].Resource == nil {
+				t.Fatalf("resource content = %+v, want one embedded resource", result.Content)
+			}
+			resource := result.Content[0].Resource
+			if resource.URI != tt.wantURI || resource.MimeType != tt.wantMime || resource.Blob != tt.wantBlob {
+				t.Errorf("resource = %+v, want uri=%q mimeType=%q blob=%q", resource, tt.wantURI, tt.wantMime, tt.wantBlob)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/media_policy.go
+++ b/internal/mcp/media_policy.go
@@ -90,14 +90,13 @@ func rewriteMCPToolResultMedia(raw json.RawMessage, policy *config.MediaPolicy, 
 
 	changed := false
 	exposures := make([]audit.MediaExposureInfo, 0, len(content))
+	var rawContentBlocks []map[string]json.RawMessage
 
 	for i := range content {
 		fields := mcpMediaPayloadFields(content[i])
 		if len(fields) == 0 {
 			continue
 		}
-
-		contentType, hinted := mcpMediaHint(content[i])
 
 		for _, field := range fields {
 			decoded, ok := decodeMCPMediaPayload(field.encoded)
@@ -108,11 +107,11 @@ func rewriteMCPToolResultMedia(raw json.RawMessage, policy *config.MediaPolicy, 
 				continue
 			}
 
-			verdict := applyMCPMediaPolicy(policy, contentType, decoded, transport)
+			verdict := applyMCPMediaPolicy(policy, field.contentType, decoded, transport)
 			if verdict.Exposure != nil {
 				exposures = append(exposures, *verdict.Exposure)
 			}
-			if hinted && verdict.MediaType == "" {
+			if field.looksLikeMedia && verdict.MediaType == "" {
 				return raw, changed, fmt.Sprintf("media_policy: unsupported media in result.content[%d].%s", i, field.name), exposures
 			}
 			if verdict.Blocked {
@@ -120,13 +119,16 @@ func rewriteMCPToolResultMedia(raw json.RawMessage, policy *config.MediaPolicy, 
 			}
 			if verdict.StripResult != nil && verdict.StripResult.Changed() {
 				encodedOut := base64.StdEncoding.EncodeToString(verdict.Body)
-				switch field.name {
-				case "data":
-					content[i].Data = encodedOut
-				case "blob":
-					content[i].Blob = encodedOut
-				case "raw":
-					content[i].Raw = encodedOut
+				if rawContentBlocks == nil {
+					if err := json.Unmarshal(contentRaw, &rawContentBlocks); err != nil {
+						return raw, changed, fmt.Sprintf("media_policy: parse tool result content for rewrite: %v", err), exposures
+					}
+					if len(rawContentBlocks) != len(content) {
+						return raw, changed, "media_policy: content block count changed during rewrite", exposures
+					}
+				}
+				if err := setMCPMediaPayload(rawContentBlocks[i], field.name, encodedOut); err != nil {
+					return raw, changed, fmt.Sprintf("media_policy: rewrite result.content[%d].%s: %v", i, field.name, err), exposures
 				}
 				changed = true
 			}
@@ -137,7 +139,7 @@ func rewriteMCPToolResultMedia(raw json.RawMessage, policy *config.MediaPolicy, 
 		return raw, false, "", exposures
 	}
 
-	updatedContent, err := json.Marshal(content)
+	updatedContent, err := json.Marshal(rawContentBlocks)
 	if err != nil {
 		return raw, false, fmt.Sprintf("media_policy: re-marshal tool result content: %v", err), exposures
 	}
@@ -150,28 +152,73 @@ func rewriteMCPToolResultMedia(raw json.RawMessage, policy *config.MediaPolicy, 
 	return updated, true, "", exposures
 }
 
+func setMCPMediaPayload(block map[string]json.RawMessage, field, encoded string) error {
+	encodedPayload, err := json.Marshal(encoded)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	switch field {
+	case "data", "blob", "raw":
+		block[field] = encodedPayload
+		return nil
+	case "resource.blob":
+		resourceRaw, ok := block["resource"]
+		if !ok {
+			return fmt.Errorf("resource is missing")
+		}
+		var resource map[string]json.RawMessage
+		if err := json.Unmarshal(resourceRaw, &resource); err != nil {
+			return fmt.Errorf("parse resource: %w", err)
+		}
+		if resource == nil {
+			return fmt.Errorf("resource is null")
+		}
+		resource["blob"] = encodedPayload
+		updatedResource, err := json.Marshal(resource)
+		if err != nil {
+			return fmt.Errorf("re-marshal resource: %w", err)
+		}
+		block["resource"] = updatedResource
+		return nil
+	default:
+		return fmt.Errorf("unknown payload field")
+	}
+}
+
 // mcpMediaField represents a single payload field within a content block.
 type mcpMediaField struct {
 	name           string
 	encoded        string
+	contentType    string
 	looksLikeMedia bool
 }
 
 // mcpMediaPayloadFields returns ALL non-empty payload fields (data, blob, raw)
-// for a content block. The MCP spec allows only ONE payload field per block, but
-// fail-closed means we scan all populated fields to prevent a bypass where
-// blocked media hides in blob while benign content sits in data.
+// for a content block and resource.blob for an embedded resource. The MCP spec
+// allows only ONE payload field per block, but fail-closed means we scan all
+// populated fields to prevent a bypass where blocked media hides in blob while
+// benign content sits in data, or in a resource nested beneath type="resource".
 func mcpMediaPayloadFields(block jsonrpc.ContentBlock) []mcpMediaField {
-	looksMedia := mcpContentBlockLooksLikeMedia(block)
+	contentType, looksMedia := mcpMediaHint(block)
 	var fields []mcpMediaField
 	if block.Data != "" {
-		fields = append(fields, mcpMediaField{"data", block.Data, looksMedia})
+		fields = append(fields, mcpMediaField{name: "data", encoded: block.Data, contentType: contentType, looksLikeMedia: looksMedia})
 	}
 	if block.Blob != "" {
-		fields = append(fields, mcpMediaField{"blob", block.Blob, looksMedia})
+		fields = append(fields, mcpMediaField{name: "blob", encoded: block.Blob, contentType: contentType, looksLikeMedia: looksMedia})
 	}
 	if block.Raw != "" {
-		fields = append(fields, mcpMediaField{"raw", block.Raw, looksMedia})
+		fields = append(fields, mcpMediaField{name: "raw", encoded: block.Raw, contentType: contentType, looksLikeMedia: looksMedia})
+	}
+	if block.Resource != nil && block.Resource.Blob != "" {
+		resourceType, resourceLooksMedia := mcpResourceMediaHint(*block.Resource)
+		fields = append(fields, mcpMediaField{
+			name:           "resource.blob",
+			encoded:        block.Resource.Blob,
+			contentType:    resourceType,
+			looksLikeMedia: resourceLooksMedia,
+		})
 	}
 	return fields
 }
@@ -205,6 +252,13 @@ func mcpMediaHint(block jsonrpc.ContentBlock) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func mcpResourceMediaHint(resource jsonrpc.ResourceContents) (string, bool) {
+	if mt := canonicalMCPContentType(resource.MimeType); isMCPMediaType(mt) {
+		return mt, true
+	}
+	return "", false
 }
 
 func decodeMCPMediaPayload(encoded string) ([]byte, bool) {

--- a/internal/mcp/media_policy_test.go
+++ b/internal/mcp/media_policy_test.go
@@ -604,9 +604,21 @@ func TestForwardScanned_MediaPolicyStripsEmbeddedResourceImage(t *testing.T) {
 	if resource := result.Content[0].Resource; resource.URI != "file:///photo.jpg" || resource.MimeType != "image/jpeg" {
 		t.Fatalf("resource metadata = %+v, want uri and mimeType preserved", resource)
 	}
+	var rawResult map[string]json.RawMessage
+	if err := json.Unmarshal(rpc.Result, &rawResult); err != nil {
+		t.Fatalf("unmarshal raw result: %v", err)
+	}
+	var rawContent []map[string]json.RawMessage
+	if err := json.Unmarshal(rawResult["content"], &rawContent); err != nil || len(rawContent) == 0 {
+		t.Fatalf("raw content = %s", rawResult["content"])
+	}
+	resourceRaw, ok := rawContent[0]["resource"]
+	if !ok {
+		t.Fatal("rewritten content[0] dropped resource")
+	}
 	for _, want := range []string{`"vendor.example/trace":"keep"`, `"x-vendor-extension":{"retention":"keep"}`} {
-		if !bytes.Contains(rpc.Result, []byte(want)) {
-			t.Fatalf("rewritten result dropped resource extension %s: %s", want, rpc.Result)
+		if !bytes.Contains(resourceRaw, []byte(want)) {
+			t.Fatalf("resource dropped extension %s: %s", want, resourceRaw)
 		}
 	}
 	if result.Content[1].Text != "safe" {
@@ -622,6 +634,87 @@ func TestForwardScanned_MediaPolicyStripsEmbeddedResourceImage(t *testing.T) {
 	}
 	if len(decoded) >= len(jpeg) {
 		t.Fatalf("stripped embedded resource image length %d >= original %d", len(decoded), len(jpeg))
+	}
+}
+
+func TestForwardScanned_EmbeddedResourceSniffsMediaWithoutMimeType(t *testing.T) {
+	sc, cfg := newMCPScannerWithMediaPolicy(t)
+	jpeg := buildMCPValidJPEG([]byte("Exif\x00\x00sniffed-mcp-secret-metadata"))
+	line := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":44,"result":{"content":[{"type":"resource","resource":{"uri":"file:///photo.bin","blob":"%s"}}]}}`,
+		base64.StdEncoding.EncodeToString(jpeg),
+	)
+
+	var out, log bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(line+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		nil,
+		MCPProxyOpts{
+			Scanner:     sc,
+			MediaPolicy: &cfg.MediaPolicy,
+			Transport:   testMCPMediaTransport,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("expected media-policy handling without an injection finding")
+	}
+	var rpc jsonrpc.RPCResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &rpc); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	var result jsonrpc.ToolResult
+	if err := json.Unmarshal(rpc.Result, &result); err != nil {
+		t.Fatalf("unmarshal tool result: %v", err)
+	}
+	if len(result.Content) != 1 || result.Content[0].Resource == nil {
+		t.Fatalf("content = %+v, want sniffed embedded resource", result.Content)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(result.Content[0].Resource.Blob)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	if bytes.Contains(decoded, []byte("sniffed-mcp-secret-metadata")) {
+		t.Fatal("resource blob without mimeType was not sniffed as image media")
+	}
+}
+
+func TestForwardScanned_EmbeddedResourcePlainBlobIsNotMediaPolicy(t *testing.T) {
+	sc, cfg := newMCPScannerWithMediaPolicy(t)
+	payload := base64.StdEncoding.EncodeToString([]byte(`{"note":"ok"}`))
+	line := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":45,"result":{"content":[{"type":"resource","resource":{"uri":"file:///note.json","mimeType":"application/json","blob":"%s"}}]}}`,
+		payload,
+	)
+
+	var out, log bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(line+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		nil,
+		MCPProxyOpts{
+			Scanner:     sc,
+			MediaPolicy: &cfg.MediaPolicy,
+			Transport:   testMCPMediaTransport,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("plain JSON resource blob should not become an injection finding")
+	}
+	var resp rpcError
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err == nil && resp.Error.Code == -32002 {
+		t.Fatalf("plain JSON resource blob was media-blocked: %s", resp.Error.Message)
+	}
+	if !bytes.Contains(out.Bytes(), []byte(`"note":"ok"`)) && !bytes.Contains(out.Bytes(), []byte(payload)) {
+		t.Fatalf("plain JSON resource blob was dropped: %s", bytes.TrimSpace(out.Bytes()))
 	}
 }
 

--- a/internal/mcp/media_policy_test.go
+++ b/internal/mcp/media_policy_test.go
@@ -472,6 +472,10 @@ func TestForwardScanned_MediaPolicyBlocksEmbeddedResourceMedia(t *testing.T) {
 	}
 }
 
+// mcpJPEGScanMarker is SOS entropy-coded payload in buildMCPValidJPEG.
+// Metadata strip must keep it; tests use it so an empty rewrite cannot pass.
+var mcpJPEGScanMarker = []byte{0x11, 0x22, 0x33}
+
 func buildMCPValidJPEG(app1Payload []byte) []byte {
 	writeSegmentLen := func(b *bytes.Buffer, length int) {
 		if length < 0 || length > math.MaxUint16 {
@@ -492,9 +496,22 @@ func buildMCPValidJPEG(app1Payload []byte) []byte {
 	b.Write(app1Payload)
 	b.Write([]byte{0xFF, 0xDA})
 	b.Write([]byte{0x00, 0x08, 0x01, 0x00, 0x00, 0x00, 0x3F, 0x00})
-	b.Write([]byte{0x11, 0x22, 0x33})
+	b.Write(mcpJPEGScanMarker)
 	b.Write([]byte{0xFF, 0xD9})
 	return b.Bytes()
+}
+
+func assertMCPJPEGMetadataStripped(t *testing.T, decoded, original, secret []byte, secretGoneMsg string) {
+	t.Helper()
+	if bytes.Contains(decoded, secret) {
+		t.Fatal(secretGoneMsg)
+	}
+	if len(decoded) >= len(original) {
+		t.Fatalf("stripped JPEG length %d >= original %d", len(decoded), len(original))
+	}
+	if !bytes.Contains(decoded, mcpJPEGScanMarker) {
+		t.Fatal("stripped JPEG lost image scan data")
+	}
 }
 
 func newMCPScannerWithMediaPolicy(t *testing.T) (*scanner.Scanner, *config.Config) {
@@ -555,12 +572,7 @@ func TestForwardScanned_MediaPolicyStripsToolResultImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeString: %v", err)
 	}
-	if bytes.Contains(decoded, []byte("mcp-secret-metadata")) {
-		t.Fatal("stripped MCP image block still contains metadata payload")
-	}
-	if len(decoded) >= len(jpeg) {
-		t.Fatalf("stripped MCP image length %d >= original %d", len(decoded), len(jpeg))
-	}
+	assertMCPJPEGMetadataStripped(t, decoded, jpeg, []byte("mcp-secret-metadata"), "stripped MCP image block still contains metadata payload")
 }
 
 func TestForwardScanned_MediaPolicyStripsEmbeddedResourceImage(t *testing.T) {
@@ -629,12 +641,7 @@ func TestForwardScanned_MediaPolicyStripsEmbeddedResourceImage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeString: %v", err)
 	}
-	if bytes.Contains(decoded, []byte("nested-mcp-secret-metadata")) {
-		t.Fatal("stripped embedded resource image still contains metadata payload")
-	}
-	if len(decoded) >= len(jpeg) {
-		t.Fatalf("stripped embedded resource image length %d >= original %d", len(decoded), len(jpeg))
-	}
+	assertMCPJPEGMetadataStripped(t, decoded, jpeg, []byte("nested-mcp-secret-metadata"), "stripped embedded resource image still contains metadata payload")
 }
 
 func TestForwardScanned_EmbeddedResourceSniffsMediaWithoutMimeType(t *testing.T) {
@@ -678,9 +685,7 @@ func TestForwardScanned_EmbeddedResourceSniffsMediaWithoutMimeType(t *testing.T)
 	if err != nil {
 		t.Fatalf("DecodeString: %v", err)
 	}
-	if bytes.Contains(decoded, []byte("sniffed-mcp-secret-metadata")) {
-		t.Fatal("resource blob without mimeType was not sniffed as image media")
-	}
+	assertMCPJPEGMetadataStripped(t, decoded, jpeg, []byte("sniffed-mcp-secret-metadata"), "resource blob without mimeType was not sniffed as image media")
 }
 
 func TestForwardScanned_EmbeddedResourcePlainBlobIsNotMediaPolicy(t *testing.T) {

--- a/internal/mcp/media_policy_test.go
+++ b/internal/mcp/media_policy_test.go
@@ -155,6 +155,12 @@ func TestMCPMediaPayloadFields(t *testing.T) {
 			wantNames: []string{"data", "blob", "raw"},
 		},
 		{
+			name:      "embedded_resource_blob",
+			block:     jsonrpc.ContentBlock{Type: "resource", Resource: &jsonrpc.ResourceContents{MimeType: "video/mp4", Blob: "Y2xpcA=="}},
+			wantCount: 1,
+			wantNames: []string{"resource.blob"},
+		},
+		{
 			name:      "no_payload_fields",
 			block:     jsonrpc.ContentBlock{Type: "text", Text: "hello"},
 			wantCount: 0,
@@ -173,6 +179,98 @@ func TestMCPMediaPayloadFields(t *testing.T) {
 				if fields[i].name != wantName {
 					t.Errorf("field[%d].name = %q, want %q", i, fields[i].name, wantName)
 				}
+			}
+		})
+	}
+}
+
+func TestMCPResourceMediaHint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		resource   jsonrpc.ResourceContents
+		wantType   string
+		wantHinted bool
+	}{
+		{
+			name:       "video_mime",
+			resource:   jsonrpc.ResourceContents{MimeType: "video/mp4"},
+			wantType:   "video/mp4",
+			wantHinted: true,
+		},
+		{
+			name:       "non_media_mime",
+			resource:   jsonrpc.ResourceContents{MimeType: "text/plain"},
+			wantType:   "",
+			wantHinted: false,
+		},
+		{
+			name:       "empty",
+			resource:   jsonrpc.ResourceContents{},
+			wantType:   "",
+			wantHinted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotType, gotHinted := mcpResourceMediaHint(tt.resource)
+			if gotType != tt.wantType {
+				t.Errorf("mcpResourceMediaHint() type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotHinted != tt.wantHinted {
+				t.Errorf("mcpResourceMediaHint() hinted = %v, want %v", gotHinted, tt.wantHinted)
+			}
+		})
+	}
+}
+
+func TestSetMCPMediaPayloadRejectsUnsafeRewriteShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		block   map[string]json.RawMessage
+		field   string
+		wantErr string
+	}{
+		{
+			name:    "unknown_field",
+			block:   map[string]json.RawMessage{},
+			field:   "sidecar",
+			wantErr: "unknown payload field",
+		},
+		{
+			name:    "resource_missing",
+			block:   map[string]json.RawMessage{},
+			field:   "resource.blob",
+			wantErr: "resource is missing",
+		},
+		{
+			name:    "resource_not_object",
+			block:   map[string]json.RawMessage{"resource": json.RawMessage(`"not-an-object"`)},
+			field:   "resource.blob",
+			wantErr: "parse resource",
+		},
+		{
+			name:    "resource_null",
+			block:   map[string]json.RawMessage{"resource": json.RawMessage(`null`)},
+			field:   "resource.blob",
+			wantErr: "resource is null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := setMCPMediaPayload(tt.block, tt.field, "YQ==")
+			if err == nil {
+				t.Fatal("setMCPMediaPayload() error = nil, want rejection")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("setMCPMediaPayload() error = %q, want %q", err, tt.wantErr)
 			}
 		})
 	}
@@ -299,6 +397,78 @@ func TestForwardScanned_MediaPolicyBlocksBlobOnlyField(t *testing.T) {
 	}
 }
 
+func TestForwardScanned_MediaPolicyBlocksEmbeddedResourceMedia(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       int
+		mimeType string
+		payload  string
+		blob     string
+	}{
+		{
+			name:     "video_blob",
+			id:       70,
+			mimeType: "video/mp4",
+			payload:  "fake video bytes",
+		},
+		{
+			name:     "audio_blob",
+			id:       71,
+			mimeType: "audio/wav",
+			payload:  "fake audio bytes",
+		},
+		{
+			name:     "invalid_base64_video",
+			id:       72,
+			mimeType: "video/mp4",
+			blob:     "not-base64!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc, cfg := newMCPScannerWithMediaPolicy(t)
+			encoded := tt.blob
+			if encoded == "" {
+				encoded = base64.StdEncoding.EncodeToString([]byte(tt.payload))
+			}
+			line := fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%d,"result":{"content":[{"type":"resource","resource":{"uri":"file:///attachment","mimeType":"%s","blob":"%s"}}]}}`,
+				tt.id,
+				tt.mimeType,
+				encoded,
+			)
+
+			var out, log bytes.Buffer
+			found, err := ForwardScanned(
+				transport.NewStdioReader(strings.NewReader(line+"\n")),
+				transport.NewStdioWriter(&out),
+				&log,
+				nil,
+				MCPProxyOpts{
+					Scanner:     sc,
+					MediaPolicy: &cfg.MediaPolicy,
+					Transport:   testMCPMediaTransport,
+				},
+			)
+			if err != nil {
+				t.Fatalf("ForwardScanned: %v", err)
+			}
+			if found {
+				t.Fatal("expected media-policy block without an injection finding")
+			}
+
+			var resp rpcError
+			if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+				t.Fatalf("unmarshal block response: %v", err)
+			}
+			if string(resp.ID) != fmt.Sprintf("%d", tt.id) {
+				t.Fatalf("block response id = %s, want %d", string(resp.ID), tt.id)
+			}
+		})
+	}
+}
+
 func buildMCPValidJPEG(app1Payload []byte) []byte {
 	writeSegmentLen := func(b *bytes.Buffer, length int) {
 		if length < 0 || length > math.MaxUint16 {
@@ -387,6 +557,68 @@ func TestForwardScanned_MediaPolicyStripsToolResultImage(t *testing.T) {
 	}
 	if len(decoded) >= len(jpeg) {
 		t.Fatalf("stripped MCP image length %d >= original %d", len(decoded), len(jpeg))
+	}
+}
+
+func TestForwardScanned_MediaPolicyStripsEmbeddedResourceImage(t *testing.T) {
+	sc, cfg := newMCPScannerWithMediaPolicy(t)
+	jpeg := buildMCPValidJPEG([]byte("Exif\x00\x00nested-mcp-secret-metadata"))
+	line := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":43,"result":{"content":[{"type":"resource","resource":{"uri":"file:///photo.jpg","mimeType":"image/jpeg","blob":"%s","_meta":{"vendor.example/trace":"keep"},"x-vendor-extension":{"retention":"keep"}}},{"type":"text","text":"safe"}]}}`,
+		base64.StdEncoding.EncodeToString(jpeg),
+	)
+
+	var out, log bytes.Buffer
+	found, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(line+"\n")),
+		transport.NewStdioWriter(&out),
+		&log,
+		nil,
+		MCPProxyOpts{
+			Scanner:     sc,
+			MediaPolicy: &cfg.MediaPolicy,
+			Transport:   transportMCPStdio,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if found {
+		t.Fatal("expected no injection finding for media-only response")
+	}
+
+	var rpc jsonrpc.RPCResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &rpc); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	var result jsonrpc.ToolResult
+	if err := json.Unmarshal(rpc.Result, &result); err != nil {
+		t.Fatalf("unmarshal tool result: %v", err)
+	}
+	if len(result.Content) != 2 || result.Content[0].Resource == nil {
+		t.Fatalf("content = %+v, want embedded resource and text block", result.Content)
+	}
+	if resource := result.Content[0].Resource; resource.URI != "file:///photo.jpg" || resource.MimeType != "image/jpeg" {
+		t.Fatalf("resource metadata = %+v, want uri and mimeType preserved", resource)
+	}
+	for _, want := range []string{`"vendor.example/trace":"keep"`, `"x-vendor-extension":{"retention":"keep"}`} {
+		if !bytes.Contains(rpc.Result, []byte(want)) {
+			t.Fatalf("rewritten result dropped resource extension %s: %s", want, rpc.Result)
+		}
+	}
+	if result.Content[1].Text != "safe" {
+		t.Fatalf("text block = %q, want safe", result.Content[1].Text)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Content[0].Resource.Blob)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	if bytes.Contains(decoded, []byte("nested-mcp-secret-metadata")) {
+		t.Fatal("stripped embedded resource image still contains metadata payload")
+	}
+	if len(decoded) >= len(jpeg) {
+		t.Fatalf("stripped embedded resource image length %d >= original %d", len(decoded), len(jpeg))
 	}
 }
 

--- a/internal/mcp/media_policy_test.go
+++ b/internal/mcp/media_policy_test.go
@@ -465,6 +465,9 @@ func TestForwardScanned_MediaPolicyBlocksEmbeddedResourceMedia(t *testing.T) {
 			if string(resp.ID) != fmt.Sprintf("%d", tt.id) {
 				t.Fatalf("block response id = %s, want %d", string(resp.ID), tt.id)
 			}
+			if resp.Error.Code != -32002 || !strings.Contains(resp.Error.Message, "media policy") {
+				t.Fatalf("block response = (%d, %q), want media-policy error", resp.Error.Code, resp.Error.Message)
+			}
 		})
 	}
 }

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -497,7 +497,11 @@ type BodyEntropyWarnRouteMatch struct {
 // BodyScanRequest groups the parameters for scanRequestBody, keeping the
 // function signature under the 6-parameter guideline (ctx is passed separately).
 type BodyScanRequest struct {
-	Body            io.Reader
+	Body io.Reader
+	// Trailer is populated by net/http only after Body reaches EOF. Request
+	// scanning does not yet inspect trailer fields, so a populated map must
+	// fail closed rather than let values bypass the scanned body and headers.
+	Trailer         http.Header
 	Scheme          string
 	Method          string
 	ContentType     string
@@ -586,6 +590,18 @@ func scanRequestBody(ctx context.Context, req BodyScanRequest) ([]byte, BodyScan
 			Clean:  false,
 			Action: config.ActionBlock,
 			Reason: fmt.Sprintf("error reading request body: %v", err),
+		}
+	}
+	if len(req.Trailer) != 0 {
+		// A Trailer header is hop-by-hop, but removing that header does not clear
+		// Request.Trailer. The values become available only after the body drain
+		// above, and they are not part of the body or header DLP surfaces yet.
+		// Return no replayable bytes so every caller treats this as fail-closed,
+		// including in audit mode.
+		return nil, BodyScanResult{
+			Clean:  false,
+			Action: config.ActionBlock,
+			Reason: "request trailers cannot be scanned for secrets",
 		}
 	}
 

--- a/internal/proxy/daybreak_finding_repro_test.go
+++ b/internal/proxy/daybreak_finding_repro_test.go
@@ -357,6 +357,80 @@ func TestDaybreak_SameHost308StillFollowed(t *testing.T) {
 	}
 }
 
+func TestDaybreak_A2AOnlyTrailerFailsClosed(t *testing.T) {
+	t.Run("forward", testDaybreakForwardA2ATrailerBlock)
+	t.Run("tls intercept", testDaybreakInterceptA2ATrailerBlock)
+}
+
+func newDaybreakA2ATrailerRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+	req := newDaybreakTrailerRequest(t, target)
+	req.Header.Set("Content-Type", "application/a2a+json")
+	return req
+}
+
+func testDaybreakForwardA2ATrailerBlock(t *testing.T) {
+	t.Helper()
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = false
+		cfg.A2AScanning.Enabled = true
+		cfg.A2AScanning.Action = config.ActionBlock
+	})
+	defer cleanup()
+	client := &http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+	}}}
+
+	resp, err := client.Do(newDaybreakA2ATrailerRequest(t, upstream.URL+"/message:send"))
+	if err != nil {
+		t.Fatalf("forward A2A trailer request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream requests = %d, want 0", got)
+	}
+}
+
+func testDaybreakInterceptA2ATrailerBlock(t *testing.T) {
+	t.Helper()
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.RequestBodyScanning.Enabled = false
+	cfg.A2AScanning.Enabled = true
+	cfg.A2AScanning.Action = config.ActionBlock
+	var upstreamHits atomic.Int32
+	rt := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		upstreamHits.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{headerContentType: {"application/a2a+json"}},
+			Body:       io.NopCloser(strings.NewReader("unexpected")),
+		}, nil
+	})
+
+	resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+		&InterceptContext{TargetHost: "api.vendor.example", TargetPort: "443"},
+		newDaybreakA2ATrailerRequest(t, "https://api.vendor.example/message:send"))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream RoundTrip calls = %d, want 0", got)
+	}
+}
+
 func TestRedirectReplaysBodyToNewAuthorityGuards(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/daybreak_finding_repro_test.go
+++ b/internal/proxy/daybreak_finding_repro_test.go
@@ -1,0 +1,381 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// Daybreak Blue scan reproductions. A failing test means the finding's
+// security property is violated at this revision.
+
+func TestDaybreak_ForwardTrailerSecretIsBlockedOrDropped(t *testing.T) {
+	var sawTrailer string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		sawTrailer = r.Trailer.Get("X-Pipelock-Test")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.ScanHeaders = true
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.MaxBodyBytes = 1024 * 1024
+	})
+	defer cleanup()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(_ *http.Request) (*url.URL, error) {
+				return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+			},
+		},
+	}
+
+	bodySecret, err := http.NewRequestWithContext(t.Context(), http.MethodPost, upstream.URL+"/body", strings.NewReader(`{"k":"`+fakeAPIKey()+`"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodySecret.Header.Set("Content-Type", "application/json")
+	bodyResp, err := client.Do(bodySecret)
+	if err != nil {
+		t.Fatalf("body secret request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, bodyResp.Body)
+	_ = bodyResp.Body.Close()
+	if bodyResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("control: body secret status = %d, want 403", bodyResp.StatusCode)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, upstream.URL+"/trailer", strings.NewReader("ok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Trailer", "X-Pipelock-Test")
+	req.Trailer = http.Header{"X-Pipelock-Test": {fakeAPIKey()}}
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("trailer secret request: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("trailer secret status = %d, want 403; upstream trailer=%q", resp.StatusCode, sawTrailer)
+	}
+}
+
+func TestDaybreak_TrailerSecretFailsClosedAcrossHTTPPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{name: "forward", run: testDaybreakForwardTrailerBlock},
+		{name: "tls intercept", run: testDaybreakInterceptTrailerBlock},
+		{name: "reverse", run: testDaybreakReverseTrailerBlock},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}
+
+func newDaybreakTrailerRequest(t *testing.T, target string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, target, strings.NewReader("ok"))
+	if err != nil {
+		t.Fatalf("new trailer request: %v", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Trailer", "X-Pipelock-Test")
+	req.Trailer = http.Header{"X-Pipelock-Test": {fakeAPIKey()}}
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	return req
+}
+
+func testDaybreakForwardTrailerBlock(t *testing.T) {
+	t.Helper()
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+	})
+	defer cleanup()
+	client := &http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+	}}}
+
+	resp, err := client.Do(newDaybreakTrailerRequest(t, upstream.URL+"/trailer"))
+	if err != nil {
+		t.Fatalf("forward trailer request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream requests = %d, want 0", got)
+	}
+}
+
+func testDaybreakInterceptTrailerBlock(t *testing.T) {
+	t.Helper()
+	cache, pool, cfg, sc, logger, m := testInterceptSetup(t)
+	cfg.RequestBodyScanning.Enabled = true
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	var upstreamHits atomic.Int32
+	rt := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		upstreamHits.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{headerContentType: {"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("unexpected")),
+		}, nil
+	})
+
+	resp := interceptWithRT(t, cache, pool, cfg, sc, logger, m, rt,
+		&InterceptContext{TargetHost: "api.vendor.example", TargetPort: "443"},
+		newDaybreakTrailerRequest(t, "https://api.vendor.example/trailer"))
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream RoundTrip calls = %d, want 0", got)
+	}
+}
+
+func testDaybreakReverseTrailerBlock(t *testing.T) {
+	t.Helper()
+	var upstreamHits atomic.Int32
+	proxy := reverseTestSetup(t, reverseTestConfig(), func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	resp, err := http.DefaultClient.Do(newDaybreakTrailerRequest(t, proxy.URL+"/trailer"))
+	if err != nil {
+		t.Fatalf("reverse trailer request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream requests = %d, want 0", got)
+	}
+}
+
+func TestDaybreak_AbsoluteFormHostOverride(t *testing.T) {
+	var gotHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	_, p, cleanup := setupForwardProxyWithInstance(t, nil)
+	defer cleanup()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, upstream.URL+"/path", nil)
+	req.Host = "other.vendor.example"
+	req.Header.Set("Host", "other.vendor.example")
+	rec := httptest.NewRecorder()
+	p.handleForwardHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("forward status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if gotHost != req.URL.Host {
+		t.Errorf("upstream Host = %q, want scanned URL authority %q", gotHost, req.URL.Host)
+	}
+}
+
+func TestDaybreak_RedirectReusesSuppressedBodyDLP(t *testing.T) {
+	secretBody := `{"input":"` + fakeAnthropicKey() + `"}`
+	var secondBody string
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		secondBody = string(b)
+		_, _ = w.Write([]byte("final"))
+	}))
+	defer second.Close()
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", second.URL+"/finish")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer first.Close()
+
+	firstURL, err := url.Parse(first.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+		cfg.RequestBodyScanning.MaxBodyBytes = 1024 * 1024
+		cfg.Suppress = []config.SuppressEntry{{
+			Rule:   "Anthropic API Key",
+			Path:   "*" + firstURL.Hostname() + "*",
+			Reason: "daybreak redirect reproduction",
+		}}
+	})
+	defer cleanup()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(_ *http.Request) (*url.URL, error) {
+				return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+			},
+		},
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, first.URL+"/start", strings.NewReader(secretBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(secretBody)), nil
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("redirected post: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("redirect status = %d, want 403", resp.StatusCode)
+	}
+	if secondBody != "" {
+		t.Errorf("308 replay reached %s with body %q", second.URL, secondBody)
+	}
+}
+
+func TestDaybreak_TrailerSecretFailsClosedInWarnMode(t *testing.T) {
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.Mode = config.ModeAudit
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionWarn
+	})
+	defer cleanup()
+	client := &http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+	}}}
+
+	resp, err := client.Do(newDaybreakTrailerRequest(t, upstream.URL+"/trailer"))
+	if err != nil {
+		t.Fatalf("warn-mode trailer request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("audit/warn trailer status = %d, want 403", resp.StatusCode)
+	}
+	if got := upstreamHits.Load(); got != 0 {
+		t.Fatalf("upstream requests = %d, want 0", got)
+	}
+}
+
+func TestDaybreak_SameHost308StillFollowed(t *testing.T) {
+	var hits atomic.Int32
+	var mux http.ServeMux
+	srv := httptest.NewServer(&mux)
+	defer srv.Close()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", srv.URL+"/finish")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	})
+	mux.HandleFunc("/finish", func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		_, _ = w.Write([]byte("final"))
+	})
+
+	proxyAddr, _, cleanup := setupForwardProxyWithInstance(t, func(cfg *config.Config) {
+		cfg.RequestBodyScanning.Enabled = true
+		cfg.RequestBodyScanning.Action = config.ActionBlock
+	})
+	defer cleanup()
+	client := &http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return &url.URL{Scheme: "http", Host: proxyAddr}, nil
+	}}}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/start", strings.NewReader(`{"ok":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("same-host 308: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("same-host 308 status = %d, want 200", resp.StatusCode)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("finish hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestRedirectReplaysBodyToNewAuthorityGuards(t *testing.T) {
+	t.Parallel()
+
+	getBody := func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("{}")), nil
+	}
+	req := &http.Request{
+		URL:     &url.URL{Host: "second.vendor.example"},
+		GetBody: getBody,
+	}
+
+	if redirectReplaysBodyToNewAuthority(req, []*http.Request{nil}) {
+		t.Fatal("nil previous hop should not count as an authority change")
+	}
+	if redirectReplaysBodyToNewAuthority(req, []*http.Request{{GetBody: getBody}}) {
+		t.Fatal("previous hop without a URL should not count as an authority change")
+	}
+	previous := &http.Request{URL: &url.URL{Host: "first.vendor.example"}}
+	if !redirectReplaysBodyToNewAuthority(req, []*http.Request{previous}) {
+		t.Fatal("307/308 replay to a different host should count as an authority change")
+	}
+}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1356,6 +1356,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	if cfg.RequestBodyScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
 		bodyReq := BodyScanRequest{
 			Body:             r.Body,
+			Trailer:          r.Trailer,
 			Scheme:           r.URL.Scheme,
 			Method:           r.Method,
 			ContentType:      r.Header.Get("Content-Type"),
@@ -1910,6 +1911,9 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = withAllowedSSRFDialScanSnapshot(ctx, sc, r.URL.Hostname(), effectiveURLPort(r.URL), result)
 	outReq := r.Clone(ctx)
 	outReq.RequestURI = "" // required for http.Client
+	// The URL authority is the value policy admitted. Never propagate a
+	// client-controlled Host override to the upstream request.
+	outReq.Host = outReq.URL.Host
 	outReq = outReq.WithContext(context.WithValue(outReq.Context(), ctxKeyEnvelopeEmitter, envelopeEmitterSnapshot{emitter: envEmitter}))
 	// Strip the internal identity header AND the ?agent= query param before
 	// the request leaves pipelock. Either vector could otherwise bleed an

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -1312,7 +1312,7 @@ func (p *Proxy) handleForwardHTTP(w http.ResponseWriter, r *http.Request) {
 		return false
 	}
 	if !cfg.RequestBodyScanning.Enabled && isA2A && cfg.A2AScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
-		buf, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), cfg.RequestBodyScanning.MaxBodyBytes)
+		buf, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), cfg.RequestBodyScanning.MaxBodyBytes, r.Trailer)
 		if err != nil {
 			reason := "a2a: " + err.Error()
 			p.logger.LogBlocked(actx, scannerLabelA2A, reason)
@@ -2930,7 +2930,7 @@ func recordA2AContentEntropyTelemetry(logger *audit.Logger, m *metrics.Metrics, 
 	logger.LogBodyScan(actx, scanner.AuditBodyEntropy, action, 1, []string{contentEntropyReason(result.EntropyFinding)})
 }
 
-func readForwardBodyForProtocolScan(body io.Reader, contentEncoding string, maxBytes int) ([]byte, error) {
+func readForwardBodyForProtocolScan(body io.Reader, contentEncoding string, maxBytes int, trailer http.Header) ([]byte, error) {
 	if hasNonIdentityEncoding(contentEncoding) {
 		return nil, fmt.Errorf("request body uses Content-Encoding %q; compressed bodies cannot be scanned", contentEncoding)
 	}
@@ -2941,6 +2941,9 @@ func readForwardBodyForProtocolScan(body io.Reader, contentEncoding string, maxB
 	}
 	if len(buf) > maxBytes {
 		return nil, fmt.Errorf("request body exceeds max_body_bytes (%d)", maxBytes)
+	}
+	if len(trailer) != 0 {
+		return nil, fmt.Errorf("request trailers cannot be scanned for secrets")
 	}
 	return buf, nil
 }

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -987,6 +987,7 @@ func newInterceptHandler(
 			}
 			bodyReq := BodyScanRequest{
 				Body:             r.Body,
+				Trailer:          r.Trailer,
 				Scheme:           "https",
 				Method:           r.Method,
 				ContentType:      r.Header.Get("Content-Type"),

--- a/internal/proxy/intercept.go
+++ b/internal/proxy/intercept.go
@@ -902,7 +902,7 @@ func newInterceptHandler(
 		var interceptBodyBytes []byte
 		var interceptEntropyWarningPattern string
 		if !ic.Config.RequestBodyScanning.Enabled && isA2A && ic.Config.A2AScanning.Enabled && r.Body != nil && r.Body != http.NoBody {
-			bodyBytes, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), ic.Config.RequestBodyScanning.MaxBodyBytes)
+			bodyBytes, err := readForwardBodyForProtocolScan(r.Body, r.Header.Get("Content-Encoding"), ic.Config.RequestBodyScanning.MaxBodyBytes, r.Trailer)
 			if err != nil {
 				reason := "a2a: " + err.Error()
 				ic.Logger.LogBlocked(actx, scannerLabelA2A, reason)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -792,6 +792,9 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 			if currentScanner == nil {
 				currentScanner = p.scannerPtr.Load()
 			}
+			if redirectReplaysBodyToNewAuthority(req, via) {
+				return newRedirectBlockedRequest(scannerLabelBodyDLP, "redirect replay changes destination authority")
+			}
 			if admitted, ok := req.Context().Value(ctxKeyEntropyWarnRoute).(*BodyEntropyWarnRouteMatch); ok && admitted != nil {
 				matched := matchBodyEntropyWarnRoute(BodyScanRequest{
 					Scheme: req.URL.Scheme, Method: req.Method, ContentType: req.Header.Get(headerContentType),
@@ -947,6 +950,22 @@ func New(cfg *config.Config, logger *audit.Logger, sc *scanner.Scanner, m *metri
 	p.tlsTransport = newTLSInterceptTransport(p.ssrfSafeDialContext, m.RecordTLSHandshake, nil)
 
 	return p, nil
+}
+
+// redirectReplaysBodyToNewAuthority reports whether net/http is about to
+// replay a request body (the 307/308 path) to a different authority. Body DLP
+// suppressions are destination-scoped, so retaining the first-hop decision on
+// a changed authority would fail open. Re-evaluation can replace this guard
+// when redirect-time body scanning is implemented.
+func redirectReplaysBodyToNewAuthority(req *http.Request, via []*http.Request) bool {
+	if req == nil || req.URL == nil || req.GetBody == nil || len(via) == 0 {
+		return false
+	}
+	previous := via[len(via)-1]
+	if previous == nil || previous.URL == nil {
+		return false
+	}
+	return !strings.EqualFold(req.URL.Host, previous.URL.Host)
 }
 
 // refreshEnvelopeForRedirect rebuilds the Pipelock-Mediation header

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -1293,6 +1293,7 @@ func (rp *ReverseProxyHandler) scanRequest(w http.ResponseWriter, r *http.Reques
 
 	bodyReq := BodyScanRequest{
 		Body:             r.Body,
+		Trailer:          r.Trailer,
 		Scheme:           rp.upstream.Scheme,
 		Method:           r.Method,
 		ContentType:      r.Header.Get("Content-Type"),

--- a/sdk/verifiers/python/src/pipelock_aarp_verify/receipt.py
+++ b/sdk/verifiers/python/src/pipelock_aarp_verify/receipt.py
@@ -1032,7 +1032,9 @@ def verify_evidence_receipt(
 ) -> None:
     normalize_evidence_receipt(receipt)
     signature = _require_object(receipt.get("signature"), "signature")
-    _require_string(signature.get("signer_key_id"), "signature.signer_key_id")
+    signer_key_id = _require_string(
+        signature.get("signer_key_id"), "signature.signer_key_id"
+    )
     key_hex = expected_key_hex.lower()
     if not key_hex:
         raise ReceiptError("EvidenceReceipt v2 verification requires --key")
@@ -1049,6 +1051,8 @@ def verify_evidence_receipt(
         public_key.verify(sig, _evidence_preimage(receipt))
     except InvalidSignature as exc:
         raise ReceiptError("signature verification failed") from exc
+    if signer_key_id != key_hex:
+        raise ReceiptError("signature.signer_key_id does not match pinned public key")
 
 
 def verify_action_receipt(receipt: dict[str, Any], expected_key_hex: str = "") -> None:

--- a/sdk/verifiers/python/tests/test_receipt_v2.py
+++ b/sdk/verifiers/python/tests/test_receipt_v2.py
@@ -47,8 +47,19 @@ V2_PRIVATE_SEED_HEX = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031
 TESTDATA_PRIVATE_SEED_HEX = TESTDATA_KEY_INFO["seed_hex"]
 
 
-def test_valid_spanned_v2_receipt_verifies() -> None:
-    report = verify_receipt_file(VALID_SPANNED_V2, V2_GOLDEN_PUBLIC_KEY)
+def _write_canonical_v2_receipt(source: Path, tmp_path: Path, name: str) -> Path:
+    receipt = json.loads(source.read_text())
+    receipt["signature"]["signer_key_id"] = V2_GOLDEN_PUBLIC_KEY
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(receipt))
+    return path
+
+
+def test_valid_spanned_v2_receipt_verifies(tmp_path: Path) -> None:
+    report = verify_receipt_file(
+        _write_canonical_v2_receipt(VALID_SPANNED_V2, tmp_path, "valid-spanned"),
+        V2_GOLDEN_PUBLIC_KEY,
+    )
     assert report["valid"] is True, report.get("error")
     assert report["action_id"] == "01F8MECHZX3TBDSZ7XRADM79ZS"
     assert report["verdict"] == "block"
@@ -57,10 +68,24 @@ def test_valid_spanned_v2_receipt_verifies() -> None:
     assert report["policy_hash"] == V2_GOLDEN_POLICY_HASH
 
 
-def test_valid_plain_v2_receipt_verifies() -> None:
-    report = verify_receipt_file(VALID_PLAIN_V2, V2_GOLDEN_PUBLIC_KEY)
+def test_valid_plain_v2_receipt_verifies(tmp_path: Path) -> None:
+    report = verify_receipt_file(
+        _write_canonical_v2_receipt(VALID_PLAIN_V2, tmp_path, "valid-plain"),
+        V2_GOLDEN_PUBLIC_KEY,
+    )
     assert report["valid"] is True, report.get("error")
     assert report["policy_hash"] == V2_GOLDEN_POLICY_HASH
+
+
+def test_relabelled_v2_signer_is_rejected_under_pinned_key(tmp_path: Path) -> None:
+    path = _write_canonical_v2_receipt(VALID_PLAIN_V2, tmp_path, "relabeled")
+    receipt = json.loads(path.read_text())
+    receipt["signature"]["signer_key_id"] = "attacker-label"
+    path.write_text(json.dumps(receipt))
+
+    report = verify_receipt_file(path, V2_GOLDEN_PUBLIC_KEY)
+    assert report["valid"] is False
+    assert "signer_key_id does not match pinned public key" in report["error"]
 
 
 def test_receipt_rejects_number_outside_cross_language_range(tmp_path: Path) -> None:
@@ -258,9 +283,10 @@ def test_spanned_v2_receipt_does_not_expose_oracle_key() -> None:
     assert "golden-span-mac-key" not in json.dumps(receipt)
 
 
-def test_receipt_cli_json(capsys) -> None:  # type: ignore[no-untyped-def]
+def test_receipt_cli_json(capsys, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    path = _write_canonical_v2_receipt(VALID_SPANNED_V2, tmp_path, "cli")
     code = main(
-        ["receipt", str(VALID_SPANNED_V2), "--key", V2_GOLDEN_PUBLIC_KEY, "--json"]
+        ["receipt", str(path), "--key", V2_GOLDEN_PUBLIC_KEY, "--json"]
     )
     captured = capsys.readouterr()
     assert code == 0
@@ -663,8 +689,7 @@ def _build_v2_chain(count: int) -> list[dict[str, object]]:
 def _sign_v2_receipt(receipt: dict[str, object]) -> None:
     from pipelock_aarp_verify.canonical import canonicalize
 
-    signature = receipt["signature"]
-    assert isinstance(signature, dict)
+    assert isinstance(receipt["signature"], dict)
     receipt["signature"] = {
         "signer_key_id": "",
         "key_purpose": "",
@@ -674,7 +699,7 @@ def _sign_v2_receipt(receipt: dict[str, object]) -> None:
     key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(V2_PRIVATE_SEED_HEX))
     sig = key.sign(canonicalize(receipt))
     receipt["signature"] = {
-        "signer_key_id": signature.get("signer_key_id", "receipt-signing-test"),
+        "signer_key_id": V2_GOLDEN_PUBLIC_KEY,
         "key_purpose": "receipt-signing",
         "algorithm": "ed25519",
         "signature": f"ed25519:{sig.hex()}",

--- a/sdk/verifiers/rust/src/signing.rs
+++ b/sdk/verifiers/rust/src/signing.rs
@@ -103,7 +103,7 @@ pub fn verify_evidence_receipt(
         .get("signature")
         .and_then(|value| value.as_object())
         .ok_or_else(|| "signature is required".to_string())?;
-    require_string(
+    let signer_key_id = require_string(
         signature_obj.get("signer_key_id"),
         "signature.signer_key_id",
     )?;
@@ -128,7 +128,11 @@ pub fn verify_evidence_receipt(
         Signature::from_slice(&sig_bytes).map_err(|err| format!("invalid signature: {err}"))?;
     verifying_key
         .verify_strict(&evidence_preimage(receipt)?, &signature)
-        .map_err(|_| "signature verification failed".to_string())
+        .map_err(|_| "signature verification failed".to_string())?;
+    if signer_key_id != key_hex {
+        return Err("signature.signer_key_id does not match pinned public key".to_string());
+    }
+    Ok(())
 }
 
 pub fn normalize_evidence_receipt(receipt: &Receipt) -> std::result::Result<(), String> {

--- a/sdk/verifiers/rust/tests/chain.rs
+++ b/sdk/verifiers/rust/tests/chain.rs
@@ -1193,10 +1193,6 @@ fn build_evidence_chain(count: usize) -> Vec<Value> {
 }
 
 fn sign_evidence_receipt(receipt: &mut Value) {
-    let signer_key_id = receipt["signature"]["signer_key_id"]
-        .as_str()
-        .unwrap_or("receipt-signing-test")
-        .to_string();
     let mut clone = receipt.clone();
     clone["signature"] = json!({
         "signer_key_id": "",
@@ -1211,7 +1207,7 @@ fn sign_evidence_receipt(receipt: &mut Value) {
     let key = SigningKey::from_bytes(&seed);
     let signature = key.sign(&canonicalize_jcs_value(&clone).expect("canonicalize receipt"));
     receipt["signature"] = json!({
-        "signer_key_id": signer_key_id,
+        "signer_key_id": V2_GOLDEN_PUBLIC_KEY,
         "key_purpose": "receipt-signing",
         "algorithm": "ed25519",
         "signature": format!("ed25519:{}", hex::encode(signature.to_bytes()))

--- a/sdk/verifiers/rust/tests/receipt.rs
+++ b/sdk/verifiers/rust/tests/receipt.rs
@@ -7,12 +7,24 @@ use base64::Engine;
 use pipelock_verifier_rs::receipt::run_receipt;
 use serde_json::Value;
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const V2_GOLDEN_PUBLIC_KEY: &str =
     "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
 const V2_GOLDEN_POLICY_HASH: &str =
     "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+fn write_canonical_v2_receipt(source: &Path, name: &str) -> PathBuf {
+    let mut receipt: Value = serde_json::from_str(&fs::read_to_string(source).unwrap()).unwrap();
+    receipt["signature"]["signer_key_id"] = Value::String(V2_GOLDEN_PUBLIC_KEY.to_string());
+    let path = std::env::temp_dir().join(format!(
+        "pipelock-rust-verifier-v2-{name}-{}.json",
+        std::process::id()
+    ));
+    fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
+    path
+}
 
 #[test]
 fn valid_single_receipt_verifies_with_shared_key() {
@@ -135,14 +147,12 @@ fn cli_accepts_key_equals_value() {
 #[test]
 fn valid_spanned_v2_receipt_verifies_with_shared_key() {
     let root = common::repo_root();
-    let report = run_receipt(
-        root.join("internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision_with_spans.json")
-            .to_str()
-            .unwrap(),
-        V2_GOLDEN_PUBLIC_KEY,
-    false,
-    )
-    .unwrap();
+    let path = write_canonical_v2_receipt(
+        &root.join("internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision_with_spans.json"),
+        "valid-spanned",
+    );
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
+    let _ = fs::remove_file(path);
     assert!(report.valid, "{:?}", report.error);
     assert_eq!(
         report.action_id.as_deref(),
@@ -157,16 +167,35 @@ fn valid_spanned_v2_receipt_verifies_with_shared_key() {
 #[test]
 fn valid_plain_v2_receipt_verifies_with_shared_key() {
     let root = common::repo_root();
-    let report = run_receipt(
-        root.join("internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json")
-            .to_str()
-            .unwrap(),
-        V2_GOLDEN_PUBLIC_KEY,
-        false,
-    )
-    .unwrap();
+    let path = write_canonical_v2_receipt(
+        &root.join("internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json"),
+        "valid-plain",
+    );
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
+    let _ = fs::remove_file(path);
     assert!(report.valid, "{:?}", report.error);
     assert_eq!(report.policy_hash.as_deref(), Some(V2_GOLDEN_POLICY_HASH));
+}
+
+#[test]
+fn relabeled_v2_signer_is_rejected_under_pinned_key() {
+    let root = common::repo_root();
+    let path = write_canonical_v2_receipt(
+        &root.join("internal/contract/testdata/golden/valid_evidence_receipt_proxy_decision.json"),
+        "relabeled",
+    );
+    let mut receipt: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    receipt["signature"]["signer_key_id"] = Value::String("attacker-label".to_string());
+    fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();
+
+    let report = run_receipt(path.to_str().unwrap(), V2_GOLDEN_PUBLIC_KEY, false).unwrap();
+    let _ = fs::remove_file(path);
+    assert!(!report.valid);
+    assert!(report
+        .error
+        .as_deref()
+        .unwrap_or("")
+        .contains("signer_key_id does not match pinned public key"));
 }
 
 #[test]

--- a/sdk/verifiers/ts/src/signing.ts
+++ b/sdk/verifiers/ts/src/signing.ts
@@ -463,4 +463,7 @@ export async function verifyEvidenceReceipt(receipt: Receipt, expectedKeyHex = "
   );
   const ok = await ed25519.verifyAsync(sig, evidencePreimage(receipt), pubKey, { zip215: false });
   if (!ok) throw new Error("signature verification failed");
+  if (requireString(signature["signer_key_id"], "signature.signer_key_id") !== keyHex) {
+    throw new Error("signature.signer_key_id does not match pinned public key");
+  }
 }

--- a/sdk/verifiers/ts/tests/chain.test.ts
+++ b/sdk/verifiers/ts/tests/chain.test.ts
@@ -18,7 +18,7 @@ import {
   verifyChainWithEndorsements,
   verifyRotationEndorsement,
 } from "../src/rotation.js";
-import type { JSONObject, Receipt } from "../src/types.js";
+import type { Receipt } from "../src/types.js";
 import { InvalidError } from "../src/util.js";
 
 const validChain = "../../conformance/testdata/valid-chain.jsonl";
@@ -1042,7 +1042,6 @@ async function buildEvidenceChain(count: number): Promise<Receipt[]> {
 }
 
 async function signEvidenceReceipt(receipt: Receipt): Promise<void> {
-  const signature = receipt.signature as JSONObject;
   receipt.signature = {
     signer_key_id: "",
     key_purpose: "",
@@ -1054,7 +1053,7 @@ async function signEvidenceReceipt(receipt: Receipt): Promise<void> {
     Buffer.from(v2PrivateSeedHex, "hex"),
   );
   receipt.signature = {
-    signer_key_id: signature["signer_key_id"] ?? "receipt-signing-test",
+    signer_key_id: v2GoldenPublicKey,
     key_purpose: "receipt-signing",
     algorithm: "ed25519",
     signature: `ed25519:${Buffer.from(sig).toString("hex")}`,

--- a/sdk/verifiers/ts/tests/receipt.test.ts
+++ b/sdk/verifiers/ts/tests/receipt.test.ts
@@ -19,6 +19,17 @@ const v2GoldenPublicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021
 const v2GoldenPolicyHash =
   "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+function writeCanonicalV2Receipt(source: string, name: string): string {
+  const receipt = JSON.parse(readFileSync(source, "utf8")) as Receipt;
+  (receipt.signature as Record<string, unknown>)["signer_key_id"] = v2GoldenPublicKey;
+  const pathname = join(
+    process.env["TMPDIR"] ?? "/tmp",
+    `pipelock-verifier-ts-v2-${name}-${process.pid}.json`,
+  );
+  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  return pathname;
+}
+
 test("receipt command accepts a valid Go-generated receipt", async () => {
   const report = await runReceipt(validSingle, "");
   assert.equal(report.valid, false);
@@ -83,19 +94,43 @@ test("receipt command rejects invalid UTF-8 before parsing", async () => {
 });
 
 test("receipt command accepts a valid EvidenceReceipt v2 spanned proxy decision", async () => {
-  const report = await runReceipt(validSpannedV2, v2GoldenPublicKey);
-  assert.equal(report.valid, true, report.error);
-  assert.equal(report.action_id, "01F8MECHZX3TBDSZ7XRADM79ZS");
-  assert.equal(report.verdict, "block");
-  assert.equal(report.transport, "forward");
-  assert.equal(report.signer_key, v2GoldenPublicKey);
-  assert.equal(report.policy_hash, v2GoldenPolicyHash);
+  const pathname = writeCanonicalV2Receipt(validSpannedV2, "valid-spanned");
+  try {
+    const report = await runReceipt(pathname, v2GoldenPublicKey);
+    assert.equal(report.valid, true, report.error);
+    assert.equal(report.action_id, "01F8MECHZX3TBDSZ7XRADM79ZS");
+    assert.equal(report.verdict, "block");
+    assert.equal(report.transport, "forward");
+    assert.equal(report.signer_key, v2GoldenPublicKey);
+    assert.equal(report.policy_hash, v2GoldenPolicyHash);
+  } finally {
+    rmSync(pathname, { force: true });
+  }
 });
 
 test("receipt command accepts a valid EvidenceReceipt v2 plain proxy decision", async () => {
-  const report = await runReceipt(validPlainV2, v2GoldenPublicKey);
-  assert.equal(report.valid, true, report.error);
-  assert.equal(report.policy_hash, v2GoldenPolicyHash);
+  const pathname = writeCanonicalV2Receipt(validPlainV2, "valid-plain");
+  try {
+    const report = await runReceipt(pathname, v2GoldenPublicKey);
+    assert.equal(report.valid, true, report.error);
+    assert.equal(report.policy_hash, v2GoldenPolicyHash);
+  } finally {
+    rmSync(pathname, { force: true });
+  }
+});
+
+test("receipt command rejects a relabeled EvidenceReceipt v2 signer", async () => {
+  const pathname = writeCanonicalV2Receipt(validPlainV2, "relabeled");
+  const receipt = JSON.parse(readFileSync(pathname, "utf8")) as Receipt;
+  (receipt.signature as Record<string, unknown>)["signer_key_id"] = "attacker-label";
+  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  try {
+    const report = await runReceipt(pathname, v2GoldenPublicKey);
+    assert.equal(report.valid, false);
+    assert.match(report.error ?? "", /signer_key_id.*pinned public key/u);
+  } finally {
+    rmSync(pathname, { force: true });
+  }
 });
 
 test("receipt command rejects EvidenceReceipt v2 decisions missing policy_hash", async () => {

--- a/sdk/verifiers/ts/tests/receipt.test.ts
+++ b/sdk/verifiers/ts/tests/receipt.test.ts
@@ -1,8 +1,9 @@
 // Copyright 2026 Pipelock contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { runReceipt } from "../src/receipt.js";
@@ -19,15 +20,21 @@ const v2GoldenPublicKey = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021
 const v2GoldenPolicyHash =
   "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+function writeTempJSON(name: string, contents: string | Buffer): string {
+  const dir = mkdtempSync(join(process.env["TMPDIR"] ?? tmpdir(), `pipelock-verifier-ts-${name}-`));
+  const pathname = join(dir, "receipt.json");
+  writeFileSync(pathname, contents, { flag: "wx", mode: 0o600 });
+  return pathname;
+}
+
+function removeTempJSON(pathname: string): void {
+  rmSync(dirname(pathname), { recursive: true, force: true });
+}
+
 function writeCanonicalV2Receipt(source: string, name: string): string {
   const receipt = JSON.parse(readFileSync(source, "utf8")) as Receipt;
   (receipt.signature as Record<string, unknown>)["signer_key_id"] = v2GoldenPublicKey;
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-${name}-${process.pid}.json`,
-  );
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
-  return pathname;
+  return writeTempJSON(`v2-${name}`, JSON.stringify(receipt));
 }
 
 test("receipt command accepts a valid Go-generated receipt", async () => {
@@ -57,14 +64,9 @@ test("receipt verifier rejects a pinned-key mismatch", async () => {
 });
 
 test("receipt command rejects duplicate keys before populating metadata", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-dup-${process.pid}.json`,
-  );
-  writeFileSync(
-    pathname,
+  const pathname = writeTempJSON(
+    "dup",
     '{"version":1,"action_record":{"version":1,"action_id":"x","action_type":"write","timestamp":"2026-04-15T12:00:00Z","verdict":"allow","verdict":"block","target":"https://e.example","transport":"https","chain_prev_hash":"genesis","chain_seq":0},"signature":"ed25519:00","signer_key":"00"}',
-    { mode: 0o600 },
   );
   try {
     const report = await runReceipt(pathname, "");
@@ -72,24 +74,21 @@ test("receipt command rejects duplicate keys before populating metadata", async 
     assert.match(report.error ?? "", /duplicate object key/u);
     assert.equal(report.verdict, undefined);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects invalid UTF-8 before parsing", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-utf8-${process.pid}.json`,
+  const pathname = writeTempJSON(
+    "utf8",
+    Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]),
   );
-  writeFileSync(pathname, Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]), {
-    mode: 0o600,
-  });
   try {
     const report = await runReceipt(pathname, "");
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /invalid UTF-8/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
@@ -104,7 +103,7 @@ test("receipt command accepts a valid EvidenceReceipt v2 spanned proxy decision"
     assert.equal(report.signer_key, v2GoldenPublicKey);
     assert.equal(report.policy_hash, v2GoldenPolicyHash);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
@@ -115,7 +114,7 @@ test("receipt command accepts a valid EvidenceReceipt v2 plain proxy decision", 
     assert.equal(report.valid, true, report.error);
     assert.equal(report.policy_hash, v2GoldenPolicyHash);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
@@ -129,163 +128,127 @@ test("receipt command rejects a relabeled EvidenceReceipt v2 signer", async () =
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /signer_key_id.*pinned public key/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects EvidenceReceipt v2 decisions missing policy_hash", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-missing-policy-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validPlainV2, "utf8")) as Record<string, unknown>;
   delete receipt["policy_hash"];
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-missing-policy", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /policy_hash/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects reserved EvidenceReceipt v2 defer payload kinds", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-defer-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validPlainV2, "utf8")) as Record<string, unknown>;
   receipt["payload_kind"] = "defer_opened";
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-defer", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /known but not implemented/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects a tampered EvidenceReceipt v2 span", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-tamper-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   const payload = receipt.payload as { source_spans: Array<{ rule_id: string }> };
   payload.source_spans[0]!.rule_id = "aws_access_key_tampered";
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-tamper", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /signature verification failed/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects unknown EvidenceReceipt v2 span fields", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-unknown-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   const payload = receipt.payload as { source_spans: Array<Record<string, unknown>> };
   payload.source_spans[0]!["raw_match"] = "lowentropy";
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-unknown", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /unknown field raw_match/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects empty dlp normalized suffix", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-empty-view-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   const payload = receipt.payload as { source_spans: Array<Record<string, unknown>> };
   payload.source_spans[0]!["normalized_view"] = "dlp_normalized:";
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-empty-view", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /normalized_view is invalid/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects unsupported EvidenceReceipt v2 canonicalization", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-bad-canon-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   (receipt.canonicalization as Record<string, unknown>)["jcs_profile"] = "rfc8785";
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-bad-canon", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /canonicalization\.jcs_profile is invalid/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects missing source_spans critical marker", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-missing-crit-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   receipt.crit = ["canonicalization"];
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-missing-crit", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /crit must include source_spans/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects unknown EvidenceReceipt v2 critical marker", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-unknown-crit-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validSpannedV2, "utf8")) as Receipt;
   receipt.crit = ["canonicalization", "source_spans", "future_extension"];
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-unknown-crit", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /crit has unknown field future_extension/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 
 test("receipt command rejects source_spans critical marker on plain EvidenceReceipt v2", async () => {
-  const pathname = join(
-    process.env["TMPDIR"] ?? "/tmp",
-    `pipelock-verifier-ts-v2-plain-span-crit-${process.pid}.json`,
-  );
   const receipt = JSON.parse(readFileSync(validPlainV2, "utf8")) as Receipt;
   receipt.crit = ["canonicalization", "source_spans"];
-  writeFileSync(pathname, JSON.stringify(receipt), { mode: 0o600 });
+  const pathname = writeTempJSON("v2-plain-span-crit", JSON.stringify(receipt));
   try {
     const report = await runReceipt(pathname, v2GoldenPublicKey);
     assert.equal(report.valid, false);
     assert.match(report.error ?? "", /crit source_spans is invalid for proxy_decision/u);
   } finally {
-    rmSync(pathname, { force: true });
+    removeTempJSON(pathname);
   }
 });
 

--- a/testdata/python_verifier_fixture/verify.py
+++ b/testdata/python_verifier_fixture/verify.py
@@ -121,9 +121,11 @@ def verify_evidence_receipt(fixture: Path, pubkey: bytes) -> tuple[bool, str]:
     pk = Ed25519PublicKey.from_public_bytes(pubkey)
     try:
         pk.verify(sig, preimage)
-        return True, ""
     except InvalidSignature as e:
         return False, f"verify failed: {e}"
+    if sig_obj.get("signer_key_id") != pubkey.hex():
+        return False, "signer_key_id does not match pinned public key"
+    return True, ""
 
 
 def fingerprint(pubkey_bytes: bytes) -> str:


### PR DESCRIPTION
## What changed

The HTTP proxy refuses request trailers it can't scan, sends the Host that policy already admitted, and won't replay a scanned body onto a different host after a redirect.

MCP media policy now inspects nested resource blobs. Strict reload rejects dropping the MCP listener state-token requirement. Pinned receipt verify binds signer_key_id to the pinned key.

Missing those fields used to look like a clean allow or a clean verify. The ignored field still went through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Pinned-key receipt verification now rejects relabeled or mismatched signer identities across supported verifiers.
  - HTTP trailers are scanned safely; requests containing unscanned trailer data are blocked.
  - Redirects that replay request bodies to a different destination are blocked.
  - Client-controlled `Host` values can no longer override the approved destination.

- **Media Protection**
  - MCP media policies now inspect embedded resource audio, video, and image content.

- **Configuration**
  - Strict-mode reloads reject disabling listener state-token requirements and provide clearer warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->