### PR TITLE
fix(conductor): require a verifiable follower version

### DIFF
--- a/enterprise/conductor/applycache/cache.go
+++ b/enterprise/conductor/applycache/cache.go
@@ -79,18 +79,6 @@ type verifyOptions struct {
 	LocalVersion  string
 	Now           func() time.Time
 	AllowRollback bool
-	// RequireProvenVersion makes a follower that cannot prove its own version
-	// refuse a bundle declaring min_pipelock, instead of accepting it.
-	//
-	// It defaults to false, which keeps the behavior fleet policy delivery has
-	// always had. Release binaries report a version and are compared strictly
-	// either way, so this only decides what an unversioned build does, and for
-	// those the alternative is applying no policy at all. A follower that
-	// silently enforces nothing is the worse failure and is the one this
-	// project has already been bitten by. It is a field rather than a literal
-	// so the choice is named at the call site and an operator-facing strict
-	// mode has somewhere to attach.
-	RequireProvenVersion bool
 }
 
 type Cache struct {
@@ -490,20 +478,11 @@ func verifyBundle(now time.Time, bundle conductor.PolicyBundle, opts verifyOptio
 	if err := bundle.ValidateForFollower(opts.Identity.OrgID, opts.Identity.FleetID, opts.Identity.InstanceID, opts.Identity.Labels); err != nil {
 		return err
 	}
-	if strings.TrimSpace(opts.LocalVersion) != "" {
-		// allowUnversioned is true here on purpose: the refusal added for RULE
-		// bundles is deliberately not extended to fleet policy delivery. A
-		// release binary reports a version and is checked strictly, exactly as
-		// before. Only a build that cannot prove its version is affected, and
-		// for those the choice is between accepting policy it may not fully
-		// support and applying NO policy at all. A follower that silently
-		// enforces nothing is the worse failure, and it is the one this project
-		// has already been burned by twice. This preserves the behavior on
-		// main, where a development build satisfied min_pipelock; it does not
-		// open a new gap.
-		if err := rules.CheckMinPipelock(bundle.MinPipelockVersion, opts.LocalVersion, !opts.RequireProvenVersion); err != nil {
-			return fmt.Errorf("%w: %w", ErrUnsupportedMinVersion, err)
+	if err := rules.CheckMinPipelock(bundle.MinPipelockVersion, opts.LocalVersion, false); err != nil {
+		if errors.Is(err, rules.ErrUnverifiableVersion) {
+			return fmt.Errorf("%w: %w: follower version %q cannot verify policy minimum %q; install a released binary that meets the minimum", ErrUnsupportedMinVersion, rules.ErrUnverifiableVersion, opts.LocalVersion, bundle.MinPipelockVersion)
 		}
+		return fmt.Errorf("%w: follower version %q cannot satisfy policy minimum %q; install a released binary that meets the minimum: %w", ErrUnsupportedMinVersion, opts.LocalVersion, bundle.MinPipelockVersion, err)
 	}
 	return nil
 }

--- a/enterprise/conductor/applycache/cache_integrity_test.go
+++ b/enterprise/conductor/applycache/cache_integrity_test.go
@@ -8,6 +8,7 @@ package applycache
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/luckyPipewrench/pipelock/enterprise/conductor"
+	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/signing"
 )
 
@@ -924,6 +926,73 @@ func TestUnsupportedMinVersionRejected(t *testing.T) {
 	opts.LocalVersion = "1.2.3"
 	if _, err := cache.storeVerified(bundle, opts); !errors.Is(err, ErrUnsupportedMinVersion) {
 		t.Fatalf("storeVerified(min version) = %v, want ErrUnsupportedMinVersion", err)
+	}
+}
+
+func TestMinPipelockVersionRequiresVerifiableFollowerVersion(t *testing.T) {
+	key := newTestKey(t)
+	cases := []struct {
+		name         string
+		minVersion   string
+		localVersion string
+		wantErr      bool
+	}{
+		{name: "minimum with absent local version", minVersion: "1.2.3", wantErr: true},
+		{name: "minimum with blank local version", minVersion: "1.2.3", localVersion: "  ", wantErr: true},
+		{name: "minimum with development version", minVersion: "1.2.3", localVersion: "0.0.0-dev.unknown", wantErr: true},
+		{name: "minimum with malformed local version", minVersion: "1.2.3", localVersion: "not-a-version", wantErr: true},
+		{name: "minimum with supported local version", minVersion: "1.2.3", localVersion: "1.2.3"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := openTestCache(t)
+			prior := signedTestBundle(t, key, "bundle-prior", 1, "")
+			verified, seedErr := cache.storeVerified(prior, testVerifyOptions(key))
+			if seedErr != nil {
+				t.Fatalf("seed active bundle: %v", seedErr)
+			}
+			bundle := signedTestBundle(t, key, "bundle-2", 2, verified.BundleHash)
+			bundle.MinPipelockVersion = tc.minVersion
+			bundle.Signatures = []conductor.SignatureProof{signProof(t, key, bundle.SignablePreimage)}
+			reloadCalled := false
+			boundary := Boundary{
+				Cache:        cache,
+				Identity:     testIdentity(),
+				Resolver:     testResolver(key),
+				LocalVersion: tc.localVersion,
+				Now:          func() time.Time { return testNow },
+				Reload: func(*config.Config) error {
+					reloadCalled = true
+					return nil
+				},
+			}
+
+			_, err := boundary.Apply(bundle, ApplyOptions{})
+			if got := errors.Is(err, ErrUnsupportedMinVersion); got != tc.wantErr {
+				t.Fatalf("Apply() unsupported minimum error = %v, want %v (err = %v)", got, tc.wantErr, err)
+			}
+			if err != nil && strings.Contains(err.Error(), "allow_unversioned_bundle_load") {
+				t.Fatalf("Apply() recommends a rule-bundle setting that fleet apply does not read: %v", err)
+			}
+			if tc.wantErr {
+				for _, want := range []string{fmt.Sprintf("%q", tc.localVersion), fmt.Sprintf("%q", tc.minVersion), "install a released binary"} {
+					if err == nil || !strings.Contains(err.Error(), want) {
+						t.Fatalf("Apply() error = %v, missing guidance %q", err, want)
+					}
+				}
+				active, activeErr := cache.Active()
+				if activeErr != nil {
+					t.Fatalf("read retained active bundle: %v", activeErr)
+				}
+				if active.BundleHash != verified.BundleHash {
+					t.Fatalf("rejected apply changed active bundle: got %s, want %s", active.BundleHash, verified.BundleHash)
+				}
+			}
+			if reloadCalled == tc.wantErr {
+				t.Fatalf("Reload called = %v, want %v", reloadCalled, !tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/enterprise/conductor/applycache/policy_hash_ordering_test.go
+++ b/enterprise/conductor/applycache/policy_hash_ordering_test.go
@@ -36,8 +36,9 @@ func TestVerifyBundleSignatureGateRunsBeforePolicyHashTolerance(t *testing.T) {
 	// Sanity: as signed, this bundle verifies. Otherwise the negative case below
 	// could pass for an unrelated reason.
 	if err := verifyBundle(testNow, bundle, verifyOptions{
-		Resolver: testResolver(key),
-		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		Resolver:     testResolver(key),
+		Identity:     Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		LocalVersion: "1.2.3",
 	}); err != nil {
 		t.Fatalf("verifyBundle(as signed) = %v, want nil", err)
 	}
@@ -50,8 +51,9 @@ func TestVerifyBundleSignatureGateRunsBeforePolicyHashTolerance(t *testing.T) {
 	// The policy_hash is now tolerated, but provenance is broken, so the
 	// signature gate must refuse it.
 	if err := verifyBundle(testNow, bundle, verifyOptions{
-		Resolver: testResolver(key),
-		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		Resolver:     testResolver(key),
+		Identity:     Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		LocalVersion: "1.2.3",
 	}); err == nil {
 		t.Fatal("verifyBundle(tolerated policy_hash, broken signature) = nil, want error")
 	}
@@ -74,8 +76,9 @@ func TestVerifyBundleAcceptsForeignPolicyHashWhenProperlySigned(t *testing.T) {
 		t.Fatalf("PolicyHashStatus() = %q, want %q", status, conductor.PolicyHashUnknownUnverified)
 	}
 	if err := verifyBundle(testNow, bundle, verifyOptions{
-		Resolver: testResolver(key),
-		Identity: Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		Resolver:     testResolver(key),
+		Identity:     Identity{OrgID: "org-1", FleetID: "fleet-1", InstanceID: "instance-1"},
+		LocalVersion: "1.2.3",
 	}); err != nil {
 		t.Fatalf("verifyBundle(properly signed, unreproducible policy_hash) = %v, want nil", err)
 	}

--- a/internal/cli/runtime/conductor_test.go
+++ b/internal/cli/runtime/conductor_test.go
@@ -1281,6 +1281,11 @@ func newConductorApplyTestServer(t *testing.T) (*Server, runtimePolicySigner) {
 	// conductor.enabled triggers the fleet-license gate; install a real
 	// Enterprise token for the test so the production gate path is exercised.
 	setTestFleetLicense(t)
+	// This serial fixture models a released follower. Restore after server
+	// cleanup so other runtime tests retain the unstamped development version.
+	previousVersion := cliutil.Version
+	cliutil.Version = "1.0.0"
+	t.Cleanup(func() { cliutil.Version = previousVersion })
 	tmp, err := os.MkdirTemp(".", ".runtime-conductor-apply-*")
 	if err != nil {
 		t.Fatalf("MkdirTemp: %v", err)


### PR DESCRIPTION
## What changed
Require a verifiable follower version before applying a policy bundle with a minimum version, retaining the active policy when verification fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minimum version policies are now consistently enforced for bundle application.
  * Bundles with missing, blank, development, or malformed follower versions are rejected with clearer error messages.
  * Successful bundle applications continue to trigger reloads, while rejected applications do not.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->