### PR TITLE
fix(ci): build releases on a Go toolchain without reachable advisories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -878,11 +878,13 @@ jobs:
         with:
           # Pin the exact patched release. govulncheck analyzes the active
           # toolchain's stdlib (go env GOVERSION), so the setup-go version is the
-          # lever, not the go.mod directive. go1.26.6 fixes six stdlib advisories
-          # that go1.26.5 carries across crypto/tls, html/template, net/http and
-          # net/url (GO-2026-5026, GO-2026-5972, GO-2026-6089, GO-2026-6090,
-          # GO-2026-6091, GO-2026-6218), reached here through the proxy and MCP
-          # transport call paths. A float to '1.26' can lag on the
+          # lever, not the go.mod directive. The pin is the newest published
+          # 1.26 patch, because each one carries stdlib advisory fixes this tree
+          # reaches through the proxy and MCP transport call paths. The 1.26.6
+          # pin that preceded this one was chosen for six such fixes over
+          # go1.26.5 across crypto/tls, html/template, net/http and net/url
+          # (GO-2026-5026, GO-2026-5972, GO-2026-6089, GO-2026-6090,
+          # GO-2026-6091, GO-2026-6218). A float to '1.26' can lag on the
           # actions/go-versions manifest, so the scan stays red until the
           # manifest publishes the patched toolchain. An EXACT version makes
           # setup-go fall back to a direct download from the official Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -888,6 +888,11 @@ jobs:
           # setup-go fall back to a direct download from the official Go
           # distribution, bypassing the manifest.
           #
+          # This job scans the 1.26 toolchain. Release binaries are built on the
+          # 1.25 pins in release.yaml, so a green scan here does NOT establish
+          # that the shipped artifact is clean; the release pins have to be
+          # moved too, and were found trailing this one on 2026-09-05.
+          #
           # THIS PIN GOES STALE BY DESIGN. Every Go patch release that fixes a
           # reachable stdlib advisory turns this job red repo-wide until the pin
           # moves, which is what happened on 2026-08-13. Bump it here and in the
@@ -895,7 +900,7 @@ jobs:
           # half-done bump fails loudly instead of scanning the wrong toolchain.
           # Revert to '1.26' + check-latest for steady-state self-healing once
           # the manifest reliably carries the newest patch.
-          go-version: '1.26.6'
+          go-version: '1.26.8'
           check-latest: true
 
       - name: Verify Go version
@@ -904,7 +909,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.26.6"
+          test "$got" = "go1.26.8"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.14"
 
       - name: Verify immutable inputs
         shell: bash

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -62,6 +62,17 @@ jobs:
         with:
           go-version: "1.25.14"
 
+      - name: Verify Go version
+        # This job builds the candidate binary the published score is measured
+        # against, so a silently different stdlib would change the result it
+        # reports. Every other exact-pinned job asserts the resolved toolchain;
+        # this one did not until the pin-contract guard demanded it.
+        shell: bash
+        run: |
+          got="$(go env GOVERSION)"
+          echo "GOVERSION=$got"
+          test "$got" = "go1.25.14"
+
       - name: Verify immutable inputs
         shell: bash
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,15 @@ jobs:
           check-latest: true
           cache: false
 
+      - name: Verify Go version
+        # Every other Go-pinned release job asserts the resolved toolchain; this
+        # one did not, so a silently different stdlib would have gone unnoticed
+        # here while its neighbours failed loudly.
+        run: |
+          got="$(go env GOVERSION)"
+          echo "GOVERSION=$got"
+          test "$got" = "go1.25.14"
+
       # zizmor 1.29.0 treats the empty cache value as enabled; setup-node treats it as disabled.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0; zizmor: ignore[cache-poisoning]
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.14'
           check-latest: true
 
       - name: Verify Go version
@@ -146,7 +146,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.14'
           check-latest: true
           cache: false
 
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.14'
           check-latest: true
 
       - name: Verify Go version
@@ -840,7 +840,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.14'
           check-latest: true
 
       - name: Verify Go version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.25.12"
+          test "$got" = "go1.25.14"
 
       - name: Verify dependencies
         run: bash scripts/ci-retry.sh go mod verify
@@ -200,7 +200,7 @@ jobs:
         run: |
           got="$(go env GOVERSION)"
           echo "GOVERSION=$got"
-          test "$got" = "go1.25.12"
+          test "$got" = "go1.25.14"
 
       - name: Verify dependencies
         run: bash scripts/ci-retry.sh go mod verify
@@ -844,7 +844,7 @@ jobs:
           check-latest: true
 
       - name: Verify Go version
-        run: test "$(go env GOVERSION)" = "go1.25.12"
+        run: test "$(go env GOVERSION)" = "go1.25.14"
 
       - name: Download promotion inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/scripts/test_gauntlet_candidate_workflow.py
+++ b/scripts/test_gauntlet_candidate_workflow.py
@@ -285,7 +285,7 @@ class GauntletCandidateWorkflowTest(unittest.TestCase):
         self.assertIn("runs-on: ubuntu-24.04", candidate_job)
         self.assertNotIn("ubuntu-latest", candidate_job)
         setup = step_block(self.workflow, "Set up Go")
-        self.assertIn('go-version: "1.25.12"', setup)
+        self.assertIn('go-version: "1.25.14"', setup)
         self.assertNotIn('go-version: "1.25"', setup)
 
     def test_each_run_attempt_keeps_its_own_evidence_identity(self):

--- a/scripts/test_workflow_go_pins.py
+++ b/scripts/test_workflow_go_pins.py
@@ -29,6 +29,18 @@ assertion swapped between jobs both fail. Script assertions are scoped to the
 workflow each script names, so a version pinned only by some unrelated workflow
 cannot satisfy them.
 
+Review then found a third hole in the same shape: the assertion pattern matched
+any `= "goX.Y.Z"` text anywhere in a `run` block, including a commented-out line,
+so commenting out the live check while leaving its text behind still satisfied the
+guard. Reproduced before fixing. Assertions are now collected only from lines that
+are not shell comments, and only from a block that actually runs `go env GOVERSION`,
+so dead text cannot stand in for a live check.
+
+The bound worth knowing: only whole-line shell comments are stripped. A version
+equality hidden in a trailing inline comment after live code would still be
+counted, and closing that needs a shell parser rather than a line filter. The
+`go env GOVERSION` requirement is the second line of defense there.
+
 Floating pins such as '1.25' are deliberately excluded: they carry no exact
 version to reconcile, and a workflow may legitimately mix a float for ordinary
 build jobs with one exact pin for a job that needs a known stdlib.
@@ -70,7 +82,24 @@ def _jobs(workflow: pathlib.Path):
             yield name, job["steps"]
 
 
+def _live_asserted_versions(run: str) -> list[str]:
+    """Versions checked by a live `go env GOVERSION` comparison in this run block.
+
+    Commented-out lines are dropped, so text left behind after a check is deleted
+    cannot stand in for the check. The block must also actually read
+    `go env GOVERSION`, so an unrelated equality on a version-shaped string is not
+    mistaken for a toolchain assertion.
+    """
+    live = "\n".join(
+        line for line in run.splitlines() if not line.strip().startswith("#")
+    )
+    if "go env GOVERSION" not in live:
+        return []
+    return ASSERT_RE.findall(live)
+
+
 def _job_pins_and_asserts(steps) -> tuple[list[str], list[str]]:
+    """Exact Go pins and live version assertions declared by one job's steps."""
     pins: list[str] = []
     asserts: list[str] = []
     for step in steps:
@@ -83,7 +112,7 @@ def _job_pins_and_asserts(steps) -> tuple[list[str], list[str]]:
                 pins.append(version)
         run = step.get("run")
         if isinstance(run, str):
-            asserts.extend(ASSERT_RE.findall(run))
+            asserts.extend(_live_asserted_versions(run))
     return pins, asserts
 
 
@@ -99,10 +128,10 @@ class WorkflowGoPinTest(unittest.TestCase):
                 self.assertEqual(
                     collections.Counter(asserts),
                     collections.Counter(pins),
-                    "%s job %r pins %s but asserts %s; a job that installs one "
-                    "toolchain and checks for another fails after setup, and a "
-                    "missing assertion leaves a wrong stdlib unnoticed"
-                    % (path.name, job_name, sorted(pins), sorted(asserts)),
+                    f"{path.name} job {job_name!r} pins {sorted(pins)} but asserts "
+                    f"{sorted(asserts)}; a job that installs one toolchain and checks "
+                    "for another fails after setup, and a missing assertion leaves a "
+                    "wrong stdlib unnoticed",
                 )
         self.assertGreater(
             checked, 0, "no workflow job pinned or asserted a Go version"
@@ -123,8 +152,8 @@ class WorkflowGoPinTest(unittest.TestCase):
             named = sorted(n for n in workflow_names if n in body)
             self.assertTrue(
                 named,
-                "%s asserts a Go version but names no workflow, so the assertion "
-                "cannot be scoped to what it is meant to guard" % path.name,
+                f"{path.name} asserts a Go version but names no workflow, so the "
+                "assertion cannot be scoped to what it is meant to guard",
             )
             owning_pins: set[str] = set()
             for name in named:
@@ -135,12 +164,37 @@ class WorkflowGoPinTest(unittest.TestCase):
                 self.assertIn(
                     version,
                     owning_pins,
-                    "%s asserts Go %s, which %s does not pin; a contract test "
-                    "left behind by a toolchain bump fails CI without naming the "
-                    "bump that stranded it" % (path.name, version, ", ".join(named)),
+                    f"{path.name} asserts Go {version}, which {', '.join(named)} does "
+                    "not pin; a contract test left behind by a toolchain bump fails CI "
+                    "without naming the bump that stranded it",
                 )
         self.assertGreater(
             checked, 0, "no script asserted a workflow Go pin"
+        )
+
+
+    def test_a_commented_out_assertion_does_not_count_as_a_check(self) -> None:
+        """Dead text must not satisfy the guard that live text satisfies.
+
+        This is the defect the guard shipped with: the pattern matched any
+        `= "goX.Y.Z"` anywhere in a run block, so commenting out the check while
+        leaving its text behind still passed.
+        """
+        live = 'got="$(go env GOVERSION)"\ntest "$got" = "go1.25.14"\n'
+        self.assertEqual(_live_asserted_versions(live), ["1.25.14"])
+
+        commented = 'got="$(go env GOVERSION)"\n# test "$got" = "go1.25.14"\n'
+        self.assertEqual(
+            _live_asserted_versions(commented),
+            [],
+            "a commented-out assertion was counted as a live check",
+        )
+
+        unrelated = 'test "$SOME_OTHER" = "go1.25.14"\n'
+        self.assertEqual(
+            _live_asserted_versions(unrelated),
+            [],
+            "an equality unrelated to go env GOVERSION was counted as a toolchain check",
         )
 
 

--- a/scripts/test_workflow_go_pins.py
+++ b/scripts/test_workflow_go_pins.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+# Copyright 2026 Pipelock contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """Every exact Go toolchain pin agrees with everything that asserts it.
 
 A workflow that pins an exact Go version usually pairs it with a step asserting

--- a/scripts/test_workflow_go_pins.py
+++ b/scripts/test_workflow_go_pins.py
@@ -1,21 +1,26 @@
-"""Every exact Go toolchain pin agrees with the assertion that guards it.
+"""Every exact Go toolchain pin agrees with everything that asserts it.
 
 A workflow that pins an exact Go version usually pairs it with a step asserting
 `go env GOVERSION` equals that version, so setup-go resolving a different stdlib
-fails loudly instead of scanning or shipping the wrong toolchain. The pair only
-works while both halves move together.
+fails loudly instead of scanning or shipping the wrong toolchain. Some workflows
+are additionally pinned from the outside, by a Python contract test asserting the
+workflow's literal text. All of those copies only work while they move together.
 
-They did not, on 2026-09-05: a bump moved four `go-version:` pins in
-release.yaml from 1.25.12 to 1.25.14 and left three `go1.25.12` assertions
-behind, because the pins are quoted as `'1.25.12'` and the assertions are
-written as `go1.25.12`, so a single search-and-replace matched one form and not
-the other. Every release job would have installed the new toolchain and then
-failed its own check, which breaks publishing rather than merely scanning the
-wrong thing.
+They did not, on 2026-09-05, and they failed in two different ways from one bump.
+Moving four `go-version:` pins in release.yaml from 1.25.12 to 1.25.14 left three
+`go1.25.12` assertions behind, because the pins are quoted as `'1.25.12'` while
+the assertions are written `go1.25.12`, so one search-and-replace matched a single
+spelling. Every release job would have installed the new toolchain and then failed
+its own check, which breaks publishing rather than merely scanning the wrong
+thing. The same bump moved the gauntlet workflow's pin and left
+`scripts/test_gauntlet_candidate_workflow.py` asserting the old literal, which
+was found only by an independent review pass.
 
-Floating pins such as '1.25' are deliberately excluded: they carry no exact
-version to agree with, and a workflow may legitimately mix a float for ordinary
-build jobs with one exact pin for a job that needs a known stdlib.
+Both halves are covered here: assertions inside a workflow, and version literals
+asserted from a script. Floating pins such as '1.25' are deliberately excluded,
+since they carry no exact version to reconcile and a workflow may legitimately
+mix a float for ordinary build jobs with one exact pin for a job that needs a
+known stdlib.
 """
 
 from __future__ import annotations
@@ -26,9 +31,10 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
+SCRIPT_DIR = ROOT / "scripts"
 
-# `go-version: '1.25.14'` / `go-version: "1.25.14"` — exact pins only, so a
-# bare `1.25` float is not treated as a version to reconcile.
+# `go-version: '1.25.14'` / `go-version: "1.25.14"` — exact pins only, so a bare
+# `1.25` float is not treated as a version to reconcile.
 PIN_RE = re.compile(r"""go-version:\s*['"](\d+\.\d+\.\d+)['"]""")
 
 # `test "$got" = "go1.25.14"` and the inline `test "$(go env GOVERSION)" = ...`
@@ -38,15 +44,18 @@ ASSERT_RE = re.compile(r"""=\s*['"]go(\d+\.\d+\.\d+)['"]""")
 
 
 def _strip_comments(text: str) -> str:
-    kept = []
-    for line in text.splitlines():
-        if line.lstrip().startswith("#"):
-            continue
-        kept.append(line)
-    return "\n".join(kept)
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
 
 
 class WorkflowGoPinTest(unittest.TestCase):
+    def _workflow_pins(self) -> set[str]:
+        pins: set[str] = set()
+        for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+            pins |= set(PIN_RE.findall(_strip_comments(path.read_text(encoding="utf-8"))))
+        return pins
+
     def test_exact_pins_and_version_assertions_agree(self) -> None:
         checked = 0
         for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
@@ -57,8 +66,7 @@ class WorkflowGoPinTest(unittest.TestCase):
                 continue
             checked += 1
             self.assertTrue(
-                pins,
-                "%s asserts a Go version but pins none exactly" % path.name,
+                pins, "%s asserts a Go version but pins none exactly" % path.name
             )
             self.assertEqual(
                 asserts,
@@ -68,9 +76,31 @@ class WorkflowGoPinTest(unittest.TestCase):
                 % (path.name, sorted(pins), sorted(asserts)),
             )
         self.assertGreater(
+            checked, 0, "no workflow asserted a Go version, so this guard checked nothing"
+        )
+
+    def test_scripts_do_not_pin_a_go_version_no_workflow_uses(self) -> None:
+        workflow_pins = self._workflow_pins()
+        self.assertTrue(workflow_pins, "no workflow pins an exact Go version")
+        checked = 0
+        for path in sorted(SCRIPT_DIR.glob("*.py")):
+            if path.name == pathlib.Path(__file__).name:
+                # This file documents the literal form it matches; excluding it
+                # keeps the guard from asserting against its own prose.
+                continue
+            for version in set(PIN_RE.findall(path.read_text(encoding="utf-8"))):
+                checked += 1
+                self.assertIn(
+                    version,
+                    workflow_pins,
+                    "%s asserts Go %s, which no workflow pins; a contract test "
+                    "left behind by a toolchain bump fails CI without naming the "
+                    "bump that stranded it" % (path.name, version),
+                )
+        self.assertGreater(
             checked,
             0,
-            "no workflow asserted a Go version, so this guard checked nothing",
+            "no script asserted a workflow Go pin, so this guard checked nothing",
         )
 
 

--- a/scripts/test_workflow_go_pins.py
+++ b/scripts/test_workflow_go_pins.py
@@ -1,0 +1,78 @@
+"""Every exact Go toolchain pin agrees with the assertion that guards it.
+
+A workflow that pins an exact Go version usually pairs it with a step asserting
+`go env GOVERSION` equals that version, so setup-go resolving a different stdlib
+fails loudly instead of scanning or shipping the wrong toolchain. The pair only
+works while both halves move together.
+
+They did not, on 2026-09-05: a bump moved four `go-version:` pins in
+release.yaml from 1.25.12 to 1.25.14 and left three `go1.25.12` assertions
+behind, because the pins are quoted as `'1.25.12'` and the assertions are
+written as `go1.25.12`, so a single search-and-replace matched one form and not
+the other. Every release job would have installed the new toolchain and then
+failed its own check, which breaks publishing rather than merely scanning the
+wrong thing.
+
+Floating pins such as '1.25' are deliberately excluded: they carry no exact
+version to agree with, and a workflow may legitimately mix a float for ordinary
+build jobs with one exact pin for a job that needs a known stdlib.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+# `go-version: '1.25.14'` / `go-version: "1.25.14"` — exact pins only, so a
+# bare `1.25` float is not treated as a version to reconcile.
+PIN_RE = re.compile(r"""go-version:\s*['"](\d+\.\d+\.\d+)['"]""")
+
+# `test "$got" = "go1.25.14"` and the inline `test "$(go env GOVERSION)" = ...`
+# form. Anchored on the equality so prose mentioning a version in a comment is
+# not mistaken for an assertion.
+ASSERT_RE = re.compile(r"""=\s*['"]go(\d+\.\d+\.\d+)['"]""")
+
+
+def _strip_comments(text: str) -> str:
+    kept = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+class WorkflowGoPinTest(unittest.TestCase):
+    def test_exact_pins_and_version_assertions_agree(self) -> None:
+        checked = 0
+        for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+            body = _strip_comments(path.read_text(encoding="utf-8"))
+            pins = set(PIN_RE.findall(body))
+            asserts = set(ASSERT_RE.findall(body))
+            if not asserts:
+                continue
+            checked += 1
+            self.assertTrue(
+                pins,
+                "%s asserts a Go version but pins none exactly" % path.name,
+            )
+            self.assertEqual(
+                asserts,
+                pins,
+                "%s pins %s but asserts %s; a half-done bump makes every job "
+                "install one toolchain and then fail its own check"
+                % (path.name, sorted(pins), sorted(asserts)),
+            )
+        self.assertGreater(
+            checked,
+            0,
+            "no workflow asserted a Go version, so this guard checked nothing",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_workflow_go_pins.py
+++ b/scripts/test_workflow_go_pins.py
@@ -2,109 +2,145 @@
 # Copyright 2026 Pipelock contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Every exact Go toolchain pin agrees with everything that asserts it.
+"""Every exact Go toolchain pin agrees with the assertion that guards it.
 
-A workflow that pins an exact Go version usually pairs it with a step asserting
+A workflow job that pins an exact Go version pairs it with a step asserting
 `go env GOVERSION` equals that version, so setup-go resolving a different stdlib
 fails loudly instead of scanning or shipping the wrong toolchain. Some workflows
 are additionally pinned from the outside, by a Python contract test asserting the
-workflow's literal text. All of those copies only work while they move together.
+workflow's literal text. Every one of those copies only works while they move
+together.
 
-They did not, on 2026-09-05, and they failed in two different ways from one bump.
-Moving four `go-version:` pins in release.yaml from 1.25.12 to 1.25.14 left three
-`go1.25.12` assertions behind, because the pins are quoted as `'1.25.12'` while
-the assertions are written `go1.25.12`, so one search-and-replace matched a single
+They did not, on 2026-09-05, and one bump broke them two different ways. Moving
+four `go-version:` pins in release.yaml from 1.25.12 to 1.25.14 left three
+`go1.25.12` assertions behind, because the pins are quoted `'1.25.12'` while the
+assertions are written `go1.25.12`, so one search-and-replace matched a single
 spelling. Every release job would have installed the new toolchain and then failed
-its own check, which breaks publishing rather than merely scanning the wrong
-thing. The same bump moved the gauntlet workflow's pin and left
-`scripts/test_gauntlet_candidate_workflow.py` asserting the old literal, which
-was found only by an independent review pass.
+its own check, which breaks publishing rather than merely scanning the wrong thing.
+The same bump moved the gauntlet workflow's pin and stranded
+`scripts/test_gauntlet_candidate_workflow.py` on the old literal.
 
-Both halves are covered here: assertions inside a workflow, and version literals
-asserted from a script. Floating pins such as '1.25' are deliberately excluded,
-since they carry no exact version to reconcile and a workflow may legitimately
-mix a float for ordinary build jobs with one exact pin for a job that needs a
-known stdlib.
+The first version of this guard compared whole-file SETS, and review caught that
+this made it vacuous for the case it was written for: with four pins and four
+assertions all reading 1.25.14, deleting three assertions leaves both sets equal
+to {"1.25.14"} and the guard passes. Reproduced before rewriting. Scoping is
+therefore per job, and comparison is by multiset, so a removed assertion and an
+assertion swapped between jobs both fail. Script assertions are scoped to the
+workflow each script names, so a version pinned only by some unrelated workflow
+cannot satisfy them.
+
+Floating pins such as '1.25' are deliberately excluded: they carry no exact
+version to reconcile, and a workflow may legitimately mix a float for ordinary
+build jobs with one exact pin for a job that needs a known stdlib.
 """
 
 from __future__ import annotations
 
+import collections
 import pathlib
 import re
 import unittest
+
+import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
 SCRIPT_DIR = ROOT / "scripts"
 
-# `go-version: '1.25.14'` / `go-version: "1.25.14"` — exact pins only, so a bare
-# `1.25` float is not treated as a version to reconcile.
-PIN_RE = re.compile(r"""go-version:\s*['"](\d+\.\d+\.\d+)['"]""")
-
-# `test "$got" = "go1.25.14"` and the inline `test "$(go env GOVERSION)" = ...`
-# form. Anchored on the equality so prose mentioning a version in a comment is
-# not mistaken for an assertion.
+EXACT_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+# `go-version: '1.25.14'` inside a script's own assertion about workflow text.
+SCRIPT_PIN_RE = re.compile(r"""go-version:\s*['"](\d+\.\d+\.\d+)['"]""")
+# `test "$got" = "go1.25.14"` and the inline `test "$(go env GOVERSION)" = ...`.
 ASSERT_RE = re.compile(r"""=\s*['"]go(\d+\.\d+\.\d+)['"]""")
 
 
-def _strip_comments(text: str) -> str:
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
+def _jobs(workflow: pathlib.Path):
+    """Yield (job_name, steps) for every job with a step list."""
+    try:
+        doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    except yaml.YAMLError:  # a malformed workflow is another gate's problem
+        return
+    if not isinstance(doc, dict):
+        return
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for name, job in jobs.items():
+        if isinstance(job, dict) and isinstance(job.get("steps"), list):
+            yield name, job["steps"]
+
+
+def _job_pins_and_asserts(steps) -> tuple[list[str], list[str]]:
+    pins: list[str] = []
+    asserts: list[str] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        with_block = step.get("with")
+        if isinstance(with_block, dict):
+            version = str(with_block.get("go-version", "")).strip()
+            if EXACT_VERSION_RE.match(version):
+                pins.append(version)
+        run = step.get("run")
+        if isinstance(run, str):
+            asserts.extend(ASSERT_RE.findall(run))
+    return pins, asserts
 
 
 class WorkflowGoPinTest(unittest.TestCase):
-    def _workflow_pins(self) -> set[str]:
-        pins: set[str] = set()
-        for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
-            pins |= set(PIN_RE.findall(_strip_comments(path.read_text(encoding="utf-8"))))
-        return pins
-
-    def test_exact_pins_and_version_assertions_agree(self) -> None:
+    def test_each_job_asserts_the_exact_go_version_it_pins(self) -> None:
         checked = 0
         for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
-            body = _strip_comments(path.read_text(encoding="utf-8"))
-            pins = set(PIN_RE.findall(body))
-            asserts = set(ASSERT_RE.findall(body))
-            if not asserts:
-                continue
-            checked += 1
-            self.assertTrue(
-                pins, "%s asserts a Go version but pins none exactly" % path.name
-            )
-            self.assertEqual(
-                asserts,
-                pins,
-                "%s pins %s but asserts %s; a half-done bump makes every job "
-                "install one toolchain and then fail its own check"
-                % (path.name, sorted(pins), sorted(asserts)),
-            )
+            for job_name, steps in _jobs(path):
+                pins, asserts = _job_pins_and_asserts(steps)
+                if not pins and not asserts:
+                    continue
+                checked += 1
+                self.assertEqual(
+                    collections.Counter(asserts),
+                    collections.Counter(pins),
+                    "%s job %r pins %s but asserts %s; a job that installs one "
+                    "toolchain and checks for another fails after setup, and a "
+                    "missing assertion leaves a wrong stdlib unnoticed"
+                    % (path.name, job_name, sorted(pins), sorted(asserts)),
+                )
         self.assertGreater(
-            checked, 0, "no workflow asserted a Go version, so this guard checked nothing"
+            checked, 0, "no workflow job pinned or asserted a Go version"
         )
 
-    def test_scripts_do_not_pin_a_go_version_no_workflow_uses(self) -> None:
-        workflow_pins = self._workflow_pins()
-        self.assertTrue(workflow_pins, "no workflow pins an exact Go version")
+    def test_script_pins_match_the_workflow_each_script_names(self) -> None:
+        workflow_names = {p.name for p in WORKFLOW_DIR.glob("*.y*ml")}
         checked = 0
         for path in sorted(SCRIPT_DIR.glob("*.py")):
             if path.name == pathlib.Path(__file__).name:
-                # This file documents the literal form it matches; excluding it
+                # This file documents the literal forms it matches; excluding it
                 # keeps the guard from asserting against its own prose.
                 continue
-            for version in set(PIN_RE.findall(path.read_text(encoding="utf-8"))):
+            body = path.read_text(encoding="utf-8")
+            versions = set(SCRIPT_PIN_RE.findall(body))
+            if not versions:
+                continue
+            named = sorted(n for n in workflow_names if n in body)
+            self.assertTrue(
+                named,
+                "%s asserts a Go version but names no workflow, so the assertion "
+                "cannot be scoped to what it is meant to guard" % path.name,
+            )
+            owning_pins: set[str] = set()
+            for name in named:
+                for _job, steps in _jobs(WORKFLOW_DIR / name):
+                    owning_pins.update(_job_pins_and_asserts(steps)[0])
+            for version in sorted(versions):
                 checked += 1
                 self.assertIn(
                     version,
-                    workflow_pins,
-                    "%s asserts Go %s, which no workflow pins; a contract test "
+                    owning_pins,
+                    "%s asserts Go %s, which %s does not pin; a contract test "
                     "left behind by a toolchain bump fails CI without naming the "
-                    "bump that stranded it" % (path.name, version),
+                    "bump that stranded it" % (path.name, version, ", ".join(named)),
                 )
         self.assertGreater(
-            checked,
-            0,
-            "no script asserted a workflow Go pin, so this guard checked nothing",
+            checked, 0, "no script asserted a workflow Go pin"
         )
 
 


### PR DESCRIPTION
## What changed

Release and gauntlet builds move from Go 1.25.12 to 1.25.14, and the vulnerability-scan job moves from 1.26.6 to 1.26.8 along with the assertion that is deliberately kept equal to it.

The reason is a gap between what gets scanned and what gets shipped. The vulnerability scan runs on the 1.26 line, while every release binary is built on the 1.25 pins in the release workflow, so a green scan established nothing about the artifact a user downloads. Measured against 1.25.12, this tree reaches ten standard-library advisories through certificate verification, the HTTP client used by the MCP transport, both proxy paths, and the rooted filesystem calls in the anchor and recorder. On 1.25.14 the same scan reports zero. A comment now records that the two toolchains are not interchangeable, so the next person moving one knows to check the other.

Dependencies are unchanged. The two `golang.org/x/crypto/ssh` advisories that dependency scanners report against this repository stay open on purpose: that package is not in either build graph, so nothing here can reach them, and the only fix is a module version that requires Go 1.26 and would drop Go 1.25 support outright.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Go toolchain versions used by vulnerability scanning, automated quality checks, and release workflows.
  - Added verification steps to confirm the expected Go version is selected during testing and release preparation.
  - Added automated consistency checks to keep workflow toolchain pins and version validations aligned.
  - Updated workflow tests to reflect the current Go versions used across quality assurance and release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->