### PR TITLE
chore: advance the Gauntlet Bench revision

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  AEB_REF: 1dfb4f0ec5e0cc911c65b9cf3ccfaf3d2e7e15d7
+  AEB_REF: efda9aa26d6b3cacc711450c31d784d0c725155d
 
 jobs:
   candidate:

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
-EXPECTED_AEB_REF = "1dfb4f0ec5e0cc911c65b9cf3ccfaf3d2e7e15d7"
+EXPECTED_AEB_REF = "efda9aa26d6b3cacc711450c31d784d0c725155d"
 GAUNTLET_WORKFLOW_URL = (
     "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
 )


### PR DESCRIPTION
## What changed

Advance the candidate-only Gauntlet workflow to the merged Bench revision that validates current active-set scope against its authenticated corpus authority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the pinned Agent Egress Bench reference used by the continuous validation workflow.
  - Updated the corresponding validation check to verify the new reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->