### PR TITLE
fix(setup): handle Codex warnings and Windows app discovery

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -541,6 +541,9 @@ jobs:
       - name: secperm OS split (mode checks skipped on Windows)
         run: go test -count=1 ./internal/secperm/...
 
+      - name: Discover classic and packaged desktop configurations
+        run: go test -count=1 -run "TestDiscoverClaudeWindowsLayouts" ./internal/discover/...
+
       - name: Signing key / salt / header-file load at any reported mode (#695)
         run: go test -count=1 -run "TestWindows" ./internal/signing/... ./internal/contract/privacy/... ./internal/cli/runtime/... ./internal/recorder/...
 
@@ -586,6 +589,9 @@ jobs:
       # Unix permission assertions that make a full Windows suite misleading.
       - name: secperm OS split (mode checks skipped on Windows)
         run: go test -count=1 ./internal/secperm/...
+
+      - name: Discover classic and packaged desktop configurations
+        run: go test -count=1 -run "TestDiscoverClaudeWindowsLayouts" ./internal/discover/...
 
       - name: Signing key / salt / header-file load at any reported mode (#695)
         run: go test -count=1 -run "TestWindows" ./internal/signing/... ./internal/contract/privacy/... ./internal/cli/runtime/... ./internal/recorder/...

--- a/docs/compliance/owasp-mcp-top10.md
+++ b/docs/compliance/owasp-mcp-top10.md
@@ -179,7 +179,7 @@ trigger fields.
 
 **Pipelock coverage:**
 
-- **Discovery:** `pipelock discover` reports MCP server configurations for its supported local clients, including Claude Code, Cursor, VS Code, Cline, Continue, Junie, and Zed.
+- **Discovery:** `pipelock discover` reports MCP server configurations for its supported local clients, including Claude Code, Claude Desktop, Cursor, VS Code, Cline, Continue, Junie, and Zed.
 - **Preflight checks:** `pipelock preflight` validates deployment readiness (network isolation, config completeness, proxy routing).
 - **Diagnostics:** `pipelock diagnose` reports environment state, connectivity, and configuration issues.
 

--- a/docs/compliance/owasp-mcp-top10.md
+++ b/docs/compliance/owasp-mcp-top10.md
@@ -179,7 +179,7 @@ trigger fields.
 
 **Pipelock coverage:**
 
-- **Discovery:** `pipelock discover` auto-detects MCP server configurations across Claude Code, Cursor, Windsurf, VS Code, Gemini CLI, and other agent platforms on the local machine.
+- **Discovery:** `pipelock discover` reports MCP server configurations for its supported local clients, including Claude Code, Cursor, VS Code, Cline, Continue, Junie, and Zed.
 - **Preflight checks:** `pipelock preflight` validates deployment readiness (network isolation, config completeness, proxy routing).
 - **Diagnostics:** `pipelock diagnose` reports environment state, connectivity, and configuration issues.
 

--- a/docs/guides/autogen.md
+++ b/docs/guides/autogen.md
@@ -285,15 +285,20 @@ services:
       - pipelock-internal
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
     depends_on:
       pipelock:
         condition: service_healthy
 ```
 
-The agent container can only reach the `pipelock` service. All HTTP traffic goes
-through the fetch proxy. MCP servers running as subprocesses inside the agent
-container are wrapped with `pipelock mcp proxy` as shown above.
+The agent container can only reach the `pipelock` service. The proxy
+environment variables route HTTP libraries that honor them through Pipelock.
+`PIPELOCK_FETCH_URL` is an application-defined helper value: it is useful only
+when your code explicitly calls the `/fetch` endpoint and does not redirect an
+AutoGen SDK request by itself. MCP servers running as subprocesses inside the
+agent container are wrapped with `pipelock mcp proxy` as shown above.
 
 You can also generate this template with:
 

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -79,6 +79,11 @@ members get the same MCP security configuration.
 }
 ```
 
+Restart Claude Code after changing `.mcp.json`. When Claude Code asks you to
+approve a project MCP server, review the server and make that approval yourself.
+Then use Claude Code's MCP status view and a harmless tool action to confirm it
+connected. A project configuration entry is not itself a connection result.
+
 ### User-Level (`~/.claude.json`)
 
 For personal MCP servers that shouldn't be in git:
@@ -196,6 +201,27 @@ At install time, Pipelock validates the config path, embeds the resolved
 absolute path into the generated hook command, and prints the config source. If
 no standard config is available, the hook is installed with built-in defaults
 and the setup output says so.
+
+`pipelock claude setup` and `pipelock claude remove` modify
+`~/.claude/settings.json` by default; add `--project` for
+`.claude/settings.json` in the current project. Preview the same scope before
+writing it. Both operations preserve unrelated settings and hooks, and a real
+change saves the previous file as a one-version `.bak` backup.
+
+```bash
+# Preview and remove only Pipelock-managed hooks from the user scope.
+pipelock claude remove --dry-run
+pipelock claude remove
+
+# Use this form for the current project's .claude/settings.json.
+pipelock claude remove --project --dry-run
+pipelock claude remove --project
+```
+
+Restart Claude Code and check the affected hooks or MCP connection after a
+change. If the settings file is not usable, inspect the `.bak` alongside that
+same settings file before restoring it; it contains only the version that
+immediately preceded the last real setup or removal.
 
 This registers pipelock as a `PreToolUse` hook for security-relevant tools:
 

--- a/docs/guides/codex.md
+++ b/docs/guides/codex.md
@@ -35,13 +35,17 @@ git clone --branch v3.5.0 --depth 1 https://github.com/luckyPipewrench/pipelock.
 make -C pipelock install
 # or (macOS): brew install luckyPipewrench/tap/pipelock
 
-# 2. Wrap every Codex MCP server with pipelock in one shot
-pipelock codex install
-
-# 3. Generate a config to work from
+# 2. Generate a config before installing wrappers
 pipelock generate config --preset balanced -o pipelock.yaml
 
-# 4. Run an assessment before first use
+# 3. Preview, then wrap every registered Codex MCP server
+pipelock codex install --config "$PWD/pipelock.yaml" --dry-run
+pipelock codex install --config "$PWD/pipelock.yaml"
+
+# 4. Restart Codex, then inspect the registered MCP servers
+codex mcp list
+
+# 5. Run an assessment before first use
 pipelock assess init --config pipelock.yaml
 pipelock assess run assessment-*/
 pipelock assess finalize assessment-*/
@@ -55,6 +59,10 @@ The installer validates and embeds an absolute Pipelock config path when you pas
 or `/etc/pipelock/pipelock.yaml`. It prints the selected config source during
 install so the wrapped MCP servers do not depend on Codex's later working
 directory.
+
+Restart Codex after an install or removal and confirm the expected server in
+`codex mcp list`; then run a harmless tool action. A registered server is not
+evidence that the client successfully connected to it.
 
 For manual / per-server control, the original pattern still works:
 
@@ -254,6 +262,23 @@ codex mcp add my-server \
 ```bash
 codex mcp list
 ```
+
+### Previewing, removing, and recovering wrappers
+
+```bash
+# Preview without changing Codex configuration.
+pipelock codex install --config "$PWD/pipelock.yaml" --dry-run
+
+# Restore only MCP servers previously wrapped by Pipelock.
+pipelock codex remove --dry-run
+pipelock codex remove
+```
+
+The installer replaces each server registration and attempts to restore the
+previous registration if that replacement fails. If it reports that rollback
+also failed, stop and inspect `codex mcp list` before retrying or editing the
+server. The remove command leaves registrations it does not recognize as
+Pipelock wrappers unchanged.
 
 ### False positives
 

--- a/docs/guides/crewai.md
+++ b/docs/guides/crewai.md
@@ -238,14 +238,19 @@ services:
       - pipelock-internal
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
     depends_on:
       pipelock:
         condition: service_healthy
 ```
 
-The agent container can only reach the `pipelock` service. All HTTP traffic goes
-through the fetch proxy. MCP servers running as subprocesses inside the agent
+The agent container can only reach the `pipelock` service. The proxy
+environment variables route HTTP libraries that honor them through Pipelock.
+`PIPELOCK_FETCH_URL` is an application-defined helper value: it is useful only
+when your code explicitly calls the `/fetch` endpoint and does not redirect a
+CrewAI request by itself. MCP servers running as subprocesses inside the agent
 container are wrapped with `pipelock mcp proxy` as shown above.
 
 You can also generate this template with:

--- a/docs/guides/google-adk.md
+++ b/docs/guides/google-adk.md
@@ -306,14 +306,19 @@ services:
       - pipelock-internal
     environment:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
-      - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
     depends_on:
       pipelock:
         condition: service_healthy
 ```
 
-The agent container can only reach the `pipelock` service. All HTTP traffic goes
-through the fetch proxy. MCP servers running as subprocesses inside the agent
+The agent container can only reach the `pipelock` service. The proxy
+environment variables route HTTP libraries that honor them through Pipelock.
+`PIPELOCK_FETCH_URL` is an application-defined helper value: it is useful only
+when your code explicitly calls the `/fetch` endpoint and does not redirect an
+ADK request by itself. MCP servers running as subprocesses inside the agent
 container are wrapped with `pipelock mcp proxy` as shown above.
 
 You can also generate this template with:

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -27,7 +27,7 @@ from langchain.chat_models import init_chat_model
 async def main():
     model = init_chat_model("anthropic:claude-sonnet-4-20250514")
 
-    async with MultiServerMCPClient(
+    client = MultiServerMCPClient(
         {
             "filesystem": {
                 "transport": "stdio",
@@ -40,12 +40,12 @@ async def main():
                 ],
             }
         }
-    ) as client:
-        tools = await client.get_tools()
-        agent = create_react_agent(model, tools)
-        result = await agent.ainvoke(
-            {"messages": [("user", "List files in /workspace")]}
-        )
+    )
+    tools = await client.get_tools()
+    agent = create_react_agent(model, tools)
+    result = await agent.ainvoke(
+        {"messages": [("user", "List files in /workspace")]}
+    )
 ```
 
 Pipelock intercepts all MCP traffic between LangGraph and the filesystem server,
@@ -78,7 +78,7 @@ from langchain.chat_models import init_chat_model
 
 model = init_chat_model("anthropic:claude-sonnet-4-20250514")
 
-async with MultiServerMCPClient(
+client = MultiServerMCPClient(
     {
         "filesystem": {
             "transport": "stdio",
@@ -93,12 +93,12 @@ async with MultiServerMCPClient(
                      "python", "-m", "mcp_server_sqlite", "--db", "/data/app.db"],
         },
     }
-) as client:
-    tools = await client.get_tools()
-    agent = create_react_agent(model, tools)
-    result = await agent.ainvoke(
-        {"messages": [("user", "What tables exist in the database?")]}
-    )
+)
+tools = await client.get_tools()
+agent = create_react_agent(model, tools)
+result = await agent.ainvoke(
+    {"messages": [("user", "What tables exist in the database?")]}
+)
 ```
 
 Each server gets its own Pipelock proxy instance. A poisoned response from one
@@ -116,7 +116,7 @@ from langchain.chat_models import init_chat_model
 
 model = init_chat_model("anthropic:claude-sonnet-4-20250514")
 
-async with MultiServerMCPClient(
+client = MultiServerMCPClient(
     {
         "filesystem": {
             "transport": "stdio",
@@ -125,23 +125,23 @@ async with MultiServerMCPClient(
                      "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
         }
     }
-) as client:
-    tools = await client.get_tools()
+)
+tools = await client.get_tools()
 
-    def call_model(state: MessagesState):
-        return {"messages": model.bind_tools(tools).invoke(state["messages"])}
+def call_model(state: MessagesState):
+    return {"messages": model.bind_tools(tools).invoke(state["messages"])}
 
-    builder = StateGraph(MessagesState)
-    builder.add_node("agent", call_model)
-    builder.add_node("tools", ToolNode(tools))
-    builder.add_edge(START, "agent")
-    builder.add_conditional_edges("agent", tools_condition)
-    builder.add_edge("tools", "agent")
-    graph = builder.compile()
+builder = StateGraph(MessagesState)
+builder.add_node("agent", call_model)
+builder.add_node("tools", ToolNode(tools))
+builder.add_edge(START, "agent")
+builder.add_conditional_edges("agent", tools_condition)
+builder.add_edge("tools", "agent")
+graph = builder.compile()
 
-    result = await graph.ainvoke(
-        {"messages": [("user", "Read /workspace/config.yaml")]}
-    )
+result = await graph.ainvoke(
+    {"messages": [("user", "Read /workspace/config.yaml")]}
+)
 ```
 
 ### Pattern C: `load_mcp_tools` (single server)
@@ -213,7 +213,7 @@ from langgraph.prebuilt import create_react_agent
 from langchain.chat_models import init_chat_model
 
 async def make_graph():
-    async with MultiServerMCPClient(
+    client = MultiServerMCPClient(
         {
             "filesystem": {
                 "transport": "stdio",
@@ -222,10 +222,10 @@ async def make_graph():
                          "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
             }
         }
-    ) as client:
-        tools = await client.get_tools()
-        model = init_chat_model("anthropic:claude-sonnet-4-20250514")
-        return create_react_agent(model, tools)
+    )
+    tools = await client.get_tools()
+    model = init_chat_model("anthropic:claude-sonnet-4-20250514")
+    return create_react_agent(model, tools)
 ```
 
 Build and run:
@@ -296,7 +296,9 @@ services:
       - pipelock-internal
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
       - DATABASE_URI=postgres://langgraph:${POSTGRES_PASSWORD}@langgraph-postgres:5432/langgraph
       - REDIS_URI=redis://langgraph-redis:6379
     depends_on:
@@ -311,8 +313,11 @@ volumes:
   pgdata:
 ```
 
-The agent container can only reach Pipelock, Postgres, and Redis. All outbound
-HTTP goes through the fetch proxy.
+The agent container can only reach Pipelock, Postgres, and Redis. The proxy
+environment variables route HTTP libraries that honor them through Pipelock.
+`PIPELOCK_FETCH_URL` is an application-defined helper value: it is useful only
+when your code explicitly calls the `/fetch` endpoint and does not redirect
+LangGraph or an SDK's ordinary requests by itself.
 
 You can also generate a base template with:
 

--- a/docs/guides/langgraph.md
+++ b/docs/guides/langgraph.md
@@ -20,6 +20,8 @@ pip install langchain-mcp-adapters langgraph
 ```
 
 ```python
+import asyncio
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
 from langchain.chat_models import init_chat_model
@@ -46,6 +48,8 @@ async def main():
     result = await agent.ainvoke(
         {"messages": [("user", "List files in /workspace")]}
     )
+
+asyncio.run(main())
 ```
 
 Pipelock intercepts all MCP traffic between LangGraph and the filesystem server,
@@ -72,33 +76,37 @@ The `create_react_agent` helper builds a tool-calling agent loop. Set `command`
 to `pipelock` in the `StdioConnection`:
 
 ```python
+import asyncio
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("anthropic:claude-sonnet-4-20250514")
+async def main():
+    model = init_chat_model("anthropic:claude-sonnet-4-20250514")
+    client = MultiServerMCPClient(
+        {
+            "filesystem": {
+                "transport": "stdio",
+                "command": "pipelock",
+                "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
+                         "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+            },
+            "database": {
+                "transport": "stdio",
+                "command": "pipelock",
+                "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
+                         "python", "-m", "mcp_server_sqlite", "--db", "/data/app.db"],
+            },
+        }
+    )
+    tools = await client.get_tools()
+    agent = create_react_agent(model, tools)
+    result = await agent.ainvoke(
+        {"messages": [("user", "What tables exist in the database?")]}
+    )
 
-client = MultiServerMCPClient(
-    {
-        "filesystem": {
-            "transport": "stdio",
-            "command": "pipelock",
-            "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
-                     "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
-        },
-        "database": {
-            "transport": "stdio",
-            "command": "pipelock",
-            "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
-                     "python", "-m", "mcp_server_sqlite", "--db", "/data/app.db"],
-        },
-    }
-)
-tools = await client.get_tools()
-agent = create_react_agent(model, tools)
-result = await agent.ainvoke(
-    {"messages": [("user", "What tables exist in the database?")]}
-)
+asyncio.run(main())
 ```
 
 Each server gets its own Pipelock proxy instance. A poisoned response from one
@@ -109,39 +117,43 @@ server doesn't affect the other.
 For full control over the agent loop:
 
 ```python
+import asyncio
+
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.graph import StateGraph, MessagesState, START
 from langgraph.prebuilt import ToolNode, tools_condition
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("anthropic:claude-sonnet-4-20250514")
-
-client = MultiServerMCPClient(
-    {
-        "filesystem": {
-            "transport": "stdio",
-            "command": "pipelock",
-            "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
-                     "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+async def main():
+    model = init_chat_model("anthropic:claude-sonnet-4-20250514")
+    client = MultiServerMCPClient(
+        {
+            "filesystem": {
+                "transport": "stdio",
+                "command": "pipelock",
+                "args": ["mcp", "proxy", "--config", "pipelock.yaml", "--",
+                         "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+            }
         }
-    }
-)
-tools = await client.get_tools()
+    )
+    tools = await client.get_tools()
 
-def call_model(state: MessagesState):
-    return {"messages": model.bind_tools(tools).invoke(state["messages"])}
+    def call_model(state: MessagesState):
+        return {"messages": model.bind_tools(tools).invoke(state["messages"])}
 
-builder = StateGraph(MessagesState)
-builder.add_node("agent", call_model)
-builder.add_node("tools", ToolNode(tools))
-builder.add_edge(START, "agent")
-builder.add_conditional_edges("agent", tools_condition)
-builder.add_edge("tools", "agent")
-graph = builder.compile()
+    builder = StateGraph(MessagesState)
+    builder.add_node("agent", call_model)
+    builder.add_node("tools", ToolNode(tools))
+    builder.add_edge(START, "agent")
+    builder.add_conditional_edges("agent", tools_condition)
+    builder.add_edge("tools", "agent")
+    graph = builder.compile()
 
-result = await graph.ainvoke(
-    {"messages": [("user", "Read /workspace/config.yaml")]}
-)
+    result = await graph.ainvoke(
+        {"messages": [("user", "Read /workspace/config.yaml")]}
+    )
+
+asyncio.run(main())
 ```
 
 ### Pattern C: `load_mcp_tools` (single server)
@@ -149,28 +161,33 @@ result = await graph.ainvoke(
 For wrapping a single MCP server without `MultiServerMCPClient`:
 
 ```python
+import asyncio
+
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langgraph.prebuilt import create_react_agent
 from langchain.chat_models import init_chat_model
 
-server_params = StdioServerParameters(
-    command="pipelock",
-    args=["mcp", "proxy", "--config", "pipelock.yaml", "--",
-          "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
-)
+async def main():
+    server_params = StdioServerParameters(
+        command="pipelock",
+        args=["mcp", "proxy", "--config", "pipelock.yaml", "--",
+              "npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+    )
 
-async with stdio_client(server_params) as (read, write):
-    async with ClientSession(read, write) as session:
-        await session.initialize()
-        tools = await load_mcp_tools(session)
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await load_mcp_tools(session)
 
-        model = init_chat_model("anthropic:claude-sonnet-4-20250514")
-        agent = create_react_agent(model, tools)
-        result = await agent.ainvoke(
-            {"messages": [("user", "List files in /workspace")]}
-        )
+            model = init_chat_model("anthropic:claude-sonnet-4-20250514")
+            agent = create_react_agent(model, tools)
+            result = await agent.ainvoke(
+                {"messages": [("user", "List files in /workspace")]}
+            )
+
+asyncio.run(main())
 ```
 
 ### Stdio Transport Fields

--- a/docs/guides/openai-agents.md
+++ b/docs/guides/openai-agents.md
@@ -294,15 +294,20 @@ services:
       - pipelock-internal
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
     depends_on:
       pipelock:
         condition: service_healthy
 ```
 
-The agent container can only reach the `pipelock` service. All HTTP traffic goes
-through the fetch proxy. MCP servers running as subprocesses inside the agent
-container are wrapped with `pipelock mcp proxy` as shown above.
+The agent container can only reach the `pipelock` service. The proxy
+environment variables route HTTP libraries that honor them through Pipelock.
+`PIPELOCK_FETCH_URL` is an application-defined helper value: it is useful only
+when your code explicitly calls the `/fetch` endpoint and does not redirect an
+OpenAI SDK request by itself. MCP servers running as subprocesses inside the
+agent container are wrapped with `pipelock mcp proxy` as shown above.
 
 You can also generate this template with:
 

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -22,13 +22,23 @@ git clone --branch v3.5.0 --depth 1 https://github.com/luckyPipewrench/pipelock.
 make -C pipelock install
 # or (macOS): brew install luckyPipewrench/tap/pipelock
 
-# 2. Wrap every OpenCode MCP server with pipelock in one shot
-pipelock opencode install
+# 2. Generate a config, then preview the wrapper changes
+pipelock generate config --preset balanced -o pipelock.yaml
+pipelock opencode install --config "$PWD/pipelock.yaml" --dry-run
 
-# 3. Restart OpenCode so it picks up the wrapped MCP entries
+# 3. Apply the same change and restart OpenCode
+pipelock opencode install --config "$PWD/pipelock.yaml"
 ```
 
-`pipelock opencode install` discovers OpenCode's MCP server entries, rewrites each one to launch through `pipelock mcp proxy`, and is idempotent — re-running it on an already-installed setup is a no-op. After adding or removing an MCP server in OpenCode's configuration, re-run the installer to wrap any new entries.
+`pipelock opencode install` reads `OPENCODE_CONFIG` when set, otherwise
+`~/.config/opencode/opencode.json` (or its JSONC variant), rewrites each MCP
+server to launch through `pipelock mcp proxy`, and is idempotent. Pass
+`--path` to target another config. After adding or removing an MCP server in
+OpenCode's configuration, re-run the installer to wrap new entries.
+
+After restarting OpenCode, use `opencode mcp list` and a harmless tool action
+to confirm the server connects. A rewritten config does not by itself prove an
+MCP connection.
 
 ## What Gets Scanned
 
@@ -77,7 +87,27 @@ OpenCode reads MCP servers from its configuration file. Run `opencode mcp list` 
 
 ### A tool call hangs
 
-Bridge-style MCP servers (those that stdio in but call out over HTTPS to a SaaS) need network egress. If you've enabled `sandbox.enabled: true` on the wrap, the proxy will isolate the MCP server in a network namespace and the upstream call will fail. Set `sandbox: false` on bridge servers via the install flag.
+Bridge-style MCP servers (those that stdio in but call out over HTTPS to a SaaS)
+need network egress. `pipelock opencode install` has no per-install sandbox
+flag. Configure sandbox behavior in the Pipelock config used by the wrapper,
+then preview and re-run the install with `--config`.
+
+### Previewing or removing the wrapper
+
+```bash
+# Inspect the change without writing files.
+pipelock opencode install --config "$PWD/pipelock.yaml" --dry-run
+
+# Restore only entries previously wrapped by Pipelock.
+pipelock opencode remove --dry-run
+pipelock opencode remove
+```
+
+Install and remove create a one-version `.bak` backup before a real change.
+Removal restores wrapped entries from their `_pipelock` metadata and leaves
+other entries alone. If removal warns about an invalid entry or header-sidecar
+cleanup, inspect `opencode mcp list` after restarting before changing the
+backup. A backup is not a substitute for checking the active client config.
 
 ### Receipts and audit trail
 

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -99,8 +99,8 @@ then preview and re-run the install with `--config`.
 pipelock opencode install --config "$PWD/pipelock.yaml" --dry-run
 
 # Restore only entries previously wrapped by Pipelock.
-pipelock opencode remove --dry-run
-pipelock opencode remove
+pipelock opencode remove --path /path/to/opencode.json --dry-run
+pipelock opencode remove --path /path/to/opencode.json
 ```
 
 Install and remove create a one-version `.bak` backup before a real change.

--- a/examples/opencode-integration/README.md
+++ b/examples/opencode-integration/README.md
@@ -40,16 +40,27 @@ Or from this directory: `./verify.sh` (with `PIPELOCK_BIN` set if needed).
 
 ```bash
 "$PIPELOCK_BIN" opencode install --path /path/to/opencode.json \
+  --config examples/opencode-integration/pipelock.yaml --dry-run
+
+"$PIPELOCK_BIN" opencode install --path /path/to/opencode.json \
   --config examples/opencode-integration/pipelock.yaml
 ```
 
 If `pipelock` is already on your `PATH`, you can use `pipelock` instead of `"$PIPELOCK_BIN"`.
 
-Restart OpenCode after install so it picks up the wrapped MCP entries.
+Restart OpenCode after install, then use `opencode mcp list` and a harmless
+tool action to confirm the server connects. The changed config alone is not a
+connection result.
 
 ```bash
+"$PIPELOCK_BIN" opencode remove --path /path/to/opencode.json --dry-run
 "$PIPELOCK_BIN" opencode remove --path /path/to/opencode.json
 ```
+
+Install and remove create a one-version `.bak` backup before a real change.
+Removal restores only Pipelock-wrapped entries from `_pipelock` metadata. If it
+warns about an entry or header-sidecar cleanup, restart OpenCode and inspect the
+MCP list before using the backup.
 
 ## Config Notes
 

--- a/internal/cli/generate/generate_compose.go
+++ b/internal/cli/generate/generate_compose.go
@@ -153,6 +153,9 @@ func genericAgentService() string {
       - pipelock-internal    # Can ONLY reach pipelock — no internet
     environment:
       - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       # Add your agent's env vars here.
       # Secrets are safe — this container has no internet access.
@@ -186,6 +189,9 @@ func claudeCodeAgentService() string {
       - pipelock-internal    # Can ONLY reach pipelock — no internet
     environment:
       - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     volumes:
       - ./workspace:/workspace
@@ -206,6 +212,9 @@ func openhandsAgentService() string {
       - "3000:3000"
     environment:
       - PIPELOCK_FETCH_URL=http://pipelock:8888/fetch
+      - HTTP_PROXY=http://pipelock:8888
+      - HTTPS_PROXY=http://pipelock:8888
+      - NO_PROXY=localhost,127.0.0.1
       - LLM_API_KEY=${ANTHROPIC_API_KEY}
       - SANDBOX_NETWORK_MODE=none
       # Route OpenHands HTTP traffic through pipelock:

--- a/internal/cli/generate/generate_compose_test.go
+++ b/internal/cli/generate/generate_compose_test.go
@@ -44,6 +44,15 @@ func TestGenerateDockerCompose_AllAgentTypes(t *testing.T) {
 			if !strings.Contains(tmpl, "PIPELOCK_FETCH_URL=http://pipelock:8888/fetch") {
 				t.Error("expected PIPELOCK_FETCH_URL env var in agent service")
 			}
+			for _, proxyEnv := range []string{
+				"HTTP_PROXY=http://pipelock:8888",
+				"HTTPS_PROXY=http://pipelock:8888",
+				"NO_PROXY=localhost,127.0.0.1",
+			} {
+				if !strings.Contains(tmpl, proxyEnv) {
+					t.Errorf("expected %s env var in agent service", proxyEnv)
+				}
+			}
 			if !strings.Contains(tmpl, "condition: service_healthy") {
 				t.Error("expected healthcheck dependency")
 			}

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -186,11 +186,28 @@ func resolvePipelockBinary() (string, error) {
 
 // codexMCPList shells out to `codex mcp list --json` and parses the result.
 func codexMCPList(ctx context.Context, codexBin string) ([]codexMCPServer, error) {
-	out, err := runCodexCommand(ctx, codexBin, "mcp", "list", "--json")
+	out, err := runCodexMCPListCommand(ctx, codexBin)
 	if err != nil {
 		return nil, fmt.Errorf("codex mcp list: %w", err)
 	}
 	return parseCodexMCPList(out)
+}
+
+// runCodexMCPListCommand returns only stdout because Codex emits the JSON list
+// there. Stderr remains available in a failed-command diagnostic; it must not
+// be mixed into the JSON parser when a successful command prints a warning.
+//
+//nolint:gosec // G204: canonical CLI subprocess invocation; see runCodexCommand.
+func runCodexMCPListCommand(ctx context.Context, codexBin string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, codexBin, "mcp", "list", "--json")
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return stdout, fmt.Errorf("%w: %s", err, bytes.TrimSpace(stderr.Bytes()))
+	}
+	return stdout, nil
 }
 
 // parseCodexMCPList separates parsing from the shell-out so tests can feed

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -106,6 +106,79 @@ func TestParseCodexMCPList(t *testing.T) {
 	}
 }
 
+func TestCodexMCPListCommandStreams(t *testing.T) {
+	if runtime.GOOS == osWindows {
+		t.Skip("shell helper not supported on Windows")
+	}
+
+	const validList = `[{"name":"demo","transport":{"type":"stdio","command":"node"}}]`
+	tests := []struct {
+		name       string
+		stdout     string
+		stderr     string
+		exitCode   int
+		wantErr    bool
+		wantErrSub string
+		wantNames  []string
+	}{
+		{
+			name:      "valid stdout ignores stderr warning",
+			stdout:    validList,
+			stderr:    "warning: helper alias is unavailable",
+			wantNames: []string{"demo"},
+		},
+		{
+			name:       "malformed stdout remains an error",
+			stdout:     `[{"name":`,
+			stderr:     "warning: helper alias is unavailable",
+			wantErr:    true,
+			wantErrSub: "parsing codex mcp list JSON",
+		},
+		{
+			name:       "nonzero command preserves stderr diagnostic",
+			stdout:     validList,
+			stderr:     "Error: Codex configuration is unavailable",
+			exitCode:   1,
+			wantErr:    true,
+			wantErrSub: "Codex configuration is unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			codexBin := filepath.Join(dir, "codex")
+			script := fmt.Sprintf(`#!/bin/sh
+printf '%%s' %q
+printf '%%s' %q >&2
+exit %d
+`, tt.stdout, tt.stderr, tt.exitCode)
+			writeShellScript(t, codexBin, script)
+
+			servers, err := codexMCPList(context.Background(), codexBin)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrSub) {
+					t.Errorf("error = %v, want it to contain %q", err, tt.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("codexMCPList: %v", err)
+			}
+			gotNames := make([]string, 0, len(servers))
+			for _, server := range servers {
+				gotNames = append(gotNames, server.Name)
+			}
+			if !reflect.DeepEqual(gotNames, tt.wantNames) {
+				t.Errorf("server names = %v, want %v", gotNames, tt.wantNames)
+			}
+		})
+	}
+}
+
 func TestClassifyCodexWrapper(t *testing.T) {
 	// The binary that is genuinely mediating is the one running this test, since
 	// that is what an install writes into the config. A path merely NAMED pipelock

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -273,9 +273,13 @@ func fileExists(path string) bool {
 // ~/Library/Application Support/, Windows uses %APPDATA%. Clients that store
 // config in the home directory (claude-code, cursor, continue) work on all platforms.
 func configPaths(home string) []clientPath {
-	appData := appDataDir(home)
+	return configPathsForOS(home, runtime.GOOS)
+}
 
-	return []clientPath{
+func configPathsForOS(home, goos string) []clientPath {
+	appData := appDataDirForOS(home, goos)
+
+	paths := []clientPath{
 		{
 			Client: clientClaudeCode,
 			Path:   filepath.Join(home, ".claude.json"),
@@ -358,6 +362,22 @@ func configPaths(home string) []clientPath {
 		// an explicit project root parameter (future work). Consistent
 		// with VS Code (.vscode/mcp.json also not scanned).
 	}
+	if goos == osWindows {
+		// Packaged desktop apps can redirect Roaming data into their private
+		// LocalCache. Keep both locations: an existing classic installation
+		// can have different entries, and each result retains its source path.
+		// Family and config location verified on Claude Desktop 1.40609.0.0
+		// via Get-AppxPackage (2026-09-04). Windows package data redirection:
+		// https://learn.microsoft.com/windows/msix/desktop/desktop-to-uwp-behind-the-scenes
+		paths = append(paths, clientPath{
+			Client: clientClaudeDesktop,
+			Path: filepath.Join(home, "AppData", "Local", "Packages",
+				"Claude_pzs8sxrjxfjjc", "LocalCache", "Roaming", "Claude", "claude_desktop_config.json"),
+			Key:   configKeyMCPServers,
+			Scope: scopeUser,
+		})
+	}
+	return paths
 }
 
 // appDataDir returns the platform-specific application data directory
@@ -366,7 +386,11 @@ func configPaths(home string) []clientPath {
 // Linux: home/.config, macOS: home/Library/Application Support,
 // Windows: home/AppData/Roaming.
 func appDataDir(home string) string {
-	switch runtime.GOOS {
+	return appDataDirForOS(home, runtime.GOOS)
+}
+
+func appDataDirForOS(home, goos string) string {
+	switch goos {
 	case osDarwin:
 		return filepath.Join(home, "Library", "Application Support")
 	case osWindows:

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -20,6 +20,39 @@ func TestConfigPathsNotEmpty(t *testing.T) {
 	}
 }
 
+func TestConfigPathsClaudeDesktopPlatforms(t *testing.T) {
+	home := t.TempDir()
+	for _, tt := range []struct {
+		goos string
+		dirs []string
+	}{
+		{goos: "linux", dirs: []string{filepath.Join(home, ".config", "Claude")}},
+		{goos: osDarwin, dirs: []string{filepath.Join(home, "Library", "Application Support", "Claude")}},
+		{goos: osWindows, dirs: []string{
+			filepath.Join(home, "AppData", "Roaming", "Claude"),
+			filepath.Join(home, "AppData", "Local", "Packages", "Claude_pzs8sxrjxfjjc", "LocalCache", "Roaming", "Claude"),
+		}},
+	} {
+		t.Run(tt.goos, func(t *testing.T) {
+			var paths []string
+			for _, cp := range configPathsForOS(home, tt.goos) {
+				if cp.Client == clientClaudeDesktop {
+					paths = append(paths, cp.Path)
+				}
+			}
+			if len(paths) != len(tt.dirs) {
+				t.Fatalf("paths = %v, want %d Claude configs", paths, len(tt.dirs))
+			}
+			for i, dir := range tt.dirs {
+				want := filepath.Join(dir, "claude_desktop_config.json")
+				if paths[i] != want {
+					t.Errorf("path %d = %q, want %q", i, paths[i], want)
+				}
+			}
+		})
+	}
+}
+
 func TestConfigPathsExpandHome(t *testing.T) {
 	paths := configPaths("/home/testuser")
 	for _, p := range paths {

--- a/internal/discover/discover_windows_test.go
+++ b/internal/discover/discover_windows_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverClaudeWindowsLayouts(t *testing.T) {
+	const serverConfig = `{"mcpServers":{"ordinary":{"command":"node","args":["server.js"]}}}`
+	for _, tt := range []struct {
+		name          string
+		classic       string
+		packaged      string
+		wantServers   int
+		wantClients   int
+		wantParseErrs int
+	}{
+		{name: "absent"},
+		{name: "classic", classic: serverConfig, wantServers: 1, wantClients: 1},
+		{name: "packaged", packaged: serverConfig, wantServers: 1, wantClients: 1},
+		{name: "both retain source", classic: serverConfig, packaged: serverConfig, wantServers: 2, wantClients: 2},
+		{name: "packaged parse error", packaged: "{", wantClients: 1, wantParseErrs: 1},
+		{name: "classic survives packaged error", classic: serverConfig, packaged: "{", wantServers: 1, wantClients: 2, wantParseErrs: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			classic := filepath.Join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json")
+			packaged := filepath.Join(home, "AppData", "Local", "Packages", "Claude_pzs8sxrjxfjjc",
+				"LocalCache", "Roaming", "Claude", "claude_desktop_config.json")
+			for path, content := range map[string]string{classic: tt.classic, packaged: tt.packaged} {
+				if content == "" {
+					continue
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			report, err := Discover(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if report.Summary.TotalServers != tt.wantServers || report.Summary.TotalClients != tt.wantClients || report.Summary.ParseErrors != tt.wantParseErrs {
+				t.Fatalf("summary = %+v, want servers=%d clients=%d parse errors=%d", report.Summary, tt.wantServers, tt.wantClients, tt.wantParseErrs)
+			}
+			seen := make(map[string]bool)
+			for _, server := range report.Servers {
+				if server.ConfigPath != classic && server.ConfigPath != packaged {
+					t.Errorf("unexpected config path %q", server.ConfigPath)
+				}
+				if seen[server.ConfigPath] {
+					t.Errorf("duplicate config path %q", server.ConfigPath)
+				}
+				seen[server.ConfigPath] = true
+				if server.Client != clientClaudeDesktop || server.Protection != Unprotected {
+					t.Errorf("unexpected server classification: %+v", server)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Parse Codex MCP list JSON separately from diagnostics and discover packaged Claude Desktop configurations on Windows.
- Correct integration examples and document previews, connection checks, removal and recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex MCP detection when commands emit warnings alongside valid JSON.
  * Expanded Windows Claude Desktop discovery to include packaged installations and preserve valid results when other configurations are malformed.

* **Documentation**
  * Updated integration guides and generated Compose templates to route HTTP traffic through proxy settings.
  * Added clearer setup, verification, preview, removal, backup, and recovery guidance across integrations.
  * Clarified MCP discovery support and configuration behavior for supported clients.
  * Updated LangGraph examples for current client usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->