### PR TITLE
fix(gauntlet): drop a baseline field the benchmark schema rejects

### DIFF
--- a/benchmark/gauntlet-baseline.json
+++ b/benchmark/gauntlet-baseline.json
@@ -3,7 +3,6 @@
   "schema_version": 1,
   "recorded_on": "2026-09-03",
   "pipelock_version": "3.5.0",
-  "corpus_release_tag": "v1.0.0",
   "corpus_git_sha": "06399746918ae0005f59a914fc9ec100a2f27fb8",
   "corpus_sha256": "3d098eaa77e2eee83070f3ddb2bc754493d7fa4d2beba0f404a4e7f059e10ba6",
   "corpus_version": "v2.8.0",


### PR DESCRIPTION
## What changed

The promotion baseline is validated against a benchmark-owned schema that declares a closed property set, and version 1 of that schema is frozen. A release-tag field added to it made the evaluator reject the baseline, so the Gauntlet lane blocked before it could reach a verdict. No public result changed, because the lane fails closed.

The release tag is already bound where it can be checked: the workflow resolves it against the pinned commit and fails when they disagree, and the acceptance contract records it. The baseline does not need a second copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `corpus_release_tag` metadata field from the Pipelock baseline data.
  * Existing corpus identification metadata remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->