### PR TITLE
fix(enterprise): grade listener and CIDR identities as bound

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2131,7 +2131,7 @@ agents:
 Pipelock resolves the agent name for each request using this priority order:
 
 1. **Listener binding**: matched by the port the request arrived on (injected as a context override, spoof-proof)
-2. **Source CIDRs**: matched by client IP against `source_cidrs` ranges defined on each agent profile
+2. **Source CIDRs**: matched by client IP against `source_cidrs` ranges defined on each agent profile. The client IP is the connection's own peer address; forwarded-address headers such as `X-Forwarded-For` are ignored, so a deployment behind another proxy sees that proxy's address here
 3. **Header** (`X-Pipelock-Agent`): set by the calling agent or orchestrator
 4. **Query parameter** (`?agent=name`): appended to fetch/WebSocket URLs
 5. **Fallback**: `_default` profile if defined, otherwise base config

--- a/enterprise/registry.go
+++ b/enterprise/registry.go
@@ -169,8 +169,7 @@ func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Reques
 	// strongest identity path from OCSF/CEF identity fields and collapses
 	// per-agent CEE/DoW state keys to the client IP.
 	if profile, ok := edition.AgentOverrideFromContext(ctx); ok {
-		id := edition.AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
-		return r.Lookup(id.Profile), id
+		return r.resolveInfrastructureIdentity(profile)
 	}
 
 	// Source CIDR match: map client IP to profile. The mapping is operator
@@ -179,8 +178,7 @@ func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Reques
 	// agent per request: graded bound like the listener path.
 	if clientIP := extractIP(req); clientIP != nil {
 		if profile, ok := r.MatchCIDR(clientIP); ok {
-			id := edition.AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
-			return r.Lookup(id.Profile), id
+			return r.resolveInfrastructureIdentity(profile)
 		}
 	}
 
@@ -192,6 +190,22 @@ func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Reques
 	}
 	id := edition.ResolveAgentIdentity(req, known, defaultCfg.DefaultAgentIdentity, defaultCfg.BindDefaultAgentIdentity)
 	return r.Lookup(id.Profile), id
+}
+
+// resolveInfrastructureIdentity grades an identity that infrastructure
+// established (listener binding or source CIDR). It is bound only while the
+// profile it names is the profile whose policy was actually selected. When
+// Lookup falls back because the license expired, the request runs under the
+// fallback policy, and the expired profile's label must not ride into
+// OCSF/CEF identity fields or per-agent CEE/DoW state as a trusted identity,
+// so the grade is unknown and the profile is the fallback's. The name is kept
+// so the audit log still shows which mapping the connection matched.
+func (r *AgentRegistry) resolveInfrastructureIdentity(profile string) (*edition.ResolvedAgent, edition.AgentIdentity) {
+	resolved := r.Lookup(profile)
+	if resolved.Name != profile {
+		return resolved, edition.AgentIdentity{Name: profile, Profile: resolved.Name, Auth: envelope.ActorAuthUnknown}
+	}
+	return resolved, edition.AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
 }
 
 // ProfileForPort returns the agent profile name bound to a listen address.

--- a/enterprise/registry.go
+++ b/enterprise/registry.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -161,16 +162,24 @@ func (r *AgentRegistry) LookupByName(name string) (*edition.ResolvedAgent, bool)
 // ResolveFromRequest implements the 4-step agent resolution for Edition.ResolveAgent.
 // Priority: context override > CIDR > header/query > fallback.
 func (r *AgentRegistry) ResolveFromRequest(ctx context.Context, req *http.Request, defaultCfg *config.Config, defaultSc *scanner.Scanner) (*edition.ResolvedAgent, edition.AgentIdentity) {
-	// Context override (set by per-agent listener binding).
+	// Context override (set by per-agent listener binding). The identity was
+	// injected by the listener the connection arrived on, so nothing the
+	// caller wrote into the request can change it: graded bound. Leaving the
+	// grade empty here reads as unknown downstream, which excludes the
+	// strongest identity path from OCSF/CEF identity fields and collapses
+	// per-agent CEE/DoW state keys to the client IP.
 	if profile, ok := edition.AgentOverrideFromContext(ctx); ok {
-		id := edition.AgentIdentity{Name: profile, Profile: profile}
+		id := edition.AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
 		return r.Lookup(id.Profile), id
 	}
 
-	// Source CIDR match: map client IP to profile.
+	// Source CIDR match: map client IP to profile. The mapping is operator
+	// config applied to the connection's own source address (RemoteAddr,
+	// never a forwarded header), so the caller cannot select a different
+	// agent per request: graded bound like the listener path.
 	if clientIP := extractIP(req); clientIP != nil {
 		if profile, ok := r.MatchCIDR(clientIP); ok {
-			id := edition.AgentIdentity{Name: profile, Profile: profile}
+			id := edition.AgentIdentity{Name: profile, Profile: profile, Auth: envelope.ActorAuthBound}
 			return r.Lookup(id.Profile), id
 		}
 	}

--- a/enterprise/registry_test.go
+++ b/enterprise/registry_test.go
@@ -642,6 +642,57 @@ func TestAgentRegistryResolveFromRequest_Fallback(t *testing.T) {
 	}
 }
 
+func TestAgentRegistryResolveFromRequest_ExpiredProfileIsNotBound(t *testing.T) {
+	// An expired license makes Lookup fall back to _default. The identity
+	// must fall with it: an infrastructure match on a profile whose policy
+	// was not selected cannot present that profile as a trusted identity.
+	cases := []struct {
+		name  string
+		setup func(r *http.Request) *http.Request
+	}{
+		{"listener", func(r *http.Request) *http.Request {
+			return r.WithContext(edition.WithAgentOverride(r.Context(), testProfileClaudeCode))
+		}},
+		{"cidr", func(r *http.Request) *http.Request {
+			r.RemoteAddr = "10.0.0.42:12345"
+			return r
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.Agents = map[string]config.AgentProfile{
+				testProfileClaudeCode: {Mode: config.ModeStrict, SourceCIDRs: []string{"10.0.0.0/24"}},
+				testProfileDefault:    {Mode: config.ModeAudit},
+			}
+			cfg.LicenseExpiresAt = time.Now().Add(-1 * time.Hour).Unix()
+
+			reg, err := NewAgentRegistry(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer reg.Close()
+
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+			r = tc.setup(r)
+
+			ra, id := reg.ResolveFromRequest(r.Context(), r, cfg, nil)
+			if ra.Name != testProfileDefault {
+				t.Fatalf("resolved = %q, want fallback %q", ra.Name, testProfileDefault)
+			}
+			if id.Profile != testProfileDefault {
+				t.Errorf("id.Profile = %q, want fallback %q", id.Profile, testProfileDefault)
+			}
+			if id.Name != testProfileClaudeCode {
+				t.Errorf("id.Name = %q, want matched mapping %q kept for audit", id.Name, testProfileClaudeCode)
+			}
+			if id.Auth == envelope.ActorAuthBound || id.Auth.TrustedForIdentity() {
+				t.Errorf("auth = %q, want untrusted after expiry fallback", id.Auth)
+			}
+		})
+	}
+}
+
 func TestAgentRegistryNilClose(t *testing.T) {
 	var reg *AgentRegistry
 	reg.Close() // should not panic

--- a/enterprise/registry_test.go
+++ b/enterprise/registry_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 )
 
@@ -520,6 +521,39 @@ func TestAgentRegistryResolveFromRequest_ContextOverride(t *testing.T) {
 	if ra.Name != testProfileClaudeCode {
 		t.Errorf("name = %q, want %q", ra.Name, testProfileClaudeCode)
 	}
+	// A listener-bound identity is infrastructure-set and spoof-proof; the
+	// grade must say so or every downstream identity consumer (OCSF/CEF
+	// identity fields, CEE/DoW state keys, the audit log) treats the
+	// strongest identity path as untrusted.
+	if id.Auth != envelope.ActorAuthBound {
+		t.Errorf("auth = %q, want %q", id.Auth, envelope.ActorAuthBound)
+	}
+}
+
+func TestAgentRegistryResolveFromRequest_ContextOverrideBeatsSpoofedHeader(t *testing.T) {
+	cfg := testConfig()
+	cfg.Agents = map[string]config.AgentProfile{
+		testProfileClaudeCode: {Mode: config.ModeStrict},
+		testProfileCursor:     {Mode: config.ModeBalanced},
+	}
+
+	reg, err := NewAgentRegistry(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reg.Close()
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+	r.Header.Set(edition.AgentHeader, testProfileCursor)
+	r = r.WithContext(edition.WithAgentOverride(r.Context(), testProfileClaudeCode))
+
+	_, id := reg.ResolveFromRequest(r.Context(), r, cfg, nil)
+	if id.Name != testProfileClaudeCode {
+		t.Errorf("name = %q, want listener-bound %q despite spoofed header", id.Name, testProfileClaudeCode)
+	}
+	if id.Auth != envelope.ActorAuthBound {
+		t.Errorf("auth = %q, want %q", id.Auth, envelope.ActorAuthBound)
+	}
 }
 
 func TestAgentRegistryResolveFromRequest_CIDR(t *testing.T) {
@@ -536,6 +570,8 @@ func TestAgentRegistryResolveFromRequest_CIDR(t *testing.T) {
 
 	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 	r.RemoteAddr = "10.0.0.42:12345"
+	// A caller-supplied header must not outrank the operator's network mapping.
+	r.Header.Set(edition.AgentHeader, testProfileCursor)
 
 	ra, id := reg.ResolveFromRequest(context.Background(), r, cfg, nil)
 	if id.Profile != testProfileClaudeCode {
@@ -543,6 +579,11 @@ func TestAgentRegistryResolveFromRequest_CIDR(t *testing.T) {
 	}
 	if ra.Name != testProfileClaudeCode {
 		t.Errorf("name = %q, want %q", ra.Name, testProfileClaudeCode)
+	}
+	// The identity came from the connection's source address matched against
+	// operator config, not from anything the caller wrote into the request.
+	if id.Auth != envelope.ActorAuthBound {
+		t.Errorf("auth = %q, want %q", id.Auth, envelope.ActorAuthBound)
 	}
 }
 
@@ -568,6 +609,10 @@ func TestAgentRegistryResolveFromRequest_Header(t *testing.T) {
 	if ra.Name != testProfileClaudeCode {
 		t.Errorf("name = %q, want %q", ra.Name, testProfileClaudeCode)
 	}
+	// Self-declared, even though the name matches a configured profile.
+	if id.Auth != envelope.ActorAuthMatched {
+		t.Errorf("auth = %q, want %q", id.Auth, envelope.ActorAuthMatched)
+	}
 }
 
 func TestAgentRegistryResolveFromRequest_Fallback(t *testing.T) {
@@ -591,6 +636,9 @@ func TestAgentRegistryResolveFromRequest_Fallback(t *testing.T) {
 	}
 	if ra.Name != edition.ProfileDefault {
 		t.Errorf("name = %q, want %q", ra.Name, edition.ProfileDefault)
+	}
+	if id.Auth != envelope.ActorAuthSelfDeclared {
+		t.Errorf("auth = %q, want %q", id.Auth, envelope.ActorAuthSelfDeclared)
 	}
 }
 

--- a/enterprise/registry_test.go
+++ b/enterprise/registry_test.go
@@ -686,8 +686,8 @@ func TestAgentRegistryResolveFromRequest_ExpiredProfileIsNotBound(t *testing.T) 
 			if id.Name != testProfileClaudeCode {
 				t.Errorf("id.Name = %q, want matched mapping %q kept for audit", id.Name, testProfileClaudeCode)
 			}
-			if id.Auth == envelope.ActorAuthBound || id.Auth.TrustedForIdentity() {
-				t.Errorf("auth = %q, want untrusted after expiry fallback", id.Auth)
+			if id.Auth != envelope.ActorAuthUnknown {
+				t.Errorf("auth = %q, want %q after expiry fallback", id.Auth, envelope.ActorAuthUnknown)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

The enterprise agent resolver now grades identities that come from a per-agent listener or a `source_cidrs` match as `bound`. Before this, both paths returned an empty grade, which every consumer normalizes to `unknown` and treats as untrusted. The two identity sources a caller can't spoof were being reported as the least trustworthy, while a name typed into `X-Pipelock-Agent` was graded correctly as `matched` or `self-declared`.

The visible effects were an `agent_auth: "unknown"` audit field on listener-bound requests, empty OCSF and CEF identity fields for those agents, and per-agent CEE and DoW state keys collapsing to the client IP. Nothing about allow or block decisions changed. The failure was under-reporting trust that the deployment had already established. The CIDR path gets `bound` for the same reason as the listener path: the mapping is operator config applied to the connection's own source address, never a forwarded header, so a caller can't pick a different agent per request. A shared NAT range still maps many callers to one profile, and that is what the operator asked for when they configured it.

The grade is `bound` only while the matched profile is the one whose policy was selected. When the license has expired and lookup falls back to `_default`, the identity now reports the fallback profile with an untrusted grade instead of carrying the expired profile's name into identity fields and per-agent state as if it were still licensed. The matched name is kept on the identity so the audit log still shows which mapping the connection hit.

The configuration guide now says that CIDR matching uses the connection's peer address and ignores forwarded-address headers, since a deployment behind another proxy will see that proxy's address.

Tests assert the grade on all four resolver paths, on a header spoof arriving through a bound listener, and on the expired-license fallback for both infrastructure paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that source-CIDR agent matching uses the connection’s direct peer IP and ignores forwarded-address headers.

* **Security**
  * Improved authentication metadata for listener- and source-CIDR-based agent matching.
  * Distinguished trusted, matched, and self-declared agent identities.
  * Prevented expired-license fallback to the default profile from being treated as trusted.
  * Ensured context-based identity overrides take precedence over conflicting request headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->