### PR TITLE
chore(release): pin verifier 0.3.1 packages

### DIFF
--- a/cmd/pipelock-release-manifest/main_test.go
+++ b/cmd/pipelock-release-manifest/main_test.go
@@ -158,6 +158,8 @@ func TestRunGenKeyFailsWhenStdoutWriteFails(t *testing.T) {
 }
 
 func TestRunRejectsMissingInputs(t *testing.T) {
+	t.Setenv("RELEASE_KEYRING_HEX", "")
+
 	tests := []struct {
 		name string
 		args []string

--- a/release/verifier-installers.json
+++ b/release/verifier-installers.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_blocked": true,
+  "release_blocked": false,
   "verifiers": [
     {
       "language": "Go",
@@ -21,13 +21,13 @@
       "package": "@pipelock/verifier-ts",
       "version": "0.3.1",
       "install_source": "npm",
-      "artifact_digest": "REPLACE_WITH_NPM_DIST_INTEGRITY",
+      "artifact_digest": "sha512-/aA/k+f2OUixk2MvXhKRU39+HFFQ9Gn5j44VORyBYWCAufHyRNhS0m7nScamvADX19DV5QwXokvRgI8qmRaqaQ==",
       "publisher": {
         "repository": "luckyPipewrench/pipelock",
         "workflow": ".github/workflows/publish-verifiers.yaml",
         "environment": "verifier-release",
         "source_ref": "verifier-v0.3.1",
-        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_1_TAG_COMMIT"
+        "source_commit": "d794fb901796702dea0e7a4a62b36756f52efbc0"
       }
     },
     {
@@ -35,13 +35,13 @@
       "package": "pipelock-verifier-rs",
       "version": "0.3.1",
       "install_source": "crates.io",
-      "artifact_digest": "REPLACE_WITH_CRATES_IO_SHA256",
+      "artifact_digest": "2e194db775db730eed1fe107f18ab5087341b10e755ea95f32d9ef0771b98e51",
       "publisher": {
         "repository": "luckyPipewrench/pipelock",
         "workflow": ".github/workflows/publish-verifiers.yaml",
         "environment": "verifier-release",
         "source_ref": "verifier-v0.3.1",
-        "source_commit": "REPLACE_WITH_VERIFIER_V0_3_1_TAG_COMMIT"
+        "source_commit": "d794fb901796702dea0e7a4a62b36756f52efbc0"
       }
     },
     {


### PR DESCRIPTION
## What changed
- Pin the published TypeScript and Rust verifier 0.3.1 packages to their registry digests and signed tag commit.
- Isolate missing-input tests from the ambient release key so release tooling can’t change which error is checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * The verifier installers release is now unblocked and available.
  * Added verified artifact checksums and source commit information for the TypeScript and Rust verifier packages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->