### PR TITLE
fix(playground): seal a delegated run against its root key

### DIFF
--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -321,18 +321,27 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		// delegation would sign a run no published key authorized. Retain the
 		// verified root: the session key signs the manifest, but it must never
 		// be presented as the root that signed the delegation at seal time.
-		root, rootErr := trustedDelegationRoot()
+		resolved, rootErr := trustedDelegationRoot()
 		if rootErr != nil {
 			err = rootErr
 			return nil, err
 		}
+		// Copy and size-check BEFORE verifying, then use only the copy. The
+		// resolver hands back a slice this function does not own, so verifying
+		// the caller's slice and retaining a copy taken afterwards would let the
+		// bytes that were authenticated differ from the bytes kept for sealing
+		// and for the trust root stamped into the downloaded archive.
+		// Size is checked downstream by delegation verification, which owns that
+		// error contract; duplicating it here would only give the same refusal
+		// two different messages.
+		root := append(ed25519.PublicKey(nil), resolved...)
 		if delErr := verifySessionDelegationWithRoot(root, opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); delErr != nil {
 			err = fmt.Errorf("session delegation: %w", delErr)
 			return nil, err
 		}
 		lr.orchestratorPriv = opts.SessionPrivateKey
 		lr.orchestratorPub = lr.orchestratorPriv.Public().(ed25519.PublicKey)
-		lr.delegationRoot = append(ed25519.PublicKey(nil), root...)
+		lr.delegationRoot = root
 	case opts.OrchestratorKeyPath != "":
 		var loadErr error
 		lr.orchestratorPriv, loadErr = LoadOrchestratorSigningKey(opts.OrchestratorKeyPath)

--- a/internal/playground/liverun.go
+++ b/internal/playground/liverun.go
@@ -133,10 +133,14 @@ type LiveRun struct {
 	// Keys
 	orchestratorPub  ed25519.PublicKey
 	orchestratorPriv ed25519.PrivateKey
-	collectorPub     ed25519.PublicKey
-	collectorPriv    ed25519.PrivateKey
-	pipelockPub      ed25519.PublicKey
-	pipelockPriv     ed25519.PrivateKey
+	// delegationRoot is the durable root that authenticated orchestratorPub when
+	// this run uses delegated signing. It is retained so sealing verifies the
+	// delegation against the root rather than against the delegated signer.
+	delegationRoot ed25519.PublicKey
+	collectorPub   ed25519.PublicKey
+	collectorPriv  ed25519.PrivateKey
+	pipelockPub    ed25519.PublicKey
+	pipelockPriv   ed25519.PrivateKey
 
 	// Infrastructure
 	safeTarget   *SafeTarget
@@ -314,13 +318,21 @@ func StartLiveRun(ctx context.Context, opts LiveRunOpts) (*LiveRun, error) {
 		}
 		// Verify at the signing boundary too. A direct caller reaches this
 		// path without passing through the server's check, and an unverified
-		// delegation would sign a run no published key authorized.
-		if delErr := VerifySessionDelegation(opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); delErr != nil {
+		// delegation would sign a run no published key authorized. Retain the
+		// verified root: the session key signs the manifest, but it must never
+		// be presented as the root that signed the delegation at seal time.
+		root, rootErr := trustedDelegationRoot()
+		if rootErr != nil {
+			err = rootErr
+			return nil, err
+		}
+		if delErr := verifySessionDelegationWithRoot(root, opts.SessionPrivateKey, *opts.Delegation, opts.RunNonce); delErr != nil {
 			err = fmt.Errorf("session delegation: %w", delErr)
 			return nil, err
 		}
 		lr.orchestratorPriv = opts.SessionPrivateKey
 		lr.orchestratorPub = lr.orchestratorPriv.Public().(ed25519.PublicKey)
+		lr.delegationRoot = append(ed25519.PublicKey(nil), root...)
 	case opts.OrchestratorKeyPath != "":
 		var loadErr error
 		lr.orchestratorPriv, loadErr = LoadOrchestratorSigningKey(opts.OrchestratorKeyPath)
@@ -903,7 +915,7 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 	}
 
 	// --- Verify ---
-	rep, err := VerifyRun(runDir, hex.EncodeToString(lr.orchestratorPub))
+	rep, err := VerifyRun(runDir, lr.OrchestratorPubHex())
 	if err != nil {
 		return VerifyReport{}, fmt.Errorf("verify run: %w", err)
 	}
@@ -917,6 +929,9 @@ func (lr *LiveRun) AssembleAndVerify(runDir string) (VerifyReport, error) {
 // OrchestratorPubHex returns the run's trust-root (orchestrator) public key as
 // hex -- the key a downloaded session bundle is verified against offline.
 func (lr *LiveRun) OrchestratorPubHex() string {
+	if len(lr.delegationRoot) != 0 {
+		return hex.EncodeToString(lr.delegationRoot)
+	}
 	return hex.EncodeToString(lr.orchestratorPub)
 }
 

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -71,6 +71,46 @@ func TestStartLiveRun_DelegatedSessionBindsManifest(t *testing.T) {
 	}
 }
 
+// A delegated run has two identities: its session key signs the manifest, while
+// the root authorizes that session key. Final sealing and a downloaded verifier
+// must receive the latter, or they compare root_key_id against the session key
+// and reject a valid delegation.
+func TestLiveRun_DelegatedSessionReportsDelegationRoot(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "delegated-trust-root"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err != nil {
+		t.Fatalf("StartLiveRun: %v", err)
+	}
+	defer lr.Close()
+
+	if got, want := lr.OrchestratorPubHex(), hex.EncodeToString(root.Public().(ed25519.PublicKey)); got != want {
+		t.Fatalf("OrchestratorPubHex = %q, want delegation root %q", got, want)
+	}
+	if got := lr.OrchestratorPubHex(); got == minted.Delegation.SessionPublicKey {
+		t.Fatal("delegated session key must not be reported as the delegation trust root")
+	}
+
+	sessionPub := minted.PrivateKey.Public().(ed25519.PublicKey)
+	if err := VerifyOrchestratorDelegation(sessionPub, minted.Delegation, DelegationExpectations{RunNonce: nonce, ImageDigest: testRunImageDigest}); err == nil || !strings.Contains(err.Error(), "root_key_id does not match expected root") {
+		t.Fatalf("session signer verification error = %v, want root key id mismatch", err)
+	}
+	if err := VerifyOrchestratorDelegation(root.Public().(ed25519.PublicKey), minted.Delegation, DelegationExpectations{RunNonce: nonce, ImageDigest: testRunImageDigest}); err != nil {
+		t.Fatalf("delegation root verification: %v", err)
+	}
+}
+
 // The delegation travels with the run directory, so an offline verifier can
 // walk session key back to the published root without contacting anything.
 func TestLiveRun_DelegatedRunWritesDelegationArtifact(t *testing.T) {

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -433,3 +433,45 @@ func TestVerifySessionDelegation_RefusesMalformedPrivateKey(t *testing.T) {
 		t.Fatal("a malformed session private key must be refused")
 	}
 }
+
+// The resolver hands back a slice the run does not own. Verification and the
+// retained root must therefore read the same immutable bytes: if the run kept a
+// copy taken after verification, a resolver that reused or mutated its buffer
+// could authenticate one key and stamp a different one into the sealed archive.
+func TestStartLiveRun_RetainedRootIgnoresResolverMutation(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "resolver-mutation-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	// Hand back one shared, mutable buffer on every call.
+	previous := trustedDelegationRoot
+	shared := append(ed25519.PublicKey(nil), root.Public().(ed25519.PublicKey)...)
+	trustedDelegationRoot = func() (ed25519.PublicKey, error) { return shared, nil }
+	t.Cleanup(func() { trustedDelegationRoot = previous })
+
+	want := hex.EncodeToString(shared)
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err != nil {
+		t.Fatalf("StartLiveRun: %v", err)
+	}
+	defer lr.Close()
+
+	// Corrupt the resolver's buffer after the run started.
+	for i := range shared {
+		shared[i] ^= 0xff
+	}
+
+	if got := lr.OrchestratorPubHex(); got != want {
+		t.Fatalf("retained root = %s, want %s; the run kept the resolver's buffer instead of its own copy", got, want)
+	}
+}

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -348,3 +348,88 @@ func TestStartLiveRun_RefusesWhenTrustedRootUnavailable(t *testing.T) {
 		t.Fatalf("error = %v, want the trusted-root failure surfaced", err)
 	}
 }
+
+// A resolver returning bytes that are not an Ed25519 public key must fail
+// closed. It is not enough to reject a resolver error: a partial key is just
+// as incapable of authenticating a delegation.
+func TestStartLiveRun_RefusesMalformedTrustedRoot(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "malformed-root-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	previous := trustedDelegationRoot
+	trustedDelegationRoot = func() (ed25519.PublicKey, error) {
+		return ed25519.PublicKey("short"), nil
+	}
+	t.Cleanup(func() { trustedDelegationRoot = previous })
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err == nil {
+		lr.Close()
+		t.Fatal("a malformed trusted root must refuse the run")
+	}
+	if !strings.Contains(err.Error(), "delegation root public key has wrong size") {
+		t.Fatalf("error = %v, want malformed-root refusal", err)
+	}
+}
+
+// The delegation root is resolved from a caller-owned byte slice. Retaining
+// that slice would let later mutation change the root shown to the offline
+// verifier after the delegation was authenticated.
+func TestLiveRun_DelegationRootIsCopied(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "copied-root-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err != nil {
+		t.Fatalf("StartLiveRun: %v", err)
+	}
+	defer lr.Close()
+
+	want := hex.EncodeToString(root.Public().(ed25519.PublicKey))
+	resolved, err := trustedDelegationRoot()
+	if err != nil {
+		t.Fatalf("trustedDelegationRoot: %v", err)
+	}
+	resolved[0] ^= 0xff
+
+	if got := lr.OrchestratorPubHex(); got != want {
+		t.Fatalf("OrchestratorPubHex after root mutation = %q, want retained root %q", got, want)
+	}
+}
+
+// VerifySessionDelegation is a package entry point as well as StartLiveRun's
+// internal guard. A malformed direct caller must receive a refusal rather than
+// causing PrivateKey.Public to panic before a delegation can be checked.
+func TestVerifySessionDelegation_RefusesMalformedPrivateKey(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "malformed-session-private-key"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	if err := VerifySessionDelegation(ed25519.PrivateKey("short"), minted.Delegation, nonce); err == nil {
+		t.Fatal("a malformed session private key must be refused")
+	}
+}

--- a/internal/playground/liverun_delegation_internal_test.go
+++ b/internal/playground/liverun_delegation_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -311,5 +312,39 @@ func TestParseOrchestratorPrivateKeyHex_RejectsMalformedShapes(t *testing.T) {
 				t.Fatalf("%q must be refused", tc.name)
 			}
 		})
+	}
+}
+
+// A delegated run cannot be authorized when the trusted root itself is
+// unreadable. Refusing is the only safe direction: continuing would sign a run
+// under a session key nothing verified, which is the state that produced a
+// bundle no visitor could verify.
+func TestStartLiveRun_RefusesWhenTrustedRootUnavailable(t *testing.T) {
+	root := testRunRoot(t)
+	const nonce = "unreadable-root-nonce"
+
+	minted, err := MintSessionDelegation(root, nonce, testRunImageDigest, time.Now().UTC(), 0)
+	if err != nil {
+		t.Fatalf("MintSessionDelegation: %v", err)
+	}
+
+	previous := trustedDelegationRoot
+	trustedDelegationRoot = func() (ed25519.PublicKey, error) {
+		return nil, errors.New("published root unavailable")
+	}
+	t.Cleanup(func() { trustedDelegationRoot = previous })
+
+	lr, err := StartLiveRun(t.Context(), LiveRunOpts{
+		ScenarioID:        LiveDemoScenarioID,
+		RunNonce:          nonce,
+		SessionPrivateKey: minted.PrivateKey,
+		Delegation:        &minted.Delegation,
+	})
+	if err == nil {
+		lr.Close()
+		t.Fatal("an unreadable trusted root must refuse the run")
+	}
+	if !strings.Contains(err.Error(), "published root unavailable") {
+		t.Fatalf("error = %v, want the trusted-root failure surfaced", err)
 	}
 }

--- a/internal/playground/session_delegation.go
+++ b/internal/playground/session_delegation.go
@@ -41,6 +41,9 @@ func VerifySessionDelegation(priv ed25519.PrivateKey, d OrchestratorDelegation, 
 // selected by the caller. Keeping that selected root lets a live run carry the
 // same trust root through its final offline verification and download metadata.
 func verifySessionDelegationWithRoot(root ed25519.PublicKey, priv ed25519.PrivateKey, d OrchestratorDelegation, runNonce string) error {
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return fmt.Errorf("session signing key: %w", err)
+	}
 	if runNonce == "" {
 		return fmt.Errorf("delegated session requires a run nonce")
 	}

--- a/internal/playground/session_delegation.go
+++ b/internal/playground/session_delegation.go
@@ -30,12 +30,19 @@ var trustedDelegationRoot = PublishedOrchestratorPublicKey
 // proves only that a delegation is well formed; without this a caller could
 // present a structurally valid delegation it signed itself.
 func VerifySessionDelegation(priv ed25519.PrivateKey, d OrchestratorDelegation, runNonce string) error {
-	if runNonce == "" {
-		return fmt.Errorf("delegated session requires a run nonce")
-	}
 	root, err := trustedDelegationRoot()
 	if err != nil {
 		return err
+	}
+	return verifySessionDelegationWithRoot(root, priv, d, runNonce)
+}
+
+// verifySessionDelegationWithRoot verifies a delegated session against the root
+// selected by the caller. Keeping that selected root lets a live run carry the
+// same trust root through its final offline verification and download metadata.
+func verifySessionDelegationWithRoot(root ed25519.PublicKey, priv ed25519.PrivateKey, d OrchestratorDelegation, runNonce string) error {
+	if runNonce == "" {
+		return fmt.Errorf("delegated session requires a run nonce")
 	}
 	if err := VerifyOrchestratorDelegation(root, d, DelegationExpectations{RunNonce: runNonce}); err != nil {
 		return err


### PR DESCRIPTION
## What changed

A delegated playground run signs its launch manifest with a short-lived session key that a root-signed delegation authorizes. Sealing and the downloaded archive presented that session key as the run's trust root, so verification compared the delegation's root against the delegated signer and refused. The run now retains the root that authenticated the session key and presents that instead, leaving the signed delegation format, the manifest schema and the verifier protocol unchanged.

The failure direction was closed rather than open: a bad trust anchor made the seal refuse and release nothing, so visitors saw a failed download instead of an unverifiable bundle. The same accessor also stamps the trust root into the archive a visitor downloads, so bundles produced before this change name a key that cannot verify them offline.

Verifying a delegated session with a malformed private key panicked inside the standard library instead of returning an error. Key consistency is now validated before use, so malformed input is refused at the boundary.

A reviewer confirmed that verify kits intentionally pin the compiled published root. That is correct for public sessions and means a development server running a different legitimate root can produce a kit that rejects its own bundle. It is left unchanged here because accepting a root from the archive would weaken the kit's trust boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Delegated runs now report and verify against the durable delegation root instead of the temporary session key.
  - Session delegation verification fails safely when the trusted root is unavailable, malformed, or inconsistent with the expected signing identity.
  - Additional validation prevents malformed private keys from causing verification failures or unexpected crashes.

- **Reliability**
  - Delegation-root information remains stable even if the original key data is later modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->