### PR TITLE
fix(deps): update fast-uri to 3.1.7

### DIFF
--- a/sdk/verifiers/ts/package-lock.json
+++ b/sdk/verifiers/ts/package-lock.json
@@ -100,9 +100,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What changed
Update the TypeScript verifier lockfile to fast-uri 3.1.7, clearing four high-severity Dependabot alerts affecting earlier releases.
