### PR TITLE
chore: prepare v3.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-31
+
+### Breaking Changes / Upgrade Notes
+
+- **npm lifecycle scripts are disabled by default in contained environments.** Commands that require dependency install scripts must use the documented explicit override.
+- **Emit configuration changes now require a restart.** Reloads leave the active emitter unchanged and report the ignored change.
+- **Provider-key detection now requires a valid leading boundary.** This removes false positives and accidental redaction of ordinary prose; keys glued directly to a preceding key-alphabet character are no longer matched.
+- **Immutable core DLP and response floors can no longer be suppressed.** Existing suppressions naming those protected patterns must be removed or replaced with the documented scoped alternatives.
+- **Invalid duration values that overflow internal conversion are rejected during configuration validation.**
+
+### Added
+
+- **External authority propagation at forwarding gates**, including audit, emission, WebSocket, and MCP paths.
+- **Offline recorder compaction and legacy recorder-epoch inventory** with bounded reads and integrity-preserving publication.
+- **Native AEL evidence emission** for session lifecycle and activity records.
+- **License-expiry warnings** and **rules-bundle compatibility warnings** in operator status surfaces.
+- **A code-checked capability manifest** that reports the supported capabilities from attached implementation.
+- **Route-scoped entropy warnings** for selected request paths.
+- **Detection and redaction for current GitHub installation-token and Azure SAS token formats.**
+- **An exported rules reader-schema contract** with atomic bundle loading and status publication.
+
+### Changed
+
+- Canary matching now uses bounded recursive decoding across whole-text and segmented views.
+- Shielded large-response handling is consistent across forward and reverse proxy paths and records the configured cap and remedy.
+- Audit, evidence, and dashboard surfaces distinguish recorded agent labels from identities established by trusted provenance.
+- AEL liveness evidence begins with an immediate heartbeat so short sessions can satisfy the declared cadence.
+- Conductor follower state uses signed applied-state heartbeats with bounded negotiation retry.
+- Verified PNG and JPEG bodies bypass text prompt scanning while readable metadata and malformed or non-image bodies remain scanned.
+- DLP prefiltering uses proven required literals to reduce unnecessary pattern work while retaining an always-run path for patterns whose anchors cannot be proven.
+- MCP tool-definition scanning avoids reprocessing duplicate input-schema text while retaining one scan of every agent-visible field.
+
+### Fixed
+
+- URL paths now participate in cross-request exfiltration detection.
+- Skill and file scanning discovers extensionless references, scans text before classifying binary content, and prevents symlink or path-replacement escapes from presenting as clean.
+- MCP setup and generated wrappers verify executable identity and proxy invocation rather than trusting self-written markers.
+- MCP tool arguments that redaction cannot safely inspect now fail closed.
+- Generic non-media responses and WebSocket control payloads are scanned, with taint attribution preserved across frames.
+- A2A Agent Card controls run on forwarded MCP responses.
+- Redirect policy and official rules-registry origin checks remain enforced across repeated fetch, update, and sink paths.
+- Conductor audit/admin operations are organization-scoped, including removed-follower handling.
+- Unreadable posture evidence warns without taking down receipt-enabled startup.
+- Files already present in newly created file-sentry directories are scanned without blocking event processing.
+- Response prefiltering preserves required literals across regex alternation branches, keeping candidate selection deterministic and never skipping patterns without a proven anchor.
+- HTTP request trailers fail closed when they cannot be scanned; forwarded hosts follow the admitted URL, and scanned bodies are not replayed across authority-changing redirects.
+- MCP media policy scans and safely rewrites nested `resource.blob` payloads.
+- Strict reloads cannot remove an active MCP listener state-token requirement.
+- Pinned EvidenceReceipt verification requires `signer_key_id` to match the pinned public key across the bundled verifiers.
+- Description-scoped bundle rules match only tool and input-schema descriptions, including Hyper-Schema link descriptions, while built-in scanning retains broader field coverage.
+
 ## [3.4.0] - 2026-08-20
 
 ### Breaking Changes / Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provider-key detection now requires a valid leading boundary.** This removes false positives and accidental redaction of ordinary prose; keys glued directly to a preceding key-alphabet character are no longer matched.
 - **Immutable core DLP and response floors can no longer be suppressed.** Existing suppressions naming those protected patterns must be removed or replaced with the documented scoped alternatives.
 - **Invalid duration values that overflow internal conversion are rejected during configuration validation.**
+- **Unsafe request trailers and opaque MCP arguments are now rejected.** Populated HTTP trailers that cannot be scanned and MCP tool arguments that redaction cannot safely inspect fail closed.
 
 ### Added
 

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -6,8 +6,8 @@ type: application
 # gate enforces that both equal the release tag. The chart publishes to an
 # OCI registry under this version as the tag, so a version that did not move
 # every release would overwrite the previously published chart in place.
-version: 3.4.0
-appVersion: "3.4.0"
+version: 3.5.0
+appVersion: "3.5.0"
 home: https://pipelab.org
 sources:
   - https://github.com/luckyPipewrench/pipelock
@@ -41,12 +41,16 @@ annotations:
       url: https://github.com/luckyPipewrench/pipelock-verify-python
   artifacthub.io/changes: |
     - kind: changed
-      description: Pipelock appVersion 3.4.0. MCP reasoning trust can no longer weaken a stricter response action, and scan-diff now distinguishes findings from instrument errors.
+      description: Pipelock appVersion 3.5.0. External authority propagation, native AEL evidence, and the code-checked capability manifest make trust and support claims explicit.
     - kind: added
-      description: Containment-aware upgrades, filesystem and command guard enforcement, exact destination grants, and commitment-key lifecycle operations.
+      description: Route-scoped entropy warnings, license and rules-compatibility warnings, and detection for current GitHub installation and Azure SAS token formats.
     - kind: added
-      description: Reverse-proxy scan-capacity budgeting and v3 outer-chain namespace support for recorder readers.
+      description: Offline recorder compaction, legacy recorder-epoch inventory, and an exported rules reader-schema contract.
     - kind: fixed
-      description: Reverse-proxy media request bodies are scanned, oversized bodies fail closed, and provider-opaque carve-outs require ciphertext-like content.
+      description: File, skill, MCP, WebSocket, redirect, and generic response paths cover previously missed content and refuse unsafe handling where their contracts require it.
     - kind: fixed
-      description: Credential matching covers encoding noise, path-query seams, and credentials split across more than four query values.
+      description: Response prefiltering preserves required literals across regex alternation branches and always evaluates patterns without a proven anchor.
+    - kind: fixed
+      description: Request trailers, cross-authority body replays, nested MCP media, strict state-token reloads, and pinned receipt signer identities now fail closed.
+    - kind: fixed
+      description: Description-scoped bundle rules honor their field contract while built-in MCP scanning continues to cover every agent-visible field.

--- a/charts/pipelock/Chart.yaml
+++ b/charts/pipelock/Chart.yaml
@@ -37,7 +37,7 @@ annotations:
       url: https://pipelab.org/learn/
     - name: Release notes
       url: https://github.com/luckyPipewrench/pipelock/releases
-    - name: Audit Packet verifier
+    - name: Receipt verifier (Python)
       url: https://github.com/luckyPipewrench/pipelock-verify-python
   artifacthub.io/changes: |
     - kind: changed


### PR DESCRIPTION
## What changed
- Add the v3.5.0 changelog and upgrade notes.
- Set the Helm chart and Artifact Hub metadata to 3.5.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Contained environments disable npm lifecycle scripts by default.
  * Configuration changes require a restart; invalid overflow durations are rejected.
  * Core data-loss prevention and response safeguards can no longer be suppressed.

* **New Features**
  * Added capability reporting, offline recorder compaction, native evidence output, and rules-bundle warnings.
  * Added GitHub installation-token and Azure SAS-token detection.

* **Improvements**
  * Enhanced scanning, redaction, redirect enforcement, MCP handling, heartbeat reporting, and large-response consistency.
  * Fixed URL-path exfiltration detection and organization-scoped operations.

* **Release**
  * Updated the release version to 3.5.0.
  * Renamed the Audit Packet verifier to Receipt verifier (Python).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->