### PR TITLE
feat(playground): add delegated session signing format

### DIFF
--- a/internal/playground/bundle_archive.go
+++ b/internal/playground/bundle_archive.go
@@ -35,6 +35,7 @@ var archiveArtifacts = []struct {
 	required bool
 }{
 	{launchManifestFile, true},
+	{orchestratorDelegationFile, false}, // absent only for legacy direct-root bundles
 	{witnessFile, true},
 	{redWitnessFile, true},
 	{hostContainmentWitnessFile, false},

--- a/internal/playground/bundle_archive_test.go
+++ b/internal/playground/bundle_archive_test.go
@@ -108,6 +108,27 @@ func TestArchiveRunForDownload_IncludesVerifiableArtifacts(t *testing.T) {
 	}
 }
 
+func TestArchiveRunForDownload_RoundTripsOptionalDelegation(t *testing.T) {
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	want := []byte(`{"format":"pipelock-playground-delegation/v1"}`)
+	if err := os.WriteFile(filepath.Join(dir, orchestratorDelegationFile), want, 0o600); err != nil {
+		t.Fatalf("write delegation: %v", err)
+	}
+
+	bundle, err := ArchiveRunForDownload(dir, strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatalf("ArchiveRunForDownload: %v", err)
+	}
+	artifacts, err := ExtractRunArtifactsFromBundle(bundle)
+	if err != nil {
+		t.Fatalf("ExtractRunArtifactsFromBundle: %v", err)
+	}
+	if !bytes.Equal(artifacts.OrchestratorDelegation, want) {
+		t.Fatalf("delegation = %q, want %q", artifacts.OrchestratorDelegation, want)
+	}
+}
+
 func TestArchiveRunForDownload_IncludesContainmentWitnessWhenPresent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/playground/delegation.go
+++ b/internal/playground/delegation.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	OrchestratorDelegationFormat = "pipelock-playground-delegation/v1"
+	delegationDomainSeparator    = "pipelock-playground-delegation-v1\x00"
+)
+
+var (
+	lowerHex64Pattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	lowerHex128Pattern = regexp.MustCompile(`^[0-9a-f]{128}$`)
+	runNoncePattern    = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+)
+
+// OrchestratorDelegation authorizes one short-lived session signing key for
+// exactly one playground run and immutable VM image. The stable root signs this
+// object; the delegated private key signs the launch manifest.
+//
+// INVARIANT: fields stay map-free and declaration-ordered because SignedBytes
+// is a public wire contract.
+type OrchestratorDelegation struct {
+	Format           string `json:"format"`
+	RootKeyID        string `json:"root_key_id"`
+	DelegationID     string `json:"delegation_id"`
+	RunNonce         string `json:"run_nonce"`
+	SessionPublicKey string `json:"session_public_key"`
+	ImageDigest      string `json:"image_digest"`
+	IssuedAtUnix     int64  `json:"issued_at_unix"`
+	NotBeforeUnix    int64  `json:"not_before_unix"`
+	ExpiresAtUnix    int64  `json:"expires_at_unix"`
+	Signature        string `json:"signature,omitempty"`
+}
+
+// DelegationExpectations applies caller-known bounds without weakening the
+// format's intrinsic validation. Zero values mean the caller has no additional
+// expectation for that field.
+type DelegationExpectations struct {
+	RootKeyID   string
+	RunNonce    string
+	ImageDigest string
+	MaxLifetime time.Duration
+}
+
+// RootKeyID returns the stable identifier for an Ed25519 root public key. It
+// reuses the locked, cross-implementation signing.Fingerprint format rather than
+// duplicating it, so the delegation root_key_id can never drift from the
+// fingerprint the rest of pipelock (and the Python verifier) computes. A key of
+// the wrong length has no canonical fingerprint; RootKeyID returns a sentinel
+// that fails the root_key_id claim check rather than a plausible-looking digest.
+func RootKeyID(pub ed25519.PublicKey) string {
+	fp, err := signing.Fingerprint(pub)
+	if err != nil {
+		return "sha256:invalid"
+	}
+	return fp
+}
+
+// SignedBytes returns the exact domain-separated bytes signed by the root.
+func (d OrchestratorDelegation) SignedBytes() []byte {
+	d.Signature = ""
+	b, _ := json.Marshal(d)
+	return append([]byte(delegationDomainSeparator), b...)
+}
+
+// ParseOrchestratorDelegation strictly decodes and validates a delegation's
+// structure and claims. It does NOT authenticate the root signature (it has no
+// key to verify against); a returned delegation is well-formed, not trusted.
+// Callers MUST pass the result to VerifyOrchestratorDelegation with the trusted
+// root key before relying on any field.
+func ParseOrchestratorDelegation(data []byte) (OrchestratorDelegation, error) {
+	var d OrchestratorDelegation
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return OrchestratorDelegation{}, fmt.Errorf("%s is invalid JSON: %w", orchestratorDelegationFile, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&d); err != nil {
+		return OrchestratorDelegation{}, fmt.Errorf("parse %s: %w", orchestratorDelegationFile, err)
+	}
+	if err := ensureDelegationJSONEOF(dec); err != nil {
+		return OrchestratorDelegation{}, err
+	}
+	if err := ValidateOrchestratorDelegationClaims(d, DelegationExpectations{}); err != nil {
+		return OrchestratorDelegation{}, err
+	}
+	if d.Signature == "" {
+		return OrchestratorDelegation{}, fmt.Errorf("delegation signature is required")
+	}
+	return d, nil
+}
+
+func ensureDelegationJSONEOF(dec *json.Decoder) error {
+	var extra any
+	if err := dec.Decode(&extra); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return fmt.Errorf("parse %s trailer: %w", orchestratorDelegationFile, err)
+	}
+	return fmt.Errorf("parse %s: multiple JSON values", orchestratorDelegationFile)
+}
+
+// ValidateOrchestratorDelegationClaims validates intrinsic field constraints
+// plus any broker/verifier expectations supplied by the caller.
+func ValidateOrchestratorDelegationClaims(d OrchestratorDelegation, want DelegationExpectations) error {
+	if d.Format != OrchestratorDelegationFormat {
+		return fmt.Errorf("delegation format %q, want %q", d.Format, OrchestratorDelegationFormat)
+	}
+	if !strings.HasPrefix(d.RootKeyID, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(d.RootKeyID, "sha256:")) {
+		return fmt.Errorf("delegation root_key_id is not canonical sha256")
+	}
+	if !lowerHex64Pattern.MatchString(d.DelegationID) {
+		return fmt.Errorf("delegation_id must be 32-byte lowercase hex")
+	}
+	if !runNoncePattern.MatchString(d.RunNonce) {
+		return fmt.Errorf("delegation run_nonce must be 1-128 URL-safe characters")
+	}
+	if !lowerHex64Pattern.MatchString(d.SessionPublicKey) {
+		return fmt.Errorf("session_public_key must be 32-byte lowercase hex")
+	}
+	if !strings.HasPrefix(d.ImageDigest, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(d.ImageDigest, "sha256:")) {
+		return fmt.Errorf("image_digest must be canonical sha256")
+	}
+	if d.IssuedAtUnix <= 0 || d.NotBeforeUnix <= 0 || d.ExpiresAtUnix <= 0 {
+		return fmt.Errorf("delegation timestamps must be positive Unix seconds")
+	}
+	if d.NotBeforeUnix > d.IssuedAtUnix {
+		return fmt.Errorf("delegation not_before is after issued_at")
+	}
+	if d.IssuedAtUnix >= d.ExpiresAtUnix {
+		return fmt.Errorf("delegation expires_at must be after issued_at")
+	}
+	if want.MaxLifetime > 0 {
+		maxSeconds := int64(want.MaxLifetime / time.Second)
+		if want.MaxLifetime%time.Second != 0 {
+			maxSeconds++
+		}
+		if d.ExpiresAtUnix-d.NotBeforeUnix > maxSeconds {
+			return fmt.Errorf("delegation lifetime exceeds %s", want.MaxLifetime)
+		}
+	}
+	if want.RootKeyID != "" && d.RootKeyID != want.RootKeyID {
+		return fmt.Errorf("delegation root_key_id does not match expected root")
+	}
+	if want.RunNonce != "" && d.RunNonce != want.RunNonce {
+		return fmt.Errorf("delegation run_nonce does not match expected run")
+	}
+	if want.ImageDigest != "" && d.ImageDigest != want.ImageDigest {
+		return fmt.Errorf("delegation image_digest does not match expected image")
+	}
+	if d.Signature != "" && !lowerHex128Pattern.MatchString(d.Signature) {
+		return fmt.Errorf("delegation signature must be 64-byte lowercase hex")
+	}
+	return nil
+}
+
+// SignOrchestratorDelegation signs a validated delegation with the root key.
+func SignOrchestratorDelegation(priv ed25519.PrivateKey, d OrchestratorDelegation) (OrchestratorDelegation, error) {
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return OrchestratorDelegation{}, fmt.Errorf("delegation root key: %w", err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	if err := ValidateOrchestratorDelegationClaims(d, DelegationExpectations{RootKeyID: RootKeyID(pub)}); err != nil {
+		return OrchestratorDelegation{}, err
+	}
+	d.Signature = hex.EncodeToString(ed25519.Sign(priv, d.SignedBytes()))
+	return d, nil
+}
+
+// VerifyOrchestratorDelegation verifies claims and the root signature.
+func VerifyOrchestratorDelegation(pub ed25519.PublicKey, d OrchestratorDelegation, want DelegationExpectations) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("delegation root public key has wrong size")
+	}
+	want.RootKeyID = RootKeyID(pub)
+	if err := ValidateOrchestratorDelegationClaims(d, want); err != nil {
+		return err
+	}
+	sig, err := hex.DecodeString(d.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize || !ed25519.Verify(pub, d.SignedBytes(), sig) {
+		return fmt.Errorf("delegation signature invalid under root key")
+	}
+	return nil
+}
+
+// DelegationBindsLaunchManifest reports whether a delegated manifest repeats
+// the exact run, delegation, and immutable image authorized by the root.
+func DelegationBindsLaunchManifest(d OrchestratorDelegation, lm LaunchManifest) bool {
+	return d.RunNonce != "" &&
+		d.DelegationID != "" &&
+		d.ImageDigest != "" &&
+		lm.RunNonce == d.RunNonce &&
+		lm.DelegationID == d.DelegationID &&
+		lm.ImageDigest == d.ImageDigest
+}

--- a/internal/playground/delegation.go
+++ b/internal/playground/delegation.go
@@ -186,6 +186,10 @@ func SignOrchestratorDelegation(priv ed25519.PrivateKey, d OrchestratorDelegatio
 
 // VerifyOrchestratorDelegation verifies claims and the root signature.
 func VerifyOrchestratorDelegation(pub ed25519.PublicKey, d OrchestratorDelegation, want DelegationExpectations) error {
+	return verifyOrchestratorDelegationAt(pub, d, want, time.Now().UTC())
+}
+
+func verifyOrchestratorDelegationAt(pub ed25519.PublicKey, d OrchestratorDelegation, want DelegationExpectations, now time.Time) error {
 	if len(pub) != ed25519.PublicKeySize {
 		return fmt.Errorf("delegation root public key has wrong size")
 	}
@@ -196,6 +200,13 @@ func VerifyOrchestratorDelegation(pub ed25519.PublicKey, d OrchestratorDelegatio
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil || len(sig) != ed25519.SignatureSize || !ed25519.Verify(pub, d.SignedBytes(), sig) {
 		return fmt.Errorf("delegation signature invalid under root key")
+	}
+	nowUnix := now.Unix()
+	if nowUnix < d.NotBeforeUnix {
+		return fmt.Errorf("delegation is not valid yet")
+	}
+	if nowUnix >= d.ExpiresAtUnix {
+		return fmt.Errorf("delegation has expired")
 	}
 	return nil
 }

--- a/internal/playground/delegation_test.go
+++ b/internal/playground/delegation_test.go
@@ -69,9 +69,19 @@ func TestOrchestratorDelegationSignParseVerifyAndBind(t *testing.T) {
 	if !DelegationBindsLaunchManifest(parsed, lm) {
 		t.Fatal("delegation did not bind matching manifest")
 	}
-	lm.ImageDigest = "sha256:" + strings.Repeat("4", 64)
-	if DelegationBindsLaunchManifest(parsed, lm) {
-		t.Fatal("delegation bound manifest with wrong image")
+	mutations := map[string]func(*LaunchManifest){
+		"run nonce":     func(m *LaunchManifest) { m.RunNonce = "run-2" },
+		"delegation id": func(m *LaunchManifest) { m.DelegationID = strings.Repeat("b", 64) },
+		"image digest":  func(m *LaunchManifest) { m.ImageDigest = "sha256:" + strings.Repeat("4", 64) },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			mismatched := lm
+			mutate(&mismatched)
+			if DelegationBindsLaunchManifest(parsed, mismatched) {
+				t.Fatalf("delegation bound manifest with wrong %s", name)
+			}
+		})
 	}
 	if DelegationBindsLaunchManifest(OrchestratorDelegation{}, LaunchManifest{}) {
 		t.Fatal("empty delegation bound empty manifest")

--- a/internal/playground/delegation_test.go
+++ b/internal/playground/delegation_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func delegationTestKey(fill byte) (ed25519.PublicKey, ed25519.PrivateKey) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = fill
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	return priv.Public().(ed25519.PublicKey), priv
+}
+
+func validDelegation(pub ed25519.PublicKey) OrchestratorDelegation {
+	return OrchestratorDelegation{
+		Format:           OrchestratorDelegationFormat,
+		RootKeyID:        RootKeyID(pub),
+		DelegationID:     strings.Repeat("a", 64),
+		RunNonce:         "run-1",
+		SessionPublicKey: strings.Repeat("2", 64),
+		ImageDigest:      "sha256:" + strings.Repeat("3", 64),
+		IssuedAtUnix:     1_800_000_010,
+		NotBeforeUnix:    1_800_000_000,
+		ExpiresAtUnix:    1_800_001_800,
+	}
+}
+
+func TestOrchestratorDelegationSignParseVerifyAndBind(t *testing.T) {
+	rootPub, rootPriv := delegationTestKey(0x41)
+	sessionPub, _ := delegationTestKey(0x42)
+	d := validDelegation(rootPub)
+	d.SessionPublicKey = hex.EncodeToString(sessionPub)
+
+	signed, err := SignOrchestratorDelegation(rootPriv, d)
+	if err != nil {
+		t.Fatalf("SignOrchestratorDelegation: %v", err)
+	}
+	raw, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	parsed, err := ParseOrchestratorDelegation(raw)
+	if err != nil {
+		t.Fatalf("ParseOrchestratorDelegation: %v", err)
+	}
+	want := DelegationExpectations{
+		RunNonce:    d.RunNonce,
+		ImageDigest: d.ImageDigest,
+		MaxLifetime: 31 * time.Minute,
+	}
+	if err := VerifyOrchestratorDelegation(rootPub, parsed, want); err != nil {
+		t.Fatalf("VerifyOrchestratorDelegation: %v", err)
+	}
+	lm := LaunchManifest{RunNonce: d.RunNonce, DelegationID: d.DelegationID, ImageDigest: d.ImageDigest}
+	if !DelegationBindsLaunchManifest(parsed, lm) {
+		t.Fatal("delegation did not bind matching manifest")
+	}
+	lm.ImageDigest = "sha256:" + strings.Repeat("4", 64)
+	if DelegationBindsLaunchManifest(parsed, lm) {
+		t.Fatal("delegation bound manifest with wrong image")
+	}
+	if DelegationBindsLaunchManifest(OrchestratorDelegation{}, LaunchManifest{}) {
+		t.Fatal("empty delegation bound empty manifest")
+	}
+}
+
+func TestOrchestratorDelegationCanonicalBytes(t *testing.T) {
+	pub, _ := delegationTestKey(0x41)
+	d := validDelegation(pub)
+	wantJSON := `{"format":"pipelock-playground-delegation/v1","root_key_id":"` + d.RootKeyID + `","delegation_id":"` + strings.Repeat("a", 64) + `","run_nonce":"run-1","session_public_key":"` + strings.Repeat("2", 64) + `","image_digest":"sha256:` + strings.Repeat("3", 64) + `","issued_at_unix":1800000010,"not_before_unix":1800000000,"expires_at_unix":1800001800}`
+	want := delegationDomainSeparator + wantJSON
+	if got := string(d.SignedBytes()); got != want {
+		t.Fatalf("SignedBytes changed\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func TestOrchestratorDelegationRejectsMutationAndWrongScope(t *testing.T) {
+	rootPub, rootPriv := delegationTestKey(0x41)
+	otherPub, _ := delegationTestKey(0x43)
+	signed, err := SignOrchestratorDelegation(rootPriv, validDelegation(rootPub))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mutations := map[string]func(*OrchestratorDelegation){
+		"format":        func(d *OrchestratorDelegation) { d.Format += "-other" },
+		"root key":      func(d *OrchestratorDelegation) { d.RootKeyID = RootKeyID(otherPub) },
+		"delegation id": func(d *OrchestratorDelegation) { d.DelegationID = strings.Repeat("4", 64) },
+		"run nonce":     func(d *OrchestratorDelegation) { d.RunNonce = "run-2" },
+		"session key":   func(d *OrchestratorDelegation) { d.SessionPublicKey = strings.Repeat("5", 64) },
+		"image":         func(d *OrchestratorDelegation) { d.ImageDigest = "sha256:" + strings.Repeat("6", 64) },
+		"issued":        func(d *OrchestratorDelegation) { d.IssuedAtUnix++ },
+		"not before":    func(d *OrchestratorDelegation) { d.NotBeforeUnix-- },
+		"expires":       func(d *OrchestratorDelegation) { d.ExpiresAtUnix++ },
+		"signature":     func(d *OrchestratorDelegation) { d.Signature = strings.Repeat("0", 128) },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			got := signed
+			mutate(&got)
+			if err := VerifyOrchestratorDelegation(rootPub, got, DelegationExpectations{}); err == nil {
+				t.Fatal("mutated delegation verified")
+			}
+		})
+	}
+	if err := VerifyOrchestratorDelegation(rootPub, signed, DelegationExpectations{RunNonce: "other"}); err == nil {
+		t.Fatal("wrong expected run verified")
+	}
+	if err := VerifyOrchestratorDelegation(rootPub, signed, DelegationExpectations{ImageDigest: "sha256:" + strings.Repeat("7", 64)}); err == nil {
+		t.Fatal("wrong expected image verified")
+	}
+}
+
+func TestParseOrchestratorDelegationStrictJSONAndClaims(t *testing.T) {
+	pub, priv := delegationTestKey(0x41)
+	signed, err := SignOrchestratorDelegation(priv, validDelegation(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(signed)
+
+	cases := map[string][]byte{
+		"unknown field":   []byte(strings.TrimSuffix(string(raw), "}") + `,"extra":true}`),
+		"duplicate field": []byte(strings.Replace(string(raw), `"format":`, `"format":"duplicate","format":`, 1)),
+		"second value":    append(append([]byte{}, raw...), []byte(` {}`)...),
+		"invalid trailer": append(append([]byte{}, raw...), []byte(` x`)...),
+		"uppercase id":    []byte(strings.Replace(string(raw), signed.DelegationID, strings.ToUpper(signed.DelegationID), 1)),
+		"empty nonce":     []byte(strings.Replace(string(raw), `"run_nonce":"run-1"`, `"run_nonce":""`, 1)),
+		"unsafe nonce":    []byte(strings.Replace(string(raw), `"run_nonce":"run-1"`, `"run_nonce":"run/../1"`, 1)),
+		"missing signature": func() []byte {
+			unsigned := signed
+			unsigned.Signature = ""
+			out, _ := json.Marshal(unsigned)
+			return out
+		}(),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseOrchestratorDelegation(input); err == nil {
+				t.Fatal("ParseOrchestratorDelegation accepted invalid input")
+			}
+		})
+	}
+
+	tooLong := signed
+	tooLong.ExpiresAtUnix = tooLong.NotBeforeUnix + int64((2 * time.Hour).Seconds())
+	tooLong.Signature = ""
+	tooLong, err = SignOrchestratorDelegation(priv, tooLong)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyOrchestratorDelegation(pub, tooLong, DelegationExpectations{MaxLifetime: time.Hour}); err == nil {
+		t.Fatal("delegation exceeding caller lifetime verified")
+	}
+	overflow := signed
+	overflow.ExpiresAtUnix = int64(^uint64(0) >> 1)
+	overflow.Signature = ""
+	overflow, err = SignOrchestratorDelegation(priv, overflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyOrchestratorDelegation(pub, overflow, DelegationExpectations{MaxLifetime: time.Hour}); err == nil {
+		t.Fatal("overflow-sized delegation lifetime verified")
+	}
+	zeroWindow := signed
+	zeroWindow.ExpiresAtUnix = zeroWindow.IssuedAtUnix
+	zeroWindow.Signature = ""
+	if _, err := SignOrchestratorDelegation(priv, zeroWindow); err == nil {
+		t.Fatal("zero-window delegation was signed")
+	}
+}
+
+func TestOrchestratorDelegationRejectsInvalidClaimClasses(t *testing.T) {
+	pub, _ := delegationTestKey(0x41)
+	base := validDelegation(pub)
+	cases := map[string]func(*OrchestratorDelegation){
+		"root key id":  func(d *OrchestratorDelegation) { d.RootKeyID = "sha256:bad" },
+		"session key":  func(d *OrchestratorDelegation) { d.SessionPublicKey = "bad" },
+		"image digest": func(d *OrchestratorDelegation) { d.ImageDigest = "sha256:bad" },
+		"timestamp":    func(d *OrchestratorDelegation) { d.IssuedAtUnix = 0 },
+		"not before":   func(d *OrchestratorDelegation) { d.NotBeforeUnix = d.IssuedAtUnix + 1 },
+		"signature":    func(d *OrchestratorDelegation) { d.Signature = "bad" },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := base
+			mutate(&d)
+			if err := ValidateOrchestratorDelegationClaims(d, DelegationExpectations{}); err == nil {
+				t.Fatal("invalid delegation claim was accepted")
+			}
+		})
+	}
+
+	if got := RootKeyID(ed25519.PublicKey("short")); got != "sha256:invalid" {
+		t.Fatalf("invalid root key ID = %q", got)
+	}
+	if _, err := SignOrchestratorDelegation(ed25519.PrivateKey("short"), base); err == nil {
+		t.Fatal("invalid root private key was accepted")
+	}
+	if err := VerifyOrchestratorDelegation(ed25519.PublicKey("short"), base, DelegationExpectations{}); err == nil {
+		t.Fatal("invalid root public key was accepted")
+	}
+
+	ceil := base
+	ceil.NotBeforeUnix = 100
+	ceil.IssuedAtUnix = 100
+	ceil.ExpiresAtUnix = 102
+	if err := ValidateOrchestratorDelegationClaims(ceil, DelegationExpectations{MaxLifetime: 1500 * time.Millisecond}); err != nil {
+		t.Fatalf("subsecond max lifetime was not rounded up: %v", err)
+	}
+}
+
+func TestLegacyLaunchManifestCanonicalBytesRemainStable(t *testing.T) {
+	lm := LaunchManifest{
+		RunNonce:              "legacy-run",
+		ScenarioID:            "exfil-canary",
+		CanaryID:              "canary",
+		PipelockPubKey:        "pipe",
+		CollectorPubKey:       "collector",
+		PolicyHash:            "policy",
+		CollectorConfigDigest: "collector-config",
+		TargetHost:            "collector.test",
+		StartedAt:             time.Date(2026, time.June, 16, 12, 0, 0, 0, time.UTC),
+		Contained:             true,
+		AgentKind:             AgentKindModel,
+	}
+	want := `{"run_nonce":"legacy-run","scenario_id":"exfil-canary","canary_id":"canary","pipelock_pubkey":"pipe","collector_pubkey":"collector","policy_hash":"policy","collector_config_digest":"collector-config","target_host":"collector.test","started_at":"2026-06-16T12:00:00Z","contained":true,"agent_kind":"model"}`
+	if got := string(canonicalLaunchManifestBytes(lm)); got != want {
+		t.Fatalf("legacy canonical bytes changed\ngot:  %s\nwant: %s", got, want)
+	}
+	_, priv := delegationTestKey(0x44)
+	signed := SignLaunchManifest(priv, lm)
+	if !VerifyLaunchManifest(priv.Public().(ed25519.PublicKey), signed) {
+		t.Fatal("legacy launch manifest signature no longer verifies")
+	}
+}

--- a/internal/playground/delegation_test.go
+++ b/internal/playground/delegation_test.go
@@ -35,6 +35,10 @@ func validDelegation(pub ed25519.PublicKey) OrchestratorDelegation {
 	}
 }
 
+func delegationTestNow() time.Time {
+	return time.Unix(1_800_000_020, 0).UTC()
+}
+
 func TestOrchestratorDelegationSignParseVerifyAndBind(t *testing.T) {
 	rootPub, rootPriv := delegationTestKey(0x41)
 	sessionPub, _ := delegationTestKey(0x42)
@@ -58,7 +62,7 @@ func TestOrchestratorDelegationSignParseVerifyAndBind(t *testing.T) {
 		ImageDigest: d.ImageDigest,
 		MaxLifetime: 31 * time.Minute,
 	}
-	if err := VerifyOrchestratorDelegation(rootPub, parsed, want); err != nil {
+	if err := verifyOrchestratorDelegationAt(rootPub, parsed, want, delegationTestNow()); err != nil {
 		t.Fatalf("VerifyOrchestratorDelegation: %v", err)
 	}
 	lm := LaunchManifest{RunNonce: d.RunNonce, DelegationID: d.DelegationID, ImageDigest: d.ImageDigest}
@@ -108,16 +112,36 @@ func TestOrchestratorDelegationRejectsMutationAndWrongScope(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := signed
 			mutate(&got)
-			if err := VerifyOrchestratorDelegation(rootPub, got, DelegationExpectations{}); err == nil {
+			if err := verifyOrchestratorDelegationAt(rootPub, got, DelegationExpectations{}, delegationTestNow()); err == nil {
 				t.Fatal("mutated delegation verified")
 			}
 		})
 	}
-	if err := VerifyOrchestratorDelegation(rootPub, signed, DelegationExpectations{RunNonce: "other"}); err == nil {
+	if err := verifyOrchestratorDelegationAt(rootPub, signed, DelegationExpectations{RunNonce: "other"}, delegationTestNow()); err == nil {
 		t.Fatal("wrong expected run verified")
 	}
-	if err := VerifyOrchestratorDelegation(rootPub, signed, DelegationExpectations{ImageDigest: "sha256:" + strings.Repeat("7", 64)}); err == nil {
+	if err := verifyOrchestratorDelegationAt(rootPub, signed, DelegationExpectations{ImageDigest: "sha256:" + strings.Repeat("7", 64)}, delegationTestNow()); err == nil {
 		t.Fatal("wrong expected image verified")
+	}
+}
+
+func TestOrchestratorDelegationValidityWindow(t *testing.T) {
+	pub, priv := delegationTestKey(0x41)
+	signed, err := SignOrchestratorDelegation(priv, validDelegation(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyOrchestratorDelegationAt(pub, signed, DelegationExpectations{}, time.Unix(signed.NotBeforeUnix-1, 0)); err == nil {
+		t.Fatal("delegation verified before not_before")
+	}
+	if err := verifyOrchestratorDelegationAt(pub, signed, DelegationExpectations{}, time.Unix(signed.NotBeforeUnix, 0)); err != nil {
+		t.Fatalf("delegation rejected at not_before: %v", err)
+	}
+	if err := verifyOrchestratorDelegationAt(pub, signed, DelegationExpectations{}, time.Unix(signed.ExpiresAtUnix-1, 0)); err != nil {
+		t.Fatalf("delegation rejected before expiry: %v", err)
+	}
+	if err := verifyOrchestratorDelegationAt(pub, signed, DelegationExpectations{}, time.Unix(signed.ExpiresAtUnix, 0)); err == nil {
+		t.Fatal("delegation verified at expiry")
 	}
 }
 
@@ -159,7 +183,7 @@ func TestParseOrchestratorDelegationStrictJSONAndClaims(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := VerifyOrchestratorDelegation(pub, tooLong, DelegationExpectations{MaxLifetime: time.Hour}); err == nil {
+	if err := verifyOrchestratorDelegationAt(pub, tooLong, DelegationExpectations{MaxLifetime: time.Hour}, delegationTestNow()); err == nil {
 		t.Fatal("delegation exceeding caller lifetime verified")
 	}
 	overflow := signed
@@ -169,7 +193,7 @@ func TestParseOrchestratorDelegationStrictJSONAndClaims(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := VerifyOrchestratorDelegation(pub, overflow, DelegationExpectations{MaxLifetime: time.Hour}); err == nil {
+	if err := verifyOrchestratorDelegationAt(pub, overflow, DelegationExpectations{MaxLifetime: time.Hour}, delegationTestNow()); err == nil {
 		t.Fatal("overflow-sized delegation lifetime verified")
 	}
 	zeroWindow := signed
@@ -242,5 +266,15 @@ func TestLegacyLaunchManifestCanonicalBytesRemainStable(t *testing.T) {
 	signed := SignLaunchManifest(priv, lm)
 	if !VerifyLaunchManifest(priv.Public().(ed25519.PublicKey), signed) {
 		t.Fatal("legacy launch manifest signature no longer verifies")
+	}
+	withDelegationID := signed
+	withDelegationID.DelegationID = strings.Repeat("a", 64)
+	if VerifyLaunchManifest(priv.Public().(ed25519.PublicKey), withDelegationID) {
+		t.Fatal("launch manifest verified after delegation_id mutation")
+	}
+	withImageDigest := signed
+	withImageDigest.ImageDigest = "sha256:" + strings.Repeat("b", 64)
+	if VerifyLaunchManifest(priv.Public().(ed25519.PublicKey), withImageDigest) {
+		t.Fatal("launch manifest verified after image_digest mutation")
 	}
 }

--- a/internal/playground/types.go
+++ b/internal/playground/types.go
@@ -40,7 +40,12 @@ type LaunchManifest struct {
 	// deterministic one. Covered by the manifest signature, so it cannot be
 	// flipped to dodge the stricter check.
 	AgentKind string `json:"agent_kind,omitempty"`
-	Signature string `json:"signature,omitempty"`
+	// DelegationID and ImageDigest bind delegated manifests to the root-signed
+	// session authorization. They remain absent from legacy manifests so the
+	// legacy canonical signed bytes stay byte-identical.
+	DelegationID string `json:"delegation_id,omitempty"`
+	ImageDigest  string `json:"image_digest,omitempty"`
+	Signature    string `json:"signature,omitempty"`
 }
 
 // Agent kinds recorded in LaunchManifest.AgentKind. Empty is treated as

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -59,6 +59,7 @@ const (
 	hostContainmentWitnessFile = "host-containment-witness.json"
 	verifyInstructionsFile     = "VERIFY.txt"
 	checkManifestSig           = "launch-manifest-signature"
+	checkDelegation            = "orchestrator-delegation"
 	checkPinnedPipelock        = "pinned-pipelock-key"
 	checkAuditPacket           = "audit-packet-chain"
 	checkPinnedCollector       = "pinned-collector-key"
@@ -81,6 +82,7 @@ const (
 // cannot silently produce OK=true.
 var requiredChecks = []string{
 	checkManifestSig,
+	checkDelegation,
 	checkPinnedPipelock,
 	checkAuditPacket,
 	checkPinnedCollector,
@@ -362,7 +364,7 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 		return finalize(rep, required), nil
 	}
 
-	// --- Step 1: Verify launch manifest signature under orchestrator key ---
+	// --- Step 1: Select and authenticate the launch-manifest signer ---
 
 	orchPub, err := hex.DecodeString(orchestratorPubHex)
 	if err != nil || len(orchPub) != ed25519.PublicKeySize {
@@ -373,11 +375,65 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 		})
 		return finalize(rep, required), nil
 	}
-	if !VerifyLaunchManifest(ed25519.PublicKey(orchPub), lm) {
+	manifestPub := ed25519.PublicKey(orchPub)
+	if len(artifacts.OrchestratorDelegation) == 0 {
+		if lm.DelegationID != "" || lm.ImageDigest != "" {
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkDelegation,
+				OK:     false,
+				Reason: "manifest claims delegated signing but orchestrator-delegation.json is missing",
+			})
+			return finalize(rep, required), nil
+		}
+		rep.Checks = append(rep.Checks, Check{
+			Name:   checkDelegation,
+			OK:     true,
+			Reason: "legacy direct-root manifest",
+		})
+	} else {
+		delegation, parseErr := ParseOrchestratorDelegation(artifacts.OrchestratorDelegation)
+		if parseErr != nil {
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkDelegation,
+				OK:     false,
+				Reason: fmt.Sprintf("invalid orchestrator delegation: %v", parseErr),
+			})
+			return finalize(rep, required), nil
+		}
+		want := DelegationExpectations{RunNonce: lm.RunNonce, ImageDigest: lm.ImageDigest}
+		if verifyErr := VerifyOrchestratorDelegation(ed25519.PublicKey(orchPub), delegation, want); verifyErr != nil {
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkDelegation,
+				OK:     false,
+				Reason: fmt.Sprintf("orchestrator delegation verification failed: %v", verifyErr),
+			})
+			return finalize(rep, required), nil
+		}
+		if !DelegationBindsLaunchManifest(delegation, lm) {
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkDelegation,
+				OK:     false,
+				Reason: "orchestrator delegation does not bind the launch manifest",
+			})
+			return finalize(rep, required), nil
+		}
+		sessionPub, decodeErr := hex.DecodeString(delegation.SessionPublicKey)
+		if decodeErr != nil || len(sessionPub) != ed25519.PublicKeySize {
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkDelegation,
+				OK:     false,
+				Reason: "orchestrator delegation carries an invalid session public key",
+			})
+			return finalize(rep, required), nil
+		}
+		manifestPub = ed25519.PublicKey(sessionPub)
+		rep.Checks = append(rep.Checks, Check{Name: checkDelegation, OK: true})
+	}
+	if !VerifyLaunchManifest(manifestPub, lm) {
 		rep.Checks = append(rep.Checks, Check{
 			Name:   checkManifestSig,
 			OK:     false,
-			Reason: "launch manifest signature invalid under orchestrator key",
+			Reason: "launch manifest signature invalid under authenticated signing key",
 		})
 		return finalize(rep, required), nil
 	}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -53,6 +53,7 @@ type VerifyReport struct {
 const (
 	packetSubdir               = "packet"
 	launchManifestFile         = "launch-manifest.json"
+	orchestratorDelegationFile = "orchestrator-delegation.json"
 	witnessFile                = "witness.json"
 	redWitnessFile             = "red-witness.json"
 	hostContainmentWitnessFile = "host-containment-witness.json"
@@ -103,6 +104,7 @@ var containmentChecks = []string{
 // files inside a run directory and inside the downloadable tar.gz bundle.
 type RunArtifacts struct {
 	LaunchManifest         []byte
+	OrchestratorDelegation []byte
 	Witness                []byte
 	RedWitness             []byte
 	HostContainmentWitness []byte
@@ -182,6 +184,8 @@ func ExtractRunArtifactsFromBundle(bundle []byte) (RunArtifacts, error) {
 		switch name {
 		case launchManifestFile:
 			artifacts.LaunchManifest = data
+		case orchestratorDelegationFile:
+			artifacts.OrchestratorDelegation = data
 		case witnessFile:
 			artifacts.Witness = data
 		case redWitnessFile:
@@ -215,6 +219,7 @@ func bundleArtifactName(raw string, typeflag byte) (name string, retain bool, er
 	case verifyInstructionsFile:
 		return name, false, nil
 	case launchManifestFile,
+		orchestratorDelegationFile,
 		witnessFile,
 		redWitnessFile,
 		hostContainmentWitnessFile,
@@ -264,6 +269,9 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 	var artifacts RunArtifacts
 	var err error
 	if artifacts.LaunchManifest, err = readRunArtifact(cleanDir, launchManifestFile); err != nil {
+		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
+	}
+	if artifacts.OrchestratorDelegation, err = readRunArtifact(cleanDir, orchestratorDelegationFile); err != nil {
 		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
 	}
 	if artifacts.Witness, err = readRunArtifact(cleanDir, witnessFile); err != nil {

--- a/internal/playground/verify_hardening_failure_paths_test.go
+++ b/internal/playground/verify_hardening_failure_paths_test.go
@@ -63,6 +63,7 @@ func TestHardeningVerifyRunPreservesEveryArtifactReadFailure(t *testing.T) {
 
 	names := []string{
 		launchManifestFile,
+		orchestratorDelegationFile,
 		witnessFile,
 		redWitnessFile,
 		hostContainmentWitnessFile,

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -80,6 +80,7 @@ var verifyKitRequiredFiles = []string{
 // fail the kit build.
 var verifyKitOptionalFiles = []string{
 	hostContainmentWitnessFile,
+	orchestratorDelegationFile,
 	"VERIFY.txt",
 }
 

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -285,15 +285,17 @@ func TestVerify_AllGood_Passes(t *testing.T) {
 		}
 		t.Fatalf("good run must pass: OK=false")
 	}
-	// Every check must have passed. 8 required checks in the full chain.
-	const expectedChecks = 8
-	if len(rep.Checks) < expectedChecks {
-		t.Fatalf("expected at least %d checks, got %d", expectedChecks, len(rep.Checks))
-	}
+	delegationChecked := false
 	for _, c := range rep.Checks {
 		if !c.OK {
 			t.Fatalf("check %q failed: %s", c.Name, c.Reason)
 		}
+		if c.Name == "orchestrator-delegation" {
+			delegationChecked = true
+		}
+	}
+	if !delegationChecked {
+		t.Fatal("verification report omitted orchestrator-delegation check")
 	}
 }
 
@@ -335,6 +337,33 @@ func TestVerify_DelegationFailuresFailClosed(t *testing.T) {
 		}
 		if rep.OK {
 			t.Fatal("malformed delegation artifact passed")
+		}
+	})
+	t.Run("invalid signature", func(t *testing.T) {
+		dir, orchPubHex, _ := buildDelegatedRunDir(t)
+		path := filepath.Join(dir, "orchestrator-delegation.json")
+		raw, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		delegation, err := playground.ParseOrchestratorDelegation(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delegation.Signature = strings.Repeat("0", ed25519.SignatureSize*2)
+		raw, err = json.Marshal(delegation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rep, err := playground.VerifyRun(dir, orchPubHex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rep.OK {
+			t.Fatal("delegation with invalid signature passed")
 		}
 	})
 	t.Run("mismatched image", func(t *testing.T) {

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -57,6 +57,14 @@ func goodRunDir(t *testing.T) (string, string) {
 // run-bound, enforced host-containment-witness.json signed by the orchestrator
 // key. It returns the orchestrator private key so callers can re-sign or tamper.
 func buildRunDir(t *testing.T, contained bool) (string, string, ed25519.PrivateKey) {
+	return buildRunDirMode(t, contained, false)
+}
+
+func buildDelegatedRunDir(t *testing.T) (string, string, ed25519.PrivateKey) {
+	return buildRunDirMode(t, false, true)
+}
+
+func buildRunDirMode(t *testing.T, contained, delegated bool) (string, string, ed25519.PrivateKey) {
 	t.Helper()
 
 	// 1. Generate keys.
@@ -122,7 +130,34 @@ func buildRunDir(t *testing.T, contained bool) (string, string, ed25519.PrivateK
 		StartedAt:       time.Now().UTC(),
 		Contained:       contained,
 	}
-	lm = playground.SignLaunchManifest(orchPriv, lm)
+	var delegationBytes []byte
+	if delegated {
+		sessionPub, sessionPriv := testGenKey(t)
+		lm.DelegationID = strings.Repeat("a", 64)
+		lm.ImageDigest = "sha256:" + strings.Repeat("b", 64)
+		now := time.Now().UTC()
+		delegation, signErr := playground.SignOrchestratorDelegation(orchPriv, playground.OrchestratorDelegation{
+			Format:           playground.OrchestratorDelegationFormat,
+			RootKeyID:        playground.RootKeyID(orchPub),
+			DelegationID:     lm.DelegationID,
+			RunNonce:         lm.RunNonce,
+			SessionPublicKey: hex.EncodeToString(sessionPub),
+			ImageDigest:      lm.ImageDigest,
+			IssuedAtUnix:     now.Unix(),
+			NotBeforeUnix:    now.Add(-time.Minute).Unix(),
+			ExpiresAtUnix:    now.Add(time.Hour).Unix(),
+		})
+		if signErr != nil {
+			t.Fatalf("SignOrchestratorDelegation: %v", signErr)
+		}
+		delegationBytes, err = json.Marshal(delegation)
+		if err != nil {
+			t.Fatalf("marshal delegation: %v", err)
+		}
+		lm = playground.SignLaunchManifest(sessionPriv, lm)
+	} else {
+		lm = playground.SignLaunchManifest(orchPriv, lm)
+	}
 
 	// 5. Run red-case calibration.
 	ctx := context.Background()
@@ -153,6 +188,11 @@ func buildRunDir(t *testing.T, contained bool) (string, string, ed25519.PrivateK
 	}
 	if err := os.WriteFile(filepath.Join(runDir, "launch-manifest.json"), lmBytes, 0o600); err != nil {
 		t.Fatalf("write manifest: %v", err)
+	}
+	if len(delegationBytes) > 0 {
+		if err := os.WriteFile(filepath.Join(runDir, "orchestrator-delegation.json"), delegationBytes, 0o600); err != nil {
+			t.Fatalf("write delegation: %v", err)
+		}
 	}
 
 	wBytes, err := json.Marshal(witness)
@@ -255,6 +295,80 @@ func TestVerify_AllGood_Passes(t *testing.T) {
 			t.Fatalf("check %q failed: %s", c.Name, c.Reason)
 		}
 	}
+}
+
+func TestVerify_DelegatedGood_Passes(t *testing.T) {
+	t.Parallel()
+	dir, orchPubHex, _ := buildDelegatedRunDir(t)
+	rep, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.OK {
+		t.Fatalf("delegated run must pass: %+v", rep.Checks)
+	}
+}
+
+func TestVerify_DelegationFailuresFailClosed(t *testing.T) {
+	t.Parallel()
+	t.Run("missing", func(t *testing.T) {
+		dir, orchPubHex, _ := buildDelegatedRunDir(t)
+		if err := os.Remove(filepath.Join(dir, "orchestrator-delegation.json")); err != nil {
+			t.Fatal(err)
+		}
+		rep, err := playground.VerifyRun(dir, orchPubHex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rep.OK {
+			t.Fatal("delegated manifest passed without delegation artifact")
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		dir, orchPubHex, _ := buildDelegatedRunDir(t)
+		if err := os.WriteFile(filepath.Join(dir, "orchestrator-delegation.json"), []byte(`{"bad":true}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rep, err := playground.VerifyRun(dir, orchPubHex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rep.OK {
+			t.Fatal("malformed delegation artifact passed")
+		}
+	})
+	t.Run("mismatched image", func(t *testing.T) {
+		dir, orchPubHex, orchPriv := buildDelegatedRunDir(t)
+		path := filepath.Join(dir, "orchestrator-delegation.json")
+		raw, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		delegation, err := playground.ParseOrchestratorDelegation(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delegation.ImageDigest = "sha256:" + strings.Repeat("c", 64)
+		delegation.Signature = ""
+		delegation, err = playground.SignOrchestratorDelegation(orchPriv, delegation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err = json.Marshal(delegation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rep, err := playground.VerifyRun(dir, orchPubHex)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rep.OK {
+			t.Fatal("delegation bound to the wrong image passed")
+		}
+	})
 }
 
 func TestVerifyRun_PreservesArtifactReadError(t *testing.T) {


### PR DESCRIPTION
## What changed

- Define strict root-signed delegation primitives that bind a session key to one run and immutable image; malformed, mismatched, or invalidly signed delegations are rejected.
- Carry optional delegation artifacts through archives and verification kits while preserving legacy manifest canonical bytes and signatures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional orchestrator delegation artifacts in downloadable bundles and verification kits.
  * Added signed delegation metadata binding a run, session key, and VM image to its launch manifest.
  * Added delegation and image details to launch manifests while preserving compatibility with legacy manifests.

* **Bug Fixes**
  * Improved verification to authenticate delegated manifests and reject missing, malformed, mismatched, or invalid delegation data.
  * Ensured delegation artifacts are preserved during archive extraction and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->