### PR TITLE
fix(playground): give a visitor their own session evidence unedited

### DIFF
--- a/internal/playground/assemble_shared.go
+++ b/internal/playground/assemble_shared.go
@@ -25,10 +25,9 @@ func AssembleFromEvidenceWithScenario(evidenceFile, pubKeyHex string, sc *replay
 	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt, replaycapture.AudiencePublicGallery)
 }
 
-// AssembleSessionOwnerFromEvidence assembles a visitor's own session evidence.
-// It delivers the exact signed chain, including receipts whose target is a real
-// host, because the visitor watched those decisions live and the alternative is
-// handing them nothing at all.
+// AssembleSessionOwnerFromEvidence assembles a visitor's exact signed session
+// evidence, including receipts whose target is a real host. The caller must
+// authorize delivery over that session's short-lived channel.
 func AssembleSessionOwnerFromEvidence(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
 	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt, replaycapture.AudienceSessionOwner)
 }

--- a/internal/playground/assemble_shared.go
+++ b/internal/playground/assemble_shared.go
@@ -22,7 +22,15 @@ import (
 // When sc is nil the function falls back to deriving a bare Scenario from the
 // evidence path (identical to AssembleFromEvidence).
 func AssembleFromEvidenceWithScenario(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
-	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt)
+	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt, replaycapture.AudiencePublicGallery)
+}
+
+// AssembleSessionOwnerFromEvidence assembles a visitor's own session evidence.
+// It delivers the exact signed chain, including receipts whose target is a real
+// host, because the visitor watched those decisions live and the alternative is
+// handing them nothing at all.
+func AssembleSessionOwnerFromEvidence(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
+	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, sc, outDir, generatedAt, replaycapture.AudienceSessionOwner)
 }
 
 // AssembleFromEvidence turns a live evidence JSONL file (written by a real
@@ -42,10 +50,10 @@ func AssembleFromEvidenceWithScenario(evidenceFile, pubKeyHex string, sc *replay
 // evidence alone. AssemblePacket uses only Scenario.ID; callers that also need
 // BuildManifest must supply the full Scenario separately.
 func AssembleFromEvidence(evidenceFile, pubKeyHex, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
-	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, nil, outDir, generatedAt)
+	return assembleFromEvidenceCore(evidenceFile, pubKeyHex, nil, outDir, generatedAt, replaycapture.AudiencePublicGallery)
 }
 
-func assembleFromEvidenceCore(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time) (*replaycapture.AssembleResult, error) {
+func assembleFromEvidenceCore(evidenceFile, pubKeyHex string, sc *replaycapture.Scenario, outDir string, generatedAt time.Time, audience replaycapture.Audience) (*replaycapture.AssembleResult, error) {
 	cleanPath := filepath.Clean(evidenceFile)
 
 	if _, err := os.Stat(cleanPath); err != nil {
@@ -94,7 +102,7 @@ func assembleFromEvidenceCore(evidenceFile, pubKeyHex string, sc *replaycapture.
 		ChainResult:  chain,
 	}
 
-	result, err := replaycapture.AssemblePacket(cs, outDir, generatedAt)
+	result, err := replaycapture.AssemblePacketFor(cs, outDir, generatedAt, audience)
 	if err != nil {
 		return nil, fmt.Errorf("assemble packet: %w", err)
 	}

--- a/internal/playground/assemble_shared_test.go
+++ b/internal/playground/assemble_shared_test.go
@@ -4,10 +4,19 @@
 package playground_test
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/internal/playground"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/recorder"
 	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
 )
 
@@ -65,5 +74,90 @@ func TestAssembleFromEvidence_ProducesVerifiablePacket(t *testing.T) {
 	// that the shipped pipelock-verifier uses.
 	if err := replaycapture.VerifyPacketDir(result.PacketDir, engine.PublicKeyHex()); err != nil {
 		t.Fatalf("VerifyPacketDir: %v", err)
+	}
+}
+
+// TestAssembleSessionOwnerFromEvidence_RealHostKeepsValidChain covers the
+// production evidence-file seam with an intact signed receipt, rather than
+// changing an in-memory receipt after capture. The target is evidence only;
+// this test never contacts it.
+func TestAssembleSessionOwnerFromEvidence_RealHostKeepsValidChain(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	pubKeyHex := hex.EncodeToString(pub)
+	stamp := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+
+	r, err := receipt.Sign(receipt.ActionRecord{
+		Version:         receipt.ActionRecordVersion,
+		ActionID:        "visitor-real-host-receipt",
+		ActionType:      receipt.ActionWrite,
+		Principal:       "pipelock-lab",
+		Actor:           "lab-agent",
+		Timestamp:       stamp,
+		Target:          "https://sts.amazonaws.com/",
+		SideEffectClass: receipt.SideEffectExternalWrite,
+		Reversibility:   receipt.ReversibilityUnknown,
+		PolicyHash:      "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		Verdict:         "block",
+		Transport:       "forward",
+		Method:          "POST",
+		Layer:           "core_dlp",
+		ChainPrevHash:   receipt.GenesisHash,
+		ChainSeq:        0,
+	}, priv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	evidenceDir := filepath.Join(t.TempDir(), "visitor-real-host")
+	if err := os.MkdirAll(evidenceDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll evidence: %v", err)
+	}
+	evidenceFile := filepath.Join(evidenceDir, "evidence.jsonl")
+	entry := recorder.Entry{
+		Version:   recorder.EntryVersion,
+		Sequence:  0,
+		Timestamp: stamp,
+		SessionID: "visitor-session",
+		Type:      "action_receipt",
+		EventKind: "write",
+		Transport: "forward",
+		Summary:   "signed visitor receipt",
+		Detail:    r,
+		PrevHash:  recorder.GenesisHash,
+	}
+	entry.Hash = recorder.ComputeHash(entry)
+	line, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal evidence entry: %v", err)
+	}
+	if err := os.WriteFile(evidenceFile, append(line, '\n'), 0o600); err != nil {
+		t.Fatalf("WriteFile evidence: %v", err)
+	}
+
+	// The same valid signed evidence remains unpublishable to the gallery.
+	if _, err := playground.AssembleFromEvidence(evidenceFile, pubKeyHex, t.TempDir(), stamp); err == nil || !strings.Contains(err.Error(), "allowlist") {
+		t.Fatalf("gallery assembly error = %v, want public-safe allowlist refusal", err)
+	}
+
+	result, err := playground.AssembleSessionOwnerFromEvidence(
+		evidenceFile,
+		pubKeyHex,
+		&replaycapture.Scenario{ID: "visitor-real-host"},
+		t.TempDir(),
+		stamp,
+	)
+	if err != nil {
+		t.Fatalf("AssembleSessionOwnerFromEvidence: %v", err)
+	}
+	if err := replaycapture.VerifyPacketDir(result.PacketDir, pubKeyHex); err != nil {
+		t.Fatalf("VerifyPacketDir: %v", err)
+	}
+	if got, want := result.Packet.Summary.DomainsTouched, []string{"sts.amazonaws.com"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("domains_touched = %v, want %v", got, want)
 	}
 }

--- a/internal/playground/coverage_more_test.go
+++ b/internal/playground/coverage_more_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/receipt"
+	"github.com/luckyPipewrench/pipelock/internal/replaycapture"
 )
 
 const rootRequirement = "requires root"
@@ -707,7 +708,7 @@ func TestWitnessVerificationRejectsMalformedInputs(t *testing.T) {
 func TestAssembleFromEvidenceRejectsMissingAndEmptyEvidence(t *testing.T) {
 	t.Parallel()
 
-	if _, err := assembleFromEvidenceCore(filepath.Join(t.TempDir(), "missing.jsonl"), "", nil, t.TempDir(), time.Now()); err == nil {
+	if _, err := assembleFromEvidenceCore(filepath.Join(t.TempDir(), "missing.jsonl"), "", nil, t.TempDir(), time.Now(), replaycapture.AudiencePublicGallery); err == nil {
 		t.Fatal("missing evidence file must fail")
 	}
 
@@ -715,7 +716,7 @@ func TestAssembleFromEvidenceRejectsMissingAndEmptyEvidence(t *testing.T) {
 	if err := os.WriteFile(evidenceFile, nil, 0o600); err != nil {
 		t.Fatalf("write empty evidence: %v", err)
 	}
-	if _, err := assembleFromEvidenceCore(evidenceFile, "", nil, t.TempDir(), time.Now()); err == nil {
+	if _, err := assembleFromEvidenceCore(evidenceFile, "", nil, t.TempDir(), time.Now(), replaycapture.AudiencePublicGallery); err == nil {
 		t.Fatal("empty evidence file must fail")
 	}
 }

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -644,7 +644,11 @@ func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 	// "finish and prove it" semantic. Fail closed if the run did not verify.
 	if err := s.seal(entry); err != nil {
 		s.releaseSessionResources(entry)
-		writeErr(w, http.StatusServiceUnavailable, "session bundle is not available")
+		// Say that nothing partial was released, because the visitor's next
+		// question is whether they were handed a half-made bundle. Do not name
+		// the target, policy, or layer that failed: the reason can itself be
+		// the sensitive part.
+		writeErr(w, http.StatusServiceUnavailable, "we could not create a verifiable bundle for this session; nothing partial was released")
 		return
 	}
 	s.releaseSessionResources(entry)

--- a/internal/playground/livechat/server.go
+++ b/internal/playground/livechat/server.go
@@ -606,6 +606,10 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 // session already torn down) cannot download.
 func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
 	s.setCORS(w)
+	// This is the owner-only artifact and can include real targets. The session
+	// token bounds retrieval at this server; no-store prevents an HTTP cache from
+	// extending that delivery channel after the token expires.
+	w.Header().Set("Cache-Control", "no-store")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -229,6 +229,11 @@ func TestServer_Bundle_SealFailureReleasesCapacity(t *testing.T) {
 	if failure.Error != "we could not create a verifiable bundle for this session; nothing partial was released" {
 		t.Fatalf("bundle failure = %q, want generic no-partial-release message", failure.Error)
 	}
+	// The failure path is still an owner-scoped response on a short-lived token,
+	// so it carries the same caching guarantee as a successful download.
+	if cc := dl.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("seal-failure Cache-Control = %q, want no-store", cc)
+	}
 	if got := srv.conc.InUse(); got != 0 {
 		t.Fatalf("failed seal did not release session capacity: in_use=%d", got)
 	}

--- a/internal/playground/livechat/server_bundle_test.go
+++ b/internal/playground/livechat/server_bundle_test.go
@@ -153,6 +153,9 @@ func TestServer_Bundle_DownloadsVerifiableArchive(t *testing.T) {
 	if ct := dl.Header.Get("Content-Type"); ct != "application/gzip" {
 		t.Errorf("bundle Content-Type = %q, want application/gzip", ct)
 	}
+	if cc := dl.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("bundle Cache-Control = %q, want no-store", cc)
+	}
 	if cd := dl.Header.Get("Content-Disposition"); !strings.Contains(cd, "attachment") || !strings.Contains(cd, ".tar.gz") {
 		t.Errorf("bundle Content-Disposition = %q, want an attachment .tar.gz", cd)
 	}
@@ -213,9 +216,18 @@ func TestServer_Bundle_SealFailureReleasesCapacity(t *testing.T) {
 	// download must fail closed, but the now-terminal session must not keep
 	// holding capacity until TTL.
 	dl := getRaw(t, ts.URL+RouteBundle+"?token="+cr.Token)
+	var failure struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(dl.Body).Decode(&failure); err != nil {
+		t.Fatalf("decode bundle failure: %v", err)
+	}
 	_ = dl.Body.Close()
 	if dl.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("bundle download before verifiable actions = %d, want 503", dl.StatusCode)
+	}
+	if failure.Error != "we could not create a verifiable bundle for this session; nothing partial was released" {
+		t.Fatalf("bundle failure = %q, want generic no-partial-release message", failure.Error)
 	}
 	if got := srv.conc.InUse(); got != 0 {
 		t.Fatalf("failed seal did not release session capacity: in_use=%d", got)

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -856,7 +856,7 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 		return VerifyReport{}, fmt.Errorf("verify run: %w", err)
 	}
 	if !rep.OK {
-		return rep, fmt.Errorf("verify run: failed checks")
+		return rep, fmt.Errorf("verify run: %s", rep.FailureSummary())
 	}
 
 	return rep, nil

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -781,7 +781,8 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	// manual reset. The manifest/witness JSON files are overwritten in place.
 	_ = os.RemoveAll(filepath.Join(runDir, "packet"))
 	_ = os.RemoveAll(filepath.Join(runDir, sc.ID))
-	asmResult, asmErr := AssembleFromEvidenceWithScenario(
+	// This is the visitor sealing their own run, not a gallery publication.
+	asmResult, asmErr := AssembleSessionOwnerFromEvidence(
 		evidenceFile,
 		hex.EncodeToString(lr.pipelockPub),
 		&sc,

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -44,6 +44,29 @@ type VerifyReport struct {
 	OrchestratorKey string `json:"orchestrator_key"`
 }
 
+// FailureSummary names the checks that failed and why. A seal failure that
+// reports only that something failed cannot be acted on: the report already
+// carries the reason, and discarding it turns a one-line diagnosis into a
+// guess. It returns "no failed checks" when nothing failed, so a caller cannot
+// print an empty reason and imply one.
+func (r VerifyReport) FailureSummary() string {
+	var failed []string
+	for _, c := range r.Checks {
+		if c.OK {
+			continue
+		}
+		if c.Reason == "" {
+			failed = append(failed, c.Name)
+			continue
+		}
+		failed = append(failed, c.Name+": "+c.Reason)
+	}
+	if len(failed) == 0 {
+		return "no failed checks"
+	}
+	return "failed checks: " + strings.Join(failed, "; ")
+}
+
 // Run directory layout (produced by the demo runner, consumed by VerifyRun):
 //
 //	<rundir>/

--- a/internal/playground/verify_summary_test.go
+++ b/internal/playground/verify_summary_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !js
+
+package playground
+
+import (
+	"strings"
+	"testing"
+)
+
+// A seal failure has to say which check failed and why. Reporting only that
+// something failed sent an operator hunting through source for a reason the
+// report was already holding.
+func TestVerifyReport_FailureSummary(t *testing.T) {
+	rep := VerifyReport{
+		Checks: []Check{
+			{Name: "launch-manifest-signature", OK: true},
+			{Name: "orchestrator-delegation", OK: false, Reason: "delegation does not bind the launch manifest"},
+			{Name: "live-demo-semantics", OK: false},
+		},
+	}
+
+	got := rep.FailureSummary()
+	for _, want := range []string{
+		"orchestrator-delegation: delegation does not bind the launch manifest",
+		"live-demo-semantics",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary %q must name %q", got, want)
+		}
+	}
+	if strings.Contains(got, "launch-manifest-signature") {
+		t.Fatalf("summary %q must not name a check that passed", got)
+	}
+}
+
+// An all-passing report must not produce an empty reason that reads as a
+// nameless failure.
+func TestVerifyReport_FailureSummary_NoFailures(t *testing.T) {
+	rep := VerifyReport{Checks: []Check{{Name: "launch-manifest-signature", OK: true}}}
+	if got := rep.FailureSummary(); got != "no failed checks" {
+		t.Fatalf("summary = %q, want %q", got, "no failed checks")
+	}
+}

--- a/internal/replaycapture/assemble.go
+++ b/internal/replaycapture/assemble.go
@@ -48,12 +48,47 @@ type AssembleResult struct {
 	Receipts  int
 }
 
+// Audience names who an assembled packet is for. It is the only thing that
+// decides whether the public-safe gates run, because those gates answer a
+// publication question, not a correctness one.
+//
+// The zero value is AudiencePublicGallery, so a caller that says nothing gets
+// the strict path. Adding an audience must never be a way to weaken a packet by
+// omission.
+type Audience int
+
+const (
+	// AudiencePublicGallery is a packet published for anyone to read. Every
+	// receipt and the envelope must pass the public-safe allowlist: a target
+	// hostname can be sensitive whatever the verdict was, and a published
+	// artifact outlives the session that produced it.
+	AudiencePublicGallery Audience = iota
+
+	// AudienceSessionOwner is a packet handed back to the one visitor whose
+	// session produced it, over a short-lived authorized channel. They already
+	// watched every decision, including its target, so withholding the same
+	// facts from their own signed evidence protects nobody and denies them the
+	// proof the run exists to provide. The chain is delivered exactly as
+	// signed; nothing is scrubbed and no receipt is dropped.
+	AudienceSessionOwner
+)
+
 // AssemblePacket gates a captured scenario through the public-safe allowlist,
 // builds an Audit Packet v0 from safe constants and the real receipt chain,
 // validates it (schema + envelope safety), and writes the packet directory
 // (packet.json, evidence.jsonl, verifier.txt, summary.md). generatedAt is
 // injected so callers control the stamp (and tests stay deterministic).
+//
+// This is the public-publication path and stays the default for every caller
+// that does not name an audience.
 func AssemblePacket(cs *CapturedScenario, outDir string, generatedAt time.Time) (*AssembleResult, error) {
+	return AssemblePacketFor(cs, outDir, generatedAt, AudiencePublicGallery)
+}
+
+// AssemblePacketFor assembles a packet for a named audience. Both audiences get
+// the same signed bytes, the same schema validation, and the same chain; they
+// differ only in whether the public-safe publication gates apply.
+func AssemblePacketFor(cs *CapturedScenario, outDir string, generatedAt time.Time, audience Audience) (*AssembleResult, error) {
 	if cs == nil {
 		return nil, errors.New("assemble: nil captured scenario")
 	}
@@ -62,9 +97,12 @@ func AssemblePacket(cs *CapturedScenario, outDir string, generatedAt time.Time) 
 	}
 
 	// Gate: every receipt must pass the public-safe allowlist BEFORE assembly.
-	for i := range cs.Receipts {
-		if err := ValidateReceiptPublicSafe(cs.Receipts[i].ActionRecord); err != nil {
-			return nil, fmt.Errorf("assemble %s: receipt %d: %w", cs.Scenario.ID, i, err)
+	// Publication only; see Audience.
+	if audience == AudiencePublicGallery {
+		for i := range cs.Receipts {
+			if err := ValidateReceiptPublicSafe(cs.Receipts[i].ActionRecord); err != nil {
+				return nil, fmt.Errorf("assemble %s: receipt %d: %w", cs.Scenario.ID, i, err)
+			}
 		}
 	}
 
@@ -73,8 +111,10 @@ func AssemblePacket(cs *CapturedScenario, outDir string, generatedAt time.Time) 
 	if err := pkt.Validate(); err != nil {
 		return nil, fmt.Errorf("assemble %s: packet schema: %w", cs.Scenario.ID, err)
 	}
-	if err := ValidatePacketEnvelopePublicSafe(pkt); err != nil {
-		return nil, fmt.Errorf("assemble %s: %w", cs.Scenario.ID, err)
+	if audience == AudiencePublicGallery {
+		if err := ValidatePacketEnvelopePublicSafe(pkt); err != nil {
+			return nil, fmt.Errorf("assemble %s: %w", cs.Scenario.ID, err)
+		}
 	}
 
 	packetDir := filepath.Join(outDir, cs.Scenario.ID)

--- a/internal/replaycapture/assemble.go
+++ b/internal/replaycapture/assemble.go
@@ -64,12 +64,11 @@ const (
 	// artifact outlives the session that produced it.
 	AudiencePublicGallery Audience = iota
 
-	// AudienceSessionOwner is a packet handed back to the one visitor whose
-	// session produced it, over a short-lived authorized channel. They already
-	// watched every decision, including its target, so withholding the same
-	// facts from their own signed evidence protects nobody and denies them the
-	// proof the run exists to provide. The chain is delivered exactly as
-	// signed; nothing is scrubbed and no receipt is dropped.
+	// AudienceSessionOwner is a packet for the visitor whose session produced it.
+	// Callers must authorize delivery over that session's short-lived channel;
+	// selecting this audience does not itself grant access. The chain is
+	// delivered exactly as signed, including real targets: nothing is scrubbed
+	// and no receipt is dropped.
 	AudienceSessionOwner
 )
 
@@ -96,9 +95,18 @@ func AssemblePacketFor(cs *CapturedScenario, outDir string, generatedAt time.Tim
 		return nil, fmt.Errorf("assemble %s: no receipts", cs.Scenario.ID)
 	}
 
+	publicSafe := false
+	switch audience {
+	case AudiencePublicGallery:
+		publicSafe = true
+	case AudienceSessionOwner:
+	default:
+		return nil, fmt.Errorf("assemble %s: unknown audience %d", cs.Scenario.ID, audience)
+	}
+
 	// Gate: every receipt must pass the public-safe allowlist BEFORE assembly.
 	// Publication only; see Audience.
-	if audience == AudiencePublicGallery {
+	if publicSafe {
 		for i := range cs.Receipts {
 			if err := ValidateReceiptPublicSafe(cs.Receipts[i].ActionRecord); err != nil {
 				return nil, fmt.Errorf("assemble %s: receipt %d: %w", cs.Scenario.ID, i, err)
@@ -111,7 +119,7 @@ func AssemblePacketFor(cs *CapturedScenario, outDir string, generatedAt time.Tim
 	if err := pkt.Validate(); err != nil {
 		return nil, fmt.Errorf("assemble %s: packet schema: %w", cs.Scenario.ID, err)
 	}
-	if audience == AudiencePublicGallery {
+	if publicSafe {
 		if err := ValidatePacketEnvelopePublicSafe(pkt); err != nil {
 			return nil, fmt.Errorf("assemble %s: %w", cs.Scenario.ID, err)
 		}

--- a/internal/replaycapture/audience_test.go
+++ b/internal/replaycapture/audience_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !js
+
+package replaycapture
+
+import (
+	"strings"
+	"testing"
+)
+
+// captureWithTargetHost drives a real capture and then rewrites the decisive
+// receipt's target to the given URL.
+//
+// The rewrite is deliberate and is what makes the fixture useful: the shipped
+// scenarios only ever reach synthetic lab hosts, which is exactly why a
+// real-host receipt was never exercised before it reached a live visitor.
+// Assembly consumes the in-memory ActionRecord, so this drives the publication
+// gate under test. Chain and signature verification happen upstream of assembly
+// and are covered by the chain tests, not here.
+func captureWithTargetHost(t *testing.T, target string) *CapturedScenario {
+	t.Helper()
+	eng := newTestEngine(t)
+
+	var scenario Scenario
+	for _, s := range DefaultScenarios() {
+		if s.ExpectedVerdict == verdictBlock {
+			scenario = s
+			break
+		}
+	}
+	if scenario.ID == "" {
+		t.Fatal("no blocking scenario available to build a fixture from")
+	}
+
+	cs, err := eng.Capture(scenario)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if len(cs.Receipts) == 0 {
+		t.Fatal("capture produced no receipts")
+	}
+	cs.Receipts[len(cs.Receipts)-1].ActionRecord.Target = target
+	return cs
+}
+
+// A real target host must still stop a gallery publication. The hostname itself
+// is the disclosure, so the verdict on that action is not the deciding fact and
+// a blocked attempt earns no exemption.
+func TestAssemblePacketFor_GalleryStillRefusesRealHost(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		audience Audience
+	}{
+		{name: "explicit_gallery", audience: AudiencePublicGallery},
+		{name: "zero_value_defaults_to_gallery", audience: Audience(0)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
+			_, err := AssemblePacketFor(cs, t.TempDir(), fixedStamp(), tc.audience)
+			if err == nil {
+				t.Fatal("a real target host must not be publishable to the gallery")
+			}
+			if !strings.Contains(err.Error(), "allowlist") {
+				t.Fatalf("error %v must name the allowlist refusal", err)
+			}
+		})
+	}
+}
+
+// The default entry point keeps the strict behavior, so introducing an audience
+// cannot weaken an existing caller that never names one.
+func TestAssemblePacket_DefaultRemainsGallery(t *testing.T) {
+	cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
+	if _, err := AssemblePacket(cs, t.TempDir(), fixedStamp()); err == nil {
+		t.Fatal("AssemblePacket must keep refusing a real host")
+	}
+}
+
+// The visitor's own session assembles with the real host intact. They watched
+// that decision stream past live, so withholding the same fact from their signed
+// evidence protects nobody and denies them the proof the run exists to give.
+func TestAssemblePacketFor_SessionOwnerKeepsRealHost(t *testing.T) {
+	cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
+	want := len(cs.Receipts)
+
+	res, err := AssemblePacketFor(cs, t.TempDir(), fixedStamp(), AudienceSessionOwner)
+	if err != nil {
+		t.Fatalf("a session owner must receive their own evidence: %v", err)
+	}
+	if res == nil || res.PacketDir == "" {
+		t.Fatal("assembly produced no packet")
+	}
+	if res.Receipts != want {
+		t.Fatalf("packet carries %d receipts, want all %d; the chain must never be trimmed to make it publishable", res.Receipts, want)
+	}
+}
+
+// A synthetic lab host assembles for both audiences, which proves the refusals
+// above come from the real hostname rather than from anything else the fixture
+// happens to carry.
+func TestAssemblePacketFor_LabHostServesBothAudiences(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		audience Audience
+	}{
+		{name: "gallery", audience: AudiencePublicGallery},
+		{name: "session_owner", audience: AudienceSessionOwner},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := captureWithTargetHost(t, "http://intake.lab.test/")
+			if _, err := AssemblePacketFor(cs, t.TempDir(), fixedStamp(), tc.audience); err != nil {
+				t.Fatalf("a synthetic lab host must assemble for %s: %v", tc.name, err)
+			}
+		})
+	}
+}

--- a/internal/replaycapture/audience_test.go
+++ b/internal/replaycapture/audience_test.go
@@ -6,6 +6,7 @@
 package replaycapture
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -78,9 +79,8 @@ func TestAssemblePacket_DefaultRemainsGallery(t *testing.T) {
 	}
 }
 
-// The visitor's own session assembles with the real host intact. They watched
-// that decision stream past live, so withholding the same fact from their signed
-// evidence protects nobody and denies them the proof the run exists to give.
+// The visitor's own authorized session assembles with the real host intact.
+// The signed chain must not be altered merely to make it publicly publishable.
 func TestAssemblePacketFor_SessionOwnerKeepsRealHost(t *testing.T) {
 	cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
 	want := len(cs.Receipts)
@@ -94,6 +94,36 @@ func TestAssemblePacketFor_SessionOwnerKeepsRealHost(t *testing.T) {
 	}
 	if res.Receipts != want {
 		t.Fatalf("packet carries %d receipts, want all %d; the chain must never be trimmed to make it publishable", res.Receipts, want)
+	}
+}
+
+// Session-owner delivery relaxes publication safety only. It must retain the
+// packet schema gate that makes the evidence independently verifiable.
+func TestAssemblePacketFor_SessionOwnerStillValidatesPacket(t *testing.T) {
+	cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
+	cs.SignerKeyHex = ""
+
+	_, err := AssemblePacketFor(cs, t.TempDir(), fixedStamp(), AudienceSessionOwner)
+	if err == nil || !strings.Contains(err.Error(), "packet schema") {
+		t.Fatalf("session-owner invalid packet error = %v, want schema refusal", err)
+	}
+}
+
+// Unknown values must not become a future bypass around the gallery gates.
+func TestAssemblePacketFor_RejectsUnknownAudience(t *testing.T) {
+	cs := captureWithTargetHost(t, "https://sts.amazonaws.com/")
+	outDir := t.TempDir()
+
+	_, err := AssemblePacketFor(cs, outDir, fixedStamp(), Audience(99))
+	if err == nil || !strings.Contains(err.Error(), "unknown audience") {
+		t.Fatalf("unknown audience error = %v, want refusal", err)
+	}
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("read output directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("unknown audience wrote packet artifacts: %v", entries)
 	}
 }
 

--- a/internal/replaycapture/audience_test.go
+++ b/internal/replaycapture/audience_test.go
@@ -6,7 +6,9 @@
 package replaycapture
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -20,6 +22,13 @@ import (
 // Assembly consumes the in-memory ActionRecord, so this drives the publication
 // gate under test. Chain and signature verification happen upstream of assembly
 // and are covered by the chain tests, not here.
+//
+// The limit worth knowing: evidence.jsonl is copied from the capture's own
+// evidence file, which this rewrite does not touch, so these tests can speak
+// for packet.json and not for that file. The end-to-end property, a genuinely
+// signed real-host receipt surviving into both, is proven by
+// TestAssembleSessionOwnerFromEvidence_RealHostKeepsValidChain in the
+// playground package, which drives the real evidence-file seam.
 func captureWithTargetHost(t *testing.T, target string) *CapturedScenario {
 	t.Helper()
 	eng := newTestEngine(t)
@@ -94,6 +103,16 @@ func TestAssemblePacketFor_SessionOwnerKeepsRealHost(t *testing.T) {
 	}
 	if res.Receipts != want {
 		t.Fatalf("packet carries %d receipts, want all %d; the chain must never be trimmed to make it publishable", res.Receipts, want)
+	}
+
+	// Cardinality alone would pass if the owner path redacted the host, so
+	// assert the target survives into the bytes actually written.
+	packet, err := os.ReadFile(filepath.Clean(filepath.Join(res.PacketDir, artifactPacketName)))
+	if err != nil {
+		t.Fatalf("read packet.json: %v", err)
+	}
+	if !bytes.Contains(packet, []byte("sts.amazonaws.com")) {
+		t.Fatal("the owner's packet must retain the real target rather than redact it")
 	}
 }
 


### PR DESCRIPTION
## What changed

A visitor's own session bundle is assembled for them rather than for public publication, so it carries the exact signed chain including receipts whose target is a real host. Publishing to the public gallery is unchanged: every receipt and the packet envelope still pass the public-safe allowlist, because a hostname can be sensitive whatever the verdict on that action was.

The audience is explicit at every assembly call. Its zero value is the public-gallery path, so a caller that names no audience gets the strict one, and an unrecognized value is refused before any artifact is written rather than skipping the publication gates.

Previously the two paths shared one gate, so a session whose agent reached any non-synthetic host produced signed evidence the visitor could not obtain or verify. The bundle failure message now states that nothing partial was released, without naming the target, policy, or layer that failed, and bundle responses are no longer cacheable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-specific evidence and packet assembly for public gallery and session-owner views.
  * Session owners can receive complete run details, including real target hosts, while public gallery output remains restricted.
  * Verification errors now include specific failed-check summaries.

* **Security & Reliability**
  * Bundle downloads are no longer cached.
  * Failed bundle sealing now returns a generic message confirming that no partial artifact was released.
  * Invalid audience values are rejected without generating artifacts.

* **Tests**
  * Added coverage for audience-specific assembly, validation, caching headers, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->