### PR TITLE
fix(config): canonicalize host sets before policy hashing

### DIFF
--- a/internal/config/canonical.go
+++ b/internal/config/canonical.go
@@ -227,23 +227,27 @@ func (c *Config) policySemanticView() canonicalPolicyView {
 
 	// Set-like string slices: canonicalise to sorted order so two
 	// configs that list the same domains in different order hash equal.
-	view.APIAllowlist = sortedCopy(view.APIAllowlist)
+	view.APIAllowlist = canonicalHostSet(view.APIAllowlist)
 	view.Internal = sortedCopy(view.Internal)
-	view.TrustedDomains = sortedCopy(view.TrustedDomains)
+	view.TrustedDomains = canonicalHostSet(view.TrustedDomains)
 	view.Taint.TrustedMCPServers = sortedCopy(view.Taint.TrustedMCPServers)
 	view.A2AScanning.TrustedAgentCardKeys = canonicalA2ATrustedCardKeys(view.A2AScanning.TrustedAgentCardKeys)
-	view.ResponseScanning.SizeExemptDomains = sortedCopy(view.ResponseScanning.SizeExemptDomains)
+	view.ResponseScanning.ExemptDomains = canonicalHostSet(view.ResponseScanning.ExemptDomains)
+	view.ResponseScanning.SizeExemptDomains = canonicalHostSet(view.ResponseScanning.SizeExemptDomains)
 	view.ResponseScanning.UnscannablePassthrough = canonicalUnscannablePassthrough(view.ResponseScanning.UnscannablePassthrough)
 	view.ResponseScanning.AuthenticatedArtifacts = canonicalAuthenticatedArtifacts(view.ResponseScanning.AuthenticatedArtifacts)
 	view.ResponseScanning.MCPServers = canonicalMCPResponseServers(view.ResponseScanning.MCPServers)
 	view.FetchProxy.Monitoring.QueryEntropyParamExclusions = canonicalQueryEntropyParamExclusions(view.FetchProxy.Monitoring.QueryEntropyParamExclusions)
-	view.RequestBodyScanning.ContentEntropyExclusions = sortedCopy(view.RequestBodyScanning.ContentEntropyExclusions)
-	view.RequestBodyScanning.TrustedHosts = sortedCopy(view.RequestBodyScanning.TrustedHosts)
+	view.FetchProxy.Monitoring.Blocklist = canonicalHostSet(view.FetchProxy.Monitoring.Blocklist)
+	view.FetchProxy.Monitoring.SubdomainEntropyExclusions = canonicalHostSet(view.FetchProxy.Monitoring.SubdomainEntropyExclusions)
+	view.FetchProxy.Monitoring.QueryEntropyExclusions = canonicalHostSet(view.FetchProxy.Monitoring.QueryEntropyExclusions)
+	view.RequestBodyScanning.ContentEntropyExclusions = canonicalHostSet(view.RequestBodyScanning.ContentEntropyExclusions)
+	view.RequestBodyScanning.TrustedHosts = canonicalHostSet(view.RequestBodyScanning.TrustedHosts)
 	view.RequestBodyScanning.ContentEntropyWarnRoutes = canonicalRequestBodyEntropyWarnRoutes(view.RequestBodyScanning.ContentEntropyWarnRoutes)
 	view.RequestBodyScanning.SigV4CredentialRoutes = canonicalRequestBodySigV4CredentialRoutes(view.RequestBodyScanning.SigV4CredentialRoutes)
-	view.WebSocketProxy.ContentEntropyExclusions = sortedCopy(view.WebSocketProxy.ContentEntropyExclusions)
+	view.WebSocketProxy.ContentEntropyExclusions = canonicalHostSet(view.WebSocketProxy.ContentEntropyExclusions)
 	if view.Redaction.Enabled {
-		view.Redaction.AllowlistUnparseable = sortedCopy(view.Redaction.AllowlistUnparseable)
+		view.Redaction.AllowlistUnparseable = canonicalHostSet(view.Redaction.AllowlistUnparseable)
 	} else {
 		view.Redaction.AllowlistUnparseable = nil
 	}
@@ -492,7 +496,7 @@ func canonicalRedactionProviders(enabled bool, providers map[string]redact.Provi
 	out := make(map[string]redact.ProviderSpec, len(providers))
 	for name, spec := range providers {
 		cpy := spec
-		cpy.HostPatterns = sortedCopy(cpy.HostPatterns)
+		cpy.HostPatterns = canonicalHostSet(cpy.HostPatterns)
 		cpy.PathPrefixes = sortedCopy(cpy.PathPrefixes)
 		out[name] = cpy
 	}
@@ -507,6 +511,27 @@ func sortedCopy(s []string) []string {
 	}
 	out := make([]string, len(s))
 	copy(out, s)
+	sort.Strings(out)
+	return out
+}
+
+// canonicalHostSet returns a sorted, lowercase copy of a set-like host or host
+// pattern list. Host matching is case-insensitive, so case-only edits cannot
+// represent a different effective policy or change its canonical hash.
+func canonicalHostSet(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(s))
+	out := make([]string, 0, len(s))
+	for _, host := range s {
+		host = strings.TrimSuffix(strings.ToLower(host), ".")
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		out = append(out, host)
+	}
 	sort.Strings(out)
 	return out
 }

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -355,7 +355,9 @@ const (
 	// Re-bumped for fetch_proxy.monitoring.scan_nested_urls: nested query
 	// destinations are an enforcement floor, so mixed versions must not
 	// report the same policy identity.
-	goldenHashDefaults = "84e6c2924e8c3713f868821583d55d70303f21e613e702984aa26884bee3b77b"
+	// Re-bumped when host-set hashing adopted runtime-equivalent case,
+	// duplicate, and trailing-dot normalization.
+	goldenHashDefaults = "6013ddd31af350126da95206ec226224f6c572aa628640745141d4a9c0a55eaa"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -537,7 +539,9 @@ const (
 	// Re-bumped for fetch_proxy.monitoring.scan_nested_urls: see
 	// goldenHashDefaults. The rich fixture omits the field, so nil (enabled)
 	// flows into ph identically to Defaults().
-	goldenHashRichConfig = "a1581b6af98fded59cc543f58a253429955518cb0abaa9f4c93bc3d4366d0f0c"
+	// Re-bumped for runtime-equivalent host-set normalization; see
+	// goldenHashDefaults above.
+	goldenHashRichConfig = "0d78b75e6e65becb10e7ed9b6b3fca2846eebc5ab52bad45aa4cbb55ca533e6b"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/canonical_test.go
+++ b/internal/config/canonical_test.go
@@ -613,6 +613,246 @@ func TestCanonicalPolicyHash_SetLikeSlicesSortedIntoCanonicalOrder(t *testing.T)
 	}
 }
 
+func TestCanonicalPolicyHash_HostSetsCanonicalized(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lowercase func(*Config)
+		uppercase func(*Config)
+		duplicate func(*Config)
+		trailing  func(*Config)
+		different func(*Config)
+	}{
+		{
+			name: "api allowlist",
+			lowercase: func(c *Config) {
+				c.APIAllowlist = []string{"api.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.APIAllowlist = []string{"API.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.APIAllowlist = []string{"api.vendor.example", "API.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.APIAllowlist = []string{"api.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.APIAllowlist = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "trusted domains",
+			lowercase: func(c *Config) {
+				c.TrustedDomains = []string{"trusted.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.TrustedDomains = []string{"TRUSTED.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.TrustedDomains = []string{"trusted.vendor.example", "TRUSTED.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.TrustedDomains = []string{"trusted.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.TrustedDomains = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name:      "response scanning exempt domains",
+			lowercase: func(c *Config) { c.ResponseScanning.ExemptDomains = []string{"trusted.vendor.example"} },
+			uppercase: func(c *Config) { c.ResponseScanning.ExemptDomains = []string{"TRUSTED.VENDOR.EXAMPLE"} },
+			duplicate: func(c *Config) {
+				c.ResponseScanning.ExemptDomains = []string{"trusted.vendor.example", "TRUSTED.VENDOR.EXAMPLE"}
+			},
+			trailing:  func(c *Config) { c.ResponseScanning.ExemptDomains = []string{"trusted.vendor.example."} },
+			different: func(c *Config) { c.ResponseScanning.ExemptDomains = []string{"other.vendor.example"} },
+		},
+		{
+			name: "response size exempt domains",
+			lowercase: func(c *Config) {
+				c.ResponseScanning.SizeExemptDomains = []string{"downloads.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.ResponseScanning.SizeExemptDomains = []string{"DOWNLOADS.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.ResponseScanning.SizeExemptDomains = []string{"downloads.vendor.example", "DOWNLOADS.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.ResponseScanning.SizeExemptDomains = []string{"downloads.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.ResponseScanning.SizeExemptDomains = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "request body content entropy exclusions",
+			lowercase: func(c *Config) {
+				c.RequestBodyScanning.ContentEntropyExclusions = []string{"uploads.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.RequestBodyScanning.ContentEntropyExclusions = []string{"UPLOADS.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.RequestBodyScanning.ContentEntropyExclusions = []string{"uploads.vendor.example", "UPLOADS.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.RequestBodyScanning.ContentEntropyExclusions = []string{"uploads.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.RequestBodyScanning.ContentEntropyExclusions = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "request body trusted hosts",
+			lowercase: func(c *Config) {
+				c.RequestBodyScanning.TrustedHosts = []string{"api.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.RequestBodyScanning.TrustedHosts = []string{"API.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.RequestBodyScanning.TrustedHosts = []string{"api.vendor.example", "API.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.RequestBodyScanning.TrustedHosts = []string{"api.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.RequestBodyScanning.TrustedHosts = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "websocket content entropy exclusions",
+			lowercase: func(c *Config) {
+				c.WebSocketProxy.ContentEntropyExclusions = []string{"stream.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.WebSocketProxy.ContentEntropyExclusions = []string{"STREAM.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.WebSocketProxy.ContentEntropyExclusions = []string{"stream.vendor.example", "STREAM.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.WebSocketProxy.ContentEntropyExclusions = []string{"stream.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.WebSocketProxy.ContentEntropyExclusions = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "fetch monitoring blocklist",
+			lowercase: func(c *Config) {
+				c.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.FetchProxy.Monitoring.Blocklist = []string{"BLOCKED.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example", "BLOCKED.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.FetchProxy.Monitoring.Blocklist = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "fetch monitoring subdomain entropy exclusions",
+			lowercase: func(c *Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"uploads.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"UPLOADS.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"uploads.vendor.example", "UPLOADS.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"uploads.vendor.example."}
+			},
+			different: func(c *Config) { c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"other.vendor.example"} },
+		},
+		{
+			name:      "fetch monitoring query entropy exclusions",
+			lowercase: func(c *Config) { c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"query.vendor.example"} },
+			uppercase: func(c *Config) { c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"QUERY.VENDOR.EXAMPLE"} },
+			duplicate: func(c *Config) {
+				c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"query.vendor.example", "QUERY.VENDOR.EXAMPLE"}
+			},
+			trailing:  func(c *Config) { c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"query.vendor.example."} },
+			different: func(c *Config) { c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"other.vendor.example"} },
+		},
+		{
+			name: "redaction unparseable allowlist",
+			lowercase: func(c *Config) {
+				c.Redaction.Enabled = true
+				c.Redaction.AllowlistUnparseable = []string{"api.vendor.example"}
+			},
+			uppercase: func(c *Config) {
+				c.Redaction.Enabled = true
+				c.Redaction.AllowlistUnparseable = []string{"API.VENDOR.EXAMPLE"}
+			},
+			duplicate: func(c *Config) {
+				c.Redaction.Enabled = true
+				c.Redaction.AllowlistUnparseable = []string{"api.vendor.example", "API.VENDOR.EXAMPLE"}
+			},
+			trailing: func(c *Config) {
+				c.Redaction.Enabled = true
+				c.Redaction.AllowlistUnparseable = []string{"api.vendor.example."}
+			},
+			different: func(c *Config) {
+				c.Redaction.Enabled = true
+				c.Redaction.AllowlistUnparseable = []string{"other.vendor.example"}
+			},
+		},
+		{
+			name: "redaction provider host patterns",
+			lowercase: func(c *Config) {
+				c.Redaction = canonicalProviderTestRedaction([]string{"api.vendor.example"}, []string{"/v1"})
+			},
+			uppercase: func(c *Config) {
+				c.Redaction = canonicalProviderTestRedaction([]string{"API.VENDOR.EXAMPLE"}, []string{"/v1"})
+			},
+			duplicate: func(c *Config) {
+				c.Redaction = canonicalProviderTestRedaction([]string{"api.vendor.example", "API.VENDOR.EXAMPLE"}, []string{"/v1"})
+			},
+			trailing: func(c *Config) {
+				c.Redaction = canonicalProviderTestRedaction([]string{"api.vendor.example."}, []string{"/v1"})
+			},
+			different: func(c *Config) {
+				c.Redaction = canonicalProviderTestRedaction([]string{"other.vendor.example"}, []string{"/v1"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lowercase := canonicalHashOf(t, tt.lowercase)
+			uppercase := canonicalHashOf(t, tt.uppercase)
+			if lowercase != uppercase {
+				t.Fatalf("case-only host configuration changed canonical hash:\n  lowercase = %s\n  uppercase = %s", lowercase, uppercase)
+			}
+			duplicate := canonicalHashOf(t, tt.duplicate)
+			if lowercase != duplicate {
+				t.Fatalf("duplicate host configuration changed canonical hash:\n  single = %s\n  duplicate = %s", lowercase, duplicate)
+			}
+			trailing := canonicalHashOf(t, tt.trailing)
+			if lowercase != trailing {
+				t.Fatalf("trailing-dot host configuration changed canonical hash:\n  bare = %s\n  trailing = %s", lowercase, trailing)
+			}
+
+			different := canonicalHashOf(t, tt.different)
+			if lowercase == different {
+				t.Fatalf("different host configuration did not change canonical hash:\n  same = %s", lowercase)
+			}
+		})
+	}
+}
+
 func TestCanonicalPolicyHash_BehavioralSlicesPreserveOrder(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Normalize case, duplicate entries, and trailing dots for host-based policy sets before calculating canonical policy hashes.
- Keep distinct host policies different while preventing runtime-equivalent configurations from producing different identities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Canonical policy hashes now treat equivalent host entries consistently, regardless of capitalization, trailing dots, or duplicates.
  - Host normalization now applies across additional scanning, proxy monitoring, entropy exclusion, and redaction settings.
  - Equivalent host configurations now produce identical hashes, while genuinely different hosts remain distinct.

- **Tests**
  - Added coverage for host normalization across policy allowlists, blocklists, trusted hosts, redaction settings, provider patterns, and related configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->