### PR TITLE
docs: fix latest release archive downloads

### DIFF
--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -197,7 +197,7 @@ Use `dockerfile_lines` in `langgraph.json` to install Pipelock into the image:
     "env": ".env",
     "dockerfile_lines": [
         "RUN apt-get update && apt-get install -y curl",
-        "RUN curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/latest/download/pipelock_linux_amd64.tar.gz | tar xz -C /usr/local/bin/",
+        "RUN release_tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/luckyPipewrench/pipelock/releases/latest) && release_tag=${release_tag##*/} && curl -fsSL \"https://github.com/luckyPipewrench/pipelock/releases/download/${release_tag}/pipelock_${release_tag#v}_linux_amd64.tar.gz\" | tar xz -C /usr/local/bin/",
         "COPY pipelock-config.yaml /etc/pipelock/config.yaml"
     ]
 }

--- a/docs/guides/openclaw.md
+++ b/docs/guides/openclaw.md
@@ -22,8 +22,10 @@ Pipelock blocks the post-compromise steps of this chain: tool policy blocks dang
 # From source (Go 1.25+)
 go install github.com/luckyPipewrench/pipelock/cmd/pipelock@latest
 
-# Or download binary
-curl -fsSL https://github.com/luckyPipewrench/pipelock/releases/latest/download/pipelock_linux_amd64.tar.gz | tar xz
+# Or download the latest binary
+release_tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/luckyPipewrench/pipelock/releases/latest)
+release_tag=${release_tag##*/}
+curl -fsSL "https://github.com/luckyPipewrench/pipelock/releases/download/${release_tag}/pipelock_${release_tag#v}_linux_amd64.tar.gz" | tar xz
 sudo mv pipelock /usr/local/bin/
 
 # Or Homebrew (macOS)

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -153,6 +153,7 @@ check_no_match 'timeline (lists|of) every mediated decision' 'unprovable evidenc
 check_no_match 'stale_policy\.(grace_multiplier|after_grace).*\| Reserved' 'stale-policy-as-reserved claim'
 check_no_match 'Every signed bundle hash is written to an append-only transparency log' 'unshipped universal transparency-log claim'
 check_no_match 'No implementation should start until these are accepted' 'obsolete Conductor pre-implementation gate'
+check_no_match 'releases/latest/download/pipelock_(linux|darwin|windows)' 'unversioned release archive URL'
 
 for conductor_doc in \
 	docs/guides/conductor.md \


### PR DESCRIPTION
## What changed

Resolve the latest release tag before constructing Linux archive download URLs, and reject docs that use the nonexistent unversioned archive path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to download version-matched release archives across supported platforms.
  * Improved Quick Start guidance for resolving the latest release before downloading.
* **Tests**
  * Added checks to detect outdated, unversioned release URLs in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->