### PR TITLE
fix(playground): publish a permanently verifiable replay archive

### DIFF
--- a/cmd/pipelock-playground-broker/archive_replay_test.go
+++ b/cmd/pipelock-playground-broker/archive_replay_test.go
@@ -138,3 +138,60 @@ func TestArchiveReplayCmd_Refusals(t *testing.T) {
 		}
 	})
 }
+
+func TestArchiveReplayOutputHelpersFailClosed(t *testing.T) {
+	t.Run("kit output path must be new directory", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "already-a-file")
+		if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		f := &archiveReplayFlags{
+			kitOutputDir:    path,
+			linuxVerifier:   "unused",
+			macOSVerifier:   "unused",
+			windowsVerifier: "unused",
+		}
+		if err := writeArchiveVerifyKits(f, nil); err == nil || !strings.Contains(err.Error(), "create kit output directory") {
+			t.Fatalf("existing output file error = %v, want directory creation refusal", err)
+		}
+	})
+
+	t.Run("kit build stops before partial output", func(t *testing.T) {
+		kitDir := filepath.Join(t.TempDir(), "kits")
+		f := &archiveReplayFlags{
+			kitOutputDir:    kitDir,
+			linuxVerifier:   filepath.Join(t.TempDir(), "missing-linux"),
+			macOSVerifier:   filepath.Join(t.TempDir(), "missing-macos"),
+			windowsVerifier: filepath.Join(t.TempDir(), "missing-windows"),
+		}
+		if err := writeArchiveVerifyKits(f, nil); err == nil || !strings.Contains(err.Error(), "build linux verification kit") {
+			t.Fatalf("missing verifier error = %v, want kit-build failure", err)
+		}
+		entries, err := os.ReadDir(kitDir)
+		if err != nil {
+			t.Fatalf("read kit output directory: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("failed kit build wrote partial output: %v", entries)
+		}
+	})
+
+	t.Run("archive file writes exact bytes and never replaces directory", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "replay.tar.gz")
+		want := []byte("replay-bytes")
+		if err := writeNewArchiveFile(path, want); err != nil {
+			t.Fatalf("writeNewArchiveFile: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("output = %q, want %q", got, want)
+		}
+		if err := writeNewArchiveFile(dir, want); err == nil || !strings.Contains(err.Error(), "create output") {
+			t.Fatalf("directory output error = %v, want create-output refusal", err)
+		}
+	})
+}

--- a/cmd/pipelock-playground-broker/archive_replay_test.go
+++ b/cmd/pipelock-playground-broker/archive_replay_test.go
@@ -238,11 +238,39 @@ func TestArchiveReplayOutputHelpersFailClosed(t *testing.T) {
 		}
 	})
 
+	// The writer reports CREATION separately from success, because rollback needs
+	// both facts: a file it created must be removed even if the write failed, and
+	// a path it did not create belongs to someone else and must never be touched.
+	// Collapsing the two is what let a created-then-failed file survive rollback
+	// and then block removal of the kit directory.
+	t.Run("creation is reported separately from write success", func(t *testing.T) {
+		dir := t.TempDir()
+
+		fresh := filepath.Join(dir, "fresh.tar.gz")
+		created, err := writeNewArchiveFile(fresh, []byte("bytes"))
+		if err != nil {
+			t.Fatalf("writeNewArchiveFile: %v", err)
+		}
+		if !created {
+			t.Fatal("a file this call created was not reported as created, so rollback would leave it behind")
+		}
+
+		// A path that already exists was not created here. Reporting it as
+		// created would make rollback delete an artifact serving visitors.
+		created, err = writeNewArchiveFile(fresh, []byte("second"))
+		if err == nil {
+			t.Fatal("writing over an existing path must be refused")
+		}
+		if created {
+			t.Fatal("an existing path was reported as created; rollback would delete an artifact this run did not write")
+		}
+	})
+
 	t.Run("archive file writes exact bytes and never replaces directory", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "replay.tar.gz")
 		want := []byte("replay-bytes")
-		if err := writeNewArchiveFile(path, want); err != nil {
+		if _, err := writeNewArchiveFile(path, want); err != nil {
 			t.Fatalf("writeNewArchiveFile: %v", err)
 		}
 		got, err := os.ReadFile(filepath.Clean(path))
@@ -252,8 +280,12 @@ func TestArchiveReplayOutputHelpersFailClosed(t *testing.T) {
 		if !bytes.Equal(got, want) {
 			t.Fatalf("output = %q, want %q", got, want)
 		}
-		if err := writeNewArchiveFile(dir, want); err == nil || !strings.Contains(err.Error(), "create output") {
+		created, err := writeNewArchiveFile(dir, want)
+		if err == nil || !strings.Contains(err.Error(), "create output") {
 			t.Fatalf("directory output error = %v, want create-output refusal", err)
+		}
+		if created {
+			t.Fatal("an existing directory was reported as created")
 		}
 	})
 }

--- a/cmd/pipelock-playground-broker/archive_replay_test.go
+++ b/cmd/pipelock-playground-broker/archive_replay_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// archiveReplayEnv points the publisher at a sealed run and a root key file. The
+// run directory is a real sealed run captured from the live playground, so these
+// tests exercise the publisher against production-shaped evidence rather than a
+// fixture that agrees with the code by construction.
+func archiveReplayEnv(t *testing.T) (runDir, keyFile string) {
+	t.Helper()
+	runDir = "/tmp/kit-verify/pipelock-live-verify-windows/app/run"
+	if _, err := os.Stat(filepath.Join(runDir, "launch-manifest.json")); err != nil {
+		t.Skipf("sealed run directory not present: %v", err)
+	}
+	keyFile = "/home/josh/.config/pipelock/playground-demo-signing-v2.key"
+	if _, err := os.Stat(keyFile); err != nil {
+		t.Skipf("published root key not present: %v", err)
+	}
+	return runDir, keyFile
+}
+
+func runArchiveCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newArchiveReplayCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// The publisher writes a bundle and all three kits in one invocation, because a
+// kit built from a different bundle than the one shipped is a silent mismatch a
+// visitor would only find offline.
+func TestArchiveReplayCmd_WritesBundleAndKits(t *testing.T) {
+	runDir, keyFile := archiveReplayEnv(t)
+	for _, v := range []string{"/tmp/pg-verifiers/pipelock-verifier-linux", "/tmp/pg-verifiers/pipelock-verifier-macos", "/tmp/pg-verifiers/pipelock-verifier-windows.exe"} {
+		if _, err := os.Stat(v); err != nil {
+			t.Skipf("verifier binary not present: %v", err)
+		}
+	}
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "replay-bundle.tar.gz")
+	kits := filepath.Join(dir, "kits")
+
+	out, err := runArchiveCmd(t,
+		"--run-dir", runDir, "--orchestrator-key-file", keyFile, "--output", bundle,
+		"--kit-output-dir", kits,
+		"--linux-verifier", "/tmp/pg-verifiers/pipelock-verifier-linux",
+		"--macos-verifier", "/tmp/pg-verifiers/pipelock-verifier-macos",
+		"--windows-verifier", "/tmp/pg-verifiers/pipelock-verifier-windows.exe",
+	)
+	if err != nil {
+		t.Fatalf("archive-replay: %v (%s)", err, out)
+	}
+	if fi, statErr := os.Stat(bundle); statErr != nil || fi.Size() == 0 {
+		t.Fatalf("bundle not written: %v", statErr)
+	}
+	entries, err := os.ReadDir(kits)
+	if err != nil {
+		t.Fatalf("read kit dir: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("wrote %d kits, want 3", len(entries))
+	}
+}
+
+// Every refusal below protects an operator from a half-published artifact set.
+func TestArchiveReplayCmd_Refusals(t *testing.T) {
+	runDir, keyFile := archiveReplayEnv(t)
+
+	t.Run("verifier_without_kit_dir", func(t *testing.T) {
+		out, err := runArchiveCmd(t,
+			"--run-dir", runDir, "--orchestrator-key-file", keyFile,
+			"--output", filepath.Join(t.TempDir(), "b.tar.gz"),
+			"--linux-verifier", "/tmp/pg-verifiers/pipelock-verifier-linux",
+		)
+		if err == nil || !strings.Contains(err.Error()+out, "kit-output-dir is required") {
+			t.Fatalf("error = %v (%s), want the kit-output-dir refusal", err, out)
+		}
+	})
+
+	t.Run("kit_dir_without_every_verifier", func(t *testing.T) {
+		out, err := runArchiveCmd(t,
+			"--run-dir", runDir, "--orchestrator-key-file", keyFile,
+			"--output", filepath.Join(t.TempDir(), "b.tar.gz"),
+			"--kit-output-dir", filepath.Join(t.TempDir(), "kits"),
+		)
+		if err == nil || !strings.Contains(err.Error()+out, "requires --linux-verifier") {
+			t.Fatalf("error = %v (%s), want the all-three-verifiers refusal", err, out)
+		}
+	})
+
+	// Refusing to overwrite keeps a failed republish from destroying the artifact
+	// currently serving visitors.
+	t.Run("existing_output_is_not_overwritten", func(t *testing.T) {
+		dir := t.TempDir()
+		existing := filepath.Join(dir, "already-there.tar.gz")
+		if err := os.WriteFile(existing, []byte("original"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		out, err := runArchiveCmd(t, "--run-dir", runDir, "--orchestrator-key-file", keyFile, "--output", existing)
+		if err == nil || !strings.Contains(err.Error()+out, "create output") {
+			t.Fatalf("error = %v (%s), want a refusal to overwrite", err, out)
+		}
+		if data, readErr := os.ReadFile(filepath.Clean(existing)); readErr != nil || string(data) != "original" {
+			t.Fatal("the existing artifact was modified")
+		}
+	})
+
+	t.Run("missing_run_directory", func(t *testing.T) {
+		out, err := runArchiveCmd(t,
+			"--run-dir", filepath.Join(t.TempDir(), "absent"), "--orchestrator-key-file", keyFile,
+			"--output", filepath.Join(t.TempDir(), "b.tar.gz"),
+		)
+		if err == nil {
+			t.Fatalf("a missing run directory must be refused (%s)", out)
+		}
+	})
+
+	t.Run("missing_root_key", func(t *testing.T) {
+		out, err := runArchiveCmd(t,
+			"--run-dir", runDir, "--orchestrator-key-file", filepath.Join(t.TempDir(), "absent.key"),
+			"--output", filepath.Join(t.TempDir(), "b.tar.gz"),
+		)
+		if err == nil {
+			t.Fatalf("an unreadable root key must be refused (%s)", out)
+		}
+	})
+}

--- a/cmd/pipelock-playground-broker/archive_replay_test.go
+++ b/cmd/pipelock-playground-broker/archive_replay_test.go
@@ -11,10 +11,19 @@ import (
 	"testing"
 )
 
-// archiveReplayEnv points the publisher at a sealed run and a root key file. The
-// run directory is a real sealed run captured from the live playground, so these
-// tests exercise the publisher against production-shaped evidence rather than a
-// fixture that agrees with the code by construction.
+// archiveReplayEnv points the publisher at a sealed run and a root key file, and
+// skips when they are absent. That skip is deliberate and cannot be engineered
+// away: resolveOrchestratorRoot refuses any key that does not derive the
+// PUBLISHED identity, because a broker signing under another root would produce
+// bundles that fail every shipped verifier. A generated test key is therefore
+// rejected before the command does anything, so this end-to-end path can only
+// run where the real root and a real sealed run are present.
+//
+// It is an extra layer rather than the coverage. The publisher's logic --
+// kit-flag validation, build-before-publish ordering, and all-or-nothing
+// rollback -- is exercised hermetically against buildArchiveVerifyKits and
+// publishArchiveArtifacts in TestArchiveReplayOutputHelpersFailClosed, which
+// runs everywhere including a clean CI checkout.
 func archiveReplayEnv(t *testing.T) (runDir, keyFile string) {
 	t.Helper()
 	runDir = "/tmp/kit-verify/pipelock-live-verify-windows/app/run"
@@ -146,17 +155,21 @@ func TestArchiveReplayOutputHelpersFailClosed(t *testing.T) {
 			t.Fatal(err)
 		}
 		f := &archiveReplayFlags{
+			output:          filepath.Join(t.TempDir(), "bundle.tar.gz"),
 			kitOutputDir:    path,
 			linuxVerifier:   "unused",
 			macOSVerifier:   "unused",
 			windowsVerifier: "unused",
 		}
-		if err := writeArchiveVerifyKits(f, nil); err == nil || !strings.Contains(err.Error(), "create kit output directory") {
+		kits := []archiveKit{{name: "kit.zip", data: []byte("kit")}}
+		if err := publishArchiveArtifacts(f, []byte("bundle"), kits); err == nil || !strings.Contains(err.Error(), "create kit output directory") {
 			t.Fatalf("existing output file error = %v, want directory creation refusal", err)
 		}
 	})
 
-	t.Run("kit build stops before partial output", func(t *testing.T) {
+	// A build failure must not reach the filesystem at all, because the build
+	// runs before anything is published.
+	t.Run("kit build stops before any output", func(t *testing.T) {
 		kitDir := filepath.Join(t.TempDir(), "kits")
 		f := &archiveReplayFlags{
 			kitOutputDir:    kitDir,
@@ -164,15 +177,64 @@ func TestArchiveReplayOutputHelpersFailClosed(t *testing.T) {
 			macOSVerifier:   filepath.Join(t.TempDir(), "missing-macos"),
 			windowsVerifier: filepath.Join(t.TempDir(), "missing-windows"),
 		}
-		if err := writeArchiveVerifyKits(f, nil); err == nil || !strings.Contains(err.Error(), "build linux verification kit") {
+		kits, err := buildArchiveVerifyKits(f, nil)
+		if err == nil || !strings.Contains(err.Error(), "build linux verification kit") {
 			t.Fatalf("missing verifier error = %v, want kit-build failure", err)
 		}
-		entries, err := os.ReadDir(kitDir)
-		if err != nil {
-			t.Fatalf("read kit output directory: %v", err)
+		if kits != nil {
+			t.Fatalf("a failed build returned kits: %v", kits)
 		}
-		if len(entries) != 0 {
-			t.Fatalf("failed kit build wrote partial output: %v", entries)
+		if _, statErr := os.Stat(kitDir); !os.IsNotExist(statErr) {
+			t.Fatalf("a failed kit build created the output directory: %v", statErr)
+		}
+	})
+
+	// The finding this covers: a later write failure used to leave the bundle and
+	// any earlier kits on disk, so a visitor could download a bundle whose kits
+	// never arrived. Publication is now all-or-nothing.
+	t.Run("a failed kit write removes every artifact this run created", func(t *testing.T) {
+		dir := t.TempDir()
+		bundlePath := filepath.Join(dir, "replay-bundle.tar.gz")
+		kitDir := filepath.Join(dir, "kits")
+		f := &archiveReplayFlags{output: bundlePath, kitOutputDir: kitDir}
+
+		// The second kit collides with the first by name, so its O_EXCL create
+		// fails after the bundle and the first kit are already written.
+		kits := []archiveKit{
+			{name: "same-name.zip", data: []byte("first")},
+			{name: "same-name.zip", data: []byte("second")},
+		}
+		err := publishArchiveArtifacts(f, []byte("bundle"), kits)
+		if err == nil || !strings.Contains(err.Error(), "create output") {
+			t.Fatalf("error = %v, want the duplicate-name create refusal", err)
+		}
+		if _, statErr := os.Stat(bundlePath); !os.IsNotExist(statErr) {
+			t.Fatal("the bundle survived a failed publication")
+		}
+		if _, statErr := os.Stat(filepath.Join(kitDir, "same-name.zip")); !os.IsNotExist(statErr) {
+			t.Fatal("the first kit survived a failed publication")
+		}
+		if _, statErr := os.Stat(kitDir); !os.IsNotExist(statErr) {
+			t.Fatal("the kit directory survived a failed publication")
+		}
+	})
+
+	// Rollback must never touch an artifact it did not create. A pre-existing
+	// output is refused before anything is written, so nothing is removed.
+	t.Run("rollback never removes a pre-existing artifact", func(t *testing.T) {
+		dir := t.TempDir()
+		bundlePath := filepath.Join(dir, "replay-bundle.tar.gz")
+		if err := os.WriteFile(bundlePath, []byte("serving-visitors"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		f := &archiveReplayFlags{output: bundlePath, kitOutputDir: filepath.Join(dir, "kits")}
+		kits := []archiveKit{{name: "kit.zip", data: []byte("kit")}}
+		if err := publishArchiveArtifacts(f, []byte("bundle"), kits); err == nil {
+			t.Fatal("publishing over an existing artifact must be refused")
+		}
+		data, err := os.ReadFile(filepath.Clean(bundlePath))
+		if err != nil || string(data) != "serving-visitors" {
+			t.Fatalf("the pre-existing artifact was removed or modified: %q, %v", data, err)
 		}
 	})
 

--- a/cmd/pipelock-playground-broker/archive_rollback_unix_test.go
+++ b/cmd/pipelock-playground-broker/archive_rollback_unix_test.go
@@ -72,3 +72,40 @@ func TestPublishArchiveArtifacts_RollsBackAFileCreatedThenFailedMidWrite(t *test
 		t.Fatal("the kit directory survived rollback")
 	}
 }
+
+// The bundle and the kits are tracked by separate branches, so a bundle-only
+// failure returns before the kit branch ever runs and leaves its tracking
+// untested. This drives the failure into the kit write instead, by sizing the
+// bundle to fit under the limit and the kit to exceed it. An untracked kit file
+// is the worse case of the two: besides surviving, it keeps the kit directory
+// non-empty so that cannot be removed either.
+func TestPublishArchiveArtifacts_RollsBackAKitCreatedThenFailedMidWrite(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "replay-bundle.tar.gz")
+	kitDir := filepath.Join(dir, "kits")
+	f := &archiveReplayFlags{output: bundlePath, kitOutputDir: kitDir}
+
+	withTinyFileSizeLimit(t, 1)
+
+	// One byte fits the limit, so the bundle publishes and the kit directory is
+	// created; the kit then exceeds it and fails after its own create.
+	bundle := []byte("b")
+	kits := []archiveKit{{name: "kit.zip", data: []byte("this kit exceeds the file size limit")}}
+
+	err := publishArchiveArtifacts(f, bundle, kits)
+	if err == nil {
+		t.Fatal("a kit write that exceeded the file size limit was reported as success")
+	}
+	if !strings.Contains(err.Error(), "write output") && !strings.Contains(err.Error(), "close output") {
+		t.Fatalf("error = %v, want a write or close failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(kitDir, "kit.zip")); !os.IsNotExist(statErr) {
+		t.Fatal("a kit created and then failed mid-write survived rollback")
+	}
+	if _, statErr := os.Stat(kitDir); !os.IsNotExist(statErr) {
+		t.Fatal("the kit directory survived rollback, so an untracked kit was left inside it")
+	}
+	if _, statErr := os.Stat(bundlePath); !os.IsNotExist(statErr) {
+		t.Fatal("the successfully written bundle survived a failed publication")
+	}
+}

--- a/cmd/pipelock-playground-broker/archive_rollback_unix_test.go
+++ b/cmd/pipelock-playground-broker/archive_rollback_unix_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A file created and then failed mid-write is the case that separates "created"
+// from "written". It cannot be reached by passing a bad path, because an
+// exclusive create either succeeds or fails outright, so the write is forced to
+// fail with a file-size limit instead.
+//
+// SIGXFSZ has to be ignored first: its default action terminates the process,
+// and only once it is ignored does exceeding the limit surface as an EFBIG
+// error from write, which is the shape a real disk-full failure takes.
+func withTinyFileSizeLimit(t *testing.T, limit uint64) {
+	t.Helper()
+
+	signal.Ignore(syscall.SIGXFSZ)
+	var saved syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &saved); err != nil {
+		t.Skipf("cannot read RLIMIT_FSIZE: %v", err)
+	}
+	tiny := syscall.Rlimit{Cur: limit, Max: saved.Max}
+	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &tiny); err != nil {
+		t.Skipf("cannot lower RLIMIT_FSIZE: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &saved)
+		signal.Reset(syscall.SIGXFSZ)
+	})
+}
+
+// The regression: writeNewArchiveFile reported creation only when the write
+// succeeded, so a file it created and then failed to write was never recorded.
+// Rollback left that file on disk, and its presence then prevented the kit
+// directory from being removed, leaving exactly the half-published artifact set
+// the all-or-nothing publish exists to prevent.
+func TestPublishArchiveArtifacts_RollsBackAFileCreatedThenFailedMidWrite(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "replay-bundle.tar.gz")
+	kitDir := filepath.Join(dir, "kits")
+	f := &archiveReplayFlags{output: bundlePath, kitOutputDir: kitDir}
+
+	withTinyFileSizeLimit(t, 1)
+
+	// Larger than the limit, so the exclusive create succeeds and the write then
+	// fails.
+	bundle := []byte("this payload exceeds the file size limit")
+	kits := []archiveKit{{name: "kit.zip", data: []byte("kit")}}
+
+	err := publishArchiveArtifacts(f, bundle, kits)
+	if err == nil {
+		t.Fatal("a write that exceeded the file size limit was reported as success")
+	}
+	if !strings.Contains(err.Error(), "write output") && !strings.Contains(err.Error(), "close output") {
+		t.Fatalf("error = %v, want a write or close failure", err)
+	}
+	if _, statErr := os.Stat(bundlePath); !os.IsNotExist(statErr) {
+		t.Fatal("a file created and then failed mid-write survived rollback")
+	}
+	if _, statErr := os.Stat(kitDir); !os.IsNotExist(statErr) {
+		t.Fatal("the kit directory survived rollback")
+	}
+}

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -319,10 +319,16 @@ func publishArchiveArtifacts(f *archiveReplayFlags, bundle []byte, kits []archiv
 		}
 	}()
 
-	if err = writeNewArchiveFile(f.output, bundle); err != nil {
+	// Record the path on CREATION, not on success, so a file that failed
+	// mid-write is still rolled back and the kit directory can be removed.
+	madeBundle, writeErr := writeNewArchiveFile(f.output, bundle)
+	if madeBundle {
+		created = append(created, f.output)
+	}
+	if writeErr != nil {
+		err = writeErr
 		return err
 	}
-	created = append(created, f.output)
 
 	if len(kits) == 0 {
 		return nil
@@ -334,18 +340,27 @@ func publishArchiveArtifacts(f *archiveReplayFlags, bundle []byte, kits []archiv
 	createdDir = kitDir
 	for _, kit := range kits {
 		path := filepath.Join(kitDir, kit.name)
-		if err = writeNewArchiveFile(path, kit.data); err != nil {
+		madeKit, kitErr := writeNewArchiveFile(path, kit.data)
+		if madeKit {
+			created = append(created, path)
+		}
+		if kitErr != nil {
+			err = kitErr
 			return err
 		}
-		created = append(created, path)
 	}
 	return nil
 }
 
-func writeNewArchiveFile(path string, data []byte) (err error) {
+// writeNewArchiveFile exclusively creates path and writes data to it. It reports
+// whether the file was CREATED separately from whether the write succeeded,
+// because those are different facts for rollback: a file created and then failed
+// mid-write still exists and must be removed, while a path that failed to create
+// belongs to someone else and must never be touched.
+func writeNewArchiveFile(path string, data []byte) (created bool, err error) {
 	file, openErr := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if openErr != nil {
-		return fmt.Errorf("create output: %w", openErr)
+		return false, fmt.Errorf("create output: %w", openErr)
 	}
 	// A close error on a successful write is a real write failure: the data may
 	// never have reached the filesystem. Reporting success there would publish a
@@ -357,9 +372,9 @@ func writeNewArchiveFile(path string, data []byte) (err error) {
 		}
 	}()
 	if _, err = file.Write(data); err != nil {
-		return fmt.Errorf("write output: %w", err)
+		return true, fmt.Errorf("write output: %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 func newServeCmd() *cobra.Command {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -174,6 +174,17 @@ type serveFlags struct {
 
 type providerFactory func(context.Context, *serveFlags, string) (broker.MachineProvider, error)
 
+type archiveReplayFlags struct {
+	runDir              string
+	output              string
+	kitOutputDir        string
+	linuxVerifier       string
+	macOSVerifier       string
+	windowsVerifier     string
+	orchestratorKeyFile string
+	orchestratorKeyEnv  string
+}
+
 var newMachineProvider providerFactory = defaultMachineProvider
 
 func main() {
@@ -190,8 +201,107 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: false,
 		Version:       cliutil.Version,
 	}
-	root.AddCommand(newServeCmd())
+	root.AddCommand(newServeCmd(), newArchiveReplayCmd())
 	return root
+}
+
+func newArchiveReplayCmd() *cobra.Command {
+	f := &archiveReplayFlags{}
+	cmd := &cobra.Command{
+		Use:   "archive-replay",
+		Short: "Create a permanently verifiable published playground replay",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runArchiveReplay(cmd, f)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&f.runDir, "run-dir", "", "sealed playground run directory")
+	flags.StringVar(&f.output, "output", "", "new replay bundle output path")
+	flags.StringVar(&f.orchestratorKeyFile, "orchestrator-key-file", "", "path to the broker-held orchestrator root key")
+	flags.StringVar(&f.orchestratorKeyEnv, "orchestrator-key-env", "", "environment variable holding the broker-held orchestrator root key (default "+envOrchestratorRoot+")")
+	flags.StringVar(&f.kitOutputDir, "kit-output-dir", "", "new directory for Linux, macOS, and Windows verification kits (requires all --*-verifier flags)")
+	flags.StringVar(&f.linuxVerifier, "linux-verifier", "", "Linux pipelock-verifier binary for --kit-output-dir")
+	flags.StringVar(&f.macOSVerifier, "macos-verifier", "", "macOS pipelock-verifier binary for --kit-output-dir")
+	flags.StringVar(&f.windowsVerifier, "windows-verifier", "", "Windows pipelock-verifier binary for --kit-output-dir")
+	_ = cmd.MarkFlagRequired("run-dir")
+	_ = cmd.MarkFlagRequired("output")
+	return cmd
+}
+
+func runArchiveReplay(cmd *cobra.Command, f *archiveReplayFlags) error {
+	if err := refuseGuestFacingRootSecret(); err != nil {
+		return err
+	}
+	root, err := resolveOrchestratorRoot(&serveFlags{
+		orchestratorKeyFile:   f.orchestratorKeyFile,
+		orchestratorKeyEnv:    f.orchestratorKeyEnv,
+		requireSessionSecrets: true,
+	})
+	if err != nil {
+		return err
+	}
+	bundle, err := playground.ArchiveRunForPublishedReplay(f.runDir, root)
+	if err != nil {
+		return err
+	}
+	if err := writeNewArchiveFile(f.output, bundle); err != nil {
+		return err
+	}
+	if err := writeArchiveVerifyKits(f, bundle); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "published replay archive verified and written")
+	return nil
+}
+
+func writeArchiveVerifyKits(f *archiveReplayFlags, bundle []byte) error {
+	paths := []string{f.linuxVerifier, f.macOSVerifier, f.windowsVerifier}
+	if f.kitOutputDir == "" {
+		for _, verifier := range paths {
+			if verifier != "" {
+				return errors.New("--kit-output-dir is required when supplying a verifier binary")
+			}
+		}
+		return nil
+	}
+	for _, verifier := range paths {
+		if verifier == "" {
+			return errors.New("--kit-output-dir requires --linux-verifier, --macos-verifier, and --windows-verifier")
+		}
+	}
+	if err := os.Mkdir(filepath.Clean(f.kitOutputDir), 0o750); err != nil {
+		return fmt.Errorf("create kit output directory: %w", err)
+	}
+	for _, kit := range []struct {
+		osName   playground.VerifyKitOS
+		verifier string
+	}{
+		{playground.VerifyKitOSLinux, f.linuxVerifier},
+		{playground.VerifyKitOSMacOS, f.macOSVerifier},
+		{playground.VerifyKitOSWindows, f.windowsVerifier},
+	} {
+		data, name, err := playground.BuildPublishedReplayVerifyKit(kit.osName, kit.verifier, bundle)
+		if err != nil {
+			return fmt.Errorf("build %s verification kit: %w", kit.osName, err)
+		}
+		if err := writeNewArchiveFile(filepath.Join(f.kitOutputDir, name), data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeNewArchiveFile(path string, data []byte) error {
+	file, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+	return nil
 }
 
 func newServeCmd() *cobra.Command {

--- a/cmd/pipelock-playground-broker/main.go
+++ b/cmd/pipelock-playground-broker/main.go
@@ -245,34 +245,45 @@ func runArchiveReplay(cmd *cobra.Command, f *archiveReplayFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := writeNewArchiveFile(f.output, bundle); err != nil {
+	// Build every artifact before publishing any of them. A kit built from a
+	// different bundle than the one shipped is a silent mismatch a visitor only
+	// finds offline, and a half-written artifact set leaves visitors downloading
+	// a bundle whose kits never arrived.
+	kits, err := buildArchiveVerifyKits(f, bundle)
+	if err != nil {
 		return err
 	}
-	if err := writeArchiveVerifyKits(f, bundle); err != nil {
+	if err := publishArchiveArtifacts(f, bundle, kits); err != nil {
 		return err
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "published replay archive verified and written")
 	return nil
 }
 
-func writeArchiveVerifyKits(f *archiveReplayFlags, bundle []byte) error {
+// archiveKit is one built, not-yet-written verification kit.
+type archiveKit struct {
+	name string
+	data []byte
+}
+
+// buildArchiveVerifyKits validates the kit flags and builds every kit in memory.
+// It writes nothing, so a build failure cannot leave output behind.
+func buildArchiveVerifyKits(f *archiveReplayFlags, bundle []byte) ([]archiveKit, error) {
 	paths := []string{f.linuxVerifier, f.macOSVerifier, f.windowsVerifier}
 	if f.kitOutputDir == "" {
 		for _, verifier := range paths {
 			if verifier != "" {
-				return errors.New("--kit-output-dir is required when supplying a verifier binary")
+				return nil, errors.New("--kit-output-dir is required when supplying a verifier binary")
 			}
 		}
-		return nil
+		return nil, nil
 	}
 	for _, verifier := range paths {
 		if verifier == "" {
-			return errors.New("--kit-output-dir requires --linux-verifier, --macos-verifier, and --windows-verifier")
+			return nil, errors.New("--kit-output-dir requires --linux-verifier, --macos-verifier, and --windows-verifier")
 		}
 	}
-	if err := os.Mkdir(filepath.Clean(f.kitOutputDir), 0o750); err != nil {
-		return fmt.Errorf("create kit output directory: %w", err)
-	}
+	kits := make([]archiveKit, 0, len(paths))
 	for _, kit := range []struct {
 		osName   playground.VerifyKitOS
 		verifier string
@@ -283,22 +294,69 @@ func writeArchiveVerifyKits(f *archiveReplayFlags, bundle []byte) error {
 	} {
 		data, name, err := playground.BuildPublishedReplayVerifyKit(kit.osName, kit.verifier, bundle)
 		if err != nil {
-			return fmt.Errorf("build %s verification kit: %w", kit.osName, err)
+			return nil, fmt.Errorf("build %s verification kit: %w", kit.osName, err)
 		}
-		if err := writeNewArchiveFile(filepath.Join(f.kitOutputDir, name), data); err != nil {
+		kits = append(kits, archiveKit{name: name, data: data})
+	}
+	return kits, nil
+}
+
+// publishArchiveArtifacts writes the bundle and every kit, and removes anything
+// this invocation created if a later write fails. Every path it removes was
+// created here under O_EXCL, so it can never delete a pre-existing artifact.
+func publishArchiveArtifacts(f *archiveReplayFlags, bundle []byte, kits []archiveKit) (err error) {
+	var created []string
+	var createdDir string
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, path := range created {
+			_ = os.Remove(path)
+		}
+		if createdDir != "" {
+			_ = os.Remove(createdDir)
+		}
+	}()
+
+	if err = writeNewArchiveFile(f.output, bundle); err != nil {
+		return err
+	}
+	created = append(created, f.output)
+
+	if len(kits) == 0 {
+		return nil
+	}
+	kitDir := filepath.Clean(f.kitOutputDir)
+	if err = os.Mkdir(kitDir, 0o750); err != nil {
+		return fmt.Errorf("create kit output directory: %w", err)
+	}
+	createdDir = kitDir
+	for _, kit := range kits {
+		path := filepath.Join(kitDir, kit.name)
+		if err = writeNewArchiveFile(path, kit.data); err != nil {
 			return err
 		}
+		created = append(created, path)
 	}
 	return nil
 }
 
-func writeNewArchiveFile(path string, data []byte) error {
-	file, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return fmt.Errorf("create output: %w", err)
+func writeNewArchiveFile(path string, data []byte) (err error) {
+	file, openErr := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if openErr != nil {
+		return fmt.Errorf("create output: %w", openErr)
 	}
-	defer func() { _ = file.Close() }()
-	if _, err := file.Write(data); err != nil {
+	// A close error on a successful write is a real write failure: the data may
+	// never have reached the filesystem. Reporting success there would publish a
+	// truncated artifact.
+	defer func() {
+		closeErr := file.Close()
+		if err == nil && closeErr != nil {
+			err = fmt.Errorf("close output: %w", closeErr)
+		}
+	}()
+	if _, err = file.Write(data); err != nil {
 		return fmt.Errorf("write output: %w", err)
 	}
 	return nil

--- a/cmd/pipelock-verifier/main_test.go
+++ b/cmd/pipelock-verifier/main_test.go
@@ -1427,6 +1427,39 @@ func TestVerifyRunJSONFailureExitsNonZero(t *testing.T) {
 	}
 }
 
+func TestVerifyRunArchiveModePrintsItsDifferentSemantics(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"launch-manifest.json",
+		"orchestrator-delegation.json",
+		"replay-archive-authorization.json",
+		"witness.json",
+		"red-witness.json",
+		"host-containment-witness.json",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	packetDir := filepath.Join(dir, "packet")
+	if err := os.Mkdir(packetDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"packet.json", "evidence.jsonl", "manifest.json"} {
+		if err := os.WriteFile(filepath.Join(packetDir, name), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("write packet/%s: %v", name, err)
+		}
+	}
+
+	stdout, _, code := runRoot(t, "verify-run", "--archive", dir)
+	if code == cliutil.ExitOK {
+		t.Fatalf("malformed archive run exited 0: %s", stdout)
+	}
+	if !strings.Contains(stdout, "archive mode: root-authorized permanent replay") {
+		t.Fatalf("archive-mode output omitted its changed semantics: %s", stdout)
+	}
+}
+
 func TestReceipt_V1AllowUnpinned(t *testing.T) {
 	t.Parallel()
 	fix := newFixture(t, 1)

--- a/cmd/pipelock-verifier/verifyrun.go
+++ b/cmd/pipelock-verifier/verifyrun.go
@@ -17,6 +17,7 @@ func newVerifyRunCmd() *cobra.Command {
 	var (
 		orchKey  string
 		jsonMode bool
+		archive  bool
 	)
 
 	cmd := &cobra.Command{
@@ -39,7 +40,11 @@ The full chain checks:
 Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 		Args: exactOneArg,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			rep, err := playground.VerifyRun(args[0], orchKey)
+			verify := playground.VerifyRun
+			if archive {
+				verify = playground.VerifyArchivedReplay
+			}
+			rep, err := verify(args[0], orchKey)
 			if err != nil {
 				return err
 			}
@@ -70,6 +75,10 @@ Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 				_, _ = fmt.Fprintln(w)
 			}
 			_, _ = fmt.Fprintln(w)
+			if archive {
+				_, _ = fmt.Fprintln(w, "archive mode: root-authorized permanent replay; delegation time window intentionally not evaluated")
+				_, _ = fmt.Fprintln(w)
+			}
 			if rep.OK {
 				_, _ = fmt.Fprintf(w, "result: VALID  run_nonce=%s observed=%d\n", rep.RunNonce, rep.ObservedCount)
 				return nil
@@ -79,5 +88,6 @@ Exit code 0 = every check passed. Non-zero = at least one check failed.`,
 	}
 	cmd.Flags().StringVar(&orchKey, "orchestrator-key", playground.PublishedOrchestratorPubKeyHex, "hex-encoded orchestrator Ed25519 public key (trust root)")
 	cmd.Flags().BoolVar(&jsonMode, "json", false, "emit machine-readable JSON output")
+	cmd.Flags().BoolVar(&archive, "archive", false, "verify a root-authorized permanent replay; requires replay-archive-authorization.json")
 	return cmd
 }

--- a/docs/guides/playground-replay-archive.md
+++ b/docs/guides/playground-replay-archive.md
@@ -1,0 +1,90 @@
+# Publishing a permanently verifiable playground replay
+
+A live playground session and a published replay have different lifecycles.
+The live session uses a short-lived delegated signing key. Its root-signed
+delegation expires so that a copied live signing credential stops being useful.
+That expiry is a required live-session control: normal `verify-run` continues to
+reject an expired delegation.
+
+A published replay is different. It is a sealed, public record, not a signing
+credential. A replay that cannot be re-verified after its live delegation
+expires does not provide durable evidence.
+
+## Decision
+
+Published replay archives use an explicit, root-signed replay archive
+authorization. It binds the published root identity, run nonce, immutable image
+digest, signed launch-manifest hash, and hash of the exact delegation artifact.
+Archive verification authenticates every one of those bindings and the
+delegation signature, but deliberately does not evaluate the delegation's live
+time window. The verifier prints that it used archive semantics.
+
+The authorization is separate from the delegation. It grants no signing power,
+cannot start a session, cannot extend a delegation, and cannot turn an ordinary
+live bundle into an archive by adding a field. The durable root must sign the
+authorization after the run is sealed. The verifier's `--archive` invocation is
+necessary but not sufficient: without a valid authorization for the exact
+artifacts it fails closed.
+
+This rejects the other available shapes:
+
+- A bare archive switch would let a verifier ignore expiry for any live bundle.
+- A long-lived delegation would create a long-lived signing credential.
+- A direct-root manifest would restore the legacy key-distribution shape that
+  delegated signing removed.
+- Removing downloadable replays would discard the durable, offline evidence
+  visitors need to inspect independently.
+
+## Produce the replay
+
+Start with a sealed run directory. Verify it normally before its delegation
+expires; that confirms the live-session path. Then use the trusted publisher
+environment, where the durable root is already protected, to create a new
+archive and optional operating-system kits:
+
+```bash
+go run ./cmd/pipelock-playground-broker archive-replay \
+  --run-dir /path/to/sealed-run \
+  --output /path/to/replay-bundle.tar.gz \
+  --orchestrator-key-file /path/to/protected-root \
+  --kit-output-dir /path/to/verify-kits \
+  --linux-verifier /path/to/pipelock-verifier-linux \
+  --macos-verifier /path/to/pipelock-verifier-macos \
+  --windows-verifier /path/to/pipelock-verifier-windows.exe
+```
+
+The root is read only by the publisher. The command never writes it into the
+bundle or prints it. It refuses to overwrite output paths, verifies the archive
+before writing it, and creates kits only when all three verifier binaries are
+supplied. The generated archive contains
+`replay-archive-authorization.json`; the generated kits include that file and
+use archive verification visibly in their scripts.
+
+Do not use `archive-replay` for an ordinary visitor download. Live downloads
+must continue to use `ArchiveRunForDownload` and strict `verify-run` semantics.
+
+## Verify before publishing
+
+Extract the proposed archive and run the public verifier against the pinned
+published root:
+
+```bash
+tar xzf replay-bundle.tar.gz
+go run ./cmd/pipelock-verifier verify-run pipelock-session \
+  --orchestrator-key <published-public-key> \
+  --archive
+```
+
+Success prints `archive mode: root-authorized permanent replay; delegation time
+window intentionally not evaluated` before `result: VALID`. That line is part
+of the evidence: a reader must be able to distinguish archive semantics from a
+currently live session.
+
+Also run the same command **without** `--archive`. Once the delegation has
+expired it must fail at `orchestrator-delegation`; that proves the live path has
+not been weakened. Finally, remove or alter
+`replay-archive-authorization.json` in a disposable copy and rerun with
+`--archive`; it must fail at `replay-archive-authorization`.
+
+The published public key is the only trust root. Never accept a root key from a
+replay bundle, a kit, or an archive authorization.

--- a/docs/guides/playground-replay-archive.md
+++ b/docs/guides/playground-replay-archive.md
@@ -63,6 +63,27 @@ use archive verification visibly in their scripts.
 Do not use `archive-replay` for an ordinary visitor download. Live downloads
 must continue to use `ArchiveRunForDownload` and strict `verify-run` semantics.
 
+## The browser verifier decides for itself, and why that is safe
+
+The published bundle has two consumers, not one. The downloadable kits run the
+command-line verifier, where `--archive` is an explicit choice. The viewer's
+"Verify in your browser" button runs the WebAssembly verifier, which has no
+flags and serves both a live session bundle and the published archive from the
+same entry point.
+
+So that path selects on whether a replay archive authorization is present, and
+verifies it in full when it is. A bundle without one takes the strict path and an
+expired delegation still fails closed there.
+
+That is not a bundle choosing its own leniency. The authorization is a root
+signature over this run's exact manifest hash, delegation bytes, run nonce and
+image digest, so only the holder of the published root can produce one, and an
+authorization lifted from another run fails its binding check. An attacker
+cannot mint leniency; at most they can present a genuine root-authorized run,
+which is what the archive is for. Keep both surfaces in step: a change that
+teaches one of them archive semantics and not the other leaves a visitor with a
+kit that passes and a button that fails on a single artifact.
+
 ## Verify before publishing
 
 Extract the proposed archive and run the public verifier against the pinned

--- a/internal/playground/archive_failopen_test.go
+++ b/internal/playground/archive_failopen_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+// Archive mode must never report a run VALID without a root-signed archive
+// authorization, whatever shape the run takes. Two independent gaps combined to
+// break that for a contained run signed directly by the root: the containment
+// branch rebuilt the required-check set from the base list and dropped the
+// archive check, and the no-delegation path never recorded that check at all.
+// Either one alone is caught -- the required set fails a missing check, and the
+// delegated path records the failure explicitly -- so only the pair fails open,
+// and every real playground run is contained.
+func TestVerifyArchivedReplay_ContainedDirectRootRunIsNotAuthorized(t *testing.T) {
+	dir, pubHex, _ := buildRunDir(t, true)
+
+	rep, err := playground.VerifyArchivedReplay(dir, pubHex)
+	if err != nil {
+		t.Fatalf("VerifyArchivedReplay: %v", err)
+	}
+	if rep.OK {
+		t.Fatal("a run carrying no replay archive authorization was reported VALID in archive mode")
+	}
+
+	var archiveCheck *playground.Check
+	for i := range rep.Checks {
+		if rep.Checks[i].Name == "replay-archive-authorization" {
+			archiveCheck = &rep.Checks[i]
+			break
+		}
+	}
+	if archiveCheck == nil {
+		t.Fatal("archive mode recorded no replay-archive-authorization check at all")
+	}
+	if archiveCheck.OK {
+		t.Fatalf("replay-archive-authorization passed without an authorization: %s", archiveCheck.Reason)
+	}
+
+	// Control: the same run still verifies in strict mode, so the refusal above
+	// comes from the missing authorization and not from a broken fixture.
+	strict, err := playground.VerifyRun(dir, pubHex)
+	if err != nil {
+		t.Fatalf("VerifyRun: %v", err)
+	}
+	if !strict.OK {
+		t.Fatalf("the fixture does not verify in strict mode: %+v", strict.Checks)
+	}
+}

--- a/internal/playground/browser_archive_gap_test.go
+++ b/internal/playground/browser_archive_gap_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"os"
+	"testing"
+)
+
+// The wasm verifier behind the viewer's "Verify in your browser" button serves
+// BOTH surfaces: viewer-live.js drives it for a live session bundle, and the
+// Replay tab drives it for the published archive. They need different semantics,
+// so both are asserted here. Shipping only the archive half would break live
+// verification; shipping only the strict half leaves the Replay tab failing on
+// an artifact the downloadable kit accepts, which is worse than either alone
+// because it makes the product disagree with itself about its own evidence.
+func TestVerifyPublishedBundleBytes_ArchiveAndLiveSemantics(t *testing.T) {
+	t.Run("root_authorized_archive_verifies", func(t *testing.T) {
+		bundle, err := os.ReadFile("/tmp/archive-proof/replay-bundle.tar.gz")
+		if err != nil {
+			t.Skipf("archived proof bundle not present: %v", err)
+		}
+		rep, err := VerifyPublishedBundleBytes(bundle)
+		if err != nil {
+			t.Fatalf("VerifyPublishedBundleBytes: %v", err)
+		}
+		if !rep.OK {
+			t.Fatalf("the browser verifier rejected a root-authorized published replay: %s", rep.FailureSummary())
+		}
+	})
+
+	// A live bundle carries no archive authorization. It must take the strict
+	// path, where an expired delegation still fails closed exactly as it does
+	// for the CLI.
+	t.Run("bundle_without_authorization_stays_strict", func(t *testing.T) {
+		bundle, err := os.ReadFile("/tmp/pg-artifacts/replay-bundle.tar.gz")
+		if err != nil {
+			t.Skipf("unauthorized proof bundle not present: %v", err)
+		}
+		rep, err := VerifyPublishedBundleBytes(bundle)
+		if err != nil {
+			t.Fatalf("VerifyPublishedBundleBytes: %v", err)
+		}
+		if rep.OK {
+			t.Fatal("a bundle with no archive authorization must be verified strictly, and this one's delegation has expired")
+		}
+	})
+}

--- a/internal/playground/browser_archive_routing_test.go
+++ b/internal/playground/browser_archive_routing_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+// The wasm verifier behind the viewer's "Verify in your browser" button serves
+// BOTH surfaces: viewer-live.js drives it for a live session bundle, and the
+// Replay tab drives it for the published archive. Because it takes no flags, it
+// decides for itself which semantics to apply, and this is the test of that
+// decision.
+//
+// It asserts the MODE rather than a passing verification, which is what makes it
+// hermetic. VerifyPublishedBundleBytes pins the compiled published root, so a
+// bundle signed by a test key can never verify OK here and any test that
+// demanded OK would have to read a machine-local artifact and skip on CI. The
+// routing is the part this code owns, and the mode reports it directly.
+func TestVerifyPublishedBundleBytes_SelectsModeFromAuthorization(t *testing.T) {
+	t.Run("authorization present selects archive semantics", func(t *testing.T) {
+		dir, _, orchPriv := buildDelegatedRunDir(t)
+		bundle, err := playground.ArchiveRunForPublishedReplay(dir, orchPriv)
+		if err != nil {
+			t.Fatalf("ArchiveRunForPublishedReplay: %v", err)
+		}
+		rep, err := playground.VerifyPublishedBundleBytes(bundle)
+		if err != nil {
+			t.Fatalf("VerifyPublishedBundleBytes: %v", err)
+		}
+		if rep.Mode != "published-replay-archive" {
+			t.Fatalf("mode = %q, want the archive mode; the Replay tab would fail on an artifact the kit accepts", rep.Mode)
+		}
+	})
+
+	// A live bundle carries no archive authorization and must take the strict
+	// path, where an expired delegation still fails closed exactly as it does for
+	// the command-line verifier.
+	t.Run("no authorization stays strict", func(t *testing.T) {
+		dir, pubHex, _ := buildDelegatedRunDir(t)
+		bundle, err := playground.ArchiveRunForDownload(dir, pubHex)
+		if err != nil {
+			t.Fatalf("ArchiveRunForDownload: %v", err)
+		}
+		rep, err := playground.VerifyPublishedBundleBytes(bundle)
+		if err != nil {
+			t.Fatalf("VerifyPublishedBundleBytes: %v", err)
+		}
+		if rep.Mode != "strict-live" {
+			t.Fatalf("mode = %q, want strict; a bundle must not select its own leniency", rep.Mode)
+		}
+	})
+
+	// Guard against the fixture accidentally being signed by the published root,
+	// which would make the assertions above pass for the wrong reason.
+	t.Run("the test root is not the published root", func(t *testing.T) {
+		_, pubHex, _ := buildDelegatedRunDir(t)
+		if pubHex == playground.PublishedOrchestratorPubKeyHex {
+			t.Fatal("the test fixture is signed by the published root")
+		}
+		if _, err := hex.DecodeString(pubHex); err != nil {
+			t.Fatalf("fixture key is not hex: %v", err)
+		}
+	})
+}

--- a/internal/playground/bundle_archive.go
+++ b/internal/playground/bundle_archive.go
@@ -7,6 +7,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/ed25519"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,6 +57,54 @@ var archiveArtifacts = []struct {
 // It must be called after AssembleAndVerify has written the artifacts; a missing
 // required artifact fails closed with an error rather than a partial bundle.
 func ArchiveRunForDownload(runDir, orchestratorPubHex string) ([]byte, error) {
+	return archiveRunForDownload(runDir, orchestratorPubHex, nil)
+}
+
+// ArchiveRunForPublishedReplay creates a permanently verifiable replay bundle.
+// It is intentionally separate from ArchiveRunForDownload: live downloads must
+// retain strict delegation expiry and never receive archive authorization.
+func ArchiveRunForPublishedReplay(runDir string, root ed25519.PrivateKey) ([]byte, error) {
+	cleanRun := filepath.Clean(runDir)
+	manifestBytes, err := os.ReadFile(filepath.Join(cleanRun, launchManifestFile))
+	if err != nil {
+		return nil, fmt.Errorf("read artifact %s: %w", launchManifestFile, err)
+	}
+	var manifest LaunchManifest
+	if err := unmarshalStrictArtifact(launchManifestFile, manifestBytes, &manifest); err != nil {
+		return nil, err
+	}
+	delegationBytes, err := os.ReadFile(filepath.Join(cleanRun, orchestratorDelegationFile))
+	if err != nil {
+		return nil, fmt.Errorf("read artifact %s: %w", orchestratorDelegationFile, err)
+	}
+	authorization, err := SignReplayArchiveAuthorization(root, manifest, delegationBytes)
+	if err != nil {
+		return nil, err
+	}
+	authorizationBytes, err := json.Marshal(authorization)
+	if err != nil {
+		return nil, fmt.Errorf("marshal replay archive authorization: %w", err)
+	}
+	pub := root.Public().(ed25519.PublicKey)
+	bundle, err := archiveRunForDownload(cleanRun, fmt.Sprintf("%x", pub), authorizationBytes)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, err := ExtractRunArtifactsFromBundle(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("re-read published replay: %w", err)
+	}
+	report, err := VerifyArchivedReplayArtifacts(artifacts, fmt.Sprintf("%x", pub))
+	if err != nil {
+		return nil, fmt.Errorf("verify published replay: %w", err)
+	}
+	if !report.OK {
+		return nil, fmt.Errorf("verify published replay: %s", report.FailureSummary())
+	}
+	return bundle, nil
+}
+
+func archiveRunForDownload(runDir, orchestratorPubHex string, archiveAuthorization []byte) ([]byte, error) {
 	cleanRun := filepath.Clean(runDir)
 
 	var buf bytes.Buffer
@@ -62,13 +112,18 @@ func ArchiveRunForDownload(runDir, orchestratorPubHex string) ([]byte, error) {
 	tw := tar.NewWriter(gz)
 
 	// The verify instructions go first so a visitor who opens the tar sees them.
-	verifyTxt := buildVerifyInstructions(orchestratorPubHex)
+	verifyTxt := buildVerifyInstructions(orchestratorPubHex, len(archiveAuthorization) > 0)
 	if err := writeTarFile(tw, downloadArchivePrefix+"/VERIFY.txt", []byte(verifyTxt)); err != nil {
 		return nil, err
 	}
 
 	for _, f := range archiveArtifacts {
 		if err := addRunFile(tw, cleanRun, f.name, f.required); err != nil {
+			return nil, err
+		}
+	}
+	if len(archiveAuthorization) > 0 {
+		if err := writeTarFile(tw, downloadArchivePrefix+"/"+replayArchiveAuthorizationFile, archiveAuthorization); err != nil {
 			return nil, err
 		}
 	}
@@ -119,7 +174,13 @@ func writeTarFile(tw *tar.Writer, name string, data []byte) error {
 // command, so the proof stands on its own: no server, no account, just the key
 // the verifier is told to trust. In the public demo this key must match the
 // separately published demo key.
-func buildVerifyInstructions(orchestratorPubHex string) string {
+func buildVerifyInstructions(orchestratorPubHex string, archive bool) string {
+	mode := ""
+	archiveNote := ""
+	if archive {
+		mode = " --archive"
+		archiveNote = "\nThis is a root-authorized permanent replay. Archive verification authenticates the exact delegation and its binding, but deliberately does not evaluate that delegation's live expiry window.\n"
+	}
 	return fmt.Sprintf(`Pipelock playground -- verify this session yourself, offline
 ============================================================
 
@@ -132,7 +193,7 @@ vanished tomorrow, the proof still stands on its own math.
      tar xzf pipelock-session.tar.gz
 
 2. Verify (using the SAME binary any customer downloads):
-     pipelock-playground-demo verify %s --orchestrator-key %s
+     pipelock-verifier verify-run %s --orchestrator-key %s%s
 
 A passing run prints OK and the list of checks it ran: receipt-chain
 completeness, sequence gaps, canonical JSON, collector-witness binding, and the
@@ -141,5 +202,5 @@ signed trace is the truth.
 
 Session trust-root (orchestrator) key:
   %s
-`, downloadArchivePrefix, orchestratorPubHex, orchestratorPubHex)
+%s`, downloadArchivePrefix, orchestratorPubHex, mode, orchestratorPubHex, archiveNote)
 }

--- a/internal/playground/bundle_archive_published_test.go
+++ b/internal/playground/bundle_archive_published_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/playground"
+)
+
+func TestArchiveRunForPublishedReplay_SealsAndVerifiesDelegatedRun(t *testing.T) {
+	runDir, _, root := buildDelegatedRunDir(t)
+
+	bundle, err := playground.ArchiveRunForPublishedReplay(runDir, root)
+	if err != nil {
+		t.Fatalf("ArchiveRunForPublishedReplay: %v", err)
+	}
+	artifacts, err := playground.ExtractRunArtifactsFromBundle(bundle)
+	if err != nil {
+		t.Fatalf("ExtractRunArtifactsFromBundle: %v", err)
+	}
+	if len(artifacts.ReplayArchiveAuthorization) == 0 {
+		t.Fatal("published replay omitted its root authorization")
+	}
+	report, err := playground.VerifyArchivedReplayArtifacts(artifacts, fmt.Sprintf("%x", root.Public().(ed25519.PublicKey)))
+	if err != nil {
+		t.Fatalf("VerifyArchivedReplayArtifacts: %v", err)
+	}
+	if !report.OK {
+		t.Fatalf("published replay did not verify: %s", report.FailureSummary())
+	}
+}
+
+func TestArchiveRunForPublishedReplay_RefusesUnreadableOrInvalidInputs(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, runDir string)
+		want   string
+	}{
+		{
+			name: "missing manifest",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(runDir, "launch-manifest.json")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "read artifact launch-manifest.json",
+		},
+		{
+			name: "malformed manifest",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				path := filepath.Join(runDir, "launch-manifest.json")
+				if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "launch-manifest.json",
+		},
+		{
+			name: "unreadable delegation",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				path := filepath.Join(runDir, "orchestrator-delegation.json")
+				if err := os.Chmod(path, 0o000); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+			},
+			want: "read artifact orchestrator-delegation.json",
+		},
+		{
+			name: "malformed delegation",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				path := filepath.Join(runDir, "orchestrator-delegation.json")
+				if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "orchestrator-delegation.json",
+		},
+		{
+			name: "missing required archive artifact",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(runDir, "witness.json")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "read artifact witness.json",
+		},
+		{
+			name: "invalid sealed witness",
+			mutate: func(t *testing.T, runDir string) {
+				t.Helper()
+				path := filepath.Join(runDir, "witness.json")
+				if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "verify published replay",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runDir, _, root := buildDelegatedRunDir(t)
+			tc.mutate(t, runDir)
+
+			_, err := playground.ArchiveRunForPublishedReplay(runDir, root)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ArchiveRunForPublishedReplay error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestArchiveRunForPublishedReplay_RejectsInvalidRoot(t *testing.T) {
+	runDir, _, _ := buildDelegatedRunDir(t)
+	_, err := playground.ArchiveRunForPublishedReplay(runDir, ed25519.PrivateKey("short"))
+	if err == nil || !strings.Contains(err.Error(), "archive authorization root key") {
+		t.Fatalf("invalid root error = %v, want root-key refusal", err)
+	}
+}
+
+func TestSignReplayArchiveAuthorization_RejectsMalformedDelegation(t *testing.T) {
+	_, root := testGenKey(t)
+	_, err := playground.SignReplayArchiveAuthorization(root, playground.LaunchManifest{}, []byte("{"))
+	if err == nil || !strings.Contains(err.Error(), "orchestrator-delegation.json") {
+		t.Fatalf("malformed delegation error = %v, want delegation parse refusal", err)
+	}
+}
+
+func TestVerifyArchivedReplay_RefusesMalformedOrUnreadableAuthorization(t *testing.T) {
+	t.Run("malformed authorization", func(t *testing.T) {
+		dir, pub, _ := buildDelegatedRunDir(t)
+		path := filepath.Join(dir, "replay-archive-authorization.json")
+		if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		report, err := playground.VerifyArchivedReplay(dir, pub)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if report.OK || !strings.Contains(report.FailureSummary(), "invalid replay archive authorization") {
+			t.Fatalf("malformed authorization report = %+v", report)
+		}
+	})
+
+	t.Run("authorization is directory", func(t *testing.T) {
+		dir, pub, _ := buildDelegatedRunDir(t)
+		path := filepath.Join(dir, "replay-archive-authorization.json")
+		if err := os.Mkdir(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		_, err := playground.VerifyArchivedReplay(dir, pub)
+		if err == nil || !strings.Contains(err.Error(), "cannot read replay-archive-authorization.json") {
+			t.Fatalf("directory authorization error = %v", err)
+		}
+	})
+}

--- a/internal/playground/bundle_archive_published_test.go
+++ b/internal/playground/bundle_archive_published_test.go
@@ -69,10 +69,7 @@ func TestArchiveRunForPublishedReplay_RefusesUnreadableOrInvalidInputs(t *testin
 			mutate: func(t *testing.T, runDir string) {
 				t.Helper()
 				path := filepath.Join(runDir, "orchestrator-delegation.json")
-				if err := os.Chmod(path, 0o000); err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+				makeUnreadable(t, path)
 			},
 			want: "read artifact orchestrator-delegation.json",
 		},

--- a/internal/playground/bundle_archive_test.go
+++ b/internal/playground/bundle_archive_test.go
@@ -162,10 +162,7 @@ func TestArchiveRunForDownload_FailsClosedOnUnreadableRequiredArtifact(t *testin
 	dir := t.TempDir()
 	writeRunArtifacts(t, dir, false)
 	witnessPath := filepath.Join(dir, witnessFile)
-	if err := os.Chmod(witnessPath, 0o000); err != nil {
-		t.Fatalf("chmod witness: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(witnessPath, 0o600) })
+	makeUnreadable(t, witnessPath)
 
 	_, err := ArchiveRunForDownload(dir, "abc")
 	if err == nil || !strings.Contains(err.Error(), "read artifact "+witnessFile) {

--- a/internal/playground/bundle_archive_test.go
+++ b/internal/playground/bundle_archive_test.go
@@ -101,7 +101,7 @@ func TestArchiveRunForDownload_IncludesVerifiableArtifacts(t *testing.T) {
 	}
 	// VERIFY.txt names the session trust-root key and the exact verify command.
 	verify := files[downloadArchivePrefix+"/VERIFY.txt"]
-	for _, want := range []string{pubHex, "pipelock-playground-demo verify " + downloadArchivePrefix, "--orchestrator-key"} {
+	for _, want := range []string{pubHex, "pipelock-verifier verify-run " + downloadArchivePrefix, "--orchestrator-key"} {
 		if !strings.Contains(verify, want) {
 			t.Errorf("VERIFY.txt missing %q:\n%s", want, verify)
 		}

--- a/internal/playground/bundle_archive_test.go
+++ b/internal/playground/bundle_archive_test.go
@@ -158,6 +158,38 @@ func TestArchiveRunForDownload_FailsClosedOnMissingRequiredArtifact(t *testing.T
 	}
 }
 
+func TestArchiveRunForDownload_FailsClosedOnUnreadableRequiredArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	witnessPath := filepath.Join(dir, witnessFile)
+	if err := os.Chmod(witnessPath, 0o000); err != nil {
+		t.Fatalf("chmod witness: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(witnessPath, 0o600) })
+
+	_, err := ArchiveRunForDownload(dir, "abc")
+	if err == nil || !strings.Contains(err.Error(), "read artifact "+witnessFile) {
+		t.Fatalf("unreadable witness error = %v, want read failure for %s", err, witnessFile)
+	}
+}
+
+func TestArchiveRunForDownload_FailsClosedWhenRequiredFileIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeRunArtifacts(t, dir, false)
+	manifestPath := filepath.Join(dir, launchManifestFile)
+	if err := os.Remove(manifestPath); err != nil {
+		t.Fatalf("remove manifest: %v", err)
+	}
+	if err := os.Mkdir(manifestPath, 0o750); err != nil {
+		t.Fatalf("replace manifest with directory: %v", err)
+	}
+
+	_, err := ArchiveRunForDownload(dir, "abc")
+	if err == nil || !strings.Contains(err.Error(), "read artifact "+launchManifestFile) {
+		t.Fatalf("directory artifact error = %v, want read failure for %s", err, launchManifestFile)
+	}
+}
+
 func TestArchiveRunForDownload_IsDeterministic(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/playground/delegation.go
+++ b/internal/playground/delegation.go
@@ -201,6 +201,25 @@ func VerifyOrchestratorDelegation(pub ed25519.PublicKey, d OrchestratorDelegatio
 }
 
 func verifyOrchestratorDelegationAt(pub ed25519.PublicKey, d OrchestratorDelegation, want DelegationExpectations, now time.Time) error {
+	if err := verifyOrchestratorDelegationSignature(pub, d, want); err != nil {
+		return err
+	}
+	nowUnix := now.Unix()
+	if nowUnix < d.NotBeforeUnix {
+		return fmt.Errorf("delegation is not valid yet")
+	}
+	if nowUnix >= d.ExpiresAtUnix {
+		return fmt.Errorf("delegation has expired")
+	}
+	return nil
+}
+
+// verifyOrchestratorDelegationSignature verifies every intrinsic delegation
+// claim and its root signature, but deliberately does not evaluate time. It is
+// used only after a separate durable replay authorization has bound the exact
+// delegation to a sealed archive. Live callers must use
+// VerifyOrchestratorDelegation instead.
+func verifyOrchestratorDelegationSignature(pub ed25519.PublicKey, d OrchestratorDelegation, want DelegationExpectations) error {
 	if len(pub) != ed25519.PublicKeySize {
 		return fmt.Errorf("delegation root public key has wrong size")
 	}
@@ -211,13 +230,6 @@ func verifyOrchestratorDelegationAt(pub ed25519.PublicKey, d OrchestratorDelegat
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil || len(sig) != ed25519.SignatureSize || !ed25519.Verify(pub, d.SignedBytes(), sig) {
 		return fmt.Errorf("delegation signature invalid under root key")
-	}
-	nowUnix := now.Unix()
-	if nowUnix < d.NotBeforeUnix {
-		return fmt.Errorf("delegation is not valid yet")
-	}
-	if nowUnix >= d.ExpiresAtUnix {
-		return fmt.Errorf("delegation has expired")
 	}
 	return nil
 }

--- a/internal/playground/replay_archive.go
+++ b/internal/playground/replay_archive.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/luckyPipewrench/pipelock/internal/jsonscan"
+	"github.com/luckyPipewrench/pipelock/internal/signing"
+)
+
+const (
+	ReplayArchiveAuthorizationFormat = "pipelock-playground-replay-archive/v1"
+	replayArchiveAuthorizationFile   = "replay-archive-authorization.json"
+	replayArchiveDomainSeparator     = "pipelock-playground-replay-archive-v1\x00"
+)
+
+// ReplayArchiveAuthorization is a root-signed, durable authorization for one
+// sealed delegated run. It authorizes no signing key and cannot start or extend
+// a live session.
+type ReplayArchiveAuthorization struct {
+	Format               string `json:"format"`
+	RootKeyID            string `json:"root_key_id"`
+	RunNonce             string `json:"run_nonce"`
+	ImageDigest          string `json:"image_digest"`
+	LaunchManifestHash   string `json:"launch_manifest_hash"`
+	DelegationArtifactID string `json:"delegation_artifact_id"`
+	Signature            string `json:"signature,omitempty"`
+}
+
+func (a ReplayArchiveAuthorization) SignedBytes() []byte {
+	a.Signature = ""
+	b, _ := json.Marshal(a)
+	return append([]byte(replayArchiveDomainSeparator), b...)
+}
+
+func ParseReplayArchiveAuthorization(data []byte) (ReplayArchiveAuthorization, error) {
+	var a ReplayArchiveAuthorization
+	if err := jsonscan.RejectDuplicateKeys(data); err != nil {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("%s is invalid JSON: %w", replayArchiveAuthorizationFile, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&a); err != nil {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("parse %s: %w", replayArchiveAuthorizationFile, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return ReplayArchiveAuthorization{}, fmt.Errorf("parse %s: multiple JSON values", replayArchiveAuthorizationFile)
+		}
+		return ReplayArchiveAuthorization{}, fmt.Errorf("parse %s trailer: %w", replayArchiveAuthorizationFile, err)
+	}
+	if err := validateReplayArchiveAuthorization(a, ""); err != nil {
+		return ReplayArchiveAuthorization{}, err
+	}
+	if a.Signature == "" {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("%s signature is required", replayArchiveAuthorizationFile)
+	}
+	return a, nil
+}
+
+// SignReplayArchiveAuthorization creates a durable authorization for the exact
+// signed manifest and delegation artifact. The resulting authorization contains
+// public evidence, never key material.
+func SignReplayArchiveAuthorization(priv ed25519.PrivateKey, lm LaunchManifest, delegationBytes []byte) (ReplayArchiveAuthorization, error) {
+	if err := signing.ValidatePrivateKeyConsistency(priv); err != nil {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("archive authorization root key: %w", err)
+	}
+	delegation, err := ParseOrchestratorDelegation(delegationBytes)
+	if err != nil {
+		return ReplayArchiveAuthorization{}, err
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	if err := verifyOrchestratorDelegationSignature(pub, delegation, DelegationExpectations{RunNonce: lm.RunNonce, ImageDigest: lm.ImageDigest}); err != nil {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("archive authorization delegation: %w", err)
+	}
+	if !DelegationBindsLaunchManifest(delegation, lm) {
+		return ReplayArchiveAuthorization{}, fmt.Errorf("archive authorization delegation does not bind launch manifest")
+	}
+	a := ReplayArchiveAuthorization{
+		Format:               ReplayArchiveAuthorizationFormat,
+		RootKeyID:            RootKeyID(pub),
+		RunNonce:             lm.RunNonce,
+		ImageDigest:          lm.ImageDigest,
+		LaunchManifestHash:   lm.Hash(),
+		DelegationArtifactID: replayArchiveArtifactID(delegationBytes),
+	}
+	a.Signature = hex.EncodeToString(ed25519.Sign(priv, a.SignedBytes()))
+	return a, nil
+}
+
+// VerifyReplayArchiveAuthorization authenticates the archive authorization
+// under the caller-pinned root and binds it to these exact run artifacts. It
+// intentionally performs no time check: it authorizes a record, not a live
+// signing credential.
+func VerifyReplayArchiveAuthorization(pub ed25519.PublicKey, a ReplayArchiveAuthorization, lm LaunchManifest, delegationBytes []byte) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("archive authorization root public key has wrong size")
+	}
+	if err := validateReplayArchiveAuthorization(a, RootKeyID(pub)); err != nil {
+		return err
+	}
+	if a.RunNonce != lm.RunNonce || a.ImageDigest != lm.ImageDigest || a.LaunchManifestHash != lm.Hash() || a.DelegationArtifactID != replayArchiveArtifactID(delegationBytes) {
+		return fmt.Errorf("archive authorization does not bind these run artifacts")
+	}
+	sig, err := hex.DecodeString(a.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize || !ed25519.Verify(pub, a.SignedBytes(), sig) {
+		return fmt.Errorf("archive authorization signature invalid under root key")
+	}
+	return nil
+}
+
+func validateReplayArchiveAuthorization(a ReplayArchiveAuthorization, wantRootKeyID string) error {
+	if a.Format != ReplayArchiveAuthorizationFormat {
+		return fmt.Errorf("archive authorization format %q, want %q", a.Format, ReplayArchiveAuthorizationFormat)
+	}
+	if !strings.HasPrefix(a.RootKeyID, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(a.RootKeyID, "sha256:")) {
+		return fmt.Errorf("archive authorization root_key_id is not canonical sha256")
+	}
+	if wantRootKeyID != "" && a.RootKeyID != wantRootKeyID {
+		return fmt.Errorf("archive authorization root_key_id does not match expected root")
+	}
+	if !runNoncePattern.MatchString(a.RunNonce) {
+		return fmt.Errorf("archive authorization run_nonce must be 1-128 URL-safe characters")
+	}
+	if err := ValidateCanonicalImageDigest(a.ImageDigest); err != nil {
+		return fmt.Errorf("archive authorization %w", err)
+	}
+	if !lowerHex64Pattern.MatchString(a.LaunchManifestHash) {
+		return fmt.Errorf("archive authorization launch_manifest_hash must be 32-byte lowercase hex")
+	}
+	if !strings.HasPrefix(a.DelegationArtifactID, "sha256:") || !lowerHex64Pattern.MatchString(strings.TrimPrefix(a.DelegationArtifactID, "sha256:")) {
+		return fmt.Errorf("archive authorization delegation_artifact_id is not canonical sha256")
+	}
+	if a.Signature != "" && !lowerHex128Pattern.MatchString(a.Signature) {
+		return fmt.Errorf("archive authorization signature must be 64-byte lowercase hex")
+	}
+	return nil
+}
+
+func replayArchiveArtifactID(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/playground/replay_archive_test.go
+++ b/internal/playground/replay_archive_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func archiveAuthorizationFixture(t *testing.T) (ed25519.PublicKey, LaunchManifest, []byte, ReplayArchiveAuthorization) {
+	t.Helper()
+	pub, priv := delegationTestKey(0x61)
+	d := validDelegation(pub)
+	lm := LaunchManifest{RunNonce: d.RunNonce, DelegationID: d.DelegationID, ImageDigest: d.ImageDigest}
+	d, err := SignOrchestratorDelegation(priv, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := SignReplayArchiveAuthorization(priv, lm, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, lm, raw, a
+}
+
+func TestReplayArchiveAuthorization_SignParseVerifyAndBind(t *testing.T) {
+	pub, lm, delegation, authorization := archiveAuthorizationFixture(t)
+	raw, err := json.Marshal(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseReplayArchiveAuthorization(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyReplayArchiveAuthorization(pub, parsed, lm, delegation); err != nil {
+		t.Fatalf("VerifyReplayArchiveAuthorization: %v", err)
+	}
+
+	mutations := map[string]func(*ReplayArchiveAuthorization){
+		"format":     func(a *ReplayArchiveAuthorization) { a.Format += "-other" },
+		"root":       func(a *ReplayArchiveAuthorization) { a.RootKeyID = "sha256:" + strings.Repeat("0", 64) },
+		"nonce":      func(a *ReplayArchiveAuthorization) { a.RunNonce = "other" },
+		"image":      func(a *ReplayArchiveAuthorization) { a.ImageDigest = "sha256:" + strings.Repeat("0", 64) },
+		"manifest":   func(a *ReplayArchiveAuthorization) { a.LaunchManifestHash = strings.Repeat("0", 64) },
+		"delegation": func(a *ReplayArchiveAuthorization) { a.DelegationArtifactID = "sha256:" + strings.Repeat("0", 64) },
+		"signature":  func(a *ReplayArchiveAuthorization) { a.Signature = strings.Repeat("0", 128) },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			got := parsed
+			mutate(&got)
+			if err := VerifyReplayArchiveAuthorization(pub, got, lm, delegation); err == nil {
+				t.Fatal("mutated archive authorization verified")
+			}
+		})
+	}
+	if err := VerifyReplayArchiveAuthorization(ed25519.PublicKey("short"), parsed, lm, delegation); err == nil {
+		t.Fatal("short root public key verified archive authorization")
+	}
+}
+
+func TestParseReplayArchiveAuthorization_StrictJSONAndClaims(t *testing.T) {
+	_, _, _, authorization := archiveAuthorizationFixture(t)
+	raw, err := json.Marshal(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string][]byte{
+		"unknown":   []byte(strings.TrimSuffix(string(raw), "}") + `,"extra":true}`),
+		"duplicate": []byte(strings.Replace(string(raw), `"format":`, `"format":"other","format":`, 1)),
+		"second":    append(append([]byte{}, raw...), []byte(` {}`)...),
+		"trailer":   append(append([]byte{}, raw...), []byte(` x`)...),
+		"empty":     []byte(`{}`),
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseReplayArchiveAuthorization(input); err == nil {
+				t.Fatal("invalid archive authorization parsed")
+			}
+		})
+	}
+
+	claimCases := map[string]func(*ReplayArchiveAuthorization){
+		"root":       func(a *ReplayArchiveAuthorization) { a.RootKeyID = "bad" },
+		"nonce":      func(a *ReplayArchiveAuthorization) { a.RunNonce = "bad/nonce" },
+		"image":      func(a *ReplayArchiveAuthorization) { a.ImageDigest = "sha256:bad" },
+		"manifest":   func(a *ReplayArchiveAuthorization) { a.LaunchManifestHash = "bad" },
+		"delegation": func(a *ReplayArchiveAuthorization) { a.DelegationArtifactID = "bad" },
+		"signature":  func(a *ReplayArchiveAuthorization) { a.Signature = "bad" },
+	}
+	for name, mutate := range claimCases {
+		t.Run(name, func(t *testing.T) {
+			got := authorization
+			mutate(&got)
+			input, marshalErr := json.Marshal(got)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			if _, err := ParseReplayArchiveAuthorization(input); err == nil {
+				t.Fatal("invalid archive authorization claim parsed")
+			}
+		})
+	}
+}

--- a/internal/playground/replay_archive_transplant_test.go
+++ b/internal/playground/replay_archive_transplant_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Editing any field of an authorization also breaks its signature, so the
+// signature check masks the artifact-binding check for every tampering case.
+// The binding check earns its place against the one attack the signature cannot
+// catch: lifting a GENUINELY signed authorization off one published run and
+// presenting it alongside a different run's evidence. Without this test,
+// removing the binding check entirely breaks nothing in the suite.
+func TestVerifyReplayArchiveAuthorization_RefusesATransplantedAuthorization(t *testing.T) {
+	pub, _, raw, authorized := archiveAuthorizationFixture(t)
+
+	// A second run under the same root: its own nonce, digest and delegation.
+	other := validDelegation(pub)
+	other.RunNonce = "a-different-published-run"
+	otherManifest := LaunchManifest{
+		RunNonce:     other.RunNonce,
+		DelegationID: other.DelegationID,
+		ImageDigest:  other.ImageDigest,
+	}
+	otherRaw, err := json.Marshal(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The authorization is untouched and its signature still verifies; only the
+	// evidence beside it has been swapped.
+	err = VerifyReplayArchiveAuthorization(pub, authorized, otherManifest, otherRaw)
+	if err == nil {
+		t.Fatal("a validly signed authorization from another run must not authorize this one")
+	}
+	if !strings.Contains(err.Error(), "does not bind these run artifacts") {
+		t.Fatalf("error = %v, want the artifact-binding refusal rather than a signature failure", err)
+	}
+
+	// Control: the same authorization still accepts the run it was issued for,
+	// so the refusal above comes from the binding and not from a broken fixture.
+	_, lm, ownRaw, own := archiveAuthorizationFixture(t)
+	if err := VerifyReplayArchiveAuthorization(pub, own, lm, ownRaw); err != nil {
+		t.Fatalf("the authorization was rejected for its own run: %v", err)
+	}
+	_ = raw
+}

--- a/internal/playground/unreadable_external_helper_test.go
+++ b/internal/playground/unreadable_external_helper_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// makeUnreadable is the playground_test copy of the helper in
+// unreadable_helper_test.go. Go test helpers cannot cross the internal/external
+// test package boundary, and both packages have unreadable-file cases, so the
+// two copies must stay in step. See that file for why each skip exists.
+func makeUnreadable(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not enforce mode 0o000, so an unreadable-file case cannot be set up this way")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which bypasses the mode bits this case depends on")
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+}

--- a/internal/playground/unreadable_helper_test.go
+++ b/internal/playground/unreadable_helper_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package playground
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// makeUnreadable removes read permission from path for the duration of the test
+// and skips where that cannot work. Windows does not enforce Unix mode 0o000, so
+// the file stays readable and the "read artifact ..." assertion fails for a
+// reason that has nothing to do with the code under test. Root ignores the mode
+// bits for the same reason, which matters because some CI containers run as
+// root.
+func makeUnreadable(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not enforce mode 0o000, so an unreadable-file case cannot be set up this way")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which bypasses the mode bits this case depends on")
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+}

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -419,7 +419,10 @@ func verifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string, archi
 	// false to skip the checks, or to true on an uncontained run -- breaks the
 	// signature and fails step 1 below, so this can only fail closed.
 	if lm.Contained {
-		required = append(append([]string{}, requiredChecks...), containmentChecks...)
+		// Rebuild from the CURRENT required set, not from requiredChecks: the
+		// archive check was already appended above and must survive here, or a
+		// contained archive run loses it and finalize stops enforcing it.
+		required = append(append([]string{}, required...), containmentChecks...)
 	}
 
 	if len(artifacts.Witness) == 0 {
@@ -466,6 +469,17 @@ func verifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string, archi
 			OK:     true,
 			Reason: "legacy direct-root manifest",
 		})
+		if archive {
+			// An archive authorization binds a delegation artifact, so a
+			// direct-root run cannot carry one and cannot be published as an
+			// archive. Fail closed rather than inheriting the strict-mode pass.
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkReplayArchive,
+				OK:     false,
+				Reason: "archive verification requires a root-signed replay archive authorization, which a direct-root run cannot carry",
+			})
+			return finalize(rep, required), nil
+		}
 	} else {
 		delegation, parseErr := ParseOrchestratorDelegation(artifacts.OrchestratorDelegation)
 		if parseErr != nil {

--- a/internal/playground/verify.go
+++ b/internal/playground/verify.go
@@ -32,6 +32,7 @@ type Check struct {
 // VerifyReport is the all-or-nothing result of VerifyRun.
 type VerifyReport struct {
 	OK            bool    `json:"ok"`
+	Mode          string  `json:"mode"`
 	Checks        []Check `json:"checks"`
 	ObservedCount int     `json:"observed_count"` // reported, NOT a pass/fail gate
 	RunNonce      string  `json:"run_nonce"`
@@ -83,6 +84,7 @@ const (
 	verifyInstructionsFile     = "VERIFY.txt"
 	checkManifestSig           = "launch-manifest-signature"
 	checkDelegation            = "orchestrator-delegation"
+	checkReplayArchive         = "replay-archive-authorization"
 	checkPinnedPipelock        = "pinned-pipelock-key"
 	checkAuditPacket           = "audit-packet-chain"
 	checkPinnedCollector       = "pinned-collector-key"
@@ -128,14 +130,15 @@ var containmentChecks = []string{
 // RunArtifacts is the in-memory form of a sealed playground run. It mirrors the
 // files inside a run directory and inside the downloadable tar.gz bundle.
 type RunArtifacts struct {
-	LaunchManifest         []byte
-	OrchestratorDelegation []byte
-	Witness                []byte
-	RedWitness             []byte
-	HostContainmentWitness []byte
-	PacketJSON             []byte
-	PacketEvidenceJSONL    []byte
-	PacketManifestJSON     []byte
+	LaunchManifest             []byte
+	OrchestratorDelegation     []byte
+	ReplayArchiveAuthorization []byte
+	Witness                    []byte
+	RedWitness                 []byte
+	HostContainmentWitness     []byte
+	PacketJSON                 []byte
+	PacketEvidenceJSONL        []byte
+	PacketManifestJSON         []byte
 }
 
 // VerifyPublishedBundleBytes verifies the raw playground bundle served by
@@ -151,6 +154,21 @@ func VerifyPublishedBundleBytes(bundle []byte) (VerifyReport, error) {
 			Reason: fmt.Sprintf("cannot read session bundle: %v", err),
 		})
 		return finalize(rep, requiredChecks), nil
+	}
+	// The browser verifier serves BOTH a live session bundle and the published
+	// archive, and they need different semantics: a live bundle has no archive
+	// authorization and must be verified strictly, while the published archive
+	// carries one and its delegation has aged out by design.
+	//
+	// Selecting on the authorization's PRESENCE does not let a bundle choose its
+	// own leniency. The authorization is a root signature over this run's exact
+	// manifest hash, delegation bytes, run nonce and image digest, so only the
+	// holder of the published root can produce one, and a transplanted or edited
+	// authorization fails its binding check. An attacker cannot mint leniency;
+	// they can at most present a genuine root-authorized run, which is not an
+	// attack. The strict path remains the default for anything without one.
+	if len(artifacts.ReplayArchiveAuthorization) != 0 {
+		return VerifyArchivedReplayArtifacts(artifacts, PublishedOrchestratorPubKeyHex)
 	}
 	return VerifyRunArtifacts(artifacts, PublishedOrchestratorPubKeyHex)
 }
@@ -211,6 +229,8 @@ func ExtractRunArtifactsFromBundle(bundle []byte) (RunArtifacts, error) {
 			artifacts.LaunchManifest = data
 		case orchestratorDelegationFile:
 			artifacts.OrchestratorDelegation = data
+		case replayArchiveAuthorizationFile:
+			artifacts.ReplayArchiveAuthorization = data
 		case witnessFile:
 			artifacts.Witness = data
 		case redWitnessFile:
@@ -245,6 +265,7 @@ func bundleArtifactName(raw string, typeflag byte) (name string, retain bool, er
 		return name, false, nil
 	case launchManifestFile,
 		orchestratorDelegationFile,
+		replayArchiveAuthorizationFile,
 		witnessFile,
 		redWitnessFile,
 		hostContainmentWitnessFile,
@@ -290,6 +311,17 @@ func cleanBundleMemberName(raw string) (string, error) {
 // OK = logical AND of all checks. Any single failure => OK=false with a
 // specific reason. Missing/malformed files fail closed (no panic).
 func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
+	return verifyRun(dir, orchestratorPubHex, false)
+}
+
+// VerifyArchivedReplay verifies a root-authorized published replay. It is not
+// a general lenient mode: an expired delegation remains rejected unless the
+// exact run carries a valid ReplayArchiveAuthorization.
+func VerifyArchivedReplay(dir, orchestratorPubHex string) (VerifyReport, error) {
+	return verifyRun(dir, orchestratorPubHex, true)
+}
+
+func verifyRun(dir, orchestratorPubHex string, archive bool) (VerifyReport, error) {
 	cleanDir := filepath.Clean(dir)
 	var artifacts RunArtifacts
 	var err error
@@ -297,6 +329,9 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
 	}
 	if artifacts.OrchestratorDelegation, err = readRunArtifact(cleanDir, orchestratorDelegationFile); err != nil {
+		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
+	}
+	if artifacts.ReplayArchiveAuthorization, err = readRunArtifact(cleanDir, replayArchiveAuthorizationFile); err != nil {
 		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
 	}
 	if artifacts.Witness, err = readRunArtifact(cleanDir, witnessFile); err != nil {
@@ -317,7 +352,7 @@ func VerifyRun(dir, orchestratorPubHex string) (VerifyReport, error) {
 	if artifacts.PacketManifestJSON, err = readRunArtifact(cleanDir, filepath.Join(packetSubdir, packetManifestFile)); err != nil {
 		return VerifyReport{OrchestratorKey: orchestratorPubHex}, err
 	}
-	return VerifyRunArtifacts(artifacts, orchestratorPubHex)
+	return verifyRunArtifacts(artifacts, orchestratorPubHex, archive)
 }
 
 func readRunArtifact(cleanDir, name string) ([]byte, error) {
@@ -335,11 +370,29 @@ func readRunArtifact(cleanDir, name string) ([]byte, error) {
 // playground demo run from in-memory bytes. This is the shared verifier used by
 // the browser/WASM path.
 func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (VerifyReport, error) {
-	rep := VerifyReport{OrchestratorKey: orchestratorPubHex}
+	return verifyRunArtifacts(artifacts, orchestratorPubHex, false)
+}
+
+// VerifyArchivedReplayArtifacts verifies a root-authorized published replay
+// from in-memory artifacts. Browser and live-session callers use
+// VerifyRunArtifacts, which remains strict.
+func VerifyArchivedReplayArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (VerifyReport, error) {
+	return verifyRunArtifacts(artifacts, orchestratorPubHex, true)
+}
+
+func verifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string, archive bool) (VerifyReport, error) {
+	mode := "strict-live"
+	if archive {
+		mode = "published-replay-archive"
+	}
+	rep := VerifyReport{Mode: mode, OrchestratorKey: orchestratorPubHex}
 
 	// required is the base check set until the manifest reveals whether this was
 	// a contained run, at which point the containment checks are appended.
 	required := requiredChecks
+	if archive {
+		required = append(append([]string{}, requiredChecks...), checkReplayArchive)
+	}
 
 	// --- Load files (fail closed on missing/malformed) ---
 
@@ -424,7 +477,46 @@ func VerifyRunArtifacts(artifacts RunArtifacts, orchestratorPubHex string) (Veri
 			return finalize(rep, required), nil
 		}
 		want := DelegationExpectations{RunNonce: lm.RunNonce, ImageDigest: lm.ImageDigest}
-		if verifyErr := VerifyOrchestratorDelegation(ed25519.PublicKey(orchPub), delegation, want); verifyErr != nil {
+		if archive {
+			if len(artifacts.ReplayArchiveAuthorization) == 0 {
+				rep.Checks = append(rep.Checks, Check{
+					Name:   checkReplayArchive,
+					OK:     false,
+					Reason: "archive verification requires a root-signed replay archive authorization",
+				})
+				return finalize(rep, required), nil
+			}
+			authorization, authorizationErr := ParseReplayArchiveAuthorization(artifacts.ReplayArchiveAuthorization)
+			if authorizationErr != nil {
+				rep.Checks = append(rep.Checks, Check{
+					Name:   checkReplayArchive,
+					OK:     false,
+					Reason: fmt.Sprintf("invalid replay archive authorization: %v", authorizationErr),
+				})
+				return finalize(rep, required), nil
+			}
+			if authorizationErr := VerifyReplayArchiveAuthorization(ed25519.PublicKey(orchPub), authorization, lm, artifacts.OrchestratorDelegation); authorizationErr != nil {
+				rep.Checks = append(rep.Checks, Check{
+					Name:   checkReplayArchive,
+					OK:     false,
+					Reason: fmt.Sprintf("replay archive authorization verification failed: %v", authorizationErr),
+				})
+				return finalize(rep, required), nil
+			}
+			if verifyErr := verifyOrchestratorDelegationSignature(ed25519.PublicKey(orchPub), delegation, want); verifyErr != nil {
+				rep.Checks = append(rep.Checks, Check{
+					Name:   checkDelegation,
+					OK:     false,
+					Reason: fmt.Sprintf("orchestrator delegation verification failed: %v", verifyErr),
+				})
+				return finalize(rep, required), nil
+			}
+			rep.Checks = append(rep.Checks, Check{
+				Name:   checkReplayArchive,
+				OK:     true,
+				Reason: "root-authorized permanent replay; delegation time window intentionally not evaluated",
+			})
+		} else if verifyErr := VerifyOrchestratorDelegation(ed25519.PublicKey(orchPub), delegation, want); verifyErr != nil {
 			rep.Checks = append(rep.Checks, Check{
 				Name:   checkDelegation,
 				OK:     false,

--- a/internal/playground/verify_kit.go
+++ b/internal/playground/verify_kit.go
@@ -93,6 +93,16 @@ var verifyKitOptionalFiles = []string{
 // kit never derives, extracts, or falls back to a key from the bundle -- a
 // tampered bundle cannot ship its own key.
 func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte) ([]byte, string, error) {
+	return buildVerifyKit(osName, verifierPath, sessionTarGz, false)
+}
+
+// BuildPublishedReplayVerifyKit creates an offline kit for a root-authorized,
+// permanent replay. Its script visibly selects archive verification.
+func BuildPublishedReplayVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte) ([]byte, string, error) {
+	return buildVerifyKit(osName, verifierPath, sessionTarGz, true)
+}
+
+func buildVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []byte, archive bool) ([]byte, string, error) {
 	if verifierPath == "" {
 		return nil, "", errors.New("verifier binary path is not configured")
 	}
@@ -114,7 +124,7 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 	if err := zipFile(zw, root+"/README.txt", []byte(liveKitReadme(osName)), 0o600); err != nil {
 		return nil, "", err
 	}
-	scriptName, scriptBody, err := liveKitScript(osName, trustKey)
+	scriptName, scriptBody, err := liveKitScript(osName, trustKey, archive)
 	if err != nil {
 		return nil, "", err
 	}
@@ -150,8 +160,17 @@ func BuildLiveVerifyKit(osName VerifyKitOS, verifierPath string, sessionTarGz []
 			return nil, "", err
 		}
 	}
+	if archive {
+		data, ok := files[replayArchiveAuthorizationFile]
+		if !ok {
+			return nil, "", fmt.Errorf("published replay bundle missing %s", replayArchiveAuthorizationFile)
+		}
+		if err := zipFile(zw, root+"/app/run/"+replayArchiveAuthorizationFile, data, 0o600); err != nil {
+			return nil, "", err
+		}
+	}
 
-	if err := zipFile(zw, root+"/app/run/verifier.txt", []byte(liveKitVerifierTxt(trustKey)), 0o600); err != nil {
+	if err := zipFile(zw, root+"/app/run/verifier.txt", []byte(liveKitVerifierTxt(trustKey, archive)), 0o600); err != nil {
 		return nil, "", err
 	}
 
@@ -176,6 +195,7 @@ func extractLiveKitFiles(sessionTarGz []byte) (map[string][]byte, error) {
 	for _, f := range verifyKitOptionalFiles {
 		want[f] = true
 	}
+	want[replayArchiveAuthorizationFile] = true
 
 	files := make(map[string][]byte)
 	tr := tar.NewReader(gr)
@@ -234,26 +254,34 @@ func liveKitReadme(osName VerifyKitOS) string {
 	}
 }
 
-func liveKitScript(osName VerifyKitOS, orchKey string) (string, string, error) {
+func liveKitScript(osName VerifyKitOS, orchKey string, archive bool) (string, string, error) {
+	mode := ""
+	if archive {
+		mode = " --archive"
+	}
 	switch osName {
 	case VerifyKitOSWindows:
-		return "Verify.bat", "@echo off\r\ncd /d \"%~dp0app\"\r\necho Verifying the full Pipelock playground trust chain, offline...\r\necho.\r\npipelock-verifier.exe verify-run run --orchestrator-key " + orchKey + "\r\necho.\r\necho result: VALID means every signature, the receipt chain, witnesses, and run binding held.\r\necho No network was used.\r\necho.\r\npause\r\n", nil
+		return "Verify.bat", "@echo off\r\ncd /d \"%~dp0app\"\r\necho Verifying the full Pipelock playground trust chain, offline...\r\necho.\r\npipelock-verifier.exe verify-run run --orchestrator-key " + orchKey + mode + "\r\necho.\r\necho result: VALID means every signature, the receipt chain, witnesses, and run binding held.\r\necho No network was used.\r\necho.\r\npause\r\n", nil
 	case VerifyKitOSMacOS:
-		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
+		return "Verify.command", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + mode + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\nread -n 1 -s -r -p \"Press any key to close.\"\n", nil
 	case VerifyKitOSLinux:
-		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\n", nil
+		return "verify.sh", "#!/bin/bash\ncd \"$(dirname \"$0\")/app\"\necho \"Verifying the full Pipelock playground trust chain, offline...\"\necho\n./pipelock-verifier verify-run run --orchestrator-key " + orchKey + mode + "\necho\necho \"result: VALID means every signature, the receipt chain, witnesses, and run binding held.\"\necho \"No network was used.\"\n", nil
 	default:
 		return "", "", fmt.Errorf("unsupported verify kit OS %q", osName)
 	}
 }
 
-func liveKitVerifierTxt(orchKey string) string {
+func liveKitVerifierTxt(orchKey string, archive bool) string {
+	mode := ""
+	if archive {
+		mode = " --archive"
+	}
 	return fmt.Sprintf(`Pipelock live session - full trust chain verification
 trust_root: %s (published Pipelock Playground orchestrator key)
-verdict: run pipelock-verifier verify-run run --orchestrator-key %s
+verdict: run pipelock-verifier verify-run run --orchestrator-key %s%s
 
 Verify it yourself from this directory:
-  pipelock-verifier verify-run run --orchestrator-key %s
+  pipelock-verifier verify-run run --orchestrator-key %s%s
 
 This performs the full verification chain:
   - Launch manifest signature (orchestrator key)
@@ -261,5 +289,5 @@ This performs the full verification chain:
   - Collector witness signature and run binding
   - Red-case calibration
   - Host-containment witness (if contained)
-`, orchKey, orchKey, orchKey)
+`, orchKey, orchKey, mode, orchKey, mode)
 }

--- a/internal/playground/verify_kit_test.go
+++ b/internal/playground/verify_kit_test.go
@@ -191,6 +191,29 @@ func TestBuildLiveVerifyKit_AlwaysUsesPublishedKey(t *testing.T) {
 	}
 }
 
+func TestBuildPublishedReplayVerifyKit_RequiresAuthorizationAndSelectsArchiveMode(t *testing.T) {
+	t.Parallel()
+	files := fullKitSessionFiles()
+	files[replayArchiveAuthorizationFile] = `{"format":"pipelock-playground-replay-archive/v1"}`
+	session := buildKitSession(t, files, false, false)
+	kit, _, err := BuildPublishedReplayVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), session)
+	if err != nil {
+		t.Fatalf("BuildPublishedReplayVerifyKit: %v", err)
+	}
+	script := readZipEntry(t, kit, "pipelock-live-verify-linux/verify.sh")
+	if !strings.Contains(script, "--archive") {
+		t.Fatalf("published replay script omitted archive mode: %s", script)
+	}
+	if got := readZipEntry(t, kit, "pipelock-live-verify-linux/app/run/"+replayArchiveAuthorizationFile); got != files[replayArchiveAuthorizationFile] {
+		t.Fatalf("archive authorization = %q, want %q", got, files[replayArchiveAuthorizationFile])
+	}
+
+	delete(files, replayArchiveAuthorizationFile)
+	if _, _, err := BuildPublishedReplayVerifyKit(VerifyKitOSLinux, writeTempVerifier(t), buildKitSession(t, files, false, false)); err == nil {
+		t.Fatal("published replay kit accepted a bundle without archive authorization")
+	}
+}
+
 func TestBuildLiveVerifyKit_FailsClosedWithoutVerifier(t *testing.T) {
 	t.Parallel()
 	if _, _, err := BuildLiveVerifyKit(VerifyKitOSLinux, "", []byte("not-used")); err == nil {
@@ -248,7 +271,7 @@ func TestLiveKitReadmeAndScript_PerOS(t *testing.T) {
 			if readme := liveKitReadme(osName); !strings.Contains(readme, "Pipelock") {
 				t.Fatalf("readme(%q) missing brand: %q", osName, readme)
 			}
-			name, body, err := liveKitScript(osName, orchKey)
+			name, body, err := liveKitScript(osName, orchKey, false)
 			if err != nil {
 				t.Fatalf("liveKitScript(%q): %v", osName, err)
 			}
@@ -263,7 +286,7 @@ func TestLiveKitReadmeAndScript_PerOS(t *testing.T) {
 	if r := liveKitReadme(VerifyKitOS("x86")); !strings.Contains(r, "Linux") {
 		t.Fatalf("default readme should fall back to Linux text: %q", r)
 	}
-	if _, _, err := liveKitScript(VerifyKitOS("x86"), orchKey); err == nil {
+	if _, _, err := liveKitScript(VerifyKitOS("x86"), orchKey, false); err == nil {
 		t.Fatal("liveKitScript with unsupported OS should error")
 	}
 }

--- a/internal/playground/verify_test.go
+++ b/internal/playground/verify_test.go
@@ -311,6 +311,111 @@ func TestVerify_DelegatedGood_Passes(t *testing.T) {
 	}
 }
 
+// A published replay may outlive its live delegation, but only when the
+// durable root has separately authorized the exact sealed record. This proves
+// both directions: strict live verification still fails on expiry, and archive
+// verification refuses the same run until the signed authorization is present.
+func TestVerifyArchivedReplay_ExpiredDelegationRequiresRootAuthorization(t *testing.T) {
+	dir, orchPubHex, orchPriv := buildDelegatedRunDir(t)
+	delegationPath := filepath.Join(dir, "orchestrator-delegation.json")
+	raw, err := os.ReadFile(filepath.Clean(delegationPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delegation, err := playground.ParseOrchestratorDelegation(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	delegation.NotBeforeUnix = now.Add(-2 * time.Hour).Unix()
+	delegation.IssuedAtUnix = now.Add(-time.Hour).Unix()
+	delegation.ExpiresAtUnix = now.Add(-time.Minute).Unix()
+	delegation, err = playground.SignOrchestratorDelegation(orchPriv, delegation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err = json.Marshal(delegation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(delegationPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	strict, err := playground.VerifyRun(dir, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strict.OK {
+		t.Fatal("expired live delegation verified under strict mode")
+	}
+	strictDelegation := findCheck(t, strict.Checks, "orchestrator-delegation")
+	if strictDelegation.OK || !strings.Contains(strictDelegation.Reason, "has expired") {
+		t.Fatalf("strict delegation check = %+v, want expiry refusal", strictDelegation)
+	}
+
+	archiveWithoutAuthorization, err := playground.VerifyArchivedReplay(dir, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archiveWithoutAuthorization.OK {
+		t.Fatal("archive mode accepted an expired live session without root authorization")
+	}
+	archiveCheck := findCheck(t, archiveWithoutAuthorization.Checks, "replay-archive-authorization")
+	if archiveCheck.OK || !strings.Contains(archiveCheck.Reason, "requires") {
+		t.Fatalf("archive authorization check = %+v, want required refusal", archiveCheck)
+	}
+
+	bundle, err := playground.ArchiveRunForPublishedReplay(dir, orchPriv)
+	if err != nil {
+		t.Fatalf("ArchiveRunForPublishedReplay: %v", err)
+	}
+	artifacts, err := playground.ExtractRunArtifactsFromBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := playground.VerifyArchivedReplayArtifacts(artifacts, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !archive.OK {
+		t.Fatalf("root-authorized expired replay failed: %+v", archive.Checks)
+	}
+	if archive.Mode != "published-replay-archive" {
+		t.Fatalf("archive mode = %q", archive.Mode)
+	}
+	archiveCheck = findCheck(t, archive.Checks, "replay-archive-authorization")
+	if !archiveCheck.OK || !strings.Contains(archiveCheck.Reason, "time window intentionally not evaluated") {
+		t.Fatalf("archive authorization check = %+v", archiveCheck)
+	}
+
+	tamperedAuthorization, err := playground.ParseReplayArchiveAuthorization(artifacts.ReplayArchiveAuthorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tamperedAuthorization.Signature = strings.Repeat("0", ed25519.SignatureSize*2)
+	artifacts.ReplayArchiveAuthorization, err = json.Marshal(tamperedAuthorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered, err := playground.VerifyArchivedReplayArtifacts(artifacts, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tampered.OK {
+		t.Fatal("archive mode accepted a tampered root authorization")
+	}
+
+	artifacts.ReplayArchiveAuthorization = nil
+	denied, err := playground.VerifyArchivedReplayArtifacts(artifacts, orchPubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if denied.OK {
+		t.Fatal("archive mode accepted an expired delegation after authorization removal")
+	}
+}
+
 func TestVerify_DelegationFailuresFailClosed(t *testing.T) {
 	t.Parallel()
 	t.Run("missing", func(t *testing.T) {


### PR DESCRIPTION
## What changed

The published replay bundle verified only while its session delegation was unexpired, so an artifact meant to stay checkable indefinitely began failing for every visitor once that window closed. A published run now carries a replay archive authorization: a root signature binding that one run's launch manifest hash, delegation bytes, run nonce, and image digest.

Verification stays strict by default. Archive semantics apply only when a valid root-signed authorization is present, and the authorization carries no session public key, so it authorizes no signing key and cannot start or extend a session. It notarizes a fixed set of bytes and nothing else.

The failure direction that matters is the one the signature alone cannot cover. Editing any field of an authorization breaks its signature, but a genuinely signed authorization lifted from one published run and presented beside another run's evidence would still verify as a signature. The artifact binding refuses that case, and a test now covers it directly.

The browser verifier shares one entry point with live sessions, so it selects on whether a valid authorization is present rather than on a bundle flag. A bundle without one takes the strict path and an expired delegation still fails closed there.

The publisher writes the bundle and all three verification kits in one invocation, refuses to overwrite an artifact already serving visitors, and refuses a partial kit set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating permanently verifiable playground replay archives.
  - Added optional Linux, macOS, and Windows verification kits.
  - Added archive verification with root-authorized replay validation.
  - Published archives remain verifiable after delegation expiry and bind verification to their run artifacts.
  - Bundles automatically select archive or strict-live verification based on authorization.
  - Added archive-mode reporting to verification output.

- **Documentation**
  - Added guidance for creating, verifying, and publishing replay archives.

- **Bug Fixes**
  - Improved fail-closed handling and rollback for invalid, missing, altered, or incomplete replay artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->