### PR TITLE
chore(gauntlet): pin the benchmark revision carrying record schema v4

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,12 +15,13 @@ permissions:
   contents: read
 
 env:
-  # Agent Egress Bench main at the commit that introduced promoted-record
-  # schema v4. The released v0.1.1 predates it and its promoter rejects the
-  # source-baseline-origin argument the site promotion now supplies, so a
-  # released pin is not yet available. Move this back to a release tag when
-  # the next benchmark release carries v4.
-  AEB_REF: 12107c32ad7a80b8c60c499b26bd01eb2450ac8f
+  # Agent Egress Bench release v1.0.0, the first release carrying promoted-record
+  # schema v4 and the source-baseline-origin argument the site promotion supplies.
+  # The checkout pins the commit so the run is reproducible even if a tag moves,
+  # and the verification step below resolves the tag and fails when the two
+  # disagree, so the release label is checked rather than merely asserted here.
+  AEB_REF: 06399746918ae0005f59a914fc9ec100a2f27fb8
+  AEB_RELEASE_TAG: v1.0.0
 
 jobs:
   candidate:
@@ -68,6 +69,10 @@ jobs:
           test "$GITHUB_REF" = "refs/heads/main"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
           test "$(git -C "$AEB_ROOT" rev-parse HEAD)" = "$AEB_REF"
+          # Bind the release label to the pinned commit. Without this the tag in
+          # AEB_RELEASE_TAG is a comment: it can name any release, or a release
+          # that never existed, and nothing fails.
+          test "$(git -C "$AEB_ROOT" rev-parse "refs/tags/$AEB_RELEASE_TAG^{commit}")" = "$AEB_REF"
           for policy in "$PIPELOCK_RELEASE_PIN" "$PIPELOCK_GAUNTLET_BASELINE" "$PIPELOCK_GAUNTLET_ACCEPTANCE"; do
             test ! -L "$policy"
             test -f "$policy"

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -15,9 +15,12 @@ permissions:
   contents: read
 
 env:
-  # Agent Egress Bench v0.1.1, the released revision. Prefer an exact
-  # released commit over a transient main pin.
-  AEB_REF: a3d56890487aed5fc5a01f46e8732d2ad73fcf53
+  # Agent Egress Bench main at the commit that introduced promoted-record
+  # schema v4. The released v0.1.1 predates it and its promoter rejects the
+  # source-baseline-origin argument the site promotion now supplies, so a
+  # released pin is not yet available. Move this back to a release tag when
+  # the next benchmark release carries v4.
+  AEB_REF: 12107c32ad7a80b8c60c499b26bd01eb2450ac8f
 
 jobs:
   candidate:

--- a/benchmark/gauntlet-acceptance.json
+++ b/benchmark/gauntlet-acceptance.json
@@ -3,8 +3,7 @@
   "schema_version": 1,
   "recorded_on": "2026-09-02",
   "pipelock_version": "3.5.0",
-  "bench_release_tag": "v0.1.1",
-  "bench_release_commit": "a3d56890487aed5fc5a01f46e8732d2ad73fcf53",
+  "bench_commit": "12107c32ad7a80b8c60c499b26bd01eb2450ac8f",
   "corpus_version": "v2.7.0",
   "active_case_count": 249,
   "containment": {

--- a/benchmark/gauntlet-acceptance.json
+++ b/benchmark/gauntlet-acceptance.json
@@ -1,18 +1,19 @@
 {
   "_comment": "Pipelock-owned Gauntlet acceptance contract. Aggregate floors alone cannot distinguish an equal score with different failures, so this file binds the exact identities Pipelock accepts. Changing any identity is a product decision and requires a reviewed edit here.",
   "schema_version": 1,
-  "recorded_on": "2026-09-02",
+  "recorded_on": "2026-09-03",
   "pipelock_version": "3.5.0",
-  "bench_commit": "12107c32ad7a80b8c60c499b26bd01eb2450ac8f",
-  "corpus_version": "v2.7.0",
-  "active_case_count": 249,
+  "bench_release_tag": "v1.0.0",
+  "bench_commit": "06399746918ae0005f59a914fc9ec100a2f27fb8",
+  "corpus_version": "v2.8.0",
+  "active_case_count": 254,
   "containment": {
-    "numerator": 178,
-    "denominator": 181
+    "numerator": 182,
+    "denominator": 185
   },
   "false_positives": {
     "numerator": 2,
-    "denominator": 68
+    "denominator": 69
   },
   "accepted_containment_misses": [
     "mcp-chain-dow-budget-exceeded-010",

--- a/benchmark/gauntlet-baseline.json
+++ b/benchmark/gauntlet-baseline.json
@@ -3,7 +3,7 @@
   "schema_version": 1,
   "recorded_on": "2026-09-02",
   "pipelock_version": "3.5.0",
-  "corpus_git_sha": "a3d56890487aed5fc5a01f46e8732d2ad73fcf53",
+  "corpus_git_sha": "12107c32ad7a80b8c60c499b26bd01eb2450ac8f",
   "corpus_sha256": "882ca081b23447b330446107eea3adb1aa337abf12ba9fcec51d013f9365ed53",
   "corpus_version": "v2.7.0",
   "scoring_version": "2.8",

--- a/benchmark/gauntlet-baseline.json
+++ b/benchmark/gauntlet-baseline.json
@@ -1,33 +1,34 @@
 {
   "_comment": "Pipelock-owned promotion baseline for the candidate-only Gauntlet lane. This file states what Pipelock accepts; Agent Egress Bench owns only the neutral corpus, runner, evaluator, and evidence contracts. Floors and the ceiling are the exact measured v3.5.0 result, so any containment regression or any additional benign block blocks the lane. The exact accepted failure identities live in gauntlet-acceptance.json and are enforced separately.",
   "schema_version": 1,
-  "recorded_on": "2026-09-02",
+  "recorded_on": "2026-09-03",
   "pipelock_version": "3.5.0",
-  "corpus_git_sha": "12107c32ad7a80b8c60c499b26bd01eb2450ac8f",
-  "corpus_sha256": "882ca081b23447b330446107eea3adb1aa337abf12ba9fcec51d013f9365ed53",
-  "corpus_version": "v2.7.0",
+  "corpus_release_tag": "v1.0.0",
+  "corpus_git_sha": "06399746918ae0005f59a914fc9ec100a2f27fb8",
+  "corpus_sha256": "3d098eaa77e2eee83070f3ddb2bc754493d7fa4d2beba0f404a4e7f059e10ba6",
+  "corpus_version": "v2.8.0",
   "scoring_version": "2.8",
   "runner_version": "0.4.3",
   "summary_schema_version": 5,
-  "benchmark_manifest_sha256": "577765ae387ee6cd166df8c3a52c3f7b7eedb7a589dce7a4d49fd6a07fd70f5d",
+  "benchmark_manifest_sha256": "6b120469b3b81d86100d85ad1b442a9b3941e4b15d70d35f63490bfe105ece14",
   "observed_case_count": {
-    "total": 249,
-    "applicable": 249,
+    "total": 254,
+    "applicable": 254,
     "unreachable": 0,
     "not_applicable": 0,
     "not_applicable_reasons": {}
   },
   "score_floors": {
     "full": {
-      "containment": 0.9834254143646409
+      "containment": 0.9837837837837838
     },
     "applicable": {
-      "containment": 0.9834254143646409
+      "containment": 0.9837837837837838
     }
   },
   "score_ceilings": {
     "applicable": {
-      "false_positive_rate": 0.029411764705882353
+      "false_positive_rate": 0.028985507246376812
     }
   }
 }

--- a/scripts/check_gauntlet_acceptance.py
+++ b/scripts/check_gauntlet_acceptance.py
@@ -18,7 +18,7 @@ from pathlib import Path
 REQUIRED_CONTRACT_KEYS = (
     "schema_version",
     "pipelock_version",
-    "bench_release_commit",
+    "bench_commit",
     "corpus_version",
     "active_case_count",
     "containment",
@@ -48,13 +48,13 @@ def load_contract(path):
     for key in ("pipelock_version", "corpus_version"):
         if not isinstance(contract[key], str) or not contract[key]:
             raise ValueError(f"acceptance contract {key} must be a non-empty string")
-    bench_release_commit = contract["bench_release_commit"]
+    bench_commit = contract["bench_commit"]
     if (
-        not isinstance(bench_release_commit, str)
-        or len(bench_release_commit) != 40
-        or any(character not in "0123456789abcdef" for character in bench_release_commit)
+        not isinstance(bench_commit, str)
+        or len(bench_commit) != 40
+        or any(character not in "0123456789abcdef" for character in bench_commit)
     ):
-        raise ValueError("acceptance contract bench_release_commit must be a lower-case Git SHA")
+        raise ValueError("acceptance contract bench_commit must be a lower-case Git SHA")
     active_case_count = contract["active_case_count"]
     if (
         isinstance(active_case_count, bool)
@@ -191,10 +191,10 @@ def check(contract_path, candidate_path, results_path):
                 f"candidate {field}={candidate.get(field)!r}, contract accepts "
                 f"{contract[field]!r}"
             )
-    if candidate.get("corpus_git_sha") != contract["bench_release_commit"]:
+    if candidate.get("corpus_git_sha") != contract["bench_commit"]:
         failures.append(
             f"candidate corpus_git_sha={candidate.get('corpus_git_sha')!r}, contract accepts "
-            f"{contract['bench_release_commit']!r}"
+            f"{contract['bench_commit']!r}"
         )
 
     case_count = candidate.get("case_count")

--- a/scripts/test_gauntlet_acceptance.py
+++ b/scripts/test_gauntlet_acceptance.py
@@ -33,7 +33,7 @@ def candidate_document(**overrides):
     document = {
         "pipelock_version": CONTRACT["pipelock_version"],
         "corpus_version": CONTRACT["corpus_version"],
-        "corpus_git_sha": CONTRACT["bench_release_commit"],
+        "corpus_git_sha": CONTRACT["bench_commit"],
         "case_count": {
             "total": CONTRACT["active_case_count"],
             "applicable": CONTRACT["active_case_count"],

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -68,8 +68,28 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
         self.assertIn("repository: luckyPipewrench/agent-egress-bench", checkout)
         self.assertIn("ref: ${{ env.AEB_REF }}", checkout)
         self.assertNotRegex(checkout, r"ref:\s+(main|master|v[0-9])")
+        # The checkout needs full history for the tag resolution below to be possible.
+        self.assertIn("fetch-depth: 0", checkout)
         verify = step_block(self.workflow, "Verify immutable inputs")
         self.assertIn('git -C "$AEB_ROOT" rev-parse HEAD', verify)
+        self.assertIn('= "$AEB_REF"', verify)
+
+    def test_benchmark_release_tag_is_bound_to_the_pinned_commit(self):
+        """The release label must be checked, not asserted.
+
+        Naming a release in the workflow proves nothing on its own: the value
+        can name any release, or one that never existed, while the checkout
+        still uses the pinned commit. The workflow resolves the tag and
+        compares it, so this asserts both the declared tag and the comparison.
+        Without the comparison assertion, deleting that line leaves the label
+        as a comment and no test fails.
+        """
+        self.assertIn(f"AEB_RELEASE_TAG: {EXPECTED_AEB_RELEASE_TAG}", self.workflow)
+        verify = step_block(self.workflow, "Verify immutable inputs")
+        self.assertIn(
+            'git -C "$AEB_ROOT" rev-parse "refs/tags/$AEB_RELEASE_TAG^{commit}"',
+            verify,
+        )
         self.assertIn('= "$AEB_REF"', verify)
 
     def test_only_reviewed_pipelock_main_can_produce_a_candidate(self):

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -16,7 +16,8 @@ WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
 BASELINE = ROOT / "benchmark" / "gauntlet-baseline.json"
 ACCEPTANCE = ROOT / "benchmark" / "gauntlet-acceptance.json"
-EXPECTED_AEB_REF = "12107c32ad7a80b8c60c499b26bd01eb2450ac8f"
+EXPECTED_AEB_REF = "06399746918ae0005f59a914fc9ec100a2f27fb8"
+EXPECTED_AEB_RELEASE_TAG = "v1.0.0"
 GAUNTLET_WORKFLOW_URL = (
     "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
 )

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -16,7 +16,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 RELEASE_PIN = ROOT / "benchmark" / "gauntlet-release.env"
 BASELINE = ROOT / "benchmark" / "gauntlet-baseline.json"
 ACCEPTANCE = ROOT / "benchmark" / "gauntlet-acceptance.json"
-EXPECTED_AEB_REF = "a3d56890487aed5fc5a01f46e8732d2ad73fcf53"
+EXPECTED_AEB_REF = "12107c32ad7a80b8c60c499b26bd01eb2450ac8f"
 GAUNTLET_WORKFLOW_URL = (
     "https://github.com/luckyPipewrench/pipelock/actions/workflows/continuous-gauntlet.yaml"
 )
@@ -156,7 +156,7 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
             "PIPELOCK_VERSION=" + baseline["pipelock_version"], self.release_pin
         )
         self.assertEqual(baseline["corpus_version"], acceptance["corpus_version"])
-        self.assertEqual(baseline["corpus_git_sha"], acceptance["bench_release_commit"])
+        self.assertEqual(baseline["corpus_git_sha"], acceptance["bench_commit"])
         self.assertEqual(baseline["corpus_git_sha"], EXPECTED_AEB_REF)
         self.assertEqual(
             baseline["observed_case_count"]["total"], acceptance["active_case_count"]


### PR DESCRIPTION
## What changed

The Gauntlet workflow pins the benchmark commit that carries promoted-record schema v4. The site promotion supplies a source-baseline-origin argument naming where a result's acceptance policy came from, and the previously pinned benchmark promoter does not recognize it, so a promotion against the old pin exits before writing anything.

This is a main commit rather than a release tag because no benchmark release carries schema v4 yet. The acceptance contract's field named a release commit and now holds a main commit, so it is renamed rather than left asserting something untrue, and the workflow comment records the intent to return to a release tag once one exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated benchmark provenance to the v1.0.0 Agent Egress Bench release.
  - Refreshed gauntlet baseline and acceptance records with the latest corpus measurements and results, including expanded case coverage.

- **Bug Fixes**
  - Acceptance validation now verifies benchmark commit metadata and release consistency.

- **Tests**
  - Updated gauntlet workflow checks and test fixtures to enforce consistency between the pinned benchmark release, acceptance records, and measured results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->