### PR TITLE
fix(scanner): refuse exempt_domains on core DLP pattern names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -785,6 +785,8 @@ dlp:
 
 For built-in provider-key patterns, the default config already exempts the provider's own API host for URL DLP and adds matching `suppress` entries for request-body and request-header DLP. The same key is still blocked when sent to any other destination. See [Provider-Key DLP Coverage](security/provider-key-dlp-coverage.md) for included shapes, exclusions, and the custom provider-key path.
 
+Core safety-floor patterns (`AWS Access ID`, `AWS Secret Key`, `GitHub Token`, `GitHub Fine-Grained PAT`, `GitLab PAT`, `Slack Token`, `Private Key Header`, `GCP Service Account Key`) cannot be exempted this way. A pattern that reuses one of those names with `exempt_domains` is rejected at startup and on reload, and the configured scanner ignores the field for those names even if one slipped through, so a core credential class is blocked on every destination regardless of overrides.
+
 ### Built-in DLP Patterns (65)
 
 | Pattern | Regex Prefix | Severity |

--- a/docs/false-positive-tuning.md
+++ b/docs/false-positive-tuning.md
@@ -106,14 +106,14 @@ Each DLP pattern supports an `exempt_domains` field. To exempt a domain for a sp
 dlp:
   include_defaults: true
   patterns:
-    - name: "AWS Access ID"
-      regex: "(AKIA|A3T|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16,}"
-      severity: "critical"
+    - name: "Google API Key"
+      regex: 'AIza[0-9A-Za-z\-_]{35}\b'
+      severity: "high"
       exempt_domains:
         - "internal-testing.example.com"
 ```
 
-This keeps the configurable pattern active everywhere else while skipping it for the specified domain. It does not change the compiled core URL floor, which does not consult operator exemptions.
+This keeps the configurable pattern active everywhere else while skipping it for the specified domain. Core safety-floor names (`AWS Access ID`, `AWS Secret Key`, `GitHub Token`, `GitHub Fine-Grained PAT`, `GitLab PAT`, `Slack Token`, `Private Key Header`, `GCP Service Account Key`) cannot carry `exempt_domains`: the compiled core URL floor never consults operator exemptions, so a config that tries is rejected at startup and reload instead of shipping an exemption that does nothing.
 
 ### Suppressing specific findings
 

--- a/docs/false-positive-tuning.md
+++ b/docs/false-positive-tuning.md
@@ -240,7 +240,7 @@ cross_request_detection:
 |----------|---------|---------|-----|
 | API returns docs that trigger a non-core response rule | response | Jailbreak Attempt | Add a `suppress` entry for `Jailbreak Attempt` scoped to that host's URLs. Core response floor matches require a pattern precision fix. Use `response_scanning.exempt_domains` only to trust the whole host, which also drops media stripping, Browser Shield, and the response size cap there |
 | URL contains UUID path segments | entropy | (path entropy) | Raise `entropy_threshold` or add to `subdomain_entropy_exclusions` |
-| Base64-encoded JWT in Authorization header | dlp | JWT Token | Add per-pattern `exempt_domains` for the auth provider |
+| Base64-encoded JWT in Authorization header | dlp | JWT Token | Add a `suppress` entry for `JWT Token` scoped to the auth provider's URLs. Header and body DLP read `suppress`; per-pattern `exempt_domains` only affects URL scans |
 | High-entropy CDN URLs | entropy | (subdomain entropy) | Add CDN to `subdomain_entropy_exclusions` |
 | Service with long hex/base32 subdomain labels | subdomain_entropy | (structural hostname-exfil signal) | Add the host to `subdomain_entropy_exclusions` (raising the threshold does not allow encoded labels) |
 | Internal API keys matching AWS format, in a URL or query | core_dlp | AWS Access ID | The compiled core URL floor does not consult `suppress` or operator `exempt_domains`. Fix the pattern precision; structurally valid S3 presigned URLs already use the narrow built-in carve-out described below |

--- a/internal/config/dlp_exempt_core_test.go
+++ b/internal/config/dlp_exempt_core_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/dlp_exempt_core_test.go
+++ b/internal/config/dlp_exempt_core_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A pattern that reuses a core floor name cannot carry exempt_domains: the
+// scanner never honors it for that class, so accepting it would ship a knob
+// that reads as an allowance and does nothing.
+func TestValidate_DLPExemptDomainsRejectedOnCorePatternName(t *testing.T) {
+	for _, name := range []string{"AWS Access ID", "aws access id", "GCP Service Account Key"} {
+		cfg := Defaults()
+		cfg.DLP.Patterns = []DLPPattern{
+			{Name: name, Regex: `AKIA[0-9A-Z]{16}`, Severity: SeverityCritical, ExemptDomains: []string{"api.vendor.example"}},
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatalf("%q: expected core pattern with exempt_domains to be rejected", name)
+		}
+		if !strings.Contains(err.Error(), "core safety-floor pattern") {
+			t.Fatalf("%q: error must name the core floor, got %v", name, err)
+		}
+	}
+}
+
+func TestValidate_DLPExemptDomainsAcceptedOnCustomPatternName(t *testing.T) {
+	cfg := Defaults()
+	cfg.DLP.Patterns = []DLPPattern{
+		{Name: "Vendor Token", Regex: `vt-[a-z0-9]{32}`, Severity: SeverityCritical, ExemptDomains: []string{"api.vendor.example"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("custom pattern exemption must stay valid: %v", err)
+	}
+}
+
+func TestValidate_DLPDefaultCorePatternsCarryNoExemptions(t *testing.T) {
+	cfg := Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("defaults must validate: %v", err)
+	}
+	for _, p := range cfg.DLP.Patterns {
+		if IsCoreDLPPatternName(p.Name) && len(p.ExemptDomains) > 0 {
+			t.Fatalf("shipped core pattern %q carries exempt_domains", p.Name)
+		}
+	}
+}
+
+// First load and hot reload go through the same validator, so a reload that
+// introduces the exemption on a core name fails the same way a fresh start does.
+func TestReload_DLPExemptDomainsOnCorePatternNameRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	clean := `
+version: 1
+dlp:
+  patterns:
+    - name: Vendor Token
+      regex: 'vt-[a-z0-9]{32}'
+      severity: critical
+      exempt_domains:
+        - api.vendor.example
+`
+	tainted := `
+version: 1
+dlp:
+  patterns:
+    - name: AWS Access ID
+      regex: 'AKIA[0-9A-Z]{16}'
+      severity: critical
+      exempt_domains:
+        - api.vendor.example
+`
+	if err := os.WriteFile(cfgPath, []byte(clean), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(cfgPath); err != nil {
+		t.Fatalf("first load must accept a custom exemption: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(tainted), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(cfgPath); err == nil {
+		t.Fatal("reload into a core-name exemption must be rejected")
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1129,6 +1129,13 @@ func (c *Config) validateDLPPatternConfig() error {
 		if err := ValidateTrustedDomains(p.ExemptDomains, fmt.Sprintf("DLP pattern %q exempt_domains", p.Name)); err != nil {
 			return err
 		}
+		// The immutable floor ignores exemptions, so a pattern that reuses a
+		// core name with exempt_domains would document an allowance the scanner
+		// never grants. Refuse it at load and reload instead of shipping a knob
+		// that silently does nothing for that credential class.
+		if len(p.ExemptDomains) > 0 && IsCoreDLPPatternName(p.Name) {
+			return fmt.Errorf("DLP pattern %q is a core safety-floor pattern and cannot set exempt_domains; core credential classes are blocked on every destination", p.Name)
+		}
 	}
 
 	if err := validateCanaryTokens(c); err != nil {

--- a/internal/scanner/dlp_exempt_core_test.go
+++ b/internal/scanner/dlp_exempt_core_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
 package scanner
 
 import (

--- a/internal/scanner/dlp_exempt_core_test.go
+++ b/internal/scanner/dlp_exempt_core_test.go
@@ -1,0 +1,113 @@
+package scanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+const corePatternExemptHost = "api.vendor.example"
+
+// corePatternExemptCases exercise each configured-DLP view that consults a
+// pattern's exempt_domains. The AWS shape reaches the per-view match; the
+// private-key shape splits its literal spaces across query values with a
+// same-class decoy between them, so only the query-subsequence concatenation
+// reassembles it and the noise-stripped views cannot.
+var corePatternExemptCases = []struct {
+	name    string
+	pattern string
+	regex   string
+	url     string
+}{
+	{
+		name:    "path view",
+		pattern: "AWS Access ID",
+		regex:   `AKIA[0-9A-Z]{16}`,
+		url:     "https://" + corePatternExemptHost + "/upload/" + "AKIA" + "IOSFODNN7EXAMPLE",
+	},
+	{
+		name:    "query value view",
+		pattern: "AWS Access ID",
+		regex:   `AKIA[0-9A-Z]{16}`,
+		url:     "https://" + corePatternExemptHost + "/upload?key=" + "AKIA" + "IOSFODNN7EXAMPLE",
+	},
+	{
+		name:    "query subsequence view",
+		pattern: "Private Key Header",
+		regex:   "-----BEGIN" + " PRIVATE" + " KEY-----",
+		url:     "https://" + corePatternExemptHost + "/upload?a=-----BEGIN%20" + "PRIVATE&x=%3D&b=%20KEY-----",
+	},
+}
+
+func newCorePatternExemptScanner(t *testing.T, pattern, regex string) *Scanner {
+	t.Helper()
+	cfg := testConfig()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 0
+	cfg.DLP.Patterns = []config.DLPPattern{{
+		Name:          pattern,
+		Regex:         regex,
+		Severity:      config.SeverityCritical,
+		ExemptDomains: []string{corePatternExemptHost},
+	}}
+	return MustNew(cfg)
+}
+
+// A custom DLP pattern that reuses a core pattern's name must not be able to
+// carry a domain exemption for that credential class. The core floor blocks
+// first regardless, and the configured scanner must also refuse to honor the
+// exemption so the two layers never disagree about a core credential.
+func TestScan_DLPExemptDomainsIgnoredForCorePatternName(t *testing.T) {
+	for _, tc := range corePatternExemptCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newCorePatternExemptScanner(t, tc.pattern, tc.regex)
+			defer s.Close()
+			if r := s.Scan(context.Background(), tc.url); r.Allowed {
+				t.Fatalf("core credential to exempted host was allowed; exemption on a core pattern name must be ignored")
+			}
+		})
+	}
+}
+
+// The configured scanner's own guard must hold even when the core floor is
+// absent, otherwise the guard is vacuous and the floor is the only defense.
+func TestScan_DLPExemptDomainsIgnoredForCorePatternNameWithoutCoreFloor(t *testing.T) {
+	for _, tc := range corePatternExemptCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newCorePatternExemptScanner(t, tc.pattern, tc.regex)
+			defer s.Close()
+			s.core = nil
+			r := s.Scan(context.Background(), tc.url)
+			if r.Allowed {
+				t.Fatalf("configured scanner honored an exemption on a core pattern name")
+			}
+			if r.Scanner != ScannerDLP {
+				t.Fatalf("block came from %q, so the configured DLP guard was not exercised", r.Scanner)
+			}
+		})
+	}
+}
+
+// A non-core custom pattern keeps its exemption: the guard must not widen into
+// refusing every exemption, or operators disable the knob.
+func TestScan_DLPExemptDomainsStillHonoredForCustomPattern(t *testing.T) {
+	cfg := testConfig()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.FetchProxy.Monitoring.EntropyThreshold = 0
+	cfg.DLP.Patterns = []config.DLPPattern{{
+		Name:          "Vendor Bot Token",
+		Regex:         `[0-9]{8,10}:[A-Za-z0-9_-]{35}`,
+		Severity:      config.SeverityCritical,
+		ExemptDomains: []string{corePatternExemptHost},
+	}}
+	s := MustNew(cfg)
+	defer s.Close()
+	token := "1234567890:" + strings.Repeat("A", 35)
+	if r := s.Scan(context.Background(), "https://"+corePatternExemptHost+"/bot"+token+"/getMe"); !r.Allowed {
+		t.Fatalf("custom pattern exemption no longer honored: %s", r.Reason)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -331,6 +331,7 @@ type compiledPattern struct {
 	severity            string
 	validate            func(string) bool // post-match checksum (nil = regex-only)
 	exemptDomains       []string          // domains where this pattern is skipped (wildcard supported)
+	core                bool              // name belongs to the immutable floor: exemptDomains is never honored
 	bundle              string            // empty for built-in/config patterns
 	bundleVersion       string
 	warn                bool // true when pattern action is "warn" - matches are informational only
@@ -421,6 +422,7 @@ func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 			re:            re,
 			severity:      p.Severity,
 			exemptDomains: p.ExemptDomains,
+			core:          config.IsCoreDLPPatternName(p.Name),
 			bundle:        p.Bundle,
 			bundleVersion: p.BundleVersion,
 			warn:          p.Action == config.ActionWarn,
@@ -2409,7 +2411,10 @@ func (s *Scanner) checkDLP(parsed *url.URL) (Result, []WarnMatch) {
 			p := s.dlpPatterns[idx]
 			if start, end, ok := p.matchSpanInView(cleaned, proseSource); ok {
 				// Skip pattern if the destination domain is explicitly exempted.
-				if len(p.exemptDomains) > 0 && matchesDomainList(parsed.Hostname(), p.exemptDomains) {
+				// A pattern carrying a core floor name never honors an exemption,
+				// matching the body and response filters, so a custom pattern
+				// cannot exempt a core credential class by reusing its name.
+				if !p.core && len(p.exemptDomains) > 0 && matchesDomainList(parsed.Hostname(), p.exemptDomains) {
 					continue
 				}
 				span := newMatchSpan(start, end, target.viewLabel, p.name, p.bundle, p.bundleVersion)
@@ -2632,7 +2637,7 @@ func (s *Scanner) checkDLPCombinations(values []string, n, size int, hostname st
 			for _, idx := range s.dlpPreFilter.patternsToCheck(cleaned) {
 				p := s.dlpPatterns[idx]
 				if start, end, ok := p.matchSpanInView(cleaned, candidate.proseSource); ok {
-					if len(p.exemptDomains) > 0 && matchesDomainList(hostname, p.exemptDomains) {
+					if !p.core && len(p.exemptDomains) > 0 && matchesDomainList(hostname, p.exemptDomains) {
 						continue
 					}
 					span := newMatchSpan(start, end, candidate.viewLabel, p.name, p.bundle, p.bundleVersion)


### PR DESCRIPTION
## What changed

A custom DLP pattern that reuses a core safety-floor name (`AWS Access ID`, `Private Key Header`, and the other core names) can no longer carry `exempt_domains`. Config validation rejects it at startup and on hot reload, and the URL scanner's per-view and query-subsequence paths ignore the field for core names even when no validation ran, matching the guard the body and response filters already have.

The core floor already blocks these credentials first, so the visible change is that an inert exemption now fails loud instead of reading as an allowance and the configured layer can no longer disagree with the floor. Custom pattern exemptions are unchanged, and no shipped preset sets one on a core name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Core safety-floor DLP patterns can no longer be exempted for specific domains.
  - Invalid exemptions are rejected during configuration startup and reload.
  - Core credential protections remain enforced across all destinations, including query scanning.
  - Custom DLP patterns continue to support domain exemptions.

- **Documentation**
  - Clarified the rules for per-pattern domain exemptions.
  - Updated examples to use configurable patterns when demonstrating domain exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->