### PR TITLE
fix: correct an unsound drain-test claim and a silent version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,17 @@ GOLANGCI_LINT_PIN := $(shell sed -n 's/[[:space:]]*version:[[:space:]]*v\([0-9][
 
 .PHONY: check-lint-version
 check-lint-version:
-	@have=$$(golangci-lint --version 2>/dev/null | sed -n 's/.*version \([0-9][0-9.]*\).*/\1/p' | head -1); \
-	if [ -n "$(GOLANGCI_LINT_PIN)" ] && [ -n "$$have" ] && [ "$$have" != "$(GOLANGCI_LINT_PIN)" ]; then \
+	@pin='$(GOLANGCI_LINT_PIN)'; \
+	if [ -z "$$pin" ]; then \
+	  printf 'warning: could not read the pinned golangci-lint version from the CI workflow, so local and CI formatting are unchecked.\n' >&2; \
+	  exit 0; \
+	fi; \
+	have=$$(golangci-lint --version 2>/dev/null | sed -n 's/.*version \([0-9][0-9.]*\).*/\1/p' | head -1); \
+	if [ -z "$$have" ]; then \
+	  printf 'warning: could not read the local golangci-lint version; CI pins %s.\n' "$$pin" >&2; \
+	elif [ "$$have" != "$$pin" ]; then \
 	  printf 'warning: golangci-lint %s locally, CI pins %s. Formatting and lint results can differ from CI.\n' \
-	    "$$have" "$(GOLANGCI_LINT_PIN)" >&2; \
+	    "$$have" "$$pin" >&2; \
 	fi
 
 fmt: check-lint-version

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ check-lint-version:
 	  printf 'warning: could not read the pinned golangci-lint version from the CI workflow, so local and CI formatting are unchecked.\n' >&2; \
 	  exit 0; \
 	fi; \
-	have=$$(golangci-lint --version 2>/dev/null | sed -n 's/.*version \([0-9][0-9.]*\).*/\1/p' | head -1); \
+	have=$$(golangci-lint --version 2>/dev/null | sed -n 's/.*version v\{0,1\}\([0-9][0-9.]*\).*/\1/p' | head -1); \
 	if [ -z "$$have" ]; then \
 	  printf 'warning: could not read the local golangci-lint version; CI pins %s.\n' "$$pin" >&2; \
 	elif [ "$$have" != "$$pin" ]; then \

--- a/internal/scanner/lifecycle_test.go
+++ b/internal/scanner/lifecycle_test.go
@@ -70,6 +70,12 @@ func TestScanner_BeginUse_FailsAfterClose(t *testing.T) {
 // Close does not return until every outstanding BeginUse caller has
 // invoked its release func. Without the WaitGroup drain, a future
 // destructive Close would race with mid-scan callers.
+//
+// closeOpportunityWindow is how long a wrongly-unblocked Close is given to
+// return before the test concludes it is genuinely blocked. It cannot cause a
+// spurious failure, because a correct Close stays blocked however long the wait.
+const closeOpportunityWindow = 250 * time.Millisecond
+
 func TestScanner_Close_BlocksUntilDrain(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil
@@ -94,15 +100,17 @@ func TestScanner_Close_BlocksUntilDrain(t *testing.T) {
 		close(closeReturned)
 	}()
 
-	// Wait for closed=true rather than sleeping: under load a fixed window
-	// expires before the goroutine is scheduled, which fails the test for a
-	// scheduling artifact. The timeout is a hang backstop, not the assertion.
+	// Wait for closed=true rather than sleeping. The original test slept and
+	// then asserted publication, so under load the window expired before the
+	// goroutine was scheduled and it failed for a scheduling artifact. Waiting
+	// removes that failure; the timeout here is a hang backstop.
 	//
-	// This is also what makes the two negative checks below sound rather than
-	// timing guesses. Close publishes closed=true BEFORE it starts draining, so
-	// once publication is observable, a Close that does not drain has already
-	// reached its return path. Waiting on publication therefore gives a broken
-	// implementation its full opportunity to return early.
+	// Publication does NOT prove Close reached the drain: it is published while
+	// the lock is held, and a Close that skipped the drain could still be
+	// descheduled between unlocking and returning. The two checks below are
+	// therefore bounded OPPORTUNITY windows, not proofs. They are sound in the
+	// direction that matters, because a correct Close stays blocked for any
+	// window length, so a longer wait cannot make them fail spuriously.
 	testwait.For(t, 5*time.Second, sc.Closed, "Close goroutine did not publish closed=true")
 
 	if release3, ok3 := sc.BeginUse(); ok3 {
@@ -113,7 +121,7 @@ func TestScanner_Close_BlocksUntilDrain(t *testing.T) {
 	select {
 	case <-closeReturned:
 		t.Fatal("Close returned with two users still in flight")
-	default:
+	case <-time.After(closeOpportunityWindow):
 	}
 
 	// Partial drain: the in-flight count drops but does not reach zero, so Close
@@ -123,7 +131,7 @@ func TestScanner_Close_BlocksUntilDrain(t *testing.T) {
 	select {
 	case <-closeReturned:
 		t.Fatal("Close returned after a partial drain, with one user still in flight")
-	default:
+	case <-time.After(closeOpportunityWindow):
 	}
 
 	releaseSecond()

--- a/internal/scanner/lifecycle_test.go
+++ b/internal/scanner/lifecycle_test.go
@@ -66,16 +66,15 @@ func TestScanner_BeginUse_FailsAfterClose(t *testing.T) {
 	}
 }
 
+// closeOpportunityWindow is how long a wrongly-unblocked Close is given to
+// return before a test concludes it is genuinely blocked. It cannot cause a
+// spurious failure, because a correct Close stays blocked however long the wait.
+const closeOpportunityWindow = 250 * time.Millisecond
+
 // TestScanner_Close_BlocksUntilDrain verifies the core drain invariant:
 // Close does not return until every outstanding BeginUse caller has
 // invoked its release func. Without the WaitGroup drain, a future
 // destructive Close would race with mid-scan callers.
-//
-// closeOpportunityWindow is how long a wrongly-unblocked Close is given to
-// return before the test concludes it is genuinely blocked. It cannot cause a
-// spurious failure, because a correct Close stays blocked however long the wait.
-const closeOpportunityWindow = 250 * time.Millisecond
-
 func TestScanner_Close_BlocksUntilDrain(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil


### PR DESCRIPTION
## What changed

Corrects a claim the previous change made about the scanner drain test. It asserted that waiting for the closed flag made its two negative checks sound, on the reasoning that publication happens before the drain begins. That reasoning is wrong: publication happens while the lock is still held, so a Close that skipped the drain can be descheduled between unlocking and returning, and an immediate non-blocking check then passes.

Each check now uses a bounded observation window, and the comment says plainly that these are opportunity windows rather than proofs. The direction is safe, because a correct Close stays blocked however long the window, so a longer wait cannot produce a spurious failure.

Also makes the linter version check report when it cannot verify. An unreadable pin left it passing silently, so a drift it exists to catch would have looked verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved lint-version checks to warn clearly when CI or local versions cannot be detected, while allowing the checks to complete.
  - Local lint-version detection now accepts versions with or without a leading `v`.

- **Tests**
  - Improved scanner shutdown test timing to more reliably detect premature closure behavior and avoid false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->