### PR TITLE
fix(examples): make the receipt tamper step edit a signed field

### DIFF
--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -210,6 +210,25 @@ match their recorded hash. Those symptoms narrow the cause but do not by
 themselves establish it: a fork and a crafted edit can present the same
 structure.
 
+### Falsify a captured record
+
+The runnable [receipt verification example](../../examples/receipt-verify/README.md)
+captures a blocked request, verifies it with a pinned key, then in step 5 changes
+the blocked receipt's `detail.action_record.verdict` from `block` to `allow`.
+The verifier fails closed (exit 1) with this output shape from an actual run:
+
+```text
+CHAIN BROKEN: /tmp/.../evidence-proxy-0.tampered.jsonl
+  Error:    seq 2: signature: signature verification failed
+  Broke at: seq 2
+```
+
+Receipt-chain verification covers the signed `action_record` (including the
+action, policy hash, verdict, target, and chain linkage), but not outer
+flight-recorder metadata such as a JSONL entry's `seq`, `type`, or `summary`.
+Changing an outer field therefore is not a tamper demonstration for this
+verification mode.
+
 ### Compacting an over-cap recorder directory
 
 Evidence readers refuse a session with more than 256 JSONL shards or an individual shard above 8 MiB. Stop the recorder before running the offline compaction ceremony. The compactor has its own bounded reader for legacy oversized shards, so a normal `pipelock evidence doctor` run isn't a prerequisite.

--- a/docs/guides/receipt-verification.md
+++ b/docs/guides/receipt-verification.md
@@ -223,11 +223,12 @@ CHAIN BROKEN: /tmp/.../evidence-proxy-0.tampered.jsonl
   Broke at: seq 2
 ```
 
-Receipt-chain verification covers the signed `action_record` (including the
-action, policy hash, verdict, target, and chain linkage), but not outer
-flight-recorder metadata such as a JSONL entry's `seq`, `type`, or `summary`.
-Changing an outer field therefore is not a tamper demonstration for this
-verification mode.
+Receipt-chain verification authenticates the signed `action_record` (including
+the action, policy hash, verdict, target, and chain linkage), not the outer
+flight-recorder hash chain. An entry's `seq` and `summary` are not checked in
+this mode. Its `type` is not signed, but it does select whether the entry is
+extracted as an action receipt; unknown types fail closed. Changing an outer
+field is therefore not a tamper demonstration for receipt-chain verification.
 
 ### Compacting an over-cap recorder directory
 

--- a/examples/receipt-verify/README.md
+++ b/examples/receipt-verify/README.md
@@ -13,7 +13,7 @@ Fully offline: runtime-generated signing key + metadata-IP `/fetch` block.
 | Block | `/fetch` to `169.254.169.254` returns HTTP 403 |
 | Receipt on disk | `evidence-proxy-0.jsonl` contains a fetch `block` receipt |
 | Verify pass | `pipelock verify-receipt --key` exits 0 |
-| Tamper fails | Flipping one signature byte makes verify exit non-zero |
+| Tamper fails | Changing a captured receipt's signed `action_record.verdict` makes chain verification exit 1 |
 
 ## Prerequisites
 
@@ -34,6 +34,13 @@ From the repository root:
 ```
 
 Or from this directory: `./verify.sh` (with `PIPELOCK_BIN` set if needed).
+
+The script's fifth step changes `detail.action_record.verdict` in a captured
+`action_receipt` record, then runs `verify-receipt` with the generated public
+key. It must print `CHAIN BROKEN` and exit 1. Receipt-chain verification covers
+the signed `action_record` (including the action, policy hash, verdict, target,
+and chain linkage), but not outer flight-recorder metadata such as a JSONL
+entry's `seq`, `type`, or `summary`.
 
 ## Manual Try
 

--- a/examples/receipt-verify/README.md
+++ b/examples/receipt-verify/README.md
@@ -37,10 +37,12 @@ Or from this directory: `./verify.sh` (with `PIPELOCK_BIN` set if needed).
 
 The script's fifth step changes `detail.action_record.verdict` in a captured
 `action_receipt` record, then runs `verify-receipt` with the generated public
-key. It must print `CHAIN BROKEN` and exit 1. Receipt-chain verification covers
-the signed `action_record` (including the action, policy hash, verdict, target,
-and chain linkage), but not outer flight-recorder metadata such as a JSONL
-entry's `seq`, `type`, or `summary`.
+key. It must report a signature failure at that receipt's chain sequence and
+exit 1. Receipt-chain verification authenticates the signed `action_record`
+(including the action, policy hash, verdict, target, and chain linkage), not
+the outer flight-recorder hash chain. An entry's `seq` and `summary` are not
+checked in this mode. Its `type` is not signed, but it selects whether the
+entry is extracted as an action receipt; unknown types fail closed.
 
 ## Manual Try
 

--- a/examples/receipt-verify/verify.sh
+++ b/examples/receipt-verify/verify.sh
@@ -129,21 +129,31 @@ print(len(blocks))
 PY
 }
 
-tamper_receipt() {
+tamper_captured_record() {
   local src="$1"
   local dst="$2"
   python3 - <<'PY' "$src" "$dst"
-import copy, json, sys
+import json, sys
 from pathlib import Path
 
 src, dst = sys.argv[1:3]
-receipt = json.loads(Path(src).read_text())
-tampered = copy.deepcopy(receipt)
-prefix, value = tampered["signature"].split(":", 1)
-first = value[:2]
-flipped = "00" if first.lower() != "00" else "ff"
-tampered["signature"] = f"{prefix}:{flipped}{value[2:]}"
-Path(dst).write_text(json.dumps(tampered, indent=2) + "\n")
+records = [json.loads(line) for line in Path(src).read_text().splitlines() if line.strip()]
+for record in records:
+    if record.get("type") != "action_receipt":
+        continue
+    detail = record.get("detail")
+    was_string = isinstance(detail, str)
+    if was_string:
+        detail = json.loads(detail)
+    action_record = detail.get("action_record") if isinstance(detail, dict) else None
+    if isinstance(action_record, dict) and action_record.get("verdict") == "block":
+        action_record["verdict"] = "allow"
+        if was_string:
+            record["detail"] = json.dumps(detail, separators=(",", ":"))
+        break
+else:
+    raise SystemExit("no blocked action_receipt record")
+Path(dst).write_text("".join(json.dumps(record) + "\n" for record in records))
 PY
 }
 
@@ -253,13 +263,19 @@ else
 fi
 
 # -- Test 5 -------------------------------------------------------------------
-step "Test 5: tampered receipt fails verification (required)"
-TAMPERED="$WORK/block-receipt.tampered.json"
-tamper_receipt "$BLOCK_RECEIPT" "$TAMPERED"
-if "$PIPELOCK" verify-receipt "$TAMPERED" --key "$PUB" >/dev/null 2>"$WORK/verify-tampered.err"; then
-  fail "tampered receipt unexpectedly verified"
+step "Test 5: tampered captured record fails verification (required)"
+TAMPERED="$WORK/evidence-proxy-0.tampered.jsonl"
+tamper_captured_record "$EVIDENCE" "$TAMPERED"
+if "$PIPELOCK" verify-receipt "$TAMPERED" --key "$PUB" >"$WORK/verify-tampered.out" 2>"$WORK/verify-tampered.err"; then
+  fail "tampered captured record unexpectedly verified"
+elif grep -q '^CHAIN BROKEN:' "$WORK/verify-tampered.out" \
+  && grep -q 'signature verification failed' "$WORK/verify-tampered.out"; then
+  cat "$WORK/verify-tampered.out"
+  pass "tampered captured record rejected by verify-receipt"
 else
-  pass "tampered receipt rejected by verify-receipt"
+  fail "tampered captured record had an unexpected verification failure"
+  cat "$WORK/verify-tampered.out" >&2 || true
+  cat "$WORK/verify-tampered.err" >&2 || true
 fi
 
 # -- Summary ------------------------------------------------------------------

--- a/examples/receipt-verify/verify.sh
+++ b/examples/receipt-verify/verify.sh
@@ -147,9 +147,13 @@ for record in records:
         detail = json.loads(detail)
     action_record = detail.get("action_record") if isinstance(detail, dict) else None
     if isinstance(action_record, dict) and action_record.get("verdict") == "block":
+        chain_seq = action_record.get("chain_seq")
+        if not isinstance(chain_seq, int):
+            raise SystemExit("blocked action_receipt has no numeric chain_seq")
         action_record["verdict"] = "allow"
         if was_string:
             record["detail"] = json.dumps(detail, separators=(",", ":"))
+        print(chain_seq)
         break
 else:
     raise SystemExit("no blocked action_receipt record")
@@ -265,11 +269,12 @@ fi
 # -- Test 5 -------------------------------------------------------------------
 step "Test 5: tampered captured record fails verification (required)"
 TAMPERED="$WORK/evidence-proxy-0.tampered.jsonl"
-tamper_captured_record "$EVIDENCE" "$TAMPERED"
+TAMPERED_RECEIPT_SEQ="$(tamper_captured_record "$EVIDENCE" "$TAMPERED")"
 if "$PIPELOCK" verify-receipt "$TAMPERED" --key "$PUB" >"$WORK/verify-tampered.out" 2>"$WORK/verify-tampered.err"; then
   fail "tampered captured record unexpectedly verified"
 elif grep -q '^CHAIN BROKEN:' "$WORK/verify-tampered.out" \
-  && grep -q 'signature verification failed' "$WORK/verify-tampered.out"; then
+  && grep -q "^  Error:    seq ${TAMPERED_RECEIPT_SEQ}: signature: signature verification failed$" "$WORK/verify-tampered.out" \
+  && grep -q "^  Broke at: seq ${TAMPERED_RECEIPT_SEQ}$" "$WORK/verify-tampered.out"; then
   cat "$WORK/verify-tampered.out"
   pass "tampered captured record rejected by verify-receipt"
 else

--- a/examples/receipt-verify/verify.sh
+++ b/examples/receipt-verify/verify.sh
@@ -148,8 +148,20 @@ for record in records:
     action_record = detail.get("action_record") if isinstance(detail, dict) else None
     if isinstance(action_record, dict) and action_record.get("verdict") == "block":
         chain_seq = action_record.get("chain_seq")
-        if not isinstance(chain_seq, int):
+        if type(chain_seq) is not int:
             raise SystemExit("blocked action_receipt has no numeric chain_seq")
+        same_seq_count = 0
+        for candidate in records:
+            if candidate.get("type") != "action_receipt":
+                continue
+            candidate_detail = candidate.get("detail")
+            if isinstance(candidate_detail, str):
+                candidate_detail = json.loads(candidate_detail)
+            candidate_action = candidate_detail.get("action_record") if isinstance(candidate_detail, dict) else None
+            if isinstance(candidate_action, dict) and candidate_action.get("chain_seq") == chain_seq:
+                same_seq_count += 1
+        if same_seq_count != 1:
+            raise SystemExit(f"blocked action_receipt chain_seq {chain_seq} is ambiguous in this capture")
         action_record["verdict"] = "allow"
         if was_string:
             record["detail"] = json.dumps(detail, separators=(",", ":"))


### PR DESCRIPTION
## What changed

The receipt verification example's tamper step now edits a signed field. Step 5 flips the blocked receipt's `action_record.verdict` inside the captured evidence file, and the verifier fails closed with `CHAIN BROKEN`, a signature failure at that receipt's sequence, and a non-zero exit. The old step changed a field that verification never covered, so it still printed `CHAIN VALID`, and a reader following it would have believed they'd proved tamper detection when they hadn't.

The assertion is bound to the receipt the step changed. It requires the signature failure and the `Broke at` line to name that sequence. It also refuses a capture where the sequence appears more than once, because rotated segments can legitimately reuse sequence numbers and a coincidental match would be an empty proof. The guide now states which fields receipt-chain verification covers. Outer flight-recorder metadata such as `seq` and `summary` sits outside it, while `type` controls extraction and rejects unknown values.

Failure direction is the same on every path. A tampered signed field exits 1. An ambiguous capture fails the example with a message instead of passing on a coincidence. Changing only an unsigned field makes the example itself fail rather than claim proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing receipt tampering by changing a captured action verdict.
  * Clarified which signed receipt details are authenticated and how verification responds to altered or unknown record types.

* **Examples**
  * Updated the receipt-verification example to tamper with captured evidence rather than modify a signature directly.
  * The example now confirms verification fails closed with a clear chain-break error at the affected record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->