### PR TITLE
fix(scanner): evaluate URL destinations named inside query parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,15 +100,16 @@ Three proxy modes share the main listener:
 4. Strict-mode allowlist
 5. Domain blocklist
 6. Core SSRF literal-IP floor, including private and metadata IP literals
-7. SigV4 presigned-URL credential carve-out
-8. Core DLP immutable floor
-9. DLP (65 built-in credential patterns + checksum validators + env/file leak detection)
-10. Path entropy analysis
-11. Subdomain entropy analysis
-12. SSRF / DNS resolution for private IPs, metadata, and rebinding
-13. Rate limiting
-14. Data budget
-15. Final context check
+7. Nested URL destinations in query parameters (allowlist, blocklist, SSRF on URL-shaped values)
+8. SigV4 presigned-URL credential carve-out
+9. Core DLP immutable floor
+10. DLP (65 built-in credential patterns + checksum validators + env/file leak detection)
+11. Path entropy analysis
+12. Subdomain entropy analysis
+13. SSRF / DNS resolution for private IPs, metadata, and rebinding
+14. Rate limiting
+15. Data budget
+16. Final context check
 
 Core and configured DLP run before DNS resolution; SSRF/DNS runs after them. `cfg.Internal = nil` disables DNS-based configured SSRF checks, not the literal-IP core SSRF floor.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,16 +100,20 @@ Three proxy modes share the main listener:
 4. Strict-mode allowlist
 5. Domain blocklist
 6. Core SSRF literal-IP floor, including private and metadata IP literals
-7. Nested URL destinations in query parameters (allowlist, blocklist, SSRF on URL-shaped values)
-8. SigV4 presigned-URL credential carve-out
-9. Core DLP immutable floor
-10. DLP (65 built-in credential patterns + checksum validators + env/file leak detection)
-11. Path entropy analysis
-12. Subdomain entropy analysis
+7. SigV4 presigned-URL credential carve-out
+8. Core DLP immutable floor
+9. DLP (65 built-in credential patterns + checksum validators + env/file leak detection)
+10. Path entropy analysis
+11. Subdomain entropy analysis
+12. Nested URL destinations in query parameters (allowlist, blocklist, SSRF on URL-shaped values)
 13. SSRF / DNS resolution for private IPs, metadata, and rebinding
 14. Rate limiting
 15. Data budget
 16. Final context check
+
+Nested destinations sit after every check that needs no network and before the
+first that does. A check that can time out must not run ahead of one that cannot,
+or a slow resolver decides the request before the content findings are made.
 
 Core and configured DLP run before DNS resolution; SSRF/DNS runs after them. `cfg.Internal = nil` disables DNS-based configured SSRF checks, not the literal-IP core SSRF floor.
 

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -43,6 +43,10 @@ fetch_proxy:
       - "files.pythonhosted.org"
       - "pypi.org"
       - "objects.githubusercontent.com"
+    # Evaluate URL-shaped query values as destinations (allowlist, blocklist,
+    # SSRF). Default enabled (nil). Set false only for an endpoint whose
+    # contract legitimately carries private or blocklisted URLs in query strings.
+    # scan_nested_urls: true
 
 forward_proxy:
   enabled: true

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -42,6 +42,10 @@ fetch_proxy:
       - "files.pythonhosted.org"
       - "pypi.org"
       - "objects.githubusercontent.com"
+    # Evaluate URL-shaped query values as destinations (allowlist, blocklist,
+    # SSRF). Default enabled (nil). Set false only for an endpoint whose
+    # contract legitimately carries private or blocklisted URLs in query strings.
+    # scan_nested_urls: true
 
 forward_proxy:
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,7 @@ fetch_proxy:
       - "files.pythonhosted.org"
       - "pypi.org"
       - "objects.githubusercontent.com"
+    # scan_nested_urls: true  # default (nil); URL-shaped query values are destinations
 ```
 
 | Field | Default | Description |
@@ -147,6 +148,7 @@ fetch_proxy:
 | `monitoring.max_data_per_minute` | `0` | Per-domain byte budget (0 = disabled) |
 | `monitoring.blocklist` | 6 domains | Blocked exfiltration targets |
 | `monitoring.subdomain_entropy_exclusions` | `files.pythonhosted.org`, `pypi.org`, `objects.githubusercontent.com` | Domains excluded from subdomain and path entropy checks; override to replace defaults, or set an empty list to disable exclusions entirely (query entropy still checked) |
+| `monitoring.scan_nested_urls` | `true` (nil) | Evaluate URL-shaped query parameter values as destinations |
 | `monitoring.query_entropy_exclusions` | `[]` | Host-wide query-string entropy exclusions for hosts whose query values are broadly opaque by contract |
 | `monitoring.query_entropy_param_exclusions` | `[]` | Exact HTTPS endpoint+parameter query-value entropy exclusions; DLP, SSRF, query-key entropy, adjacent parameters, path/subdomain entropy, rate limits, and data budgets still apply |
 
@@ -198,6 +200,29 @@ fetch_proxy:
   monitoring:
     query_entropy_exclusions:
       - "provider.example"
+```
+
+**Nested URL destination scanning** treats an `http`/`https` URL in a query
+parameter as a destination of its own. After iterative percent-decoding, a
+value that parses as an absolute `http`/`https` URL with a hostname is run
+through the same allowlist, blocklist, and SSRF checks as the outer host.
+The check is one level deep: a nested URL that itself contains a nested URL
+is not expanded. Relative paths, bare words, `mailto:`, and `data:` values
+are ignored. At most 32 query values are inspected per request; remaining
+values are skipped while the outer pipeline continues. Default is enabled
+(`nil` or `true`). Set `false` only for an endpoint whose contract
+legitimately carries private or blocklisted URLs in query strings.
+
+CONNECT is out of scope: the CONNECT handler scans a synthetic `https://host/`
+URL with no query string, so nested query destinations never appear on that
+surface. Fetch, forward absolute-URI, TLS intercept, redirect follow, and
+reverse-proxy submit profile all call `Scan` on the real URL and inherit the
+check.
+
+```yaml
+fetch_proxy:
+  monitoring:
+    scan_nested_urls: true
 ```
 
 **Path entropy and governed API routes.** Path entropy is *also* skipped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,7 +207,8 @@ parameter as a destination of its own. After iterative percent-decoding, a
 value that parses as an absolute `http`/`https` URL with a hostname is run
 through the same allowlist, blocklist, and SSRF checks as the outer host.
 The check is one level deep: a nested URL that itself contains a nested URL
-is not expanded. Relative paths, bare words, `mailto:`, and `data:` values
+is not expanded. Relative paths, bare words, `mailto:` values, and `data:`
+values are ignored, because none of them names an `http` or `https` destination.
 There is no cap on how many query components are examined; parsing and literal-IP
 checks need no I/O and are bounded by the URL length limit. Every nested DNS lookup a
 request needs shares one resolution budget equal to the single-lookup SSRF ceiling, and
@@ -218,7 +219,8 @@ scheme-relative `//host/...` value is evaluated as an https destination.
 
 CONNECT is out of scope: the CONNECT handler scans a synthetic `https://host/`
 URL with no query string, so nested query destinations never appear on that
-surface. Fetch, forward absolute-URI, TLS intercept, redirect follow, and
+surface. Fetch, forward absolute-URI, TLS intercept, redirect follow, WebSocket
+(the `/ws?url=...` handler passes the caller-supplied URL to `Scan`), and
 reverse-proxy submit profile all call `Scan` on the real URL and inherit the
 check.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,10 +208,13 @@ value that parses as an absolute `http`/`https` URL with a hostname is run
 through the same allowlist, blocklist, and SSRF checks as the outer host.
 The check is one level deep: a nested URL that itself contains a nested URL
 is not expanded. Relative paths, bare words, `mailto:`, and `data:` values
-are ignored. At most 32 query values are inspected per request; remaining
-values are skipped while the outer pipeline continues. Default is enabled
-(`nil` or `true`). Set `false` only for an endpoint whose contract
-legitimately carries private or blocklisted URLs in query strings.
+There is no cap on how many query components are examined; parsing and literal-IP
+checks need no I/O and are bounded by the URL length limit. Every nested DNS lookup a
+request needs shares one resolution budget equal to the single-lookup SSRF ceiling, and
+exhausting that budget refuses the request rather than forwarding it with nested
+destinations unverified. Both query keys and values are examined, in raw form, after
+percent-decoding, and through the same hex, base64, and base32 layers DLP applies; a
+scheme-relative `//host/...` value is evaluated as an https destination.
 
 CONNECT is out of scope: the CONNECT handler scans a synthetic `https://host/`
 URL with no query string, so nested query destinations never appear on that

--- a/docs/guides/request-policy.md
+++ b/docs/guides/request-policy.md
@@ -209,6 +209,16 @@ request_policy:
         methods: ["POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"]
 ```
 
+Read that rule as "these write methods are refused", not as "only fetch is permitted".
+`request_policy` is allow-by-default and has no allow-only method predicate, so a method
+absent from the list still reaches the host: `TRACE` and `OPTIONS` are accepted by
+validation, and any verb the validator does not recognise is rejected at load rather than
+silently blocked. A rule naming the write verbs a registry actually uses is the posture
+this rail can express today. If you need a true fetch-only boundary, terminate it where
+an allow-list exists, such as the registry's own credentials or an upstream gateway, and
+treat this rule as defence in depth rather than the boundary itself.
+
+
 ### What this rule does and does not cover
 
 `request_policy` rules are a deny-list: a request forwards unless a rule matches

--- a/docs/guides/request-policy.md
+++ b/docs/guides/request-policy.md
@@ -209,6 +209,21 @@ request_policy:
         methods: ["POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"]
 ```
 
+### What this rule does and does not cover
+
+`request_policy` rules are a deny-list: a request forwards unless a rule matches
+it. This recipe therefore refuses exactly the methods it names. It is not an
+allow-only rail, and there is no `methods_except` form today. A method outside
+the list, including `OPTIONS` or any verb a future registry adds, is still
+forwarded.
+
+That is usually the right trade for a package mirror, because the risk being
+closed is publish and relocate rather than read. Name every write verb the
+registry actually accepts, and revisit the list when the registry's API changes.
+If a host genuinely needs read-only enforcement rather than a deny-list, put it
+behind an allowlist that names the paths it may serve instead of enumerating the
+methods it may not.
+
 ## Enforcement, audit, and receipts
 
 A matched rule records a decision metric and an audit event with bounded,

--- a/docs/guides/request-policy.md
+++ b/docs/guides/request-policy.md
@@ -206,7 +206,7 @@ request_policy:
       reason: "registry.vendor.example is allowlisted for package fetch only; write methods are a publish/relay channel"
       route:
         hosts: ["registry.vendor.example"]
-        methods: ["POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"]
+        methods: ["POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK"]
 ```
 
 Read that rule as "these write methods are refused", not as "only fetch is permitted".

--- a/docs/guides/request-policy.md
+++ b/docs/guides/request-policy.md
@@ -180,6 +180,35 @@ A `shadow` match never enforces; an enforced match always wins over a shadow mat
 of equal strictness. Promote to `action: block` (and drop `shadow`) once the logs
 show the rule matches only what you intend.
 
+## Fetch-only package registries
+
+An allowlisted helper with any-method access is a publish and relay channel: `GET`
+and `HEAD` are the package fetch, but `POST`/`PUT`/`PATCH`/`DELETE` and the WebDAV
+verbs that registries use to create or move artifacts turn the same host into a
+write path. That is operator intent about one host, not a scanner default. Defaulting
+the rail to "fetch only" would break `npm publish` and dataset pushes for operators
+who actually need those methods.
+
+The rail sees the method only with TLS interception on and the host not in
+`passthrough_domains`. Config validation already warns when a rule needs inner HTTP
+that the deployment cannot see.
+
+```yaml
+version: 1
+mode: balanced
+request_policy:
+  enabled: true
+  on_parse_error: block
+  on_opaque_operation: block
+  rules:
+    - name: "fetch-only-vendor-registry"
+      action: block
+      reason: "registry.vendor.example is allowlisted for package fetch only; write methods are a publish/relay channel"
+      route:
+        hosts: ["registry.vendor.example"]
+        methods: ["POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"]
+```
+
 ## Enforcement, audit, and receipts
 
 A matched rule records a decision metric and an audit event with bounded,

--- a/docs/security-assurance.md
+++ b/docs/security-assurance.md
@@ -133,10 +133,17 @@ canonicalization, the current order is:
 9. Configured DLP
 10. Path entropy
 11. Subdomain entropy
-12. DNS-based SSRF, private-address, metadata, and rebinding checks
-13. Rate limiting
-14. Data budget
-15. Final context check
+12. Nested URL destinations named inside query components
+13. DNS-based SSRF, private-address, metadata, and rebinding checks
+14. Rate limiting
+15. Data budget
+16. Final context check
+
+Step 12 evaluates a URL-shaped query key or value as a destination in its own
+right, running the same allowlist, blocklist, and SSRF checks the outer host
+receives. It closes the case where an allowed host fetches a target the caller
+names. It is placed after every check that needs no network so that a content
+finding is always established before any check that can time out.
 
 Core and configured DLP run before DNS resolution, so a detected secret can be
 blocked before the proxy performs a destination lookup. Response, body,

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -352,7 +352,10 @@ const (
 	// presigned URL and therefore belongs in the policy identity.
 	// Re-bumped for issuer-backed GitHub stateless-token and decoded Azure SAS
 	// coverage in the default DLP pattern set.
-	goldenHashDefaults = "88d9b0f0909023d23017f4982737d7cf771bae3cd71261e079a670a35d6b276e"
+	// Re-bumped for fetch_proxy.monitoring.scan_nested_urls: nested query
+	// destinations are an enforcement floor, so mixed versions must not
+	// report the same policy identity.
+	goldenHashDefaults = "6be082af03f853f5e7f70b737e94440b1ab616a1a8997bcb704d824b1171905c"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -531,7 +534,10 @@ const (
 	// Re-bumped for route-scoped SigV4 body credentials: see goldenHashDefaults.
 	// Re-bumped for issuer-backed GitHub stateless-token and decoded Azure SAS
 	// coverage: the rich fixture inherits the default DLP pattern set.
-	goldenHashRichConfig = "9028a9d0f3902660b84acee629ea483e9454cfc4197738596b5e2efec6ec7fba"
+	// Re-bumped for fetch_proxy.monitoring.scan_nested_urls: see
+	// goldenHashDefaults. The rich fixture omits the field, so nil (enabled)
+	// flows into ph identically to Defaults().
+	goldenHashRichConfig = "c56ab6b21a273b026b9d0ee492256933eb016cca4617ee90988e0f3b5f7eabee"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/docs_accuracy_test.go
+++ b/internal/config/docs_accuracy_test.go
@@ -26,6 +26,8 @@ func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 		mustContain(t, configDoc, "request_body_scanning:\n  enabled: true")
 		mustContain(t, configDoc, "| `enabled` | `true` | Enable request body/header DLP scanning")
 		mustContain(t, configDoc, "Omitting `request_body_scanning.enabled` or `request_body_scanning.scan_headers` defaults both to `true`")
+		mustContain(t, configDoc, "`monitoring.scan_nested_urls`")
+		mustContain(t, configDoc, "CONNECT is out of scope")
 		mustNotContain(t, configDoc, "omitting the field from your YAML file gives `false`")
 	})
 
@@ -45,6 +47,7 @@ func TestDocsDeclareLiveStatsAndDefaults(t *testing.T) {
 		mustContain(t, agentDoc, fmt.Sprintf("DLP (%d built-in credential patterns", dlpCount))
 		mustContain(t, agentDoc, "Path entropy analysis")
 		mustContain(t, agentDoc, "Subdomain entropy analysis")
+		mustContain(t, agentDoc, "Nested URL destinations in query parameters")
 		mustContain(t, agentDoc, "Run `make stats` before citing the current direct-dependency count")
 		mustNotContain(t, agentDoc, "48 regex patterns")
 		mustNotContain(t, agentDoc, "20 direct dependencies")

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -437,7 +437,7 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
-	if old.FetchProxy.Monitoring.NestedURLScanningEnabled() && !updated.FetchProxy.Monitoring.NestedURLScanningEnabled() {
+	if old.FetchProxy.Monitoring.ScanNestedURLsEnabled() && !updated.FetchProxy.Monitoring.ScanNestedURLsEnabled() {
 		warnings = append(warnings, ReloadWarning{
 			Field:   "fetch_proxy.monitoring.scan_nested_urls",
 			Message: "nested URL destination scanning disabled — query-parameter destinations will not be evaluated",

--- a/internal/config/reloadwarn.go
+++ b/internal/config/reloadwarn.go
@@ -437,6 +437,13 @@ func ValidateReload(old, updated *Config) []ReloadWarning {
 		})
 	}
 
+	if old.FetchProxy.Monitoring.NestedURLScanningEnabled() && !updated.FetchProxy.Monitoring.NestedURLScanningEnabled() {
+		warnings = append(warnings, ReloadWarning{
+			Field:   "fetch_proxy.monitoring.scan_nested_urls",
+			Message: "nested URL destination scanning disabled — query-parameter destinations will not be evaluated",
+		})
+	}
+
 	// Trusted domains expanded (SSRF protection scope reduced)
 	if added := passthroughDomainsAdded(old.TrustedDomains, updated.TrustedDomains); len(added) > 0 {
 		warnings = append(warnings, ReloadWarning{

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -151,6 +151,17 @@ func TestValidHTTPMethodRecognizesWebDAV(t *testing.T) {
 	}
 }
 
+// A method rail is fail-closed: an unrecognised spelling must be rejected at
+// load rather than silently matching nothing at request time.
+func TestValidHTTPMethodRejectsNearMissWebDAV(t *testing.T) {
+	t.Parallel()
+	for _, m := range []string{"mkcol", "MKCOL ", " MKCOL", "MKCOLL", "MKCOL\t", "MOVE;", "COPY\n", "PROPATCH", "PROPPATCHH", ""} {
+		if validHTTPMethod(m) {
+			t.Errorf("validHTTPMethod(%q) = true, want false", m)
+		}
+	}
+}
+
 func TestFetchOnlyRegistryRecipeLoads(t *testing.T) {
 	body := readDocAccuracyFile(t, repoRootForDocsAccuracy(t), "docs/guides/request-policy.md")
 	marker := "## Fetch-only package registries"

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -138,6 +140,75 @@ func TestValidHTTPMethodRecognizesQuery(t *testing.T) {
 	}
 	if validHTTPMethod("FOO") {
 		t.Fatal("validHTTPMethod(FOO) = true, want false")
+	}
+}
+
+func TestValidHTTPMethodRecognizesWebDAV(t *testing.T) {
+	for _, method := range []string{"MKCOL", "MOVE", "COPY", "PROPPATCH"} {
+		if !validHTTPMethod(method) {
+			t.Fatalf("validHTTPMethod(%q) = false, want true for fetch-only registry recipes", method)
+		}
+	}
+}
+
+func TestFetchOnlyRegistryRecipeLoads(t *testing.T) {
+	body := readDocAccuracyFile(t, repoRootForDocsAccuracy(t), "docs/guides/request-policy.md")
+	marker := "## Fetch-only package registries"
+	idx := strings.Index(body, marker)
+	if idx < 0 {
+		t.Fatal("request-policy.md missing Fetch-only package registries section")
+	}
+	section := body[idx:]
+	start := strings.Index(section, "```yaml\n")
+	if start < 0 {
+		t.Fatal("section missing yaml fence")
+	}
+	start += len("```yaml\n")
+	end := strings.Index(section[start:], "```")
+	if end < 0 {
+		t.Fatal("section yaml fence is unclosed")
+	}
+	example := section[start : start+end]
+	if !strings.Contains(example, "registry.vendor.example") {
+		t.Fatalf("example host is not the documented placeholder:\n%s", example)
+	}
+	if strings.Contains(example, "npm") || strings.Contains(example, "pypi") {
+		t.Fatal("example must not name a real registry hostname")
+	}
+
+	path := filepath.Join(t.TempDir(), "pipelock.yaml")
+	if err := os.WriteFile(path, []byte(example), 0o600); err != nil {
+		t.Fatalf("write example: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(fetch-only registry recipe): %v", err)
+	}
+	if !cfg.RequestPolicy.Enabled {
+		t.Fatal("recipe request_policy.enabled is false")
+	}
+	if len(cfg.RequestPolicy.Rules) != 1 {
+		t.Fatalf("recipe rules = %d, want 1", len(cfg.RequestPolicy.Rules))
+	}
+	got := cfg.RequestPolicy.Rules[0].Route.Methods
+	want := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("methods = %v, want %v", got, want)
+	}
+
+	warnings, err := cfg.ValidateWithWarnings()
+	if err != nil {
+		t.Fatalf("ValidateWithWarnings: %v", err)
+	}
+	var sawVisibility bool
+	for _, w := range warnings {
+		if strings.Contains(w.Field, "fetch-only-vendor-registry") &&
+			strings.Contains(w.Message, "tls_interception is disabled") {
+			sawVisibility = true
+		}
+	}
+	if !sawVisibility {
+		t.Fatalf("recipe must surface the inner-HTTP visibility warning when TLS interception is off: %+v", warnings)
 	}
 }
 

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -99,6 +99,11 @@ func TestValidateRequestPolicy_Errors(t *testing.T) {
 			want: "not a valid HTTP method",
 		},
 		{
+			name: "unknown inbound-looking method rejected at load",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"LOCK"}}}),
+			want: "not a valid HTTP method",
+		},
+		{
 			name: "invalid path pattern",
 			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{PathPatterns: []string{"("}}}),
 			want: "invalid path_pattern",
@@ -140,6 +145,15 @@ func TestValidHTTPMethodRecognizesQuery(t *testing.T) {
 	}
 	if validHTTPMethod("FOO") {
 		t.Fatal("validHTTPMethod(FOO) = true, want false")
+	}
+}
+
+func TestValidHTTPMethodRecognizesOptionsAndTrace(t *testing.T) {
+	t.Parallel()
+	for _, method := range []string{"OPTIONS", "TRACE"} {
+		if !validHTTPMethod(method) {
+			t.Fatalf("validHTTPMethod(%q) = false, want true", method)
+		}
 	}
 }
 

--- a/internal/config/requestpolicy_validate_test.go
+++ b/internal/config/requestpolicy_validate_test.go
@@ -99,8 +99,11 @@ func TestValidateRequestPolicy_Errors(t *testing.T) {
 			want: "not a valid HTTP method",
 		},
 		{
-			name: "unknown inbound-looking method rejected at load",
-			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"LOCK"}}}),
+			// PROPFIND is a real WebDAV method and a read, so validate.go
+			// leaves it out of the accepted set on purpose. Rejecting it at
+			// load is that decision under test.
+			name: "unaccepted WebDAV read method rejected at load",
+			cfg:  enabledPolicy(RequestPolicyRule{Name: "r", Action: ActionBlock, Route: RequestPolicyRoute{Methods: []string{"PROPFIND"}}}),
 			want: "not a valid HTTP method",
 		},
 		{
@@ -158,7 +161,7 @@ func TestValidHTTPMethodRecognizesOptionsAndTrace(t *testing.T) {
 }
 
 func TestValidHTTPMethodRecognizesWebDAV(t *testing.T) {
-	for _, method := range []string{"MKCOL", "MOVE", "COPY", "PROPPATCH"} {
+	for _, method := range []string{"MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK"} {
 		if !validHTTPMethod(method) {
 			t.Fatalf("validHTTPMethod(%q) = false, want true for fetch-only registry recipes", method)
 		}
@@ -215,8 +218,18 @@ func TestFetchOnlyRegistryRecipeLoads(t *testing.T) {
 	if len(cfg.RequestPolicy.Rules) != 1 {
 		t.Fatalf("recipe rules = %d, want 1", len(cfg.RequestPolicy.Rules))
 	}
-	got := cfg.RequestPolicy.Rules[0].Route.Methods
-	want := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"}
+	rule := cfg.RequestPolicy.Rules[0]
+	// Assert the parsed rule, not the YAML text. Without this the test passes
+	// on a recipe that only warns, or one aimed at a different host, because
+	// the method list alone says nothing about what the rule does.
+	if rule.Action != ActionBlock {
+		t.Fatalf("recipe action = %q, want %q", rule.Action, ActionBlock)
+	}
+	if len(rule.Route.Hosts) != 1 || rule.Route.Hosts[0] != "registry.vendor.example" {
+		t.Fatalf("recipe hosts = %v, want [registry.vendor.example]", rule.Route.Hosts)
+	}
+	got := rule.Route.Methods
+	want := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("methods = %v, want %v", got, want)
 	}

--- a/internal/config/scan_nested_urls_default_test.go
+++ b/internal/config/scan_nested_urls_default_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// scan_nested_urls decides whether URL-shaped query values are evaluated as
+// destinations, so its zero value is a security posture rather than a
+// convenience default. The repo requires the full matrix for a field like
+// this: omitted, YAML null, blank, explicit false, explicit true, and a
+// reload in both directions.
+func TestScanNestedURLsParsingMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{name: "omitted defaults to enabled", yaml: "mode: balanced\nfetch_proxy:\n  monitoring:\n    entropy_threshold: 4.5\n", want: true},
+		{name: "yaml null defaults to enabled", yaml: "mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls:\n", want: true},
+		{name: "explicit false disables", yaml: "mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n", want: false},
+		{name: "explicit true enables", yaml: "mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "pipelock.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if got := cfg.FetchProxy.Monitoring.NestedURLScanningEnabled(); got != tc.want {
+				t.Fatalf("NestedURLScanningEnabled = %v, want %v (ptr=%v)", got, tc.want, cfg.FetchProxy.Monitoring.ScanNestedURLs)
+			}
+		})
+	}
+}
+
+// A reload must move the value in both directions. Re-enabling matters most:
+// an operator who disabled nested URL scanning to get past one endpoint and
+// then removed the override should not keep the relaxed posture until the
+// process restarts.
+func TestScanNestedURLsReloadBothDirections(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+
+	write := func(body string) *Config {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		return cfg
+	}
+
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); got {
+		t.Fatalf("initial load = %v, want false", got)
+	}
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); !got {
+		t.Fatalf("reload to true = %v, want true", got)
+	}
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); !got {
+		t.Fatalf("reload with no change = %v, want true", got)
+	}
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); got {
+		t.Fatalf("reload back to false = %v, want false; a relaxed posture must not persist", got)
+	}
+}
+
+func TestValidateReload_ScanNestedURLsDisabled(t *testing.T) {
+	t.Parallel()
+
+	old := Defaults()
+	updated := Defaults()
+	disabled := false
+	updated.FetchProxy.Monitoring.ScanNestedURLs = &disabled
+
+	var found bool
+	for _, warning := range ValidateReload(old, updated) {
+		if warning.Field == "fetch_proxy.monitoring.scan_nested_urls" {
+			found = true
+			if warning.Message == "" {
+				t.Fatal("reload warning message is empty")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("disabling nested URL scanning must warn as a security downgrade")
+	}
+
+	same := Defaults()
+	for _, warning := range ValidateReload(old, same) {
+		if warning.Field == "fetch_proxy.monitoring.scan_nested_urls" {
+			t.Fatalf("unchanged nested URL scanning warned: %+v", warning)
+		}
+	}
+
+	enabled := true
+	old.FetchProxy.Monitoring.ScanNestedURLs = &disabled
+	updated.FetchProxy.Monitoring.ScanNestedURLs = &enabled
+	for _, warning := range ValidateReload(old, updated) {
+		if warning.Field == "fetch_proxy.monitoring.scan_nested_urls" {
+			t.Fatalf("re-enabling nested URL scanning warned: %+v", warning)
+		}
+	}
+}

--- a/internal/config/scan_nested_urls_default_test.go
+++ b/internal/config/scan_nested_urls_default_test.go
@@ -39,8 +39,8 @@ func TestScanNestedURLsParsingMatrix(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Load: %v", err)
 			}
-			if got := cfg.FetchProxy.Monitoring.NestedURLScanningEnabled(); got != tc.want {
-				t.Fatalf("NestedURLScanningEnabled = %v, want %v (ptr=%v)", got, tc.want, cfg.FetchProxy.Monitoring.ScanNestedURLs)
+			if got := cfg.FetchProxy.Monitoring.ScanNestedURLsEnabled(); got != tc.want {
+				t.Fatalf("ScanNestedURLsEnabled = %v, want %v (ptr=%v)", got, tc.want, cfg.FetchProxy.Monitoring.ScanNestedURLs)
 			}
 		})
 	}
@@ -68,16 +68,16 @@ func TestScanNestedURLsReloadBothDirections(t *testing.T) {
 		return cfg
 	}
 
-	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); got {
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.ScanNestedURLsEnabled(); got {
 		t.Fatalf("initial load = %v, want false", got)
 	}
-	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); !got {
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.ScanNestedURLsEnabled(); !got {
 		t.Fatalf("reload to true = %v, want true", got)
 	}
-	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); !got {
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: true\n").FetchProxy.Monitoring.ScanNestedURLsEnabled(); !got {
 		t.Fatalf("reload with no change = %v, want true", got)
 	}
-	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.NestedURLScanningEnabled(); got {
+	if got := write("mode: balanced\nfetch_proxy:\n  monitoring:\n    scan_nested_urls: false\n").FetchProxy.Monitoring.ScanNestedURLsEnabled(); got {
 		t.Fatalf("reload back to false = %v, want false; a relaxed posture must not persist", got)
 	}
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1068,6 +1068,13 @@ type Monitoring struct {
 	// heuristic. DLP, SSRF, path/subdomain entropy, query-key entropy, adjacent
 	// parameters, rate limits, data budgets, and every other scanner still run.
 	QueryEntropyParamExclusions []QueryEntropyParamExclusion `yaml:"query_entropy_param_exclusions,omitempty"`
+
+	// ScanNestedURLs evaluates URL-shaped query parameter values as destinations
+	// in their own right, running the allowlist, blocklist, and SSRF checks on the
+	// nested host. It closes the relay class where an allowed host fetches an
+	// attacker-named target. nil = enabled. Set false only for an endpoint whose
+	// contract legitimately carries private or blocklisted URLs in query strings.
+	ScanNestedURLs *bool `yaml:"scan_nested_urls"`
 }
 
 // QueryEntropyParamExclusion is a narrow query-value entropy exemption for one

--- a/internal/config/schema_receiver_methods.go
+++ b/internal/config/schema_receiver_methods.go
@@ -248,6 +248,13 @@ func toSlash(s string) string {
 	return strings.ReplaceAll(s, "\\", "/")
 }
 
+// NestedURLScanningEnabled reports whether URL-shaped query values are
+// evaluated as destinations. Omitting the field or setting YAML null keeps
+// the check enabled; only an explicit false disables it.
+func (m Monitoring) NestedURLScanningEnabled() bool {
+	return m.ScanNestedURLs == nil || *m.ScanNestedURLs
+}
+
 // SNIVerificationEnabled returns whether SNI verification is active.
 // Defaults to true when not explicitly set.
 func (f ForwardProxy) SNIVerificationEnabled() bool {

--- a/internal/config/schema_receiver_methods.go
+++ b/internal/config/schema_receiver_methods.go
@@ -248,10 +248,13 @@ func toSlash(s string) string {
 	return strings.ReplaceAll(s, "\\", "/")
 }
 
-// NestedURLScanningEnabled reports whether URL-shaped query values are
+// ScanNestedURLsEnabled reports whether URL-shaped query values are
 // evaluated as destinations. Omitting the field or setting YAML null keeps
 // the check enabled; only an explicit false disables it.
-func (m Monitoring) NestedURLScanningEnabled() bool {
+// The name matches the ScanNestedURLs field so the config-consumption gate
+// can see the knob is read; that gate looks for .FieldName or
+// .FieldNameEnabled() outside internal/config.
+func (m Monitoring) ScanNestedURLsEnabled() bool {
 	return m.ScanNestedURLs == nil || *m.ScanNestedURLs
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2062,7 +2062,11 @@ func validHTTPMethod(m string) bool {
 		// The HTTP QUERY method (draft-ietf-httpbis-safe-method-w-body) is a
 		// safe method that carries a request body; recognize it so operators
 		// can write request_policy rules that target QUERY requests.
-		methodQuery:
+		methodQuery,
+		// WebDAV methods used by package-registry publish/relocate flows.
+		// Needed so a fetch-only registry recipe can name them in
+		// request_policy without failing validation.
+		"MKCOL", "MOVE", "COPY", "PROPPATCH":
 		return true
 	default:
 		return false

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2063,10 +2063,13 @@ func validHTTPMethod(m string) bool {
 		// safe method that carries a request body; recognize it so operators
 		// can write request_policy rules that target QUERY requests.
 		methodQuery,
-		// WebDAV methods used by package-registry publish/relocate flows.
-		// Needed so a fetch-only registry recipe can name them in
-		// request_policy without failing validation.
-		"MKCOL", "MOVE", "COPY", "PROPPATCH":
+		// State-changing WebDAV methods (RFC 4918), used by package-registry
+		// publish and relocate flows. Needed so a fetch-only registry recipe
+		// can name them in request_policy without failing validation. LOCK and
+		// UNLOCK belong here for the same reason the others do: both write
+		// server state, so a recipe that cannot name them cannot refuse them.
+		// PROPFIND is deliberately absent, being a read.
+		"MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK":
 		return true
 	default:
 		return false

--- a/internal/proxy/nested_url_reload_test.go
+++ b/internal/proxy/nested_url_reload_test.go
@@ -112,7 +112,12 @@ func TestProxy_ReloadScanNestedURLs_MovesEnforcementBothWays(t *testing.T) {
 	if got.Allowed {
 		t.Fatal("reload back to true left the relaxed scanner installed")
 	}
-	if got.Scanner != scanner.ScannerSSRF && got.Scanner != scanner.ScannerCoreSSRF {
+	// The destination is a metadata address, so any of the three SSRF labels is
+	// a correct attribution. Pinning two of them would fail on a legitimate
+	// verdict rather than on a regression.
+	switch got.Scanner {
+	case scanner.ScannerSSRF, scanner.ScannerSSRFMetadata, scanner.ScannerCoreSSRF:
+	default:
 		t.Fatalf("re-enabled block came from %q, want an SSRF scanner", got.Scanner)
 	}
 }

--- a/internal/proxy/nested_url_reload_test.go
+++ b/internal/proxy/nested_url_reload_test.go
@@ -101,6 +101,12 @@ func TestProxy_ReloadScanNestedURLs_MovesEnforcementBothWays(t *testing.T) {
 		t.Fatalf("unchanged reload flipped enforcement back on: reason=%q", got.Reason)
 	}
 
+	// Removing the override must restore the secure default. Reloading to
+	// explicit true would still pass if nil kept the previous false value.
+	if got := reloadInto(t, p, nil); got.Allowed {
+		t.Fatal("removing scan_nested_urls override left nested scanning disabled")
+	}
+
 	// Re-enable through reload: enforcement must return without a restart.
 	got := reloadInto(t, p, &enabled)
 	if got.Allowed {

--- a/internal/proxy/nested_url_reload_test.go
+++ b/internal/proxy/nested_url_reload_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// nestedURLReloadConfig is a config whose only interesting property is whether
+// nested query destinations are evaluated. SSRF stays literal-only so the test
+// needs no resolver, and the metadata address is not IP-allowlisted.
+func nestedURLReloadConfig(t *testing.T, enabled *bool) *config.Config {
+	t.Helper()
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = nil
+	cfg.APIAllowlist = nil
+	cfg.DLP.Patterns = nil
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+	cfg.FetchProxy.Monitoring.MaxURLLength = 4096
+	cfg.FetchProxy.Monitoring.ScanNestedURLs = enabled
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("cfg.Validate: %v", err)
+	}
+	return cfg
+}
+
+// nestedURLReloadProxy builds a proxy whose active scanner starts from cfg.
+func nestedURLReloadProxy(t *testing.T, cfg *config.Config) *Proxy {
+	t.Helper()
+	sc := scanner.MustNew(cfg)
+	p, err := New(cfg, audit.NewNop(), sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+	return p
+}
+
+// scanThroughLiveScanner scans a nested metadata URL through whatever scanner
+// the proxy is CURRENTLY serving from. Reading p.scannerPtr rather than a
+// locally built scanner is the whole point: a reload that swaps config without
+// swapping the scanner would pass a test that built its own.
+func scanThroughLiveScanner(t *testing.T, p *Proxy) scanner.Result {
+	t.Helper()
+	sc := p.scannerPtr.Load()
+	if sc == nil {
+		t.Fatal("proxy has no active scanner")
+	}
+	raw := "https://mirror.fixture.example.com/pkg?target=" +
+		url.QueryEscape("http://169.254.169.254/latest/meta-data/")
+	return sc.Scan(context.Background(), raw)
+}
+
+// reloadInto swaps the proxy onto a config with the given setting, through the
+// production Reload path, and returns the verdict the live scanner then gives.
+func reloadInto(t *testing.T, p *Proxy, enabled *bool) scanner.Result {
+	t.Helper()
+	cfg := nestedURLReloadConfig(t, enabled)
+	if !p.Reload(cfg, scanner.MustNew(cfg)) {
+		t.Fatal("Reload reported failure")
+	}
+	return scanThroughLiveScanner(t, p)
+}
+
+// TestProxy_ReloadScanNestedURLs_MovesEnforcementBothWays drives
+// fetch_proxy.monitoring.scan_nested_urls through the RUNNING reload path and
+// asserts the serving scanner reflects each change.
+//
+// A security boolean needs reload-with-change in both directions plus
+// reload-without-change: an operator who disables a control to get past an
+// incident and then removes the override must not keep the relaxed posture
+// until the process restarts. Constructing a fresh Config per assertion cannot
+// see that failure, because it never asks what the running proxy is serving.
+func TestProxy_ReloadScanNestedURLs_MovesEnforcementBothWays(t *testing.T) {
+	t.Parallel()
+
+	enabled, disabled := true, false
+
+	// Default (omitted) evaluates nested destinations.
+	p := nestedURLReloadProxy(t, nestedURLReloadConfig(t, nil))
+	if got := scanThroughLiveScanner(t, p); got.Allowed {
+		t.Fatal("omitted scan_nested_urls did not evaluate the nested destination")
+	}
+
+	// Disable through reload: the running scanner must stop evaluating.
+	if got := reloadInto(t, p, &disabled); !got.Allowed {
+		t.Fatalf("reload to false still blocked: scanner=%s reason=%q", got.Scanner, got.Reason)
+	}
+
+	// Reload with NO change: the relaxed posture must persist, not oscillate.
+	if got := reloadInto(t, p, &disabled); !got.Allowed {
+		t.Fatalf("unchanged reload flipped enforcement back on: reason=%q", got.Reason)
+	}
+
+	// Re-enable through reload: enforcement must return without a restart.
+	got := reloadInto(t, p, &enabled)
+	if got.Allowed {
+		t.Fatal("reload back to true left the relaxed scanner installed")
+	}
+	if got.Scanner != scanner.ScannerSSRF && got.Scanner != scanner.ScannerCoreSSRF {
+		t.Fatalf("re-enabled block came from %q, want an SSRF scanner", got.Scanner)
+	}
+}

--- a/internal/proxy/nested_url_transport_test.go
+++ b/internal/proxy/nested_url_transport_test.go
@@ -92,7 +92,9 @@ func TestForwardHTTP_NestedMetadataURLBlocked(t *testing.T) {
 }
 
 func TestInterceptTunnel_NestedMetadataURLBlocked(t *testing.T) {
+	var hits atomic.Int32
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()
@@ -109,6 +111,11 @@ func TestInterceptTunnel_NestedMetadataURLBlocked(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status=%d want 403", resp.StatusCode)
+	}
+	// A 403 alone is satisfied by a proxy that forwards first and refuses after.
+	// The destination must never be contacted.
+	if hits.Load() != 0 {
+		t.Fatalf("upstream contacted %d time(s) despite a nested metadata destination", hits.Load())
 	}
 }
 

--- a/internal/proxy/nested_url_transport_test.go
+++ b/internal/proxy/nested_url_transport_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const nestedMetadataQuery = "target=http://169.254.169.254/latest/meta-data/"
+
+func nestedURLProxyConfig() *config.Config {
+	cfg := config.Defaults()
+	cfg.APIAllowlist = nil
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+	cfg.DLP.Patterns = nil
+	return cfg
+}
+
+func TestFetchEndpoint_NestedMetadataURLBlocked(t *testing.T) {
+	cfg := nestedURLProxyConfig()
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	target := "https://mirror.vendor.example/pkg?" + nestedMetadataQuery
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+url.QueryEscape(target), nil)
+	w := httptest.NewRecorder()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fetch", p.handleFetch)
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want 403 body=%s", w.Code, w.Body.String())
+	}
+	var resp FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if !resp.Blocked {
+		t.Fatal("expected blocked=true")
+	}
+	if !strings.Contains(resp.BlockReason, "nested URL") {
+		t.Fatalf("block_reason=%q want nested URL", resp.BlockReason)
+	}
+}
+
+func TestForwardHTTP_NestedMetadataURLBlocked(t *testing.T) {
+	var hits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer backend.Close()
+
+	proxyAddr, cleanup := setupForwardProxy(t, func(cfg *config.Config) {
+		cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+		cfg.DLP.Patterns = nil
+	})
+	defer cleanup()
+
+	resp := doGet(t, proxyClient(proxyAddr), backend.URL+"/pkg?"+nestedMetadataQuery)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d want 403 body=%s", resp.StatusCode, body)
+	}
+	if hits.Load() != 0 {
+		t.Fatal("upstream invoked despite nested metadata URL")
+	}
+}
+
+func TestInterceptTunnel_NestedMetadataURLBlocked(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cache, pool, cfg, _, logger, m := testInterceptSetup(t)
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+	cfg.DLP.Patterns = nil
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	addr := upstream.Listener.Addr().String()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+addr+"/api?"+nestedMetadataQuery, nil)
+	resp := interceptAndRequest(t, upstream, cache, pool, cfg, sc, logger, m, req)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d want 403", resp.StatusCode)
+	}
+}
+
+func TestFetchEndpoint_RedirectNestedMetadataURLBlocked(t *testing.T) {
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://mirror.vendor.example/pkg?"+nestedMetadataQuery, http.StatusFound)
+	}))
+	defer backend.Close()
+
+	cfg := nestedURLProxyConfig()
+	cfg.FetchProxy.TimeoutSeconds = 5
+	logger := audit.NewNop()
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	p, err := New(cfg, logger, sc, metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	t.Cleanup(p.Close)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/fetch?url="+url.QueryEscape(backend.URL+"/start"), nil)
+	w := httptest.NewRecorder()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fetch", p.handleFetch)
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want 403 body=%s", w.Code, w.Body.String())
+	}
+	var resp FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if !resp.Blocked {
+		t.Fatal("expected blocked=true")
+	}
+	if !strings.Contains(resp.BlockReason, "nested URL") {
+		t.Fatalf("block_reason=%q want nested URL", resp.BlockReason)
+	}
+}
+
+func TestSubmitProfile_NestedMetadataURLBlocked(t *testing.T) {
+	var upstreamHit atomic.Bool
+	upstream := newIPv4Server(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+
+	cfg, upstreamURL := submitProfileTestConfig(upstream.URL)
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+	cfg.DLP.Patterns = nil
+	proxy := submitProfileReverseProxy(t, cfg, upstreamURL)
+
+	reqURL := proxy.URL + "/v1/batch?" + nestedMetadataQuery
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, reqURL, strings.NewReader(`{"clean":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d want 403", resp.StatusCode)
+	}
+	if upstreamHit.Load() {
+		t.Fatal("upstream invoked despite nested metadata URL")
+	}
+}

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -33,6 +33,38 @@ func apiWriteRule() config.RequestPolicyRule {
 	}
 }
 
+func TestEvaluate_FetchOnlyDenyListMissesUnlistedMethods(t *testing.T) {
+	t.Parallel()
+	m := mustMatcher(t, config.RequestPolicyRule{
+		Name:   "fetch-only-vendor-registry",
+		Action: config.ActionBlock,
+		Route: config.RequestPolicyRoute{
+			Hosts:   []string{"registry.vendor.example"},
+			Methods: []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"},
+		},
+	})
+
+	blocked := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"}
+	for _, method := range blocked {
+		got := m.Evaluate(RequestMeta{Host: "registry.vendor.example", Method: method, Path: "/pkg"})
+		if got.Action != config.ActionBlock || !got.Enforced() {
+			t.Fatalf("method %q: want enforced block, got %+v", method, got)
+		}
+	}
+
+	// request_policy is allow-by-default: a method absent from the deny list
+	// reaches the host. OPTIONS and TRACE are valid configured methods that
+	// this recipe does not name. LOCK cannot be configured at all, but an
+	// inbound request can still use it and must not be treated as blocked.
+	unlisted := []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace, "LOCK"}
+	for _, method := range unlisted {
+		got := m.Evaluate(RequestMeta{Host: "registry.vendor.example", Method: method, Path: "/pkg"})
+		if got.Matched() {
+			t.Fatalf("unlisted method %q matched the write-method deny list: %+v", method, got)
+		}
+	}
+}
+
 func TestEvaluate_RouteMatch(t *testing.T) {
 	m := mustMatcher(t, apiWriteRule())
 	tests := []struct {

--- a/internal/reqpolicy/policy_test.go
+++ b/internal/reqpolicy/policy_test.go
@@ -40,11 +40,11 @@ func TestEvaluate_FetchOnlyDenyListMissesUnlistedMethods(t *testing.T) {
 		Action: config.ActionBlock,
 		Route: config.RequestPolicyRoute{
 			Hosts:   []string{"registry.vendor.example"},
-			Methods: []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"},
+			Methods: []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK"},
 		},
 	})
 
-	blocked := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"}
+	blocked := []string{"POST", "PUT", "PATCH", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH", "LOCK", "UNLOCK"}
 	for _, method := range blocked {
 		got := m.Evaluate(RequestMeta{Host: "registry.vendor.example", Method: method, Path: "/pkg"})
 		if got.Action != config.ActionBlock || !got.Enforced() {
@@ -53,10 +53,11 @@ func TestEvaluate_FetchOnlyDenyListMissesUnlistedMethods(t *testing.T) {
 	}
 
 	// request_policy is allow-by-default: a method absent from the deny list
-	// reaches the host. OPTIONS and TRACE are valid configured methods that
-	// this recipe does not name. LOCK cannot be configured at all, but an
-	// inbound request can still use it and must not be treated as blocked.
-	unlisted := []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace, "LOCK"}
+	// reaches the host. Only reads and metadata verbs belong here. A
+	// state-changing method that this recipe fails to name is a gap in the
+	// recipe, not a property to assert, so LOCK and UNLOCK are in the blocked
+	// set above rather than here.
+	unlisted := []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace}
 	for _, method := range unlisted {
 		got := m.Evaluate(RequestMeta{Host: "registry.vendor.example", Method: method, Path: "/pkg"})
 		if got.Matched() {

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -432,13 +432,20 @@ func TestScan_NestedURLBudgetExhaustionIsInfrastructureNotThreat(t *testing.T) {
 	if !result.IsAdaptiveNeutral() {
 		t.Fatal("budget exhaustion must be adaptive-neutral so resolver wobble cannot drive lockdown")
 	}
-	// The hint must not tell an operator to edit an allowlist: no allowlist entry
-	// makes a resolver answer faster.
-	if strings.Contains(result.Hint, "ip_allowlist") {
-		t.Fatalf("hint names an inert control for a timeout: %q", result.Hint)
+	// result.Hint is the AGENT surface and must stay terse: no knob, no path.
+	for _, knob := range []string{"ip_allowlist", "scan_nested_urls", "config"} {
+		if strings.Contains(result.Hint, knob) {
+			t.Fatalf("agent hint leaks remediation %q: %q", knob, result.Hint)
+		}
 	}
-	if !strings.Contains(result.Hint, "resolution budget") {
-		t.Fatalf("hint does not name the budget: %q", result.Hint)
+	// The operator surface is where the budget is explained, and it must not
+	// name an allowlist: no allowlist entry makes a resolver answer faster.
+	op := OperatorHintForResult(result.Scanner, result.Reason)
+	if strings.Contains(op, "ip_allowlist") {
+		t.Fatalf("operator hint names an inert control for a timeout: %q", op)
+	}
+	if !strings.Contains(op, "resolution budget") {
+		t.Fatalf("operator hint does not name the budget: %q", op)
 	}
 }
 
@@ -469,10 +476,11 @@ func TestScan_NestedURLDeduplicatesDestinations(t *testing.T) {
 	}
 }
 
-// Round 2 finding 3: a unix path in a query value is not a destination. Completing
-// "//tmp/x" to https://tmp/x made a failed lookup refuse a request that carried no
-// destination at all.
-func TestScan_NestedURLSchemeRelativeOnlyCompletesHosts(t *testing.T) {
+// Round 3 finding 1: deciding what is NOT a destination is an allow gate, and the
+// round-2 shape rule ("ASCII dot or IP literal") was a detection hole. Every
+// single-label internal name and every non-ASCII-dot spelling walked through it.
+// The gate is now the same parser the destination checks use.
+func TestScan_NestedURLSchemeRelativeFollowsTheParser(t *testing.T) {
 	t.Parallel()
 	cfg := nestedURLSSRFConfig()
 	for _, tc := range []struct {
@@ -480,15 +488,21 @@ func TestScan_NestedURLSchemeRelativeOnlyCompletesHosts(t *testing.T) {
 		value       string
 		wantAllowed bool
 	}{
-		{"unix path is not a host", "//tmp/x", true},
-		{"single label is not a host", "//localdir/sub", true},
-		{"dotted name is a host", "//169.254.169.254/latest/", false},
+		{"single label resolves to loopback", "//localhost/admin", false},
+		{"single label with port", "//localhost:8080/", false},
+		{"single label with userinfo", "//user@localhost/", false},
+		{"metadata literal", "//169.254.169.254/latest/", false},
+		{"metadata literal without trailing slash", "//169.254.169.254", false},
+		{"alt-form literal", "//0x7f000001/", false},
+		{"bracketed ipv6", "//[::1]/", false},
+		{"unresolvable single label is still a destination", "//tmp/x", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			raw := nestedURLOuterHost + "?u=" + url.QueryEscape(tc.value)
 			result := scanNestedWith(t, cfg, raw, &countingResolver{hosts: map[string][]string{
 				"mirror.vendor.example": {"93.184.216.34"},
+				"localhost":             {"127.0.0.1"},
 			}})
 			if result.Allowed != tc.wantAllowed {
 				t.Fatalf("%s: allowed = %v, want %v (reason %q)", tc.name, result.Allowed, tc.wantAllowed, result.Reason)
@@ -583,4 +597,60 @@ func scanNestedWith(t *testing.T, cfg *config.Config, raw string, r Resolver) Re
 	t.Cleanup(s.Close)
 	s.resolver = r
 	return s.Scan(context.Background(), raw)
+}
+
+// Round 3 finding 2 and 3: audit and explain do not read result.Hint. They call
+// GuidanceForResult(scanner, reason). A timeout must not be explained with an
+// allowlist on either surface, and the agent-facing hint must stay terse.
+func TestGuidanceForNestedBudgetNamesNoAllowlist(t *testing.T) {
+	t.Parallel()
+	reason := "nested URL destinations exceeded the shared resolution budget (5s)"
+	g, ok := GuidanceForResult(ScannerSSRF, reason)
+	if !ok {
+		t.Fatal("no guidance for a nested budget block")
+	}
+	for _, inert := range []string{"ip_allowlist", "trusted_domains", "dns.host_overrides"} {
+		if strings.Contains(g.OperatorKnob, inert) {
+			t.Fatalf("operator guidance names %q, which cannot lift a resolver timeout: %q", inert, g.OperatorKnob)
+		}
+	}
+	if !strings.Contains(g.OperatorKnob, "scan_nested_urls") {
+		t.Fatalf("operator guidance does not name the control that governs this check: %q", g.OperatorKnob)
+	}
+	// The agent-facing reason must not hand the agent a remediation knob.
+	for _, knob := range []string{"scan_nested_urls", "ip_allowlist", "config", "set "} {
+		if strings.Contains(g.AgentReason, knob) {
+			t.Fatalf("agent reason leaks remediation %q: %q", knob, g.AgentReason)
+		}
+	}
+	if got := OperatorHintForResult(ScannerSSRF, reason); strings.Contains(got, "ip_allowlist") {
+		t.Fatalf("operator hint surface still names an inert control: %q", got)
+	}
+}
+
+// Round 3 finding 4: a nested-resolution timeout is adaptive-neutral, so it must
+// not be able to run BEFORE the no-I/O content scanners. If it did, a request
+// carrying a credential plus several slow nested hostnames would return the
+// timeout, the DLP finding would never reach audit, and nothing would be
+// recorded against the session.
+func TestScan_NestedURLCannotMaskCredentialFindings(t *testing.T) {
+	setNestedURLResolveBudgetForTest(t, 30*time.Millisecond)
+	cfg := nestedURLSSRFConfig()
+	cfg.DLP = config.Defaults().DLP
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.resolver = blockingResolver{}
+	raw := nestedURLOuterHost + "?key=" + url.QueryEscape("AKIA"+"IOSFODNN7EXAMPLE") +
+		"&a=" + url.QueryEscape("https://one.example.net/") +
+		"&b=" + url.QueryEscape("https://two.example.net/")
+	result := s.Scan(context.Background(), raw)
+	if result.Allowed {
+		t.Fatal("credential in the query was allowed")
+	}
+	if strings.Contains(result.Reason, "shared resolution budget") {
+		t.Fatalf("a nested resolution timeout preempted the credential finding: %q", result.Reason)
+	}
+	if result.IsAdaptiveNeutral() {
+		t.Fatalf("a credential block was reported as adaptive-neutral: scanner=%s reason=%q", result.Scanner, result.Reason)
+	}
 }

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -5,6 +5,7 @@ package scanner
 
 import (
 	"context"
+	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -238,13 +239,16 @@ func TestScan_NestedURLDestinations(t *testing.T) {
 	}
 }
 
-// setNestedURLResolveBudgetForTest shrinks the shared nested-DNS budget so a
-// test can exhaust it without waiting on the production ceiling.
-func setNestedURLResolveBudgetForTest(t *testing.T, d time.Duration) {
+// newScannerWithBudget builds a scanner whose nested-resolution budget is short
+// enough to exhaust without waiting on the production ceiling. The budget is
+// per-Scanner state, so this is safe in a parallel test: nothing is shared.
+func newScannerWithBudget(t *testing.T, cfg *config.Config, d time.Duration, r Resolver) *Scanner {
 	t.Helper()
-	prev := nestedURLResolveBudget
-	nestedURLResolveBudget = d
-	t.Cleanup(func() { nestedURLResolveBudget = prev })
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.nestedURLResolveBudget = d
+	s.resolver = r
+	return s
 }
 
 // blockingResolver never answers; it returns only when the caller's context
@@ -292,11 +296,8 @@ func TestScan_NestedURLNoCountCap(t *testing.T) {
 // Exhausting the shared resolution budget must refuse the request, never
 // forward it with nested destinations left unverified.
 func TestScan_NestedURLResolveBudgetExhaustionFailsClosed(t *testing.T) {
-	setNestedURLResolveBudgetForTest(t, 50*time.Millisecond)
-	cfg := nestedURLSSRFConfig()
-	s := MustNew(cfg)
-	t.Cleanup(s.Close)
-	s.resolver = blockingResolver{}
+	t.Parallel()
+	s := newScannerWithBudget(t, nestedURLSSRFConfig(), 50*time.Millisecond, blockingResolver{})
 	raw := nestedURLOuterHost + "?a=" + url.QueryEscape("https://one.example.net/") +
 		"&b=" + url.QueryEscape("https://two.example.net/") +
 		"&c=" + url.QueryEscape("https://three.example.net/")
@@ -330,6 +331,7 @@ func TestScan_NestedURLDecodingParity(t *testing.T) {
 		{"url_in_key", nestedURLOuterHost + "?" + url.QueryEscape(meta) + "=x"},
 		{"base64_value", nestedURLOuterHost + "?u=" + base64.StdEncoding.EncodeToString([]byte(meta))},
 		{"hex_value", nestedURLOuterHost + "?u=" + hex.EncodeToString([]byte(meta))},
+		{"base32_value", nestedURLOuterHost + "?u=" + base32.StdEncoding.EncodeToString([]byte(meta))},
 		{"scheme_relative", nestedURLOuterHost + "?u=" + url.QueryEscape("//169.254.169.254/latest/")},
 		{"leading_space", nestedURLOuterHost + "?u=" + url.QueryEscape("  "+meta)},
 		{"ipv6_zone_id", nestedURLOuterHost + "?u=http://[fe80::1%25eth0]/"},
@@ -415,11 +417,8 @@ func TestOperatorHintForNestedURLNamesConsultedKnob(t *testing.T) {
 // accumulate adaptive-enforcement signal until a session is locked down, which is
 // the same defect checkSSRF already avoids for the outer host.
 func TestScan_NestedURLBudgetExhaustionIsInfrastructureNotThreat(t *testing.T) {
-	setNestedURLResolveBudgetForTest(t, 50*time.Millisecond)
-	cfg := nestedURLSSRFConfig()
-	s := MustNew(cfg)
-	t.Cleanup(s.Close)
-	s.resolver = blockingResolver{}
+	t.Parallel()
+	s := newScannerWithBudget(t, nestedURLSSRFConfig(), 50*time.Millisecond, blockingResolver{})
 	raw := nestedURLOuterHost + "?a=" + url.QueryEscape("https://one.example.net/") +
 		"&b=" + url.QueryEscape("https://two.example.net/")
 	result := s.Scan(context.Background(), raw)
@@ -634,12 +633,10 @@ func TestGuidanceForNestedBudgetNamesNoAllowlist(t *testing.T) {
 // timeout, the DLP finding would never reach audit, and nothing would be
 // recorded against the session.
 func TestScan_NestedURLCannotMaskCredentialFindings(t *testing.T) {
-	setNestedURLResolveBudgetForTest(t, 30*time.Millisecond)
+	t.Parallel()
 	cfg := nestedURLSSRFConfig()
 	cfg.DLP = config.Defaults().DLP
-	s := MustNew(cfg)
-	t.Cleanup(s.Close)
-	s.resolver = blockingResolver{}
+	s := newScannerWithBudget(t, cfg, 30*time.Millisecond, blockingResolver{})
 	raw := nestedURLOuterHost + "?key=" + url.QueryEscape("AKIA"+"IOSFODNN7EXAMPLE") +
 		"&a=" + url.QueryEscape("https://one.example.net/") +
 		"&b=" + url.QueryEscape("https://two.example.net/")
@@ -684,5 +681,38 @@ func TestGuidanceForNestedResultKeyCannotSuppressAnnotation(t *testing.T) {
 	g, ok := GuidanceForResult(ScannerSSRF, "nested URL destinations exceeded the shared resolution budget (5s)")
 	if !ok || strings.Contains(g.OperatorKnob, "ip_allowlist") {
 		t.Fatalf("budget guidance regressed: ok=%v knob=%q", ok, g.OperatorKnob)
+	}
+}
+
+// The config-level matrix in internal/config proves Load parses the field. It
+// cannot prove the value reaches the component that enforces it: a reloader that
+// built a new Config and kept the old scanner would pass it. Hot reload rebuilds
+// the scanner from config, so exercise that rebuild in both directions and assert
+// the nested destination verdict actually moves. A relaxed posture must not
+// survive a re-tighten, which is the direction that matters.
+func TestScan_NestedURLReloadMovesEnforcementBothWays(t *testing.T) {
+	t.Parallel()
+	metadata := nestedURLOuterHost + "?u=" + url.QueryEscape(nestedURLMetadataPath)
+
+	rebuild := func(enabled bool) Result {
+		cfg := nestedURLConfig()
+		cfg.SSRF.IPAllowlist = nil
+		cfg.FetchProxy.Monitoring.ScanNestedURLs = &enabled
+		s := MustNew(cfg)
+		t.Cleanup(s.Close)
+		s.resolver = failOnLookupResolver{t: t}
+		return s.Scan(context.Background(), metadata)
+	}
+
+	if r := rebuild(true); r.Allowed {
+		t.Fatal("enabled: nested metadata destination was allowed")
+	}
+	if r := rebuild(false); !r.Allowed {
+		t.Fatalf("disabled: expected the check to be off, got scanner=%s reason=%q", r.Scanner, r.Reason)
+	}
+	// Re-tightening has to take effect without a restart. If it did not, an
+	// operator who relaxed the setting once would keep the relaxed posture.
+	if r := rebuild(true); r.Allowed {
+		t.Fatal("re-enabled: the relaxed posture survived a reload")
 	}
 }

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -654,3 +654,35 @@ func TestScan_NestedURLCannotMaskCredentialFindings(t *testing.T) {
 		t.Fatalf("a credential block was reported as adaptive-neutral: scanner=%s reason=%q", result.Scanner, result.Reason)
 	}
 }
+
+// Round 4: the annotation skip must test the STRIPPED reason. The raw reason
+// carries the query key, which the client chooses, so matching on it let a
+// parameter named after the budget suppress the nested-destination sentence on a
+// genuine destination block. Not a fail-open, but the same class as round 2: the
+// caller must not be able to steer what the operator is told.
+func TestGuidanceForNestedResultKeyCannotSuppressAnnotation(t *testing.T) {
+	t.Parallel()
+	private := Result{
+		Allowed: false,
+		Reason:  "SSRF blocked: 10.0.0.12 is an internal IP",
+		Scanner: ScannerSSRF,
+	}
+	for _, key := range []string{"target", "shared resolution budget", "SHARED RESOLUTION BUDGET"} {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			blocked := prefixNestedURLResult(key, private)
+			g, ok := GuidanceForResult(blocked.Scanner, blocked.Reason)
+			if !ok {
+				t.Fatal("no guidance for a nested SSRF block")
+			}
+			if !strings.Contains(g.OperatorKnob, "scan_nested_urls") {
+				t.Fatalf("query key %q suppressed the nested-destination sentence: %q", key, g.OperatorKnob)
+			}
+		})
+	}
+	// A genuine budget block still gets budget guidance and no allowlist.
+	g, ok := GuidanceForResult(ScannerSSRF, "nested URL destinations exceeded the shared resolution budget (5s)")
+	if !ok || strings.Contains(g.OperatorKnob, "ip_allowlist") {
+		t.Fatalf("budget guidance regressed: ok=%v knob=%q", ok, g.OperatorKnob)
+	}
+}

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const (
+	nestedURLOuterHost    = "https://mirror.vendor.example/pkg"
+	nestedURLMetadataPath = "http://169.254.169.254/latest/meta-data/"
+	nestedURLPrivatePath  = "http://10.0.0.12:8500/v1/kv/x"
+	nestedURLPublicHost   = "https://app.example.com/cb"
+)
+
+func nestedURLConfig() *config.Config {
+	cfg := testConfig()
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 8.0
+	cfg.FetchProxy.Monitoring.MaxURLLength = 4096
+	cfg.DLP.Patterns = nil
+	return cfg
+}
+
+func nestedURLSSRFConfig() *config.Config {
+	cfg := nestedURLConfig()
+	// Non-empty Internal activates checkSSRF (and skips the core-literal
+	// safety net). Core CIDRs are merged, so metadata/private literals still
+	// block, and the scanner label is the production SSRF/metadata label.
+	cfg.Internal = []string{"203.0.113.0/24"}
+	cfg.SSRF.IPAllowlist = nil
+	return cfg
+}
+
+func scanNested(t *testing.T, cfg *config.Config, raw string) Result {
+	t.Helper()
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.resolver = failOnLookupResolver{t: t}
+	return s.Scan(context.Background(), raw)
+}
+
+func TestScan_NestedURLDestinations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         func() *config.Config
+		raw         string
+		wantAllow   bool
+		wantScanner string
+		wantReason  string
+	}{
+		{
+			name:        "nested metadata literal",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?target=" + nestedURLMetadataPath,
+			wantScanner: ScannerSSRFMetadata,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested RFC1918 literal",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?url=" + nestedURLPrivatePath,
+			wantScanner: ScannerSSRF,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested hex loopback",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?u=http://0x7f000001/",
+			wantScanner: ScannerSSRF,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested decimal loopback",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?u=http://2130706433/",
+			wantScanner: ScannerSSRF,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested ipv4-mapped loopback",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?u=http://[::ffff:127.0.0.1]/",
+			wantScanner: ScannerSSRF,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested percent-encoded once",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?u=http%3A%2F%2F169.254.169.254%2F",
+			wantScanner: ScannerSSRFMetadata,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:        "nested percent-encoded twice",
+			cfg:         nestedURLSSRFConfig,
+			raw:         nestedURLOuterHost + "?u=http%253A%252F%252F169.254.169.254%252F",
+			wantScanner: ScannerSSRFMetadata,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name: "nested blocklisted host",
+			cfg: func() *config.Config {
+				cfg := nestedURLConfig()
+				cfg.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example"}
+				return cfg
+			},
+			raw:         nestedURLOuterHost + "?u=https://blocked.vendor.example/pkg",
+			wantScanner: ScannerBlocklist,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name:      "nested public host allowed",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?redirect_uri=" + nestedURLPublicHost,
+			wantAllow: true,
+		},
+		{
+			name:      "nested bare word ignored",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?q=hello",
+			wantAllow: true,
+		},
+		{
+			name:      "nested relative path ignored",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?path=/a/b",
+			wantAllow: true,
+		},
+		{
+			name:      "nested mailto ignored",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?u=mailto:x@y",
+			wantAllow: true,
+		},
+		{
+			name:      "nested data URI ignored",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?u=data:text/plain,x",
+			wantAllow: true,
+		},
+		{
+			name: "scan_nested_urls false allows metadata",
+			cfg: func() *config.Config {
+				cfg := nestedURLConfig()
+				disabled := false
+				cfg.FetchProxy.Monitoring.ScanNestedURLs = &disabled
+				return cfg
+			},
+			raw:       nestedURLOuterHost + "?target=" + nestedURLMetadataPath,
+			wantAllow: true,
+		},
+		{
+			name: "strict mode nested host not on allowlist",
+			cfg: func() *config.Config {
+				cfg := nestedURLConfig()
+				cfg.Mode = config.ModeStrict
+				cfg.APIAllowlist = []string{"mirror.vendor.example"}
+				return cfg
+			},
+			raw:         nestedURLOuterHost + "?redirect_uri=" + nestedURLPublicHost,
+			wantScanner: ScannerAllowlist,
+			wantReason:  nestedURLReasonPrefix,
+		},
+		{
+			name: "strict mode nested host on allowlist",
+			cfg: func() *config.Config {
+				cfg := nestedURLConfig()
+				cfg.Mode = config.ModeStrict
+				cfg.APIAllowlist = []string{"mirror.vendor.example", "app.example.com"}
+				return cfg
+			},
+			raw:       nestedURLOuterHost + "?redirect_uri=" + nestedURLPublicHost,
+			wantAllow: true,
+		},
+		{
+			name: "ssrf ip_allowlist covers nested private IP",
+			cfg: func() *config.Config {
+				cfg := nestedURLConfig()
+				cfg.SSRF.IPAllowlist = []string{"10.0.0.12/32"}
+				return cfg
+			},
+			raw:       nestedURLOuterHost + "?url=" + nestedURLPrivatePath,
+			wantAllow: true,
+		},
+		{
+			name: "one-level nesting is not expanded",
+			cfg:  nestedURLConfig,
+			raw: nestedURLOuterHost + "?u=" + url.QueryEscape(
+				nestedURLPublicHost+"?target="+nestedURLMetadataPath,
+			),
+			wantAllow: true,
+		},
+		{
+			name:      "nested bad port is not a URL",
+			cfg:       nestedURLConfig,
+			raw:       nestedURLOuterHost + "?u=http://app.example.com:99999/",
+			wantAllow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := scanNested(t, tt.cfg(), tt.raw)
+			if tt.wantAllow {
+				if !result.Allowed {
+					t.Fatalf("allowed=false scanner=%s reason=%s", result.Scanner, result.Reason)
+				}
+				return
+			}
+			if result.Allowed {
+				t.Fatal("expected block")
+			}
+			if result.Scanner != tt.wantScanner {
+				t.Fatalf("scanner=%s want %s reason=%s", result.Scanner, tt.wantScanner, result.Reason)
+			}
+			if !strings.Contains(result.Reason, tt.wantReason) {
+				t.Fatalf("reason=%q want substring %q", result.Reason, tt.wantReason)
+			}
+			if result.Score != 1.0 {
+				t.Fatalf("score=%v want 1.0", result.Score)
+			}
+		})
+	}
+}
+
+func TestScan_NestedURLQueryValueCap(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLConfig()
+	var b strings.Builder
+	b.WriteString(nestedURLOuterHost)
+	b.WriteByte('?')
+	for i := range 40 {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		fmt.Fprintf(&b, "n%02d=", i)
+		if i == 39 {
+			b.WriteString(url.QueryEscape(nestedURLMetadataPath))
+		} else {
+			b.WriteByte('x')
+		}
+	}
+	result := scanNested(t, cfg, b.String())
+	// Cap is 32 query values. Keys sort as n00..n39, so the metadata URL is
+	// the 40th value and is not expanded. Fail-open on the cap is acceptable
+	// only because outer-host checks still run.
+	if !result.Allowed {
+		t.Fatalf("40th nested metadata value should pass the cap, got scanner=%s reason=%s", result.Scanner, result.Reason)
+	}
+}
+
+func TestCheckNestedURLs_SkipsOversizeValues(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+	s.maxURLLength = 16
+	parsed, err := url.Parse(nestedURLOuterHost + "?target=" + nestedURLMetadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := s.checkNestedURLs(context.Background(), parsed)
+	if !result.Allowed {
+		t.Fatalf("oversize nested value should be skipped, got %s", result.Reason)
+	}
+}
+
+func TestCheckNestedURLs_NilAndEmpty(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+	if result := s.checkNestedURLs(context.Background(), nil); !result.Allowed {
+		t.Fatalf("nil parsed URL: %s", result.Reason)
+	}
+	parsed, err := url.Parse("https://mirror.vendor.example/pkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := s.checkNestedURLs(context.Background(), parsed); !result.Allowed {
+		t.Fatalf("empty query: %s", result.Reason)
+	}
+}
+
+func TestOperatorHintForNestedURLNamesConsultedKnob(t *testing.T) {
+	t.Parallel()
+	ssrfHint := OperatorHintForResult(ScannerSSRF, nestedURLReasonPrefix+` "url": SSRF blocked: 10.0.0.12 is an internal IP`)
+	for _, want := range []string{
+		"fetch_proxy.monitoring.scan_nested_urls",
+		"ssrf.ip_allowlist",
+		"trusted_domains",
+		"dns.host_overrides",
+	} {
+		if !strings.Contains(ssrfHint, want) {
+			t.Fatalf("SSRF nested hint missing %q: %s", want, ssrfHint)
+		}
+	}
+
+	metaHint := OperatorHintForResult(ScannerSSRFMetadata, nestedURLReasonPrefix+` "target": SSRF blocked: 169.254.169.254 is a cloud metadata endpoint`)
+	if !strings.Contains(metaHint, "fetch_proxy.monitoring.scan_nested_urls") {
+		t.Fatalf("metadata nested hint missing scan_nested_urls: %s", metaHint)
+	}
+	if !strings.Contains(metaHint, "no allow knob") {
+		t.Fatalf("metadata nested hint must keep the non-overridable wording: %s", metaHint)
+	}
+
+	blockHint := OperatorHintForResult(ScannerBlocklist, nestedURLReasonPrefix+` "u": domain blocked: blocked.vendor.example matches blocked.vendor.example`)
+	if !strings.Contains(blockHint, "fetch_proxy.monitoring.scan_nested_urls") {
+		t.Fatalf("blocklist nested hint missing scan_nested_urls: %s", blockHint)
+	}
+	if !strings.Contains(blockHint, "blocklist") {
+		t.Fatalf("blocklist nested hint missing inner knob: %s", blockHint)
+	}
+}

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -406,4 +408,179 @@ func TestOperatorHintForNestedURLNamesConsultedKnob(t *testing.T) {
 	if !strings.Contains(blockHint, "blocklist") {
 		t.Fatalf("blocklist nested hint missing inner knob: %s", blockHint)
 	}
+}
+
+// Round 2 finding 1: budget exhaustion is a resolver-availability condition, not
+// evidence of an adversary. Classifying it as a threat would let resolver wobble
+// accumulate adaptive-enforcement signal until a session is locked down, which is
+// the same defect checkSSRF already avoids for the outer host.
+func TestScan_NestedURLBudgetExhaustionIsInfrastructureNotThreat(t *testing.T) {
+	setNestedURLResolveBudgetForTest(t, 50*time.Millisecond)
+	cfg := nestedURLSSRFConfig()
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.resolver = blockingResolver{}
+	raw := nestedURLOuterHost + "?a=" + url.QueryEscape("https://one.example.net/") +
+		"&b=" + url.QueryEscape("https://two.example.net/")
+	result := s.Scan(context.Background(), raw)
+	if result.Allowed {
+		t.Fatal("budget exhaustion allowed the request")
+	}
+	if result.Class != ClassInfrastructureError {
+		t.Fatalf("class = %v, want ClassInfrastructureError: a timeout resolved no destination and is not threat evidence", result.Class)
+	}
+	if !result.IsAdaptiveNeutral() {
+		t.Fatal("budget exhaustion must be adaptive-neutral so resolver wobble cannot drive lockdown")
+	}
+	// The hint must not tell an operator to edit an allowlist: no allowlist entry
+	// makes a resolver answer faster.
+	if strings.Contains(result.Hint, "ip_allowlist") {
+		t.Fatalf("hint names an inert control for a timeout: %q", result.Hint)
+	}
+	if !strings.Contains(result.Hint, "resolution budget") {
+		t.Fatalf("hint does not name the budget: %q", result.Hint)
+	}
+}
+
+// Round 2 finding 2: one verdict per distinct destination. The same callback URL
+// repeated across parameters is one destination and must cost one lookup.
+func TestScan_NestedURLDeduplicatesDestinations(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLSSRFConfig()
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	counting := &countingResolver{hosts: map[string][]string{
+		"mirror.vendor.example": {"93.184.216.34"},
+		"app.example.com":       {"93.184.216.34"},
+	}}
+	s.resolver = counting
+	var b strings.Builder
+	b.WriteString(nestedURLOuterHost)
+	for i := range 10 {
+		fmt.Fprintf(&b, "%cu%d=%s", map[bool]rune{true: '?', false: '&'}[i == 0], i,
+			url.QueryEscape("https://app.example.com/cb"))
+	}
+	result := s.Scan(context.Background(), b.String())
+	if !result.Allowed {
+		t.Fatalf("ten copies of one public callback were refused: %s", result.Reason)
+	}
+	if got := counting.count("app.example.com"); got != 1 {
+		t.Fatalf("lookups for the repeated host = %d, want 1", got)
+	}
+}
+
+// Round 2 finding 3: a unix path in a query value is not a destination. Completing
+// "//tmp/x" to https://tmp/x made a failed lookup refuse a request that carried no
+// destination at all.
+func TestScan_NestedURLSchemeRelativeOnlyCompletesHosts(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLSSRFConfig()
+	for _, tc := range []struct {
+		name        string
+		value       string
+		wantAllowed bool
+	}{
+		{"unix path is not a host", "//tmp/x", true},
+		{"single label is not a host", "//localdir/sub", true},
+		{"dotted name is a host", "//169.254.169.254/latest/", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			raw := nestedURLOuterHost + "?u=" + url.QueryEscape(tc.value)
+			result := scanNestedWith(t, cfg, raw, &countingResolver{hosts: map[string][]string{
+				"mirror.vendor.example": {"93.184.216.34"},
+			}})
+			if result.Allowed != tc.wantAllowed {
+				t.Fatalf("%s: allowed = %v, want %v (reason %q)", tc.name, result.Allowed, tc.wantAllowed, result.Reason)
+			}
+		})
+	}
+}
+
+// Round 2 finding 4: the query key is attacker-chosen and must not steer operator
+// guidance. A parameter named "metadata" must not turn a private-IP block into the
+// immutable cloud-metadata explanation that says there is no allow knob.
+func TestGuidanceForNestedResultRoutesOnInnerReason(t *testing.T) {
+	t.Parallel()
+	private := Result{
+		Allowed: false,
+		Reason:  "SSRF blocked: 10.0.0.12 is an internal IP",
+		Scanner: ScannerSSRF,
+	}
+	hostile := prefixNestedURLResult("metadata", private)
+	g, ok := GuidanceForResult(hostile.Scanner, hostile.Reason)
+	if !ok {
+		t.Fatal("no guidance for a nested SSRF block")
+	}
+	if g.Immutable {
+		t.Fatalf("a parameter named %q routed a private-IP block to immutable metadata guidance: %q", "metadata", g.OperatorKnob)
+	}
+	genuine := prefixNestedURLResult("target", Result{
+		Allowed: false,
+		Reason:  "SSRF blocked: 169.254.169.254 is a cloud metadata endpoint",
+		Scanner: ScannerSSRF,
+	})
+	gm, ok := GuidanceForResult(genuine.Scanner, genuine.Reason)
+	if !ok || !gm.Immutable {
+		t.Fatalf("a genuine nested metadata block lost its immutable guidance: ok=%v immutable=%v", ok, gm.Immutable)
+	}
+}
+
+// Coverage for the early returns in the nested path: a query with no candidate,
+// a parsed URL with no host, and an alternative-form literal carrying a port.
+func TestScan_NestedURLEdgeShapes(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLConfig()
+	cfg.SSRF.IPAllowlist = nil
+	for _, tc := range []struct {
+		name        string
+		raw         string
+		wantAllowed bool
+	}{
+		{"query with no url-shaped candidate", nestedURLOuterHost + "?a=1&b=2", true},
+		{"scheme without host", nestedURLOuterHost + "?u=" + url.QueryEscape("http:///etc/passwd"), true},
+		{"alt-form literal with port", nestedURLOuterHost + "?u=" + url.QueryEscape("http://0x7f000001:8080/"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := scanNested(t, cfg, tc.raw)
+			if result.Allowed != tc.wantAllowed {
+				t.Fatalf("%s: allowed = %v, want %v (scanner %s reason %q)", tc.name, result.Allowed, tc.wantAllowed, result.Scanner, result.Reason)
+			}
+		})
+	}
+}
+
+// countingResolver records how many times each host was looked up.
+type countingResolver struct {
+	mu    sync.Mutex
+	hosts map[string][]string
+	seen  map[string]int
+}
+
+func (c *countingResolver) LookupHost(_ context.Context, host string) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.seen == nil {
+		c.seen = map[string]int{}
+	}
+	c.seen[host]++
+	if ips, ok := c.hosts[host]; ok {
+		return ips, nil
+	}
+	return nil, errors.New("no such host")
+}
+
+func (c *countingResolver) count(host string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.seen[host]
+}
+
+func scanNestedWith(t *testing.T, cfg *config.Config, raw string, r Resolver) Result {
+	t.Helper()
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.resolver = r
+	return s.Scan(context.Background(), raw)
 }

--- a/internal/scanner/nested_url_test.go
+++ b/internal/scanner/nested_url_test.go
@@ -5,10 +5,13 @@ package scanner
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 )
@@ -233,29 +236,111 @@ func TestScan_NestedURLDestinations(t *testing.T) {
 	}
 }
 
-func TestScan_NestedURLQueryValueCap(t *testing.T) {
+// setNestedURLResolveBudgetForTest shrinks the shared nested-DNS budget so a
+// test can exhaust it without waiting on the production ceiling.
+func setNestedURLResolveBudgetForTest(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := nestedURLResolveBudget
+	nestedURLResolveBudget = d
+	t.Cleanup(func() { nestedURLResolveBudget = prev })
+}
+
+// blockingResolver never answers; it returns only when the caller's context
+// ends, which is how a stalled resolver behaves against a real request.
+type blockingResolver struct{}
+
+func (blockingResolver) LookupHost(ctx context.Context, _ string) ([]string, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// A count cap was a fail-open: pad past it, then relay. There is no count cap.
+// The metadata URL must block wherever it sits in the query string.
+func TestScan_NestedURLNoCountCap(t *testing.T) {
 	t.Parallel()
 	cfg := nestedURLConfig()
-	var b strings.Builder
-	b.WriteString(nestedURLOuterHost)
-	b.WriteByte('?')
-	for i := range 40 {
-		if i > 0 {
-			b.WriteByte('&')
-		}
-		fmt.Fprintf(&b, "n%02d=", i)
-		if i == 39 {
-			b.WriteString(url.QueryEscape(nestedURLMetadataPath))
-		} else {
-			b.WriteByte('x')
-		}
+	for _, position := range []int{0, 31, 32, 39} {
+		t.Run(fmt.Sprintf("metadata_at_index_%d_of_40", position), func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			b.WriteString(nestedURLOuterHost)
+			b.WriteByte('?')
+			for i := range 40 {
+				if i > 0 {
+					b.WriteByte('&')
+				}
+				fmt.Fprintf(&b, "n%02d=", i)
+				if i == position {
+					b.WriteString(url.QueryEscape(nestedURLMetadataPath))
+				} else {
+					b.WriteByte('x')
+				}
+			}
+			result := scanNested(t, cfg, b.String())
+			if result.Allowed {
+				t.Fatalf("metadata URL at index %d was allowed; a positional gap is a fail-open", position)
+			}
+			if !strings.Contains(result.Reason, nestedURLReasonPrefix) {
+				t.Fatalf("reason %q does not name the nested parameter", result.Reason)
+			}
+		})
 	}
-	result := scanNested(t, cfg, b.String())
-	// Cap is 32 query values. Keys sort as n00..n39, so the metadata URL is
-	// the 40th value and is not expanded. Fail-open on the cap is acceptable
-	// only because outer-host checks still run.
-	if !result.Allowed {
-		t.Fatalf("40th nested metadata value should pass the cap, got scanner=%s reason=%s", result.Scanner, result.Reason)
+}
+
+// Exhausting the shared resolution budget must refuse the request, never
+// forward it with nested destinations left unverified.
+func TestScan_NestedURLResolveBudgetExhaustionFailsClosed(t *testing.T) {
+	setNestedURLResolveBudgetForTest(t, 50*time.Millisecond)
+	cfg := nestedURLSSRFConfig()
+	s := MustNew(cfg)
+	t.Cleanup(s.Close)
+	s.resolver = blockingResolver{}
+	raw := nestedURLOuterHost + "?a=" + url.QueryEscape("https://one.example.net/") +
+		"&b=" + url.QueryEscape("https://two.example.net/") +
+		"&c=" + url.QueryEscape("https://three.example.net/")
+	result := s.Scan(context.Background(), raw)
+	if result.Allowed {
+		t.Fatal("budget exhaustion allowed the request; nested destinations were never verified")
+	}
+	if !strings.Contains(result.Reason, "shared resolution budget") {
+		t.Fatalf("reason %q does not name the exhausted budget", result.Reason)
+	}
+	if result.Scanner != ScannerSSRF {
+		t.Fatalf("scanner = %q, want %q", result.Scanner, ScannerSSRF)
+	}
+}
+
+// Decoding parity with the DLP query loop: keys as well as values, hex and
+// base64 layers, scheme-relative references, IPv6 zone ids, and stray
+// whitespace must all reach the destination checks.
+func TestScan_NestedURLDecodingParity(t *testing.T) {
+	t.Parallel()
+	cfg := nestedURLConfig()
+	// testConfig allowlists 127.0.0.0/8 and ::1/128 as an operator override, and
+	// the nested path consults that allowlist exactly as the outer path does.
+	// Clear it so these rows measure decoding parity rather than the override.
+	cfg.SSRF.IPAllowlist = nil
+	meta := nestedURLMetadataPath
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"url_in_key", nestedURLOuterHost + "?" + url.QueryEscape(meta) + "=x"},
+		{"base64_value", nestedURLOuterHost + "?u=" + base64.StdEncoding.EncodeToString([]byte(meta))},
+		{"hex_value", nestedURLOuterHost + "?u=" + hex.EncodeToString([]byte(meta))},
+		{"scheme_relative", nestedURLOuterHost + "?u=" + url.QueryEscape("//169.254.169.254/latest/")},
+		{"leading_space", nestedURLOuterHost + "?u=" + url.QueryEscape("  "+meta)},
+		{"ipv6_zone_id", nestedURLOuterHost + "?u=http://[fe80::1%25eth0]/"},
+		{"ipv6_loopback", nestedURLOuterHost + "?u=" + url.QueryEscape("http://[::1]/")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := scanNested(t, cfg, tc.raw)
+			if result.Allowed {
+				t.Fatalf("%s: nested private destination was allowed", tc.name)
+			}
+		})
 	}
 }
 

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -638,6 +638,15 @@ func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
 	// knobs that cannot exempt these targets. Route those reason-specific SSRF
 	// blocks to the non-overridable guidance regardless of which SSRF label
 	// carried them.
+	// A nested-destination timeout is an availability condition wearing an SSRF
+	// label. Route it before the SSRF knobs below, which would otherwise offer
+	// ssrf.ip_allowlist and trusted_domains for a block no allowlist can lift.
+	if strings.Contains(reason, nestedURLBudgetReason) {
+		return RemediationGuidance{
+			OperatorKnob: nestedURLBudgetOperatorKnob,
+			AgentReason:  nestedURLBudgetAgentReason,
+		}, true
+	}
 	if label == ScannerSSRF || label == ScannerSSRFMetadata || label == ScannerCoreSSRF {
 		if strings.Contains(reason, "metadata") {
 			return RemediationGuidance{
@@ -657,16 +666,24 @@ func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
 	return GuidanceFor(label)
 }
 
-// nestedURLBudgetHint explains a nested-destination resolution timeout. It
-// deliberately names no allowlist: no allowlist entry can make a resolver
-// answer faster, and pointing an operator at one teaches them that policy
-// changed when nothing did.
-const nestedURLBudgetHint = "nested URL destinations could not be resolved within the shared resolution budget; the request was refused because a destination was left unverified. This is a resolver-availability condition, not a detection. Check resolver health and latency; to stop evaluating query-parameter destinations entirely, set fetch_proxy.monitoring.scan_nested_urls to false."
+// nestedURLBudgetReason is the substring that identifies a nested-destination
+// resolution timeout. Guidance for it must never name an allowlist: no allowlist
+// entry makes a resolver answer faster, and naming one teaches an operator that
+// policy changed when nothing did.
+const nestedURLBudgetReason = "shared resolution budget"
+
+const nestedURLBudgetOperatorKnob = "Nested query destinations could not be resolved within the shared resolution budget, so the request was refused with a destination left unverified. This is resolver availability, not detection: check resolver health and latency for the hostnames named in the request. To stop evaluating query-parameter destinations entirely, set `fetch_proxy.monitoring.scan_nested_urls` to false."
+
+const nestedURLBudgetAgentReason = "a destination named inside this request could not be verified in time"
 
 func annotateNestedURLGuidance(g RemediationGuidance, label, reason string) RemediationGuidance {
 	lower := strings.ToLower(reason)
-	if !strings.Contains(lower, "nested url in query parameter") &&
-		!strings.Contains(lower, "shared resolution budget") {
+	// A resolution timeout already carries its own guidance and must not be
+	// annotated with the destination-knob sentence: no allowlist lifts a timeout.
+	if strings.Contains(lower, strings.ToLower(nestedURLBudgetReason)) {
+		return g
+	}
+	if !strings.Contains(lower, "nested url in query parameter") {
 		return g
 	}
 	nestedKnob := " Nested query destinations are evaluated because `fetch_proxy.monitoring.scan_nested_urls` is enabled (nil/true). Set it false only for an endpoint whose contract legitimately carries private or blocklisted URLs in query strings."

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -364,10 +364,45 @@ func OperatorHintFor(label string) string {
 // entropy, while ScannerDenialOfWallet distinguishes budget-limit reasons.
 // Every other label falls through to the label-keyed table. This is the single
 // place that disambiguation lives, so explain, audit, and future consumers agree.
+// stripNestedURLReasonPrefix removes the "nested URL in query parameter %q: "
+// prefix so guidance routes on the INNER scanner reason. The parameter key is
+// attacker-chosen, and the SSRF routing below matches substrings such as
+// "metadata"; without this, a request naming its parameter "metadata" would be
+// explained with the immutable cloud-metadata guidance no matter what the
+// nested destination actually was.
+func stripNestedURLReasonPrefix(reason string) string {
+	open := nestedURLReasonPrefix + " \""
+	if !strings.HasPrefix(reason, open) {
+		return reason
+	}
+	rest := reason[len(open):]
+	// The key is %q-quoted, so the terminating quote is the first one not
+	// preceded by an odd number of backslashes.
+	for i := 0; i < len(rest); i++ {
+		if rest[i] != '"' {
+			continue
+		}
+		slashes := 0
+		for j := i - 1; j >= 0 && rest[j] == '\\'; j-- {
+			slashes++
+		}
+		if slashes%2 == 1 {
+			continue
+		}
+		if strings.HasPrefix(rest[i:], "\": ") {
+			return rest[i+3:]
+		}
+		return reason
+	}
+	return reason
+}
+
 func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
+	nested := reason
+	reason = stripNestedURLReasonPrefix(reason)
 	defer func() {
 		if ok {
-			g = annotateNestedURLGuidance(g, label, reason)
+			g = annotateNestedURLGuidance(g, label, nested)
 		}
 	}()
 	// Some transports retain historical audit labels for the same enforcing
@@ -622,8 +657,16 @@ func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
 	return GuidanceFor(label)
 }
 
+// nestedURLBudgetHint explains a nested-destination resolution timeout. It
+// deliberately names no allowlist: no allowlist entry can make a resolver
+// answer faster, and pointing an operator at one teaches them that policy
+// changed when nothing did.
+const nestedURLBudgetHint = "nested URL destinations could not be resolved within the shared resolution budget; the request was refused because a destination was left unverified. This is a resolver-availability condition, not a detection. Check resolver health and latency; to stop evaluating query-parameter destinations entirely, set fetch_proxy.monitoring.scan_nested_urls to false."
+
 func annotateNestedURLGuidance(g RemediationGuidance, label, reason string) RemediationGuidance {
-	if !strings.Contains(strings.ToLower(reason), "nested url in query parameter") {
+	lower := strings.ToLower(reason)
+	if !strings.Contains(lower, "nested url in query parameter") &&
+		!strings.Contains(lower, "shared resolution budget") {
 		return g
 	}
 	nestedKnob := " Nested query destinations are evaluated because `fetch_proxy.monitoring.scan_nested_urls` is enabled (nil/true). Set it false only for an endpoint whose contract legitimately carries private or blocklisted URLs in query strings."

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -402,7 +402,7 @@ func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
 	reason = stripNestedURLReasonPrefix(reason)
 	defer func() {
 		if ok {
-			g = annotateNestedURLGuidance(g, label, nested)
+			g = annotateNestedURLGuidance(g, label, nested, reason)
 		}
 	}()
 	// Some transports retain historical audit labels for the same enforcing
@@ -676,14 +676,16 @@ const nestedURLBudgetOperatorKnob = "Nested query destinations could not be reso
 
 const nestedURLBudgetAgentReason = "a destination named inside this request could not be verified in time"
 
-func annotateNestedURLGuidance(g RemediationGuidance, label, reason string) RemediationGuidance {
-	lower := strings.ToLower(reason)
+func annotateNestedURLGuidance(g RemediationGuidance, label, reason, stripped string) RemediationGuidance {
 	// A resolution timeout already carries its own guidance and must not be
 	// annotated with the destination-knob sentence: no allowlist lifts a timeout.
-	if strings.Contains(lower, strings.ToLower(nestedURLBudgetReason)) {
+	// Test the STRIPPED reason, never the raw one. The raw reason still carries
+	// the query key, which the client chooses, so matching on it let a parameter
+	// named after the budget suppress the sentence on a genuine destination block.
+	if strings.Contains(strings.ToLower(stripped), strings.ToLower(nestedURLBudgetReason)) {
 		return g
 	}
-	if !strings.Contains(lower, "nested url in query parameter") {
+	if !strings.Contains(strings.ToLower(reason), "nested url in query parameter") {
 		return g
 	}
 	nestedKnob := " Nested query destinations are evaluated because `fetch_proxy.monitoring.scan_nested_urls` is enabled (nil/true). Set it false only for an endpoint whose contract legitimately carries private or blocklisted URLs in query strings."

--- a/internal/scanner/remediation.go
+++ b/internal/scanner/remediation.go
@@ -364,7 +364,12 @@ func OperatorHintFor(label string) string {
 // entropy, while ScannerDenialOfWallet distinguishes budget-limit reasons.
 // Every other label falls through to the label-keyed table. This is the single
 // place that disambiguation lives, so explain, audit, and future consumers agree.
-func GuidanceForResult(label, reason string) (RemediationGuidance, bool) {
+func GuidanceForResult(label, reason string) (g RemediationGuidance, ok bool) {
+	defer func() {
+		if ok {
+			g = annotateNestedURLGuidance(g, label, reason)
+		}
+	}()
 	// Some transports retain historical audit labels for the same enforcing
 	// family. Normalize them before reason routing so alternate labels cannot
 	// drift to a less accurate hint.
@@ -615,6 +620,21 @@ func GuidanceForResult(label, reason string) (RemediationGuidance, bool) {
 		}
 	}
 	return GuidanceFor(label)
+}
+
+func annotateNestedURLGuidance(g RemediationGuidance, label, reason string) RemediationGuidance {
+	if !strings.Contains(strings.ToLower(reason), "nested url in query parameter") {
+		return g
+	}
+	nestedKnob := " Nested query destinations are evaluated because `fetch_proxy.monitoring.scan_nested_urls` is enabled (nil/true). Set it false only for an endpoint whose contract legitimately carries private or blocklisted URLs in query strings."
+	switch label {
+	case ScannerSSRF, ScannerCoreSSRF:
+		if !g.Immutable {
+			nestedKnob += " The nested host consults `ssrf.ip_allowlist`, `trusted_domains`, and `dns.host_overrides` because it reuses the same destination checks as the outer host."
+		}
+	}
+	g.OperatorKnob += nestedKnob
+	return g
 }
 
 // OperatorHintForResult is OperatorHintFor with Reason-based disambiguation. Use

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1202,7 +1202,7 @@ func (s *Scanner) checkSSRF(ctx context.Context, dest destination.Destination) R
 
 	// Resolve hostname to IP for SSRF check.
 	// Fail closed: if we can't resolve DNS, we can't verify the IP is safe.
-	dnsCtx, dnsCancel := context.WithTimeout(ctx, 5*time.Second) // 5s: DNS resolution ceiling; inherits caller cancellation
+	dnsCtx, dnsCancel := context.WithTimeout(ctx, ssrfLookupCeiling) // inherits caller cancellation
 	defer dnsCancel()
 	ips, err := s.resolver.LookupHost(dnsCtx, hostname)
 	if err != nil {
@@ -1347,15 +1347,25 @@ func (s *Scanner) checkBlocklist(hostname string) Result {
 	return Result{Allowed: true}
 }
 
-// nestedURLResolveBudget bounds the total resolver time one request may spend
-// on nested destinations. It equals the single-lookup ceiling checkSSRF already
-// applies to the outer host, so a request carrying many nested hostnames cannot
-// hold more resolver time than one ordinary lookup. Exhausting the budget fails
-// CLOSED: a nested destination that could not be resolved in time is refused,
-// never forwarded. Parsing and literal-IP checks need no I/O and are bounded by
-// the outer URL length, so there is deliberately no cap on how many query values
-// are examined; a count cap was a fail-open (pad past it, then relay).
-var nestedURLResolveBudget = 5 * time.Second
+// ssrfLookupCeiling is the deadline one SSRF hostname resolution may take. The
+// outer host and the nested-destination budget share it so the two cannot drift.
+const ssrfLookupCeiling = 5 * time.Second
+
+// nestedURLResolveBudget bounds the total resolver time one request may spend on
+// nested destinations. It equals one lookup ceiling, so a request carrying nested
+// hostnames cannot hold more resolver time than one ordinary outer lookup. What
+// makes one ceiling sufficient in practice is that distinct destinations are
+// resolved once per request (see the seen set in checkNestedURLs): the common
+// shape, one callback URL repeated, costs a single lookup. A request naming many
+// DISTINCT slow hostnames can still exhaust it, which is why exhaustion is
+// classified as an infrastructure error rather than a threat.
+//
+// Exhausting the budget fails CLOSED: a nested destination that could not be
+// resolved in time is refused, never forwarded. Parsing and literal-IP checks
+// need no I/O and are bounded by the outer URL length, so there is deliberately
+// no cap on how many query values are examined; a count cap was a fail-open
+// (pad past it, then relay).
+var nestedURLResolveBudget = ssrfLookupCeiling
 
 const nestedURLReasonPrefix = "nested URL in query parameter"
 
@@ -1364,6 +1374,37 @@ const nestedURLReasonPrefix = "nested URL in query parameter"
 type nestedURLCandidate struct {
 	key  string
 	text string
+}
+
+// schemeRelativeNamesHost reports whether a "//..." reference names something
+// host-shaped: a bracketed IPv6 literal, an IP literal, or a dotted name. A
+// single label such as "//tmp/x" is a filesystem path far more often than a
+// host, and treating it as a destination is a false positive.
+func schemeRelativeNamesHost(text string) bool {
+	authority := strings.TrimPrefix(text, "//")
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority = authority[:i]
+	}
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		authority = authority[at+1:]
+	}
+	if authority == "" {
+		return false
+	}
+	if strings.HasPrefix(authority, "[") {
+		return true
+	}
+	host := authority
+	if i := strings.LastIndex(host, ":"); i >= 0 {
+		host = host[:i]
+	}
+	if host == "" {
+		return false
+	}
+	if destination.ParseIPLiteral(host) != nil {
+		return true
+	}
+	return strings.Contains(strings.TrimSuffix(host, "."), ".")
 }
 
 // nestedURLCandidates enumerates every query component that could hide a nested
@@ -1381,6 +1422,13 @@ func nestedURLCandidates(rawQuery string, maxLen int) []nestedURLCandidate {
 			return
 		}
 		if strings.HasPrefix(text, "//") {
+			// Complete a scheme-relative reference only when what follows looks
+			// like a host. Without this, an ordinary unix path in a query value
+			// ("//tmp/x") becomes https://tmp/x, and with SSRF configured its
+			// failed lookup refuses a request that carried no destination.
+			if !schemeRelativeNamesHost(text) {
+				return
+			}
 			text = "https:" + text
 		}
 		out = append(out, nestedURLCandidate{key: key, text: text})
@@ -1424,20 +1472,30 @@ func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 	runDNSSSRF := len(s.internalCIDRs) > 0 || s.destinationGrants.Len() > 0
 	nestedCtx, cancel := context.WithTimeout(ctx, nestedURLResolveBudget)
 	defer cancel()
+	// One verdict per distinct destination. The same callback URL repeated
+	// across parameters, or reached through several encodings, is one
+	// destination and must cost one resolution, not one per occurrence.
+	seen := make(map[string]struct{}, len(candidates))
 	for _, c := range candidates {
-		result := s.checkNestedURLValue(nestedCtx, c.key, c.text, runDNSSSRF)
+		result := s.checkNestedURLValue(nestedCtx, c.key, c.text, runDNSSSRF, seen)
 		if result.Allowed {
 			continue
 		}
 		if nestedCtx.Err() != nil && ctx.Err() == nil {
 			// The shared budget ran out before every nested destination was
-			// resolved. Refuse the request: an unverified nested destination
-			// is exactly what this step exists to stop.
+			// resolved. Refuse the request, because an unverified nested
+			// destination is exactly what this step exists to stop. Classify it
+			// as an infrastructure error, not a threat: nothing was resolved, so
+			// there is no evidence of an adversary, and adaptive enforcement must
+			// not accumulate lockdown signal from resolver wobble. This matches
+			// how checkSSRF already classifies an outer-host resolver failure.
 			return Result{
 				Allowed: false,
-				Reason:  fmt.Sprintf("%s %q: nested URL destinations exceeded the shared resolution budget (%s)", nestedURLReasonPrefix, c.key, nestedURLResolveBudget),
+				Reason:  fmt.Sprintf("nested URL destinations exceeded the shared resolution budget (%s)", nestedURLResolveBudget),
 				Scanner: ScannerSSRF,
 				Score:   1.0,
+				Class:   ClassInfrastructureError,
+				Hint:    nestedURLBudgetHint,
 			}
 		}
 		return result
@@ -1445,7 +1503,7 @@ func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 	return Result{Allowed: true}
 }
 
-func (s *Scanner) checkNestedURLValue(ctx context.Context, key, text string, runDNSSSRF bool) Result {
+func (s *Scanner) checkNestedURLValue(ctx context.Context, key, text string, runDNSSSRF bool, seen map[string]struct{}) Result {
 	nestedParsed, err := url.Parse(text)
 	if err != nil {
 		return Result{Allowed: true}
@@ -1472,6 +1530,15 @@ func (s *Scanner) checkNestedURLValue(ctx context.Context, key, text string, run
 	if !ok {
 		// Bad port: treat as not a URL rather than blocking.
 		return Result{Allowed: true}
+	}
+	// Key on host and port: the same name on a different port is a different
+	// destination for allowlist and grant purposes.
+	dedupKey := fmt.Sprintf("%s:%d", nestedDest.Host, nestedDest.Port)
+	if seen != nil {
+		if _, done := seen[dedupKey]; done {
+			return Result{Allowed: true}
+		}
+		seen[dedupKey] = struct{}{}
 	}
 	if result := s.checkAllowlist(nestedDest); !result.Allowed {
 		return prefixNestedURLResult(key, result)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1009,14 +1009,6 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 		return result
 	}
 
-	// Nested URL destinations in query parameters. Runs after the outer
-	// allowlist/blocklist/core-SSRF floor so a nested host must clear the
-	// same destination checks, and before SigV4/DLP/DNS so a nested private
-	// target is refused with no network I/O.
-	if result := s.checkNestedURLs(ctx, parsed); !result.Allowed {
-		return result
-	}
-
 	// SigV4 presigned URL carve-out. Detect once before content-scanning
 	// stages so core DLP, main DLP, and query-entropy all see the same
 	// scrubbed URL. The scrub replaces ONLY the AKIA component of a
@@ -1073,6 +1065,18 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	// Subdomain entropy check - catches base64/hex encoded data in subdomains
 	// (e.g., "aGVsbG8.evil.com" exfiltrating data via DNS queries).
 	if result := s.checkSubdomainEntropy(hostname); !result.Allowed {
+		return result
+	}
+
+	// Nested URL destinations in query parameters. Deliberately placed AFTER the
+	// no-I/O content scanners (core DLP, DLP, entropy) and immediately before
+	// DNS-based SSRF on the outer host. An earlier revision ran this before DLP,
+	// which let a request carrying both a credential and several slow nested
+	// hostnames return a nested-resolution timeout before DLP ever ran: the
+	// secret was still refused, but the DLP finding never reached audit and the
+	// timeout is adaptive-neutral, so nothing was recorded. Content findings that
+	// need no network must be established before any check that can time out.
+	if result := s.checkNestedURLs(ctx, parsed); !result.Allowed {
 		return result
 	}
 
@@ -1376,37 +1380,6 @@ type nestedURLCandidate struct {
 	text string
 }
 
-// schemeRelativeNamesHost reports whether a "//..." reference names something
-// host-shaped: a bracketed IPv6 literal, an IP literal, or a dotted name. A
-// single label such as "//tmp/x" is a filesystem path far more often than a
-// host, and treating it as a destination is a false positive.
-func schemeRelativeNamesHost(text string) bool {
-	authority := strings.TrimPrefix(text, "//")
-	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
-		authority = authority[:i]
-	}
-	if at := strings.LastIndex(authority, "@"); at >= 0 {
-		authority = authority[at+1:]
-	}
-	if authority == "" {
-		return false
-	}
-	if strings.HasPrefix(authority, "[") {
-		return true
-	}
-	host := authority
-	if i := strings.LastIndex(host, ":"); i >= 0 {
-		host = host[:i]
-	}
-	if host == "" {
-		return false
-	}
-	if destination.ParseIPLiteral(host) != nil {
-		return true
-	}
-	return strings.Contains(strings.TrimSuffix(host, "."), ".")
-}
-
 // nestedURLCandidates enumerates every query component that could hide a nested
 // destination. It reads RawQuery directly rather than url.URL.Query(): Query()
 // percent-decodes and folds '+' to space, which destroys IPv6 zone ids (%25) and
@@ -1422,13 +1395,14 @@ func nestedURLCandidates(rawQuery string, maxLen int) []nestedURLCandidate {
 			return
 		}
 		if strings.HasPrefix(text, "//") {
-			// Complete a scheme-relative reference only when what follows looks
-			// like a host. Without this, an ordinary unix path in a query value
-			// ("//tmp/x") becomes https://tmp/x, and with SSRF configured its
-			// failed lookup refuses a request that carried no destination.
-			if !schemeRelativeNamesHost(text) {
-				return
-			}
+			// A network-path reference names an authority (RFC 3986 4.2), so
+			// complete it and let the same parser the destination checks use
+			// decide whether a host is present. An earlier revision gated this
+			// on "contains an ASCII dot or parses as an IP literal", which read
+			// as caution and was a detection hole: it skipped every single-label
+			// internal name (localhost, consul, vault) and every host spelled
+			// with a non-ASCII dot. Deciding what is NOT a destination is an
+			// allow gate, and an invented shape rule for one is a bypass.
 			text = "https:" + text
 		}
 		out = append(out, nestedURLCandidate{key: key, text: text})
@@ -1495,7 +1469,6 @@ func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 				Scanner: ScannerSSRF,
 				Score:   1.0,
 				Class:   ClassInfrastructureError,
-				Hint:    nestedURLBudgetHint,
 			}
 		}
 		return result

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -234,7 +234,8 @@ type Scanner struct {
 	subdomainExclusions        []string // domains excluded from subdomain entropy checks
 	queryExclusions            []string // domains excluded from query parameter entropy checks (S3 pre-signed URLs, etc.)
 	queryParamExclusions       map[queryEntropyParamExclusionKey]struct{}
-	scanNestedURLs             bool // fetch_proxy.monitoring.scan_nested_urls; nil/true = enabled
+	scanNestedURLs             bool          // fetch_proxy.monitoring.scan_nested_urls; nil/true = enabled
+	nestedURLResolveBudget     time.Duration // shared deadline for all nested lookups in one request
 	// pathEntropyExempt suppresses the path-entropy gate on paths the operator
 	// already governs with a request_policy route (explicit host + path
 	// constraints). A nil or disabled matcher keeps path entropy fully active.
@@ -392,7 +393,8 @@ func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 		subdomainExclusions:       cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions,
 		queryExclusions:           cfg.FetchProxy.Monitoring.QueryEntropyExclusions,
 		queryParamExclusions:      buildQueryEntropyParamExclusions(cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions),
-		scanNestedURLs:            cfg.FetchProxy.Monitoring.NestedURLScanningEnabled(),
+		scanNestedURLs:            cfg.FetchProxy.Monitoring.ScanNestedURLsEnabled(),
+		nestedURLResolveBudget:    defaultNestedURLResolveBudget,
 		pathEntropyExempt:         buildPathEntropyExempt(cfg),
 		destinationGrants:         opts.DestinationGrants,
 	}
@@ -1369,7 +1371,10 @@ const ssrfLookupCeiling = 5 * time.Second
 // need no I/O and are bounded by the outer URL length, so there is deliberately
 // no cap on how many query values are examined; a count cap was a fail-open
 // (pad past it, then relay).
-var nestedURLResolveBudget = ssrfLookupCeiling
+// The value lives on the Scanner rather than in a package variable. A mutable
+// global would be shared by every concurrent scan, and a test that shortened it
+// would race every other test in the package.
+const defaultNestedURLResolveBudget = ssrfLookupCeiling
 
 const nestedURLReasonPrefix = "nested URL in query parameter"
 
@@ -1444,7 +1449,7 @@ func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 		return Result{Allowed: true}
 	}
 	runDNSSSRF := len(s.internalCIDRs) > 0 || s.destinationGrants.Len() > 0
-	nestedCtx, cancel := context.WithTimeout(ctx, nestedURLResolveBudget)
+	nestedCtx, cancel := context.WithTimeout(ctx, s.nestedURLResolveBudget)
 	defer cancel()
 	// One verdict per distinct destination. The same callback URL repeated
 	// across parameters, or reached through several encodings, is one
@@ -1465,7 +1470,7 @@ func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 			// how checkSSRF already classifies an outer-host resolver failure.
 			return Result{
 				Allowed: false,
-				Reason:  fmt.Sprintf("nested URL destinations exceeded the shared resolution budget (%s)", nestedURLResolveBudget),
+				Reason:  fmt.Sprintf("nested URL destinations exceeded the shared resolution budget (%s)", s.nestedURLResolveBudget),
 				Scanner: ScannerSSRF,
 				Score:   1.0,
 				Class:   ClassInfrastructureError,

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -234,6 +235,7 @@ type Scanner struct {
 	subdomainExclusions        []string // domains excluded from subdomain entropy checks
 	queryExclusions            []string // domains excluded from query parameter entropy checks (S3 pre-signed URLs, etc.)
 	queryParamExclusions       map[queryEntropyParamExclusionKey]struct{}
+	scanNestedURLs             bool // fetch_proxy.monitoring.scan_nested_urls; nil/true = enabled
 	// pathEntropyExempt suppresses the path-entropy gate on paths the operator
 	// already governs with a request_policy route (explicit host + path
 	// constraints). A nil or disabled matcher keeps path entropy fully active.
@@ -391,6 +393,7 @@ func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 		subdomainExclusions:       cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions,
 		queryExclusions:           cfg.FetchProxy.Monitoring.QueryEntropyExclusions,
 		queryParamExclusions:      buildQueryEntropyParamExclusions(cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions),
+		scanNestedURLs:            cfg.FetchProxy.Monitoring.NestedURLScanningEnabled(),
 		pathEntropyExempt:         buildPathEntropyExempt(cfg),
 		destinationGrants:         opts.DestinationGrants,
 	}
@@ -1007,6 +1010,14 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 		return result
 	}
 
+	// Nested URL destinations in query parameters. Runs after the outer
+	// allowlist/blocklist/core-SSRF floor so a nested host must clear the
+	// same destination checks, and before SigV4/DLP/DNS so a nested private
+	// target is refused with no network I/O.
+	if result := s.checkNestedURLs(ctx, parsed); !result.Allowed {
+		return result
+	}
+
 	// SigV4 presigned URL carve-out. Detect once before content-scanning
 	// stages so core DLP, main DLP, and query-entropy all see the same
 	// scrubbed URL. The scrub replaces ONLY the AKIA component of a
@@ -1335,6 +1346,109 @@ func (s *Scanner) checkBlocklist(hostname string) Result {
 		}
 	}
 	return Result{Allowed: true}
+}
+
+// maxNestedURLQueryValues caps how many query values are inspected as nested
+// destinations per request. Values past the cap are not expanded; outer-host
+// checks still run. Fail-open on the cap is acceptable only because of that.
+const maxNestedURLQueryValues = 32
+
+const nestedURLReasonPrefix = "nested URL in query parameter"
+
+// checkNestedURLs evaluates URL-shaped query parameter values as destinations
+// in their own right. Decode is at most one level of nesting: a nested URL
+// that itself contains a nested URL is not expanded. Schemeless host/path
+// strings, relative paths, and non-http(s) schemes are ignored.
+func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
+	if !s.scanNestedURLs || parsed == nil || parsed.RawQuery == "" {
+		return Result{Allowed: true}
+	}
+	query := parsed.Query()
+	if len(query) == 0 {
+		return Result{Allowed: true}
+	}
+	keys := make([]string, 0, len(query))
+	for key := range query {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	runDNSSSRF := len(s.internalCIDRs) > 0 || s.destinationGrants.Len() > 0
+	scanned := 0
+	for _, key := range keys {
+		for _, value := range query[key] {
+			if scanned >= maxNestedURLQueryValues {
+				// Remaining query values are not expanded as nested
+				// destinations. The outer pipeline continues.
+				return Result{Allowed: true}
+			}
+			scanned++
+			if result := s.checkNestedURLValue(ctx, key, value, runDNSSSRF); !result.Allowed {
+				return result
+			}
+		}
+	}
+	return Result{Allowed: true}
+}
+
+func (s *Scanner) checkNestedURLValue(ctx context.Context, key, value string, runDNSSSRF bool) Result {
+	if s.maxURLLength > 0 && len(value) > s.maxURLLength {
+		return Result{Allowed: true}
+	}
+	decoded := IterativeDecode(value)
+	if decoded == "" {
+		return Result{Allowed: true}
+	}
+	if s.maxURLLength > 0 && len(decoded) > s.maxURLLength {
+		return Result{Allowed: true}
+	}
+	nestedParsed, err := url.Parse(decoded)
+	if err != nil {
+		return Result{Allowed: true}
+	}
+	scheme := strings.ToLower(nestedParsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return Result{Allowed: true}
+	}
+	nestedHost := strings.ToLower(nestedParsed.Hostname())
+	if nestedHost == "" {
+		return Result{Allowed: true}
+	}
+	// Canonicalize alternative IPv4 forms the same way scan does for the outer host.
+	if altIP := destination.ParseIPLiteral(nestedHost); altIP != nil && altIP.To4() != nil && net.ParseIP(nestedHost) == nil {
+		nestedHost = altIP.String()
+		port := nestedParsed.Port()
+		if port != "" {
+			nestedParsed.Host = nestedHost + ":" + port
+		} else {
+			nestedParsed.Host = nestedHost
+		}
+	}
+	nestedDest, ok := urlDestination(nestedParsed, nestedHost)
+	if !ok {
+		// Bad port: treat as not a URL rather than blocking.
+		return Result{Allowed: true}
+	}
+	if result := s.checkAllowlist(nestedDest); !result.Allowed {
+		return prefixNestedURLResult(key, result)
+	}
+	if result := s.checkBlocklist(nestedHost); !result.Allowed {
+		return prefixNestedURLResult(key, result)
+	}
+	if result := s.checkCoreSSRFLiteral(nestedDest); !result.Allowed {
+		return prefixNestedURLResult(key, result)
+	}
+	if runDNSSSRF {
+		if result := s.checkSSRF(ctx, nestedDest); !result.Allowed {
+			return prefixNestedURLResult(key, result)
+		}
+	}
+	return Result{Allowed: true}
+}
+
+func prefixNestedURLResult(key string, result Result) Result {
+	result.Reason = fmt.Sprintf(nestedURLReasonPrefix+" %q: %s", key, result.Reason)
+	return result
 }
 
 // checkCRLF detects CRLF injection sequences in URLs. CR+LF bytes in a URL

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1348,61 +1347,106 @@ func (s *Scanner) checkBlocklist(hostname string) Result {
 	return Result{Allowed: true}
 }
 
-// maxNestedURLQueryValues caps how many query values are inspected as nested
-// destinations per request. Values past the cap are not expanded; outer-host
-// checks still run. Fail-open on the cap is acceptable only because of that.
-const maxNestedURLQueryValues = 32
+// nestedURLResolveBudget bounds the total resolver time one request may spend
+// on nested destinations. It equals the single-lookup ceiling checkSSRF already
+// applies to the outer host, so a request carrying many nested hostnames cannot
+// hold more resolver time than one ordinary lookup. Exhausting the budget fails
+// CLOSED: a nested destination that could not be resolved in time is refused,
+// never forwarded. Parsing and literal-IP checks need no I/O and are bounded by
+// the outer URL length, so there is deliberately no cap on how many query values
+// are examined; a count cap was a fail-open (pad past it, then relay).
+var nestedURLResolveBudget = 5 * time.Second
 
 const nestedURLReasonPrefix = "nested URL in query parameter"
 
-// checkNestedURLs evaluates URL-shaped query parameter values as destinations
-// in their own right. Decode is at most one level of nesting: a nested URL
-// that itself contains a nested URL is not expanded. Schemeless host/path
-// strings, relative paths, and non-http(s) schemes are ignored.
+// nestedURLCandidate is one query component text that may be a nested URL, with
+// the parameter key it came from for the block reason.
+type nestedURLCandidate struct {
+	key  string
+	text string
+}
+
+// nestedURLCandidates enumerates every query component that could hide a nested
+// destination. It reads RawQuery directly rather than url.URL.Query(): Query()
+// percent-decodes and folds '+' to space, which destroys IPv6 zone ids (%25) and
+// hides the encodings the DLP query loop already sees. Both keys and values are
+// candidates, in raw form, iteratively percent-decoded, and through the same
+// hex/base64/base32 layers DLP applies. A scheme-relative "//host/..." is
+// completed with https so the host is evaluated like any other destination.
+func nestedURLCandidates(rawQuery string, maxLen int) []nestedURLCandidate {
+	var out []nestedURLCandidate
+	add := func(key, text string) {
+		text = strings.TrimSpace(text)
+		if text == "" || (maxLen > 0 && len(text) > maxLen) {
+			return
+		}
+		if strings.HasPrefix(text, "//") {
+			text = "https:" + text
+		}
+		out = append(out, nestedURLCandidate{key: key, text: text})
+	}
+	for _, pair := range strings.Split(rawQuery, "&") {
+		if pair == "" {
+			continue
+		}
+		key, value, _ := strings.Cut(pair, "=")
+		decodedKey := IterativeDecode(key)
+		for _, component := range []string{key, value} {
+			if component == "" {
+				continue
+			}
+			add(decodedKey, component)
+			decoded := IterativeDecode(component)
+			if decoded != component {
+				add(decodedKey, decoded)
+			}
+			for _, d := range decodeEncodingsRecursive(decoded) {
+				add(decodedKey, d.text)
+			}
+		}
+	}
+	return out
+}
+
+// checkNestedURLs evaluates URL-shaped query components as destinations in
+// their own right, running the same allowlist, blocklist, and SSRF checks the
+// outer host receives. Decode is at most one level of nesting: a nested URL that
+// itself carries a nested URL is not expanded. Non-URL text, relative paths, and
+// non-http(s) schemes are ignored. All nested DNS lookups share one deadline.
 func (s *Scanner) checkNestedURLs(ctx context.Context, parsed *url.URL) Result {
 	if !s.scanNestedURLs || parsed == nil || parsed.RawQuery == "" {
 		return Result{Allowed: true}
 	}
-	query := parsed.Query()
-	if len(query) == 0 {
+	candidates := nestedURLCandidates(parsed.RawQuery, s.maxURLLength)
+	if len(candidates) == 0 {
 		return Result{Allowed: true}
 	}
-	keys := make([]string, 0, len(query))
-	for key := range query {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-
 	runDNSSSRF := len(s.internalCIDRs) > 0 || s.destinationGrants.Len() > 0
-	scanned := 0
-	for _, key := range keys {
-		for _, value := range query[key] {
-			if scanned >= maxNestedURLQueryValues {
-				// Remaining query values are not expanded as nested
-				// destinations. The outer pipeline continues.
-				return Result{Allowed: true}
-			}
-			scanned++
-			if result := s.checkNestedURLValue(ctx, key, value, runDNSSSRF); !result.Allowed {
-				return result
+	nestedCtx, cancel := context.WithTimeout(ctx, nestedURLResolveBudget)
+	defer cancel()
+	for _, c := range candidates {
+		result := s.checkNestedURLValue(nestedCtx, c.key, c.text, runDNSSSRF)
+		if result.Allowed {
+			continue
+		}
+		if nestedCtx.Err() != nil && ctx.Err() == nil {
+			// The shared budget ran out before every nested destination was
+			// resolved. Refuse the request: an unverified nested destination
+			// is exactly what this step exists to stop.
+			return Result{
+				Allowed: false,
+				Reason:  fmt.Sprintf("%s %q: nested URL destinations exceeded the shared resolution budget (%s)", nestedURLReasonPrefix, c.key, nestedURLResolveBudget),
+				Scanner: ScannerSSRF,
+				Score:   1.0,
 			}
 		}
+		return result
 	}
 	return Result{Allowed: true}
 }
 
-func (s *Scanner) checkNestedURLValue(ctx context.Context, key, value string, runDNSSSRF bool) Result {
-	if s.maxURLLength > 0 && len(value) > s.maxURLLength {
-		return Result{Allowed: true}
-	}
-	decoded := IterativeDecode(value)
-	if decoded == "" {
-		return Result{Allowed: true}
-	}
-	if s.maxURLLength > 0 && len(decoded) > s.maxURLLength {
-		return Result{Allowed: true}
-	}
-	nestedParsed, err := url.Parse(decoded)
+func (s *Scanner) checkNestedURLValue(ctx context.Context, key, text string, runDNSSSRF bool) Result {
+	nestedParsed, err := url.Parse(text)
 	if err != nil {
 		return Result{Allowed: true}
 	}


### PR DESCRIPTION
## What changed

Pipelock evaluates the destination a request is addressed to. It didn't evaluate a destination named *inside* the request, so a URL sitting in a query parameter of an allowed host was never checked. An allowlisted service that fetches a caller-named target is an open relay, and a destination allowlist passes it because the address on the envelope is trusted.

- URL-shaped query keys and values are now evaluated as destinations in their own right, running the same allowlist, blocklist, and SSRF checks the outer host receives. Decoding matches the DLP query loop, covering raw, percent-decoded, hex, base64, and base32 layers, and a scheme-relative reference is completed so the same parser decides whether a host is present. One level deep; a nested URL that itself carries one is not expanded.
- Every nested resolution in a request shares one DNS deadline equal to the existing single-lookup ceiling, and distinct destinations are resolved once each. Exhausting that deadline refuses the request rather than forwarding a destination that was never verified, and is classified as an infrastructure error so a slow resolver can't accumulate adaptive-enforcement signal.
- The step runs after every check that needs no network and before the first that does, so a content finding is always established before anything that can time out.
- `fetch_proxy.monitoring.scan_nested_urls` governs it, enabled unless explicitly set false, with disabling recorded as a reload downgrade. CONNECT without interception carries no query string, so nested destinations never reach that path.

`request_policy` gains the WebDAV verbs a package registry uses for publish and move, so a fetch-only registry rail can name them. `docs/guides/request-policy.md` documents that recipe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query parameters containing nested, encoded, or scheme-relative URLs are now checked for allowlist, blocklist, and SSRF violations by default.
  * Added the `scan_nested_urls` configuration option, including reload warnings when disabled.
  * WebDAV methods are now supported in request policies and reverse-proxy allowlists.
  * Added guidance for configuring fetch-only package registries.

* **Bug Fixes**
  * Improved nested-URL error guidance and fail-closed behavior when destination checks exceed resolution limits.

* **Documentation**
  * Updated scanner pipeline, security, configuration, and request-policy documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->