### PR TITLE
Accept sharded Rekor inclusion indices

### DIFF
--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -380,8 +380,11 @@ func validateRekorInclusionProof(proof Proof) error {
 	if inc.TreeSize == 0 {
 		return errors.New("rekor proof inclusion_proof.tree_size required")
 	}
-	if inc.LogIndex != proof.LogIndex {
-		return fmt.Errorf("rekor proof inclusion_proof.log_index %d does not match log_index %d", inc.LogIndex, proof.LogIndex)
+	// Rekor's entry logIndex is virtual across its shards, while the inclusion
+	// proof logIndex is relative to the shard's tree. The active-tree index
+	// therefore cannot exceed the virtual entry index, but need not equal it.
+	if inc.LogIndex > proof.LogIndex {
+		return fmt.Errorf("rekor proof inclusion_proof.log_index %d exceeds log_index %d", inc.LogIndex, proof.LogIndex)
 	}
 	if inc.LogIndex >= inc.TreeSize {
 		return fmt.Errorf("rekor proof inclusion_proof.log_index %d outside tree_size %d", inc.LogIndex, inc.TreeSize)

--- a/internal/anchor/rekor.go
+++ b/internal/anchor/rekor.go
@@ -221,6 +221,17 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if len(respBody) > rekorMaxResponseBytes {
 		return Proof{}, fmt.Errorf("read rekor response: exceeds %d bytes", rekorMaxResponseBytes)
 	}
+	if resp.StatusCode == http.StatusConflict {
+		uuid, err := rekorConflictUUID(resp.Header.Get("Location"), baseURL)
+		if err != nil {
+			return Proof{}, err
+		}
+		entry, err := r.getRekorEntry(ctx, baseURL, uuid)
+		if err != nil {
+			return Proof{}, err
+		}
+		return rekorSubmissionProof(baseURL, uuid, entry, publicKey, signature, checkpoint)
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return Proof{}, fmt.Errorf("rekor submit status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
@@ -228,6 +239,41 @@ func (r RekorLog) Submit(checkpoint Checkpoint) (Proof, error) {
 	if err != nil {
 		return Proof{}, err
 	}
+	return rekorSubmissionProof(baseURL, uuid, entry, publicKey, signature, checkpoint)
+}
+
+func (r RekorLog) getRekorEntry(ctx context.Context, baseURL, uuid string) (rekorEntry, error) {
+	entryURL, err := rekorEntryURL(baseURL, uuid)
+	if err != nil {
+		return rekorEntry{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, entryURL, nil)
+	if err != nil {
+		return rekorEntry{}, fmt.Errorf("build rekor conflict recovery request: %w", err)
+	}
+	resp, err := clientWithoutRedirects(r.HTTPClient).Do(req)
+	if err != nil {
+		return rekorEntry{}, fmt.Errorf("retrieve rekor conflict entry %q: %w", uuid, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, rekorMaxResponseBytes+1))
+	if err != nil {
+		return rekorEntry{}, fmt.Errorf("read rekor conflict entry %q: %w", uuid, err)
+	}
+	if len(respBody) > rekorMaxResponseBytes {
+		return rekorEntry{}, fmt.Errorf("read rekor conflict entry %q: exceeds %d bytes", uuid, rekorMaxResponseBytes)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return rekorEntry{}, fmt.Errorf("retrieve rekor conflict entry %q status %d: %s", uuid, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	entry, _, err := decodeRekorEntry(respBody)
+	if err != nil {
+		return rekorEntry{}, fmt.Errorf("parse rekor conflict entry %q: %w", uuid, err)
+	}
+	return entry, nil
+}
+
+func rekorSubmissionProof(baseURL, uuid string, entry rekorEntry, publicKey, signature string, checkpoint Checkpoint) (Proof, error) {
 	if uuid == "" {
 		return Proof{}, errors.New("rekor response UUID required")
 	}
@@ -1091,6 +1137,59 @@ func rekorEntriesURL(raw string) (string, error) {
 	base.RawQuery = ""
 	base.Fragment = ""
 	return base.String(), nil
+}
+
+func rekorEntryURL(baseURL, uuid string) (string, error) {
+	if !isRekorUUID(uuid) {
+		return "", fmt.Errorf("invalid rekor entry UUID %q", uuid)
+	}
+	entriesURL, err := rekorEntriesURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	return entriesURL + "/" + strings.ToLower(uuid), nil
+}
+
+// rekorConflictUUID extracts the pre-existing entry handle from Rekor's
+// documented conflict Location header. The error response message is not a
+// stable API field, so recovery must never infer an entry UUID from its text.
+func rekorConflictUUID(location, baseURL string) (string, error) {
+	if strings.TrimSpace(location) == "" {
+		return "", errors.New("rekor submit conflict has no entry Location header; the entry may already be committed, so retrieve its UUID from Rekor and retry")
+	}
+	locationURL, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("parse rekor conflict Location header: %w", err)
+	}
+	entriesURL, err := rekorEntriesURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	entries, err := url.Parse(entriesURL)
+	if err != nil {
+		return "", fmt.Errorf("parse rekor entries URL: %w", err)
+	}
+	resolved := entries.ResolveReference(locationURL)
+	if resolved.Scheme != entries.Scheme || resolved.Host != entries.Host || resolved.RawQuery != "" || resolved.Fragment != "" {
+		return "", errors.New("rekor submit conflict Location header does not identify an entry on the configured log")
+	}
+	prefix := strings.TrimRight(entries.Path, "/") + "/"
+	if !strings.HasPrefix(resolved.Path, prefix) {
+		return "", errors.New("rekor submit conflict Location header does not identify a log entry")
+	}
+	uuid := strings.TrimPrefix(resolved.Path, prefix)
+	if strings.Contains(uuid, "/") || !isRekorUUID(uuid) {
+		return "", errors.New("rekor submit conflict Location header has an invalid entry UUID")
+	}
+	return strings.ToLower(uuid), nil
+}
+
+func isRekorUUID(uuid string) bool {
+	if len(uuid) != 64 && len(uuid) != 80 {
+		return false
+	}
+	_, err := hex.DecodeString(uuid)
+	return err == nil
 }
 
 func decodeRekorEntry(data []byte) (rekorEntry, string, error) {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -91,6 +92,270 @@ func TestRekorLogSubmitRecordsSubmissionProof(t *testing.T) {
 	report = VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}})
 	if !report.Valid {
 		t.Fatalf("VerifyBundle with trusted Rekor key invalid: %s", report.Error)
+	}
+}
+
+func TestRekorLogSubmitRecoversConflictByRetrievingExistingEntry(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 2)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	freshServer, logPub := fakeTrustedRekorServer(t)
+	fresh, err := (RekorLog{URL: freshServer.URL, Signer: signer}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("fresh Submit: %v", err)
+	}
+	const uuid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	entry := rekorEntryFromProof(fresh)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/log/entries":
+			w.Header().Set("Location", server.URL+"/api/v1/log/entries/"+uuid)
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"code":409,"message":"an equivalent entry already exists"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/log/entries/"+uuid:
+			_ = json.NewEncoder(w).Encode(entry)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	recovered, err := (RekorLog{URL: server.URL, Signer: signer}).Submit(checkpoint)
+	if err != nil {
+		t.Fatalf("recover Submit: %v", err)
+	}
+	want := fresh
+	want.Rekor = cloneRekorProof(fresh.Rekor)
+	want.Rekor.URL = server.URL
+	want.Rekor.UUID = uuid
+	if !reflect.DeepEqual(recovered, want) {
+		t.Fatalf("recovered proof = %+v, want fresh proof %+v", recovered, want)
+	}
+	if report := VerifyBundle(NewBundle(checkpoint, recovered), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{logPub}}); !report.Valid {
+		t.Fatalf("recovered bundle invalid: %s", report.Error)
+	}
+}
+
+func TestRekorLogSubmitConflictWithoutEntryLocationFailsCleanly(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("{"))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err = (RekorLog{URL: server.URL, Signer: signer}).Submit(checkpoint)
+	if err == nil || !strings.Contains(err.Error(), "no entry Location header") {
+		t.Fatalf("Submit error = %v, want actionable missing Location error", err)
+	}
+}
+
+func TestRekorLogSubmitConflictMissingEntryFails(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	const uuid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set("Location", server.URL+"/api/v1/log/entries/"+uuid)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err = (RekorLog{URL: server.URL, Signer: signer}).Submit(checkpoint)
+	if err == nil || !strings.Contains(err.Error(), "retrieve rekor conflict entry") || !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("Submit error = %v, want missing conflict entry error", err)
+	}
+}
+
+func TestRekorLogSubmitDoesNotRecoverOtherClientErrors(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var getCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getCalls++
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":400,"message":"invalid entry"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err = (RekorLog{URL: server.URL, Signer: signer}).Submit(checkpoint)
+	if err == nil || !strings.Contains(err.Error(), "rekor submit status 400") {
+		t.Fatalf("Submit error = %v, want ordinary client error", err)
+	}
+	if getCalls != 0 {
+		t.Fatalf("GET calls = %d, want 0 for non-conflict client error", getCalls)
+	}
+}
+
+func TestRekorLogSubmitConflictRejectsDifferentCheckpoint(t *testing.T) {
+	receipts, keyHex := testReceiptChain(t, 1)
+	checkpoint, err := BuildCheckpoint("proxy", receipts, []string{keyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	otherReceipts, otherKeyHex := testReceiptChain(t, 2)
+	otherCheckpoint, err := BuildCheckpoint("proxy", otherReceipts, []string{otherKeyHex})
+	if err != nil {
+		t.Fatalf("BuildCheckpoint other: %v", err)
+	}
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	freshServer, _ := fakeTrustedRekorServer(t)
+	otherProof, err := (RekorLog{URL: freshServer.URL, Signer: signer}).Submit(otherCheckpoint)
+	if err != nil {
+		t.Fatalf("other checkpoint Submit: %v", err)
+	}
+	const uuid = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	entry := rekorEntryFromProof(otherProof)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost:
+			w.Header().Set("Location", server.URL+"/api/v1/log/entries/"+uuid)
+			w.WriteHeader(http.StatusConflict)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/log/entries/"+uuid:
+			_ = json.NewEncoder(w).Encode(entry)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err = (RekorLog{URL: server.URL, Signer: signer}).Submit(checkpoint)
+	if err == nil || !strings.Contains(err.Error(), "checkpoint digest") {
+		t.Fatalf("Submit error = %v, want checkpoint binding rejection", err)
+	}
+}
+
+func TestRekorConflictUUIDAcceptsOnlyConfiguredLogEntryLocation(t *testing.T) {
+	const (
+		baseURL = "https://rekor.vendor.example"
+		uuid    = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	)
+	validLocation := baseURL + "/api/v1/log/entries/" + uuid
+	got, err := rekorConflictUUID(validLocation, baseURL)
+	if err != nil {
+		t.Fatalf("rekorConflictUUID valid location: %v", err)
+	}
+	if got != uuid {
+		t.Fatalf("rekorConflictUUID = %q, want %q", got, uuid)
+	}
+	for _, location := range []string{
+		"%",
+		"https://other.vendor.example/api/v1/log/entries/" + uuid,
+		baseURL + "/not-an-entry/" + uuid,
+		baseURL + "/api/v1/log/entries/not-a-uuid",
+		baseURL + "/api/v1/log/entries/" + uuid + "?redirect=elsewhere",
+	} {
+		if _, err := rekorConflictUUID(location, baseURL); err == nil {
+			t.Fatalf("rekorConflictUUID(%q) succeeded, want rejection", location)
+		}
+	}
+}
+
+func TestRekorEntryURL(t *testing.T) {
+	const (
+		baseURL = "https://rekor.vendor.example"
+		uuid    = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	)
+	got, err := rekorEntryURL(baseURL, uuid)
+	if err != nil {
+		t.Fatalf("rekorEntryURL: %v", err)
+	}
+	want := baseURL + "/api/v1/log/entries/" + uuid
+	if got != want {
+		t.Fatalf("rekorEntryURL = %q, want %q", got, want)
+	}
+	if _, err := rekorEntryURL(baseURL, "not-a-uuid"); err == nil {
+		t.Fatal("rekorEntryURL accepted malformed UUID")
+	}
+	if _, err := rekorEntryURL(baseURL+"?unexpected=query", uuid); err == nil {
+		t.Fatal("rekorEntryURL accepted a non-canonical base URL")
+	}
+}
+
+func TestRekorLogGetConflictEntryFailures(t *testing.T) {
+	const uuid = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if _, err := (RekorLog{}).getRekorEntry(context.Background(), "https://rekor.vendor.example", "not-a-uuid"); err == nil {
+		t.Fatal("getRekorEntry accepted malformed UUID")
+	}
+	for _, tc := range []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{name: "malformed entry", body: []byte("{"), want: "parse rekor conflict entry"},
+		{name: "oversize entry", body: bytes.Repeat([]byte("x"), rekorMaxResponseBytes+1), want: "exceeds"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(tc.body)
+			}))
+			t.Cleanup(server.Close)
+			_, err := (RekorLog{}).getRekorEntry(context.Background(), server.URL, uuid)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("getRekorEntry error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name   string
+		client *http.Client
+		want   string
+	}{
+		{name: "transport", client: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network unavailable")
+		})}, want: "network unavailable"},
+		{name: "body read", client: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: errorReadCloser{err: errors.New("read failed")}}, nil
+		})}, want: "read failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := (RekorLog{HTTPClient: tc.client}).getRekorEntry(context.Background(), "https://rekor.vendor.example", uuid)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("getRekorEntry error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -1312,6 +1577,25 @@ func fakeRekorServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	server, _ := fakeTrustedRekorServer(t)
 	return server
+}
+
+func rekorEntryFromProof(proof Proof) rekorEntry {
+	return rekorEntry{
+		LogID:          proof.LogID,
+		LogIndex:       proof.LogIndex,
+		IntegratedTime: proof.Rekor.IntegratedTime,
+		Body:           proof.Rekor.Body,
+		Verification: rekorVerification{
+			SignedEntryTimestamp: proof.Rekor.SignedEntryTimestamp,
+			InclusionProof: rekorInclusionProof{
+				RootHash:   proof.Rekor.InclusionProof.RootHash,
+				LogIndex:   proof.Rekor.InclusionProof.LogIndex,
+				TreeSize:   proof.Rekor.InclusionProof.TreeSize,
+				Hashes:     append([]string(nil), proof.Rekor.InclusionProof.Hashes...),
+				Checkpoint: proof.Rekor.InclusionProof.Checkpoint,
+			},
+		},
+	}
 }
 
 func fakeTrustedRekorServer(t *testing.T) (*httptest.Server, ed25519.PublicKey) {

--- a/internal/anchor/rekor_test.go
+++ b/internal/anchor/rekor_test.go
@@ -578,10 +578,10 @@ func TestRekorSubmissionRecordRequiresMetadata(t *testing.T) {
 		{name: "set whitespace", edit: func(p *Proof) { p.Rekor.SignedEntryTimestamp = " \t" }, want: "signed_entry_timestamp"},
 		{name: "inclusion proof", edit: func(p *Proof) { p.Rekor.InclusionProof = nil }, want: "inclusion_proof"},
 		{name: "inclusion root mismatch", edit: func(p *Proof) { p.Rekor.InclusionProof.RootHash = strings.Repeat("0", 64) }, want: "root_hash"},
-		{name: "inclusion log index mismatch", edit: func(p *Proof) {
+		{name: "inclusion index exceeds entry index", edit: func(p *Proof) {
 			p.Rekor.InclusionProof.TreeSize = 2
 			p.Rekor.InclusionProof.LogIndex = 1
-		}, want: "log_index"},
+		}, want: "exceeds log_index"},
 		{name: "inclusion tree size", edit: func(p *Proof) { p.Rekor.InclusionProof.TreeSize = 0 }, want: "tree_size"},
 		{name: "inclusion checkpoint", edit: func(p *Proof) { p.Rekor.InclusionProof.Checkpoint = "" }, want: "checkpoint"},
 		{name: "inclusion root hash short", edit: func(p *Proof) {
@@ -754,6 +754,49 @@ func TestRekorLogVerifyRejectsForgedSelfConsistentProof(t *testing.T) {
 	report := VerifyBundle(NewBundle(checkpoint, proof), receipts, []string{keyHex}, RekorLog{TrustedLogKeys: []crypto.PublicKey{trustedLogPub}})
 	if report.Valid || !strings.Contains(report.Error, "signed_entry_timestamp") {
 		t.Fatalf("forged Rekor proof report = %+v, want SET verification failure", report)
+	}
+}
+
+func TestRekorLogVerifyAcceptsShardedEntryIndex(t *testing.T) {
+	checkpoint, entrySigner := securityRekorCheckpoint(t)
+	logPublic, logSigner, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey log: %v", err)
+	}
+	proof := selfConsistentRekorProof(t, checkpoint, entrySigner, logSigner)
+
+	bodyBytes, err := base64.StdEncoding.DecodeString(proof.Rekor.Body)
+	if err != nil {
+		t.Fatalf("DecodeString body: %v", err)
+	}
+	const retiredShardEntries = uint64(121_904_262)
+	activeTreeIndex := uint64(1)
+	sibling := rfc6962LeafHash([]byte("another active-shard leaf"))
+	root := rfc6962NodeHash(sibling, rfc6962LeafHash(bodyBytes))
+	proof.LogIndex = retiredShardEntries + activeTreeIndex
+	proof.LogRootHash = hex.EncodeToString(root)
+	proof.Rekor.InclusionProof.RootHash = proof.LogRootHash
+	proof.Rekor.InclusionProof.LogIndex = activeTreeIndex
+	proof.Rekor.InclusionProof.TreeSize = 2
+	proof.Rekor.InclusionProof.Hashes = []string{hex.EncodeToString(sibling)}
+	proof.Rekor.InclusionProof.Checkpoint = signedCheckpointForTest(t, 2, root, logSigner)
+	proof.Rekor.SignedEntryTimestamp = signedEntryTimestampForTest(t, proof.LogID, proof.LogIndex, proof.Rekor.Body, logSigner)
+
+	if err := validateRekorSubmissionRecord(proof, checkpoint); err != nil {
+		t.Fatalf("validate sharded submission record: %v", err)
+	}
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPublic}}).Verify(proof, checkpoint); err != nil {
+		t.Fatalf("Verify sharded proof: %v", err)
+	}
+
+	corrupted := proof
+	corrupted.Rekor = cloneRekorProof(proof.Rekor)
+	corrupted.Rekor.InclusionProof.LogIndex = 0
+	if err := validateRekorSubmissionRecord(corrupted, checkpoint); err != nil {
+		t.Fatalf("validate wrong active-tree index: %v", err)
+	}
+	if err := (RekorLog{TrustedLogKeys: []crypto.PublicKey{logPublic}}).Verify(corrupted, checkpoint); err == nil || !strings.Contains(err.Error(), "computed root does not match proof root") {
+		t.Fatalf("Verify wrong active-tree index error = %v, want RFC 6962 root mismatch", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Two fixes to Rekor anchoring, both found by anchoring a real receipt chain to a public transparency log rather than a self-hosted one.

Anchor proof validation required the Rekor entry's log index to equal the inclusion proof's log index. Those are different quantities on a log that has rotated shards: the entry index counts across every shard the log has had, while the inclusion proof index is relative to the current tree. Anchoring to such a log failed after the entry had already been accepted, and the same validation runs during offline verification, so bundles from those logs could not be verified either. Validation now requires the tree-relative index not to exceed the entry index, which holds for both shapes. The inclusion proof still carries the proof: the RFC 6962 computation binds the entry to the signed root, and a test asserting the old equality is replaced by one that perturbs the inclusion index and shows the root computation rejects it.

A transparency log deduplicates by entry content, so resubmitting a checkpoint returns a conflict and the log will never accept that entry again. Submission treated that as a failure and wrote no bundle, which left an operator with a committed public entry and no proof of it after a crash, a network failure, or a retry. Submission now recovers the existing entry through the conflict response's documented entry location, restricted to an entry URL on the configured log, and carries it through the same validation and proof construction a fresh submission uses. That validation binds the returned entry to the submitted checkpoint and signer, so a recovered entry cannot stand in for a different one. Other client errors are unchanged and there is no retry loop.
