### PR TITLE
fix: verify persisted containment rules

### DIFF
--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -1119,7 +1119,7 @@ func probeNFTContainment(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, fmt.Sprintf("chain %s is not the managed output base chain (want type filter hook output priority filter/0 policy accept)", env.nftChain)
 	}
 	if env.nftPersistUnitPath != "" && env.nftRulesPath != "" {
-		if err := verifyNFTPersistence(env); err != nil {
+		if err := verifyNFTPersistence(env, current); err != nil {
 			return statusFail, err.Error()
 		}
 	}
@@ -1236,7 +1236,7 @@ func parseNFTRulesHeaderUIDs(data []byte) (nftRulesHeaderUIDs, bool, error) {
 	return nftRulesHeaderUIDs{}, false, nil
 }
 
-func verifyNFTPersistence(env *probeEnv) error {
+func verifyNFTPersistence(env *probeEnv, current containmentUIDs) error {
 	data, err := env.readFile(env.nftPersistUnitPath)
 	if err != nil {
 		return fmt.Errorf("read nftables persistence unit %s: %w", env.nftPersistUnitPath, err)
@@ -1244,6 +1244,30 @@ func verifyNFTPersistence(env *probeEnv) error {
 	body := string(data)
 	if !execStartLineContains(body, env.nftRulesPath) {
 		return fmt.Errorf("%s missing ExecStart for %s", env.nftPersistUnitPath, env.nftRulesPath)
+	}
+	rules, err := env.readFile(env.nftRulesPath)
+	if err != nil {
+		return fmt.Errorf("read persisted nftables rules file %s: %w", env.nftRulesPath, err)
+	}
+	if !current.operatorKnown {
+		return fmt.Errorf("persisted nftables rules file %s is missing the managed operator uid header", env.nftRulesPath)
+	}
+	operatorUID := current.operatorUID
+	if env.operatorUser != "" {
+		operatorUID, err = lookupUID(env.lookupUser, env.operatorUser)
+		if err != nil {
+			return fmt.Errorf("lookup operator uid %s: %w", env.operatorUser, err)
+		}
+		if operatorUID == current.agentUID {
+			return fmt.Errorf("%s and %s both resolve to uid %d; contained agent must not be allow-listed", env.operatorUser, env.agentUserName, current.agentUID)
+		}
+		if current.operatorUID != operatorUID {
+			return fmt.Errorf("nftables rules file operator uid %d does not match current %s uid %d", current.operatorUID, env.operatorUser, operatorUID)
+		}
+	}
+	want := renderNFTRules(operatorUID, current.proxyUID, current.agentUID, env.port, env.nftTable, env.nftChain)
+	if string(rules) != want {
+		return fmt.Errorf("persisted nftables rules file %s does not match the canonical containment boundary; rerun pipelock contain install before reboot", env.nftRulesPath)
 	}
 	return nil
 }

--- a/internal/cli/contain/verify_lifecycle_failures_test.go
+++ b/internal/cli/contain/verify_lifecycle_failures_test.go
@@ -804,8 +804,89 @@ func TestVerificationParsersRejectIncompleteSafetyEvidence(t *testing.T) {
 			env.nftPersistUnitPath = "/managed/pipelock-nft.service"
 			env.readFile = func(string) ([]byte, error) { return nil, os.ErrPermission }
 		})
-		err := verifyNFTPersistence(env)
+		err := verifyNFTPersistence(env, containmentUIDs{})
 		if err == nil || !strings.Contains(err.Error(), "read nftables persistence unit") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("persisted rules unreadable", func(t *testing.T) {
+		const rulesPath = "/managed/pipelock.nft"
+		env := makeProbeEnv(t, func(env *probeEnv) {
+			env.nftPersistUnitPath = "/managed/pipelock-nft.service"
+			env.nftRulesPath = rulesPath
+			env.readFile = func(path string) ([]byte, error) {
+				if path == env.nftPersistUnitPath {
+					return []byte("[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"), nil
+				}
+				return nil, os.ErrPermission
+			}
+		})
+		err := verifyNFTPersistence(env, containmentUIDs{operatorKnown: true})
+		if err == nil || !strings.Contains(err.Error(), "read persisted nftables rules file") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("managed operator header missing", func(t *testing.T) {
+		const rulesPath = "/managed/pipelock.nft"
+		env := makeProbeEnv(t, func(env *probeEnv) {
+			env.operatorUser = ""
+			env.nftPersistUnitPath = "/managed/pipelock-nft.service"
+			env.nftRulesPath = rulesPath
+			env.readFile = func(path string) ([]byte, error) {
+				if path == env.nftPersistUnitPath {
+					return []byte("[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"), nil
+				}
+				return []byte("table inet pipelock_containment {}\n"), nil
+			}
+		})
+		err := verifyNFTPersistence(env, containmentUIDs{})
+		if err == nil || !strings.Contains(err.Error(), "missing the managed operator uid header") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("operator lookup failure", func(t *testing.T) {
+		const rulesPath = "/managed/pipelock.nft"
+		current := containmentUIDs{operatorUID: 1000, operatorKnown: true, proxyUID: 988, agentUID: 987}
+		env := makeProbeEnv(t, func(env *probeEnv) {
+			env.operatorUser = "ghost"
+			env.nftPersistUnitPath = "/managed/pipelock-nft.service"
+			env.nftRulesPath = rulesPath
+			env.lookupUser = func(string) (*user.User, error) { return nil, user.UnknownUserError("ghost") }
+			env.readFile = func(path string) ([]byte, error) {
+				if path == env.nftPersistUnitPath {
+					return []byte("[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"), nil
+				}
+				return []byte(renderNFTRules(1000, 988, 987, env.port, env.nftTable, env.nftChain)), nil
+			}
+		})
+		err := verifyNFTPersistence(env, current)
+		if err == nil || !strings.Contains(err.Error(), "lookup operator uid ghost") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("operator resolves to contained agent", func(t *testing.T) {
+		const rulesPath = "/managed/pipelock.nft"
+		current := containmentUIDs{operatorUID: 987, operatorKnown: true, proxyUID: 988, agentUID: 987}
+		env := makeProbeEnv(t, func(env *probeEnv) {
+			env.operatorUser = testOperatorUser
+			env.nftPersistUnitPath = "/managed/pipelock-nft.service"
+			env.nftRulesPath = rulesPath
+			env.lookupUser = func(name string) (*user.User, error) {
+				return &user.User{Uid: "987", Username: name}, nil
+			}
+			env.readFile = func(path string) ([]byte, error) {
+				if path == env.nftPersistUnitPath {
+					return []byte("[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"), nil
+				}
+				return []byte(renderNFTRules(987, 988, 987, env.port, env.nftTable, env.nftChain)), nil
+			}
+		})
+		err := verifyNFTPersistence(env, current)
+		if err == nil || !strings.Contains(err.Error(), "contained agent must not be allow-listed") {
 			t.Fatalf("error = %v", err)
 		}
 	})

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -1235,11 +1235,12 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 	tests := []struct {
 		name       string
 		unitBody   func(string) string
+		rulesBody  func() string
 		wantStatus string
 		wantDetail string
 	}{
 		{
-			name: "exec start points at managed rules",
+			name: "canonical rules and exec start point at managed rules",
 			unitBody: func(rulesPath string) string {
 				return "[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"
 			},
@@ -1262,6 +1263,30 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 			wantStatus: statusFail,
 			wantDetail: "missing ExecStart",
 		},
+		{
+			name: "stale persisted rules fail despite canonical live rules and matching unit",
+			unitBody: func(rulesPath string) string {
+				return "[Service]\nExecStart=/usr/sbin/nft -f " + rulesPath + "\n"
+			},
+			rulesBody: func() string {
+				return `# Pipelock containment ruleset (managed by pipelock contain install).
+# operator=1000  pipelock-proxy=988  pipelock-agent=987  proxy-port=8888
+table inet pipelock_containment {
+    chain output_filter {
+        type filter hook output priority filter; policy accept;
+
+        meta skuid 1000 accept
+        meta skuid 988 accept
+
+        meta skuid 987 ip daddr 127.0.0.1 tcp dport 8888 accept
+        meta skuid 987 drop
+    }
+}
+`
+			},
+			wantStatus: statusFail,
+			wantDetail: "does not match the canonical containment boundary",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1269,6 +1294,13 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 			tmp := t.TempDir()
 			unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
 			rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+			rulesBody := renderNFTRules(1000, 988, 987, 8888, testTable, testChain)
+			if tc.rulesBody != nil {
+				rulesBody = tc.rulesBody()
+			}
+			if err := os.WriteFile(rulesPath, []byte(rulesBody), 0o600); err != nil {
+				t.Fatalf("write persisted rules: %v", err)
+			}
 			if err := os.WriteFile(unitPath, []byte(tc.unitBody(rulesPath)), 0o600); err != nil {
 				t.Fatalf("write persistence unit: %v", err)
 			}
@@ -1290,6 +1322,36 @@ func TestProbeNFTContainment_ChecksPersistenceUnit(t *testing.T) {
 				t.Fatalf("detail: got %q, want substring %q", gotDetail, tc.wantDetail)
 			}
 		})
+	}
+}
+
+func TestProbeNFTContainment_RejectsPersistedOperatorUIDDrift(t *testing.T) {
+	tmp := t.TempDir()
+	rulesPath := filepath.Join(tmp, "50-pipelock-containment.nft")
+	unitPath := filepath.Join(tmp, "pipelock-containment-nft.service")
+	if err := os.WriteFile(rulesPath, []byte(renderNFTRules(98, 988, 987, 8888, testTable, testChain)), 0o600); err != nil {
+		t.Fatalf("write persisted rules: %v", err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/usr/sbin/nft -f "+rulesPath+"\n"), 0o600); err != nil {
+		t.Fatalf("write persistence unit: %v", err)
+	}
+	env := makeProbeEnv(t, func(e *probeEnv) {
+		e.operatorUser = testOperatorUser
+		e.lookupUser = containTestLookup
+		e.nftRulesPath = rulesPath
+		e.nftPersistUnitPath = unitPath
+		e.readFile = os.ReadFile
+		e.runCmd = func(_ context.Context, _ string, _ ...string) (string, int, error) {
+			return renderNFTRules(98, 988, 987, 8888, testTable, testChain), 0, nil
+		}
+	})
+
+	gotStatus, gotDetail := probeNFTContainment(context.Background(), env)
+	if gotStatus != statusFail {
+		t.Fatalf("status: got %q, want fail (detail=%q)", gotStatus, gotDetail)
+	}
+	if !strings.Contains(gotDetail, "does not match current operator uid 1000") {
+		t.Fatalf("detail: got %q, want current operator uid drift", gotDetail)
 	}
 }
 


### PR DESCRIPTION
## What changed
`pipelock contain verify` now fails closed when the nftables rules saved for reboot differ from the canonical containment boundary or the invoking operator identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened containment verification by checking that persisted firewall rules match the canonical configuration.
  * Detects stale or modified rules, operator identity mismatches, missing metadata, and invalid operator resolution.
  * Prevents containment from passing when the operator is the contained agent.

* **Tests**
  * Added coverage for persistence read failures, stale rules, missing headers, and operator UID drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->