### PR TITLE
fix(e2e): warm the upstream MCP package before the timed handshake

### DIFF
--- a/scripts/e2e/cline-mcp-runtime.py
+++ b/scripts/e2e/cline-mcp-runtime.py
@@ -121,6 +121,32 @@ def run_install(
         sys.exit(f"install did not wrap the expected count: {result.stdout!r}")
 
 
+def warm_upstream_package(env: dict[str, str]) -> None:
+    """Fetch the upstream server package into the hermetic npm cache first.
+
+    The hermetic home starts with an empty npm cache, so the first ``npx``
+    of the package downloads it and its dependencies. Doing that inside the
+    timed MCP handshake made a slow registry look like a hung proxy, with an
+    empty stderr tail that could not tell the two apart. The warm-up is
+    untimed apart from a generous ceiling and ignores the package's own exit
+    status: it exists only to populate the cache, so the handshake budget
+    below measures the proxy and the server, not the network.
+    """
+    print("\n[1b] warm the upstream package cache")
+    try:
+        result = subprocess.run(
+            ["npx", "-y", EVERYTHING_PACKAGE, "--version"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit("warm-up: npx did not finish fetching the upstream package within 300s")
+    print(f"  npx exit={result.returncode} (package fetched; a non-zero exit here is the server rejecting --version, not a fetch failure)")
+
+
 def extract_wrapped_argv(cfg_path: Path):
     data = json.loads(cfg_path.read_text())
     entry = data["mcpServers"]["everything"]
@@ -254,6 +280,8 @@ def main():
         cmd, args = extract_wrapped_argv(cfg_path)
         print(f"  wrapped command: {cmd}")
         print(f"  wrapped args head: {' '.join(args[:6])} ...")
+
+        warm_upstream_package(runtime_env)
 
         print("\n[2] spawn wrapped subprocess and drive MCP handshake")
         proc = subprocess.Popen(

--- a/scripts/e2e/cline-mcp-runtime.py
+++ b/scripts/e2e/cline-mcp-runtime.py
@@ -127,24 +127,26 @@ def warm_upstream_package(env: dict[str, str]) -> None:
     The hermetic home starts with an empty npm cache, so the first ``npx``
     of the package downloads it and its dependencies. Doing that inside the
     timed MCP handshake made a slow registry look like a hung proxy, with an
-    empty stderr tail that could not tell the two apart. The warm-up is
-    untimed apart from a generous ceiling and ignores the package's own exit
-    status: it exists only to populate the cache, so the handshake budget
-    below measures the proxy and the server, not the network.
+    empty stderr tail that could not tell the two apart. ``npm exec`` installs
+    the package but runs Node instead of the MCP server, so cache preparation
+    cannot block waiting for protocol input. The handshake budget below then
+    measures the proxy and the already-fetched server, not the network.
     """
     print("\n[1b] warm the upstream package cache")
     try:
-        result = subprocess.run(
-            ["npx", "-y", EVERYTHING_PACKAGE, "--version"],
+        subprocess.run(
+            ["npm", "exec", "--yes", f"--package={EVERYTHING_PACKAGE}", "--", "node", "--version"],
             capture_output=True,
             text=True,
             env=env,
             timeout=300,
-            check=False,
+            check=True,
         )
-    except subprocess.TimeoutExpired:
-        sys.exit("warm-up: npx did not finish fetching the upstream package within 300s")
-    print(f"  npx exit={result.returncode} (package fetched; a non-zero exit here is the server rejecting --version, not a fetch failure)")
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit("warm-up: npm did not fetch the upstream package within 300s") from exc
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"warm-up: npm could not fetch the upstream package: {exc.stderr}") from exc
+    print("  package fetched")
 
 
 def extract_wrapped_argv(cfg_path: Path):

--- a/scripts/e2e/opencode-mcp-runtime.py
+++ b/scripts/e2e/opencode-mcp-runtime.py
@@ -135,6 +135,32 @@ def run_install(
         sys.exit(f"install did not wrap the expected count: {result.stdout!r}")
 
 
+def warm_upstream_package(env: dict[str, str]) -> None:
+    """Fetch the upstream server package into the hermetic npm cache first.
+
+    The hermetic home starts with an empty npm cache, so the first ``npx``
+    of the package downloads it and its dependencies. Doing that inside the
+    timed MCP handshake made a slow registry look like a hung proxy, with an
+    empty stderr tail that could not tell the two apart. The warm-up is
+    untimed apart from a generous ceiling and ignores the package's own exit
+    status: it exists only to populate the cache, so the handshake budget
+    below measures the proxy and the server, not the network.
+    """
+    print("\n[1b] warm the upstream package cache")
+    try:
+        result = subprocess.run(
+            ["npx", "-y", EVERYTHING_PACKAGE, "--version"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit("warm-up: npx did not finish fetching the upstream package within 300s")
+    print(f"  npx exit={result.returncode} (package fetched; a non-zero exit here is the server rejecting --version, not a fetch failure)")
+
+
 def extract_wrapped_argv(cfg_path: Path) -> list[str]:
     data = json.loads(cfg_path.read_text())
     entry = data["mcp"]["everything"]
@@ -263,6 +289,8 @@ def main():
         run_install(pipelock, cfg_path, pipelock_cfg, runtime_env)
         argv = extract_wrapped_argv(cfg_path)
         print(f"  wrapped command head: {' '.join(argv[:6])} ...")
+
+        warm_upstream_package(runtime_env)
 
         print("\n[2] spawn wrapped subprocess and drive MCP handshake")
         proc = subprocess.Popen(

--- a/scripts/e2e/opencode-mcp-runtime.py
+++ b/scripts/e2e/opencode-mcp-runtime.py
@@ -141,24 +141,26 @@ def warm_upstream_package(env: dict[str, str]) -> None:
     The hermetic home starts with an empty npm cache, so the first ``npx``
     of the package downloads it and its dependencies. Doing that inside the
     timed MCP handshake made a slow registry look like a hung proxy, with an
-    empty stderr tail that could not tell the two apart. The warm-up is
-    untimed apart from a generous ceiling and ignores the package's own exit
-    status: it exists only to populate the cache, so the handshake budget
-    below measures the proxy and the server, not the network.
+    empty stderr tail that could not tell the two apart. ``npm exec`` installs
+    the package but runs Node instead of the MCP server, so cache preparation
+    cannot block waiting for protocol input. The handshake budget below then
+    measures the proxy and the already-fetched server, not the network.
     """
     print("\n[1b] warm the upstream package cache")
     try:
-        result = subprocess.run(
-            ["npx", "-y", EVERYTHING_PACKAGE, "--version"],
+        subprocess.run(
+            ["npm", "exec", "--yes", f"--package={EVERYTHING_PACKAGE}", "--", "node", "--version"],
             capture_output=True,
             text=True,
             env=env,
             timeout=300,
-            check=False,
+            check=True,
         )
-    except subprocess.TimeoutExpired:
-        sys.exit("warm-up: npx did not finish fetching the upstream package within 300s")
-    print(f"  npx exit={result.returncode} (package fetched; a non-zero exit here is the server rejecting --version, not a fetch failure)")
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit("warm-up: npm did not fetch the upstream package within 300s") from exc
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"warm-up: npm could not fetch the upstream package: {exc.stderr}") from exc
+    print("  package fetched")
 
 
 def extract_wrapped_argv(cfg_path: Path) -> list[str]:

--- a/scripts/test_example_verification_workflow.py
+++ b/scripts/test_example_verification_workflow.py
@@ -111,6 +111,15 @@ class ExampleVerificationWorkflowTest(unittest.TestCase):
             self.assertRegex(result.stdout, r"(?m)^FAIL: 0$")
             self.assertRegex(result.stdout, r"(?m)^SKIP: 1$")
 
+    def test_runtime_warmups_fetch_without_starting_the_mcp_server(self):
+        for path in sorted((ROOT / "scripts" / "e2e").glob("*-mcp-runtime.py")):
+            body = path.read_text(encoding="utf-8")
+            self.assertIn('"npm", "exec", "--yes"', body, path)
+            self.assertIn('"--", "node", "--version"', body, path)
+            self.assertNotIn('EVERYTHING_PACKAGE, "--version"', body, path)
+            self.assertIn("timeout=300", body, path)
+            self.assertIn("check=True", body, path)
+
     def test_quickstart_runs_the_binary_built_from_this_tree(self):
         self.assertIn('local go_binary="${PIPELOCK_VERIFY_GO:-go}"', self.runner)
         self.assertIn('CGO_ENABLED=0 "$go_binary" build -trimpath', self.runner)

--- a/scripts/test_example_verification_workflow.py
+++ b/scripts/test_example_verification_workflow.py
@@ -121,17 +121,29 @@ class ExampleVerificationWorkflowTest(unittest.TestCase):
                 for node in tree.body
                 if isinstance(node, ast.FunctionDef) and node.name == "warm_upstream_package"
             )
+            main_node = next(
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == "main"
+            )
             warm_body = ast.get_source_segment(body, warm_node)
+            main_body = ast.get_source_segment(body, main_node)
             self.assertIsNotNone(warm_body, path)
+            self.assertIsNotNone(main_body, path)
             self.assertIn('"npm", "exec", "--yes"', warm_body, path)
             self.assertIn('f"--package={EVERYTHING_PACKAGE}"', warm_body, path)
             self.assertIn('"--", "node", "--version"', warm_body, path)
             self.assertNotIn('EVERYTHING_PACKAGE, "--version"', warm_body, path)
             self.assertIn("timeout=300", warm_body, path)
             self.assertIn("check=True", warm_body, path)
-            self.assertLess(
-                body.index("warm_upstream_package(runtime_env)"),
-                body.index("proc = subprocess.Popen("),
+            sequence = (
+                main_body.index("run_install("),
+                main_body.index("warm_upstream_package(runtime_env)"),
+                main_body.index("proc = subprocess.Popen("),
+            )
+            self.assertEqual(
+                sequence,
+                tuple(sorted(sequence)),
                 path,
             )
 

--- a/scripts/test_example_verification_workflow.py
+++ b/scripts/test_example_verification_workflow.py
@@ -4,6 +4,7 @@
 
 """Structural tests for the advisory example and installation verification."""
 
+import ast
 import os
 import re
 import subprocess
@@ -114,11 +115,25 @@ class ExampleVerificationWorkflowTest(unittest.TestCase):
     def test_runtime_warmups_fetch_without_starting_the_mcp_server(self):
         for path in sorted((ROOT / "scripts" / "e2e").glob("*-mcp-runtime.py")):
             body = path.read_text(encoding="utf-8")
-            self.assertIn('"npm", "exec", "--yes"', body, path)
-            self.assertIn('"--", "node", "--version"', body, path)
-            self.assertNotIn('EVERYTHING_PACKAGE, "--version"', body, path)
-            self.assertIn("timeout=300", body, path)
-            self.assertIn("check=True", body, path)
+            tree = ast.parse(body)
+            warm_node = next(
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == "warm_upstream_package"
+            )
+            warm_body = ast.get_source_segment(body, warm_node)
+            self.assertIsNotNone(warm_body, path)
+            self.assertIn('"npm", "exec", "--yes"', warm_body, path)
+            self.assertIn('f"--package={EVERYTHING_PACKAGE}"', warm_body, path)
+            self.assertIn('"--", "node", "--version"', warm_body, path)
+            self.assertNotIn('EVERYTHING_PACKAGE, "--version"', warm_body, path)
+            self.assertIn("timeout=300", warm_body, path)
+            self.assertIn("check=True", warm_body, path)
+            self.assertLess(
+                body.index("warm_upstream_package(runtime_env)"),
+                body.index("proc = subprocess.Popen("),
+                path,
+            )
 
     def test_quickstart_runs_the_binary_built_from_this_tree(self):
         self.assertIn('local go_binary="${PIPELOCK_VERIFY_GO:-go}"', self.runner)


### PR DESCRIPTION
## What changed

The two MCP runtime end-to-end scripts fetch the upstream test server into their hermetic npm cache before the timed handshake starts. Until now the first `npx` of the package ran inside the 60-second `initialize` budget, so a slow registry looked like a hung proxy and the failure carried an empty stderr tail that couldn't tell the two apart. The warm-up has its own generous ceiling and ignores the package's exit status, since it exists only to populate the cache; the handshake budget now measures the proxy and the server alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end MCP runtime checks by pre-fetching required server packages before timed connection handshakes.
  - Reduced false timeout reports caused by slow package downloads.
  - Added clearer error reporting when package downloads fail or exceed five minutes.

- **Tests**
  - Added verification that runtime warm-ups fetch packages successfully without starting the MCP server, improving test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->