### PR TITLE
fix(mcp): scope bundle rules to descriptions

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -221,6 +221,8 @@ the `pattern.validator` field.
 | Injection pattern | `injection` | `response_scanning.patterns` |
 | Tool poison pattern | `tool-poison` | `mcp_tool_scanning` descriptions |
 
+Tool-poison rules with `scan_field: description` scan the tool's `description` and `description` fields nested in its input schema. Built-in scanning still covers every other agent-visible tool field, but those fields do not trigger description-scoped bundle rules.
+
 ### Machine-readable reader contract
 
 A release-stamped Pipelock binary can export the rule-bundle contract it enforces:

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -1226,6 +1226,7 @@ func collectHyperSchemaDescriptions(value any, result *[]string, depth int) {
 		if !ok {
 			continue
 		}
+		collectStringLeaves(link["description"], result, depth+1)
 		for _, key := range []string{"headerSchema", "hrefSchema", "submissionSchema", "targetSchema"} {
 			collectSchemaDescriptionFieldsMode(link[key], result, depth+1, false)
 		}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -1203,14 +1203,31 @@ func collectSchemaDescriptionFieldsMode(value any, result *[]string, depth int, 
 			continue
 		case "properties", "patternProperties", "dependentSchemas", "dependencies", "$defs", "definitions":
 			collectSchemaDescriptionFieldsMode(child, result, depth+1, true)
-		default:
-			if strings.HasPrefix(key, "x-") || strings.HasPrefix(key, "X-") {
-				continue
-			}
-			// Unknown keywords may introduce schema containers in newer drafts
-			// or extensions such as Hyper-Schema links. Follow structured values
-			// so a declared description cannot disappear when the dialect grows.
+		case "additionalItems", "additionalProperties", "contains", "contentSchema", "else", "if", "items", "not", "propertyNames", "then", "unevaluatedItems", "unevaluatedProperties":
 			collectSchemaDescriptionFieldsMode(child, result, depth+1, false)
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			collectSchemaDescriptionFieldsMode(child, result, depth+1, false)
+		case "links":
+			collectHyperSchemaDescriptions(child, result, depth+1)
+		}
+	}
+}
+
+func collectHyperSchemaDescriptions(value any, result *[]string, depth int) {
+	if depth > maxSchemaDepth {
+		return
+	}
+	links, ok := value.([]any)
+	if !ok {
+		return
+	}
+	for _, value := range links {
+		link, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"headerSchema", "hrefSchema", "submissionSchema", "targetSchema"} {
+			collectSchemaDescriptionFieldsMode(link[key], result, depth+1, false)
 		}
 	}
 }

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -1147,6 +1147,74 @@ func extractToolText(t ToolDef) string {
 	return strings.Join(parts, ". ")
 }
 
+// extractToolRuleDescriptionText returns only fields that the rule-bundle
+// contract calls descriptions. Built-in scanners deliberately inspect every
+// agent-visible tool field, but a community rule scoped to "description" must
+// not turn metadata, titles, defaults, or extension values into description
+// matches. Input-schema description keywords remain part of this surface.
+func extractToolRuleDescriptionText(t ToolDef) string {
+	parts := make([]string, 0, 2)
+	if t.Description != "" {
+		parts = append(parts, t.Description)
+	}
+	if len(t.InputSchema) > 0 {
+		var schema any
+		if json.Unmarshal(t.InputSchema, &schema) == nil {
+			collectSchemaDescriptionFields(schema, &parts, 0)
+		}
+	}
+	return strings.Join(parts, ". ")
+}
+
+func collectSchemaDescriptionFields(value any, result *[]string, depth int) {
+	collectSchemaDescriptionFieldsMode(value, result, depth, false)
+}
+
+func collectSchemaDescriptionFieldsMode(value any, result *[]string, depth int, schemaMap bool) {
+	if depth > maxSchemaDepth {
+		return
+	}
+	if schemas, ok := value.([]any); ok {
+		for _, schema := range schemas {
+			collectSchemaDescriptionFieldsMode(schema, result, depth+1, false)
+		}
+		return
+	}
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	if schemaMap {
+		for _, schema := range obj {
+			collectSchemaDescriptionFieldsMode(schema, result, depth+1, false)
+		}
+		return
+	}
+	if description, ok := obj["description"]; ok {
+		collectStringLeaves(description, result, depth+1)
+	}
+
+	for key, child := range obj {
+		switch key {
+		case "description", "default", "const", "enum", "examples":
+			// The description value was collected above. The other fields carry
+			// example data, not nested schemas, even when their data contains a
+			// property that happens to be named description.
+			continue
+		case "properties", "patternProperties", "dependentSchemas", "dependencies", "$defs", "definitions":
+			collectSchemaDescriptionFieldsMode(child, result, depth+1, true)
+		default:
+			if strings.HasPrefix(key, "x-") || strings.HasPrefix(key, "X-") {
+				continue
+			}
+			// Unknown keywords may introduce schema containers in newer drafts
+			// or extensions such as Hyper-Schema links. Follow structured values
+			// so a declared description cannot disappear when the dialect grows.
+			collectSchemaDescriptionFieldsMode(child, result, depth+1, false)
+		}
+	}
+}
+
 // extractToolGeneralText returns every supported agent-visible tool field
 // except Description. The response-scanning path deliberately omits all tool
 // descriptions to preserve tools/list compatibility; this dedicated tool
@@ -2182,7 +2250,7 @@ func scanToolDefs(tools []ToolDef, sc *scanner.Scanner, cfg *ToolScanConfig) (ma
 			// Community rule bundle extra-poison patterns.
 			if cfg != nil && len(cfg.ExtraPoison) > 0 {
 				normName := normalize.ForToolText(tool.Name)
-				normDesc := normalize.ForToolText(text)
+				normDesc := normalize.ForToolText(extractToolRuleDescriptionText(tool))
 				for _, ep := range cfg.ExtraPoison {
 					if ep == nil || ep.Re == nil || ep.Name == "" {
 						continue

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -3836,6 +3836,12 @@ func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
 			wantMatch: false,
 		},
 		{
+			name: "unknown schema object description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object",` +
+				`"vendor":{"description":"` + marker + `"}}}`,
+			wantMatch: false,
+		},
+		{
 			name: "input schema default object description",
 			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object",` +
 				`"default":{"description":"` + marker + `"}}}`,
@@ -3866,6 +3872,38 @@ func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectSchemaDescriptionFields_DialectsAndMalformed(t *testing.T) {
+	t.Run("single schema keyword", func(t *testing.T) {
+		var got []string
+		collectSchemaDescriptionFields(map[string]any{
+			"contains": map[string]any{"description": "nested"},
+		}, &got, 0)
+		if !slices.Contains(got, "nested") {
+			t.Fatalf("descriptions = %v, want nested", got)
+		}
+	})
+
+	t.Run("depth limits", func(t *testing.T) {
+		var got []string
+		collectSchemaDescriptionFields(map[string]any{"description": "too deep"}, &got, maxSchemaDepth+1)
+		collectHyperSchemaDescriptions([]any{map[string]any{
+			"submissionSchema": map[string]any{"description": "too deep"},
+		}}, &got, maxSchemaDepth+1)
+		if len(got) != 0 {
+			t.Fatalf("descriptions = %v, want none", got)
+		}
+	})
+
+	t.Run("malformed hyper schema links", func(t *testing.T) {
+		var got []string
+		collectHyperSchemaDescriptions(map[string]any{"description": "not a link array"}, &got, 0)
+		collectHyperSchemaDescriptions([]any{"not a link object"}, &got, 0)
+		if len(got) != 0 {
+			t.Fatalf("descriptions = %v, want none", got)
+		}
+	})
 }
 
 func TestScanTools_ExtraPoisonName(t *testing.T) {

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -3797,6 +3797,13 @@ func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
 			wantMatch: true,
 		},
 		{
+			name: "hyper schema link description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"$schema":` +
+				`"https://json-schema.org/draft/2019-09/hyper-schema","links":[{"rel":"create",` +
+				`"description":"` + marker + `"}]}}`,
+			wantMatch: true,
+		},
+		{
 			name: "non-string description",
 			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object","properties":{` +
 				`"query":{"type":"string","description":["` + marker + `"]}}}}`,
@@ -3842,6 +3849,18 @@ func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
 			wantMatch: false,
 		},
 		{
+			name: "hyper schema link title",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"links":[{` +
+				`"title":"` + marker + `"}]}}`,
+			wantMatch: false,
+		},
+		{
+			name: "hyper schema link target hints",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"links":[{` +
+				`"targetHints":{"description":"` + marker + `"}}]}}`,
+			wantMatch: false,
+		},
+		{
 			name: "input schema default object description",
 			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object",` +
 				`"default":{"description":"` + marker + `"}}}`,
@@ -3875,6 +3894,22 @@ func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
 }
 
 func TestCollectSchemaDescriptionFields_DialectsAndMalformed(t *testing.T) {
+	t.Run("hyper schema link fields", func(t *testing.T) {
+		var got []string
+		collectHyperSchemaDescriptions([]any{map[string]any{
+			"description":      "link",
+			"headerSchema":     map[string]any{"description": "header"},
+			"hrefSchema":       map[string]any{"description": "href"},
+			"submissionSchema": map[string]any{"description": "submission"},
+			"targetSchema":     map[string]any{"description": "target"},
+		}}, &got, 0)
+		for _, want := range []string{"link", "header", "href", "submission", "target"} {
+			if !slices.Contains(got, want) {
+				t.Fatalf("descriptions = %v, want %q", got, want)
+			}
+		}
+	})
+
 	t.Run("single schema keyword", func(t *testing.T) {
 		var got []string
 		collectSchemaDescriptionFields(map[string]any{

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -3752,6 +3752,122 @@ func TestScanTools_ExtraPoisonDescription(t *testing.T) {
 	}
 }
 
+func TestScanTools_ExtraPoisonDescriptionScope(t *testing.T) {
+	const marker = "scope sentinel phrase"
+	sc := testScanner(t)
+	cfg := &ToolScanConfig{
+		Action: "warn",
+		ExtraPoison: []*ExtraPoisonPattern{
+			{
+				Name:      "description-only-rule",
+				RuleID:    "test/description-only",
+				Re:        regexp.MustCompile(`scope\s+sentinel\s+phrase`),
+				ScanField: "description",
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		tool      string
+		wantMatch bool
+	}{
+		{
+			name:      "tool description",
+			tool:      `{"name":"helper","description":"` + marker + `"}`,
+			wantMatch: true,
+		},
+		{
+			name: "input schema description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object","properties":{` +
+				`"query":{"type":"string","description":"` + marker + `"}}}}`,
+			wantMatch: true,
+		},
+		{
+			name: "nested input schema description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"allOf":[{"type":"object",` +
+				`"properties":{"query":{"type":"string","description":"` + marker + `"}}}]}}`,
+			wantMatch: true,
+		},
+		{
+			name: "hyper schema nested description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"$schema":` +
+				`"https://json-schema.org/draft/2019-09/hyper-schema","links":[{"rel":"create",` +
+				`"submissionSchema":{"description":"` + marker + `"}}]}}`,
+			wantMatch: true,
+		},
+		{
+			name: "non-string description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object","properties":{` +
+				`"query":{"type":"string","description":["` + marker + `"]}}}}`,
+			wantMatch: true,
+		},
+		{
+			name: "property named default description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object","properties":{` +
+				`"default":{"type":"string","description":"` + marker + `"}}}}`,
+			wantMatch: true,
+		},
+		{
+			name:      "tool title",
+			tool:      `{"name":"helper","description":"safe","title":"` + marker + `"}`,
+			wantMatch: false,
+		},
+		{
+			name:      "metadata",
+			tool:      `{"name":"helper","description":"safe","_meta":{"note":"` + marker + `"}}`,
+			wantMatch: false,
+		},
+		{
+			name:      "annotations",
+			tool:      `{"name":"helper","description":"safe","annotations":{"note":"` + marker + `"}}`,
+			wantMatch: false,
+		},
+		{
+			name: "input schema key",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object","properties":{` +
+				`"` + marker + `":{"type":"string"}}}}`,
+			wantMatch: false,
+		},
+		{
+			name: "input schema extension",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object",` +
+				`"x-agent-note":"` + marker + `"}}`,
+			wantMatch: false,
+		},
+		{
+			name: "input schema default object description",
+			tool: `{"name":"helper","description":"safe","inputSchema":{"type":"object",` +
+				`"default":{"description":"` + marker + `"}}}`,
+			wantMatch: false,
+		},
+		{
+			name: "output schema description",
+			tool: `{"name":"helper","description":"safe","outputSchema":{"type":"object",` +
+				`"description":"` + marker + `"}}`,
+			wantMatch: false,
+		},
+		{
+			name:      "unknown extension field",
+			tool:      `{"name":"helper","description":"safe","x-vendor-note":"` + marker + `"}`,
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ScanTools(makeToolsResponse("["+tc.tool+"]"), sc, cfg)
+			matched := false
+			for _, match := range result.Matches {
+				matched = matched || slices.Contains(match.ToolPoison, "description-only-rule")
+			}
+			if matched != tc.wantMatch {
+				t.Fatalf("description-only rule matched = %t, want %t; result = %+v", matched, tc.wantMatch, result)
+			}
+		})
+	}
+}
+
 func TestScanTools_ExtraPoisonName(t *testing.T) {
 	sc := testScanner(t)
 	cfg := &ToolScanConfig{


### PR DESCRIPTION
## What changed
Limit description-scoped tool-poison bundle rules to tool and input-schema descriptions while keeping built-in scanning across every agent-visible field. This prevents metadata and structural fields from causing false blocks without creating a scanning gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Refined description-based tool scanning to include tool descriptions and nested input-schema descriptions.
  * Excluded unrelated fields—including titles, metadata, defaults, examples, extensions, and output schemas—from description-scoped scans.
  * Name-based scanning behavior remains unchanged.

* **Documentation**
  * Clarified which tool and schema fields are evaluated by description-scoped rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->