### PR TITLE
fix(runtime): refuse file_sentry block on the server listener

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2504,7 +2504,7 @@ At least one chain must be enabled when `address_protection.enabled` is `true`. 
 
 ## File Sentry
 
-Real-time filesystem monitoring for agent subprocesses. Detects secrets written to disk that bypass the MCP tool call path. `file_sentry.action: block` is supported only in subprocess MCP mode (`pipelock mcp proxy -- COMMAND`), where Pipelock can cancel the child. `pipelock run` can use file sentry with `action: warn`, but refuses `action: block` at startup; a reload that introduces it keeps the running settings and warns that the next start will refuse the config.
+Real-time filesystem monitoring for agent subprocesses. Detects secrets written to disk that bypass the MCP tool call path. `file_sentry.action: block` is supported only in subprocess MCP mode (`pipelock mcp proxy -- COMMAND`), where Pipelock can cancel the child. `pipelock run` can use file sentry with `action: warn`, but refuses `action: block` at startup and rejects a reload that introduces it, so a policy rollout cannot report success while asking for enforcement that listener cannot provide.
 
 ```yaml
 file_sentry:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2504,7 +2504,7 @@ At least one chain must be enabled when `address_protection.enabled` is `true`. 
 
 ## File Sentry
 
-Real-time filesystem monitoring for agent subprocesses. Detects secrets written to disk that bypass the MCP tool call path. Applies to subprocess MCP mode only (`pipelock mcp proxy -- COMMAND`).
+Real-time filesystem monitoring for agent subprocesses. Detects secrets written to disk that bypass the MCP tool call path. `file_sentry.action: block` is supported only in subprocess MCP mode (`pipelock mcp proxy -- COMMAND`), where Pipelock can cancel the child. `pipelock run` can use file sentry with `action: warn`, but refuses `action: block` at startup; a reload that introduces it keeps the running settings and warns that the next start will refuse the config.
 
 ```yaml
 file_sentry:
@@ -2531,7 +2531,7 @@ file_sentry:
 | `scan_content` | `true` | Run DLP scanner on modified file content. |
 | `max_file_bytes` | `0` | Max watched-file bytes to read for content scanning. `0` uses the built-in 10 MiB default; negative values are rejected. |
 | `ignore_patterns` | `[]` | Glob patterns for files and directories to skip. |
-| `action` | `warn` | Enforcement response after file sentry detects and attributes a DLP finding to an agent write. `warn` logs the finding + records a metric (current default). `block` additionally cancels the proxy context so the MCP child terminates, preventing the agent from continuing after that detected leak. Non-agent writes (editor saves, build output) never trigger the block path. |
+| `action` | `warn` | Response after file sentry detects and attributes a DLP finding to an agent write. `warn` logs the finding + records a metric (current default). In subprocess MCP mode, `block` also cancels the proxy context so the MCP child terminates after that detected leak. `pipelock run` rejects `file_sentry.action: block` because it has no child process to cancel. Non-agent writes (editor saves, build output) never trigger the block path. |
 
 File sentry setup is strict by default: any root or descendant subtree that cannot be watched fails startup after Pipelock reports every skipped subtree. Set `best_effort: true` to keep accessible siblings armed while reporting each skipped root or subtree. Startup still fails when nothing can be armed. `required: true` keeps a configured root strict even in best-effort mode. Root symlinks are rejected and child symlinks are not followed. Unknown fields in mapping entries are rejected so typos such as `require: true` do not silently change the requested behavior.
 

--- a/docs/guides/filesystem-sentinel.md
+++ b/docs/guides/filesystem-sentinel.md
@@ -11,7 +11,7 @@ This catches a class of exfiltration that the network proxy cannot see: an agent
 
 ## Scope
 
-`action: block` applies to **subprocess MCP mode only**. HTTP upstream, WebSocket, and listener modes have no local child process to cancel. `pipelock run` can use file sentry with `action: warn`, but it rejects `file_sentry.action: block` at startup; a reload that introduces it keeps the running settings and warns that the next start will refuse the config.
+`action: block` applies to **subprocess MCP mode only**. HTTP upstream, WebSocket, and listener modes have no local child process to cancel. `pipelock run` can use file sentry with `action: warn`, but it rejects `file_sentry.action: block` at startup and rejects a reload that introduces it.
 
 File sentry detects writes; it doesn't intercept them. With `action: warn` (default), findings are alerted and the agent keeps running. With `action: block`, file sentry fails closed only after it emits a detected, agent-attributed DLP finding. The consumer logs the finding, records the metric, and then cancels the proxy context, terminating the MCP child so the agent cannot continue acting on that detected leak. A skipped, unreadable, ignored, or deleted file doesn't create a finding. If the path is replaced before the scan opens it, the replacement content is scanned and can become a finding. Without a finding, block leaves the child running. Writes before Arm work the same way. A watcher backend failure from `Start()` still cancels the runtime; that is a dead watcher, not a skipped file. For write-time interception, use Landlock or the process sandbox (`--sandbox`).
 
@@ -99,6 +99,6 @@ Attribution is probabilistic: if the writing process has already closed the file
 | Feature | `pipelock integrity` | File Sentry |
 |---------|---------------------|-------------|
 | Timing | On-demand snapshot | Continuous real-time |
-| Scope | Any directory | Subprocess MCP mode only |
+| Scope | Any directory | Any listener with `action: warn`; `action: block` in subprocess MCP mode only |
 | Detection | File hashes + DLP | DLP on write events |
 | Attribution | None | Process tree (Linux) |

--- a/docs/guides/filesystem-sentinel.md
+++ b/docs/guides/filesystem-sentinel.md
@@ -11,7 +11,7 @@ This catches a class of exfiltration that the network proxy cannot see: an agent
 
 ## Scope
 
-File sentry applies to **subprocess MCP mode only**. HTTP upstream, WebSocket, and listener modes have no local child process and are out of scope.
+`action: block` applies to **subprocess MCP mode only**. HTTP upstream, WebSocket, and listener modes have no local child process to cancel. `pipelock run` can use file sentry with `action: warn`, but it rejects `file_sentry.action: block` at startup; a reload that introduces it keeps the running settings and warns that the next start will refuse the config.
 
 File sentry detects writes; it doesn't intercept them. With `action: warn` (default), findings are alerted and the agent keeps running. With `action: block`, file sentry fails closed only after it emits a detected, agent-attributed DLP finding. The consumer logs the finding, records the metric, and then cancels the proxy context, terminating the MCP child so the agent cannot continue acting on that detected leak. A skipped, unreadable, ignored, or deleted file doesn't create a finding. If the path is replaced before the scan opens it, the replacement content is scanned and can become a finding. Without a finding, block leaves the child running. Writes before Arm work the same way. A watcher backend failure from `Start()` still cancels the runtime; that is a dead watcher, not a skipped file. For write-time interception, use Landlock or the process sandbox (`--sandbox`).
 

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -841,7 +841,7 @@ func TestApplyConductorPolicyBundleReloadsAndActivates(t *testing.T) {
 	oldCfg.LicenseRequireIntermediate = &requireIntermediate
 	oldCfg.LicenseRequireIntermediateResolved = true
 	oldCfg.FileSentry.Enabled = true
-	oldCfg.FileSentry.Action = config.ActionBlock
+	oldCfg.FileSentry.Action = config.ActionWarn // block is refused on the server listener; warn is the state a live follower can carry
 	oldCfg.FileSentry.WatchPaths = []config.WatchPath{{Path: "/tmp/pipelock-watch"}}
 	oldCfg.BrowserShield.Enabled = true
 	oldCfg.BrowserShield.Strictness = config.ShieldStrictnessAggressive

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -60,7 +60,17 @@ func (f *fileSentryRuntimeFailure) get() error {
 	return f.err
 }
 
+func validateServerFileSentry(cfg *config.Config) error {
+	if cfg != nil && cfg.FileSentry.Enabled && cfg.FileSentry.Action == config.ActionBlock {
+		return errors.New("file_sentry.action: block requires subprocess MCP mode (pipelock mcp proxy -- COMMAND); pipelock run has no child process to cancel")
+	}
+	return nil
+}
+
 func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel context.CancelFunc) (func() error, error) {
+	if err := validateServerFileSentry(cfg); err != nil {
+		return nil, err
+	}
 	if cfg == nil || !cfg.FileSentry.Enabled {
 		return func() error { return nil }, nil
 	}

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -70,13 +70,15 @@ func (s *Server) reloadLocked(newCfg *config.Config) (err error) {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 		return rejectErr
 	}
-	// file_sentry is restart-only, so a reload never arms a new block mode and
-	// rejecting the whole reload for it would drop the security changes riding
-	// alongside (a fleet policy bundle applied to a follower is the common case).
-	// Warn loudly instead: the running settings stay, and the next start refuses
-	// this config until it is corrected.
+	// Startup refuses block on this listener, so a reload that asks for it is
+	// requesting enforcement this runtime cannot provide. Reject the whole
+	// reload atomically and record it through the reload audit path; applying
+	// the rest while quietly keeping the old file sentry settings would report a
+	// policy rollout as successful when its enforcement never arrived.
 	if fileSentryErr := validateServerFileSentry(newCfg); fileSentryErr != nil {
-		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: %v; file_sentry is restart-only, so this reload keeps the running settings and the next start will refuse this config\n", fileSentryErr)
+		rejectErr := fmt.Errorf("rejected: invalid config reload: %w", fileSentryErr)
+		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
+		return rejectErr
 	}
 	if s.containmentManaged {
 		if containmentErr := validateContainmentMetricsConfig(newCfg); containmentErr != nil {

--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -70,6 +70,14 @@ func (s *Server) reloadLocked(newCfg *config.Config) (err error) {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 		return rejectErr
 	}
+	// file_sentry is restart-only, so a reload never arms a new block mode and
+	// rejecting the whole reload for it would drop the security changes riding
+	// alongside (a fleet policy bundle applied to a follower is the common case).
+	// Warn loudly instead: the running settings stay, and the next start refuses
+	// this config until it is corrected.
+	if fileSentryErr := validateServerFileSentry(newCfg); fileSentryErr != nil {
+		_, _ = fmt.Fprintf(s.opts.Stderr, "WARNING: config reload: %v; file_sentry is restart-only, so this reload keeps the running settings and the next start will refuse this config\n", fileSentryErr)
+	}
 	if s.containmentManaged {
 		if containmentErr := validateContainmentMetricsConfig(newCfg); containmentErr != nil {
 			s.containmentMetricsDenied.Store(true)

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1406,7 +1406,7 @@ func TestServer_StartRejectsFileSentryBlockWithoutSubprocessChild(t *testing.T) 
 	oldNew := newFileSentryWatcher
 	newFileSentryWatcher = func(*config.FileSentry, filesentry.DLPScanner, filesentry.Lineage, func(error)) (filesentry.Watcher, error) {
 		t.Error("file sentry watcher constructed despite the block-mode refusal")
-		return newGatedFileSentryWatcher(nil), nil
+		return nil, errors.New("test: watcher must not be constructed")
 	}
 	t.Cleanup(func() { newFileSentryWatcher = oldNew })
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
+	"github.com/luckyPipewrench/pipelock/internal/filesentry"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/posture"
@@ -1400,6 +1401,14 @@ func TestServer_StartRejectsFileSentryBlockWithoutSubprocessChild(t *testing.T) 
 		o.Listen = serverTestEphemeralListen
 		o.ListenChanged = true
 	})
+	// The refusal must happen before any watcher exists: a constructed watcher
+	// would already be reading the filesystem for a block mode that cannot act.
+	oldNew := newFileSentryWatcher
+	newFileSentryWatcher = func(*config.FileSentry, filesentry.DLPScanner, filesentry.Lineage, func(error)) (filesentry.Watcher, error) {
+		t.Error("file sentry watcher constructed despite the block-mode refusal")
+		return newGatedFileSentryWatcher(nil), nil
+	}
+	t.Cleanup(func() { newFileSentryWatcher = oldNew })
 
 	err := s.Start(context.Background())
 	if err == nil {
@@ -1924,12 +1933,11 @@ func TestServer_ReloadRejectsNilConfig(t *testing.T) {
 	}
 }
 
-// A reload that introduces file_sentry block on the server listener is not
-// rejected: file_sentry is restart-only, so the running settings stay and the
-// rest of the reload (a fleet policy bundle, new DLP patterns) still lands.
-// The operator gets a loud warning that the next start will refuse the config.
-func TestServer_ReloadWarnsFileSentryBlockWithoutSubprocessChild(t *testing.T) {
-	s, buf := newTestServer(t, nil)
+// A reload that asks for file_sentry block on the server listener is rejected
+// atomically: nothing else in that reload lands either, so a policy rollout
+// cannot report success while the enforcement it asked for never arrived.
+func TestServer_ReloadRejectsFileSentryBlockWithoutSubprocessChild(t *testing.T) {
+	s, _ := newTestServer(t, nil)
 	oldCfg := s.proxy.CurrentConfig()
 
 	newCfg := oldCfg.Clone()
@@ -1938,26 +1946,23 @@ func TestServer_ReloadWarnsFileSentryBlockWithoutSubprocessChild(t *testing.T) {
 	newCfg.FileSentry.WatchPaths = []config.WatchPath{{Path: t.TempDir()}}
 	newCfg.DLP.Patterns = append(newCfg.DLP.Patterns, config.DLPPattern{Name: "reload-secret", Regex: `RELOAD_SECRET_[A-Z]+`, Severity: config.SeverityCritical})
 
-	if err := s.Reload(newCfg); err != nil {
-		t.Fatalf("Reload rejected a restart-only file_sentry change: %v", err)
+	err := s.Reload(newCfg)
+	if err == nil {
+		t.Fatal("Reload accepted file_sentry.action: block without a subprocess child")
 	}
-	for _, want := range []string{"file_sentry.action", "subprocess MCP mode", "pipelock mcp proxy -- COMMAND", "next start will refuse"} {
-		if !buf.contains(want) {
-			t.Errorf("stderr missing %q:\n%s", want, buf.String())
+	for _, want := range []string{"rejected", "file_sentry.action", "subprocess MCP mode", "pipelock mcp proxy -- COMMAND"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Reload error = %q, want substring %q", err, want)
 		}
 	}
 	live := s.proxy.CurrentConfig()
-	if !reflect.DeepEqual(live.FileSentry, oldCfg.FileSentry) {
-		t.Fatalf("file_sentry = %+v, want running settings preserved %+v", live.FileSentry, oldCfg.FileSentry)
+	if live != oldCfg {
+		t.Fatal("rejected reload swapped the live config")
 	}
-	found := false
 	for _, p := range live.DLP.Patterns {
 		if p.Name == "reload-secret" {
-			found = true
+			t.Fatal("rejected reload still applied the DLP change riding alongside it")
 		}
-	}
-	if !found {
-		t.Fatal("reload dropped the DLP change riding alongside the file_sentry warning")
 	}
 }
 

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/contract"
 	"github.com/luckyPipewrench/pipelock/internal/contract/runtime/contractruntimetest"
-	"github.com/luckyPipewrench/pipelock/internal/filesentry"
 	mcptools "github.com/luckyPipewrench/pipelock/internal/mcp/tools"
 	"github.com/luckyPipewrench/pipelock/internal/metrics"
 	"github.com/luckyPipewrench/pipelock/internal/posture"
@@ -1386,10 +1385,7 @@ func TestServer_StartKeepsCleanCancellationNilWithFileSentry(t *testing.T) {
 	}
 }
 
-func TestServer_StartKeepsFileSentryBlockCancellationNil(t *testing.T) {
-	watcher := newGatedFileSentryWatcher(errors.New("must not be returned after a file sentry block"))
-	installGatedFileSentryWatcher(t, watcher)
-
+func TestServer_StartRejectsFileSentryBlockWithoutSubprocessChild(t *testing.T) {
 	cfgPath := writeServerTestConfig(t, strings.Join([]string{
 		"mode: balanced",
 		"file_sentry:",
@@ -1405,23 +1401,17 @@ func TestServer_StartKeepsFileSentryBlockCancellationNil(t *testing.T) {
 		o.ListenChanged = true
 	})
 
-	done := make(chan error, 1)
-	go func() { done <- s.Start(context.Background()) }()
-	select {
-	case <-watcher.started:
-	case <-time.After(5 * time.Second):
-		t.Fatal("file sentry watcher did not start")
+	err := s.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start accepted file_sentry.action: block without a subprocess child")
 	}
-	waitForServerOutput(t, buf, "  Health:")
-	watcher.findings <- filesentry.Finding{Path: "agent-output", PatternName: "test", Severity: "high", IsAgent: true}
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("Start error after file sentry block cancellation = %v, want nil", err)
+	for _, want := range []string{"file_sentry.action", "subprocess MCP mode", "pipelock mcp proxy -- COMMAND"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Start error = %q, want substring %q", err, want)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Start did not return after file sentry block cancellation")
+	}
+	if buf.contains("file sentry watching") {
+		t.Fatalf("Start armed file sentry despite refusal:\n%s", buf.String())
 	}
 }
 
@@ -1931,6 +1921,43 @@ func TestServer_ReloadRejectsNilConfig(t *testing.T) {
 	}
 	if live := s.proxy.CurrentConfig(); live != oldCfg {
 		t.Fatal("rejected nil reload changed the live config")
+	}
+}
+
+// A reload that introduces file_sentry block on the server listener is not
+// rejected: file_sentry is restart-only, so the running settings stay and the
+// rest of the reload (a fleet policy bundle, new DLP patterns) still lands.
+// The operator gets a loud warning that the next start will refuse the config.
+func TestServer_ReloadWarnsFileSentryBlockWithoutSubprocessChild(t *testing.T) {
+	s, buf := newTestServer(t, nil)
+	oldCfg := s.proxy.CurrentConfig()
+
+	newCfg := oldCfg.Clone()
+	newCfg.FileSentry.Enabled = true
+	newCfg.FileSentry.Action = config.ActionBlock
+	newCfg.FileSentry.WatchPaths = []config.WatchPath{{Path: t.TempDir()}}
+	newCfg.DLP.Patterns = append(newCfg.DLP.Patterns, config.DLPPattern{Name: "reload-secret", Regex: `RELOAD_SECRET_[A-Z]+`, Severity: config.SeverityCritical})
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload rejected a restart-only file_sentry change: %v", err)
+	}
+	for _, want := range []string{"file_sentry.action", "subprocess MCP mode", "pipelock mcp proxy -- COMMAND", "next start will refuse"} {
+		if !buf.contains(want) {
+			t.Errorf("stderr missing %q:\n%s", want, buf.String())
+		}
+	}
+	live := s.proxy.CurrentConfig()
+	if !reflect.DeepEqual(live.FileSentry, oldCfg.FileSentry) {
+		t.Fatalf("file_sentry = %+v, want running settings preserved %+v", live.FileSentry, oldCfg.FileSentry)
+	}
+	found := false
+	for _, p := range live.DLP.Patterns {
+		if p.Name == "reload-secret" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("reload dropped the DLP change riding alongside the file_sentry warning")
 	}
 }
 
@@ -3895,7 +3922,7 @@ func TestServer_Reload_PreservesRestartOnlyFields(t *testing.T) {
 	newCfg.FlightRecorder.SigningKeyPath = "/tmp/new-signing-key"
 	newCfg.FlightRecorder.RequireReceipts = true
 	newCfg.Conductor.ConductorURL = "https://boss-new.example"
-	newCfg.FileSentry.Action = config.ActionBlock // file_sentry is restart-only; this change must be ignored
+	newCfg.FileSentry.Enabled = false // file_sentry is restart-only; this change must be ignored
 	newCfg.DashboardSnapshot.Path = "/tmp/new-runtime-snapshot.json"
 	newCfg.DashboardSnapshot.Interval = "2s"
 	newCfg.ReverseProxy.Listen = "127.0.0.1:28084"


### PR DESCRIPTION
## What changed

`pipelock run` now refuses `file_sentry.action: block` at startup, before any watcher is constructed, with a message naming the supported subprocess MCP mode. The server listener has no child process to cancel, so block there could only log while reading as enforcement, and the docs now say so.

A reload that asks for block on that listener is rejected atomically through the reload audit path, and nothing else in that reload lands. An earlier revision kept the running settings and warned instead; that shape let a policy rollout report success while the enforcement it asked for never arrived, so it's gone. Subprocess MCP mode is unchanged. `action: warn` still works on every listener.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted file-sentry blocking to subprocess MCP mode.
  - Unsupported blocking configurations are rejected at startup and during reloads without changing active settings or unrelated valid changes.
  - Configuration errors are reported while current runtime behavior is preserved until a valid configuration is loaded.

- **Documentation**
  - Clarified supported file-sentry actions, validation behavior, reload handling, and that warning remains the default response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->