### PR TITLE
test(proxy): observe authority denial dial boundaries

### DIFF
--- a/internal/proxy/authority_test.go
+++ b/internal/proxy/authority_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -245,22 +246,12 @@ func TestConnectAuthorityAllowReachesDialWithoutForwardingRequestHeaders(t *test
 
 func TestWebSocketAuthorityDenyMakesNoUpstreamHandshake(t *testing.T) {
 	t.Parallel()
-	backend, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen backend: %v", err)
-	}
-	defer func() { _ = backend.Close() }()
-	accepted := make(chan struct{}, 1)
-	go func() {
-		conn, acceptErr := backend.Accept()
-		if acceptErr == nil {
-			accepted <- struct{}{}
-			_ = conn.Close()
-		}
-	}()
+	backend := newAuthorityDialBarrier(t)
+	handlerDone := make(chan struct{})
 
-	proxyAddr, p, cleanup := setupWSProxyDefaultWithProxy(t, nil)
+	proxyAddr, p, cleanup := setupWSProxyWithHandlerDone(t, nil, nil, func() { close(handlerDone) })
 	defer cleanup()
+	p.dialer.ControlContext = backend.observeDial
 	receiptHelper := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	p.receiptEmitterPtr.Store(receiptHelper.emitter)
 	var verifierCalls atomic.Int32
@@ -280,34 +271,20 @@ func TestWebSocketAuthorityDenyMakesNoUpstreamHandshake(t *testing.T) {
 	if verifierCalls.Load() != 1 {
 		t.Fatalf("verifier calls = %d, want 1", verifierCalls.Load())
 	}
-	select {
-	case <-accepted:
-		t.Fatal("authority-denied WebSocket reached upstream listener")
-	case <-time.After(100 * time.Millisecond):
-	}
+	backend.assertNoDial(t, handlerDone)
 	assertSingleProxyAuthorityBlockReceipt(t, receiptHelper.findReceipts(t))
 }
 
 func TestWebSocketAuthorityDenyBeforeUpgradeWithRequiredReceipts(t *testing.T) {
 	t.Parallel()
-	backend, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen backend: %v", err)
-	}
-	defer func() { _ = backend.Close() }()
-	accepted := make(chan struct{}, 1)
-	go func() {
-		conn, acceptErr := backend.Accept()
-		if acceptErr == nil {
-			accepted <- struct{}{}
-			_ = conn.Close()
-		}
-	}()
+	backend := newAuthorityDialBarrier(t)
+	handlerDone := make(chan struct{})
 
-	proxyAddr, p, cleanup := setupWSProxyDefaultWithProxy(t, func(cfg *config.Config) {
+	proxyAddr, p, cleanup := setupWSProxyWithHandlerDone(t, func(cfg *config.Config) {
 		cfg.FlightRecorder.RequireReceipts = true
-	})
+	}, nil, func() { close(handlerDone) })
 	defer cleanup()
+	p.dialer.ControlContext = backend.observeDial
 	receiptHelper := newReceiptProxyHelperWithMetrics(t, p.metrics)
 	p.receiptEmitterPtr.Store(receiptHelper.emitter)
 	var verifierCalls atomic.Int32
@@ -323,12 +300,44 @@ func TestWebSocketAuthorityDenyBeforeUpgradeWithRequiredReceipts(t *testing.T) {
 	if verifierCalls.Load() != 1 {
 		t.Fatalf("verifier calls = %d, want 1", verifierCalls.Load())
 	}
-	select {
-	case <-accepted:
-		t.Fatal("authority-denied WebSocket reached upstream listener")
-	case <-time.After(100 * time.Millisecond):
-	}
+	backend.assertNoDial(t, handlerDone)
 	assertSingleProxyAuthorityBlockReceipt(t, receiptHelper.findReceipts(t))
+}
+
+// authorityDialBarrier counts socket creation attempts before the OS connects.
+// The handler completion signal prevents a delayed dial from escaping the check.
+type authorityDialBarrier struct {
+	listener net.Listener
+	attempts atomic.Int32
+}
+
+func newAuthorityDialBarrier(t *testing.T) *authorityDialBarrier {
+	t.Helper()
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return &authorityDialBarrier{listener: listener}
+}
+
+func (b *authorityDialBarrier) Addr() net.Addr { return b.listener.Addr() }
+
+func (b *authorityDialBarrier) observeDial(context.Context, string, string, syscall.RawConn) error {
+	b.attempts.Add(1)
+	return errors.New("test upstream dial observed")
+}
+
+func (b *authorityDialBarrier) assertNoDial(t *testing.T, handlerDone <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WebSocket handler did not finish")
+	}
+	if got := b.attempts.Load(); got != 0 {
+		t.Fatalf("authority-denied WebSocket attempted %d upstream connections", got)
+	}
 }
 
 func assertSingleProxyAuthorityBlockReceipt(t *testing.T, receipts []receipt.Receipt) {

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -270,6 +270,10 @@ func setupWSProxyDefaultWithProxy(t *testing.T, cfgMod func(*config.Config)) (st
 }
 
 func setupWSProxyDefaultWithCaptureAndProxy(t *testing.T, cfgMod func(*config.Config), obs capture.CaptureObserver) (string, *Proxy, func()) {
+	return setupWSProxyWithHandlerDone(t, cfgMod, obs, nil)
+}
+
+func setupWSProxyWithHandlerDone(t *testing.T, cfgMod func(*config.Config), obs capture.CaptureObserver, handlerDone func()) (string, *Proxy, func()) {
 	t.Helper()
 
 	cfg := config.Defaults()
@@ -310,7 +314,12 @@ func setupWSProxyDefaultWithCaptureAndProxy(t *testing.T, cfgMod func(*config.Co
 	go func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/fetch", p.handleFetch)
-		mux.HandleFunc("/ws", p.handleWebSocket)
+		mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+			if handlerDone != nil {
+				defer handlerDone()
+			}
+			p.handleWebSocket(w, r)
+		})
 		mux.HandleFunc("/health", p.handleHealth)
 
 		handler := p.buildHandler(mux)


### PR DESCRIPTION
## What changed

Check upstream dial attempts after WebSocket handlers finish so both authority-denial tests prove that denied requests never connect upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved WebSocket authority-denial test coverage to verify that rejected requests do not initiate upstream connections.
  * Added more reliable synchronization around proxy handler completion and upstream connection attempts.
  * Updated scenarios involving required receipts and pre-upgrade authorization failures for more deterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->