### PR TITLE
fix(mcp): record required startup decisions across transports

### DIFF
--- a/docs/guides/flight-recorder.md
+++ b/docs/guides/flight-recorder.md
@@ -114,7 +114,11 @@ TLS-intercepted CONNECT inner HTTP requests, WebSocket, reverse proxy, MCP
 stdio, and MCP HTTP. Block-path receipts stay best-effort because the action is
 already denied.
 
-Two operational notes:
+MCP startup requests (`initialize` and `tools/list`) receive correlated intent and outcome receipts. The `notifications/initialized` notification receives a durable forwarding receipt and does not claim a server response. Required recording still blocks forwarding when the recorder fails.
+
+Strict MCP recording currently supports startup, tool calls, and supported A2A methods. Other MCP methods, including resource and prompt operations, can be refused because their receipt identity is not defined. The error message distinguishes that limitation from a recorder failure; replacing the signing key does not add method support. Check the methods your client and server need before enabling strict recording.
+
+Operational notes:
 
 - **It needs a live signed recorder.** `require_receipts` has nothing to emit
   unless `enabled`, `dir`, and `signing_key_path` are all set. With no live

--- a/internal/mcp/input.go
+++ b/internal/mcp/input.go
@@ -138,6 +138,22 @@ const methodToolsCall = "tools/call"
 // methodResourcesRead is the JSON-RPC method for MCP resource reads.
 const methodResourcesRead = "resources/read"
 
+const methodNotificationsInitialized = "notifications/initialized"
+
+// isRequiredReceiptMetadataMethod reports whether method is part of the
+// ordinary MCP handshake that must receive an action identity when
+// require_receipts is enabled. tools/list has an established ActionRead
+// classification; initialize and notifications/initialized remain
+// ActionUnclassified under the existing receipt schema. None is a tool
+// invocation or envelope-bearing operation.
+func isRequiredReceiptMetadataMethod(method string) bool {
+	return method == "initialize" || method == "tools/list" || method == methodNotificationsInitialized
+}
+
+func isRequiredReceiptHandshakeNotification(method string, id json.RawMessage) bool {
+	return method == methodNotificationsInitialized && isRPCNotification(id)
+}
+
 // errPolicyBlocked is the error message returned when a tool call is denied by policy.
 const errPolicyBlocked = "pipelock: request blocked by tool call policy"
 
@@ -573,15 +589,21 @@ func ForwardScannedInput(
 			})
 		}
 
-		// Pre-generate actionID for receipt-bearing calls only. Metadata methods
-		// (tools/list, initialize) do not produce receipts, while A2A method
-		// calls use the JSON-RPC method as their receipt target.
+		// Pre-generate actionID for receipt-bearing calls. In required-receipt
+		// mode, the ordinary MCP handshake is also mediated action evidence:
+		// tools/list has the established read classification and initialize is
+		// represented by the existing unclassified action type. Neither gains an
+		// envelope because envelopes remain limited to tools/call.
 		actionID := ""
 		receiptTarget := toolCallName
-		receiptBearingMethod := verdict.Method == methodToolsCall
+		receiptBearingMethod := verdict.Method == methodToolsCall ||
+			(opts.requireReceipts() && isRequiredReceiptMetadataMethod(verdict.Method))
 		if receiptTarget == "" && IsA2AMethod(verdict.Method) {
 			receiptTarget = verdict.Method
 			receiptBearingMethod = true
+		}
+		if receiptTarget == "" && isRequiredReceiptMetadataMethod(verdict.Method) {
+			receiptTarget = verdict.Method
 		}
 		if receiptBearingMethod {
 			if pendingActionID != "" {
@@ -956,13 +978,17 @@ func ForwardScannedInput(
 					continue
 				}
 			}
-			if err := emitToolReceipt(config.ActionAllow, contractGate); err != nil {
+			receiptVerdict := config.ActionAllow
+			if isRequiredReceiptHandshakeNotification(verdict.Method, verdict.ID) {
+				receiptVerdict = config.ActionForward
+			}
+			if err := emitToolReceipt(receiptVerdict, contractGate); err != nil {
 				blockedCh <- BlockedRequest{
 					ID:             verdict.ID,
 					IsNotification: isRPCNotification(verdict.ID),
 					LogMessage:     "receipt emission failed",
 					ErrorCode:      -32007,
-					ErrorMessage:   "pipelock: receipt emission failed",
+					ErrorMessage:   requiredReceiptFailureMessage(err),
 					ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
 				}
 				continue

--- a/internal/mcp/input_require_receipts_test.go
+++ b/internal/mcp/input_require_receipts_test.go
@@ -137,6 +137,50 @@ func TestForwardScannedInput_RequireReceiptsBlocksEmissionFailure(t *testing.T) 
 	}
 }
 
+func TestForwardScannedInput_RequireReceiptsBlocksResourceReadWithoutIdentity(t *testing.T) {
+	sc := testInputScanner(t)
+	emitter, _, _, _ := newReceiptTestHarness(t)
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 1)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///notes.txt"}}`)),
+		transport.NewStdioWriter(&serverBuf),
+		&logBuf,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		nil,
+		MCPProxyOpts{
+			Scanner:         sc,
+			Transport:       transportMCPStdio,
+			ReceiptEmitter:  emitter,
+			RequireReceipts: true,
+		},
+	)
+	if serverBuf.Len() != 0 {
+		t.Fatalf("resources/read forwarded without required receipt: %s", serverBuf.String())
+	}
+	var blocked *BlockedRequest
+	for item := range blockedCh {
+		item := item
+		blocked = &item
+	}
+	if blocked == nil {
+		t.Fatal("expected resources/read to fail closed without a receipt identity")
+	}
+	if blocked.ErrorCode != -32007 {
+		t.Fatalf("error code = %d, want -32007", blocked.ErrorCode)
+	}
+	if !strings.Contains(string(blocked.ErrorData), string(blockreason.ReceiptEmissionFailed)) {
+		t.Fatalf("error data = %s, want %s", blocked.ErrorData, blockreason.ReceiptEmissionFailed)
+	}
+	if blocked.ErrorMessage != "pipelock: required receipt identity is not defined for this MCP method" {
+		t.Fatalf("error message = %q", blocked.ErrorMessage)
+	}
+}
+
 func TestForwardScannedInput_WarnRequireReceiptsDurabilityFailureDoesNotForward(t *testing.T) {
 	sc := testInputScanner(t)
 	msg := makeRequest(5, "tools/call", map[string]string{
@@ -207,6 +251,127 @@ func TestForwardScannedInput_A2ARequireReceiptsEmitsAllowReceipt(t *testing.T) {
 	}
 	if record.Target != "SendMessage" {
 		t.Fatalf("A2A allow receipt target = %q, want SendMessage", record.Target)
+	}
+}
+
+func TestForwardScannedInput_RequireReceiptsRecordsOrdinaryLifecycle(t *testing.T) {
+	sc := testInputScanner(t)
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"notes.txt"}}}`,
+	}, "\n") + "\n"
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	tracker := NewRequestTracker()
+
+	var serverBuf, logBuf bytes.Buffer
+	blockedCh := make(chan BlockedRequest, 3)
+	ForwardScannedInput(
+		transport.NewStdioReader(strings.NewReader(input)),
+		transport.NewStdioWriter(&serverBuf),
+		&logBuf,
+		config.ActionWarn,
+		config.ActionBlock,
+		blockedCh,
+		nil,
+		tracker,
+		MCPProxyOpts{
+			Scanner:         sc,
+			Transport:       transportMCPStdio,
+			ReceiptEmitter:  emitter,
+			RequireReceipts: true,
+		},
+	)
+	for blocked := range blockedCh {
+		t.Fatalf("ordinary lifecycle blocked: %+v", blocked)
+	}
+	var responseBuf bytes.Buffer
+	_, err := ForwardScanned(
+		transport.NewStdioReader(strings.NewReader(strings.Join([]string{
+			`{"jsonrpc":"2.0","id":1,"result":{}}`,
+			`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`,
+			`{"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"ok"}]}}`,
+		}, "\n")+"\n")),
+		transport.NewStdioWriter(&responseBuf),
+		&logBuf,
+		tracker,
+		MCPProxyOpts{Scanner: sc, Transport: transportMCPStdio, ReceiptEmitter: emitter},
+	)
+	if err != nil {
+		t.Fatalf("ForwardScanned: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	for _, method := range []string{"initialize", methodNotificationsInitialized, "tools/list", methodToolsCall} {
+		if !strings.Contains(serverBuf.String(), `"method":"`+method+`"`) {
+			t.Fatalf("forwarded lifecycle missing %q: %s", method, serverBuf.String())
+		}
+	}
+
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 7 {
+		t.Fatalf("receipt count = %d, want 7 lifecycle records", len(receipts))
+	}
+	want := []struct {
+		method     string
+		target     string
+		actionType receipt.ActionType
+	}{
+		{method: "initialize", target: "initialize", actionType: receipt.ActionUnclassified},
+		{method: "tools/list", target: "tools/list", actionType: receipt.ActionRead},
+		{method: methodToolsCall, target: "read_file", actionType: receipt.ActionRead},
+	}
+	intents := make(map[string]receipt.ActionRecord)
+	outcomes := make(map[string]receipt.ActionRecord)
+	var notification *receipt.ActionRecord
+	for _, signed := range receipts {
+		record := signed.ActionRecord
+		switch record.DecisionPhase {
+		case receipt.DecisionPhaseIntent:
+			intents[record.Target] = record
+		case receipt.DecisionPhaseOutcome:
+			outcomes[record.Target] = record
+		default:
+			if record.Target == methodNotificationsInitialized {
+				record := record
+				notification = &record
+			}
+		}
+	}
+	for _, tt := range want {
+		t.Run(tt.method, func(t *testing.T) {
+			record, ok := intents[tt.target]
+			if !ok {
+				t.Fatalf("missing intent for %q", tt.target)
+			}
+			if record.ActionID == "" {
+				t.Fatal("action_id is empty")
+			}
+			if record.Target != tt.target {
+				t.Fatalf("target = %q, want %q", record.Target, tt.target)
+			}
+			if record.ActionType != tt.actionType {
+				t.Fatalf("action_type = %q, want %q", record.ActionType, tt.actionType)
+			}
+		})
+	}
+	for _, tt := range want {
+		intent := intents[tt.target]
+		outcome, ok := outcomes[tt.target]
+		if !ok {
+			t.Fatalf("missing outcome for %q", tt.target)
+		}
+		if outcome.DecisionPhase != receipt.DecisionPhaseOutcome || outcome.ActionID != intent.ActionID {
+			t.Fatalf("receipt %q has no matching outcome: phase=%q action_id=%q", tt.target, outcome.DecisionPhase, outcome.ActionID)
+		}
+	}
+	if notification == nil {
+		t.Fatal("missing notifications/initialized forwarding receipt")
+	}
+	if notification.ActionID == "" || notification.Verdict != config.ActionForward || notification.DecisionPhase != "" {
+		t.Fatalf("notification receipt = %+v, want durable single-phase forward decision", *notification)
 	}
 }
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -839,7 +839,10 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			}
 		}
 	}
-	if effectiveAction == config.ActionDefer && actionID == "" && IsA2AMethod(verdict.Method) {
+	// Deferral stores its correlation ID before the receipt finalizer runs.
+	// Metadata must share that ID with the deferred receipt and its resolution.
+	if effectiveAction == config.ActionDefer && actionID == "" &&
+		(IsA2AMethod(verdict.Method) || (requireReceipts && isRequiredReceiptMetadataMethod(verdict.Method))) {
 		actionID = receipt.NewActionID()
 	}
 

--- a/internal/mcp/mcp_http_input.go
+++ b/internal/mcp/mcp_http_input.go
@@ -129,6 +129,23 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 		emitActionID := actionID
 		emitTarget := toolName
 		emitVerdict := receiptVerdict
+		if requireReceipts && result.Blocked == nil && isRequiredReceiptMetadataMethod(mcpMethod) {
+			// initialize and tools/list are ordinary mediated handshake actions.
+			// They do not carry a tool name or an envelope, but strict evidence
+			// still needs an action identity before the HTTP bridge forwards them.
+			if emitActionID == "" {
+				emitActionID = receipt.NewActionID()
+			}
+			if emitTarget == "" {
+				emitTarget = mcpMethod
+			}
+			if emitVerdict == "" {
+				emitVerdict = config.ActionAllow
+				if isRequiredReceiptHandshakeNotification(mcpMethod, frame.ID) {
+					emitVerdict = config.ActionForward
+				}
+			}
+		}
 		if IsA2AMethod(mcpMethod) {
 			if emitActionID == "" {
 				switch {
@@ -193,7 +210,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 				IsNotification: isRPCNotification(frame.ID),
 				LogMessage:     "receipt emission failed",
 				ErrorCode:      -32007,
-				ErrorMessage:   "pipelock: receipt emission failed",
+				ErrorMessage:   requiredReceiptFailureMessage(err),
 				ErrorData:      mcpBlockReasonData(blockreason.ReceiptEmissionFailed),
 			}
 			return
@@ -225,7 +242,7 @@ func scanHTTPInputDecision(msg []byte, logW io.Writer, sessionKey, auditSessionK
 			if receiptContractGate != nil {
 				outcomeReceipt = mcpWithContractReceipt(outcomeReceipt, *receiptContractGate)
 			}
-			result.Outcome = TrackedRequestOutcome{Receipt: outcomeReceipt}
+			result.Outcome = TrackedRequestOutcome{Receipt: outcomeReceipt, Method: mcpMethod}
 		}
 	}()
 	// Registered after the receipt finalizer so it runs first. A failed

--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -1599,7 +1599,12 @@ func RunHTTPListenerProxy(
 		// HTTP attachment alone does not correlate the JSON-RPC envelope. A
 		// hostile upstream can answer request 1 with result 999, or inject a
 		// concurrent request's ID, so validate the exact client request ID.
-		responseTracker := NewStrictRequestTrackerFor(frame.ID, frame.Method)
+		responseTracker := NewStrictRequestTracker()
+		outcome := decision.Outcome
+		if outcome.Method == "" {
+			outcome.Method = frame.Method
+		}
+		responseTracker.TrackOutcome(frame.ID, outcome)
 		upstreamIsSSE := transport.HasSingleSSEContentType(upResp.Header)
 		if setupState && upstreamIsSSE {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -1171,6 +1171,42 @@ func TestScanHTTPInput_PolicyOnlyBlock(t *testing.T) {
 	}
 }
 
+func TestScanHTTPInputDecision_RequiredMetadataDeferIdentity(t *testing.T) {
+	for _, method := range []string{"initialize", "tools/list", methodNotificationsInitialized} {
+		t.Run(method, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.Internal = nil
+			cfg.ResponseScanning.Patterns = []config.ResponseScanPattern{{Name: "manual-review-marker", Regex: "ordinary-review-marker"}}
+			sc := scanner.MustNew(cfg)
+			t.Cleanup(sc.Close)
+			emitter, rec, dir := newTestReceiptEmitter(t)
+			manager := deferred.NewManager(deferred.Config{Enabled: true, Timeout: time.Second, MaxPending: 4, MaxPendingPerSession: 4, MaxPendingBytes: 1024})
+			id := `,"id":1`
+			if method == methodNotificationsInitialized {
+				id = ""
+			}
+			msg := []byte(fmt.Sprintf(`{"jsonrpc":"2.0"%s,"method":%q,"params":{"note":"ordinary-review-marker"}}`, id, method))
+			decision := scanHTTPInputDecision(msg, io.Discard, "sess", "orig", MCPProxyOpts{
+				Scanner: sc, InputCfg: &InputScanConfig{Enabled: true, Action: config.ActionDefer, OnParseError: config.ActionBlock},
+				ReceiptEmitter: emitter, RequireReceipts: true, DeferManager: manager, Transport: deferred.SurfaceMCPHTTPUpstream,
+			})
+			if decision.Blocked != nil || decision.Deferred == nil {
+				t.Fatalf("expected deferred metadata, got blocked=%+v deferred=%+v", decision.Blocked, decision.Deferred)
+			}
+			if decision.Deferred.DeferID == "" {
+				t.Fatal("deferred metadata has no correlation identity")
+			}
+			if err := rec.Close(); err != nil {
+				t.Fatal(err)
+			}
+			record := findActionReceiptHTTP(t, readReceiptEntriesHTTP(t, dir)).ActionRecord
+			if record.ActionID != decision.Deferred.DeferID || record.DeferID != decision.Deferred.DeferID || record.Target != method || record.DecisionPhase != receipt.DecisionPhaseDefer {
+				t.Fatalf("receipt does not match deferred request: %+v", record)
+			}
+		})
+	}
+}
+
 func TestScanHTTPInputDecision_PolicyDeferEmitsReceipt(t *testing.T) {
 	cfg := config.Defaults()
 	cfg.Internal = nil
@@ -7771,6 +7807,9 @@ func TestHTTPListener_RequireReceiptsRecordsInitializeOutcome(t *testing.T) {
 	}
 	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent || receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
 		t.Fatalf("phases = %q/%q, want intent/outcome", receipts[0].ActionRecord.DecisionPhase, receipts[1].ActionRecord.DecisionPhase)
+	}
+	if receipts[0].ActionRecord.ActionID == "" {
+		t.Fatal("intent action_id is empty")
 	}
 	if receipts[0].ActionRecord.ActionID != receipts[1].ActionRecord.ActionID {
 		t.Fatalf("outcome action_id = %q, want %q", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)

--- a/internal/mcp/proxy_http_test.go
+++ b/internal/mcp/proxy_http_test.go
@@ -7615,6 +7615,168 @@ func TestScanHTTPInputDecision_RequireReceiptsBlocksEmissionFailure(t *testing.T
 	}
 }
 
+func TestScanHTTPInputDecision_RequireReceiptsInitializedNotification(t *testing.T) {
+	for _, closed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("recorder_closed_%t", closed), func(t *testing.T) {
+			emitter, rec, dir, _ := newReceiptTestHarness(t)
+			if closed {
+				if err := rec.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			msg := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+			decision := scanHTTPInputDecision(msg, io.Discard, "sess", "sess", MCPProxyOpts{
+				Scanner: testScannerForHTTP(t), ReceiptEmitter: emitter,
+				RequireReceipts: true, Transport: transportMCPHTTP,
+			})
+			if closed {
+				if decision.Blocked == nil || decision.Blocked.ErrorCode != -32007 {
+					t.Fatalf("unrecorded notification must be blocked: %+v", decision.Blocked)
+				}
+				return
+			}
+			if decision.Blocked != nil || !bytes.Equal(decision.ForwardMessage, msg) {
+				t.Fatalf("recorded notification was not forwarded: %+v", decision)
+			}
+			if decision.Outcome.Receipt.ActionID != "" {
+				t.Fatal("notification must not expect a response outcome")
+			}
+			if err := rec.Close(); err != nil {
+				t.Fatal(err)
+			}
+			records := receiptsByVerdict(readActionReceipts(t, dir), config.ActionForward)
+			if len(records) != 1 {
+				t.Fatalf("forward receipts = %d, want 1", len(records))
+			}
+			record := records[0].ActionRecord
+			if record.ActionID == "" || record.Target != methodNotificationsInitialized || record.DecisionPhase != "" {
+				t.Fatalf("expected identified single-phase notification receipt: %+v", record)
+			}
+		})
+	}
+}
+
+func TestScanHTTPInputDecision_RequireReceiptsRecordsHandshakeMetadata(t *testing.T) {
+	sc := testScannerForHTTP(t)
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	tests := []struct {
+		name       string
+		method     string
+		message    string
+		actionType receipt.ActionType
+	}{
+		{name: "initialize", method: "initialize", message: `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`, actionType: receipt.ActionUnclassified},
+		{name: "tools list", method: "tools/list", message: `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`, actionType: receipt.ActionRead},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := scanHTTPInputDecision([]byte(tt.message), io.Discard, "sess", "sess", MCPProxyOpts{
+				Scanner:         sc,
+				ReceiptEmitter:  emitter,
+				RequireReceipts: true,
+				Transport:       transportMCPHTTP,
+			})
+			if decision.Blocked != nil {
+				t.Fatalf("handshake request blocked: %+v", decision.Blocked)
+			}
+		})
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := receiptsByVerdict(readActionReceipts(t, dir), config.ActionAllow)
+	if len(receipts) != len(tests) {
+		t.Fatalf("allow receipts = %d, want %d", len(receipts), len(tests))
+	}
+	for i, tt := range tests {
+		record := receipts[i].ActionRecord
+		if record.ActionID == "" {
+			t.Fatalf("%s action_id is empty", tt.name)
+		}
+		if record.Target != tt.method {
+			t.Fatalf("%s receipt target = %q, want %q", tt.name, record.Target, tt.method)
+		}
+		if record.ActionType != tt.actionType {
+			t.Fatalf("%s action_type = %q, want %q", tt.name, record.ActionType, tt.actionType)
+		}
+	}
+}
+
+func TestScanHTTPInputDecision_RequireReceiptsBlocksResourceReadWithoutIdentity(t *testing.T) {
+	emitter, _, _, _ := newReceiptTestHarness(t)
+	decision := scanHTTPInputDecision(
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"file:///notes.txt"}}`),
+		io.Discard,
+		"sess",
+		"sess",
+		MCPProxyOpts{
+			Scanner:         testScannerForHTTP(t),
+			ReceiptEmitter:  emitter,
+			RequireReceipts: true,
+			Transport:       transportMCPHTTP,
+		},
+	)
+	if decision.Blocked == nil {
+		t.Fatal("expected resources/read to fail closed without a receipt identity")
+	}
+	if decision.Blocked.ErrorCode != -32007 {
+		t.Fatalf("error code = %d, want -32007", decision.Blocked.ErrorCode)
+	}
+	if decision.Blocked.ErrorMessage != "pipelock: required receipt identity is not defined for this MCP method" {
+		t.Fatalf("error message = %q", decision.Blocked.ErrorMessage)
+	}
+}
+
+func TestHTTPListener_RequireReceiptsRecordsInitializeOutcome(t *testing.T) {
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		var request struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{}}`, request.ID)
+	}))
+	defer upstream.Close()
+
+	baseURL, _ := startListenerProxyWithOpts(t, upstream.URL, MCPProxyOpts{
+		Scanner:         testScannerForHTTP(t),
+		ReceiptEmitter:  emitter,
+		RequireReceipts: true,
+		Transport:       "mcp_http_listener",
+	})
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, baseURL+"/", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("status = %d, want %d: %s", response.StatusCode, http.StatusOK, body)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent || receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("phases = %q/%q, want intent/outcome", receipts[0].ActionRecord.DecisionPhase, receipts[1].ActionRecord.DecisionPhase)
+	}
+	if receipts[0].ActionRecord.ActionID != receipts[1].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want %q", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+}
+
 func TestScanHTTPInputDecision_WarnRequireReceiptsDurabilityFailureBlocksForward(t *testing.T) {
 	sc := testScannerForHTTP(t)
 	receiptEmitter, receiptRecorder, _ := newTestReceiptEmitter(t)

--- a/internal/mcp/proxy_ws.go
+++ b/internal/mcp/proxy_ws.go
@@ -244,8 +244,12 @@ func RunWSProxy(
 		// Track request ID before forwarding for confused deputy protection.
 		// Only track requests (have "method"), not client responses to
 		// server-initiated calls, to prevent tracker pollution.
-		if isRequest(msg) {
-			tracker.TrackRequest(frame.ID, frame.Method)
+		if isTrackableRequest(msg, frame.ID) {
+			if decision.Outcome.Receipt.ActionID != "" {
+				tracker.TrackOutcome(frame.ID, decision.Outcome)
+			} else {
+				tracker.TrackRequest(frame.ID, frame.Method)
+			}
 		}
 
 		// Forward to upstream.

--- a/internal/mcp/proxy_ws_test.go
+++ b/internal/mcp/proxy_ws_test.go
@@ -192,6 +192,49 @@ func TestRunWSProxy_ForwardsCleanRequest(t *testing.T) {
 	}
 }
 
+func TestRunWSProxy_RequireReceiptsRecordsInitializeOutcome(t *testing.T) {
+	responseSent := make(chan struct{})
+	srv := wsRespondServer(t, []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`), responseSent)
+	defer srv.Close()
+	emitter, rec, dir, _ := newReceiptTestHarness(t)
+	sc := testScannerForWS(t)
+
+	pr, pw := io.Pipe()
+	var stdout, stderr lockedHTTPBuffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunWSProxy(ctx, pr, &stdout, &stderr, wsURL(srv), MCPProxyOpts{
+			Scanner:         sc,
+			ReceiptEmitter:  emitter,
+			RequireReceipts: true,
+		})
+	}()
+	_, _ = pw.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}` + "\n"))
+	waitForResponse(t, responseSent)
+	testwait.For(t, time.Second, func() bool {
+		return stdout.contains(`"id":1`)
+	}, "initialize response forwarded to stdout")
+	_ = pw.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunWSProxy: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder.Close: %v", err)
+	}
+	receipts := readActionReceipts(t, dir)
+	if len(receipts) != 2 {
+		t.Fatalf("receipt count = %d, want intent/outcome pair", len(receipts))
+	}
+	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent || receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
+		t.Fatalf("phases = %q/%q, want intent/outcome", receipts[0].ActionRecord.DecisionPhase, receipts[1].ActionRecord.DecisionPhase)
+	}
+	if receipts[0].ActionRecord.ActionID != receipts[1].ActionRecord.ActionID {
+		t.Fatalf("outcome action_id = %q, want %q", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
+	}
+}
+
 func TestRunWSProxy_ConfusedDeputy_SeededNullIDResponseBlocked(t *testing.T) {
 	responseSent := make(chan struct{})
 	srv := wsRespondServer(t, []byte(`{"jsonrpc":"2.0","id":null,"result":{"owned":"attack"}}`), responseSent)

--- a/internal/mcp/proxy_ws_test.go
+++ b/internal/mcp/proxy_ws_test.go
@@ -230,6 +230,9 @@ func TestRunWSProxy_RequireReceiptsRecordsInitializeOutcome(t *testing.T) {
 	if receipts[0].ActionRecord.DecisionPhase != receipt.DecisionPhaseIntent || receipts[1].ActionRecord.DecisionPhase != receipt.DecisionPhaseOutcome {
 		t.Fatalf("phases = %q/%q, want intent/outcome", receipts[0].ActionRecord.DecisionPhase, receipts[1].ActionRecord.DecisionPhase)
 	}
+	if receipts[0].ActionRecord.ActionID == "" {
+		t.Fatal("intent action_id is empty")
+	}
 	if receipts[0].ActionRecord.ActionID != receipts[1].ActionRecord.ActionID {
 		t.Fatalf("outcome action_id = %q, want %q", receipts[1].ActionRecord.ActionID, receipts[0].ActionRecord.ActionID)
 	}

--- a/internal/mcp/taint.go
+++ b/internal/mcp/taint.go
@@ -29,6 +29,8 @@ const (
 	taintScopeTask      = "task"
 )
 
+var errMCPReceiptIdentityUnavailable = errors.New("MCP method has no receipt identity")
+
 const (
 	mcpReceiptLayerA2A           = "mcp_a2a_scanning"
 	mcpReceiptLayerAirlock       = "mcp_airlock"
@@ -350,7 +352,7 @@ type mcpToolReceiptOpts struct {
 func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
 	if opts.ActionID == "" {
 		if opts.RequireReceipt {
-			err := fmt.Errorf("empty action id: %w", ErrReceiptRequired)
+			err := fmt.Errorf("%w for %q: %w", errMCPReceiptIdentityUnavailable, opts.MCPMethod, ErrReceiptRequired)
 			logReceiptEmitFailure(opts.Log, err, opts.RequireReceipts, opts.Verdict)
 			return err
 		}
@@ -407,6 +409,13 @@ func emitMCPToolReceipt(opts mcpToolReceiptOpts) error {
 		}
 	}
 	return nil
+}
+
+func requiredReceiptFailureMessage(err error) string {
+	if errors.Is(err, errMCPReceiptIdentityUnavailable) {
+		return "pipelock: required receipt identity is not defined for this MCP method"
+	}
+	return "pipelock: receipt emission failed"
 }
 
 func logReceiptEmitFailure(logW io.Writer, err error, requireReceipts bool, verdict string) {


### PR DESCRIPTION
## What changed

Record MCP initialization and tool-list requests with correlated outcomes, and record initialized notifications as durable forwarding decisions. Required recording failures still stop forwarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Required receipt recording now covers MCP startup requests, including initialization and tool discovery.
  - Initialization notifications receive durable forwarding receipts without implying a server response.
  - Receipt tracking preserves matching intent and outcome records across HTTP and WebSocket MCP connections.

- **Bug Fixes**
  - Strict recording clearly identifies unsupported MCP operations when receipt identity is unavailable.
  - Forwarding remains blocked when required receipt recording fails.

- **Documentation**
  - Updated the flight-recorder guide with MCP startup, supported operations, and fail-closed behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->