### PR TITLE
fix(diag): report inconclusive containment probes

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -14,7 +14,7 @@ the full command tree and `pipelock <command> --help` for any command's flags.
 | [`pipelock skill-scan`](skill-scan.md) | Inventory skill files, compare lock drift, and flag conservative source-to-sink combinations. |
 | [`pipelock doctor`](doctor.md) | Audit whether configured protections are actually enforceable in the current topology. |
 | [`pipelock explain`](explain.md) | Explain a URL verdict and the exact, per-scanner remediation knob for a block. |
-| [`pipelock verify-install`](verify-install.md) | Deterministic smoke checks that scanning is wired and (in containment) direct egress is blocked. |
+| [`pipelock verify-install`](verify-install.md) | Deterministic smoke checks that scanning is wired plus direct-egress probes with explicit exposed or inconclusive outcomes. |
 | [`pipelock adaptive`](adaptive.md) | Operator CLI for adaptive-enforcement state and overrides. |
 | [`pipelock session`](session.md) | Operator CLI for airlock session recovery. |
 | [`pipelock keys status`](keys.md) | Unified view of every signing-key purpose: source, presence, readability, and validity. |

--- a/docs/cli/verify-install.md
+++ b/docs/cli/verify-install.md
@@ -1,6 +1,6 @@
 # `pipelock verify-install`
 
-`pipelock verify-install` runs deterministic smoke checks against the local Pipelock binary and configuration. It is a quick proof that the scanner surfaces are wired and, when run inside a contained environment, that direct egress is blocked.
+`pipelock verify-install` runs deterministic smoke checks against the local Pipelock binary and configuration. It proves the scanner surfaces are wired. Its direct-egress probes report a successful direct connection as exposure, while an unsuccessful connection without boundary attribution is inconclusive.
 
 It complements `pipelock doctor`:
 
@@ -48,19 +48,21 @@ Containment checks:
 
 | Check | What it proves |
 |---|---|
-| `no_direct_http` | The current environment blocks direct HTTP egress. |
-| `no_direct_dns` | The current environment blocks direct DNS egress. |
-| `no_direct_https` | The current environment blocks direct HTTPS egress. |
+| `no_direct_http` | Whether a direct HTTP connection succeeded. A failed connection without containment-boundary evidence is inconclusive. |
+| `no_direct_dns` | Whether a direct DNS exchange succeeded. A failed exchange without containment-boundary evidence is inconclusive. |
+| `no_direct_https` | Whether a direct HTTPS connection succeeded. A failed connection without containment-boundary evidence is inconclusive. |
 
-The containment probes are only meaningful inside a container, pod, or similar network boundary. On a normal host they are reported as not applicable, because the operator account is expected to retain direct network access.
+The containment probes are only meaningful inside a container, pod, or similar network boundary. On a normal host they are reported as not applicable, because the operator account is expected to retain direct network access. A blocked or unavailable public endpoint does not identify the local containment boundary, so it is reported as unknown and exits non-zero. Use `pipelock contain verify` for managed Linux host containment. Container and pod deployments need evidence from their own network-policy boundary.
 
 ## Exit Codes
 
+The current container and pod probes cannot affirm containment. When all direct connections fail, the result is `unknown` with exit code `2`, even when network policy is correctly enforcing containment. This command does not ingest external policy evidence to turn that result into a pass.
+
 | Code | Meaning |
 |---|---|
-| `0` | All required checks passed. Not-applicable containment checks count as pass. |
+| `0` | All required checks passed. Host-mode, not-applicable containment checks count as pass. |
 | `1` | One or more checks failed. |
-| `2` | Config or setup error. |
+| `2` | Config or setup error, or an inconclusive containment probe. |
 
 ## Scope
 

--- a/internal/cli/assess/score_test.go
+++ b/internal/cli/assess/score_test.go
@@ -155,6 +155,18 @@ func TestScoreDeploymentVerification(t *testing.T) {
 	})
 }
 
+func TestScoreDeploymentVerification_InconclusiveReport(t *testing.T) {
+	var report diag.VerifyReport
+	data := []byte(`{"checks":[{"name":"config_valid","category":"scanning","status":"pass"},{"name":"no_direct_http","category":"containment","status":"unknown"}],"summary":{"passed":1,"unknown":1,"containment":"unknown"}}`)
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+	section := scoreDeploymentVerification(&report)
+	if section.Score != 50 || section.Applicable != 2 {
+		t.Fatalf("inconclusive check must earn no passing credit: %+v", section)
+	}
+}
+
 func TestScoreDeploymentVerification_AllNA(t *testing.T) {
 	report := &diag.VerifyReport{
 		Checks: []diag.VerifyReportCheck{

--- a/internal/cli/diag/verify_install.go
+++ b/internal/cli/diag/verify_install.go
@@ -63,7 +63,7 @@ type VerifyEnv struct {
 
 // VerifyResult is the outcome of a single check.
 type VerifyResult struct {
-	Status   string            `json:"status"` // pass, fail, not_applicable
+	Status   string            `json:"status"` // pass, fail, not_applicable, unknown
 	Detail   string            `json:"detail,omitempty"`
 	Evidence map[string]string `json:"evidence,omitempty"`
 }
@@ -94,14 +94,16 @@ type VerifyReportSummary struct {
 	Passed        int    `json:"passed"`
 	Failed        int    `json:"failed"`
 	NotApplicable int    `json:"not_applicable"`
+	Unknown       int    `json:"unknown,omitempty"`
 	Scanning      string `json:"scanning"`    // verified, degraded
 	Containment   string `json:"containment"` // contained, exposed, unknown
 }
 
 const (
-	verifyStatusPass = "pass"
-	verifyStatusFail = "fail"
-	verifyStatusNA   = "not_applicable"
+	verifyStatusPass    = "pass"
+	verifyStatusFail    = "fail"
+	verifyStatusNA      = "not_applicable"
+	verifyStatusUnknown = "unknown"
 
 	verifyCatScanning    = "scanning"
 	verifyCatContainment = "containment"
@@ -138,17 +140,23 @@ detection, MCP binary integrity smoke, and MCP tool provenance smoke.
 Containment checks (3): attempt direct HTTP (1.1.1.1:80), DNS (8.8.8.8:53),
 and HTTPS (1.1.1.1:443) egress bypassing the proxy. Only meaningful inside a
 container or pod where network policy should block direct egress. On a host,
-these are marked not_applicable. In air-gapped or enterprise networks where
-these addresses are unreachable, probes may show false passes.
+these are marked not_applicable. A failed connection alone is inconclusive: it
+does not identify the containment boundary that caused it. For managed Linux
+host containment, use pipelock contain verify. Container and pod deployments
+need evidence from their own network-policy boundary.
+
+The current container and pod probes cannot affirm containment. When all
+direct connections fail, they report unknown and exit 2, even if network
+policy is correctly enforcing containment.
 
 Without --config, uses built-in defaults with all protections enabled. With
 --config, verifies the provided config as-is: disabled features are reported
 as failures so you see your actual security posture.
 
 Exit codes:
-  0  All checks passed (not_applicable counts as pass)
+  0  All checks passed (host-mode not_applicable containment checks count as pass)
   1  One or more checks failed
-  2  Config or setup error`,
+  2  Config or setup error, or inconclusive containment probes`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.NoArgs,
@@ -296,8 +304,15 @@ func runVerifyInstall(cmd *cobra.Command, configFile string, jsonOut, noColor bo
 		printVerifyTable(cmd.OutOrStdout(), report, color)
 	}
 
+	return verifyReportExitError(report)
+}
+
+func verifyReportExitError(report VerifyReport) error {
 	if report.Summary.Failed > 0 {
 		return cliutil.ExitCodeError(1, fmt.Errorf("%d check(s) failed", report.Summary.Failed))
+	}
+	if report.Summary.Unknown > 0 {
+		return cliutil.ExitCodeError(2, fmt.Errorf("%d containment check(s) inconclusive; verification incomplete", report.Summary.Unknown))
 	}
 	return nil
 }
@@ -816,8 +831,8 @@ func checkNoDirectHTTP(env *VerifyEnv) VerifyResult {
 	conn, err := env.DialTCP("1.1.1.1:80")
 	if err != nil {
 		return VerifyResult{
-			Status:   verifyStatusPass,
-			Detail:   "Direct HTTP egress blocked",
+			Status:   verifyStatusUnknown,
+			Detail:   "Direct HTTP probe connection failed, but containment attribution is unavailable",
 			Evidence: map[string]string{"target": "1.1.1.1:80", "error": err.Error()},
 		}
 	}
@@ -842,8 +857,8 @@ func checkNoDirectDNS(env *VerifyEnv) VerifyResult {
 	conn, err := env.DialUDP("8.8.8.8:53")
 	if err != nil {
 		return VerifyResult{
-			Status:   verifyStatusPass,
-			Detail:   "Direct DNS egress blocked (dial failed)",
+			Status:   verifyStatusUnknown,
+			Detail:   "Direct DNS probe dial failed, but containment attribution is unavailable",
 			Evidence: map[string]string{"target": "8.8.8.8:53", "protocol": "udp"},
 		}
 	}
@@ -852,8 +867,8 @@ func checkNoDirectDNS(env *VerifyEnv) VerifyResult {
 	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
 	if _, err := conn.Write(query); err != nil {
 		return VerifyResult{
-			Status:   verifyStatusPass,
-			Detail:   "Direct DNS egress blocked (write failed)",
+			Status:   verifyStatusUnknown,
+			Detail:   "Direct DNS probe write failed, but containment attribution is unavailable",
 			Evidence: map[string]string{"target": "8.8.8.8:53", "protocol": "udp"},
 		}
 	}
@@ -862,8 +877,8 @@ func checkNoDirectDNS(env *VerifyEnv) VerifyResult {
 	_, err = conn.Read(buf)
 	if err != nil {
 		return VerifyResult{
-			Status:   verifyStatusPass,
-			Detail:   "Direct DNS egress blocked (no response)",
+			Status:   verifyStatusUnknown,
+			Detail:   "Direct DNS probe received no response, but containment attribution is unavailable",
 			Evidence: map[string]string{"target": "8.8.8.8:53", "protocol": "udp"},
 		}
 	}
@@ -885,8 +900,8 @@ func checkNoDirectHTTPS(env *VerifyEnv) VerifyResult {
 	conn, err := env.DialTCP("1.1.1.1:443")
 	if err != nil {
 		return VerifyResult{
-			Status:   verifyStatusPass,
-			Detail:   "Direct HTTPS egress blocked",
+			Status:   verifyStatusUnknown,
+			Detail:   "Direct HTTPS probe connection failed, but containment attribution is unavailable",
 			Evidence: map[string]string{"target": "1.1.1.1:443", "error": err.Error()},
 		}
 	}
@@ -953,7 +968,7 @@ func BuildVerifyReport(env *VerifyEnv, checks []VerifyCheck, cfgLabel string) Ve
 	}
 
 	scanPass, scanFail := 0, 0
-	containPass, containFail, containNA := 0, 0, 0
+	containPass, containFail, containNA, containUnknown := 0, 0, 0, 0
 
 	for _, c := range checks {
 		result := c.Run(env)
@@ -981,6 +996,10 @@ func BuildVerifyReport(env *VerifyEnv, checks []VerifyCheck, cfgLabel string) Ve
 				containFail++
 			case verifyStatusNA:
 				containNA++
+			case verifyStatusUnknown:
+				containUnknown++
+			default:
+				containUnknown++
 			}
 		}
 	}
@@ -990,6 +1009,7 @@ func BuildVerifyReport(env *VerifyEnv, checks []VerifyCheck, cfgLabel string) Ve
 		Passed:        scanPass + containPass,
 		Failed:        scanFail + containFail,
 		NotApplicable: containNA,
+		Unknown:       containUnknown,
 	}
 
 	if scanFail == 0 {
@@ -999,12 +1019,15 @@ func BuildVerifyReport(env *VerifyEnv, checks []VerifyCheck, cfgLabel string) Ve
 	}
 
 	switch {
-	case containNA == 3:
-		report.Summary.Containment = verifyContainmentUnknown
 	case containFail > 0:
 		report.Summary.Containment = verifyContainmentExposed
-	default:
+	case containPass > 0 && containNA == 0 && containUnknown == 0:
+		// Preserve the report contract for affirmative checks supplied by callers.
+		// The built-in connection probes cannot attribute a denial to containment
+		// and therefore never supply a containment pass.
 		report.Summary.Containment = verifyContainmentContained
+	default:
+		report.Summary.Containment = verifyContainmentUnknown
 	}
 
 	return report
@@ -1075,6 +1098,9 @@ func printVerifyTable(w io.Writer, report VerifyReport, color bool) {
 	if report.Summary.NotApplicable > 0 {
 		_, _ = fmt.Fprintf(w, ", %d not applicable", report.Summary.NotApplicable)
 	}
+	if report.Summary.Unknown > 0 {
+		_, _ = fmt.Fprintf(w, ", %d inconclusive", report.Summary.Unknown)
+	}
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintf(w, "Scanning: %s\n", report.Summary.Scanning)
 	_, _ = fmt.Fprintf(w, "Containment: %s\n", report.Summary.Containment)
@@ -1089,11 +1115,15 @@ func verifyStatusIcon(status string, color bool) string {
 			return "\033[31mFAIL\033[0m"
 		case verifyStatusNA:
 			return "\033[33m N/A\033[0m"
+		case verifyStatusUnknown:
+			return "\033[33mUNKNOWN\033[0m"
 		}
 	}
 	switch status {
 	case verifyStatusNA:
 		return " N/A"
+	case verifyStatusUnknown:
+		return "UNKNOWN"
 	default:
 		return strings.ToUpper(status)
 	}

--- a/internal/cli/diag/verify_install_test.go
+++ b/internal/cli/diag/verify_install_test.go
@@ -49,8 +49,13 @@ func TestVerifyInstallCmd_AllPass(t *testing.T) {
 	cmd := VerifyInstallCmd()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"--no-color"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("verify-install failed: %v", err)
+	err := cmd.Execute()
+	ctx := testRunContext()
+	if ctx == cliutil.RunContextHost && err != nil {
+		t.Fatalf("verify-install failed on host: %v", err)
+	}
+	if ctx != cliutil.RunContextHost && err == nil {
+		t.Fatal("expected a non-success containment outcome outside host mode")
 	}
 	out := buf.String()
 
@@ -59,7 +64,6 @@ func TestVerifyInstallCmd_AllPass(t *testing.T) {
 		t.Errorf("expected 'Scanning: verified' in output:\n%s", out)
 	}
 
-	ctx := testRunContext()
 	if ctx == cliutil.RunContextHost {
 		if !strings.Contains(out, "Containment: unknown") {
 			t.Errorf("expected 'Containment: unknown' in output:\n%s", out)
@@ -71,8 +75,8 @@ func TestVerifyInstallCmd_AllPass(t *testing.T) {
 			t.Errorf("expected '3 not applicable' in output:\n%s", out)
 		}
 	}
-	// No failures regardless of context (defaults have all protections).
-	if strings.Contains(out, "FAIL") {
+	// Host mode intentionally does not test containment.
+	if ctx == cliutil.RunContextHost && strings.Contains(out, "FAIL") {
 		t.Errorf("unexpected FAIL in output:\n%s", out)
 	}
 }
@@ -82,8 +86,12 @@ func TestVerifyInstallCmd_JSON(t *testing.T) {
 	cmd := VerifyInstallCmd()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"--json", "--no-color"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("verify-install --json failed: %v", err)
+	err := cmd.Execute()
+	if testRunContext() == cliutil.RunContextHost && err != nil {
+		t.Fatalf("verify-install --json failed on host: %v", err)
+	}
+	if testRunContext() != cliutil.RunContextHost && err == nil {
+		t.Fatal("expected a non-success containment outcome outside host mode")
 	}
 
 	var report VerifyReport
@@ -106,7 +114,7 @@ func TestVerifyInstallCmd_JSON(t *testing.T) {
 	if report.Summary.Scanning != verifyScanningVerified {
 		t.Errorf("expected scanning=verified, got %s", report.Summary.Scanning)
 	}
-	if report.Summary.Failed != 0 {
+	if ctx == cliutil.RunContextHost && report.Summary.Failed != 0 {
 		t.Errorf("expected 0 failed, got %d", report.Summary.Failed)
 	}
 
@@ -223,7 +231,7 @@ func TestVerifyInstallCmd_Help(t *testing.T) {
 		t.Fatalf("help failed: %v", err)
 	}
 	out := buf.String()
-	for _, keyword := range []string{"verify-install", "scanning", "containment", "Ed25519"} {
+	for _, keyword := range []string{"verify-install", "scanning", "containment", "inconclusive", "Ed25519"} {
 		if !strings.Contains(out, keyword) {
 			t.Errorf("expected %q in help output", keyword)
 		}
@@ -273,8 +281,12 @@ func TestVerifyInstallCmd_Sign(t *testing.T) {
 	cmd := VerifyInstallCmd()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"--json", "--no-color", "--sign", keyPath})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("verify-install --sign failed: %v", err)
+	err = cmd.Execute()
+	if testRunContext() == cliutil.RunContextHost && err != nil {
+		t.Fatalf("verify-install --sign failed on host: %v", err)
+	}
+	if testRunContext() != cliutil.RunContextHost && err == nil {
+		t.Fatal("expected a non-success containment outcome outside host mode")
 	}
 
 	var report VerifyReport
@@ -366,7 +378,7 @@ func (c *mockConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *mockConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *mockConn) SetWriteDeadline(_ time.Time) error { return nil }
 
-func TestCheckNoDirectHTTP_Blocked(t *testing.T) {
+func TestCheckNoDirectHTTP_UnattributedFailureIsInconclusive(t *testing.T) {
 	env := &VerifyEnv{
 		RunCtx: cliutil.RunContextContainer,
 		DialTCP: func(_ string) (net.Conn, error) {
@@ -374,8 +386,8 @@ func TestCheckNoDirectHTTP_Blocked(t *testing.T) {
 		},
 	}
 	r := checkNoDirectHTTP(env)
-	if r.Status != verifyStatusPass {
-		t.Errorf("expected pass (blocked), got %s: %s", r.Status, r.Detail)
+	if r.Status != verifyStatusUnknown {
+		t.Errorf("expected unknown, got %s: %s", r.Status, r.Detail)
 	}
 	if r.Evidence["error"] == "" {
 		t.Error("expected error in evidence")
@@ -399,7 +411,7 @@ func TestCheckNoDirectHTTP_Exposed(t *testing.T) {
 	}
 }
 
-func TestCheckNoDirectHTTPS_Blocked(t *testing.T) {
+func TestCheckNoDirectHTTPS_UnattributedFailureIsInconclusive(t *testing.T) {
 	env := &VerifyEnv{
 		RunCtx: cliutil.RunContextPod,
 		DialTCP: func(_ string) (net.Conn, error) {
@@ -407,8 +419,8 @@ func TestCheckNoDirectHTTPS_Blocked(t *testing.T) {
 		},
 	}
 	r := checkNoDirectHTTPS(env)
-	if r.Status != verifyStatusPass {
-		t.Errorf("expected pass (blocked), got %s: %s", r.Status, r.Detail)
+	if r.Status != verifyStatusUnknown {
+		t.Errorf("expected unknown, got %s: %s", r.Status, r.Detail)
 	}
 }
 
@@ -426,7 +438,7 @@ func TestCheckNoDirectHTTPS_Exposed(t *testing.T) {
 	}
 }
 
-func TestCheckNoDirectDNS_DialBlocked(t *testing.T) {
+func TestCheckNoDirectDNS_DialFailureIsInconclusive(t *testing.T) {
 	env := &VerifyEnv{
 		RunCtx: cliutil.RunContextContainer,
 		DialUDP: func(_ string) (net.Conn, error) {
@@ -434,12 +446,12 @@ func TestCheckNoDirectDNS_DialBlocked(t *testing.T) {
 		},
 	}
 	r := checkNoDirectDNS(env)
-	if r.Status != verifyStatusPass {
-		t.Errorf("expected pass (dial blocked), got %s: %s", r.Status, r.Detail)
+	if r.Status != verifyStatusUnknown {
+		t.Errorf("expected unknown, got %s: %s", r.Status, r.Detail)
 	}
 }
 
-func TestCheckNoDirectDNS_WriteBlocked(t *testing.T) {
+func TestCheckNoDirectDNS_WriteFailureIsInconclusive(t *testing.T) {
 	env := &VerifyEnv{
 		RunCtx: cliutil.RunContextContainer,
 		DialUDP: func(_ string) (net.Conn, error) {
@@ -447,15 +459,15 @@ func TestCheckNoDirectDNS_WriteBlocked(t *testing.T) {
 		},
 	}
 	r := checkNoDirectDNS(env)
-	if r.Status != verifyStatusPass {
-		t.Errorf("expected pass (write blocked), got %s: %s", r.Status, r.Detail)
+	if r.Status != verifyStatusUnknown {
+		t.Errorf("expected unknown, got %s: %s", r.Status, r.Detail)
 	}
 	if !strings.Contains(r.Detail, "write failed") {
 		t.Errorf("expected 'write failed' detail, got: %s", r.Detail)
 	}
 }
 
-func TestCheckNoDirectDNS_NoResponse(t *testing.T) {
+func TestCheckNoDirectDNS_NoResponseIsInconclusive(t *testing.T) {
 	env := &VerifyEnv{
 		RunCtx: cliutil.RunContextPod,
 		DialUDP: func(_ string) (net.Conn, error) {
@@ -463,11 +475,11 @@ func TestCheckNoDirectDNS_NoResponse(t *testing.T) {
 		},
 	}
 	r := checkNoDirectDNS(env)
-	if r.Status != verifyStatusPass {
-		t.Errorf("expected pass (no response), got %s: %s", r.Status, r.Detail)
+	if r.Status != verifyStatusUnknown {
+		t.Errorf("expected unknown, got %s: %s", r.Status, r.Detail)
 	}
-	if !strings.Contains(r.Detail, "no response") {
-		t.Errorf("expected 'no response' detail, got: %s", r.Detail)
+	if !strings.Contains(r.Detail, "attribution") {
+		t.Errorf("expected attribution detail, got: %s", r.Detail)
 	}
 }
 
@@ -503,9 +515,12 @@ func TestVerifyStatusIcon(t *testing.T) {
 	if got := verifyStatusIcon(verifyStatusNA, false); got != " N/A" {
 		t.Errorf("expected ' N/A', got %q", got)
 	}
+	if got := verifyStatusIcon(verifyStatusUnknown, false); got != "UNKNOWN" {
+		t.Errorf("expected UNKNOWN, got %q", got)
+	}
 
 	// With color: all statuses should contain ANSI escape.
-	for _, status := range []string{verifyStatusPass, verifyStatusFail, verifyStatusNA} {
+	for _, status := range []string{verifyStatusPass, verifyStatusFail, verifyStatusNA, verifyStatusUnknown} {
 		got := verifyStatusIcon(status, true)
 		if !strings.Contains(got, "\033[") {
 			t.Errorf("expected ANSI escape in colored %s, got %q", status, got)
@@ -904,6 +919,135 @@ func TestBuildVerifyReport_ContainmentContained(t *testing.T) {
 	report := BuildVerifyReport(env, checks, "test")
 	if report.Summary.Containment != verifyContainmentContained {
 		t.Errorf("expected containment=contained, got %s", report.Summary.Containment)
+	}
+}
+
+func TestBuildVerifyReport_InconclusiveContainment(t *testing.T) {
+	env := &VerifyEnv{RunCtx: cliutil.RunContextContainer}
+	checks := []VerifyCheck{
+		{Name: "scan1", Category: verifyCatScanning, Run: func(_ *VerifyEnv) VerifyResult {
+			return VerifyResult{Status: verifyStatusPass}
+		}},
+		{Name: "contain1", Category: verifyCatContainment, Run: func(_ *VerifyEnv) VerifyResult {
+			return VerifyResult{Status: verifyStatusUnknown, Detail: "boundary attribution is unavailable"}
+		}},
+	}
+	report := BuildVerifyReport(env, checks, "test")
+	if report.Summary.Containment != verifyContainmentUnknown {
+		t.Errorf("expected containment=unknown, got %s", report.Summary.Containment)
+	}
+	if report.Summary.Unknown != 1 {
+		t.Errorf("expected 1 unknown, got %d", report.Summary.Unknown)
+	}
+	if report.Summary.Passed != 1 || report.Summary.Failed != 0 {
+		t.Errorf("summary = %+v, want 1 pass / 0 fail", report.Summary)
+	}
+}
+
+func TestBuildVerifyReport_ContainmentOutcomePrecedence(t *testing.T) {
+	env := &VerifyEnv{RunCtx: cliutil.RunContextContainer}
+	passCheck := VerifyCheck{Name: "pass", Category: verifyCatContainment, Run: func(_ *VerifyEnv) VerifyResult {
+		return VerifyResult{Status: verifyStatusPass}
+	}}
+	failCheck := VerifyCheck{Name: "fail", Category: verifyCatContainment, Run: func(_ *VerifyEnv) VerifyResult {
+		return VerifyResult{Status: verifyStatusFail}
+	}}
+	unknownCheck := VerifyCheck{Name: "unknown", Category: verifyCatContainment, Run: func(_ *VerifyEnv) VerifyResult {
+		return VerifyResult{Status: verifyStatusUnknown}
+	}}
+	unsupportedCheck := VerifyCheck{Name: "unsupported", Category: verifyCatContainment, Run: func(_ *VerifyEnv) VerifyResult {
+		return VerifyResult{Status: "future_status"}
+	}}
+	tests := []struct {
+		name        string
+		checks      []VerifyCheck
+		containment string
+		failed      int
+		unknown     int
+	}{
+		{name: "mixed pass and unknown is unknown", checks: []VerifyCheck{passCheck, unknownCheck}, containment: verifyContainmentUnknown, unknown: 1},
+		{name: "failed probe overrides unknown", checks: []VerifyCheck{failCheck, unknownCheck}, containment: verifyContainmentExposed, failed: 1, unknown: 1},
+		{name: "empty containment is unknown", containment: verifyContainmentUnknown},
+		{name: "unexpected containment status is unknown", checks: []VerifyCheck{unsupportedCheck}, containment: verifyContainmentUnknown, unknown: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report := BuildVerifyReport(env, tc.checks, "test")
+			if report.Summary.Containment != tc.containment || report.Summary.Failed != tc.failed || report.Summary.Unknown != tc.unknown {
+				t.Errorf("summary = %+v, want containment=%s failed=%d unknown=%d", report.Summary, tc.containment, tc.failed, tc.unknown)
+			}
+		})
+	}
+}
+
+func TestVerifyReportExitError(t *testing.T) {
+	tests := []struct {
+		name   string
+		report VerifyReport
+		want   int
+	}{
+		{name: "passed", report: VerifyReport{}, want: 0},
+		{name: "failed", report: VerifyReport{Summary: VerifyReportSummary{Failed: 1}}, want: 1},
+		{name: "inconclusive", report: VerifyReport{Summary: VerifyReportSummary{Unknown: 1}}, want: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyReportExitError(tc.report)
+			got := 0
+			if err != nil {
+				got = cliutil.ExitCodeOf(err)
+			}
+			if got != tc.want {
+				t.Errorf("exit code = %d, want %d (error %v)", got, tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSignVerifyReport_PreservesInconclusiveContainment(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generating signing key: %v", err)
+	}
+	report := VerifyReport{
+		Checks: []VerifyReportCheck{{
+			Name:     "no_direct_http",
+			Category: verifyCatContainment,
+			Status:   verifyStatusUnknown,
+			Detail:   "boundary attribution is unavailable",
+		}},
+		Summary: VerifyReportSummary{Containment: verifyContainmentUnknown, Unknown: 1},
+	}
+	keyPath := filepath.Join(t.TempDir(), "verify.key")
+	if err := signing.SavePrivateKey(priv, keyPath); err != nil {
+		t.Fatalf("saving signing key: %v", err)
+	}
+	if err := signVerifyReport(&report, keyPath); err != nil {
+		t.Fatalf("signing report: %v", err)
+	}
+
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshalling signed report: %v", err)
+	}
+	var decoded VerifyReport
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshalling signed report: %v", err)
+	}
+	if decoded.Summary.Containment != verifyContainmentUnknown || decoded.Summary.Unknown != 1 || decoded.Checks[0].Status != verifyStatusUnknown {
+		t.Fatalf("inconclusive report changed after JSON round trip: %+v", decoded)
+	}
+	sig, err := base64.StdEncoding.DecodeString(decoded.Signature)
+	if err != nil {
+		t.Fatalf("decoding signature: %v", err)
+	}
+	decoded.Signature = ""
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("marshalling unsigned report: %v", err)
+	}
+	if !ed25519.Verify(pub, canonical, sig) {
+		t.Fatal("signature does not verify after preserving inconclusive containment")
 	}
 }
 


### PR DESCRIPTION
## What changed

Report containment probes as unknown when the blocking cause cannot be established, preserve that result in signed and JSON output, and return a nonzero exit status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `verify-install` now distinguishes passing, failing, and inconclusive containment checks.
  * Reports identify inconclusive results and return exit code `2` when applicable.
  * Host-mode containment checks are treated as passing where direct containment checks do not apply.

* **Documentation**
  * Updated CLI documentation to explain exposure checks, unknown containment results, and inconclusive outcomes.

* **Bug Fixes**
  * Verification scoring now includes unknown checks without awarding passing credit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->