### PR TITLE
test(runtime): observe reload mutex exclusion

### DIFF
--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -34,7 +34,9 @@ import (
 // "proxy kept the previous config" fail-safe path when proxy.Reload aborts its
 // internal swap. Silent no-ops (dedup, restart-only field changes) return nil.
 func (s *Server) Reload(newCfg *config.Config) (err error) {
+	fireReloadLockHook(false)
 	s.reloadMu.Lock()
+	fireReloadLockHook(true)
 	defer s.reloadMu.Unlock()
 	return s.reloadLocked(newCfg)
 }

--- a/internal/cli/runtime/server_reload_hooks.go
+++ b/internal/cli/runtime/server_reload_hooks.go
@@ -5,7 +5,26 @@ package runtime
 
 import "sync/atomic"
 
-var reloadAfterProxySwapHook atomic.Pointer[func(*Server)]
+var (
+	reloadAfterProxySwapHook atomic.Pointer[func(*Server)]
+	reloadLockHook           atomic.Pointer[func(acquired bool)]
+)
+
+func setReloadLockHookForTest(fn func(acquired bool)) (restore func()) {
+	prev := reloadLockHook.Load()
+	if fn == nil {
+		reloadLockHook.Store(nil)
+	} else {
+		reloadLockHook.Store(&fn)
+	}
+	return func() { reloadLockHook.Store(prev) }
+}
+
+func fireReloadLockHook(acquired bool) {
+	if p := reloadLockHook.Load(); p != nil {
+		(*p)(acquired)
+	}
+}
 
 func setReloadAfterProxySwapHookForTest(fn func(*Server)) (restore func()) {
 	prev := reloadAfterProxySwapHook.Load()

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -2738,6 +2737,21 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 	releaseFirst := make(chan struct{})
 	var reloads sync.WaitGroup
 	var hookCalls atomic.Int32
+	secondAtLock := make(chan struct{})
+	secondAcquiredLock := make(chan struct{})
+	var lockAttempts atomic.Int32
+	var lockAcquisitions atomic.Int32
+	restoreLockHook := setReloadLockHookForTest(func(acquired bool) {
+		if acquired {
+			if lockAcquisitions.Add(1) == 2 {
+				close(secondAcquiredLock)
+			}
+			return
+		}
+		if lockAttempts.Add(1) == 2 {
+			close(secondAtLock)
+		}
+	})
 	restoreHook := setReloadAfterProxySwapHookForTest(func(*Server) {
 		if hookCalls.Add(1) != 1 {
 			return
@@ -2753,6 +2767,7 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 		}
 		reloads.Wait()
 		restoreHook()
+		restoreLockHook()
 	}()
 
 	firstDone := make(chan error, 1)
@@ -2774,13 +2789,34 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 		defer reloads.Done()
 		secondDone <- s.Reload(secondConfig)
 	}
-	secondCaller := runtime.FuncForPC(reflect.ValueOf(secondReload).Pointer()).Name()
 	reloads.Add(1)
 	go secondReload()
 
-	waitForReloadMutexBlock(t, secondDone, secondCaller)
+	testwait.For(t, 5*time.Second, func() bool {
+		select {
+		case <-secondAtLock:
+			return true
+		default:
+			return false
+		}
+	}, "second reload to reach reloadMu")
+	select {
+	case <-secondAcquiredLock:
+		t.Fatal("second reload acquired reloadMu while first reload still held it")
+	case err := <-secondDone:
+		t.Fatalf("second reload completed before acquiring reloadMu: %v", err)
+	default:
+	}
 
 	close(releaseFirst)
+	testwait.For(t, 5*time.Second, func() bool {
+		select {
+		case <-secondAcquiredLock:
+			return true
+		default:
+			return false
+		}
+	}, "second reload to acquire released reloadMu")
 	if err := <-firstDone; err != nil {
 		t.Fatalf("first clean reload: %v", err)
 	}
@@ -2798,98 +2834,6 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "first-clean-tool-poison" {
 		t.Fatalf("live api token = %q, want first reload preserved", live.KillSwitch.APIToken)
 	}
-}
-
-// waitForReloadMutexBlock observes the second Reload goroutine stopped in its
-// mutex acquisition. The first reload is paused after proxy publication while
-// still holding reloadMu. Match the direct Lock -> Reload -> caller frame
-// sequence so an unrelated reload cannot satisfy the observation. A wall-clock
-// interval without completion does not establish mutual exclusion.
-func waitForReloadMutexBlock(t *testing.T, done <-chan error, caller string) {
-	t.Helper()
-
-	deadline := time.NewTimer(5 * time.Second)
-	defer deadline.Stop()
-	for {
-		if reloadBlockedOnMutex(caller) {
-			return
-		}
-		select {
-		case err := <-done:
-			t.Fatalf("second reload completed before blocking on reload exclusion: %v", err)
-		case <-deadline.C:
-			t.Fatal("second reload did not reach the reload mutex")
-		default:
-			runtime.Gosched()
-		}
-	}
-}
-
-func reloadBlockedOnMutex(caller string) bool {
-	n, _ := runtime.GoroutineProfile(nil)
-	records := make([]runtime.StackRecord, n)
-	n, ok := runtime.GoroutineProfile(records)
-	if !ok {
-		return false
-	}
-
-	for _, record := range records[:n] {
-		previousFunction := ""
-		reloadAtLock := false
-		frames := runtime.CallersFrames(record.Stack())
-		for {
-			frame, more := frames.Next()
-			if reloadAtLock {
-				if frame.Function == caller {
-					return true
-				}
-				break
-			}
-			reloadAtLock = frame.Function == "github.com/luckyPipewrench/pipelock/internal/cli/runtime.(*Server).Reload" && previousFunction == "sync.(*Mutex).Lock"
-			previousFunction = frame.Function
-			if !more {
-				break
-			}
-		}
-	}
-	return false
-}
-
-func TestReloadBlockedOnMutexIgnoresOtherCaller(t *testing.T) {
-	s, _ := newTestServer(t, nil)
-	s.reloadMu.Lock()
-	done := make(chan error, 2)
-	exited := make(chan struct{}, 2)
-	startIntended := make(chan struct{})
-	intendedStarted := false
-	defer func() {
-		if !intendedStarted {
-			close(startIntended)
-		}
-		s.reloadMu.Unlock()
-		<-exited
-		<-exited
-	}()
-	intendedReload := func() {
-		defer func() { exited <- struct{}{} }()
-		<-startIntended
-		done <- s.Reload(config.Defaults())
-	}
-	otherReload := func() {
-		defer func() { exited <- struct{}{} }()
-		done <- s.Reload(config.Defaults())
-	}
-	intendedCaller := runtime.FuncForPC(reflect.ValueOf(intendedReload).Pointer()).Name()
-	otherCaller := runtime.FuncForPC(reflect.ValueOf(otherReload).Pointer()).Name()
-	go intendedReload()
-	go otherReload()
-	waitForReloadMutexBlock(t, done, otherCaller)
-	if reloadBlockedOnMutex(intendedCaller) {
-		t.Fatal("reload observation accepted an unrelated caller")
-	}
-	close(startIntended)
-	intendedStarted = true
-	waitForReloadMutexBlock(t, done, intendedCaller)
 }
 
 func loadServerTestReloadConfig(t *testing.T, apiToken string) *config.Config {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -2763,11 +2763,13 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 	}
 
 	secondDone := make(chan error, 1)
-	go func() {
+	secondReload := func() {
 		secondDone <- s.Reload(loadServerTestReloadConfig(t, "second-should-not-activate"))
-	}()
+	}
+	secondCaller := runtime.FuncForPC(reflect.ValueOf(secondReload).Pointer()).Name()
+	go secondReload()
 
-	waitForReloadMutexBlock(t, secondDone)
+	waitForReloadMutexBlock(t, secondDone, secondCaller)
 
 	close(releaseFirst)
 	if err := <-firstDone; err != nil {
@@ -2791,16 +2793,16 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 
 // waitForReloadMutexBlock observes the second Reload goroutine stopped in its
 // mutex acquisition. The first reload is paused after proxy publication while
-// still holding reloadMu, so a Reload stack that includes sync.Mutex.Lock can
-// only be waiting for that exclusion. This is stronger than treating a
-// wall-clock interval without completion as evidence of mutual exclusion.
-func waitForReloadMutexBlock(t *testing.T, done <-chan error) {
+// still holding reloadMu. Match the direct Lock -> Reload -> caller frame
+// sequence so an unrelated reload cannot satisfy the observation. A wall-clock
+// interval without completion does not establish mutual exclusion.
+func waitForReloadMutexBlock(t *testing.T, done <-chan error, caller string) {
 	t.Helper()
 
 	deadline := time.NewTimer(5 * time.Second)
 	defer deadline.Stop()
 	for {
-		if reloadBlockedOnMutex() {
+		if reloadBlockedOnMutex(caller) {
 			return
 		}
 		select {
@@ -2814,7 +2816,7 @@ func waitForReloadMutexBlock(t *testing.T, done <-chan error) {
 	}
 }
 
-func reloadBlockedOnMutex() bool {
+func reloadBlockedOnMutex(caller string) bool {
 	n, _ := runtime.GoroutineProfile(nil)
 	records := make([]runtime.StackRecord, n)
 	n, ok := runtime.GoroutineProfile(records)
@@ -2824,12 +2826,17 @@ func reloadBlockedOnMutex() bool {
 
 	for _, record := range records[:n] {
 		previousFunction := ""
+		reloadAtLock := false
 		frames := runtime.CallersFrames(record.Stack())
 		for {
 			frame, more := frames.Next()
-			if frame.Function == "github.com/luckyPipewrench/pipelock/internal/cli/runtime.(*Server).Reload" && previousFunction == "sync.(*Mutex).Lock" {
-				return true
+			if reloadAtLock {
+				if frame.Function == caller {
+					return true
+				}
+				break
 			}
+			reloadAtLock = frame.Function == "github.com/luckyPipewrench/pipelock/internal/cli/runtime.(*Server).Reload" && previousFunction == "sync.(*Mutex).Lock"
 			previousFunction = frame.Function
 			if !more {
 				break
@@ -2837,6 +2844,27 @@ func reloadBlockedOnMutex() bool {
 		}
 	}
 	return false
+}
+
+func TestReloadBlockedOnMutexIgnoresOtherCaller(t *testing.T) {
+	s, _ := newTestServer(t, nil)
+	s.reloadMu.Lock()
+	done := make(chan error, 1)
+	exited := make(chan struct{})
+	defer func() {
+		s.reloadMu.Unlock()
+		<-exited
+	}()
+	blockedReload := func() {
+		defer close(exited)
+		done <- s.Reload(config.Defaults())
+	}
+	caller := runtime.FuncForPC(reflect.ValueOf(blockedReload).Pointer()).Name()
+	go blockedReload()
+	waitForReloadMutexBlock(t, done, caller)
+	if reloadBlockedOnMutex(caller + ".unrelated") {
+		t.Fatal("reload observation accepted an unrelated caller")
+	}
 }
 
 func loadServerTestReloadConfig(t *testing.T, apiToken string) *config.Config {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -2734,6 +2735,13 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 
 	firstPaused := make(chan struct{})
 	releaseFirst := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	}()
 	var hookCalls atomic.Int32
 	restoreHook := setReloadAfterProxySwapHookForTest(func(*Server) {
 		if hookCalls.Add(1) != 1 {
@@ -2759,11 +2767,7 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 		secondDone <- s.Reload(loadServerTestReloadConfig(t, "second-should-not-activate"))
 	}()
 
-	select {
-	case err := <-secondDone:
-		t.Fatalf("second reload completed before first reload refreshed runtime mirrors: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
+	waitForReloadMutexBlock(t, secondDone)
 
 	close(releaseFirst)
 	if err := <-firstDone; err != nil {
@@ -2783,6 +2787,56 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 	if live := s.proxy.CurrentConfig(); live.KillSwitch.APIToken != "first-clean-tool-poison" {
 		t.Fatalf("live api token = %q, want first reload preserved", live.KillSwitch.APIToken)
 	}
+}
+
+// waitForReloadMutexBlock observes the second Reload goroutine stopped in its
+// mutex acquisition. The first reload is paused after proxy publication while
+// still holding reloadMu, so a Reload stack that includes sync.Mutex.Lock can
+// only be waiting for that exclusion. This is stronger than treating a
+// wall-clock interval without completion as evidence of mutual exclusion.
+func waitForReloadMutexBlock(t *testing.T, done <-chan error) {
+	t.Helper()
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for {
+		if reloadBlockedOnMutex() {
+			return
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("second reload completed before blocking on reload exclusion: %v", err)
+		case <-deadline.C:
+			t.Fatal("second reload did not reach the reload mutex")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func reloadBlockedOnMutex() bool {
+	n, _ := runtime.GoroutineProfile(nil)
+	records := make([]runtime.StackRecord, n)
+	n, ok := runtime.GoroutineProfile(records)
+	if !ok {
+		return false
+	}
+
+	for _, record := range records[:n] {
+		previousFunction := ""
+		frames := runtime.CallersFrames(record.Stack())
+		for {
+			frame, more := frames.Next()
+			if frame.Function == "github.com/luckyPipewrench/pipelock/internal/cli/runtime.(*Server).Reload" && previousFunction == "sync.(*Mutex).Lock" {
+				return true
+			}
+			previousFunction = frame.Function
+			if !more {
+				break
+			}
+		}
+	}
+	return false
 }
 
 func loadServerTestReloadConfig(t *testing.T, apiToken string) *config.Config {

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2735,13 +2736,7 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 
 	firstPaused := make(chan struct{})
 	releaseFirst := make(chan struct{})
-	defer func() {
-		select {
-		case <-releaseFirst:
-		default:
-			close(releaseFirst)
-		}
-	}()
+	var reloads sync.WaitGroup
 	var hookCalls atomic.Int32
 	restoreHook := setReloadAfterProxySwapHookForTest(func(*Server) {
 		if hookCalls.Add(1) != 1 {
@@ -2750,11 +2745,22 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 		close(firstPaused)
 		<-releaseFirst
 	})
-	defer restoreHook()
+	defer func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+		reloads.Wait()
+		restoreHook()
+	}()
 
 	firstDone := make(chan error, 1)
+	firstConfig := loadServerTestReloadConfig(t, "first-clean-tool-poison")
+	reloads.Add(1)
 	go func() {
-		firstDone <- s.Reload(loadServerTestReloadConfig(t, "first-clean-tool-poison"))
+		defer reloads.Done()
+		firstDone <- s.Reload(firstConfig)
 	}()
 
 	<-firstPaused
@@ -2763,10 +2769,13 @@ func TestServer_Reload_SerializesBundleGateWithRuntimeMirrorRefresh(t *testing.T
 	}
 
 	secondDone := make(chan error, 1)
+	secondConfig := loadServerTestReloadConfig(t, "second-should-not-activate")
 	secondReload := func() {
-		secondDone <- s.Reload(loadServerTestReloadConfig(t, "second-should-not-activate"))
+		defer reloads.Done()
+		secondDone <- s.Reload(secondConfig)
 	}
 	secondCaller := runtime.FuncForPC(reflect.ValueOf(secondReload).Pointer()).Name()
+	reloads.Add(1)
 	go secondReload()
 
 	waitForReloadMutexBlock(t, secondDone, secondCaller)
@@ -2849,22 +2858,38 @@ func reloadBlockedOnMutex(caller string) bool {
 func TestReloadBlockedOnMutexIgnoresOtherCaller(t *testing.T) {
 	s, _ := newTestServer(t, nil)
 	s.reloadMu.Lock()
-	done := make(chan error, 1)
-	exited := make(chan struct{})
+	done := make(chan error, 2)
+	exited := make(chan struct{}, 2)
+	startIntended := make(chan struct{})
+	intendedStarted := false
 	defer func() {
+		if !intendedStarted {
+			close(startIntended)
+		}
 		s.reloadMu.Unlock()
 		<-exited
+		<-exited
 	}()
-	blockedReload := func() {
-		defer close(exited)
+	intendedReload := func() {
+		defer func() { exited <- struct{}{} }()
+		<-startIntended
 		done <- s.Reload(config.Defaults())
 	}
-	caller := runtime.FuncForPC(reflect.ValueOf(blockedReload).Pointer()).Name()
-	go blockedReload()
-	waitForReloadMutexBlock(t, done, caller)
-	if reloadBlockedOnMutex(caller + ".unrelated") {
+	otherReload := func() {
+		defer func() { exited <- struct{}{} }()
+		done <- s.Reload(config.Defaults())
+	}
+	intendedCaller := runtime.FuncForPC(reflect.ValueOf(intendedReload).Pointer()).Name()
+	otherCaller := runtime.FuncForPC(reflect.ValueOf(otherReload).Pointer()).Name()
+	go intendedReload()
+	go otherReload()
+	waitForReloadMutexBlock(t, done, otherCaller)
+	if reloadBlockedOnMutex(intendedCaller) {
 		t.Fatal("reload observation accepted an unrelated caller")
 	}
+	close(startIntended)
+	intendedStarted = true
+	waitForReloadMutexBlock(t, done, intendedCaller)
 }
 
 func loadServerTestReloadConfig(t *testing.T, apiToken string) *config.Config {


### PR DESCRIPTION
## What changed

Wait for the second reload to reach mutex exclusion before releasing the first reload, so the test verifies serialization without relying on a timing window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reload-concurrency test reliability with deterministic synchronization instead of timing-based delays.
  * Added coverage to verify that concurrent reload operations are properly serialized while another reload is in progress.
  * Strengthened test cleanup to ensure concurrent operations complete and temporary test behavior is restored consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->