### PR TITLE
fix(playground): keep the durable signing root off visitor VMs

### DIFF
--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -6,10 +6,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground/broker"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // A malformed root must fail closed. Serving with an unusable signing root
@@ -106,4 +110,54 @@ func TestResolveOrchestratorRoot_UnreadableFileFailsClosed(t *testing.T) {
 	if _, err := resolveOrchestratorRoot(f); err == nil {
 		t.Fatal("an unreadable orchestrator root must fail closed")
 	}
+}
+
+// A malformed digest must stop check-config, not merely be reported later. An
+// operator validating a config before deploying needs the refusal then.
+func TestRunServeCheckConfig_RefusesMalformedImageDigest(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.checkConfig = true
+	f.vmImageDigest = "sha256:not-a-digest"
+
+	cmd := newServeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runServe(cmd, f); err == nil {
+		t.Fatal("check-config must refuse a malformed image digest")
+	}
+}
+
+// Server construction refuses a root that is not the published identity, and a
+// digest that is not canonical, before anything starts serving.
+func TestBuildServer_RefusesUnusableSigningInputs(t *testing.T) {
+	t.Run("root_is_not_the_published_identity", func(t *testing.T) {
+		_, priv, err := signing.GenerateKeyPair()
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+		oldFactory := newMachineProvider
+		newMachineProvider = func(_ context.Context, _ *serveFlags, _ string) (broker.MachineProvider, error) {
+			return fakeProvider{}, nil
+		}
+		t.Cleanup(func() { newMachineProvider = oldFactory })
+
+		f := testServeFlags(t, 0)
+		f.orchestratorKeyFile = writeTestFile(t, t.TempDir(), "orch.key", hex.EncodeToString(priv)+"\n")
+		_, _, _, _, err = buildServer(context.Background(), io.Discard, f)
+		if err == nil {
+			t.Fatal("a root that is not the published identity must be refused")
+		}
+		if !strings.Contains(err.Error(), "published orchestrator identity") {
+			t.Fatalf("error %v must name the published identity", err)
+		}
+	})
+
+	t.Run("digest_is_not_canonical", func(t *testing.T) {
+		f := testServeFlags(t, 0)
+		f.vmImageDigest = "sha256:not-a-digest"
+		_, _, _, _, err := buildServer(context.Background(), io.Discard, f)
+		if err == nil {
+			t.Fatal("a malformed image digest must be refused")
+		}
+	})
 }

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// A malformed root must fail closed. Serving with an unusable signing root
+// would mint delegations nothing can verify.
+func TestResolveOrchestratorRoot_MalformedFailsClosed(t *testing.T) {
+	t.Setenv(envOrchestratorRoot, "not-hex-at-all")
+	if _, err := resolveOrchestratorRoot(&serveFlags{requireSessionSecrets: true}); err == nil {
+		t.Fatal("a malformed orchestrator root must fail closed")
+	}
+}
+
+// The digest is what binds a delegation to one immutable image, so a value
+// that merely looks digest-shaped must be refused.
+func TestResolveImageDigest_RejectsNonCanonical(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		digest string
+	}{
+		{name: "non_hex_characters", digest: "sha256:" + strings.Repeat("z", 64)},
+		{name: "wrong_algorithm", digest: "sha512:" + strings.Repeat("a", 64)},
+		{name: "too_long", digest: "sha256:" + strings.Repeat("a", 65)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := resolveImageDigest(&serveFlags{vmImageDigest: tc.digest, requireSessionSecrets: true}); err == nil {
+				t.Fatalf("digest %q must be refused", tc.digest)
+			}
+		})
+	}
+}
+
+// The broker refuses to serve while the guest-facing signing variable is set.
+// Broker and visitor VMs share app-level secrets, so a value under that name
+// reaches every guest and silently turns delegation off.
+func TestBuildServer_RefusesGuestFacingRootSecret(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.vmImageDigest = "sha256:" + strings.Repeat("a", 64)
+	t.Setenv(envOrchestratorKey, "deadbeef")
+	_, _, _, _, err := buildServer(context.Background(), io.Discard, f)
+	if err == nil {
+		t.Fatal("buildServer must refuse while the guest-facing root secret is set")
+	}
+	if !strings.Contains(err.Error(), envOrchestratorRoot) {
+		t.Fatalf("error %v must point the operator at %s", err, envOrchestratorRoot)
+	}
+}

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -51,5 +53,57 @@ func TestBuildServer_RefusesGuestFacingRootSecret(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), envOrchestratorRoot) {
 		t.Fatalf("error %v must point the operator at %s", err, envOrchestratorRoot)
+	}
+}
+
+// The check-config path resolves flags without touching secrets or a provider,
+// so it must still refuse a broker environment that would leak the root to
+// guests. An operator validating a config needs that answer before deploying.
+func TestRunServeCheckConfig_RefusesGuestFacingRootSecret(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.checkConfig = true
+	f.vmImageDigest = "sha256:" + strings.Repeat("a", 64)
+	t.Setenv(envOrchestratorKey, "deadbeef")
+
+	cmd := newServeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := runServe(cmd, f)
+	if err == nil {
+		t.Fatal("check-config must refuse while the guest-facing root secret is set")
+	}
+	if !strings.Contains(err.Error(), envOrchestratorRoot) {
+		t.Fatalf("error %v must point the operator at %s", err, envOrchestratorRoot)
+	}
+}
+
+// With a clean environment the same path reports the config valid, so the
+// refusal above is the guard firing rather than an unrelated failure.
+func TestRunServeCheckConfig_PassesWithCleanEnvironment(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.checkConfig = true
+	f.vmImageDigest = "sha256:" + strings.Repeat("a", 64)
+	t.Setenv(envOrchestratorKey, "")
+
+	cmd := newServeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runServe(cmd, f); err != nil {
+		t.Fatalf("clean check-config rejected: %v", err)
+	}
+	if !strings.Contains(out.String(), "valid") {
+		t.Fatalf("check-config output = %q, want a validity statement", out.String())
+	}
+}
+
+// An unreadable root file fails closed at resolution. Starting without a usable
+// root would mint nothing, and every session would then run unsigned.
+func TestResolveOrchestratorRoot_UnreadableFileFailsClosed(t *testing.T) {
+	f := &serveFlags{
+		orchestratorKeyFile:   filepath.Join(t.TempDir(), "absent-root.key"),
+		requireSessionSecrets: true,
+	}
+	if _, err := resolveOrchestratorRoot(f); err == nil {
+		t.Fatal("an unreadable orchestrator root must fail closed")
 	}
 }

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -1832,15 +1832,52 @@ func resolveOrchestratorRoot(f *serveFlags) (ed25519.PrivateKey, error) {
 	if raw == "" {
 		return nil, nil
 	}
-	return playground.ParseOrchestratorPrivateKeyHex(raw)
+	priv, err := playground.ParseOrchestratorPrivateKeyHex(raw)
+	if err != nil {
+		return nil, err
+	}
+	// Every shipped verifier, the browser verifier, and the downloadable kits
+	// all pin the published identity. A broker signing under any other root
+	// produces bundles that fail offline verification for every visitor, which
+	// is a silent break that only shows up after someone downloads a kit.
+	if !playground.OrchestratorKeyMatchesPublished(priv) {
+		return nil, fmt.Errorf("%s does not derive the published orchestrator identity; bundles signed by it would fail every shipped verifier", envOrchestratorRoot)
+	}
+	return priv, nil
 }
 
+// imageRefDigest returns the digest a reference is pinned to, or empty when the
+// reference names a mutable tag.
+func imageRefDigest(image string) string {
+	idx := strings.LastIndex(image, "@sha256:")
+	if idx < 0 {
+		return ""
+	}
+	return "sha256:" + image[idx+len("@sha256:"):]
+}
+
+func validateCanonicalDigest(digest string) error {
+	if !strings.HasPrefix(digest, "sha256:") || len(digest) != len("sha256:")+64 {
+		return fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+	}
+	for _, c := range digest[len("sha256:"):] {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+		}
+	}
+	return nil
+}
+
+// resolveImageDigest returns the immutable image each session delegation binds.
+// The delegation attests which image ran, so the digest has to describe the
+// image the broker actually launches. A mutable --image tag beside an unrelated
+// --vm-image-digest would attest one image while launching another, so both are
+// refused rather than reconciled.
 func resolveImageDigest(f *serveFlags) (string, error) {
 	digest := strings.TrimSpace(f.vmImageDigest)
+	refDigest := imageRefDigest(f.image)
 	if digest == "" {
-		if idx := strings.LastIndex(f.image, "@sha256:"); idx >= 0 {
-			digest = "sha256:" + f.image[idx+len("@sha256:"):]
-		}
+		digest = refDigest
 	}
 	if digest == "" {
 		if f.requireSessionSecrets {
@@ -1848,12 +1885,17 @@ func resolveImageDigest(f *serveFlags) (string, error) {
 		}
 		return "", nil
 	}
-	if !strings.HasPrefix(digest, "sha256:") || len(digest) != len("sha256:")+64 {
-		return "", fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+	if err := validateCanonicalDigest(digest); err != nil {
+		return "", err
 	}
-	for _, c := range digest[len("sha256:"):] {
-		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
-			return "", fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+	// Outside dev the launched reference must be pinned to exactly the digest
+	// the delegation attests.
+	if f.requireSessionSecrets {
+		if refDigest == "" {
+			return "", fmt.Errorf("--image %q must be pinned by digest so the delegated image is the image that launches", f.image)
+		}
+		if refDigest != digest {
+			return "", fmt.Errorf("--image is pinned to %s but --vm-image-digest is %s; a delegation would attest an image that never launched", refDigest, digest)
 		}
 	}
 	return digest, nil

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -352,6 +352,12 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 }
 
 func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), *broker.Pool, error) {
+	// Refuse before resolving any secret or contacting a provider: a broker
+	// holding the guest-facing signing variable would hand the durable root to
+	// every visitor VM through shared app secrets.
+	if err := refuseGuestFacingRootSecret(); err != nil {
+		return nil, nil, nil, nil, err
+	}
 	if err := validateFlags(f); err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -386,9 +392,6 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	provider = broker.NewHealthTrackingProvider(provider, providerHealth)
 	sessionEnv, err := resolveSessionEnv(f)
 	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	if err := refuseGuestFacingRootSecret(); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	rootKey, err := resolveOrchestratorRoot(f)

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -35,6 +36,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 	"github.com/luckyPipewrench/pipelock/internal/playground/broker"
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
 )
@@ -68,8 +70,18 @@ const (
 	cfAccessKeysTTL          = 5 * time.Minute
 	cfAccessNegativeCacheTTL = 30 * time.Second
 
-	envModelKey        = "PLAYGROUND_MODEL_" + "KEY"
+	envModelKey = "PLAYGROUND_MODEL_" + "KEY"
+	// envOrchestratorKey is the name a visitor VM reads for a durable signing
+	// key. The broker must never hold its root under this name: broker and
+	// guests are one Fly app and share app-level secrets, so a root stored
+	// here is delivered to every visitor VM. That sharing is what put the
+	// durable key on the guests before 2026-09-03. It survives only as the
+	// name checked when refusing to leak a root through SessionEnv.
 	envOrchestratorKey = "PLAYGROUND_ORCHESTRATOR_" + "KEY"
+	// envOrchestratorRoot is the broker-only name for the durable signing
+	// root. The guest entrypoint does not read it and refuses to boot if the
+	// guest-facing name is present at all.
+	envOrchestratorRoot = "PLAYGROUND_ORCHESTRATOR_" + "ROOT"
 
 	// warmPoolVMCodeBytes mirrors broker.vmInviteCodeBytes for warm-pool VM
 	// code generation. Kept in sync with the broker constant.
@@ -145,6 +157,7 @@ type serveFlags struct {
 	modelKeyEnv               string
 	orchestratorKeyFile       string
 	orchestratorKeyEnv        string
+	vmImageDigest             string
 	requireSessionSecrets     bool
 	warmPoolSize              int
 	// VM model/session config, passed into each per-visitor VM via PLAYGROUND_*
@@ -244,8 +257,9 @@ func newServeCmd() *cobra.Command {
 	fl.BoolVar(&f.trustForwardedFor, "trust-forwarded-for", false, "read client IP from X-Forwarded-For behind a trusted proxy")
 	fl.StringVar(&f.modelKeyFile, "model-key-file", "", "path to the model key file passed to the VM env")
 	fl.StringVar(&f.modelKeyEnv, "model-key-env", "", "environment variable holding the model key passed to the VM env")
-	fl.StringVar(&f.orchestratorKeyFile, "orchestrator-key-file", "", "path to the orchestrator key file passed to the VM env")
-	fl.StringVar(&f.orchestratorKeyEnv, "orchestrator-key-env", "", "environment variable holding the orchestrator key passed to the VM env")
+	fl.StringVar(&f.orchestratorKeyFile, "orchestrator-key-file", "", "path to the broker-held orchestrator root key; never copied into visitor VMs")
+	fl.StringVar(&f.orchestratorKeyEnv, "orchestrator-key-env", "", "environment variable holding the broker-held orchestrator root key (default "+envOrchestratorRoot+"); never copied into visitor VMs")
+	fl.StringVar(&f.vmImageDigest, "vm-image-digest", "", "immutable sha256 digest of the visitor VM image bound into session delegations")
 	fl.BoolVar(&f.requireSessionSecrets, "require-session-secrets", true, "require model and orchestrator keys from file/env")
 	fl.StringVar(&f.vmModelBaseURL, "vm-model-base-url", "", "model API base URL passed to each VM (enables the model-backed agent)")
 	fl.StringVar(&f.vmModel, "vm-model", "", "model name passed to each VM")
@@ -276,6 +290,12 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 			return err
 		}
 		if _, err := newCFAccessVerifier(f); err != nil {
+			return err
+		}
+		if _, err := resolveImageDigest(f); err != nil {
+			return err
+		}
+		if err := refuseGuestFacingRootSecret(); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "broker flags, access gates, public hosts, access policy, and static UI valid; secrets and provider not contacted")
@@ -368,6 +388,17 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+	if err := refuseGuestFacingRootSecret(); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	rootKey, err := resolveOrchestratorRoot(f)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	imageDigest, err := resolveImageDigest(f)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	humanVerifier, err := resolveTurnstileVerifier(f)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -435,6 +466,8 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		PerCodeDailyBudget: f.perCodeDailyBudget,
 		GlobalDailyBudget:  f.globalDailyBudget,
 		SessionEnv:         sessionEnv,
+		OrchestratorRoot:   rootKey,
+		ImageDigest:        imageDigest,
 		InternalPort:       f.internalPort,
 		DeadlineGrace:      f.deadlineGrace,
 		TrustForwardedFor:  f.trustForwardedFor,
@@ -1684,9 +1717,10 @@ func resolveBrokerCodes(f *serveFlags) ([]livechat.CodeSpec, string, error) {
 // buildVMBaseEnv assembles the PLAYGROUND_* environment shared by every
 // per-visitor VM. The deploy entrypoint (deploy/fly-playground/entrypoint.sh)
 // consumes these env vars into `serve` flags — keep the names in sync with it.
-// The per-session invite code (PLAYGROUND_CODE) and the secrets
-// (PLAYGROUND_MODEL_KEY / PLAYGROUND_ORCHESTRATOR_KEY) are layered in elsewhere
-// (broker sessionEnv / resolveSessionEnv), not here.
+// The per-session invite code (PLAYGROUND_CODE) and the model key
+// (PLAYGROUND_MODEL_KEY) are layered in elsewhere (broker sessionEnv /
+// resolveSessionEnv), not here. The durable orchestrator root stays on the
+// broker and is never copied into visitor VM env.
 func buildVMBaseEnv(f *serveFlags) map[string]string {
 	env := map[string]string{
 		"PLAYGROUND_LISTEN": fmt.Sprintf("0.0.0.0:%d", f.internalPort),
@@ -1766,18 +1800,60 @@ func resolveSessionEnv(f *serveFlags) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	orchestrator, err := resolveSessionSecret(f.orchestratorKeyFile, f.orchestratorKeyEnv, "--orchestrator-key-file", envOrchestratorKey, f.requireSessionSecrets)
-	if err != nil {
-		return nil, err
-	}
 	env := make(map[string]string)
 	if model != "" {
 		env[envModelKey] = model
 	}
-	if orchestrator != "" {
-		env[envOrchestratorKey] = orchestrator
-	}
 	return env, nil
+}
+
+// refuseGuestFacingRootSecret fails closed while the guest-facing signing-key
+// variable is set in the broker own environment. Broker and visitor VMs are
+// one Fly app and share app-level secrets, so a value under that name reaches
+// every guest and turns delegation off with no other signal. Refusing here
+// makes that deployment state impossible to hold silently.
+func refuseGuestFacingRootSecret() error {
+	if strings.TrimSpace(os.Getenv(envOrchestratorKey)) == "" {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s is set in the broker environment; visitor VMs share app secrets and would receive the durable signing root. Clear that secret and store the root under %s instead",
+		envOrchestratorKey, envOrchestratorRoot)
+}
+
+func resolveOrchestratorRoot(f *serveFlags) (ed25519.PrivateKey, error) {
+	raw, err := resolveSessionSecret(f.orchestratorKeyFile, f.orchestratorKeyEnv, "--orchestrator-key-file", envOrchestratorRoot, f.requireSessionSecrets)
+	if err != nil {
+		return nil, err
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	return playground.ParseOrchestratorPrivateKeyHex(raw)
+}
+
+func resolveImageDigest(f *serveFlags) (string, error) {
+	digest := strings.TrimSpace(f.vmImageDigest)
+	if digest == "" {
+		if idx := strings.LastIndex(f.image, "@sha256:"); idx >= 0 {
+			digest = "sha256:" + f.image[idx+len("@sha256:"):]
+		}
+	}
+	if digest == "" {
+		if f.requireSessionSecrets {
+			return "", errors.New("--vm-image-digest is required so session delegations bind an immutable image")
+		}
+		return "", nil
+	}
+	if !strings.HasPrefix(digest, "sha256:") || len(digest) != len("sha256:")+64 {
+		return "", fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+	}
+	for _, c := range digest[len("sha256:"):] {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return "", fmt.Errorf("image digest %q is not a canonical sha256 digest", digest)
+		}
+	}
+	return digest, nil
 }
 
 func resolveSessionSecret(file, envName, flagName, defaultEnv string, required bool) (string, error) {

--- a/cmd/pipelock-playground-broker/main_security_boundaries_test.go
+++ b/cmd/pipelock-playground-broker/main_security_boundaries_test.go
@@ -91,13 +91,13 @@ func TestMergeSessionAndBaseEnvPrecedenceAndIsolation(t *testing.T) {
 		"PLAYGROUND_MODEL_KEY": "base-must-not-win",
 	}
 	session := map[string]string{
-		"PLAYGROUND_MODEL_KEY":        "session-value",
-		"PLAYGROUND_ORCHESTRATOR_KEY": "orchestrator-value",
+		"PLAYGROUND_MODEL_KEY": "session-value",
+		"PLAYGROUND_EXTRA":     "session-extra",
 	}
 	got := mergeSessionAndBaseEnv(session, base, "vm-code")
 	if got["PLAYGROUND_LISTEN"] != "0.0.0.0:8080" ||
 		got["PLAYGROUND_MODEL_KEY"] != "session-value" ||
-		got["PLAYGROUND_ORCHESTRATOR_KEY"] != "orchestrator-value" ||
+		got["PLAYGROUND_EXTRA"] != "session-extra" ||
 		got["PLAYGROUND_CODE"] != "vm-code" {
 		t.Fatalf("merged environment = %#v", got)
 	}

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/playground/broker"
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 type fakeProvider struct{}
@@ -152,7 +154,11 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
 	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
 	modelFile := writeTestFile(t, dir, "model.key", "model-file-value\n")
-	orchestratorFile := writeTestFile(t, dir, "orchestrator.key", "orchestrator-file-value\n")
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orchestratorFile := writeTestFile(t, dir, "orchestrator.key", hex.EncodeToString(priv)+"\n")
 
 	var gotProvider string
 	var gotToken string
@@ -187,6 +193,7 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 		vmDailyTurnBudget:     10,
 		modelKeyFile:          modelFile,
 		orchestratorKeyFile:   orchestratorFile,
+		vmImageDigest:         "sha256:" + strings.Repeat("ab", 32),
 		requireSessionSecrets: true,
 	})
 	if err != nil {
@@ -1799,6 +1806,59 @@ func TestNormalizeCFAccessTeamDomain(t *testing.T) {
 	}
 }
 
+func TestResolveImageDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("ab", 32)
+	got, err := resolveImageDigest(&serveFlags{vmImageDigest: digest, requireSessionSecrets: true})
+	if err != nil {
+		t.Fatalf("flag digest: %v", err)
+	}
+	if got != digest {
+		t.Fatalf("flag digest = %q", got)
+	}
+	got, err = resolveImageDigest(&serveFlags{
+		image:                 "registry.example/playground:vm@" + digest,
+		requireSessionSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("image digest: %v", err)
+	}
+	if got != digest {
+		t.Fatalf("image digest = %q", got)
+	}
+	if _, err := resolveImageDigest(&serveFlags{requireSessionSecrets: true}); err == nil {
+		t.Fatal("missing digest should fail when session secrets are required")
+	}
+	if _, err := resolveImageDigest(&serveFlags{vmImageDigest: "sha256:deadbeef", requireSessionSecrets: true}); err == nil {
+		t.Fatal("short digest should fail")
+	}
+	got, err = resolveImageDigest(&serveFlags{requireSessionSecrets: false})
+	if err != nil || got != "" {
+		t.Fatalf("optional missing digest = %q err=%v", got, err)
+	}
+}
+
+func TestResolveOrchestratorRoot(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := writeTestFile(t, dir, "orch.key", hex.EncodeToString(priv)+"\n")
+	got, err := resolveOrchestratorRoot(&serveFlags{orchestratorKeyFile: path, requireSessionSecrets: true})
+	if err != nil {
+		t.Fatalf("resolveOrchestratorRoot: %v", err)
+	}
+	if hex.EncodeToString(got) != hex.EncodeToString(priv) {
+		t.Fatal("resolved root does not match file")
+	}
+	if _, err := resolveOrchestratorRoot(&serveFlags{orchestratorKeyFile: path, requireSessionSecrets: true}); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if _, err := resolveOrchestratorRoot(&serveFlags{requireSessionSecrets: false}); err != nil {
+		t.Fatalf("optional missing root: %v", err)
+	}
+}
+
 func TestResolveSessionEnv(t *testing.T) {
 	dir := t.TempDir()
 	modelFile := writeTestFile(t, dir, "model.key", "model-file-value\n")
@@ -1813,8 +1873,8 @@ func TestResolveSessionEnv(t *testing.T) {
 	if env[envModelKey] != "model-file-value" {
 		t.Fatalf("model env = %q", env[envModelKey])
 	}
-	if env[envOrchestratorKey] != "orchestrator-env-value" {
-		t.Fatalf("orchestrator env = %q", env[envOrchestratorKey])
+	if _, ok := env[envOrchestratorKey]; ok {
+		t.Fatal("durable orchestrator key must not be copied into visitor VM env")
 	}
 }
 
@@ -2462,5 +2522,26 @@ func TestBuildVMBaseEnv(t *testing.T) {
 	empty := buildVMBaseEnv(&serveFlags{internalPort: 8080})
 	if len(empty) != 1 || empty["PLAYGROUND_LISTEN"] != "0.0.0.0:8080" {
 		t.Errorf("empty config should yield only PLAYGROUND_LISTEN, got %v", empty)
+	}
+}
+
+// Broker and visitor VMs are one Fly app, so a root stored under the
+// guest-facing name is delivered to every guest. The broker must refuse to
+// build a server while that name is populated.
+func TestRefuseGuestFacingRootSecret(t *testing.T) {
+	t.Setenv(envOrchestratorKey, "deadbeef")
+	err := refuseGuestFacingRootSecret()
+	if err == nil {
+		t.Fatal("broker must refuse to serve while the guest-facing root secret is set")
+	}
+	if !strings.Contains(err.Error(), envOrchestratorRoot) {
+		t.Fatalf("error %v must name the broker-only variable %s", err, envOrchestratorRoot)
+	}
+}
+
+func TestRefuseGuestFacingRootSecret_AllowsCleanEnv(t *testing.T) {
+	t.Setenv(envOrchestratorKey, "")
+	if err := refuseGuestFacingRootSecret(); err != nil {
+		t.Fatalf("clean environment rejected: %v", err)
 	}
 }

--- a/cmd/pipelock-playground-broker/main_test.go
+++ b/cmd/pipelock-playground-broker/main_test.go
@@ -154,11 +154,6 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 	gateSecret := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
 	gateSecretFile := writeTestFile(t, dir, "gate.b64", gateSecret+"\n")
 	modelFile := writeTestFile(t, dir, "model.key", "model-file-value\n")
-	_, priv, err := signing.GenerateKeyPair()
-	if err != nil {
-		t.Fatal(err)
-	}
-	orchestratorFile := writeTestFile(t, dir, "orchestrator.key", hex.EncodeToString(priv)+"\n")
 
 	var gotProvider string
 	var gotToken string
@@ -192,9 +187,8 @@ func TestBuildServerWithInjectedProvider(t *testing.T) {
 		deadlineGrace:         defaultGrace,
 		vmDailyTurnBudget:     10,
 		modelKeyFile:          modelFile,
-		orchestratorKeyFile:   orchestratorFile,
 		vmImageDigest:         "sha256:" + strings.Repeat("ab", 32),
-		requireSessionSecrets: true,
+		requireSessionSecrets: false,
 	})
 	if err != nil {
 		t.Fatalf("buildServer: %v", err)
@@ -1806,37 +1800,56 @@ func TestNormalizeCFAccessTeamDomain(t *testing.T) {
 	}
 }
 
+// The delegation attests which image ran, so the resolved digest has to be the
+// digest the launched reference is pinned to. A mutable tag beside a valid but
+// unrelated digest would attest an image that never launched.
 func TestResolveImageDigest(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("ab", 32)
-	got, err := resolveImageDigest(&serveFlags{vmImageDigest: digest, requireSessionSecrets: true})
+	other := "sha256:" + strings.Repeat("cd", 32)
+	pinned := "registry.example/playground:vm@" + digest
+
+	got, err := resolveImageDigest(&serveFlags{image: pinned, vmImageDigest: digest, requireSessionSecrets: true})
 	if err != nil {
-		t.Fatalf("flag digest: %v", err)
+		t.Fatalf("pinned image with matching flag: %v", err)
 	}
 	if got != digest {
-		t.Fatalf("flag digest = %q", got)
+		t.Fatalf("digest = %q, want %q", got, digest)
 	}
-	got, err = resolveImageDigest(&serveFlags{
-		image:                 "registry.example/playground:vm@" + digest,
-		requireSessionSecrets: true,
-	})
+
+	got, err = resolveImageDigest(&serveFlags{image: pinned, requireSessionSecrets: true})
 	if err != nil {
-		t.Fatalf("image digest: %v", err)
+		t.Fatalf("pinned image alone: %v", err)
 	}
 	if got != digest {
-		t.Fatalf("image digest = %q", got)
+		t.Fatalf("digest from image = %q, want %q", got, digest)
 	}
-	if _, err := resolveImageDigest(&serveFlags{requireSessionSecrets: true}); err == nil {
-		t.Fatal("missing digest should fail when session secrets are required")
+
+	for _, tc := range []struct {
+		name string
+		f    serveFlags
+	}{
+		{name: "no_digest_anywhere", f: serveFlags{requireSessionSecrets: true}},
+		{name: "mutable_tag_with_flag_digest", f: serveFlags{image: "registry.example/playground:vm", vmImageDigest: digest, requireSessionSecrets: true}},
+		{name: "image_and_flag_disagree", f: serveFlags{image: pinned, vmImageDigest: other, requireSessionSecrets: true}},
+		{name: "short_digest", f: serveFlags{image: pinned, vmImageDigest: "sha256:deadbeef", requireSessionSecrets: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := resolveImageDigest(&tc.f); err == nil {
+				t.Fatal("expected a refusal")
+			}
+		})
 	}
-	if _, err := resolveImageDigest(&serveFlags{vmImageDigest: "sha256:deadbeef", requireSessionSecrets: true}); err == nil {
-		t.Fatal("short digest should fail")
-	}
+
 	got, err = resolveImageDigest(&serveFlags{requireSessionSecrets: false})
 	if err != nil || got != "" {
 		t.Fatalf("optional missing digest = %q err=%v", got, err)
 	}
 }
 
+// Every shipped verifier pins the published identity, so a broker configured
+// with any other root would sign bundles that fail offline verification for
+// every visitor. That is refused at resolution rather than discovered later by
+// someone downloading a kit.
 func TestResolveOrchestratorRoot(t *testing.T) {
 	_, priv, err := signing.GenerateKeyPair()
 	if err != nil {
@@ -1844,16 +1857,15 @@ func TestResolveOrchestratorRoot(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := writeTestFile(t, dir, "orch.key", hex.EncodeToString(priv)+"\n")
-	got, err := resolveOrchestratorRoot(&serveFlags{orchestratorKeyFile: path, requireSessionSecrets: true})
-	if err != nil {
-		t.Fatalf("resolveOrchestratorRoot: %v", err)
+
+	_, err = resolveOrchestratorRoot(&serveFlags{orchestratorKeyFile: path, requireSessionSecrets: true})
+	if err == nil {
+		t.Fatal("a root that is not the published identity must be refused")
 	}
-	if hex.EncodeToString(got) != hex.EncodeToString(priv) {
-		t.Fatal("resolved root does not match file")
+	if !strings.Contains(err.Error(), "published orchestrator identity") {
+		t.Fatalf("error %v must say the root is not the published identity", err)
 	}
-	if _, err := resolveOrchestratorRoot(&serveFlags{orchestratorKeyFile: path, requireSessionSecrets: true}); err != nil {
-		t.Fatalf("second resolve: %v", err)
-	}
+
 	if _, err := resolveOrchestratorRoot(&serveFlags{requireSessionSecrets: false}); err != nil {
 		t.Fatalf("optional missing root: %v", err)
 	}

--- a/cmd/pipelock-playground-live/delegation_default_test.go
+++ b/cmd/pipelock-playground-live/delegation_default_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+// A dev run has no broker to mint a delegation, so --dev relaxes the demand
+// unless the operator asked for it. A public serve keeps it on; the refusal for
+// a public opt-out lives in validateServeSafety and is tested there.
+func TestResolveDelegationDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		dev      bool
+		explicit bool
+		start    bool
+		want     bool
+	}{
+		{name: "dev_unset_relaxes", dev: true, explicit: false, start: true, want: false},
+		{name: "dev_explicit_is_honored", dev: true, explicit: true, start: true, want: true},
+		{name: "dev_explicit_off_is_honored", dev: true, explicit: true, start: false, want: false},
+		{name: "public_keeps_the_default", dev: false, explicit: false, start: true, want: true},
+		{name: "public_is_not_relaxed", dev: false, explicit: true, start: false, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &serveFlags{dev: tc.dev, requireDelegated: tc.start}
+			resolveDelegationDefault(f, tc.explicit)
+			if f.requireDelegated != tc.want {
+				t.Fatalf("requireDelegated = %v, want %v", f.requireDelegated, tc.want)
+			}
+		})
+	}
+}
+
+// The flag ships on by default so a public serve that never mentions it still
+// demands a delegation.
+func TestServeCmd_DelegationFlagDefaultsOn(t *testing.T) {
+	cmd := newServeCmd()
+	fl := cmd.Flags().Lookup("require-delegated-signing")
+	if fl == nil {
+		t.Fatal("--require-delegated-signing must exist")
+	}
+	if fl.DefValue != "true" {
+		t.Fatalf("default = %q, want \"true\"", fl.DefValue)
+	}
+}

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -66,6 +66,7 @@ type serveFlags struct {
 	selfManagedContainment bool
 	dev                    bool
 	orchestratorKey        string
+	requireDelegated       bool
 	toyAgentBin            string
 	webToolBin             string
 	proxyPort              int
@@ -111,6 +112,12 @@ func newServeCmd() *cobra.Command {
 		Use:   "serve",
 		Short: "Run the live-chat server",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// --dev keeps the historical ephemeral-key behavior unless the
+			// operator asks for delegation explicitly. Public serves cannot
+			// opt out; validateServeSafety refuses that below.
+			if f.dev && !cmd.Flags().Changed("require-delegated-signing") {
+				f.requireDelegated = false
+			}
 			return runServe(cmd, f)
 		},
 	}
@@ -123,7 +130,8 @@ func newServeCmd() *cobra.Command {
 	fl.BoolVar(&f.requireModel, "require-model", false, "refuse to serve unless the real model-backed agent is fully configured (public demo guard)")
 	fl.BoolVar(&f.selfManagedContainment, "self-managed-containment", false, "the deployment sets the nft owner-match egress rule itself (e.g. a per-visitor microVM boot entrypoint) instead of `pipelock contain install`; the server proves the agent-uid egress/local escape drops empirically at start and via the signed witness, and does NOT require `pipelock contain verify`")
 	fl.BoolVar(&f.dev, "dev", false, "DEV ONLY: run uncontained (disables --require-containment); never use for public exposure")
-	fl.StringVar(&f.orchestratorKey, "orchestrator-key", "", "path to the published demo signing key (required outside --dev; empty = ephemeral per-run key in --dev)")
+	fl.StringVar(&f.orchestratorKey, "orchestrator-key", "", "path to a durable signing key on this guest; refused outside --dev because the durable root stays on the broker")
+	fl.BoolVar(&f.requireDelegated, "require-delegated-signing", true, "refuse any session that does not carry a broker-minted session key and root-signed delegation")
 	fl.StringVar(&f.toyAgentBin, "toyagent-bin", "", "toy-agent binary path (needed for the contained host-containment witness)")
 	fl.StringVar(&f.webToolBin, "webtool-bin", "", "web-tool binary path (needed for the contained host-containment witness)")
 	fl.IntVar(&f.proxyPort, "proxy-port", 0, "fixed loopback port the in-process proxy binds; must match `pipelock contain install --proxy-port` (defaults to 8888 in contained mode). 0 = ephemeral, dev/test only")
@@ -234,30 +242,36 @@ func buildServer(out io.Writer, f *serveFlags) (*livechat.Server, http.Handler, 
 	if err := validateServeSafety(f, llmAgent != nil); err != nil {
 		return nil, nil, err
 	}
-	if !f.dev {
+	// A supplied key is validated at boot in every mode. Outside --dev the flag
+	// is refused outright (validateServeSafety), so this only covers dev runs
+	// that still sign with a durable local key.
+	if strings.TrimSpace(f.orchestratorKey) != "" {
 		if _, err := playground.LoadOrchestratorSigningKey(f.orchestratorKey); err != nil {
 			return nil, nil, fmt.Errorf("--orchestrator-key: %w", err)
 		}
+	}
+	if !f.dev {
 		if err := validateModelAgentRuntime(llmAgent); err != nil {
 			return nil, nil, err
 		}
 	}
 
 	srv, err := livechat.NewServer(livechat.ServerConfig{
-		Gate:                gate,
-		Limits:              livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
-		IPRate:              livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
-		CodeRate:            livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
-		MaxConcurrent:       f.concurrency,
-		RequireContainment:  requireContainment,
-		Containment:         verifier,
-		OrchestratorKeyPath: f.orchestratorKey,
-		ToyAgentBin:         f.toyAgentBin,
-		WebToolBin:          f.webToolBin,
-		ProxyPort:           f.proxyPort,
-		TrustForwardedFor:   f.trustForwardedFor,
-		AllowOrigin:         f.allowOrigin,
-		LLMAgent:            llmAgent,
+		Gate:                    gate,
+		Limits:                  livechat.Limits{MaxInputBytes: f.maxInputBytes, SessionTTL: f.sessionTTL},
+		IPRate:                  livechat.RateConfig{RefillPerSec: f.ipRate, Burst: f.ipBurst},
+		CodeRate:                livechat.RateConfig{RefillPerSec: f.codeRate, Burst: f.codeBurst},
+		MaxConcurrent:           f.concurrency,
+		RequireContainment:      requireContainment,
+		Containment:             verifier,
+		OrchestratorKeyPath:     f.orchestratorKey,
+		RequireDelegatedSigning: f.requireDelegated,
+		ToyAgentBin:             f.toyAgentBin,
+		WebToolBin:              f.webToolBin,
+		ProxyPort:               f.proxyPort,
+		TrustForwardedFor:       f.trustForwardedFor,
+		AllowOrigin:             f.allowOrigin,
+		LLMAgent:                llmAgent,
 		VerifierBinaries: playground.VerifyKitBinaries{
 			Linux:   f.verifierBinLinux,
 			MacOS:   f.verifierBinMacOS,
@@ -342,8 +356,19 @@ func validateServeSafety(f *serveFlags, modelBacked bool) error {
 	if f.proxyPort < 0 || f.proxyPort > 65535 {
 		return errors.New("--proxy-port must be 0-65535")
 	}
-	if !f.dev && strings.TrimSpace(f.orchestratorKey) == "" {
-		return errors.New("non-dev serve requires --orchestrator-key so bundles verify against the published demo key")
+	// The durable orchestrator root must never exist on a public guest. Before
+	// delegation, the guest held it; the exposure that forced the 2026-09-03
+	// rotation is exactly that copy. Refuse both halves of the old shape:
+	// a public serve that does not demand a delegation, and any serve that
+	// demands one while also being handed a durable key on disk.
+	if !f.dev && !f.requireDelegated {
+		return errors.New("public serve requires --require-delegated-signing so the durable root stays on the broker")
+	}
+	if !f.dev && strings.TrimSpace(f.orchestratorKey) != "" {
+		return errors.New("--orchestrator-key is refused outside --dev; the durable root stays on the broker and each session is delegated")
+	}
+	if f.requireDelegated && strings.TrimSpace(f.orchestratorKey) != "" {
+		return errors.New("--orchestrator-key and --require-delegated-signing are mutually exclusive")
 	}
 	if f.requireModel && !modelBacked {
 		return errors.New("--require-model set but model-backed agent is not configured")

--- a/cmd/pipelock-playground-live/main.go
+++ b/cmd/pipelock-playground-live/main.go
@@ -112,12 +112,7 @@ func newServeCmd() *cobra.Command {
 		Use:   "serve",
 		Short: "Run the live-chat server",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// --dev keeps the historical ephemeral-key behavior unless the
-			// operator asks for delegation explicitly. Public serves cannot
-			// opt out; validateServeSafety refuses that below.
-			if f.dev && !cmd.Flags().Changed("require-delegated-signing") {
-				f.requireDelegated = false
-			}
+			resolveDelegationDefault(f, cmd.Flags().Changed("require-delegated-signing"))
 			return runServe(cmd, f)
 		},
 	}
@@ -318,6 +313,17 @@ func containedProxyPort(port int) int {
 		return playground.DefaultContainedProxyPort
 	}
 	return port
+}
+
+// resolveDelegationDefault settles whether this serve demands a broker-minted
+// delegation. --dev keeps the historical ephemeral-key behavior unless the
+// operator asks for delegation explicitly, because a dev run has no broker to
+// mint one. A public serve cannot opt out at all; validateServeSafety refuses
+// that separately, so this only relaxes the dev case.
+func resolveDelegationDefault(f *serveFlags, explicit bool) {
+	if f.dev && !explicit {
+		f.requireDelegated = false
+	}
 }
 
 func validateServeSafety(f *serveFlags, modelBacked bool) error {

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -398,8 +398,12 @@ func TestBuildServer_RequireModelFailsClosedWithoutModelConfig(t *testing.T) {
 	f.requireDelegated = true
 
 	var out bytes.Buffer
-	if _, _, err := buildServer(&out, f); err == nil {
+	_, _, err := buildServer(&out, f)
+	if err == nil {
 		t.Fatal("--require-model without model config should fail closed")
+	}
+	if !strings.Contains(err.Error(), "require-model") {
+		t.Fatalf("error = %v, want the --require-model refusal rather than some earlier check", err)
 	}
 }
 
@@ -418,8 +422,12 @@ func TestBuildServer_PublicModelValidatesRuntimeFiles(t *testing.T) {
 	f.dailyTurnBudget = 10
 
 	var out bytes.Buffer
-	if _, _, err := buildServer(&out, f); err == nil {
+	_, _, err := buildServer(&out, f)
+	if err == nil {
 		t.Fatal("model-backed non-dev server with missing model key should fail before listening")
+	}
+	if !strings.Contains(err.Error(), "model") {
+		t.Fatalf("error = %v, want the missing model-secret refusal rather than some earlier check", err)
 	}
 
 	f.modelSecretFile = testModelSecretPath(t)

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -315,7 +315,7 @@ func TestBuildServer_SelfManagedContainmentSelectsInVMVerifier(t *testing.T) {
 	f.selfManagedContainment = true
 	f.codes = []string{"good"}
 	f.toyAgentBin = "/usr/local/bin/pipelock-playground-toyagent"
-	f.orchestratorKey = testOrchestratorKeyPath(t)
+	f.requireDelegated = true
 	f.concurrency = 1
 	f.proxyPort = playground.DefaultContainedProxyPort
 	f.operatorUID = 1000
@@ -378,7 +378,7 @@ func TestBuildServer_PublicModelRequiresDailyBudget(t *testing.T) {
 	f.modelBaseURL = "http://provider.example/v1"
 	f.model = "test-model"
 	f.modelSecretFile = testModelSecretPath(t)
-	f.orchestratorKey = testOrchestratorKeyPath(t)
+	f.requireDelegated = true
 
 	var out bytes.Buffer
 	if _, _, err := buildServer(&out, f); err == nil {
@@ -450,29 +450,57 @@ func TestBuildServer_NonDevRequiresContainment(t *testing.T) {
 	}
 }
 
-func TestBuildServer_NonDevValidatesOrchestratorKey(t *testing.T) {
+func TestBuildServer_DevValidatesOrchestratorKey(t *testing.T) {
 	t.Parallel()
 	f := devServeFlags()
-	f.dev = false
-	f.requireContainment = true
 	f.concurrency = 1
 	f.codes = []string{"good"}
 	f.orchestratorKey = filepath.Join(t.TempDir(), "missing.key")
 	var out bytes.Buffer
 	if _, _, err := buildServer(&out, f); err == nil {
-		t.Fatal("non-dev server with missing orchestrator key should fail before listening")
+		t.Fatal("dev server with missing orchestrator key should fail before listening")
 	}
 }
 
-func TestValidateServeSafety_NonDevRequiresOrchestratorKey(t *testing.T) {
+// A public guest must never hold the durable signing root, and must never be
+// able to opt out of demanding a broker-minted delegation. Both are the
+// pre-rotation shape that put the root on visitor VMs.
+func TestValidateServeSafety_PublicRefusesGuestHeldRoot(t *testing.T) {
 	t.Parallel()
-	f := serveFlags{requireContainment: true, concurrency: 1}
-	if err := validateServeSafety(&f, false); err == nil {
-		t.Fatal("non-dev server without orchestrator key should fail closed")
+	for _, tc := range []struct {
+		name string
+		f    serveFlags
+		want string
+	}{
+		{
+			name: "delegation_opt_out",
+			f:    serveFlags{requireContainment: true, concurrency: 1},
+			want: "--require-delegated-signing",
+		},
+		{
+			name: "durable_key_on_guest",
+			f:    serveFlags{requireContainment: true, concurrency: 1, requireDelegated: true, orchestratorKey: "/run/playground/orchestrator.key"},
+			want: "--orchestrator-key is refused outside --dev",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateServeSafety(&tc.f, false)
+			if err == nil {
+				t.Fatal("public serve must fail closed")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
 	}
-	f.orchestratorKey = filepath.Join(t.TempDir(), "demo-signing.key")
+}
+
+func TestValidateServeSafety_NonDevAllowsBrokerMintedSessionKey(t *testing.T) {
+	t.Parallel()
+	f := serveFlags{requireContainment: true, concurrency: 1, requireDelegated: true}
 	if err := validateServeSafety(&f, false); err != nil {
-		t.Fatalf("non-dev server with orchestrator key rejected: %v", err)
+		t.Fatalf("non-dev server without boot-time orchestrator key rejected: %v", err)
 	}
 }
 

--- a/cmd/pipelock-playground-live/main_test.go
+++ b/cmd/pipelock-playground-live/main_test.go
@@ -260,15 +260,6 @@ func devServeFlags() *serveFlags {
 	}
 }
 
-func testOrchestratorKeyPath(t *testing.T) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "demo-signing.key")
-	if _, err := playground.GenerateOrchestratorKey(path, false); err != nil {
-		t.Fatalf("GenerateOrchestratorKey: %v", err)
-	}
-	return path
-}
-
 func testExecutablePath(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "pipelock-playground-llm-agent")
@@ -404,7 +395,7 @@ func TestBuildServer_RequireModelFailsClosedWithoutModelConfig(t *testing.T) {
 	f.concurrency = 1
 	f.requireModel = true
 	f.codes = []string{"good"}
-	f.orchestratorKey = testOrchestratorKeyPath(t)
+	f.requireDelegated = true
 
 	var out bytes.Buffer
 	if _, _, err := buildServer(&out, f); err == nil {
@@ -423,7 +414,7 @@ func TestBuildServer_PublicModelValidatesRuntimeFiles(t *testing.T) {
 	f.modelBaseURL = "http://provider.example/v1"
 	f.model = "test-model"
 	f.modelSecretFile = filepath.Join(t.TempDir(), "missing-model.key")
-	f.orchestratorKey = testOrchestratorKeyPath(t)
+	f.requireDelegated = true
 	f.dailyTurnBudget = 10
 
 	var out bytes.Buffer

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -40,8 +40,8 @@ cd "${REPO_ROOT}"
 # workstation the proxy is loopback-only, so the build also uses host
 # networking; both are skipped when no proxy is set.
 DOCKER_BUILD_FLAGS=()
-if [ -n "${HTTP_PROXY:-${http_proxy:-}}" ]; then
-	proxy="${HTTP_PROXY:-$http_proxy}"
+if [ -n "${HTTP_PROXY:-${http_proxy:-${HTTPS_PROXY:-${https_proxy:-}}}}" ]; then
+	proxy="${HTTP_PROXY:-${http_proxy:-${HTTPS_PROXY:-${https_proxy:-}}}}"
 	https_proxy_val="${HTTPS_PROXY:-${https_proxy:-$proxy}}"
 	DOCKER_BUILD_FLAGS+=(
 		--network "${DOCKER_BUILD_NETWORK:-host}"

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -36,8 +36,26 @@ BROKER_TAG="${PLAYGROUND_REGISTRY}:broker"
 
 cd "${REPO_ROOT}"
 
+# Honor the host HTTP proxy for `go mod download` inside the build. On this
+# workstation the proxy is loopback-only, so the build also uses host
+# networking; both are skipped when no proxy is set.
+DOCKER_BUILD_FLAGS=()
+if [ -n "${HTTP_PROXY:-${http_proxy:-}}" ]; then
+	proxy="${HTTP_PROXY:-$http_proxy}"
+	https_proxy_val="${HTTPS_PROXY:-${https_proxy:-$proxy}}"
+	DOCKER_BUILD_FLAGS+=(
+		--network "${DOCKER_BUILD_NETWORK:-host}"
+		--build-arg "HTTP_PROXY=${proxy}"
+		--build-arg "HTTPS_PROXY=${https_proxy_val}"
+		--build-arg "http_proxy=${proxy}"
+		--build-arg "https_proxy=${https_proxy_val}"
+		--build-arg "NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
+		--build-arg "no_proxy=${NO_PROXY:-${no_proxy:-}}"
+	)
+fi
+
 echo "[build-images] building VM image ${VM_TAG}"
-docker build -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
+docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
 
 # The viewer's inline "Verify in your browser" button loads a WASM build of the
 # shipped verifier from the served dir. Build it straight into PLAYGROUND_UI_DIR
@@ -61,7 +79,7 @@ if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -newer "${wasm_stamp}" -
 fi
 
 echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"
-docker build -f deploy/fly-playground/Dockerfile.broker \
+docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile.broker \
 	--build-context "ui=${PLAYGROUND_UI_DIR}" \
 	-t "${BROKER_TAG}" .
 
@@ -71,6 +89,7 @@ docker run --rm "${BROKER_TAG}" serve \
 	--fly-app preflight \
 	--fly-token-env PREFLIGHT_FLY_TOKEN \
 	--image preflight \
+	--vm-image-digest sha256:0000000000000000000000000000000000000000000000000000000000000000 \
 	--global-daily-budget 1 \
 	--vm-daily-turn-budget 1 \
 	--turnstile-secret-env PREFLIGHT_TURNSTILE_SECRET \

--- a/deploy/fly-playground/entrypoint.sh
+++ b/deploy/fly-playground/entrypoint.sh
@@ -57,11 +57,17 @@ SECRET_DIR=/run/playground
 mkdir -p "${SECRET_DIR}"
 chmod 0700 "${SECRET_DIR}"
 
-ORCH_KEY_ARGS=""
+# The durable orchestrator root stays on the broker. Each session is authorized
+# by a short-lived key the broker mints and signs, delivered on the session
+# request. A guest that still receives the durable key is the pre-rotation shape
+# that leaked, so refuse to boot rather than silently accept it: an inherited
+# app-level secret would otherwise turn delegation off with everything green.
 if [ -n "${PLAYGROUND_ORCHESTRATOR_KEY:-}" ]; then
-	umask 077
-	printf '%s' "${PLAYGROUND_ORCHESTRATOR_KEY}" >"${SECRET_DIR}/orchestrator.key"
-	ORCH_KEY_ARGS="--orchestrator-key ${SECRET_DIR}/orchestrator.key"
+	log "FATAL: PLAYGROUND_ORCHESTRATOR_KEY is set on this guest"
+	log "The durable signing root must never reach a visitor VM. Unset the secret"
+	log "(fly secrets unset PLAYGROUND_ORCHESTRATOR_KEY) and redeploy; the broker"
+	log "mints a per-session delegated key instead."
+	exit 1
 fi
 
 MODEL_KEY_ARGS=""
@@ -108,7 +114,7 @@ fi
 
 # --- 4. Serve. One session per VM (--concurrency 1); "$@" allows extra overrides. -
 log "containment proven; starting server on ${LISTEN}"
-# shellcheck disable=SC2086  # word-splitting of ORCH_KEY_ARGS/MODEL_KEY_ARGS/EXTRA_ARGS is intended; secret paths are fixed under /run/playground (no spaces)
+# shellcheck disable=SC2086  # word-splitting of MODEL_KEY_ARGS/EXTRA_ARGS is intended; secret paths are fixed under /run/playground (no spaces)
 exec "${BIN}" serve \
 	--self-managed-containment \
 	--require-model \
@@ -122,7 +128,6 @@ exec "${BIN}" serve \
 	--verifier-bin-linux "${VERIFIER_LINUX}" \
 	--verifier-bin-macos "${VERIFIER_MACOS}" \
 	--verifier-bin-windows "${VERIFIER_WINDOWS}" \
-	${ORCH_KEY_ARGS} \
 	${MODEL_KEY_ARGS} \
 	${EXTRA_ARGS} \
 	"$@"

--- a/internal/cli/runtime/run_test.go
+++ b/internal/cli/runtime/run_test.go
@@ -925,7 +925,10 @@ logging:
 		select {
 		case err := <-cmdErr:
 			if err != nil {
-				t.Errorf("RunCmd returned error: %v", err)
+				// A different listener can answer the readiness probe after the
+				// test releases mainAddr. Let WithRetry choose a new address when
+				// our command then loses the bind race.
+				return fmt.Errorf("RunCmd returned error after readiness: %w", err)
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatal("RunCmd did not exit within 5s")
@@ -1099,7 +1102,7 @@ logging:
 		select {
 		case err := <-cmdErr:
 			if err != nil {
-				t.Errorf("RunCmd returned error: %v\nstderr:\n%s", err, stderr.String())
+				return fmt.Errorf("RunCmd returned error after readiness: %w\nstderr:\n%s", err, stderr.String())
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatal("RunCmd did not exit within 5s")
@@ -1195,7 +1198,7 @@ logging:
 		select {
 		case err := <-cmdErr:
 			if err != nil {
-				t.Errorf("RunCmd returned error: %v\nstderr:\n%s", err, stderr.String())
+				return fmt.Errorf("RunCmd returned error after readiness: %w\nstderr:\n%s", err, stderr.String())
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatal("RunCmd did not exit within 5s")
@@ -1297,7 +1300,7 @@ logging:
 		select {
 		case err := <-cmdErr:
 			if err != nil {
-				t.Errorf("RunCmd returned error: %v\nstderr:\n%s", err, stderr.String())
+				return fmt.Errorf("RunCmd returned error after readiness: %w\nstderr:\n%s", err, stderr.String())
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatal("RunCmd did not exit within 5s")
@@ -1870,7 +1873,7 @@ logging:
 		select {
 		case err := <-cmdErr:
 			if err != nil {
-				t.Errorf("RunCmd returned error: %v", err)
+				return fmt.Errorf("RunCmd returned error after readiness: %w", err)
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatal("RunCmd did not exit within 5s")

--- a/internal/playground/broker/lease.go
+++ b/internal/playground/broker/lease.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
@@ -72,6 +73,9 @@ func NewLeaseManager(cfg LeaseConfig) (*LeaseManager, error) {
 	if cfg.Image == "" {
 		return nil, errors.New("broker: LeaseConfig.Image is required")
 	}
+	// BaseEnv reaches every visitor VM. Retain a broker-owned copy so a caller
+	// cannot change the configuration after validation and construction.
+	cfg.BaseEnv = maps.Clone(cfg.BaseEnv)
 	return &LeaseManager{cfg: cfg, leases: make(map[string]*Lease)}, nil
 }
 

--- a/internal/playground/broker/lease_test.go
+++ b/internal/playground/broker/lease_test.go
@@ -121,6 +121,31 @@ func TestLeaseSuccess(t *testing.T) {
 	}
 }
 
+func TestNewLeaseManagerOwnsBaseEnv(t *testing.T) {
+	baseEnv := map[string]string{"PLAYGROUND_LISTEN": "0.0.0.0:8080"}
+	fp := &fakeProvider{}
+	lm, err := NewLeaseManager(LeaseConfig{
+		Provider:    fp,
+		Concurrency: livechat.NewConcurrencyLimiter(1),
+		Image:       "registry.fly.io/playground:test",
+		BaseEnv:     baseEnv,
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager: %v", err)
+	}
+	baseEnv["PLAYGROUND_ORCHESTRATOR_"+"KEY"] = "durable-root"
+
+	if _, err := lm.Lease(context.Background(), "sess-1", nil); err != nil {
+		t.Fatalf("Lease: %v", err)
+	}
+	fp.mu.Lock()
+	spec := fp.created[0]
+	fp.mu.Unlock()
+	if _, found := spec.Env["PLAYGROUND_ORCHESTRATOR_"+"KEY"]; found {
+		t.Fatal("lease inherited a BaseEnv mutation made after manager construction")
+	}
+}
+
 func TestLeaseAtCapacity(t *testing.T) {
 	fp := &fakeProvider{}
 	lm := newManager(t, fp, 1)

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -376,6 +376,12 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		if cfg.ImageDigest == "" {
 			return nil, errors.New("broker: ImageDigest is required when OrchestratorRoot is set")
 		}
+		// Non-empty is not enough: only a canonical digest names an immutable
+		// image, and minting rejects anything else. Fail here instead of
+		// starting a broker whose every session dies at delegation time.
+		if err := playground.ValidateCanonicalImageDigest(cfg.ImageDigest); err != nil {
+			return nil, fmt.Errorf("broker: %w", err)
+		}
 	}
 	if cfg.InternalPort == 0 {
 		cfg.InternalPort = defaultInternalPort

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -6,6 +6,7 @@ package broker
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -117,9 +118,18 @@ type ServerConfig struct {
 	PerCodeDailyBudget int
 	GlobalDailyBudget  int
 	// SessionEnv is layered into each per-VM lease along with the generated
-	// single-use VM invite code. It carries operator-provided per-session secret
-	// values such as PLAYGROUND_MODEL_KEY and PLAYGROUND_ORCHESTRATOR_KEY.
+	// single-use VM invite code. It may carry PLAYGROUND_MODEL_KEY. It must
+	// never carry the durable orchestrator private key.
 	SessionEnv map[string]string
+	// OrchestratorRoot is the broker-held durable signing root. When set, each
+	// session receives a short-lived delegated key instead of this value.
+	OrchestratorRoot ed25519.PrivateKey
+	// ImageDigest is the immutable VM image bound into each session
+	// delegation. Required when OrchestratorRoot is set.
+	ImageDigest string
+	// SessionDelegationLifetime bounds minted session keys. Zero uses
+	// playground.DefaultSessionDelegationLifetime.
+	SessionDelegationLifetime time.Duration
 	// InternalPort is the VM server port. Zero uses 8080.
 	InternalPort int
 	// DeadlineGrace extends the VM-reported session expiry before the broker
@@ -311,6 +321,13 @@ type sessionRequest struct {
 	TurnstileToken string `json:"turnstile_token,omitempty"`
 }
 
+type vmSessionRequest struct {
+	Code                   string          `json:"code"`
+	RunNonce               string          `json:"run_nonce,omitempty"`
+	SessionSigningKey      string          `json:"session_signing_key,omitempty"`
+	OrchestratorDelegation json.RawMessage `json:"orchestrator_delegation,omitempty"`
+}
+
 type vmSessionResponse struct {
 	Token     string `json:"token"`
 	SessionID string `json:"session_id"`
@@ -345,6 +362,19 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	} {
 		if c.v < 0 {
 			return nil, fmt.Errorf("broker: %s must be >= 0", c.name)
+		}
+	}
+	for k := range cfg.SessionEnv {
+		if k == "PLAYGROUND_ORCHESTRATOR_"+"KEY" {
+			return nil, errors.New("broker: SessionEnv must not carry the durable orchestrator key")
+		}
+	}
+	if len(cfg.OrchestratorRoot) != 0 {
+		if _, err := playground.ParseOrchestratorPrivateKeyHex(hex.EncodeToString(cfg.OrchestratorRoot)); err != nil {
+			return nil, fmt.Errorf("broker: OrchestratorRoot: %w", err)
+		}
+		if cfg.ImageDigest == "" {
+			return nil, errors.New("broker: ImageDigest is required when OrchestratorRoot is set")
 		}
 	}
 	if cfg.InternalPort == 0 {
@@ -648,7 +678,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, expiresAt, err := s.createVMSession(r.Context(), lease, vmCode)
+	resp, expiresAt, err := s.createVMSession(r.Context(), lease, vmCode, sessionKey)
 	if err != nil {
 		s.cfg.Leases.Release(context.WithoutCancel(r.Context()), sessionKey)
 		undo()
@@ -1018,12 +1048,25 @@ func (s *Server) fetchVMArtifact(ctx context.Context, lease *Lease, vmToken, osP
 	}, nil
 }
 
-func (s *Server) createVMSession(ctx context.Context, lease *Lease, code string) (vmSessionResponse, time.Time, error) {
+func (s *Server) createVMSession(ctx context.Context, lease *Lease, code, runNonce string) (vmSessionResponse, time.Time, error) {
 	target, err := s.targetURL(lease, livechat.RouteSession)
 	if err != nil {
 		return vmSessionResponse{}, time.Time{}, err
 	}
-	reqBody, err := json.Marshal(sessionRequest{Code: code})
+	req := vmSessionRequest{Code: code, RunNonce: runNonce}
+	if len(s.cfg.OrchestratorRoot) != 0 {
+		minted, mintErr := playground.MintSessionDelegation(s.cfg.OrchestratorRoot, runNonce, s.cfg.ImageDigest, time.Now().UTC(), s.cfg.SessionDelegationLifetime)
+		if mintErr != nil {
+			return vmSessionResponse{}, time.Time{}, fmt.Errorf("broker: mint session delegation: %w", mintErr)
+		}
+		delBytes, marshalErr := json.Marshal(minted.Delegation)
+		if marshalErr != nil {
+			return vmSessionResponse{}, time.Time{}, fmt.Errorf("broker: marshal session delegation: %w", marshalErr)
+		}
+		req.SessionSigningKey = hex.EncodeToString(minted.PrivateKey)
+		req.OrchestratorDelegation = delBytes
+	}
+	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return vmSessionResponse{}, time.Time{}, fmt.Errorf("broker: marshal vm session request: %w", err)
 	}

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -364,9 +364,15 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 			return nil, fmt.Errorf("broker: %s must be >= 0", c.name)
 		}
 	}
-	for k := range cfg.SessionEnv {
-		if k == "PLAYGROUND_ORCHESTRATOR_"+"KEY" {
-			return nil, errors.New("broker: SessionEnv must not carry the durable orchestrator key")
+	for _, source := range []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "SessionEnv", env: cfg.SessionEnv},
+		{name: "LeaseConfig.BaseEnv", env: cfg.Leases.cfg.BaseEnv},
+	} {
+		if _, found := source.env["PLAYGROUND_ORCHESTRATOR_"+"KEY"]; found {
+			return nil, fmt.Errorf("broker: %s must not carry the durable orchestrator key", source.name)
 		}
 	}
 	if len(cfg.OrchestratorRoot) != 0 {

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -364,6 +365,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 			return nil, fmt.Errorf("broker: %s must be >= 0", c.name)
 		}
 	}
+	// SessionEnv reaches every visitor VM. Keep an owned copy so a caller cannot
+	// add the durable root after this validation completes.
+	cfg.SessionEnv = maps.Clone(cfg.SessionEnv)
 	for _, source := range []struct {
 		name string
 		env  map[string]string

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 const (
@@ -409,6 +411,37 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, PerIPDailyBudget: -1}); err == nil {
 		t.Fatal("negative daily budget should error")
 	}
+	if _, err := NewServer(ServerConfig{
+		Leases:     lm,
+		Gate:       gate,
+		SessionEnv: map[string]string{"PLAYGROUND_ORCHESTRATOR_" + "KEY": "durable-root"},
+	}); err == nil {
+		t.Fatal("SessionEnv carrying the durable orchestrator key should error")
+	}
+	if _, err := NewServer(ServerConfig{
+		Leases:           lm,
+		Gate:             gate,
+		OrchestratorRoot: ed25519.PrivateKey("short"),
+	}); err == nil {
+		t.Fatal("invalid OrchestratorRoot should error")
+	}
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, OrchestratorRoot: root}); err == nil {
+		t.Fatal("OrchestratorRoot without ImageDigest should error")
+	}
+	delegated, err := NewServer(ServerConfig{
+		Leases:           lm,
+		Gate:             gate,
+		OrchestratorRoot: root,
+		ImageDigest:      "sha256:" + strings.Repeat("ab", 32),
+	})
+	if err != nil {
+		t.Fatalf("valid delegated root config rejected: %v", err)
+	}
+	delegated.Close()
 
 	customClient := &http.Client{}
 	srv, err := NewServer(ServerConfig{Leases: lm, Gate: gate, HTTPClient: customClient})

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -418,6 +418,20 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	}); err == nil {
 		t.Fatal("SessionEnv carrying the durable orchestrator key should error")
 	}
+	leaseWithRoot, err := NewLeaseManager(LeaseConfig{
+		Provider:    &serverFakeProvider{},
+		Concurrency: livechat.NewConcurrencyLimiter(brokerTestCapacity),
+		Image:       brokerTestImage,
+		BaseEnv:     map[string]string{"PLAYGROUND_ORCHESTRATOR_" + "KEY": "durable-root"},
+	})
+	if err != nil {
+		t.Fatalf("NewLeaseManager with durable base environment: %v", err)
+	}
+	if _, err := NewServer(ServerConfig{Leases: leaseWithRoot, Gate: gate}); err == nil {
+		t.Fatal("LeaseConfig.BaseEnv carrying the durable orchestrator key should error")
+	} else if !strings.Contains(err.Error(), "LeaseConfig.BaseEnv") {
+		t.Fatalf("error = %v, want the BaseEnv source named", err)
+	}
 	if _, err := NewServer(ServerConfig{
 		Leases:           lm,
 		Gate:             gate,

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -907,6 +907,22 @@ func TestServer_EndToEndProxyAndRelease(t *testing.T) {
 	}
 }
 
+func TestNewServerOwnsSessionEnv(t *testing.T) {
+	vm := newFakeVM(t, "vm-owned-session-env")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	sessionEnv := map[string]string{"PLAYGROUND_MODEL_" + "KEY": "model-test-key"}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{SessionEnv: sessionEnv})
+	sessionEnv["PLAYGROUND_ORCHESTRATOR_"+"KEY"] = "durable-root"
+
+	if status, _ := postBrokerSession(t, ts); status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+	env := provider.createdEnv(0)
+	if _, found := env["PLAYGROUND_ORCHESTRATOR_"+"KEY"]; found {
+		t.Fatal("lease inherited a SessionEnv mutation made after server construction")
+	}
+}
+
 func TestServerRouteRejectionsAndTokenHelpers(t *testing.T) {
 	vm := newFakeVM(t, "route-token")
 	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}

--- a/internal/playground/broker/session_delegation_test.go
+++ b/internal/playground/broker/session_delegation_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// testDelegationRoot returns a usable signing root and its canonical digest.
+func testDelegationRoot(t *testing.T) (ed25519.PrivateKey, string) {
+	t.Helper()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	return priv, "sha256:" + strings.Repeat("a", 64)
+}
+
+// The visitor VM must receive a short-lived session key and a root-signed
+// delegation, never the durable root. The delegation has to bind the run and
+// the image so a captured one cannot be replayed onto a different run or a
+// different VM image.
+func TestServer_CreateVMSession_SendsBoundDelegation(t *testing.T) {
+	root, digest := testDelegationRoot(t)
+
+	type captured struct {
+		Code                   string          `json:"code"`
+		RunNonce               string          `json:"run_nonce"`
+		SessionSigningKey      string          `json:"session_signing_key"`
+		OrchestratorDelegation json.RawMessage `json:"orchestrator_delegation"`
+	}
+	got := make(chan captured, 1)
+
+	vmsrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != livechat.RouteSession {
+			writeBrokerErr(w, http.StatusNotFound, "not found")
+			return
+		}
+		var req captured
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeBrokerErr(w, http.StatusBadRequest, "bad request")
+			return
+		}
+		select {
+		case got <- req:
+		default:
+		}
+		writeBrokerJSON(w, http.StatusOK, vmSessionResponse{
+			Token:     "delegated-token",
+			SessionID: "sid-delegated",
+			ExpiresAt: time.Now().Add(time.Minute).UTC().Format(time.RFC3339Nano),
+			State:     brokerTestState,
+		})
+	}))
+	t.Cleanup(vmsrv.Close)
+
+	u := vmsrv.URL
+	host := u[strings.LastIndex(u, "/")+1:]
+	provider := &serverFakeProvider{targets: []string{host}}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{
+		OrchestratorRoot: root,
+		ImageDigest:      digest,
+	})
+
+	status, _ := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+
+	var req captured
+	select {
+	case req = <-got:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the VM never received a session request")
+	}
+
+	if req.SessionSigningKey == "" || len(req.OrchestratorDelegation) == 0 {
+		t.Fatal("the VM must receive both a session key and a delegation")
+	}
+	if req.SessionSigningKey == hex.EncodeToString(root) {
+		t.Fatal("the durable root must never be sent to a visitor VM")
+	}
+
+	d, err := playground.ParseOrchestratorDelegation(req.OrchestratorDelegation)
+	if err != nil {
+		t.Fatalf("delegation does not parse: %v", err)
+	}
+	if d.ImageDigest != digest {
+		t.Fatalf("delegation image digest = %q, want %q", d.ImageDigest, digest)
+	}
+	if d.RunNonce != req.RunNonce {
+		t.Fatalf("delegation run nonce = %q, want %q", d.RunNonce, req.RunNonce)
+	}
+
+	priv, err := playground.ParseOrchestratorPrivateKeyHex(req.SessionSigningKey)
+	if err != nil {
+		t.Fatalf("session signing key does not parse: %v", err)
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatal("session key has no Ed25519 public half")
+	}
+	if hex.EncodeToString(pub) != d.SessionPublicKey {
+		t.Fatal("the delegation does not authorize the session key that was sent")
+	}
+	if d.ExpiresAtUnix <= d.NotBeforeUnix {
+		t.Fatal("the delegation must carry a bounded validity window")
+	}
+}
+
+// Without a root the broker sends no delegation, which is the local and legacy
+// shape. It must not invent one or send an unauthorized key.
+func TestServer_CreateVMSession_NoRootSendsNoDelegation(t *testing.T) {
+	vm := newFakeVM(t, "plain-token")
+	provider := &serverFakeProvider{targets: []string{vm.targetHost(t)}}
+	_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+
+	status, session := postBrokerSession(t, ts)
+	if status != http.StatusOK {
+		t.Fatalf("session status = %d, want 200", status)
+	}
+	if session.Token != vm.token {
+		t.Fatalf("session token = %q, want %q", session.Token, vm.token)
+	}
+}

--- a/internal/playground/broker/session_delegation_test.go
+++ b/internal/playground/broker/session_delegation_test.go
@@ -135,3 +135,56 @@ func TestServer_CreateVMSession_NoRootSendsNoDelegation(t *testing.T) {
 		t.Fatalf("session token = %q, want %q", session.Token, vm.token)
 	}
 }
+
+// The CLI validates the digest flag, but a library caller reaches NewServer
+// directly. Non-empty alone would let a broker start and then fail every
+// visitor session at mint time, turning a configuration mistake into an outage
+// that only appears once real visitors arrive.
+func TestNewServer_RejectsNonCanonicalImageDigest(t *testing.T) {
+	t.Parallel()
+
+	root, _ := testDelegationRoot(t)
+	for _, tc := range []struct {
+		name   string
+		digest string
+	}{
+		{name: "mutable_tag", digest: "latest"},
+		{name: "missing_algorithm", digest: strings.Repeat("a", 64)},
+		{name: "wrong_length", digest: "sha256:abc123"},
+		{name: "uppercase_hex", digest: "sha256:" + strings.Repeat("A", 64)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gate, err := livechat.NewGate(livechat.GateConfig{
+				Secret:   testBrokerSecret(),
+				Codes:    []livechat.CodeSpec{{Code: brokerTestCode}},
+				TokenTTL: time.Minute,
+			})
+			if err != nil {
+				t.Fatalf("NewGate: %v", err)
+			}
+			lm, err := NewLeaseManager(LeaseConfig{
+				Provider:    &serverFakeProvider{targets: []string{"vm.invalid"}},
+				Concurrency: livechat.NewConcurrencyLimiter(brokerTestCapacity),
+				Image:       brokerTestImage,
+			})
+			if err != nil {
+				t.Fatalf("NewLeaseManager: %v", err)
+			}
+
+			_, err = NewServer(ServerConfig{
+				Leases:           lm,
+				Gate:             gate,
+				IPRate:           livechat.RateConfig{RefillPerSec: 1000, Burst: 1000},
+				CodeRate:         livechat.RateConfig{RefillPerSec: 1000, Burst: 1000},
+				OrchestratorRoot: root,
+				ImageDigest:      tc.digest,
+			})
+			if err == nil {
+				t.Fatal("a non-canonical image digest must be refused at configuration time")
+			}
+			if !strings.Contains(err.Error(), "canonical sha256") {
+				t.Fatalf("error = %v, want it to name the canonical-digest requirement", err)
+			}
+		})
+	}
+}

--- a/internal/playground/delegation.go
+++ b/internal/playground/delegation.go
@@ -119,6 +119,17 @@ func ensureDelegationJSONEOF(dec *json.Decoder) error {
 
 // ValidateOrchestratorDelegationClaims validates intrinsic field constraints
 // plus any broker/verifier expectations supplied by the caller.
+// ValidateCanonicalImageDigest reports whether a digest identifies an immutable
+// image. A delegation attests which image ran, so a non-canonical value cannot
+// bind anything; callers validate with this at configuration time rather than
+// discovering it when a visitor's session fails to mint.
+func ValidateCanonicalImageDigest(digest string) error {
+	if !strings.HasPrefix(digest, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(digest, "sha256:")) {
+		return fmt.Errorf("image_digest must be canonical sha256")
+	}
+	return nil
+}
+
 func ValidateOrchestratorDelegationClaims(d OrchestratorDelegation, want DelegationExpectations) error {
 	if d.Format != OrchestratorDelegationFormat {
 		return fmt.Errorf("delegation format %q, want %q", d.Format, OrchestratorDelegationFormat)
@@ -135,8 +146,8 @@ func ValidateOrchestratorDelegationClaims(d OrchestratorDelegation, want Delegat
 	if !lowerHex64Pattern.MatchString(d.SessionPublicKey) {
 		return fmt.Errorf("session_public_key must be 32-byte lowercase hex")
 	}
-	if !strings.HasPrefix(d.ImageDigest, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(d.ImageDigest, "sha256:")) {
-		return fmt.Errorf("image_digest must be canonical sha256")
+	if err := ValidateCanonicalImageDigest(d.ImageDigest); err != nil {
+		return err
 	}
 	if d.IssuedAtUnix <= 0 || d.NotBeforeUnix <= 0 || d.ExpiresAtUnix <= 0 {
 		return fmt.Errorf("delegation timestamps must be positive Unix seconds")

--- a/internal/playground/live_session.go
+++ b/internal/playground/live_session.go
@@ -8,6 +8,7 @@ package playground
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"io"
@@ -167,6 +168,10 @@ type LiveSessionConfig struct {
 	// OrchestratorKeyPath loads the published demo signing key (so the run is
 	// verifiable against the published key). Empty => ephemeral per-run key.
 	OrchestratorKeyPath string
+	// SessionPrivateKey and Delegation are the broker-minted session signer.
+	// When set they take precedence over OrchestratorKeyPath.
+	SessionPrivateKey ed25519.PrivateKey
+	Delegation        *OrchestratorDelegation
 	// Agent overrides the LiveAgent. Nil => the deterministic IntentAgent.
 	// Ignored when LLMAgent is set (the model-backed subprocess drives instead).
 	Agent LiveAgent
@@ -291,6 +296,8 @@ func StartLiveSession(ctx context.Context, cfg LiveSessionConfig) (*LiveSession,
 		ScenarioID:          LiveDemoScenarioID,
 		RunNonce:            cfg.RunNonce,
 		OrchestratorKeyPath: cfg.OrchestratorKeyPath,
+		SessionPrivateKey:   cfg.SessionPrivateKey,
+		Delegation:          cfg.Delegation,
 		ToyAgentBin:         cfg.ToyAgentBin,
 		WebToolBin:          cfg.WebToolBin,
 		ProxyPort:           cfg.ProxyPort,

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -4,9 +4,14 @@
 package livechat
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
 // A half-supplied delegation is a broken caller, not a permissive one. Accepting
@@ -48,5 +53,64 @@ func TestParseSessionDelegation_RequiredRefusesEmpty(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "session signing required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A delegation minted for a different run must not authorize this one. Without
+// the nonce check a captured delegation could be replayed onto another session.
+func TestParseSessionDelegation_RunNonceMustMatch(t *testing.T) {
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	digest := "sha256:" + strings.Repeat("a", 64)
+	minted, err := playground.MintSessionDelegation(root, "minted-for-this-run", digest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	raw, err := json.Marshal(minted.Delegation)
+	if err != nil {
+		t.Fatalf("marshal delegation: %v", err)
+	}
+
+	t.Run("matching_nonce_is_accepted", func(t *testing.T) {
+		body := createReq{
+			RunNonce:               "minted-for-this-run",
+			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
+			OrchestratorDelegation: raw,
+		}
+		if _, _, err := parseSessionDelegation(body, true); err != nil {
+			t.Fatalf("a matching delegation was rejected: %v", err)
+		}
+	})
+
+	t.Run("mismatched_nonce_is_refused", func(t *testing.T) {
+		body := createReq{
+			RunNonce:               "some-other-run",
+			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
+			OrchestratorDelegation: raw,
+		}
+		_, _, err := parseSessionDelegation(body, true)
+		if err == nil {
+			t.Fatal("a delegation minted for another run must be refused")
+		}
+		if !strings.Contains(err.Error(), "run_nonce") {
+			t.Fatalf("error %v must name the nonce mismatch", err)
+		}
+	})
+}
+
+// A delegation that is not well-formed is refused before it can authorize a key.
+func TestParseSessionDelegation_MalformedDelegationRefused(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	body := createReq{
+		SessionSigningKey:      hex.EncodeToString(priv),
+		OrchestratorDelegation: json.RawMessage("{\"format\":\"nonsense\"}"),
+	}
+	if _, _, err := parseSessionDelegation(body, true); err == nil {
+		t.Fatal("a malformed delegation must be refused")
 	}
 }

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -73,29 +73,39 @@ func TestParseSessionDelegation_RunNonceMustMatch(t *testing.T) {
 		t.Fatalf("marshal delegation: %v", err)
 	}
 
-	t.Run("matching_nonce_is_accepted", func(t *testing.T) {
-		body := createReq{
-			RunNonce:               "minted-for-this-run",
-			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
-			OrchestratorDelegation: raw,
-		}
-		if _, _, err := parseSessionDelegation(body, true); err != nil {
-			t.Fatalf("a matching delegation was rejected: %v", err)
-		}
-	})
-
 	t.Run("mismatched_nonce_is_refused", func(t *testing.T) {
 		body := createReq{
 			RunNonce:               "some-other-run",
 			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
 			OrchestratorDelegation: raw,
 		}
-		_, _, err := parseSessionDelegation(body, true)
-		if err == nil {
+		if _, _, err := parseSessionDelegation(body, true); err == nil {
 			t.Fatal("a delegation minted for another run must be refused")
 		}
-		if !strings.Contains(err.Error(), "run_nonce") {
-			t.Fatalf("error %v must name the nonce mismatch", err)
+	})
+
+	t.Run("absent_nonce_is_refused", func(t *testing.T) {
+		body := createReq{
+			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
+			OrchestratorDelegation: raw,
+		}
+		_, _, err := parseSessionDelegation(body, true)
+		if err == nil {
+			t.Fatal("a delegated session without a run nonce must be refused")
+		}
+		if !strings.Contains(err.Error(), "run nonce") {
+			t.Fatalf("error %v must name the missing run nonce", err)
+		}
+	})
+
+	t.Run("untrusted_root_is_refused", func(t *testing.T) {
+		body := createReq{
+			RunNonce:               "minted-for-this-run",
+			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
+			OrchestratorDelegation: raw,
+		}
+		if _, _, err := parseSessionDelegation(body, true); err == nil {
+			t.Fatal("a delegation signed by an untrusted root must be refused")
 		}
 	})
 }

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -74,17 +74,10 @@ func TestParseSessionDelegation_RunNonceMustMatch(t *testing.T) {
 		t.Fatalf("marshal delegation: %v", err)
 	}
 
-	t.Run("mismatched_nonce_is_refused", func(t *testing.T) {
-		body := createReq{
-			RunNonce:               "some-other-run",
-			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
-			OrchestratorDelegation: raw,
-		}
-		if _, _, err := parseSessionDelegation(body, true); err == nil {
-			t.Fatal("a delegation minted for another run must be refused")
-		}
-	})
-
+	// The nonce-mismatch assertion lives in the playground package, where the
+	// trusted root can be set so signature verification succeeds and the nonce
+	// check is the thing under test. From here every minted delegation is
+	// foreign, so that assertion would pass on the root refusal instead.
 	t.Run("absent_nonce_is_refused", func(t *testing.T) {
 		body := createReq{
 			SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -4,8 +4,10 @@
 package livechat
 
 import (
+	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -119,3 +121,89 @@ func TestParseSessionDelegation_MalformedDelegationRefused(t *testing.T) {
 		t.Fatal("a malformed delegation must be refused")
 	}
 }
+
+// The parser must hand verification the run nonce from THIS request. If it ever
+// passed the delegation's own nonce instead, the binding check would compare a
+// value against itself and always succeed, so this asserts the propagation
+// directly rather than through a delegation the trusted root cannot sign here.
+func TestParseSessionDelegation_PassesRequestNonceToVerification(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	digest := "sha256:" + strings.Repeat("a", 64)
+	minted, err := playground.MintSessionDelegation(root, "delegation-own-nonce", digest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	raw, err := json.Marshal(minted.Delegation)
+	if err != nil {
+		t.Fatalf("marshal delegation: %v", err)
+	}
+
+	var gotNonce string
+	prev := verifySessionDelegation
+	verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, runNonce string) error {
+		gotNonce = runNonce
+		return nil
+	}
+	t.Cleanup(func() { verifySessionDelegation = prev })
+
+	body := createReq{
+		RunNonce:               "request-nonce",
+		SessionSigningKey:      hex.EncodeToString(priv),
+		OrchestratorDelegation: raw,
+	}
+	if _, _, err := parseSessionDelegation(body, true); err != nil {
+		t.Fatalf("parseSessionDelegation: %v", err)
+	}
+	if gotNonce != "request-nonce" {
+		t.Fatalf("verification received nonce %q, want the request nonce %q", gotNonce, "request-nonce")
+	}
+	if gotNonce == minted.Delegation.RunNonce {
+		t.Fatal("verification must not receive the delegation's own nonce")
+	}
+}
+
+// A refusal from verification is surfaced, not swallowed.
+func TestParseSessionDelegation_PropagatesVerificationRefusal(t *testing.T) {
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	digest := "sha256:" + strings.Repeat("a", 64)
+	minted, err := playground.MintSessionDelegation(root, "a-run", digest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	raw, err := json.Marshal(minted.Delegation)
+	if err != nil {
+		t.Fatalf("marshal delegation: %v", err)
+	}
+
+	prev := verifySessionDelegation
+	verifySessionDelegation = func(ed25519.PrivateKey, playground.OrchestratorDelegation, string) error {
+		return errRefusedForTest
+	}
+	t.Cleanup(func() { verifySessionDelegation = prev })
+
+	body := createReq{
+		RunNonce:               "a-run",
+		SessionSigningKey:      hex.EncodeToString(priv),
+		OrchestratorDelegation: raw,
+	}
+	_, _, err = parseSessionDelegation(body, true)
+	if !errors.Is(err, errRefusedForTest) {
+		t.Fatalf("parse error = %v, want the verification refusal to be surfaced", err)
+	}
+}
+
+var errRefusedForTest = errors.New("refused for test")

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -36,6 +36,7 @@ func TestParseSessionDelegation_HalvesAreRefused(t *testing.T) {
 // A malformed session key is refused before it can sign anything.
 func TestParseSessionDelegation_MalformedKeyRefused(t *testing.T) {
 	body := createReq{
+		RunNonce:               "a-run",
 		SessionSigningKey:      "not-hex",
 		OrchestratorDelegation: json.RawMessage("{\"format\":\"x\"}"),
 	}
@@ -117,6 +118,7 @@ func TestParseSessionDelegation_MalformedDelegationRefused(t *testing.T) {
 		t.Fatalf("GenerateKeyPair: %v", err)
 	}
 	body := createReq{
+		RunNonce:               "a-run",
 		SessionSigningKey:      hex.EncodeToString(priv),
 		OrchestratorDelegation: json.RawMessage("{\"format\":\"nonsense\"}"),
 	}

--- a/internal/playground/livechat/delegation_parse_test.go
+++ b/internal/playground/livechat/delegation_parse_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A half-supplied delegation is a broken caller, not a permissive one. Accepting
+// the key without the root-signed delegation would sign a run under a key
+// nothing authorized.
+func TestParseSessionDelegation_HalvesAreRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body createReq
+	}{
+		{name: "key_without_delegation", body: createReq{SessionSigningKey: "aa"}},
+		{name: "delegation_without_key", body: createReq{OrchestratorDelegation: json.RawMessage("{}")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := parseSessionDelegation(tc.body, false); err == nil {
+				t.Fatal("a half-supplied delegation must be refused")
+			}
+		})
+	}
+}
+
+// A malformed session key is refused before it can sign anything.
+func TestParseSessionDelegation_MalformedKeyRefused(t *testing.T) {
+	body := createReq{
+		SessionSigningKey:      "not-hex",
+		OrchestratorDelegation: json.RawMessage("{\"format\":\"x\"}"),
+	}
+	if _, _, err := parseSessionDelegation(body, true); err == nil {
+		t.Fatal("a malformed session signing key must be refused")
+	}
+}
+
+// With delegation required, a request carrying neither half is refused rather
+// than falling back to an unauthorized signer.
+func TestParseSessionDelegation_RequiredRefusesEmpty(t *testing.T) {
+	_, _, err := parseSessionDelegation(createReq{}, true)
+	if err == nil {
+		t.Fatal("required delegation must refuse an empty request")
+	}
+	if !strings.Contains(err.Error(), "session signing required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/playground/livechat/duplicate_nonce_test.go
+++ b/internal/playground/livechat/duplicate_nonce_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// The session id is the caller-supplied run nonce, so a second request can name
+// a session that is already running. Overwriting the map entry would orphan the
+// first session: its timer closes over the same id and would finalize the
+// replacement, leaving the original alive with nothing able to reap it. The
+// second request is refused and the first stays exactly where it was.
+func TestServer_DuplicateRunNonceDoesNotDisplaceTheActiveSession(t *testing.T) {
+	t.Parallel()
+
+	g, err := NewGate(GateConfig{
+		Secret:   testSecret(t),
+		Codes:    []CodeSpec{{Code: "good", MaxSessions: 5}},
+		TokenTTL: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:          g,
+		MaxConcurrent: 4,
+		IPRate:        RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:      RateConfig{RefillPerSec: 1000, Burst: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptestServer(t, srv)
+
+	const nonce = "aa" + "bbccddeeff00112233445566778899"
+
+	first := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
+	_ = first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first session status = %d, want 200", first.StatusCode)
+	}
+
+	srv.mu.Lock()
+	original, ok := srv.sessions[nonce]
+	srv.mu.Unlock()
+	if !ok {
+		t.Fatal("the first session was not stored under its run nonce")
+	}
+
+	second := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
+	_ = second.Body.Close()
+	if second.StatusCode == http.StatusOK {
+		t.Fatal("a duplicate run nonce must not start a second session")
+	}
+
+	srv.mu.Lock()
+	current, stillThere := srv.sessions[nonce]
+	srv.mu.Unlock()
+	if !stillThere {
+		t.Fatal("the duplicate request removed the original session")
+	}
+	if current != original {
+		t.Fatal("the duplicate request displaced the original session entry")
+	}
+}

--- a/internal/playground/livechat/duplicate_nonce_test.go
+++ b/internal/playground/livechat/duplicate_nonce_test.go
@@ -4,7 +4,9 @@
 package livechat
 
 import (
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
@@ -53,8 +55,8 @@ func TestServer_DuplicateRunNonceDoesNotDisplaceTheActiveSession(t *testing.T) {
 
 	second := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
 	_ = second.Body.Close()
-	if second.StatusCode == http.StatusOK {
-		t.Fatal("a duplicate run nonce must not start a second session")
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate session status = %d, want 409; any other status lets a regression pass", second.StatusCode)
 	}
 
 	srv.mu.Lock()
@@ -65,5 +67,79 @@ func TestServer_DuplicateRunNonceDoesNotDisplaceTheActiveSession(t *testing.T) {
 	}
 	if current != original {
 		t.Fatal("the duplicate request displaced the original session entry")
+	}
+}
+
+// Concurrent starts on one run nonce must cost exactly one invite allocation.
+// Gate.Redeem keys its refund record by the session id, so before the nonce was
+// reserved ahead of redemption both racers incremented the code's issued count
+// while only the loser's refund could still find a record to undo. Repeating a
+// nonce then exhausted a shared code, which is a denial of the demo rather than
+// a leak, and it is exactly what an attendee sharing a code would trip.
+func TestServer_ConcurrentDuplicateNonceConsumesOneAllocation(t *testing.T) {
+	t.Parallel()
+
+	const maxSessions = 3
+	g, err := NewGate(GateConfig{
+		Secret:   testSecret(t),
+		Codes:    []CodeSpec{{Code: "good", MaxSessions: maxSessions}},
+		TokenTTL: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:          g,
+		MaxConcurrent: 8,
+		IPRate:        RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:      RateConfig{RefillPerSec: 1000, Burst: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptestServer(t, srv)
+
+	const nonce = "cc" + "ddeeff00112233445566778899aabb"
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	start := make(chan struct{})
+	for i := range codes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
+			_ = resp.Body.Close()
+			codes[i] = resp.StatusCode
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var accepted, conflicted int
+	for _, c := range codes {
+		switch c {
+		case http.StatusOK:
+			accepted++
+		case http.StatusConflict:
+			conflicted++
+		default:
+			t.Fatalf("unexpected status %d; want one 200 and one 409", c)
+		}
+	}
+	if accepted != 1 || conflicted != 1 {
+		t.Fatalf("accepted=%d conflicted=%d, want exactly one of each", accepted, conflicted)
+	}
+
+	// The refused racer must not have spent budget. Drain the remaining
+	// allocations: one was legitimately used, so exactly maxSessions-1 remain.
+	for i := 0; i < maxSessions-1; i++ {
+		if _, _, err := g.Redeem("good", fmt.Sprintf("drain-%d", i)); err != nil {
+			t.Fatalf("allocation %d of the code was consumed by the refused duplicate: %v", i, err)
+		}
+	}
+	if _, _, err := g.Redeem("good", "one-too-many"); err == nil {
+		t.Fatal("the code handed out more allocations than it has")
 	}
 }

--- a/internal/playground/livechat/duplicate_nonce_test.go
+++ b/internal/playground/livechat/duplicate_nonce_test.go
@@ -102,6 +102,13 @@ func TestServer_ConcurrentDuplicateNonceConsumesOneAllocation(t *testing.T) {
 
 	reserved := make(chan struct{})
 	releaseFirst := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	}()
 	srv.beforeGateRedeem = func() {
 		close(reserved)
 		<-releaseFirst

--- a/internal/playground/livechat/duplicate_nonce_test.go
+++ b/internal/playground/livechat/duplicate_nonce_test.go
@@ -76,8 +76,6 @@ func TestServer_DuplicateRunNonceDoesNotDisplaceTheActiveSession(t *testing.T) {
 // nonce then exhausted a shared code, which is a denial of the demo rather than
 // a leak, and it is exactly what an attendee sharing a code would trip.
 func TestServer_ConcurrentDuplicateNonceConsumesOneAllocation(t *testing.T) {
-	t.Parallel()
-
 	const maxSessions = 3
 	g, err := NewGate(GateConfig{
 		Secret:   testSecret(t),
@@ -147,7 +145,7 @@ func TestServer_ConcurrentDuplicateNonceConsumesOneAllocation(t *testing.T) {
 		if status != http.StatusOK {
 			t.Fatalf("first request status = %d, want 200", status)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("first request did not finish after redemption was released")
 	}
 

--- a/internal/playground/livechat/duplicate_nonce_test.go
+++ b/internal/playground/livechat/duplicate_nonce_test.go
@@ -6,7 +6,6 @@ package livechat
 import (
 	"fmt"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 )
@@ -101,35 +100,48 @@ func TestServer_ConcurrentDuplicateNonceConsumesOneAllocation(t *testing.T) {
 
 	const nonce = "cc" + "ddeeff00112233445566778899aabb"
 
-	var wg sync.WaitGroup
-	codes := make([]int, 2)
-	start := make(chan struct{})
-	for i := range codes {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			resp := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
-			_ = resp.Body.Close()
-			codes[i] = resp.StatusCode
-		}()
+	reserved := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	srv.beforeGateRedeem = func() {
+		close(reserved)
+		<-releaseFirst
 	}
-	close(start)
-	wg.Wait()
 
-	var accepted, conflicted int
-	for _, c := range codes {
-		switch c {
-		case http.StatusOK:
-			accepted++
-		case http.StatusConflict:
-			conflicted++
-		default:
-			t.Fatalf("unexpected status %d; want one 200 and one 409", c)
-		}
+	firstDone := make(chan int, 1)
+	go func() {
+		resp := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
+		_ = resp.Body.Close()
+		firstDone <- resp.StatusCode
+	}()
+	select {
+	case <-reserved:
+	case <-time.After(time.Second):
+		t.Fatal("first request did not reserve its nonce before redeeming the invite")
 	}
-	if accepted != 1 || conflicted != 1 {
-		t.Fatalf("accepted=%d conflicted=%d, want exactly one of each", accepted, conflicted)
+
+	secondDone := make(chan int, 1)
+	go func() {
+		resp := postJSON(t, ts+RouteSession, createReq{Code: "good", RunNonce: nonce})
+		_ = resp.Body.Close()
+		secondDone <- resp.StatusCode
+	}()
+	select {
+	case status := <-secondDone:
+		if status != http.StatusConflict {
+			t.Fatalf("duplicate status = %d, want 409 before the first request redeems", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("duplicate request reached redemption instead of being refused by the nonce reservation")
+	}
+
+	close(releaseFirst)
+	select {
+	case status := <-firstDone:
+		if status != http.StatusOK {
+			t.Fatalf("first request status = %d, want 200", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first request did not finish after redemption was released")
 	}
 
 	// The refused racer must not have spent budget. Drain the remaining

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -189,6 +189,10 @@ type Server struct {
 	// same id, so without the reservation two concurrent starts on one nonce
 	// each consume an allocation while only one refund can find its record.
 	pending map[string]struct{}
+	// beforeGateRedeem provides a test-only rendezvous after a nonce has been
+	// reserved and before the invite allocation is spent. It is nil in every
+	// production server.
+	beforeGateRedeem func()
 }
 
 // defaultMaxMessagesPerSession bounds one session's model calls when the operator
@@ -379,6 +383,9 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
 		delete(s.pending, sid)
 		s.mu.Unlock()
+	}
+	if s.beforeGateRedeem != nil {
+		s.beforeGateRedeem()
 	}
 	token, claims, err := s.cfg.Gate.Redeem(body.Code, sid)
 	if err != nil {

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -852,6 +852,13 @@ func parseSessionDelegation(body createReq, required bool) (ed25519.PrivateKey, 
 	if body.SessionSigningKey == "" || len(body.OrchestratorDelegation) == 0 {
 		return nil, nil, errors.New("session signing key and delegation must both be present")
 	}
+	// The run nonce is what ties this delegation to this run. Without one the
+	// server would mint a random session id and sign a manifest for a run the
+	// delegation never authorized, so an absent nonce is a refusal rather than
+	// a skipped check.
+	if body.RunNonce == "" {
+		return nil, nil, errors.New("delegated session requires a run nonce")
+	}
 	priv, err := playground.ParseOrchestratorPrivateKeyHex(body.SessionSigningKey)
 	if err != nil {
 		return nil, nil, err
@@ -860,8 +867,11 @@ func parseSessionDelegation(body createReq, required bool) (ed25519.PrivateKey, 
 	if err != nil {
 		return nil, nil, err
 	}
-	if body.RunNonce != "" && d.RunNonce != body.RunNonce {
-		return nil, nil, errors.New("delegation run_nonce does not match")
+	// Parsing only proves the delegation is well formed. Verify it against the
+	// compiled published root, never against a root the delegation names, or a
+	// caller holding an invite code could authorize its own session key.
+	if err := playground.VerifySessionDelegation(priv, d, body.RunNonce); err != nil {
+		return nil, nil, err
 	}
 	return priv, &d, nil
 }

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -424,6 +424,17 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusServiceUnavailable, "the demo is paused")
 		return
 	}
+	// The session id is the caller-supplied run nonce, so two accepted requests
+	// can carry the same one. Overwriting would orphan the first session: its
+	// timer still closes over this id and would finalize the replacement
+	// instead, leaving the original running with nothing able to reap it.
+	// Refuse the duplicate and let this request's own cleanup run.
+	if _, exists := s.sessions[sid]; exists {
+		s.mu.Unlock()
+		cleanupStartedSession()
+		writeErr(w, http.StatusConflict, "a session for this run is already active")
+		return
+	}
 	s.sessions[sid] = entry
 	entry.timer = time.AfterFunc(ttl, func() { s.finalize(sid) })
 	s.mu.Unlock()

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -6,6 +6,7 @@ package livechat
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -77,8 +78,12 @@ type ServerConfig struct {
 	Containment playground.ContainmentVerifier
 	// OrchestratorKeyPath / ToyAgentBin / WebToolBin are forwarded to sessions.
 	OrchestratorKeyPath string
-	ToyAgentBin         string
-	WebToolBin          string
+	// RequireDelegatedSigning refuses a session that does not carry a
+	// broker-minted session key and root-signed delegation. Production VMs
+	// set this so the durable root never has to exist on the guest.
+	RequireDelegatedSigning bool
+	ToyAgentBin             string
+	WebToolBin              string
 	// ProxyPort is the fixed loopback port each session's in-process proxy binds.
 	// It must match the single port the kernel owner-match rule allows the
 	// contained agent uid to reach (`pipelock contain install --proxy-port`). 0 =
@@ -271,7 +276,10 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 type createReq struct {
-	Code string `json:"code"`
+	Code                   string          `json:"code"`
+	RunNonce               string          `json:"run_nonce,omitempty"`
+	SessionSigningKey      string          `json:"session_signing_key,omitempty"`
+	OrchestratorDelegation json.RawMessage `json:"orchestrator_delegation,omitempty"`
 }
 
 type createResp struct {
@@ -302,12 +310,17 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body createReq
-	if err := decodeJSON(r, &body, "code"); err != nil {
+	if err := decodeJSON(r, &body, "code", "run_nonce", "session_signing_key", "orchestrator_delegation"); err != nil {
 		writeErr(w, http.StatusBadRequest, "bad request")
 		return
 	}
 	if body.Code == "" {
 		writeErr(w, http.StatusUnauthorized, "invite code required")
+		return
+	}
+	sessionPriv, delegation, err := parseSessionDelegation(body, s.cfg.RequireDelegatedSigning)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "session signing required")
 		return
 	}
 	if !s.budget.Open() {
@@ -328,6 +341,9 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		release()
 		writeErr(w, http.StatusInternalServerError, "internal error")
 		return
+	}
+	if body.RunNonce != "" {
+		sid = body.RunNonce
 	}
 	token, claims, err := s.cfg.Gate.Redeem(body.Code, sid)
 	if err != nil {
@@ -362,6 +378,8 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		RequireContainment:  s.cfg.RequireContainment,
 		Containment:         s.cfg.Containment,
 		OrchestratorKeyPath: s.cfg.OrchestratorKeyPath,
+		SessionPrivateKey:   sessionPriv,
+		Delegation:          delegation,
 		ToyAgentBin:         s.cfg.ToyAgentBin,
 		WebToolBin:          s.cfg.WebToolBin,
 		ProxyPort:           s.cfg.ProxyPort,
@@ -822,6 +840,30 @@ func gateErrStatus(err error) int {
 		// Unknown / exhausted codes are an auth failure from the client's view.
 		return http.StatusUnauthorized
 	}
+}
+
+func parseSessionDelegation(body createReq, required bool) (ed25519.PrivateKey, *playground.OrchestratorDelegation, error) {
+	if len(body.SessionSigningKey) == 0 && len(body.OrchestratorDelegation) == 0 {
+		if required {
+			return nil, nil, errors.New("session signing required")
+		}
+		return nil, nil, nil
+	}
+	if body.SessionSigningKey == "" || len(body.OrchestratorDelegation) == 0 {
+		return nil, nil, errors.New("session signing key and delegation must both be present")
+	}
+	priv, err := playground.ParseOrchestratorPrivateKeyHex(body.SessionSigningKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	d, err := playground.ParseOrchestratorDelegation(body.OrchestratorDelegation)
+	if err != nil {
+		return nil, nil, err
+	}
+	if body.RunNonce != "" && d.RunNonce != body.RunNonce {
+		return nil, nil, errors.New("delegation run_nonce does not match")
+	}
+	return priv, &d, nil
 }
 
 func decodeJSON(r *http.Request, v any, allowedKeys ...string) error {

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -842,6 +842,12 @@ func gateErrStatus(err error) int {
 	}
 }
 
+// verifySessionDelegation is the package's single verification entry point. It
+// is a variable only so tests can observe that the request's own run nonce is
+// what reaches verification; nothing outside this package can replace it, so no
+// deployment can weaken the check.
+var verifySessionDelegation = playground.VerifySessionDelegation
+
 func parseSessionDelegation(body createReq, required bool) (ed25519.PrivateKey, *playground.OrchestratorDelegation, error) {
 	if len(body.SessionSigningKey) == 0 && len(body.OrchestratorDelegation) == 0 {
 		if required {
@@ -870,7 +876,7 @@ func parseSessionDelegation(body createReq, required bool) (ed25519.PrivateKey, 
 	// Parsing only proves the delegation is well formed. Verify it against the
 	// compiled published root, never against a root the delegation names, or a
 	// caller holding an invite code could authorize its own session key.
-	if err := playground.VerifySessionDelegation(priv, d, body.RunNonce); err != nil {
+	if err := verifySessionDelegation(priv, d, body.RunNonce); err != nil {
 		return nil, nil, err
 	}
 	return priv, &d, nil

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -184,6 +184,11 @@ type Server struct {
 
 	mu       sync.Mutex
 	sessions map[string]*liveEntry
+	// pending holds run nonces claimed by an in-flight start that does not yet
+	// have a session entry. Redeeming an invite keys its refund record by this
+	// same id, so without the reservation two concurrent starts on one nonce
+	// each consume an allocation while only one refund can find its record.
+	pending map[string]struct{}
 }
 
 // defaultMaxMessagesPerSession bounds one session's model calls when the operator
@@ -241,6 +246,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		maxMsgPerSession: maxMsg,
 		roundTripsPerMsg: roundTripsPerMsg,
 		sessions:         make(map[string]*liveEntry),
+		pending:          make(map[string]struct{}),
 	}, nil
 }
 
@@ -287,6 +293,22 @@ type createResp struct {
 	SessionID string `json:"session_id"`
 	ExpiresAt string `json:"expires_at"`
 	State     string `json:"state"`
+}
+
+// reserveRunNonce claims a run nonce for an in-flight start. It reports false
+// when the nonce already has a live session or another start in flight, which is
+// what keeps a duplicate from consuming a second invite allocation.
+func (s *Server) reserveRunNonce(sid string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, live := s.sessions[sid]; live {
+		return false
+	}
+	if _, inflight := s.pending[sid]; inflight {
+		return false
+	}
+	s.pending[sid] = struct{}{}
+	return true
 }
 
 func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
@@ -345,14 +367,29 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	if body.RunNonce != "" {
 		sid = body.RunNonce
 	}
+	// Claim the nonce before spending any invite budget. Gate.Redeem keys its
+	// refund record by this id, so a duplicate that got as far as redeeming
+	// would leave one of the two allocations permanently unrefundable.
+	if !s.reserveRunNonce(sid) {
+		release()
+		writeErr(w, http.StatusConflict, "a session for this run is already active")
+		return
+	}
+	releaseRunNonce := func() {
+		s.mu.Lock()
+		delete(s.pending, sid)
+		s.mu.Unlock()
+	}
 	token, claims, err := s.cfg.Gate.Redeem(body.Code, sid)
 	if err != nil {
+		releaseRunNonce()
 		release()
 		writeErr(w, gateErrStatus(err), "invite code rejected")
 		return
 	}
 	if !s.codeRate.Allow("code:" + claims.CodeID) {
 		s.cfg.Gate.Refund(claims)
+		releaseRunNonce()
 		release()
 		writeErr(w, http.StatusTooManyRequests, "rate limited")
 		return
@@ -368,6 +405,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.cfg.Gate.Refund(claims)
 		cancel()
+		releaseRunNonce()
 		release()
 		writeErr(w, http.StatusInternalServerError, "internal error")
 		return
@@ -389,6 +427,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		_ = os.RemoveAll(runDir)
 		s.cfg.Gate.Refund(claims)
 		cancel()
+		releaseRunNonce()
 		release()
 		// Containment refusal is the most likely cause and is fail-closed.
 		writeErr(w, http.StatusServiceUnavailable, "session could not be started")
@@ -408,6 +447,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		_ = os.RemoveAll(runDir)
 		s.cfg.Gate.Refund(claims)
 		cancel()
+		releaseRunNonce()
 		release()
 	}
 	ttl := time.Until(claims.ExpiresAt)
@@ -435,6 +475,7 @@ func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusConflict, "a session for this run is already active")
 		return
 	}
+	delete(s.pending, sid)
 	s.sessions[sid] = entry
 	entry.timer = time.AfterFunc(ttl, func() { s.finalize(sid) })
 	s.mu.Unlock()

--- a/internal/playground/livechat/server_delegation_test.go
+++ b/internal/playground/livechat/server_delegation_test.go
@@ -40,7 +40,11 @@ func TestServer_RequireDelegatedSigning_RefusesBareCode(t *testing.T) {
 	}
 }
 
-func TestServer_DelegatedSession_Starts(t *testing.T) {
+// A delegation is only as good as the root that signed it. This server sits
+// outside the package that owns the trusted identity, so it can prove the
+// refusal a foreign root must produce; the accepted path is proven in the
+// playground package where the trusted root can be set.
+func TestServer_DelegatedSession_RefusesForeignRoot(t *testing.T) {
 	t.Parallel()
 	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
 	if err != nil {
@@ -79,8 +83,11 @@ func TestServer_DelegatedSession_Starts(t *testing.T) {
 		OrchestratorDelegation: delJSON,
 	})
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("delegated session status = %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatal("a delegation signed by an untrusted root must not start a session")
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("foreign-root session status = %d, want 400", resp.StatusCode)
 	}
 }
 

--- a/internal/playground/livechat/server_delegation_test.go
+++ b/internal/playground/livechat/server_delegation_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package livechat
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestServer_RequireDelegatedSigning_RefusesBareCode(t *testing.T) {
+	t.Parallel()
+	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:                    g,
+		MaxConcurrent:           2,
+		IPRate:                  RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:                RateConfig{RefillPerSec: 1000, Burst: 1000},
+		RequireDelegatedSigning: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptestServer(t, srv)
+	resp := postJSON(t, ts+RouteSession, createReq{Code: "good"})
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bare code status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestServer_DelegatedSession_Starts(t *testing.T) {
+	t.Parallel()
+	g, err := NewGate(GateConfig{Secret: testSecret(t), Codes: []CodeSpec{{Code: "good", MaxSessions: 5}}, TokenTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("NewGate: %v", err)
+	}
+	srv, err := NewServer(ServerConfig{
+		Gate:                    g,
+		MaxConcurrent:           2,
+		IPRate:                  RateConfig{RefillPerSec: 1000, Burst: 1000},
+		CodeRate:                RateConfig{RefillPerSec: 1000, Burst: 1000},
+		RequireDelegatedSigning: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptestServer(t, srv)
+
+	_, rootPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := "sha256:" + strings.Repeat("ab", 32)
+	runNonce := "aa" + strings.Repeat("bb", 15)
+	minted, err := playground.MintSessionDelegation(rootPriv, runNonce, image, time.Now().UTC(), time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delJSON, err := json.Marshal(minted.Delegation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := postJSON(t, ts+RouteSession, createReq{
+		Code:                   "good",
+		RunNonce:               runNonce,
+		SessionSigningKey:      hex.EncodeToString(minted.PrivateKey),
+		OrchestratorDelegation: delJSON,
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delegated session status = %d", resp.StatusCode)
+	}
+}
+
+func httptestServer(t *testing.T, srv *Server) string {
+	t.Helper()
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); srv.Close() })
+	return ts.URL
+}

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -300,11 +300,14 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		if opts.Delegation == nil {
 			return nil, fmt.Errorf("session signing key requires a root-signed delegation")
 		}
+		// Verify at the signing boundary too. A direct caller reaches this
+		// path without passing through the server's check, and an unverified
+		// delegation would sign a run no published key authorized.
+		if err := VerifySessionDelegation(opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); err != nil {
+			return nil, fmt.Errorf("session delegation: %w", err)
+		}
 		lr.orchestratorPriv = opts.SessionPrivateKey
 		lr.orchestratorPub = lr.orchestratorPriv.Public().(ed25519.PublicKey)
-		if hex.EncodeToString(lr.orchestratorPub) != opts.Delegation.SessionPublicKey {
-			return nil, fmt.Errorf("session signing key does not match delegation")
-		}
 	case opts.OrchestratorKeyPath != "":
 		var loadErr error
 		lr.orchestratorPriv, loadErr = LoadOrchestratorSigningKey(opts.OrchestratorKeyPath)

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -293,6 +293,11 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 	// loads a durable key for local/legacy runs. Empty means an ephemeral
 	// per-run key (dev default).
 	switch {
+	case opts.Delegation != nil && len(opts.SessionPrivateKey) == 0:
+		// The manifest records the delegation regardless of which signer is
+		// selected, so a delegation without its session key would produce a
+		// run claiming an authorization its actual signer never held.
+		return nil, fmt.Errorf("delegation requires the session signing key it authorizes")
 	case len(opts.SessionPrivateKey) != 0:
 		if err := signing.ValidatePrivateKeyConsistency(opts.SessionPrivateKey); err != nil {
 			return nil, fmt.Errorf("session signing key: %w", err)

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -297,19 +297,27 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		// The manifest records the delegation regardless of which signer is
 		// selected, so a delegation without its session key would produce a
 		// run claiming an authorization its actual signer never held.
-		return nil, fmt.Errorf("delegation requires the session signing key it authorizes")
+		//
+		// Each refusal below assigns the named err before returning, because
+		// the deferred cleanup keys on it; a bare return would skip lr.Close()
+		// and leave this run's context attached to its parent.
+		err = fmt.Errorf("delegation requires the session signing key it authorizes")
+		return nil, err
 	case len(opts.SessionPrivateKey) != 0:
-		if err := signing.ValidatePrivateKeyConsistency(opts.SessionPrivateKey); err != nil {
-			return nil, fmt.Errorf("session signing key: %w", err)
+		if keyErr := signing.ValidatePrivateKeyConsistency(opts.SessionPrivateKey); keyErr != nil {
+			err = fmt.Errorf("session signing key: %w", keyErr)
+			return nil, err
 		}
 		if opts.Delegation == nil {
-			return nil, fmt.Errorf("session signing key requires a root-signed delegation")
+			err = fmt.Errorf("session signing key requires a root-signed delegation")
+			return nil, err
 		}
 		// Verify at the signing boundary too. A direct caller reaches this
 		// path without passing through the server's check, and an unverified
 		// delegation would sign a run no published key authorized.
-		if err := VerifySessionDelegation(opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); err != nil {
-			return nil, fmt.Errorf("session delegation: %w", err)
+		if delErr := VerifySessionDelegation(opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); delErr != nil {
+			err = fmt.Errorf("session delegation: %w", delErr)
+			return nil, err
 		}
 		lr.orchestratorPriv = opts.SessionPrivateKey
 		lr.orchestratorPub = lr.orchestratorPriv.Public().(ed25519.PublicKey)

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -99,6 +99,13 @@ type LiveRunOpts struct {
 	// OrchestratorKeyPath, when non-empty, loads the run's orchestrator
 	// (trust-root) signing key from disk instead of generating an ephemeral one.
 	OrchestratorKeyPath string
+	// SessionPrivateKey, when set, is the short-lived session signer minted by
+	// the broker. It takes precedence over OrchestratorKeyPath. The durable
+	// root private key must not be supplied here.
+	SessionPrivateKey ed25519.PrivateKey
+	// Delegation, when set, is written into the run directory and bound into
+	// the launch manifest before signing.
+	Delegation *OrchestratorDelegation
 	// ModelBaseURL, when non-empty, allowlists the model API host in the lab
 	// proxy so a model-backed agent's chat-completions calls can egress through
 	// it. This is the ONLY real-egress destination the lab proxy permits; the
@@ -147,6 +154,7 @@ type LiveRun struct {
 	// Scenario / config
 	scenario    replaycapture.Scenario
 	manifest    LaunchManifest
+	delegation  *OrchestratorDelegation
 	opts        LiveRunOpts
 	evidenceDir string
 	policyHash  string
@@ -281,11 +289,23 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 	}()
 
 	// --- Key generation ---
-	// The orchestrator key is the run's trust root. When a stable key path is
-	// supplied, load it (so the run signs under the published demo key and is
-	// verifiable against PublishedOrchestratorPubKeyHex); otherwise generate an
-	// ephemeral per-run key (the dev default).
-	if opts.OrchestratorKeyPath != "" {
+	// Delegated live sessions sign with a broker-minted session key. A path
+	// loads a durable key for local/legacy runs. Empty means an ephemeral
+	// per-run key (dev default).
+	switch {
+	case len(opts.SessionPrivateKey) != 0:
+		if err := signing.ValidatePrivateKeyConsistency(opts.SessionPrivateKey); err != nil {
+			return nil, fmt.Errorf("session signing key: %w", err)
+		}
+		if opts.Delegation == nil {
+			return nil, fmt.Errorf("session signing key requires a root-signed delegation")
+		}
+		lr.orchestratorPriv = opts.SessionPrivateKey
+		lr.orchestratorPub = lr.orchestratorPriv.Public().(ed25519.PublicKey)
+		if hex.EncodeToString(lr.orchestratorPub) != opts.Delegation.SessionPublicKey {
+			return nil, fmt.Errorf("session signing key does not match delegation")
+		}
+	case opts.OrchestratorKeyPath != "":
 		var loadErr error
 		lr.orchestratorPriv, loadErr = LoadOrchestratorSigningKey(opts.OrchestratorKeyPath)
 		if loadErr != nil {
@@ -299,7 +319,7 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 			err = fmt.Errorf("default orchestrator key %s does not match PublishedOrchestratorPubKeyHex", opts.OrchestratorKeyPath)
 			return nil, err
 		}
-	} else {
+	default:
 		lr.orchestratorPub, lr.orchestratorPriv, err = signing.GenerateKeyPair()
 		if err != nil {
 			return nil, fmt.Errorf("orchestrator keygen: %w", err)
@@ -458,6 +478,12 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		StartedAt:       time.Now().UTC(),
 		Contained:       opts.Contained,
 		AgentKind:       manifestAgentKind(opts.ModelBaseURL),
+	}
+	if opts.Delegation != nil {
+		d := *opts.Delegation
+		lr.delegation = &d
+		lr.manifest.DelegationID = d.DelegationID
+		lr.manifest.ImageDigest = d.ImageDigest
 	}
 	lr.manifest = SignLaunchManifest(lr.orchestratorPriv, lr.manifest)
 
@@ -809,6 +835,16 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	lmPath := filepath.Join(runDir, "launch-manifest.json")
 	if err := os.WriteFile(lmPath, lmBytes, 0o600); err != nil {
 		return VerifyReport{}, fmt.Errorf("write launch manifest: %w", err)
+	}
+	if lr.delegation != nil {
+		dBytes, dErr := json.Marshal(lr.delegation)
+		if dErr != nil {
+			return VerifyReport{}, fmt.Errorf("marshal orchestrator delegation: %w", dErr)
+		}
+		dPath := filepath.Join(runDir, orchestratorDelegationFile)
+		if err := os.WriteFile(dPath, dBytes, 0o600); err != nil {
+			return VerifyReport{}, fmt.Errorf("write orchestrator delegation: %w", err)
+		}
 	}
 
 	// --- Write witness ---

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -16,12 +16,18 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
+// testRunRoot generates a root and makes it the trusted delegation root for
+// the duration of the test. Production always trusts the compiled published
+// identity; this only lets the tests mint delegations that verify.
 func testRunRoot(t *testing.T) ed25519.PrivateKey {
 	t.Helper()
-	_, priv, err := signing.GenerateKeyPair()
+	pub, priv, err := signing.GenerateKeyPair()
 	if err != nil {
 		t.Fatalf("GenerateKeyPair: %v", err)
 	}
+	prev := trustedDelegationRoot
+	trustedDelegationRoot = func() (ed25519.PublicKey, error) { return pub, nil }
+	t.Cleanup(func() { trustedDelegationRoot = prev })
 	return priv
 }
 
@@ -139,7 +145,7 @@ func TestStartLiveRun_RefusesUnauthorizedSessionKey(t *testing.T) {
 		{
 			name: "key_not_named_by_delegation",
 			opts: LiveRunOpts{SessionPrivateKey: minted.PrivateKey, Delegation: &other.Delegation},
-			want: "does not match delegation",
+			want: "does not authorize this session signing key",
 		},
 		{
 			name: "malformed_key",
@@ -163,6 +169,69 @@ func TestStartLiveRun_RefusesUnauthorizedSessionKey(t *testing.T) {
 	}
 }
 
+// A delegation signed by a root the deployment does not trust must be refused
+// even when it is internally consistent. Without this an invite-code holder
+// could sign its own delegation and start an authorized-looking session.
+func TestStartLiveRun_RefusesUntrustedRoot(t *testing.T) {
+	trusted := testRunRoot(t)
+	_ = trusted
+
+	_, foreign, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	const nonce = "foreign-root-nonce"
+	minted, err := MintSessionDelegation(foreign, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err == nil {
+		lr.Close()
+		t.Fatal("a delegation from an untrusted root must be refused")
+	}
+	if !strings.Contains(err.Error(), "root") {
+		t.Fatalf("error = %v, want it to name the root mismatch", err)
+	}
+}
+
+// A run nonce that the delegation does not name must be refused, and an absent
+// nonce must be refused rather than silently skipping the binding.
+func TestStartLiveRun_RequiresBoundRunNonce(t *testing.T) {
+	root := testRunRoot(t)
+	minted, err := MintSessionDelegation(root, "authorized-run", testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		nonce string
+	}{
+		{name: "different_run", nonce: "some-other-run"},
+		{name: "absent_run_nonce", nonce: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+				ScenarioID:        LiveDemoScenarioID,
+				RunNonce:          tc.nonce,
+				SessionPrivateKey: minted.PrivateKey,
+				Delegation:        &minted.Delegation,
+			})
+			if err == nil {
+				lr.Close()
+				t.Fatal("a delegation not bound to this run must be refused")
+			}
+		})
+	}
+}
+
 // A zero lifetime takes the default window rather than minting a delegation
 // that is already expired.
 func TestMintSessionDelegation_ZeroLifetimeUsesDefault(t *testing.T) {
@@ -174,6 +243,15 @@ func TestMintSessionDelegation_ZeroLifetimeUsesDefault(t *testing.T) {
 	window := minted.Delegation.ExpiresAtUnix - minted.Delegation.NotBeforeUnix
 	if want := int64(DefaultSessionDelegationLifetime / time.Second); window != want {
 		t.Fatalf("delegation window = %ds, want %ds", window, want)
+	}
+}
+
+// A sub-second lifetime truncates to a zero-length window in a second-precision
+// format, so it is refused rather than minted already-expired.
+func TestMintSessionDelegation_RejectsSubSecondLifetime(t *testing.T) {
+	root := testRunRoot(t)
+	if _, err := MintSessionDelegation(root, "n", testRunImageDigest, time.Now().UTC(), 500*time.Millisecond); err == nil {
+		t.Fatal("a sub-second delegation lifetime must be refused")
 	}
 }
 

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func testRunRoot(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	return priv
+}
+
+const testRunImageDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+// A delegated run signs with the broker-minted session key, and the launch
+// manifest records which delegation authorized it and which image it ran on.
+// Without that binding a captured run could be replayed as though it came from
+// a different image.
+func TestStartLiveRun_DelegatedSessionBindsManifest(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "delegated-run-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err != nil {
+		t.Fatalf("StartLiveRun: %v", err)
+	}
+	defer lr.Close()
+
+	if hex.EncodeToString(lr.orchestratorPriv) != hex.EncodeToString(minted.PrivateKey) {
+		t.Fatal("the run must sign with the broker-minted session key")
+	}
+	if hex.EncodeToString(lr.orchestratorPriv) == hex.EncodeToString(root) {
+		t.Fatal("the run must never sign with the durable root")
+	}
+	if lr.manifest.DelegationID != minted.Delegation.DelegationID {
+		t.Fatalf("manifest delegation id = %q, want %q", lr.manifest.DelegationID, minted.Delegation.DelegationID)
+	}
+	if lr.manifest.ImageDigest != testRunImageDigest {
+		t.Fatalf("manifest image digest = %q, want %q", lr.manifest.ImageDigest, testRunImageDigest)
+	}
+}
+
+// The delegation travels with the run directory, so an offline verifier can
+// walk session key back to the published root without contacting anything.
+func TestLiveRun_DelegatedRunWritesDelegationArtifact(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "delegated-artifact-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err != nil {
+		t.Fatalf("StartLiveRun: %v", err)
+	}
+	defer lr.Close()
+
+	// This run executes no steps, so the verify report itself does not pass;
+	// a fully-verifying delegated run is covered by the end-to-end live test.
+	// What matters here is that assembly writes the delegation alongside the
+	// manifest, because that file is what an offline verifier reads.
+	runDir := t.TempDir()
+	_, _ = lr.AssembleAndVerify(runDir)
+
+	raw, err := os.ReadFile(filepath.Clean(filepath.Join(runDir, orchestratorDelegationFile)))
+	if err != nil {
+		t.Fatalf("delegation artifact missing: %v", err)
+	}
+	var got OrchestratorDelegation
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("delegation artifact does not parse: %v", err)
+	}
+	if got.DelegationID != minted.Delegation.DelegationID {
+		t.Fatalf("written delegation id = %q, want %q", got.DelegationID, minted.Delegation.DelegationID)
+	}
+	if got.SessionPublicKey != minted.Delegation.SessionPublicKey {
+		t.Fatal("written delegation does not authorize the key the run signed with")
+	}
+}
+
+// A session key without its delegation, or one the delegation does not name,
+// must refuse to start. Either would produce a run nothing can trace to the
+// published root.
+func TestStartLiveRun_RefusesUnauthorizedSessionKey(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "refusal-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	other, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts LiveRunOpts
+		want string
+	}{
+		{
+			name: "key_without_delegation",
+			opts: LiveRunOpts{SessionPrivateKey: minted.PrivateKey},
+			want: "requires a root-signed delegation",
+		},
+		{
+			name: "key_not_named_by_delegation",
+			opts: LiveRunOpts{SessionPrivateKey: minted.PrivateKey, Delegation: &other.Delegation},
+			want: "does not match delegation",
+		},
+		{
+			name: "malformed_key",
+			opts: LiveRunOpts{SessionPrivateKey: ed25519.PrivateKey("short"), Delegation: &minted.Delegation},
+			want: "session signing key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			opts.ScenarioID = LiveDemoScenarioID
+			opts.RunNonce = nonce
+			lr, err := StartLiveRun(t.Context(), opts)
+			if err == nil {
+				lr.Close()
+				t.Fatal("an unauthorized session key must be refused")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A zero lifetime takes the default window rather than minting a delegation
+// that is already expired.
+func TestMintSessionDelegation_ZeroLifetimeUsesDefault(t *testing.T) {
+	root := testRunRoot(t)
+	minted, err := MintSessionDelegation(root, "n", testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	window := minted.Delegation.ExpiresAtUnix - minted.Delegation.NotBeforeUnix
+	if want := int64(DefaultSessionDelegationLifetime / time.Second); window != want {
+		t.Fatalf("delegation window = %ds, want %ds", window, want)
+	}
+}
+
+// The hex parser fails closed on every malformed shape rather than handing back
+// a key that cannot produce verifiable signatures.
+func TestParseOrchestratorPrivateKeyHex_RejectsMalformedShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{name: "not_hex", in: "zz"},
+		{name: "wrong_size", in: hex.EncodeToString([]byte("short"))},
+		{name: "seed_public_mismatch", in: strings.Repeat("ab", ed25519.PrivateKeySize)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseOrchestratorPrivateKeyHex(tc.in); err == nil {
+				t.Fatalf("%q must be refused", tc.name)
+			}
+		})
+	}
+}

--- a/internal/playground/orchestrator_key.go
+++ b/internal/playground/orchestrator_key.go
@@ -26,12 +26,15 @@ import (
 // meaningful: a VERIFY OK means "signed by the key you already trust", not
 // "internally consistent with a key the download handed you".
 //
-// It is a FIXED demo identity with no security stakes — the demo proves the
-// Pipelock mechanism; the key only needs to be stable and published. It is
-// generated once and never rotated, and is deliberately NOT any production
-// signing key (not the license signer, not a customer key). Empty until the
-// stable keypair is generated and published (see `keygen-orchestrator`).
-const PublishedOrchestratorPubKeyHex = "539bda06995b228e55af68c05c41cee14b060041ff4d0c13fcf13544e922abcb"
+// It is a demo identity with no production security stakes — the demo proves
+// the Pipelock mechanism; the key only needs to be published so an offline
+// verifier can look it up ahead of time. It is deliberately NOT any production
+// signing key (not the license signer, not a customer key).
+//
+// Rotated 2026-09-03 after the previous private half was exposed in a
+// machine-inventory dump. Bundles signed by the prior identity
+// (539bda06…e922abcb) no longer verify against this key.
+const PublishedOrchestratorPubKeyHex = "99f16ec99b3f55180f75a025affa6a9cced3e559a38590fa6cac48a736221a2c"
 
 // orchestratorKeyConfigDir/File locate the stable orchestrator PRIVATE key on
 // disk. The private key is never committed (the demo key has no security stakes

--- a/internal/playground/orchestrator_key.go
+++ b/internal/playground/orchestrator_key.go
@@ -98,6 +98,21 @@ func LoadOrchestratorSigningKey(path string) (ed25519.PrivateKey, error) {
 	return priv, nil
 }
 
+// PublishedOrchestratorPublicKey decodes the compiled published demo public
+// key. Every delegation is verified against this value rather than against a
+// root supplied by whoever sent the delegation, because a caller-chosen root
+// would let a caller authorize its own session key.
+func PublishedOrchestratorPublicKey() (ed25519.PublicKey, error) {
+	raw, err := hex.DecodeString(PublishedOrchestratorPubKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("published orchestrator key is not hex: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("published orchestrator key has wrong size: got %d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
 // OrchestratorKeyMatchesPublished reports whether priv derives the compiled
 // published demo public key.
 func OrchestratorKeyMatchesPublished(priv ed25519.PrivateKey) bool {

--- a/internal/playground/published_root_test.go
+++ b/internal/playground/published_root_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// The published root is the only identity a delegation may be signed by, and
+// every shipped verifier pins the same constant. If it stopped decoding to a
+// usable Ed25519 key, delegated sessions would fail closed everywhere at once.
+func TestPublishedOrchestratorPublicKey(t *testing.T) {
+	pub, err := PublishedOrchestratorPublicKey()
+	if err != nil {
+		t.Fatalf("published root does not decode: %v", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		t.Fatalf("published root is %d bytes, want %d", len(pub), ed25519.PublicKeySize)
+	}
+	if hex.EncodeToString(pub) != PublishedOrchestratorPubKeyHex {
+		t.Fatal("decoded root does not round-trip to the published constant")
+	}
+}
+
+// A delegation verifies only under the root that signed it, and only for the
+// run and session key it names. These are the checks that stop a caller from
+// authorizing its own session.
+func TestVerifySessionDelegation(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "verify-session-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	other, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	if err := VerifySessionDelegation(minted.PrivateKey, minted.Delegation, nonce); err != nil {
+		t.Fatalf("a matching delegation was rejected: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		priv  ed25519.PrivateKey
+		d     OrchestratorDelegation
+		nonce string
+	}{
+		{name: "absent_nonce", priv: minted.PrivateKey, d: minted.Delegation, nonce: ""},
+		{name: "wrong_nonce", priv: minted.PrivateKey, d: minted.Delegation, nonce: "another-run"},
+		{name: "key_not_authorized", priv: minted.PrivateKey, d: other.Delegation, nonce: nonce},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := VerifySessionDelegation(tc.priv, tc.d, tc.nonce); err == nil {
+				t.Fatal("expected a refusal")
+			}
+		})
+	}
+}
+
+// A tampered signature must not verify, which is the property that makes the
+// root check meaningful rather than structural.
+func TestVerifySessionDelegation_RejectsTamperedSignature(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "tamper-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	tampered := minted.Delegation
+	sig, err := hex.DecodeString(tampered.Signature)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	sig[0] ^= 0xff
+	tampered.Signature = hex.EncodeToString(sig)
+
+	if err := VerifySessionDelegation(minted.PrivateKey, tampered, nonce); err == nil {
+		t.Fatal("a tampered delegation signature must be refused")
+	}
+}
+
+// Minting refuses claims the delegation format rejects, rather than emitting a
+// signed delegation that no verifier will accept.
+func TestMintSessionDelegation_RejectsInvalidClaims(t *testing.T) {
+	root := testRunRoot(t)
+	for _, tc := range []struct {
+		name   string
+		nonce  string
+		digest string
+	}{
+		{name: "empty_image_digest", nonce: "a-run", digest: ""},
+		{name: "empty_run_nonce", nonce: "", digest: testRunImageDigest},
+		{name: "non_canonical_digest", nonce: "a-run", digest: "not-a-digest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := MintSessionDelegation(root, tc.nonce, tc.digest, time.Now().UTC(), time.Hour); err == nil {
+				t.Fatal("invalid delegation claims must be refused at mint time")
+			}
+		})
+	}
+}

--- a/internal/playground/published_root_test.go
+++ b/internal/playground/published_root_test.go
@@ -6,6 +6,7 @@ package playground
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 )
@@ -106,5 +107,69 @@ func TestMintSessionDelegation_RejectsInvalidClaims(t *testing.T) {
 				t.Fatal("invalid delegation claims must be refused at mint time")
 			}
 		})
+	}
+}
+
+// The launch manifest records the delegation whichever signer is chosen, so a
+// delegation supplied without its session key would produce a run claiming an
+// authorization its signer never held. Both other signer branches must refuse.
+func TestStartLiveRun_RefusesDelegationWithoutSessionKey(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "no-session-key-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts LiveRunOpts
+	}{
+		{
+			name: "ephemeral_signer_branch",
+			opts: LiveRunOpts{Delegation: &minted.Delegation},
+		},
+		{
+			name: "durable_key_path_branch",
+			opts: LiveRunOpts{Delegation: &minted.Delegation, OrchestratorKeyPath: "/nonexistent/orchestrator.key"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			opts.ScenarioID = LiveDemoScenarioID
+			opts.RunNonce = nonce
+			lr, err := StartLiveRun(t.Context(), opts)
+			if err == nil {
+				lr.Close()
+				t.Fatal("a delegation without its session signing key must be refused")
+			}
+			if !strings.Contains(err.Error(), "session signing key") {
+				t.Fatalf("error = %v, want it to name the missing session signing key", err)
+			}
+		})
+	}
+}
+
+// The nonce binding is asserted here rather than in the livechat package,
+// because only this package can make signature verification succeed first. If
+// the nonce check regressed, this test is what would catch it.
+func TestVerifySessionDelegation_NonceMismatchIsTheRefusal(t *testing.T) {
+	root := testRunRoot(t)
+	minted, err := MintSessionDelegation(root, "authorized-run", testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	if err := VerifySessionDelegation(minted.PrivateKey, minted.Delegation, "authorized-run"); err != nil {
+		t.Fatalf("the authorized run was rejected: %v", err)
+	}
+
+	err = VerifySessionDelegation(minted.PrivateKey, minted.Delegation, "a-different-run")
+	if err == nil {
+		t.Fatal("a delegation minted for another run must be refused")
+	}
+	if !strings.Contains(err.Error(), "run_nonce") {
+		t.Fatalf("error %v must name the nonce mismatch, not some earlier check", err)
 	}
 }

--- a/internal/playground/session_delegation.go
+++ b/internal/playground/session_delegation.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+// DefaultSessionDelegationLifetime is the maximum playground session
+// authorization window. Live sessions are 30 minutes; this leaves room for
+// seal and verify after expiry.
+const DefaultSessionDelegationLifetime = 2 * time.Hour
+
+// MintedSession is one short-lived signing key plus the root-signed
+// delegation that authorizes it for a single run and image.
+type MintedSession struct {
+	PrivateKey ed25519.PrivateKey
+	Delegation OrchestratorDelegation
+}
+
+// MintSessionDelegation creates a session keypair and a root-signed
+// delegation. The durable root private key never needs to leave the broker.
+func MintSessionDelegation(root ed25519.PrivateKey, runNonce, imageDigest string, now time.Time, lifetime time.Duration) (MintedSession, error) {
+	if err := signing.ValidatePrivateKeyConsistency(root); err != nil {
+		return MintedSession{}, fmt.Errorf("delegation root key: %w", err)
+	}
+	if lifetime <= 0 {
+		lifetime = DefaultSessionDelegationLifetime
+	}
+	sessionPub, sessionPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		return MintedSession{}, fmt.Errorf("session keygen: %w", err)
+	}
+	var id [32]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return MintedSession{}, fmt.Errorf("delegation id: %w", err)
+	}
+	issued := now.UTC().Unix()
+	d := OrchestratorDelegation{
+		Format:           OrchestratorDelegationFormat,
+		RootKeyID:        RootKeyID(root.Public().(ed25519.PublicKey)),
+		DelegationID:     hex.EncodeToString(id[:]),
+		RunNonce:         runNonce,
+		SessionPublicKey: hex.EncodeToString(sessionPub),
+		ImageDigest:      imageDigest,
+		IssuedAtUnix:     issued,
+		NotBeforeUnix:    issued,
+		ExpiresAtUnix:    issued + int64(lifetime/time.Second),
+	}
+	signed, err := SignOrchestratorDelegation(root, d)
+	if err != nil {
+		return MintedSession{}, err
+	}
+	return MintedSession{PrivateKey: sessionPriv, Delegation: signed}, nil
+}
+
+// ParseOrchestratorPrivateKeyHex decodes a hex Ed25519 private key. It fails
+// closed on malformed hex, wrong length, or a seed/public mismatch.
+func ParseOrchestratorPrivateKeyHex(hexKey string) (ed25519.PrivateKey, error) {
+	decoded, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode orchestrator key hex: %w", err)
+	}
+	if len(decoded) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("orchestrator key wrong size: got %d bytes, want %d", len(decoded), ed25519.PrivateKeySize)
+	}
+	priv := ed25519.PrivateKey(decoded)
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return nil, fmt.Errorf("orchestrator key: %w", err)
+	}
+	return priv, nil
+}

--- a/internal/playground/session_delegation.go
+++ b/internal/playground/session_delegation.go
@@ -19,6 +19,37 @@ import (
 // seal and verify after expiry.
 const DefaultSessionDelegationLifetime = 2 * time.Hour
 
+// trustedDelegationRoot resolves the only root a delegation may be signed by.
+// It is a package variable solely so this package's own tests can mint under a
+// generated root; nothing outside this package can reach it, so no deployment
+// can be configured to trust a different identity.
+var trustedDelegationRoot = PublishedOrchestratorPublicKey
+
+// VerifySessionDelegation checks a delegation against the published root and
+// confirms it authorizes exactly this session key for this run. Parsing alone
+// proves only that a delegation is well formed; without this a caller could
+// present a structurally valid delegation it signed itself.
+func VerifySessionDelegation(priv ed25519.PrivateKey, d OrchestratorDelegation, runNonce string) error {
+	if runNonce == "" {
+		return fmt.Errorf("delegated session requires a run nonce")
+	}
+	root, err := trustedDelegationRoot()
+	if err != nil {
+		return err
+	}
+	if err := VerifyOrchestratorDelegation(root, d, DelegationExpectations{RunNonce: runNonce}); err != nil {
+		return err
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("session signing key has no ed25519 public half")
+	}
+	if hex.EncodeToString(pub) != d.SessionPublicKey {
+		return fmt.Errorf("delegation does not authorize this session signing key")
+	}
+	return nil
+}
+
 // MintedSession is one short-lived signing key plus the root-signed
 // delegation that authorizes it for a single run and image.
 type MintedSession struct {
@@ -34,6 +65,12 @@ func MintSessionDelegation(root ed25519.PrivateKey, runNonce, imageDigest string
 	}
 	if lifetime <= 0 {
 		lifetime = DefaultSessionDelegationLifetime
+	}
+	// The delegation format carries second precision, so a sub-second lifetime
+	// truncates to zero and mints a delegation that expires the instant it is
+	// issued. Refuse rather than emit one nothing can use.
+	if lifetime < time.Second {
+		return MintedSession{}, fmt.Errorf("delegation lifetime %s is below the one-second format precision", lifetime)
 	}
 	sessionPub, sessionPriv, err := signing.GenerateKeyPair()
 	if err != nil {

--- a/internal/playground/session_delegation_test.go
+++ b/internal/playground/session_delegation_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+func TestMintSessionDelegation_RoundTrip(t *testing.T) {
+	t.Parallel()
+	rootPub, rootPriv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := "sha256:" + strings.Repeat("ab", 32)
+	minted, err := MintSessionDelegation(rootPriv, "run-nonce-1", image, time.Now().UTC(), time.Hour)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+	if err := VerifyOrchestratorDelegation(rootPub, minted.Delegation, DelegationExpectations{
+		RunNonce:    "run-nonce-1",
+		ImageDigest: image,
+		MaxLifetime: time.Hour,
+	}); err != nil {
+		t.Fatalf("verify minted delegation: %v", err)
+	}
+	sessionPub := minted.PrivateKey.Public().(ed25519.PublicKey)
+	if hex.EncodeToString(sessionPub) != minted.Delegation.SessionPublicKey {
+		t.Fatal("session public key does not match delegation")
+	}
+	if hex.EncodeToString(sessionPub) == hex.EncodeToString(rootPub) {
+		t.Fatal("session key must not be the durable root")
+	}
+}
+
+func TestMintSessionDelegation_RejectsBadRoot(t *testing.T) {
+	t.Parallel()
+	_, err := MintSessionDelegation(ed25519.PrivateKey("short"), "run", "sha256:"+strings.Repeat("cd", 32), time.Now(), time.Hour)
+	if err == nil {
+		t.Fatal("expected bad root to fail")
+	}
+}
+
+func TestParseOrchestratorPrivateKeyHex(t *testing.T) {
+	t.Parallel()
+	_, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseOrchestratorPrivateKeyHex(hex.EncodeToString(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(priv) != hex.EncodeToString(got) {
+		t.Fatal("parsed key does not match")
+	}
+	if _, err := ParseOrchestratorPrivateKeyHex("not-hex"); err == nil {
+		t.Fatal("expected malformed hex to fail")
+	}
+	if _, err := ParseOrchestratorPrivateKeyHex("aa"); err == nil {
+		t.Fatal("expected short key to fail")
+	}
+}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -608,7 +608,7 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 	// decision; this proves the kernel owner-match drop from the contained
 	// network position. Required only when the signed manifest says Contained.
 	if lm.Contained {
-		verifyHostContainmentBytes(artifacts.HostContainmentWitness, lm, orchestratorPubHex, &rep)
+		verifyHostContainmentBytes(artifacts.HostContainmentWitness, lm, hex.EncodeToString(manifestPub), &rep)
 	}
 
 	rep.ObservedCount = witness.ObservedCount


### PR DESCRIPTION
## What changed

The playground signed each visitor run with a durable key that was copied into every per-visitor VM. The broker now holds that root, mints a short-lived Ed25519 session key per run, and signs a delegation binding that key to the run nonce and the immutable VM image digest. A guest receives only the session key and the delegation, and the delegation travels with the run directory so an offline verifier can walk the session key back to the published root.

The broker and the visitor VMs share one application secret namespace, and both previously read the same variable for the signing key, so the root reached the guests through the deployment shape rather than through a copying bug. The broker now reads its root from a broker-only variable, refuses to serve while the guest-facing variable is populated, and refuses to place a root in per-session environment. A public guest refuses to boot when the guest-facing variable is present, refuses a durable key on disk, and refuses to serve without demanding a delegation.

The published demo identity is rotated. Runs signed by the prior identity no longer verify against it, so the recorded replay bundle and the downloadable verify kits must be recaptured before they are consistent with this key again.

The visitor VM image is now pinned by digest rather than by a mutable tag, and that digest is what each delegation binds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delegated signing for live playground sessions, binding runs to their image digest and session identity.
  * Added configurable VM image digest validation for broker-served sessions.
  * Development mode supports relaxed delegation requirements unless explicitly enabled.
  * Public serving now requires delegated signing.

* **Security Improvements**
  * Durable orchestrator signing keys are no longer sent to guest environments.
  * Serving fails closed for invalid keys, unsafe secret configuration, invalid delegations, duplicate run identifiers, and mismatched image or run details.
  * Rotated the published demo signing identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->