### PR TITLE
fix(conductor): preserve containment policy during bundle apply

### DIFF
--- a/internal/cli/runtime/conductor.go
+++ b/internal/cli/runtime/conductor.go
@@ -147,10 +147,7 @@ func (s *Server) ApplyConductorPolicyBundle(bundle conductor.PolicyBundle, opts 
 		LocalVersion: cliutil.Version,
 		LoadConfig:   config.Load,
 		Reload: func(newCfg *config.Config) error {
-			if err := preserveConductorBundleLocalRuntimeState(cfg, newCfg, bundle.Payload.ConfigYAML); err != nil {
-				return err
-			}
-			return s.Reload(newCfg)
+			return s.reloadConductorPolicyBundle(newCfg, bundle.Payload.ConfigYAML)
 		},
 		// Close the in-flight apply window: teardownConductor sets conductorDown
 		// without taking conductorApplyMu (that would deadlock the poller's own
@@ -168,6 +165,17 @@ func (s *Server) ApplyConductorPolicyBundle(bundle conductor.PolicyBundle, opts 
 
 func preserveConductorBundleLocalRuntimeState(oldCfg, newCfg *config.Config, bundleYAML string) error {
 	return config.PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg, bundleYAML)
+}
+
+func (s *Server) reloadConductorPolicyBundle(newCfg *config.Config, bundleYAML string) error {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	oldCfg := s.proxy.CurrentConfig()
+	if err := preserveConductorBundleLocalRuntimeState(oldCfg, newCfg, bundleYAML); err != nil {
+		return err
+	}
+	return s.reloadLocked(newCfg)
 }
 
 func buildConductorAuditTransport(cfg *config.Config, m *metrics.Metrics) (*auditbatcher.Queue, *auditbatcher.Transport, error) {

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -772,6 +772,7 @@ func TestNewServer_WiresConductorBundlePoller(t *testing.T) {
 
 func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	s, signer := newConductorApplyTestServer(t)
+	s.containmentManaged = true
 	oldCfg := s.proxy.CurrentConfig()
 	oldCfg.FetchProxy.Listen = "127.0.0.1:18897"
 	oldCfg.ForwardProxy.Enabled = true
@@ -852,6 +853,14 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	oldCfg.Sandbox.Enabled = true
 	oldCfg.Sandbox.Workspace = "/tmp/pipelock-sandbox"
 	oldCfg.LicenseFile = "/etc/pipelock/license.token"
+	oldCfg.MetricsListen = "192.0.2.20:19090"
+	oldCfg.Containment.MetricsExposure = &config.ContainmentMetricsExposure{
+		AllowFullMetrics:   true,
+		AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+		Owner:              "observability",
+		Reason:             "Prometheus scrape",
+		ExpiresAt:          "2099-01-01T00:00:00Z",
+	}
 	bundleDLP := config.DLPPattern{Name: "bundle-secret", Regex: `BUNDLE_SECRET_[A-Z]+`, Severity: config.SeverityCritical}
 	oldCfg.ApplyDefaults()
 	expectedLocal := oldCfg.Clone()
@@ -928,6 +937,13 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	}
 	if live.Emit.Syslog.Address != oldCfg.Emit.Syslog.Address {
 		t.Fatalf("emit.syslog.address = %q, want preserved %q", live.Emit.Syslog.Address, oldCfg.Emit.Syslog.Address)
+	}
+	if live.MetricsListen != oldCfg.MetricsListen || !reflect.DeepEqual(live.Containment, oldCfg.Containment) {
+		t.Fatalf("containment metrics config = listen %q containment=%+v, want listen %q containment=%+v",
+			live.MetricsListen, live.Containment, oldCfg.MetricsListen, oldCfg.Containment)
+	}
+	if s.containmentMetricsDenied.Load() {
+		t.Fatal("valid preserved containment metrics policy left metrics denied")
 	}
 	for _, required := range []struct {
 		name string

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -36,7 +36,15 @@ import (
 func (s *Server) Reload(newCfg *config.Config) (err error) {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
+	return s.reloadLocked(newCfg)
+}
 
+// reloadLocked applies a validated runtime configuration while reloadMu is
+// held by the caller. Keeping the activation body behind this seam lets
+// Conductor preserve follower-local state from the current live config under
+// the same lock, so a concurrent operator reload cannot be overwritten by a
+// stale pre-apply snapshot.
+func (s *Server) reloadLocked(newCfg *config.Config) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			ReloadPanicHandler(r, s.sentry, s.logger, s.opts.ConfigFile)

--- a/internal/config/conductor_bundle.go
+++ b/internal/config/conductor_bundle.go
@@ -50,6 +50,12 @@ func PreserveConductorBundleLocalRuntimeState(newCfg, oldCfg *Config, bundleYAML
 	newCfg.Emit = oldCfg.Emit
 	newCfg.Sentry = oldCfg.Sentry
 	newCfg.MetricsListen = oldCfg.MetricsListen
+	newCfg.Containment = oldCfg.Containment
+	if oldCfg.Containment.MetricsExposure != nil {
+		exposure := *oldCfg.Containment.MetricsExposure
+		exposure.AllowedSourceCIDRs = append([]string(nil), oldCfg.Containment.MetricsExposure.AllowedSourceCIDRs...)
+		newCfg.Containment.MetricsExposure = &exposure
+	}
 	newCfg.MCPWSListener = oldCfg.MCPWSListener
 	newCfg.ReverseProxy = oldCfg.ReverseProxy
 	newCfg.ScanAPI = oldCfg.ScanAPI

--- a/internal/config/conductor_bundle_test.go
+++ b/internal/config/conductor_bundle_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPreserveConductorBundleLocalRuntimeStateNilInputs(t *testing.T) {
@@ -24,8 +25,15 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	t.Parallel()
 
 	oldCfg := &Config{
-		FetchProxy:           FetchProxy{Listen: "127.0.0.1:18080", TimeoutSeconds: 12},
-		MetricsListen:        "127.0.0.1:19090",
+		FetchProxy:    FetchProxy{Listen: "127.0.0.1:18080", TimeoutSeconds: 12},
+		MetricsListen: "192.0.2.20:19090",
+		Containment: ContainmentConfig{MetricsExposure: &ContainmentMetricsExposure{
+			AllowFullMetrics:   true,
+			AllowedSourceCIDRs: []string{"192.0.2.42/32"},
+			Owner:              "observability",
+			Reason:             "Prometheus scrape",
+			ExpiresAt:          "2099-01-01T00:00:00Z",
+		}},
 		Internal:             []string{"10.0.0.0/8"},
 		TrustedDomains:       []string{"trusted.example"},
 		Suppress:             []SuppressEntry{{Rule: "body_dlp", Path: "api.example/*", Reason: "fixture"}},
@@ -38,6 +46,7 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	newCfg := &Config{
 		FetchProxy:           FetchProxy{Listen: "127.0.0.1:28080"},
 		MetricsListen:        "127.0.0.1:29090",
+		Containment:          ContainmentConfig{},
 		Internal:             []string{"192.168.0.0/16"},
 		TrustedDomains:       []string{"other.example"},
 		Suppress:             []SuppressEntry{{Rule: "old", Path: "old.example/*"}},
@@ -58,6 +67,17 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	}
 	if newCfg.MetricsListen != oldCfg.MetricsListen {
 		t.Fatalf("MetricsListen = %q, want %q", newCfg.MetricsListen, oldCfg.MetricsListen)
+	}
+	if !reflect.DeepEqual(newCfg.Containment, oldCfg.Containment) {
+		t.Fatalf("Containment = %#v, want %#v", newCfg.Containment, oldCfg.Containment)
+	}
+	if err := ValidateContainmentMetricsExposure(
+		newCfg.MetricsListen,
+		8888,
+		newCfg.Containment.MetricsExposure,
+		time.Date(2098, time.January, 1, 0, 0, 0, 0, time.UTC),
+	); err != nil {
+		t.Fatalf("preserved containment metrics configuration rejected: %v", err)
 	}
 	if !reflect.DeepEqual(newCfg.Internal, oldCfg.Internal) {
 		t.Fatalf("Internal = %#v, want %#v", newCfg.Internal, oldCfg.Internal)
@@ -88,6 +108,8 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	oldCfg.TrustedDomains[0] = "mutated.example"
 	oldCfg.Suppress[0].Path = "mutated.example/*"
 	oldCfg.Agents["builder"] = AgentProfile{Sandbox: &AgentSandboxOverride{Enabled: boolPtr(false)}}
+	oldCfg.Containment.MetricsExposure.Owner = "mutated"
+	oldCfg.Containment.MetricsExposure.AllowedSourceCIDRs[0] = "192.0.2.43/32"
 	if newCfg.Internal[0] == oldCfg.Internal[0] {
 		t.Fatal("Internal slice aliases old config")
 	}
@@ -99,6 +121,12 @@ func TestPreserveConductorBundleLocalRuntimeStateCopiesFollowerLocalFields(t *te
 	}
 	if reflect.DeepEqual(newCfg.Agents["builder"], oldCfg.Agents["builder"]) {
 		t.Fatal("Agents map aliases old config")
+	}
+	if newCfg.Containment.MetricsExposure.Owner == oldCfg.Containment.MetricsExposure.Owner {
+		t.Fatal("Containment.MetricsExposure aliases old config")
+	}
+	if newCfg.Containment.MetricsExposure.AllowedSourceCIDRs[0] == oldCfg.Containment.MetricsExposure.AllowedSourceCIDRs[0] {
+		t.Fatal("Containment.MetricsExposure.AllowedSourceCIDRs aliases old config")
 	}
 }
 


### PR DESCRIPTION
## What changed

Preserve follower-local containment settings from the current live configuration when applying a Conductor policy bundle. This keeps valid non-loopback metrics policies active and prevents a concurrent local reload from being replaced by stale state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy bundle reloads so local containment settings, including metrics exposure and allowed sources, remain preserved.
  * Prevented containment metrics from being incorrectly disabled during enforcement-only updates.
  * Improved configuration reload handling to apply updates without losing active runtime state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->