### PR TITLE
fix(playground): refuse to serve without a usable signing root

### DIFF
--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -114,6 +114,37 @@ func TestRunServeCheckConfig_PassesWithCleanEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunServePrintRequiredEnvReportsNamesWithoutReadingValues(t *testing.T) {
+	f := testServeFlags(t, 0)
+	f.printRequiredEnv = true
+	f.requireSessionSecrets = true
+	f.flyTokenFile = ""
+	f.flyTokenEnv = "BROKER_FLY_TOKEN"
+	f.turnstileSecretEnv = "BROKER_TURNSTILE_SECRET"
+	f.unsafeNoHumanGate = false
+	f.turnstileSitekey = "site-key"
+	f.turnstileExpectedHostname = "playground.example"
+	f.turnstileExpectedAction = "playground-session"
+	f.image = "registry.example/playground@sha256:" + strings.Repeat("a", 64)
+	f.vmImageDigest = "sha256:" + strings.Repeat("a", 64)
+	t.Setenv("BROKER_FLY_TOKEN", "must-not-be-read-or-printed")
+
+	cmd := newServeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := runServe(cmd, f); err != nil {
+		t.Fatalf("print required env: %v", err)
+	}
+	got := strings.Fields(out.String())
+	want := []string{"BROKER_FLY_TOKEN", "BROKER_TURNSTILE_SECRET", envModelKey, envOrchestratorRoot}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("required env = %q, want %q", got, want)
+	}
+	if strings.Contains(out.String(), "must-not-be-read-or-printed") {
+		t.Fatal("required-env report exposed an environment value")
+	}
+}
+
 // An unreadable root file fails closed at resolution. Starting without a usable
 // root would mint nothing, and every session would then run unsigned.
 func TestResolveOrchestratorRoot_UnreadableFileFailsClosed(t *testing.T) {

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -64,11 +64,15 @@ func TestBuildImagesOnlyVMDoesNotRequireViewer(t *testing.T) {
 	dockerLog := filepath.Join(tmp, "docker.log")
 	dockerPath := filepath.Join(tmp, "docker")
 	dockerStub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >>\"$DOCKER_LOG\"\n"
-	if err := os.WriteFile(dockerPath, []byte(dockerStub), 0o700); err != nil {
+	if err := os.WriteFile(dockerPath, []byte(dockerStub), 0o600); err != nil {
 		t.Fatalf("write docker stub: %v", err)
 	}
-	script := filepath.Join("..", "..", "deploy", "fly-playground", "build-images.sh")
-	cmd := exec.Command("bash", script, "--only", "vm")
+	// The temporary file has to be executable because build-images.sh resolves
+	// docker through PATH. It contains only the fixed test stub above.
+	if err := os.Chmod(dockerPath, 0o700); err != nil { // #nosec G302 -- executable test stub
+		t.Fatalf("make docker stub executable: %v", err)
+	}
+	cmd := exec.Command("bash", "../../deploy/fly-playground/build-images.sh", "--only", "vm")
 	cmd.Env = append(os.Environ(),
 		"PATH="+tmp+":"+os.Getenv("PATH"),
 		"DOCKER_LOG="+dockerLog,
@@ -80,7 +84,7 @@ func TestBuildImagesOnlyVMDoesNotRequireViewer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("VM-only build failed: %v\n%s", err, output)
 	}
-	logBytes, err := os.ReadFile(dockerLog)
+	logBytes, err := os.ReadFile(filepath.Clean(dockerLog))
 	if err != nil {
 		t.Fatalf("read docker log: %v", err)
 	}

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -25,6 +25,20 @@ func TestResolveOrchestratorRoot_MalformedFailsClosed(t *testing.T) {
 	}
 }
 
+// Production derives delegated-signing enforcement from the existing session
+// secret policy. An absent root must name the default deployment variable so
+// the operator can repair the startup refusal directly.
+func TestResolveOrchestratorRoot_MissingProductionRootNamesEnvironment(t *testing.T) {
+	t.Setenv(envOrchestratorRoot, "")
+	_, err := resolveOrchestratorRoot(&serveFlags{requireSessionSecrets: true})
+	if err == nil {
+		t.Fatal("an absent production orchestrator root must fail closed")
+	}
+	if !strings.Contains(err.Error(), envOrchestratorRoot) {
+		t.Fatalf("error %v must name %s", err, envOrchestratorRoot)
+	}
+}
+
 // The digest is what binds a delegation to one immutable image, so a value
 // that merely looks digest-shaped must be refused.
 func TestResolveImageDigest_RejectsNonCanonical(t *testing.T) {

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/hex"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +17,78 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/playground/broker"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
+
+func TestBuildImagesBrokerPreflightArgumentsPassCheckConfig(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "deploy", "fly-playground", "build-images.sh"))
+	if err != nil {
+		t.Fatalf("read build-images.sh: %v", err)
+	}
+	const start = "BROKER_PREFLIGHT_ARGS=("
+	section := string(raw)
+	startAt := strings.Index(section, start)
+	if startAt < 0 {
+		t.Fatal("build-images.sh has no broker preflight argument array")
+	}
+	section = section[startAt+len(start):]
+	endAt := strings.Index(section, "\n)")
+	if endAt < 0 {
+		t.Fatal("broker preflight argument array is not terminated")
+	}
+	args := strings.Fields(section[:endAt])
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<!doctype html><title>preflight</title>"), 0o600); err != nil {
+		t.Fatalf("write preflight UI: %v", err)
+	}
+	for i, arg := range args {
+		if arg == "/srv/ui" {
+			args[i] = staticDir
+		}
+	}
+
+	t.Setenv(envOrchestratorKey, "")
+	cmd := newRootCmd()
+	cmd.SetArgs(args)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("shipped broker preflight rejected by --check-config: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "valid") {
+		t.Fatalf("preflight output = %q, want validity statement", out.String())
+	}
+}
+
+func TestBuildImagesOnlyVMDoesNotRequireViewer(t *testing.T) {
+	tmp := t.TempDir()
+	dockerLog := filepath.Join(tmp, "docker.log")
+	dockerPath := filepath.Join(tmp, "docker")
+	dockerStub := "#!/bin/sh\nprintf '%s\\n' \"$*\" >>\"$DOCKER_LOG\"\n"
+	if err := os.WriteFile(dockerPath, []byte(dockerStub), 0o700); err != nil {
+		t.Fatalf("write docker stub: %v", err)
+	}
+	script := filepath.Join("..", "..", "deploy", "fly-playground", "build-images.sh")
+	cmd := exec.Command("bash", script, "--only", "vm")
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmp+":"+os.Getenv("PATH"),
+		"DOCKER_LOG="+dockerLog,
+		"PLAYGROUND_REGISTRY=registry.example/playground",
+		"PLAYGROUND_UI_DIR=",
+		"PLAYGROUND_PUSH=",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("VM-only build failed: %v\n%s", err, output)
+	}
+	logBytes, err := os.ReadFile(dockerLog)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	logText := string(logBytes)
+	if !strings.Contains(logText, "Dockerfile") || strings.Contains(logText, "Dockerfile.broker") || strings.Contains(logText, " run ") {
+		t.Fatalf("VM-only docker calls = %q", logText)
+	}
+}
 
 // A malformed root must fail closed. Serving with an unusable signing root
 // would mint delegations nothing can verify.

--- a/cmd/pipelock-playground-broker/guardrail_coverage_test.go
+++ b/cmd/pipelock-playground-broker/guardrail_coverage_test.go
@@ -72,7 +72,7 @@ func TestBuildImagesOnlyVMDoesNotRequireViewer(t *testing.T) {
 	if err := os.Chmod(dockerPath, 0o700); err != nil { // #nosec G302 -- executable test stub
 		t.Fatalf("make docker stub executable: %v", err)
 	}
-	cmd := exec.Command("bash", "../../deploy/fly-playground/build-images.sh", "--only", "vm")
+	cmd := exec.CommandContext(t.Context(), "bash", "../../deploy/fly-playground/build-images.sh", "--only", "vm")
 	cmd.Env = append(os.Environ(),
 		"PATH="+tmp+":"+os.Getenv("PATH"),
 		"DOCKER_LOG="+dockerLog,

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -137,6 +138,7 @@ type serveFlags struct {
 	turnstileSitekey          string
 	turnstileOrigin           string
 	checkConfig               bool
+	printRequiredEnv          bool
 	sessionTTL                time.Duration
 	deadlineGrace             time.Duration
 	allowOrigin               string
@@ -240,6 +242,7 @@ func newServeCmd() *cobra.Command {
 	fl.StringVar(&f.turnstileSitekey, "turnstile-sitekey", "", "public Cloudflare Turnstile site key; reported via /health so the viewer renders the widget (the secret is set separately via --turnstile-secret-*)")
 	fl.StringVar(&f.turnstileOrigin, "turnstile-origin", "", "validated browser origin used by the Turnstile widget and added to CSP only when configured")
 	fl.BoolVar(&f.checkConfig, "check-config", false, "validate flags and static UI compatibility, then exit without resolving secrets or contacting providers")
+	fl.BoolVar(&f.printRequiredEnv, "print-required-env", false, "print required environment variable names, one per line, then exit without reading their values")
 	fl.DurationVar(&f.sessionTTL, "session-ttl", defaultSessionTTL, "VM session token TTL")
 	fl.DurationVar(&f.deadlineGrace, "deadline-grace", defaultGrace, "lease teardown grace after VM session expiry")
 	fl.StringVar(&f.allowOrigin, "allow-origin", "", "Access-Control-Allow-Origin for the browser")
@@ -281,6 +284,12 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 	}
 	if err := validateStaticUI(f.staticDir, effectiveTurnstileOrigin(f), f.externalScriptOrigins); err != nil {
 		return err
+	}
+	if f.printRequiredEnv {
+		for _, name := range requiredEnvironmentNames(f) {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), name)
+		}
+		return nil
 	}
 	if f.checkConfig {
 		if _, _, err := resolveBrokerCodes(f); err != nil {
@@ -349,6 +358,30 @@ func runServe(cmd *cobra.Command, f *serveFlags) error {
 		return err
 	}
 	return nil
+}
+
+func requiredEnvironmentNames(f *serveFlags) []string {
+	names := make([]string, 0, 6)
+	addEnvUnlessFile := func(file, configuredEnv, defaultEnv string, required bool) {
+		if strings.TrimSpace(file) != "" {
+			return
+		}
+		if name := strings.TrimSpace(configuredEnv); name != "" {
+			names = append(names, name)
+			return
+		}
+		if required && defaultEnv != "" {
+			names = append(names, defaultEnv)
+		}
+	}
+	addEnvUnlessFile(f.flyTokenFile, f.flyTokenEnv, "", true)
+	addEnvUnlessFile(f.gateSecretFile, f.gateSecretEnv, "", false)
+	addEnvUnlessFile(f.turnstileSecretFile, f.turnstileSecretEnv, "", false)
+	addEnvUnlessFile(f.adminTokenFile, f.adminTokenEnv, "", strings.TrimSpace(f.adminListen) != "")
+	addEnvUnlessFile(f.modelKeyFile, f.modelKeyEnv, envModelKey, f.requireSessionSecrets)
+	addEnvUnlessFile(f.orchestratorKeyFile, f.orchestratorKeyEnv, envOrchestratorRoot, f.requireSessionSecrets)
+	slices.Sort(names)
+	return slices.Compact(names)
 }
 
 func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Server, http.Handler, func(context.Context), *broker.Pool, error) {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -1954,7 +1954,7 @@ func resolveSessionSecret(file, envName, flagName, defaultEnv string, required b
 			return v, nil
 		}
 		if required {
-			return "", fmt.Errorf("%s, %s, or --%s-env is required", defaultEnv, flagName, strings.TrimPrefix(strings.TrimPrefix(flagName, "--"), "-"))
+			return "", fmt.Errorf("%s, %s, or %s is required", defaultEnv, flagName, strings.TrimSuffix(flagName, "-file")+"-env")
 		}
 		return "", nil
 	}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -470,12 +470,16 @@ func buildServer(ctx context.Context, out io.Writer, f *serveFlags) (*broker.Ser
 		GlobalDailyBudget:  f.globalDailyBudget,
 		SessionEnv:         sessionEnv,
 		OrchestratorRoot:   rootKey,
-		ImageDigest:        imageDigest,
-		InternalPort:       f.internalPort,
-		DeadlineGrace:      f.deadlineGrace,
-		TrustForwardedFor:  f.trustForwardedFor,
-		AllowOrigin:        f.allowOrigin,
-		ProviderHealth:     providerHealth,
+		// The existing production secret policy is also the signing policy: when
+		// session secrets are required, every visitor must use a root-authorized
+		// delegated key. Development keeps both optional through the same switch.
+		RequireDelegatedSigning: f.requireSessionSecrets,
+		ImageDigest:             imageDigest,
+		InternalPort:            f.internalPort,
+		DeadlineGrace:           f.deadlineGrace,
+		TrustForwardedFor:       f.trustForwardedFor,
+		AllowOrigin:             f.allowOrigin,
+		ProviderHealth:          providerHealth,
 	})
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -1917,7 +1921,7 @@ func resolveSessionSecret(file, envName, flagName, defaultEnv string, required b
 			return v, nil
 		}
 		if required {
-			return "", fmt.Errorf("%s or --%s-env is required", flagName, strings.TrimPrefix(strings.TrimPrefix(flagName, "--"), "-"))
+			return "", fmt.Errorf("%s, %s, or --%s-env is required", defaultEnv, flagName, strings.TrimPrefix(strings.TrimPrefix(flagName, "--"), "-"))
 		}
 		return "", nil
 	}

--- a/deploy/fly-playground/build-images.sh
+++ b/deploy/fly-playground/build-images.sh
@@ -2,7 +2,7 @@
 # Copyright 2026 Josh Waldrep
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build (and optionally push) the playground VM + broker images.
+# Build (and optionally push) the playground VM and broker images.
 #
 # The broker bundles the static playground viewer at /srv/ui via a BuildKit
 # named build context, so the viewer lives in the site repo (not vendored here)
@@ -12,23 +12,45 @@
 #
 # Required env:
 #   PLAYGROUND_REGISTRY  registry/app prefix, e.g. registry.fly.io/<fly-app>
-#   PLAYGROUND_UI_DIR    path to the site's static/playground/demo directory
+#   PLAYGROUND_UI_DIR    site static/playground/demo directory (broker builds)
 # Optional env:
-#   PLAYGROUND_PUSH=1    also `docker push` both images after building
+#   PLAYGROUND_PUSH=1    also push each selected image after building
 #
 # Example:
 #   PLAYGROUND_REGISTRY=registry.fly.io/<app> \
 #   PLAYGROUND_UI_DIR=/path/to/site/static/playground/demo \
 #   PLAYGROUND_PUSH=1 deploy/fly-playground/build-images.sh
+#
+# Build one image:
+#   deploy/fly-playground/build-images.sh --only broker
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 : "${PLAYGROUND_REGISTRY:?set PLAYGROUND_REGISTRY, e.g. registry.fly.io/<fly-app>}"
-: "${PLAYGROUND_UI_DIR:?set PLAYGROUND_UI_DIR to the site static/playground/demo dir}"
 
-if [ ! -f "${PLAYGROUND_UI_DIR}/index.html" ]; then
-	echo "PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR} has no index.html; refusing to build a broker with an empty viewer" >&2
-	exit 1
+build_vm=1
+build_broker=1
+if [ "$#" -gt 0 ]; then
+	if [ "$#" -ne 2 ] || [ "$1" != "--only" ]; then
+		echo "usage: $0 [--only vm|broker]" >&2
+		exit 2
+	fi
+	case "$2" in
+	vm) build_broker=0 ;;
+	broker) build_vm=0 ;;
+	*)
+		echo "usage: $0 [--only vm|broker]" >&2
+		exit 2
+		;;
+	esac
+fi
+
+if [ "${build_broker}" -eq 1 ]; then
+	: "${PLAYGROUND_UI_DIR:?set PLAYGROUND_UI_DIR to the site static/playground/demo dir}"
+	if [ ! -f "${PLAYGROUND_UI_DIR}/index.html" ]; then
+		echo "PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR} has no index.html; refusing to build a broker with an empty viewer" >&2
+		exit 1
+	fi
 fi
 
 VM_TAG="${PLAYGROUND_REGISTRY}:vm"
@@ -54,8 +76,10 @@ if [ -n "${HTTP_PROXY:-${http_proxy:-${HTTPS_PROXY:-${https_proxy:-}}}}" ]; then
 	)
 fi
 
-echo "[build-images] building VM image ${VM_TAG}"
-docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
+if [ "${build_vm}" -eq 1 ]; then
+	echo "[build-images] building VM image ${VM_TAG}"
+	docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile -t "${VM_TAG}" .
+fi
 
 # The viewer's inline "Verify in your browser" button loads a WASM build of the
 # shipped verifier from the served dir. Build it straight into PLAYGROUND_UI_DIR
@@ -65,44 +89,55 @@ docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile -t "
 # build path is absent or produces no .wasm, so the image cannot silently ship a
 # viewer whose inline-verify button points at missing browser-verifier assets.
 # go (with the js/wasm target) must be on PATH.
-if [ ! -x deploy/wasm-verify/build.sh ]; then
+if [ "${build_broker}" -eq 1 ] && [ ! -x deploy/wasm-verify/build.sh ]; then
 	echo "[build-images] ERROR: deploy/wasm-verify/build.sh absent; refusing to build a broker with potentially stale inline browser-verify UI" >&2
 	exit 1
 fi
-echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
-wasm_stamp="$(mktemp)"
-trap 'rm -f "${wasm_stamp}"' EXIT
-deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
-if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -newer "${wasm_stamp}" -print -quit | grep -q .; then
-	echo "[build-images] ERROR: browser-verifier build produced no .wasm under PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR}; refusing to ship unwired inline verify UI" >&2
-	exit 1
+
+BROKER_PREFLIGHT_ARGS=(
+	serve
+	--check-config
+	--fly-app preflight
+	--fly-token-env PREFLIGHT_FLY_TOKEN
+	--image registry.example/playground@sha256:0000000000000000000000000000000000000000000000000000000000000000
+	--vm-image-digest sha256:0000000000000000000000000000000000000000000000000000000000000000
+	--global-daily-budget 1
+	--vm-daily-turn-budget 1
+	--turnstile-secret-env PREFLIGHT_TURNSTILE_SECRET
+	--turnstile-sitekey 1x00000000000000000000AA
+	--turnstile-expected-hostname preflight.invalid
+	--turnstile-action preflight-session
+	--static-dir /srv/ui
+)
+
+if [ "${build_broker}" -eq 1 ]; then
+	echo "[build-images] building browser-verifier WASM into ${PLAYGROUND_UI_DIR}"
+	wasm_stamp="$(mktemp)"
+	trap 'rm -f "${wasm_stamp}"' EXIT
+	deploy/wasm-verify/build.sh "${PLAYGROUND_UI_DIR}"
+	if ! find "${PLAYGROUND_UI_DIR}" -type f -name '*.wasm' -newer "${wasm_stamp}" -print -quit | grep -q .; then
+		echo "[build-images] ERROR: browser-verifier build produced no .wasm under PLAYGROUND_UI_DIR=${PLAYGROUND_UI_DIR}; refusing to ship unwired inline verify UI" >&2
+		exit 1
+	fi
+
+	echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"
+	docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile.broker \
+		--build-context "ui=${PLAYGROUND_UI_DIR}" \
+		-t "${BROKER_TAG}" .
+
+	echo "[build-images] validating broker/viewer image contract"
+	docker run --rm "${BROKER_TAG}" "${BROKER_PREFLIGHT_ARGS[@]}"
 fi
 
-echo "[build-images] building broker image ${BROKER_TAG} (viewer from ${PLAYGROUND_UI_DIR})"
-docker build "${DOCKER_BUILD_FLAGS[@]}" -f deploy/fly-playground/Dockerfile.broker \
-	--build-context "ui=${PLAYGROUND_UI_DIR}" \
-	-t "${BROKER_TAG}" .
-
-echo "[build-images] validating broker/viewer image contract"
-docker run --rm "${BROKER_TAG}" serve \
-	--check-config \
-	--fly-app preflight \
-	--fly-token-env PREFLIGHT_FLY_TOKEN \
-	--image preflight \
-	--vm-image-digest sha256:0000000000000000000000000000000000000000000000000000000000000000 \
-	--global-daily-budget 1 \
-	--vm-daily-turn-budget 1 \
-	--turnstile-secret-env PREFLIGHT_TURNSTILE_SECRET \
-	--turnstile-sitekey 1x00000000000000000000AA \
-	--turnstile-expected-hostname preflight.invalid \
-	--turnstile-action preflight-session \
-	--static-dir /srv/ui
-
 if [ "${PLAYGROUND_PUSH:-}" = "1" ]; then
-	echo "[build-images] pushing ${VM_TAG}"
-	docker push "${VM_TAG}"
-	echo "[build-images] pushing ${BROKER_TAG}"
-	docker push "${BROKER_TAG}"
+	if [ "${build_vm}" -eq 1 ]; then
+		echo "[build-images] pushing ${VM_TAG}"
+		docker push "${VM_TAG}"
+	fi
+	if [ "${build_broker}" -eq 1 ]; then
+		echo "[build-images] pushing ${BROKER_TAG}"
+		docker push "${BROKER_TAG}"
+	fi
 fi
 
 echo "[build-images] done"

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -83,6 +83,18 @@ Secrets are loaded from files or environment variables and are never printed by
 the broker. Do not pass model keys, provider tokens, Turnstile secrets, or invite
 codes through public logs or shell history in real deployments.
 
+Deploy automation can ask the exact configured command which environment names
+it depends on without reading their values:
+
+```bash
+pipelock-playground-broker serve [the deployed flags] --print-required-env
+```
+
+The command validates the non-secret flags and static UI, prints one variable
+name per line, and exits before it resolves a secret or contacts the machine
+provider. A deployment should refuse to start when any reported name is absent
+or empty.
+
 The public health response includes `signing_ready`. Production startup succeeds
 only after the broker mints a throwaway delegation and verifies it through the
 same published-root path used by visitor VMs, so `true` means that signing path

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -44,7 +44,8 @@ pipelock-playground-broker serve \
   --provider fly \
   --fly-app playground-example \
   --fly-token-env FLY_API_TOKEN \
-  --image registry.example.com/pipelock/playground-vm:review \
+  --image registry.example.com/pipelock/playground-vm@sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  --vm-image-digest sha256:0000000000000000000000000000000000000000000000000000000000000000 \
   --region iad \
   --memory-mb 256 \
   --cpus 1 \
@@ -61,6 +62,8 @@ pipelock-playground-broker serve \
   --turnstile-action playground-session \
   --vm-model-base-url https://api.provider.example/v1 \
   --vm-model demo-model \
+  --model-key-env PLAYGROUND_MODEL_KEY \
+  --orchestrator-key-env PLAYGROUND_ORCHESTRATOR_ROOT \
   --vm-model-max-steps 20 \
   --vm-daily-turn-budget 400 \
   --vm-max-messages-per-session 20 \

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -90,7 +90,8 @@ Deploy automation can ask the exact configured command which environment names
 it depends on without reading their values:
 
 ```bash
-pipelock-playground-broker serve [the deployed flags] --print-required-env
+# Append --print-required-env to the serve command the deployment already runs.
+pipelock-playground-broker serve --print-required-env
 ```
 
 The command validates the non-secret flags and static UI, prints one variable

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -44,8 +44,8 @@ pipelock-playground-broker serve \
   --provider fly \
   --fly-app playground-example \
   --fly-token-env FLY_API_TOKEN \
-  --image registry.example.com/pipelock/playground-vm@sha256:0000000000000000000000000000000000000000000000000000000000000000 \
-  --vm-image-digest sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  --image registry.example.com/pipelock/playground-vm@sha256:REPLACE_WITH_PUBLISHED_VM_IMAGE_DIGEST \
+  --vm-image-digest sha256:REPLACE_WITH_PUBLISHED_VM_IMAGE_DIGEST \
   --region iad \
   --memory-mb 256 \
   --cpus 1 \
@@ -73,6 +73,11 @@ pipelock-playground-broker serve \
   --embed-origin https://site.example \
   --public-host playground.example.com
 ```
+
+Before deploying, replace both `REPLACE_WITH_PUBLISHED_VM_IMAGE_DIGEST` values
+with the same immutable digest of the VM image you published. The broker checks
+that the image reference and `--vm-image-digest` agree before it creates a
+delegation.
 
 This example uses Turnstile as the public authorization step and therefore
 needs no invite codes. When no `--code` values are configured, the broker

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -83,6 +83,12 @@ Secrets are loaded from files or environment variables and are never printed by
 the broker. Do not pass model keys, provider tokens, Turnstile secrets, or invite
 codes through public logs or shell history in real deployments.
 
+The public health response includes `signing_ready`. Production startup succeeds
+only after the broker mints a throwaway delegation and verifies it through the
+same published-root path used by visitor VMs, so `true` means that signing path
+passed. `published_signing_root` identifies the public key already compiled into
+the shipped verifiers. Neither field contains a private key or secret value.
+
 ### Optional counts-only analytics
 
 `--analytics-project-key` enables `POST /api/live/analytics`, a same-origin

--- a/docs/guides/playground-broker-operations.md
+++ b/docs/guides/playground-broker-operations.md
@@ -264,7 +264,8 @@ visitor to a broker that does not recognize its token.
 
 Deploy sequence:
 
-1. Build both images with `deploy/fly-playground/build-images.sh`. The build
+1. Build both images with `deploy/fly-playground/build-images.sh`. Use `--only
+   vm` or `--only broker` when only one image changed. The build
    runs `serve --check-config` inside the broker image and refuses to publish
    when the baked viewer is incompatible with its CSP or the non-secret
    configuration is invalid.

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -174,6 +174,7 @@ type Server struct {
 	client   *http.Client
 
 	vmReadyTimeout time.Duration
+	signingReady   bool
 
 	killed atomic.Bool
 
@@ -432,6 +433,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		global:         livechat.NewDailyBudget(cfg.GlobalDailyBudget),
 		client:         client,
 		vmReadyTimeout: vmReadyTimeout,
+		signingReady:   len(cfg.OrchestratorRoot) != 0,
 		bundleCache:    newArtifactCache(artifactCacheTTL),
 		tokens:         make(map[string]*tokenLease),
 		bySess:         make(map[string]string),
@@ -539,6 +541,8 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	// body, not the status line.
 	writeBrokerJSON(w, http.StatusOK, map[string]any{
 		"ok":                         s.cfg.Gate.Open() && s.global.Open() && !s.killed.Load(),
+		"signing_ready":              s.signingReady,
+		"published_signing_root":     playground.PublishedOrchestratorPubKeyHex,
 		"provider_ok":                ph.OK,
 		"provider_state":             string(ph.State),
 		"provider_failures":          ph.ConsecutiveFailures,

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -392,6 +392,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.RequireDelegatedSigning && len(cfg.OrchestratorRoot) == 0 {
 		return nil, errors.New("broker: OrchestratorRoot is required when delegated signing is required")
 	}
+	signingVerified := false
 	if len(cfg.OrchestratorRoot) != 0 {
 		if _, err := playground.ParseOrchestratorPrivateKeyHex(hex.EncodeToString(cfg.OrchestratorRoot)); err != nil {
 			return nil, fmt.Errorf("broker: OrchestratorRoot: %w", err)
@@ -408,6 +409,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		if err := checkDelegatedSigning(cfg.OrchestratorRoot, cfg.ImageDigest, cfg.SessionDelegationLifetime); err != nil {
 			return nil, err
 		}
+		signingVerified = true
 	}
 	if cfg.InternalPort == 0 {
 		cfg.InternalPort = defaultInternalPort
@@ -436,7 +438,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		global:         livechat.NewDailyBudget(cfg.GlobalDailyBudget),
 		client:         client,
 		vmReadyTimeout: vmReadyTimeout,
-		signingReady:   len(cfg.OrchestratorRoot) != 0,
+		signingReady:   signingVerified,
 		bundleCache:    newArtifactCache(artifactCacheTTL),
 		tokens:         make(map[string]*tokenLease),
 		bySess:         make(map[string]string),

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -125,6 +125,10 @@ type ServerConfig struct {
 	// OrchestratorRoot is the broker-held durable signing root. When set, each
 	// session receives a short-lived delegated key instead of this value.
 	OrchestratorRoot ed25519.PrivateKey
+	// RequireDelegatedSigning makes a usable OrchestratorRoot mandatory. The
+	// broker CLI derives this from its existing production-secret requirement;
+	// local development can leave both disabled.
+	RequireDelegatedSigning bool
 	// ImageDigest is the immutable VM image bound into each session
 	// delegation. Required when OrchestratorRoot is set.
 	ImageDigest string
@@ -378,6 +382,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		if _, found := source.env["PLAYGROUND_ORCHESTRATOR_"+"KEY"]; found {
 			return nil, fmt.Errorf("broker: %s must not carry the durable orchestrator key", source.name)
 		}
+	}
+	if cfg.RequireDelegatedSigning && len(cfg.OrchestratorRoot) == 0 {
+		return nil, errors.New("broker: OrchestratorRoot is required when delegated signing is required")
 	}
 	if len(cfg.OrchestratorRoot) != 0 {
 		if _, err := playground.ParseOrchestratorPrivateKeyHex(hex.EncodeToString(cfg.OrchestratorRoot)); err != nil {

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -373,8 +373,11 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		}
 	}
 	// SessionEnv reaches every visitor VM. Keep an owned copy so a caller cannot
-	// add the durable root after this validation completes.
+	// add the durable root after this validation completes. Own the signing key
+	// for the same reason: callers must not be able to erase or replace it after
+	// the startup self-check reports success.
 	cfg.SessionEnv = maps.Clone(cfg.SessionEnv)
+	cfg.OrchestratorRoot = bytes.Clone(cfg.OrchestratorRoot)
 	for _, source := range []struct {
 		name string
 		env  map[string]string

--- a/internal/playground/broker/server.go
+++ b/internal/playground/broker/server.go
@@ -80,6 +80,8 @@ const (
 	vmReadyPollInterval = 500 * time.Millisecond
 )
 
+var verifySessionDelegation = playground.VerifySessionDelegation
+
 // ServerConfig configures the public playground broker HTTP front door.
 type ServerConfig struct {
 	// Leases owns VM lifecycle and the global machine concurrency cap. Required.
@@ -399,6 +401,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		if err := playground.ValidateCanonicalImageDigest(cfg.ImageDigest); err != nil {
 			return nil, fmt.Errorf("broker: %w", err)
 		}
+		if err := checkDelegatedSigning(cfg.OrchestratorRoot, cfg.ImageDigest, cfg.SessionDelegationLifetime); err != nil {
+			return nil, err
+		}
 	}
 	if cfg.InternalPort == 0 {
 		cfg.InternalPort = defaultInternalPort
@@ -434,6 +439,20 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 	go s.reapLoop()
 	return s, nil
+}
+
+// checkDelegatedSigning exercises the complete visitor verification path before
+// the broker can accept traffic. Any mint or verification error refuses startup.
+func checkDelegatedSigning(root ed25519.PrivateKey, imageDigest string, lifetime time.Duration) error {
+	const nonce = "broker-startup-signing-self-check"
+	minted, err := playground.MintSessionDelegation(root, nonce, imageDigest, time.Now().UTC(), lifetime)
+	if err != nil {
+		return fmt.Errorf("broker: signing self-check mint: %w", err)
+	}
+	if err := verifySessionDelegation(minted.PrivateKey, minted.Delegation, nonce); err != nil {
+		return fmt.Errorf("broker: signing self-check verify against published identity: %w", err)
+	}
+	return nil
 }
 
 // Handler returns the broker's public /api/live/* routes.

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -510,6 +510,11 @@ func TestCheckDelegatedSigningFailsClosed(t *testing.T) {
 	if !called {
 		t.Fatal("self-check skipped the visitor verification path")
 	}
+
+	err = checkDelegatedSigning(root, digest, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "self-check mint") {
+		t.Fatalf("self-check mint error = %v", err)
+	}
 }
 
 func TestNewServerRefusesFailedSigningSelfCheck(t *testing.T) {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -512,6 +512,28 @@ func TestCheckDelegatedSigningFailsClosed(t *testing.T) {
 	}
 }
 
+func TestNewServerRefusesFailedSigningSelfCheck(t *testing.T) {
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := verifySessionDelegation
+	verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, _ string) error {
+		return errors.New("published root mismatch")
+	}
+	t.Cleanup(func() { verifySessionDelegation = previous })
+
+	_, err = NewServer(ServerConfig{
+		Leases:           testLeaseManager(t, &serverFakeProvider{}),
+		Gate:             testBrokerGate(t),
+		OrchestratorRoot: root,
+		ImageDigest:      "sha256:" + strings.Repeat("ab", 32),
+	})
+	if err == nil || !strings.Contains(err.Error(), "published root mismatch") {
+		t.Fatalf("NewServer signing self-check error = %v", err)
+	}
+}
+
 func TestServerHealthCORSKillAndResume(t *testing.T) {
 	vm := newFakeVM(t, "health-token")
 	destroyed := make(chan string, 1)

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -411,6 +411,9 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, PerIPDailyBudget: -1}); err == nil {
 		t.Fatal("negative daily budget should error")
 	}
+	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, RequireDelegatedSigning: true}); err == nil {
+		t.Fatal("required delegated signing without a root should error")
+	}
 	if _, err := NewServer(ServerConfig{
 		Leases:     lm,
 		Gate:       gate,

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -447,9 +448,7 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	previousVerify := verifySessionDelegation
-	verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, _ string) error { return nil }
-	t.Cleanup(func() { verifySessionDelegation = previousVerify })
+	realDelegationVerifier(t, root)
 	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, OrchestratorRoot: root}); err == nil {
 		t.Fatal("OrchestratorRoot without ImageDigest should error")
 	}
@@ -676,9 +675,7 @@ func TestServerHealthReportsVerifiedSigningState(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		previous := verifySessionDelegation
-		verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, _ string) error { return nil }
-		t.Cleanup(func() { verifySessionDelegation = previous })
+		realDelegationVerifier(t, root)
 		_, ts := newBrokerTestServer(t, provider, ServerConfig{
 			OrchestratorRoot: root,
 			ImageDigest:      "sha256:" + strings.Repeat("ab", 32),
@@ -2425,4 +2422,32 @@ func TestServer_BundleOversizedDoesNotCache(t *testing.T) {
 	if got := srv.cfg.Leases.ActiveLeases(); got != 1 {
 		t.Fatalf("active leases after oversize = %d, want 1 (VM not released on fetch error)", got)
 	}
+}
+
+// realDelegationVerifier installs a delegation hook that actually verifies,
+// rather than returning nil. A success-path test that stubs verification away
+// asserts only that the startup self-check RAN; it would stay green through a
+// signature or session-key binding regression, which is the exact class of
+// vacuous coverage this package exists to prevent.
+func realDelegationVerifier(t *testing.T, root ed25519.PrivateKey) {
+	t.Helper()
+	previous := verifySessionDelegation
+	verifySessionDelegation = func(sessionKey ed25519.PrivateKey, delegation playground.OrchestratorDelegation, nonce string) error {
+		pub, ok := root.Public().(ed25519.PublicKey)
+		if !ok {
+			return errors.New("test root has no ed25519 public half")
+		}
+		if err := playground.VerifyOrchestratorDelegation(pub, delegation, playground.DelegationExpectations{RunNonce: nonce}); err != nil {
+			return err
+		}
+		sessionPub, ok := sessionKey.Public().(ed25519.PublicKey)
+		if !ok {
+			return errors.New("session key has no ed25519 public half")
+		}
+		if hex.EncodeToString(sessionPub) != delegation.SessionPublicKey {
+			return errors.New("delegation does not authorize this session signing key")
+		}
+		return nil
+	}
+	t.Cleanup(func() { verifySessionDelegation = previous })
 }

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -596,6 +596,38 @@ func TestServerHealthCORSKillAndResume(t *testing.T) {
 	}
 }
 
+func TestServerHealthReportsVerifiedSigningState(t *testing.T) {
+	provider := &serverFakeProvider{}
+
+	t.Run("development_without_root", func(t *testing.T) {
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{})
+		health := getBrokerHealth(t, ts)
+		if health["signing_ready"] != false {
+			t.Fatalf("signing_ready = %v, want false", health["signing_ready"])
+		}
+		if health["published_signing_root"] != playground.PublishedOrchestratorPubKeyHex {
+			t.Fatalf("published_signing_root = %v", health["published_signing_root"])
+		}
+	})
+
+	t.Run("verified_root", func(t *testing.T) {
+		_, root, err := signing.GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		previous := verifySessionDelegation
+		verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, _ string) error { return nil }
+		t.Cleanup(func() { verifySessionDelegation = previous })
+		_, ts := newBrokerTestServer(t, provider, ServerConfig{
+			OrchestratorRoot: root,
+			ImageDigest:      "sha256:" + strings.Repeat("ab", 32),
+		})
+		if health := getBrokerHealth(t, ts); health["signing_ready"] != true {
+			t.Fatalf("signing_ready = %v, want true", health["signing_ready"])
+		}
+	})
+}
+
 func TestServerHealthProviderFieldsByState(t *testing.T) {
 	base := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -462,6 +462,11 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("valid delegated root config rejected: %v", err)
 	}
+	originalRootByte := delegated.cfg.OrchestratorRoot[0]
+	root[0] ^= 0xff
+	if delegated.cfg.OrchestratorRoot[0] != originalRootByte {
+		t.Fatal("Server retained the caller's mutable orchestrator root")
+	}
 	delegated.Close()
 
 	customClient := &http.Client{}

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luckyPipewrench/pipelock/internal/playground"
 	"github.com/luckyPipewrench/pipelock/internal/playground/livechat"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
@@ -446,6 +447,9 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	previousVerify := verifySessionDelegation
+	verifySessionDelegation = func(_ ed25519.PrivateKey, _ playground.OrchestratorDelegation, _ string) error { return nil }
+	t.Cleanup(func() { verifySessionDelegation = previousVerify })
 	if _, err := NewServer(ServerConfig{Leases: lm, Gate: gate, OrchestratorRoot: root}); err == nil {
 		t.Fatal("OrchestratorRoot without ImageDigest should error")
 	}
@@ -479,6 +483,33 @@ func TestNewServerValidationDefaultsAndClose(t *testing.T) {
 	}
 	srv.Close()
 	srv.Close()
+}
+
+func TestCheckDelegatedSigningFailsClosed(t *testing.T) {
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:" + strings.Repeat("ab", 32)
+
+	previous := verifySessionDelegation
+	t.Cleanup(func() { verifySessionDelegation = previous })
+	called := false
+	verifySessionDelegation = func(sessionKey ed25519.PrivateKey, delegation playground.OrchestratorDelegation, nonce string) error {
+		called = true
+		if len(sessionKey) != ed25519.PrivateKeySize || delegation.ImageDigest != digest || nonce == "" {
+			t.Fatal("self-check did not pass the minted delegation to the visitor verification path")
+		}
+		return errors.New("published root mismatch")
+	}
+
+	err = checkDelegatedSigning(root, digest, time.Hour)
+	if err == nil || !strings.Contains(err.Error(), "published root mismatch") {
+		t.Fatalf("self-check error = %v, want published-root refusal", err)
+	}
+	if !called {
+		t.Fatal("self-check skipped the visitor verification path")
+	}
 }
 
 func TestServerHealthCORSKillAndResume(t *testing.T) {

--- a/internal/playground/broker/server_test.go
+++ b/internal/playground/broker/server_test.go
@@ -544,6 +544,35 @@ func TestNewServerRefusesFailedSigningSelfCheck(t *testing.T) {
 	}
 }
 
+// The two self-check tests above stub verifySessionDelegation, so they prove the
+// plumbing rather than the refusal itself. This one runs the REAL shipped
+// verification path with no seam. A freshly generated root is by construction
+// not the published identity, which is exactly the production state that served
+// visitors all day on 2026-09-03: the broker held a root the visitor VMs did not
+// trust, every session ran to completion, and only the final seal failed.
+func TestNewServer_RealVerifierRefusesUnpublishedRoot(t *testing.T) {
+	_, root, err := signing.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if playground.OrchestratorKeyMatchesPublished(root) {
+		t.Fatal("a generated root must not be the published identity; this test would prove nothing")
+	}
+
+	_, err = NewServer(ServerConfig{
+		Leases:           testLeaseManager(t, &serverFakeProvider{}),
+		Gate:             testBrokerGate(t),
+		OrchestratorRoot: root,
+		ImageDigest:      "sha256:" + strings.Repeat("ab", 32),
+	})
+	if err == nil {
+		t.Fatal("a root that is not the published identity must refuse startup through the real verifier")
+	}
+	if !strings.Contains(err.Error(), "signing self-check") {
+		t.Fatalf("error = %v, want the startup self-check refusal", err)
+	}
+}
+
 func TestServerHealthCORSKillAndResume(t *testing.T) {
 	vm := newFakeVM(t, "health-token")
 	destroyed := make(chan string, 1)

--- a/internal/playground/broker/session_delegation_test.go
+++ b/internal/playground/broker/session_delegation_test.go
@@ -25,6 +25,11 @@ func testDelegationRoot(t *testing.T) (ed25519.PrivateKey, string) {
 	if err != nil {
 		t.Fatalf("GenerateKeyPair: %v", err)
 	}
+	previous := verifySessionDelegation
+	verifySessionDelegation = func(sessionKey ed25519.PrivateKey, delegation playground.OrchestratorDelegation, nonce string) error {
+		return playground.VerifyOrchestratorDelegation(priv.Public().(ed25519.PublicKey), delegation, playground.DelegationExpectations{RunNonce: nonce})
+	}
+	t.Cleanup(func() { verifySessionDelegation = previous })
 	return priv, "sha256:" + strings.Repeat("a", 64)
 }
 


### PR DESCRIPTION
## What changed

The playground broker treated a missing signing root as an acceptable state. Resolving an empty secret returned no error, validation and the published-identity check ran only when a root was present, and delegation minting was skipped entirely, so a broker with no root started cleanly, reported healthy, served visitors and produced sessions nothing could verify. A broker that requires production secrets now also requires a usable root and refuses to start without one, naming the variable it expects. Local development without a root is unchanged.

Startup now mints a throwaway delegation with the configured root and verifies it through the same path a visitor VM uses, refusing to serve on any failure. This catches an unusable root, a root that is not the published identity, and a build whose compiled published identity disagrees with the image it hands visitors, all before a single session runs.

Health reports whether the broker holds a verified signing root, and the broker can print the environment variable names it requires so a deployment can assert them without reading their values. Neither surface exposes a secret.

The image build can now build one image rather than always building both, so a failure in one image's base layers no longer blocks rebuilding the other. Its broker validation passed an unpinned image reference that the digest requirement had made invalid, which meant every broker build ended in a failed contract check; the validation now uses a digest-shaped placeholder and a test runs the shipped arguments so a future flag requirement cannot silently break it again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added delegated-signing startup validation and health status, including the published signing root.
  - Added a flag to print required environment variable names without resolving secrets or contacting providers.
  - Added options to build only the VM image or only the broker image.
  - Added support for pinned VM image digests and configurable model and orchestrator secret references.

- **Bug Fixes**
  - Improved configuration errors by identifying missing required environment settings.
  - Building only the VM image no longer requires viewer assets.

- **Documentation**
  - Updated playground broker operations guidance for signing readiness, required environment reporting, image selection, and digest-pinned deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->