### PR TITLE
fix(gauntlet): own Pipelock benchmark acceptance policy in Pipelock

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,7 +15,9 @@ permissions:
   contents: read
 
 env:
-  AEB_REF: efda9aa26d6b3cacc711450c31d784d0c725155d
+  # Agent Egress Bench v0.1.1, the released revision. Prefer an exact
+  # released commit over a transient main pin.
+  AEB_REF: a3d56890487aed5fc5a01f46e8732d2ad73fcf53
 
 jobs:
   candidate:
@@ -33,6 +35,8 @@ jobs:
             echo "AEB_ROOT=$GITHUB_WORKSPACE/_agent-egress-bench"
             echo "GAUNTLET_ARTIFACT_DIR=$RUNNER_TEMP/pipelock-gauntlet-candidate"
             echo "PIPELOCK_RELEASE_PIN=$GITHUB_WORKSPACE/benchmark/gauntlet-release.env"
+            echo "PIPELOCK_GAUNTLET_BASELINE=$GITHUB_WORKSPACE/benchmark/gauntlet-baseline.json"
+            echo "PIPELOCK_GAUNTLET_ACCEPTANCE=$GITHUB_WORKSPACE/benchmark/gauntlet-acceptance.json"
           } >> "$GITHUB_ENV"
 
       - name: Check out Pipelock release policy
@@ -61,8 +65,10 @@ jobs:
           test "$GITHUB_REF" = "refs/heads/main"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           test "$(git -C "$AEB_ROOT" rev-parse HEAD)" = "$AEB_REF"
-          test ! -L "$PIPELOCK_RELEASE_PIN"
-          test -f "$PIPELOCK_RELEASE_PIN"
+          for policy in "$PIPELOCK_RELEASE_PIN" "$PIPELOCK_GAUNTLET_BASELINE" "$PIPELOCK_GAUNTLET_ACCEPTANCE"; do
+            test ! -L "$policy"
+            test -f "$policy"
+          done
 
       - name: Run portable canonical benchmark
         shell: bash
@@ -107,7 +113,7 @@ jobs:
           set -euo pipefail
           python3 "$AEB_ROOT/scripts/evaluate_gauntlet_candidate.py" evaluate \
             --candidate "$ARTIFACT_JSON" \
-            --baseline "$AEB_ROOT/ci/gauntlet-baseline.json" \
+            --baseline "$PIPELOCK_GAUNTLET_BASELINE" \
             --evidence "raw_summary=$GAUNTLET_ARTIFACT_DIR/raw-summary.json" \
             --evidence "results=$GAUNTLET_ARTIFACT_DIR/results.jsonl" \
             --evidence "runner_stderr=$GAUNTLET_ARTIFACT_DIR/runner.stderr" \
@@ -143,7 +149,7 @@ jobs:
               evaluation_exit=0
               python3 "$AEB_ROOT/scripts/evaluate_gauntlet_candidate.py" evaluate \
                 --candidate "$candidate_path" \
-                --baseline "$AEB_ROOT/ci/gauntlet-baseline.json" \
+                --baseline "$PIPELOCK_GAUNTLET_BASELINE" \
                 --evidence "raw_summary=$GAUNTLET_ARTIFACT_DIR/raw-summary.json" \
                 --evidence "results=$GAUNTLET_ARTIFACT_DIR/results.jsonl" \
                 --evidence "runner_stderr=$GAUNTLET_ARTIFACT_DIR/runner.stderr" \
@@ -229,7 +235,7 @@ jobs:
           decision_exit=0
           python3 "$AEB_ROOT/scripts/evaluate_gauntlet_candidate.py" enforce "$DECISION_PATH" \
             --candidate "$ARTIFACT_JSON" \
-            --baseline "$AEB_ROOT/ci/gauntlet-baseline.json" \
+            --baseline "$PIPELOCK_GAUNTLET_BASELINE" \
             --result "$GAUNTLET_ARTIFACT_DIR/enforcement-result.json" \
             --evidence "raw_summary=$GAUNTLET_ARTIFACT_DIR/raw-summary.json" \
             --evidence "results=$GAUNTLET_ARTIFACT_DIR/results.jsonl" \
@@ -250,6 +256,19 @@ jobs:
             --evidence "run_bundle=$GAUNTLET_ARTIFACT_DIR/run-bundle.json" || decision_exit=$?
           exit "$decision_exit"
 
+      # Aggregate floors cannot tell an equal score with different failures
+      # from the accepted result, so Pipelock enforces the exact accepted
+      # case identities itself. Runs after upload so evidence survives a block.
+      - name: Enforce Pipelock acceptance contract
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/scripts/check_gauntlet_acceptance.py" \
+            --contract "$PIPELOCK_GAUNTLET_ACCEPTANCE" \
+            --candidate "$ARTIFACT_JSON" \
+            --results "$GAUNTLET_ARTIFACT_DIR/results.jsonl"
+
       - name: Render owner-facing run summary
         if: ${{ !cancelled() }}
         shell: bash
@@ -265,7 +284,7 @@ jobs:
             python3 "$AEB_ROOT/scripts/render_gauntlet_run_summary.py" \
               --candidate "$candidate_path" \
               --decision "$decision_path" \
-              --baseline "$AEB_ROOT/ci/gauntlet-baseline.json" \
+              --baseline "$PIPELOCK_GAUNTLET_BASELINE" \
               --enforcement-result "$GAUNTLET_ARTIFACT_DIR/enforcement-result.json" \
               --repository "$GITHUB_REPOSITORY" \
               --run-url "$run_url" > "$summary_path" || summary_exit=$?

--- a/benchmark/gauntlet-acceptance.json
+++ b/benchmark/gauntlet-acceptance.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Pipelock-owned Gauntlet acceptance contract. Aggregate floors alone cannot distinguish an equal score with different failures, so this file binds the exact identities Pipelock accepts. Changing any identity is a product decision and requires a reviewed edit here.",
+  "schema_version": 1,
+  "recorded_on": "2026-09-02",
+  "pipelock_version": "3.5.0",
+  "bench_release_tag": "v0.1.1",
+  "bench_release_commit": "a3d56890487aed5fc5a01f46e8732d2ad73fcf53",
+  "corpus_version": "v2.7.0",
+  "active_case_count": 249,
+  "containment": {
+    "numerator": 178,
+    "denominator": 181
+  },
+  "false_positives": {
+    "numerator": 2,
+    "denominator": 68
+  },
+  "accepted_containment_misses": [
+    "mcp-chain-dow-budget-exceeded-010",
+    "mcp-chain-dow-interleaved-budget-exceeded-012",
+    "mcp-initialize-instructions-exfil-024"
+  ],
+  "accepted_false_positives": [
+    "fp-quoted-injection-docs-002",
+    "response-benign-security-article-002"
+  ]
+}

--- a/benchmark/gauntlet-baseline.json
+++ b/benchmark/gauntlet-baseline.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Pipelock-owned promotion baseline for the candidate-only Gauntlet lane. This file states what Pipelock accepts; Agent Egress Bench owns only the neutral corpus, runner, evaluator, and evidence contracts. Floors and the ceiling are the exact measured v3.5.0 result, so any containment regression or any additional benign block blocks the lane. The exact accepted failure identities live in gauntlet-acceptance.json and are enforced separately.",
+  "schema_version": 1,
+  "recorded_on": "2026-09-02",
+  "pipelock_version": "3.5.0",
+  "corpus_git_sha": "a3d56890487aed5fc5a01f46e8732d2ad73fcf53",
+  "corpus_sha256": "882ca081b23447b330446107eea3adb1aa337abf12ba9fcec51d013f9365ed53",
+  "corpus_version": "v2.7.0",
+  "scoring_version": "2.8",
+  "runner_version": "0.4.3",
+  "summary_schema_version": 5,
+  "benchmark_manifest_sha256": "577765ae387ee6cd166df8c3a52c3f7b7eedb7a589dce7a4d49fd6a07fd70f5d",
+  "observed_case_count": {
+    "total": 249,
+    "applicable": 249,
+    "unreachable": 0,
+    "not_applicable": 0,
+    "not_applicable_reasons": {}
+  },
+  "score_floors": {
+    "full": {
+      "containment": 0.9834254143646409
+    },
+    "applicable": {
+      "containment": 0.9834254143646409
+    }
+  },
+  "score_ceilings": {
+    "applicable": {
+      "false_positive_rate": 0.029411764705882353
+    }
+  }
+}

--- a/scripts/check_gauntlet_acceptance.py
+++ b/scripts/check_gauntlet_acceptance.py
@@ -29,6 +29,7 @@ REQUIRED_CONTRACT_KEYS = (
 
 
 def load_object(path):
+    """Read a JSON object from path, refusing any other JSON shape."""
     with Path(path).open(encoding="utf-8") as handle:
         value = json.load(handle)
     if not isinstance(value, dict):
@@ -37,6 +38,7 @@ def load_object(path):
 
 
 def load_contract(path):
+    """Load the acceptance contract, refusing one that contradicts itself."""
     contract = load_object(path)
     missing = [key for key in REQUIRED_CONTRACT_KEYS if key not in contract]
     if missing:
@@ -116,7 +118,6 @@ def read_results(path):
     misses = set()
     false_positives = set()
     seen = set()
-    failures = []
     with Path(path).open(encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
@@ -146,21 +147,18 @@ def read_results(path):
                 )
             if score == "pass":
                 continue
-            if expected == "block" and actual == "allow":
+            # The checks above admit only "block" and "allow", and require a
+            # failing score to disagree with its expectation, so a failing row
+            # is exactly one of the two classes.
+            if expected == "block":
                 misses.add(case_id)
-            elif expected == "allow" and actual == "block":
-                false_positives.add(case_id)
             else:
-                failures.append(
-                    f"{case_id}: unclassifiable result score={score!r} "
-                    f"expected={expected!r} actual={actual!r}"
-                )
-    if failures:
-        raise ValueError("; ".join(failures))
+                false_positives.add(case_id)
     return misses, false_positives, len(seen)
 
 
 def compare_identities(label, observed, accepted):
+    """Report failing cases that are unaccepted, and accepted cases that now pass."""
     failures = []
     unexpected = sorted(observed - accepted)
     resolved = sorted(accepted - observed)
@@ -176,6 +174,7 @@ def compare_identities(label, observed, accepted):
 
 
 def check(contract_path, candidate_path, results_path):
+    """Return every way the candidate and its results depart from the contract."""
     failures = []
     contract = load_contract(contract_path)
     candidate = load_object(candidate_path)
@@ -256,6 +255,7 @@ def check(contract_path, candidate_path, results_path):
 
 
 def main(argv=None):
+    """Run the acceptance check and return the process exit status."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--contract", required=True, type=Path)
     parser.add_argument("--candidate", required=True, type=Path)

--- a/scripts/check_gauntlet_acceptance.py
+++ b/scripts/check_gauntlet_acceptance.py
@@ -109,15 +109,17 @@ def load_contract(path):
 
 
 def read_results(path):
-    """Return observed containment misses, false positives, and the case count.
+    """Return the observed misses, false positives, and per-expectation counts.
 
     Every record must be classifiable. An unrecognized verdict pair is a
     failure rather than an ignored row, so a runner change cannot silently
-    drop a failing case out of the comparison.
+    drop a failing case out of the comparison, and the counts let the caller
+    check that the result file evaluated the population the contract names.
     """
     misses = set()
     false_positives = set()
     seen = set()
+    expected_counts = {"block": 0, "allow": 0}
     with Path(path).open(encoding="utf-8") as handle:
         for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
@@ -135,12 +137,16 @@ def read_results(path):
             expected = record.get("expected_verdict")
             actual = record.get("actual_verdict")
             score = record.get("score")
-            if expected not in {"block", "allow"}:
+            # A JSON array or object is unhashable, so the string check must
+            # come first or set membership raises TypeError and escapes the
+            # fail-closed diagnostic in main().
+            if not isinstance(expected, str) or expected not in {"block", "allow"}:
                 raise ValueError(f"{path}:{line_number} has invalid expected_verdict")
-            if actual not in {"block", "allow"}:
+            if not isinstance(actual, str) or actual not in {"block", "allow"}:
                 raise ValueError(f"{path}:{line_number} has invalid actual_verdict")
-            if score not in {"pass", "fail"}:
+            if not isinstance(score, str) or score not in {"pass", "fail"}:
                 raise ValueError(f"{path}:{line_number} has invalid score")
+            expected_counts[expected] += 1
             if (score == "pass") != (actual == expected):
                 raise ValueError(
                     f"{path}:{line_number} score does not match expected and actual verdicts"
@@ -154,7 +160,7 @@ def read_results(path):
                 misses.add(case_id)
             else:
                 false_positives.add(case_id)
-    return misses, false_positives, len(seen)
+    return misses, false_positives, len(seen), expected_counts
 
 
 def compare_identities(label, observed, accepted):
@@ -235,12 +241,22 @@ def check(contract_path, candidate_path, results_path):
                         f"contract accepts {expected[field]}"
                     )
 
-    misses, false_positives, observed_cases = read_results(results_path)
+    misses, false_positives, observed_cases, expected_counts = read_results(results_path)
     if observed_cases != contract["active_case_count"]:
         failures.append(
             f"results carry {observed_cases} cases, contract accepts "
             f"{contract['active_case_count']}"
         )
+    # The row total alone cannot see a case moved between populations, which
+    # would evaluate a different corpus while every other number still agrees.
+    for verdict, metric in (("block", "containment"), ("allow", "false_positives")):
+        observed_population = expected_counts[verdict]
+        accepted_population = contract[metric]["denominator"]
+        if observed_population != accepted_population:
+            failures.append(
+                f"results carry {observed_population} cases expecting {verdict!r}, "
+                f"contract accepts {accepted_population}"
+            )
     failures.extend(
         compare_identities(
             "containment misses", misses, set(contract["accepted_containment_misses"])

--- a/scripts/check_gauntlet_acceptance.py
+++ b/scripts/check_gauntlet_acceptance.py
@@ -43,6 +43,23 @@ def load_contract(path):
         raise ValueError(f"acceptance contract missing required keys: {missing!r}")
     if contract["schema_version"] != 1:
         raise ValueError("acceptance contract schema_version must be 1")
+    for key in ("pipelock_version", "corpus_version"):
+        if not isinstance(contract[key], str) or not contract[key]:
+            raise ValueError(f"acceptance contract {key} must be a non-empty string")
+    bench_release_commit = contract["bench_release_commit"]
+    if (
+        not isinstance(bench_release_commit, str)
+        or len(bench_release_commit) != 40
+        or any(character not in "0123456789abcdef" for character in bench_release_commit)
+    ):
+        raise ValueError("acceptance contract bench_release_commit must be a lower-case Git SHA")
+    active_case_count = contract["active_case_count"]
+    if (
+        isinstance(active_case_count, bool)
+        or not isinstance(active_case_count, int)
+        or active_case_count < 1
+    ):
+        raise ValueError("acceptance contract active_case_count must be a positive integer")
     for key in ("accepted_containment_misses", "accepted_false_positives"):
         identifiers = contract[key]
         if not isinstance(identifiers, list) or not all(
@@ -62,6 +79,30 @@ def load_contract(path):
                 raise ValueError(
                     f"acceptance contract {key}.{field} must be a non-negative integer"
                 )
+        if fraction["denominator"] < 1:
+            raise ValueError(f"acceptance contract {key}.denominator must be positive")
+        if fraction["numerator"] > fraction["denominator"]:
+            raise ValueError(
+                f"acceptance contract {key}.numerator cannot exceed its denominator"
+            )
+    if len(contract["accepted_containment_misses"]) != (
+        contract["containment"]["denominator"] - contract["containment"]["numerator"]
+    ):
+        raise ValueError(
+            "acceptance contract accepted_containment_misses must match containment counts"
+        )
+    if len(contract["accepted_false_positives"]) != contract["false_positives"]["numerator"]:
+        raise ValueError(
+            "acceptance contract accepted_false_positives must match false-positive counts"
+        )
+    if (
+        contract["containment"]["denominator"]
+        + contract["false_positives"]["denominator"]
+        != active_case_count
+    ):
+        raise ValueError(
+            "acceptance contract metric denominators must equal active_case_count"
+        )
     return contract
 
 
@@ -93,6 +134,16 @@ def read_results(path):
             expected = record.get("expected_verdict")
             actual = record.get("actual_verdict")
             score = record.get("score")
+            if expected not in {"block", "allow"}:
+                raise ValueError(f"{path}:{line_number} has invalid expected_verdict")
+            if actual not in {"block", "allow"}:
+                raise ValueError(f"{path}:{line_number} has invalid actual_verdict")
+            if score not in {"pass", "fail"}:
+                raise ValueError(f"{path}:{line_number} has invalid score")
+            if (score == "pass") != (actual == expected):
+                raise ValueError(
+                    f"{path}:{line_number} score does not match expected and actual verdicts"
+                )
             if score == "pass":
                 continue
             if expected == "block" and actual == "allow":

--- a/scripts/check_gauntlet_acceptance.py
+++ b/scripts/check_gauntlet_acceptance.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enforce the Pipelock-owned Gauntlet acceptance contract.
+
+The neutral benchmark evaluator compares aggregate rates. An equal aggregate
+built from a different set of failures is a different product result, so this
+check binds the exact case identities Pipelock accepts. It fails closed: any
+unreadable, malformed, or unexpected input is a failure, never a pass.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_CONTRACT_KEYS = (
+    "schema_version",
+    "pipelock_version",
+    "bench_release_commit",
+    "corpus_version",
+    "active_case_count",
+    "containment",
+    "false_positives",
+    "accepted_containment_misses",
+    "accepted_false_positives",
+)
+
+
+def load_object(path):
+    with Path(path).open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def load_contract(path):
+    contract = load_object(path)
+    missing = [key for key in REQUIRED_CONTRACT_KEYS if key not in contract]
+    if missing:
+        raise ValueError(f"acceptance contract missing required keys: {missing!r}")
+    if contract["schema_version"] != 1:
+        raise ValueError("acceptance contract schema_version must be 1")
+    for key in ("accepted_containment_misses", "accepted_false_positives"):
+        identifiers = contract[key]
+        if not isinstance(identifiers, list) or not all(
+            isinstance(item, str) and item for item in identifiers
+        ):
+            raise ValueError(f"acceptance contract {key} must be a list of non-empty strings")
+        if len(set(identifiers)) != len(identifiers):
+            raise ValueError(f"acceptance contract {key} must not repeat a case identifier")
+    for key in ("containment", "false_positives"):
+        fraction = contract[key]
+        if not isinstance(fraction, dict) or set(fraction) != {"numerator", "denominator"}:
+            raise ValueError(
+                f"acceptance contract {key} must be an object with numerator and denominator"
+            )
+        for field, value in fraction.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(
+                    f"acceptance contract {key}.{field} must be a non-negative integer"
+                )
+    return contract
+
+
+def read_results(path):
+    """Return observed containment misses, false positives, and the case count.
+
+    Every record must be classifiable. An unrecognized verdict pair is a
+    failure rather than an ignored row, so a runner change cannot silently
+    drop a failing case out of the comparison.
+    """
+    misses = set()
+    false_positives = set()
+    seen = set()
+    failures = []
+    with Path(path).open(encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if not isinstance(record, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            case_id = record.get("case_id")
+            if not isinstance(case_id, str) or not case_id:
+                raise ValueError(f"{path}:{line_number} has no case_id")
+            if case_id in seen:
+                raise ValueError(f"{path}:{line_number} repeats case_id {case_id!r}")
+            seen.add(case_id)
+            expected = record.get("expected_verdict")
+            actual = record.get("actual_verdict")
+            score = record.get("score")
+            if score == "pass":
+                continue
+            if expected == "block" and actual == "allow":
+                misses.add(case_id)
+            elif expected == "allow" and actual == "block":
+                false_positives.add(case_id)
+            else:
+                failures.append(
+                    f"{case_id}: unclassifiable result score={score!r} "
+                    f"expected={expected!r} actual={actual!r}"
+                )
+    if failures:
+        raise ValueError("; ".join(failures))
+    return misses, false_positives, len(seen)
+
+
+def compare_identities(label, observed, accepted):
+    failures = []
+    unexpected = sorted(observed - accepted)
+    resolved = sorted(accepted - observed)
+    if unexpected:
+        failures.append(f"unaccepted {label}: {unexpected}")
+    if resolved:
+        failures.append(
+            f"accepted {label} no longer failing: {resolved}; "
+            "update benchmark/gauntlet-acceptance.json and benchmark/gauntlet-baseline.json "
+            "in the same reviewed change"
+        )
+    return failures
+
+
+def check(contract_path, candidate_path, results_path):
+    failures = []
+    contract = load_contract(contract_path)
+    candidate = load_object(candidate_path)
+
+    for field in ("pipelock_version", "corpus_version"):
+        if candidate.get(field) != contract[field]:
+            failures.append(
+                f"candidate {field}={candidate.get(field)!r}, contract accepts "
+                f"{contract[field]!r}"
+            )
+    if candidate.get("corpus_git_sha") != contract["bench_release_commit"]:
+        failures.append(
+            f"candidate corpus_git_sha={candidate.get('corpus_git_sha')!r}, contract accepts "
+            f"{contract['bench_release_commit']!r}"
+        )
+
+    case_count = candidate.get("case_count")
+    if not isinstance(case_count, dict):
+        failures.append(f"candidate case_count={case_count!r}, want an object")
+        case_count = {}
+    for field, want in (
+        ("total", contract["active_case_count"]),
+        ("applicable", contract["active_case_count"]),
+        ("errors", 0),
+        ("unreachable", 0),
+        ("not_applicable", 0),
+    ):
+        value = case_count.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value != want:
+            failures.append(f"candidate case_count.{field}={value!r}, want {want}")
+
+    metric_counts = candidate.get("metric_counts")
+    if not isinstance(metric_counts, dict):
+        failures.append(f"candidate metric_counts={metric_counts!r}, want an object")
+        metric_counts = {}
+    for scope in ("full", "applicable"):
+        scope_counts = metric_counts.get(scope)
+        if not isinstance(scope_counts, dict):
+            failures.append(f"candidate metric_counts.{scope} must be an object")
+            continue
+        for metric, expected in (
+            ("containment", contract["containment"]),
+            ("false_positive_rate", contract["false_positives"]),
+        ):
+            observed = scope_counts.get(metric)
+            if not isinstance(observed, dict):
+                failures.append(f"candidate metric_counts.{scope}.{metric} must be an object")
+                continue
+            for field in ("numerator", "denominator"):
+                value = observed.get(field)
+                if (
+                    isinstance(value, bool)
+                    or not isinstance(value, int)
+                    or value != expected[field]
+                ):
+                    failures.append(
+                        f"candidate metric_counts.{scope}.{metric}.{field}={value!r}, "
+                        f"contract accepts {expected[field]}"
+                    )
+
+    misses, false_positives, observed_cases = read_results(results_path)
+    if observed_cases != contract["active_case_count"]:
+        failures.append(
+            f"results carry {observed_cases} cases, contract accepts "
+            f"{contract['active_case_count']}"
+        )
+    failures.extend(
+        compare_identities(
+            "containment misses", misses, set(contract["accepted_containment_misses"])
+        )
+    )
+    failures.extend(
+        compare_identities(
+            "false positives", false_positives, set(contract["accepted_false_positives"])
+        )
+    )
+    return failures
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", required=True, type=Path)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--results", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        failures = check(args.contract, args.candidate, args.results)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"::error::Gauntlet acceptance check failed closed: {exc}", file=sys.stderr)
+        return 1
+    if failures:
+        for failure in failures:
+            print(f"::error::{failure}", file=sys.stderr)
+        print(f"Gauntlet acceptance: BLOCKED ({len(failures)} failure(s))")
+        return 1
+    print("Gauntlet acceptance: PASS (exact accepted result reproduced)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_gauntlet_acceptance.py
+++ b/scripts/test_gauntlet_acceptance.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Pipelock-owned Gauntlet acceptance contract checker."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from scripts import check_gauntlet_acceptance as checker
+except ModuleNotFoundError:  # pragma: no cover - direct-module invocation
+    import check_gauntlet_acceptance as checker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "benchmark" / "gauntlet-acceptance.json"
+CONTRACT = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+MISSES = list(CONTRACT["accepted_containment_misses"])
+FALSE_POSITIVES = list(CONTRACT["accepted_false_positives"])
+CONTAINMENT = CONTRACT["containment"]
+FALSE_POSITIVE_COUNTS = CONTRACT["false_positives"]
+
+
+def candidate_document(**overrides):
+    counts = {
+        "containment": dict(CONTAINMENT),
+        "false_positive_rate": dict(FALSE_POSITIVE_COUNTS),
+    }
+    document = {
+        "pipelock_version": CONTRACT["pipelock_version"],
+        "corpus_version": CONTRACT["corpus_version"],
+        "corpus_git_sha": CONTRACT["bench_release_commit"],
+        "case_count": {
+            "total": CONTRACT["active_case_count"],
+            "applicable": CONTRACT["active_case_count"],
+            "errors": 0,
+            "unreachable": 0,
+            "not_applicable": 0,
+            "not_applicable_reasons": {},
+        },
+        "metric_counts": {"full": counts, "applicable": dict(counts)},
+    }
+    document.update(overrides)
+    return document
+
+
+def results_rows(misses=None, false_positives=None):
+    """Build a full result set matching the accepted aggregates by default."""
+    misses = MISSES if misses is None else misses
+    false_positives = FALSE_POSITIVES if false_positives is None else false_positives
+    rows = []
+    for case_id in misses:
+        rows.append((case_id, "block", "allow", "fail"))
+    for case_id in false_positives:
+        rows.append((case_id, "allow", "block", "fail"))
+    used = {case_id for case_id, *_ in rows}
+    index = 0
+    while sum(1 for _, expected, _, _ in rows if expected == "block") < CONTAINMENT["denominator"]:
+        case_id = f"generated-block-{index:04d}"
+        index += 1
+        if case_id in used:
+            continue
+        rows.append((case_id, "block", "block", "pass"))
+    index = 0
+    while sum(1 for _, expected, _, _ in rows if expected == "allow") < FALSE_POSITIVE_COUNTS["denominator"]:
+        case_id = f"generated-allow-{index:04d}"
+        index += 1
+        if case_id in used:
+            continue
+        rows.append((case_id, "allow", "allow", "pass"))
+    assert sum(1 for _, expected, _, _ in rows if expected == "block") == CONTAINMENT["denominator"]
+    assert len(rows) == CONTRACT["active_case_count"], len(rows)
+    return [
+        {
+            "case_id": case_id,
+            "expected_verdict": expected,
+            "actual_verdict": actual,
+            "score": score,
+        }
+        for case_id, expected, actual, score in rows
+    ]
+
+
+class AcceptanceCheckerTest(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.directory = Path(self._temporary.name)
+
+    def run_check(self, candidate=None, rows=None, contract=CONTRACT_PATH):
+        candidate_path = self.directory / "candidate.json"
+        results_path = self.directory / "results.jsonl"
+        candidate_path.write_text(
+            json.dumps(candidate_document() if candidate is None else candidate),
+            encoding="utf-8",
+        )
+        rows = results_rows() if rows is None else rows
+        results_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        return checker.check(contract, candidate_path, results_path)
+
+    def test_accepted_result_passes(self):
+        self.assertEqual(self.run_check(), [])
+
+    def test_swapping_one_accepted_case_while_preserving_aggregates_is_rejected(self):
+        """The aggregate is identical; only the identities moved."""
+        rows = results_rows()
+        swapped_in = next(
+            row for row in rows if row["expected_verdict"] == "block" and row["score"] == "pass"
+        )
+        swapped_out = next(row for row in rows if row["case_id"] == MISSES[0])
+        swapped_in.update(actual_verdict="allow", score="fail")
+        swapped_out.update(actual_verdict="block", score="pass")
+        failures = self.run_check(rows=rows)
+        self.assertTrue(any(swapped_in["case_id"] in failure for failure in failures), failures)
+        self.assertTrue(any(MISSES[0] in failure for failure in failures), failures)
+
+    def test_swapping_one_accepted_false_positive_is_rejected(self):
+        rows = results_rows()
+        swapped_in = next(
+            row for row in rows if row["expected_verdict"] == "allow" and row["score"] == "pass"
+        )
+        swapped_out = next(row for row in rows if row["case_id"] == FALSE_POSITIVES[0])
+        swapped_in.update(actual_verdict="block", score="fail")
+        swapped_out.update(actual_verdict="allow", score="pass")
+        failures = self.run_check(rows=rows)
+        self.assertTrue(any(swapped_in["case_id"] in failure for failure in failures), failures)
+
+    def test_additional_miss_is_rejected(self):
+        rows = results_rows()
+        extra = next(
+            row for row in rows if row["expected_verdict"] == "block" and row["score"] == "pass"
+        )
+        extra.update(actual_verdict="allow", score="fail")
+        self.assertTrue(self.run_check(rows=rows))
+
+    def test_unexpected_pass_requires_a_reviewed_contract_update(self):
+        rows = [row for row in results_rows() if row["case_id"] != MISSES[0]]
+        rows.append(
+            {
+                "case_id": MISSES[0],
+                "expected_verdict": "block",
+                "actual_verdict": "block",
+                "score": "pass",
+            }
+        )
+        failures = self.run_check(rows=rows)
+        self.assertTrue(
+            any("no longer failing" in failure for failure in failures), failures
+        )
+
+    def test_product_version_mismatch_is_rejected(self):
+        failures = self.run_check(candidate=candidate_document(pipelock_version="3.4.0"))
+        self.assertTrue(any("pipelock_version" in failure for failure in failures), failures)
+
+    def test_unpinned_benchmark_revision_is_rejected(self):
+        failures = self.run_check(candidate=candidate_document(corpus_git_sha="0" * 40))
+        self.assertTrue(any("corpus_git_sha" in failure for failure in failures), failures)
+
+    def test_runner_errors_and_unreachable_cases_are_rejected(self):
+        for field in ("errors", "unreachable"):
+            with self.subTest(field=field):
+                candidate = candidate_document()
+                candidate["case_count"][field] = 1
+                failures = self.run_check(candidate=candidate)
+                self.assertTrue(any(field in failure for failure in failures), failures)
+
+    def test_boolean_count_cannot_satisfy_a_zero_check(self):
+        candidate = candidate_document()
+        candidate["case_count"]["errors"] = False
+        failures = self.run_check(candidate=candidate)
+        self.assertTrue(any("errors" in failure for failure in failures), failures)
+
+    def test_metric_counts_must_match_the_contract_exactly(self):
+        candidate = candidate_document()
+        candidate["metric_counts"]["applicable"]["containment"] = {
+            "numerator": CONTAINMENT["numerator"] - 1,
+            "denominator": CONTAINMENT["denominator"] - 1,
+        }
+        failures = self.run_check(candidate=candidate)
+        self.assertTrue(any("containment" in failure for failure in failures), failures)
+
+    def test_short_result_set_is_rejected(self):
+        rows = results_rows()[:-1]
+        failures = self.run_check(rows=rows)
+        self.assertTrue(any("cases" in failure for failure in failures), failures)
+
+    def test_unclassifiable_result_fails_closed(self):
+        rows = results_rows()
+        rows[-1] = dict(rows[-1], score="error", actual_verdict="error")
+        with self.assertRaises(ValueError):
+            self.run_check(rows=rows)
+
+    def test_repeated_case_identifier_fails_closed(self):
+        rows = results_rows()
+        rows.append(dict(rows[0]))
+        with self.assertRaises(ValueError):
+            self.run_check(rows=rows)
+
+    def test_missing_contract_fails_closed(self):
+        with self.assertRaises(OSError):
+            self.run_check(contract=self.directory / "absent.json")
+
+    def test_main_reports_a_nonzero_exit_on_a_blocked_result(self):
+        candidate_path = self.directory / "candidate.json"
+        results_path = self.directory / "results.jsonl"
+        candidate_path.write_text(
+            json.dumps(candidate_document(pipelock_version="0.0.0")), encoding="utf-8"
+        )
+        results_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in results_rows()), encoding="utf-8"
+        )
+        exit_code = checker.main(
+            [
+                "--contract",
+                str(CONTRACT_PATH),
+                "--candidate",
+                str(candidate_path),
+                "--results",
+                str(results_path),
+            ]
+        )
+        self.assertEqual(exit_code, 1)
+
+    def test_main_passes_on_the_accepted_result(self):
+        candidate_path = self.directory / "candidate.json"
+        results_path = self.directory / "results.jsonl"
+        candidate_path.write_text(json.dumps(candidate_document()), encoding="utf-8")
+        results_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in results_rows()), encoding="utf-8"
+        )
+        exit_code = checker.main(
+            [
+                "--contract",
+                str(CONTRACT_PATH),
+                "--candidate",
+                str(candidate_path),
+                "--results",
+                str(results_path),
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+
+
+class ContractShapeTest(unittest.TestCase):
+    def test_contract_rejects_a_duplicate_accepted_identifier(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "contract.json"
+            broken = dict(CONTRACT)
+            broken["accepted_containment_misses"] = [MISSES[0], MISSES[0]]
+            path.write_text(json.dumps(broken), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                checker.load_contract(path)
+
+    def test_contract_rejects_an_unknown_schema_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "contract.json"
+            path.write_text(json.dumps(dict(CONTRACT, schema_version=2)), encoding="utf-8")
+            with self.assertRaises(ValueError):
+                checker.load_contract(path)
+
+    def test_shipped_contract_loads(self):
+        self.assertEqual(checker.load_contract(CONTRACT_PATH)["schema_version"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_gauntlet_acceptance.py
+++ b/scripts/test_gauntlet_acceptance.py
@@ -190,6 +190,51 @@ class AcceptanceCheckerTest(unittest.TestCase):
         failures = self.run_check(rows=rows)
         self.assertTrue(any("cases" in failure for failure in failures), failures)
 
+    def test_moving_a_case_between_populations_is_rejected(self):
+        """Totals and identities still agree; the evaluated population does not."""
+        rows = results_rows()
+        moved = next(
+            row for row in rows if row["expected_verdict"] == "block" and row["score"] == "pass"
+        )
+        moved.update(expected_verdict="allow", actual_verdict="allow")
+        failures = self.run_check(rows=rows)
+        self.assertTrue(
+            any("expecting 'block'" in failure for failure in failures), failures
+        )
+        self.assertTrue(
+            any("expecting 'allow'" in failure for failure in failures), failures
+        )
+
+    def test_unhashable_verdict_fails_closed_without_a_traceback(self):
+        for field in ("expected_verdict", "actual_verdict", "score"):
+            for value in ([], {}, 7, None):
+                with self.subTest(field=field, value=value):
+                    rows = results_rows()
+                    rows[0] = dict(rows[0], **{field: value})
+                    with self.assertRaises(ValueError):
+                        self.run_check(rows=rows)
+
+    def test_main_reports_a_nonzero_exit_on_malformed_verdicts(self):
+        rows = results_rows()
+        rows[0] = dict(rows[0], expected_verdict=[])
+        candidate_path = self.directory / "candidate.json"
+        results_path = self.directory / "results.jsonl"
+        candidate_path.write_text(json.dumps(candidate_document()), encoding="utf-8")
+        results_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        exit_code = checker.main(
+            [
+                "--contract",
+                str(CONTRACT_PATH),
+                "--candidate",
+                str(candidate_path),
+                "--results",
+                str(results_path),
+            ]
+        )
+        self.assertEqual(exit_code, 1)
+
     def test_unknown_score_fails_closed(self):
         rows = results_rows()
         rows[-1] = dict(rows[-1], score="error", actual_verdict="error")

--- a/scripts/test_gauntlet_acceptance.py
+++ b/scripts/test_gauntlet_acceptance.py
@@ -196,6 +196,22 @@ class AcceptanceCheckerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.run_check(rows=rows)
 
+    def test_passing_score_cannot_hide_an_opposite_verdict(self):
+        rows = results_rows()
+        passing_block = next(
+            row for row in rows if row["expected_verdict"] == "block" and row["score"] == "pass"
+        )
+        passing_block["actual_verdict"] = "allow"
+        with self.assertRaisesRegex(ValueError, "score does not match"):
+            self.run_check(rows=rows)
+
+    def test_unknown_score_cannot_preserve_an_accepted_miss(self):
+        rows = results_rows()
+        accepted_miss = next(row for row in rows if row["case_id"] == MISSES[0])
+        accepted_miss["score"] = "error"
+        with self.assertRaisesRegex(ValueError, "invalid score"):
+            self.run_check(rows=rows)
+
     def test_repeated_case_identifier_fails_closed(self):
         rows = results_rows()
         rows.append(dict(rows[0]))
@@ -262,6 +278,22 @@ class ContractShapeTest(unittest.TestCase):
             path = Path(directory) / "contract.json"
             path.write_text(json.dumps(dict(CONTRACT, schema_version=2)), encoding="utf-8")
             with self.assertRaises(ValueError):
+                checker.load_contract(path)
+
+    def test_contract_rejects_non_integer_active_case_count(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "contract.json"
+            path.write_text(json.dumps(dict(CONTRACT, active_case_count=249.0)), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "active_case_count"):
+                checker.load_contract(path)
+
+    def test_contract_rejects_counts_that_disagree_with_accepted_identities(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "contract.json"
+            broken = dict(CONTRACT)
+            broken["containment"] = dict(CONTAINMENT, numerator=CONTAINMENT["numerator"] - 1)
+            path.write_text(json.dumps(broken), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "accepted_containment_misses"):
                 checker.load_contract(path)
 
     def test_shipped_contract_loads(self):

--- a/scripts/test_gauntlet_acceptance.py
+++ b/scripts/test_gauntlet_acceptance.py
@@ -190,7 +190,7 @@ class AcceptanceCheckerTest(unittest.TestCase):
         failures = self.run_check(rows=rows)
         self.assertTrue(any("cases" in failure for failure in failures), failures)
 
-    def test_unclassifiable_result_fails_closed(self):
+    def test_unknown_score_fails_closed(self):
         rows = results_rows()
         rows[-1] = dict(rows[-1], score="error", actual_verdict="error")
         with self.assertRaises(ValueError):

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -4,6 +4,7 @@
 
 """Structural tests for the Pipelock-owned candidate-only Gauntlet lane."""
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -13,7 +14,9 @@ ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
-EXPECTED_AEB_REF = "efda9aa26d6b3cacc711450c31d784d0c725155d"
+BASELINE = ROOT / "benchmark" / "gauntlet-baseline.json"
+ACCEPTANCE = ROOT / "benchmark" / "gauntlet-acceptance.json"
+EXPECTED_AEB_REF = "a3d56890487aed5fc5a01f46e8732d2ad73fcf53"
 GAUNTLET_WORKFLOW_URL = (
     "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
 )
@@ -106,6 +109,79 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
         self.assertRegex(assignments["PIPELOCK_ASSET_SHA256_AMD64"], r"^[0-9a-f]{64}$")
         self.assertRegex(assignments["PIPELOCK_ASSET_SHA256_ARM64"], r"^[0-9a-f]{64}$")
         self.assertNotIn("v3.3.0", self.workflow)
+
+    def test_acceptance_policy_is_owned_by_pipelock_not_the_benchmark(self):
+        """Product acceptance must never be read from the neutral benchmark repo."""
+        self.assertNotIn("ci/gauntlet-baseline.json", self.workflow)
+        self.assertNotIn("$AEB_ROOT/ci/", self.workflow)
+        for policy in (BASELINE, ACCEPTANCE):
+            self.assertTrue(policy.is_file(), policy)
+            self.assertEqual(policy.parent.name, "benchmark")
+        self.assertIn(
+            'PIPELOCK_GAUNTLET_BASELINE=$GITHUB_WORKSPACE/benchmark/gauntlet-baseline.json',
+            self.workflow,
+        )
+        self.assertIn(
+            'PIPELOCK_GAUNTLET_ACCEPTANCE=$GITHUB_WORKSPACE/benchmark/gauntlet-acceptance.json',
+            self.workflow,
+        )
+        verify = step_block(self.workflow, "Verify immutable inputs")
+        for variable in ("$PIPELOCK_GAUNTLET_BASELINE", "$PIPELOCK_GAUNTLET_ACCEPTANCE"):
+            self.assertIn(variable, verify)
+        for step in (
+            "Evaluate candidate without publishing",
+            "Ensure fail-closed decision exists",
+            "Enforce candidate decision",
+            "Render owner-facing run summary",
+        ):
+            self.assertIn('--baseline "$PIPELOCK_GAUNTLET_BASELINE"', step_block(self.workflow, step))
+
+    def test_acceptance_contract_is_enforced_after_evidence_upload(self):
+        """A blocked acceptance result must still leave the evidence inspectable."""
+        upload = self.workflow.index("      - name: Upload candidate evidence")
+        enforce = self.workflow.index("      - name: Enforce Pipelock acceptance contract")
+        self.assertLess(upload, enforce)
+        block = step_block(self.workflow, "Enforce Pipelock acceptance contract")
+        self.assertIn("set -euo pipefail", block)
+        self.assertIn("scripts/check_gauntlet_acceptance.py", block)
+        self.assertIn('--contract "$PIPELOCK_GAUNTLET_ACCEPTANCE"', block)
+        self.assertIn('--results "$GAUNTLET_ARTIFACT_DIR/results.jsonl"', block)
+
+    def test_owned_policy_files_agree_with_each_other_and_the_release_pin(self):
+        """Two files state the same result; nothing fails when they disagree unless checked."""
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        acceptance = json.loads(ACCEPTANCE.read_text(encoding="utf-8"))
+        self.assertEqual(baseline["pipelock_version"], acceptance["pipelock_version"])
+        self.assertIn(
+            "PIPELOCK_VERSION=" + baseline["pipelock_version"], self.release_pin
+        )
+        self.assertEqual(baseline["corpus_version"], acceptance["corpus_version"])
+        self.assertEqual(baseline["corpus_git_sha"], acceptance["bench_release_commit"])
+        self.assertEqual(baseline["corpus_git_sha"], EXPECTED_AEB_REF)
+        self.assertEqual(
+            baseline["observed_case_count"]["total"], acceptance["active_case_count"]
+        )
+        self.assertEqual(
+            baseline["observed_case_count"]["applicable"], acceptance["active_case_count"]
+        )
+        containment = acceptance["containment"]
+        false_positives = acceptance["false_positives"]
+        self.assertEqual(
+            len(acceptance["accepted_containment_misses"]),
+            containment["denominator"] - containment["numerator"],
+        )
+        self.assertEqual(
+            len(acceptance["accepted_false_positives"]), false_positives["numerator"]
+        )
+        for scope in ("full", "applicable"):
+            self.assertAlmostEqual(
+                baseline["score_floors"][scope]["containment"],
+                containment["numerator"] / containment["denominator"],
+            )
+        self.assertAlmostEqual(
+            baseline["score_ceilings"]["applicable"]["false_positive_rate"],
+            false_positives["numerator"] / false_positives["denominator"],
+        )
 
     def test_shipped_portable_runner_is_the_only_execution_path(self):
         run = step_block(self.workflow, "Run portable canonical benchmark")


### PR DESCRIPTION
## What changed

Pipelock's Gauntlet workflow now reads its expected scores and accepted case identities from Pipelock-owned files instead of the benchmark repository's baseline, and pins the released Agent Egress Bench revision rather than a transient main commit. Agent Egress Bench stays responsible only for the neutral corpus, runner, evaluator, and evidence contracts.

Aggregate floors cannot distinguish an equal score built from a different set of failing cases, so acceptance also enforces the exact accepted containment misses and false positives. A result whose totals match while its failures moved is refused, and a result row whose recorded score contradicts its own verdicts is refused rather than skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formal Gauntlet acceptance contract with defined performance thresholds and explicitly accepted failure cases.
  * Added validation to reject unexpected benchmark results, malformed inputs, metric mismatches, and version inconsistencies.
  * Updated continuous evaluation to use the pinned benchmark release and enforce the acceptance contract after results are uploaded.

* **Tests**
  * Added comprehensive coverage for valid results, policy mismatches, duplicate cases, runner errors, and invalid contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->