### PR TITLE
fix(review): run discovery at high reasoning with a matching budget

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -34,6 +34,14 @@ DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
 # candidate, never add one, so anything this phase misses is invisible and the
 # run still publishes as clean. That is the fail-open direction, which is why
 # the cheap phase is the wrong place to economize.
+#
+# Higher effort costs wall-clock, and a chunk that outruns DEFAULT_LLM_TIMEOUT_SECONDS
+# is the availability risk this trades against. It fails in the safe direction:
+# a timed-out chunk sets timed_out, derive_state turns that into `partial`, and
+# the workflow's completeness gate fails the run, so a slow discovery pass shows
+# up as a red review rather than a clean one. Raise the timeout from observed
+# partials, not preemptively; it is reserved at twice its value per call against
+# REVIEW_WALL_CLOCK_SECONDS, so raising it alone buys depth by dropping chunks.
 FAST_REASONING_EFFORT = "high"
 DEEP_REASONING_EFFORT = "xhigh"
 JUDGE_REASONING_EFFORT = "high"
@@ -97,7 +105,7 @@ DEEP_MAX_CHUNKS = 8
 # at high reasoning, so the number is deliberately unchanged here rather than
 # raised on an assumption. Raise it only from observed default-mode runs. Deep
 # mode can take a materially larger slice: the observed 321-unit PR then needs
-# six chunks instead of being capped at 160 units before the token budget is
+# six chunks instead of being capped at 180 units before the token budget is
 # even considered.
 FAST_MAX_UNITS_PER_CHUNK = 30
 DEEP_MAX_UNITS_PER_CHUNK = 60

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -30,10 +30,18 @@ import requests
 
 DEFAULT_MODEL_FAST = "gpt-5.6-luna"
 DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
-FAST_REASONING_EFFORT = "low"
+# Discovery recall bounds the entire review: the judge can only keep or drop a
+# candidate, never add one, so anything this phase misses is invisible and the
+# run still publishes as clean. That is the fail-open direction, which is why
+# the cheap phase is the wrong place to economize.
+FAST_REASONING_EFFORT = "high"
 DEEP_REASONING_EFFORT = "xhigh"
 JUDGE_REASONING_EFFORT = "high"
-DEFAULT_MAX_COMPLETION_TOKENS = 8_192
+# Reasoning tokens consume the same output allowance as the findings JSON, and
+# discovery now runs at high reasoning, so the former 8K cap could expire before
+# a single finding was emitted and publish that as a clean review. This mirrors
+# the judge cap below, which was raised for exactly this reason.
+DEFAULT_MAX_COMPLETION_TOKENS = 32_768
 DEEP_MAX_COMPLETION_TOKENS = 64_000
 # Reasoning tokens consume the same output allowance as the compact JSON
 # decision. Deep judge calls use xhigh reasoning, so the 8K discovery cap can
@@ -84,10 +92,13 @@ FAST_INPUT_TOKEN_BUDGET = 12_000
 DEEP_INPUT_TOKEN_BUDGET = 48_000
 FAST_MAX_CHUNKS = 6
 DEEP_MAX_CHUNKS = 8
-# Keep a default review small enough for a low-reasoning model to hold the
-# relationships in one call. Deep mode can take a materially larger slice: the
-# observed 321-unit PR then needs six chunks instead of being capped at 160
-# units before the token budget is even considered.
+# Keep a default review small enough to hold the relationships in one call.
+# This bound was originally sized for low-reasoning discovery; discovery now runs
+# at high reasoning, so the number is deliberately unchanged here rather than
+# raised on an assumption. Raise it only from observed default-mode runs. Deep
+# mode can take a materially larger slice: the observed 321-unit PR then needs
+# six chunks instead of being capped at 160 units before the token budget is
+# even considered.
 FAST_MAX_UNITS_PER_CHUNK = 30
 DEEP_MAX_UNITS_PER_CHUNK = 60
 # Each judge context fetch allows 30 seconds, so an unbounded candidate set

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -240,7 +240,7 @@ jobs:
             esac
           done <<< "${body}"
           case "${REVIEW_MODE}" in
-            default) profile_pattern='^\*\*Review profile:\*\* `default` with `[A-Za-z0-9._:/-]+` \(`low` reasoning\); candidate judge `[A-Za-z0-9._:/-]+` \(`high` reasoning\)\.$' ;;
+            default) profile_pattern='^\*\*Review profile:\*\* `default` with `[A-Za-z0-9._:/-]+` \(`high` reasoning\); candidate judge `[A-Za-z0-9._:/-]+` \(`high` reasoning\)\.$' ;;
             deep) profile_pattern='^\*\*Review profile:\*\* `deep` with `[A-Za-z0-9._:/-]+` \(`xhigh` reasoning\)\.$' ;;
             *) profile_pattern='a^' ;;
           esac

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2163,13 +2163,30 @@ class WallClockBudgetTest(unittest.TestCase):
 
 
 class FailureDirectionTest(unittest.TestCase):
-    def test_default_uses_fast_discovery_and_stronger_candidate_judgment(self) -> None:
+    def test_default_uses_cheaper_discovery_model_and_stronger_candidate_judgment(self) -> None:
         self.assertEqual(pr_review.model_for_phase("default", "review-chunk-1"), "gpt-5.6-luna")
-        self.assertEqual(pr_review.reasoning_for_phase("default", "review-chunk-1"), "low")
+        self.assertEqual(pr_review.reasoning_for_phase("default", "review-chunk-1"), "high")
         self.assertEqual(pr_review.model_for_phase("default", "judge"), "gpt-5.6-terra")
         self.assertEqual(pr_review.reasoning_for_phase("default", "judge"), "high")
         self.assertEqual(pr_review.model_for_phase("deep", "judge"), "gpt-5.6-terra")
         self.assertEqual(pr_review.reasoning_for_phase("deep", "judge"), "xhigh")
+
+    def test_discovery_output_budget_covers_its_reasoning_effort(self) -> None:
+        """Reasoning tokens are drawn from the same allowance as the findings JSON.
+
+        Raising discovery effort without raising this cap lets the call expire
+        before it emits a single finding, and an empty discovery pass publishes
+        as a clean review rather than as a failure. That is the fail-open
+        direction, so the two constants have to move together.
+        """
+        discovery_effort = pr_review.reasoning_for_phase("default", "review-chunk-1")
+        if discovery_effort in {"high", "xhigh"}:
+            self.assertGreaterEqual(
+                pr_review.DEFAULT_MAX_COMPLETION_TOKENS,
+                pr_review.JUDGE_MAX_COMPLETION_TOKENS,
+                "discovery runs at %s reasoning but its output allowance is below the "
+                "budget the judge already needed at high reasoning" % discovery_effort,
+            )
 
     def test_candidate_judge_payload_uses_the_phase_specific_model_and_reasoning(self) -> None:
         class Response:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2188,6 +2188,35 @@ class FailureDirectionTest(unittest.TestCase):
                 "budget the judge already needed at high reasoning" % discovery_effort,
             )
 
+    def test_default_discovery_payload_carries_the_effort_and_budget_together(self) -> None:
+        """Assert the shipped request, not the constants that feed it.
+
+        The constants can agree while the payload builder routes a phase down a
+        different branch, so this checks the dict actually sent to the provider
+        for the default discovery phase.
+        """
+        payload = pr_review.build_llm_payload(
+            pr_review.model_for_phase("default", "review-chunk-1"),
+            "system",
+            "user",
+            "default",
+            "review-chunk-1",
+        )
+        self.assertEqual(payload["reasoning_effort"], "high")
+        self.assertEqual(payload["max_completion_tokens"], 32_768)
+        self.assertEqual(
+            payload["max_completion_tokens"],
+            pr_review.build_llm_payload(
+                pr_review.model_for_phase("default", "judge"),
+                "system",
+                "user",
+                "default",
+                "judge",
+            )["max_completion_tokens"],
+            "discovery and the candidate judge both run at high reasoning, so "
+            "discovery must not be sent with the smaller allowance",
+        )
+
     def test_candidate_judge_payload_uses_the_phase_specific_model_and_reasoning(self) -> None:
         class Response:
             status_code = 200

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2184,8 +2184,8 @@ class FailureDirectionTest(unittest.TestCase):
             self.assertGreaterEqual(
                 pr_review.DEFAULT_MAX_COMPLETION_TOKENS,
                 pr_review.JUDGE_MAX_COMPLETION_TOKENS,
-                "discovery runs at %s reasoning but its output allowance is below the "
-                "budget the judge already needed at high reasoning" % discovery_effort,
+                f"discovery runs at {discovery_effort} reasoning but its output "
+                "allowance is below the budget the judge already needed at high reasoning",
             )
 
     def test_default_discovery_payload_carries_the_effort_and_budget_together(self) -> None:


### PR DESCRIPTION
## What changed

Default-mode PR review now runs its discovery pass at high reasoning instead of low. Discovery recall bounds the whole review, because the candidate judge can only keep or drop a finding and never add one, so anything discovery misses is invisible and the run still publishes as clean.

Discovery's output allowance moves from 8K to 32K tokens in the same change, because it has to. Reasoning tokens are drawn from the same allowance as the findings JSON, so raising effort alone would let the call expire before emitting a single finding, and an empty discovery pass reads as a clean review rather than as a failure. The judge's cap was already raised to 32K for exactly this reason. A new test pins the two constants together so a future effort change cannot leave the budget behind.

The reusable workflow validates the published review-profile line against a literal pattern, so that pattern now expects `high` for the default profile. Without it the workflow would reject its own status comment and fall back to reporting that the job never published an effective model.

Model selection is unchanged: discovery stays on the cheaper model and candidate judgment stays on the stronger one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved reasoning quality for the default pull request review mode.
  * Increased the default output limit to support more thorough review results.
  * Updated review configuration expectations and documentation to reflect the improved default behavior.

* **Tests**
  * Added coverage to verify that reasoning-intensive reviews have sufficient output capacity.
  * Updated existing checks for the default review mode to reflect the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->