### PR TITLE
fix(dashboard): require one authorization header

### DIFF
--- a/enterprise/cli/dashboard.go
+++ b/enterprise/cli/dashboard.go
@@ -636,7 +636,14 @@ func dashboardAuthFailureReason(r *http.Request) string {
 	if r == nil {
 		return "missing"
 	}
-	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	authorization, ok := dashboardAuthorizationHeader(r)
+	if !ok {
+		if dashboardAuthorizationHeaderCount(r) == 0 {
+			return "missing"
+		}
+		return "malformed"
+	}
+	authorization = strings.TrimSpace(authorization)
 	if authorization == "" {
 		return "missing"
 	}
@@ -715,7 +722,10 @@ func dashboardTokenMatches(r *http.Request, token string) bool {
 		return false // fail closed: no configured token means no access
 	}
 	const bearerPrefix = "bearer "
-	auth := r.Header.Get("Authorization")
+	auth, ok := dashboardAuthorizationHeader(r)
+	if !ok {
+		return false
+	}
 	if len(auth) > len(bearerPrefix) && strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) {
 		got := strings.TrimSpace(auth[len(bearerPrefix):])
 		return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
@@ -724,6 +734,23 @@ func dashboardTokenMatches(r *http.Request, token string) bool {
 		return subtle.ConstantTimeCompare([]byte(pass), []byte(token)) == 1
 	}
 	return false
+}
+
+// dashboardAuthorizationHeader returns the only Authorization field value.
+// Authentication rejects duplicate values rather than selecting one because a
+// proxy and the dashboard could otherwise authenticate different credentials.
+func dashboardAuthorizationHeader(r *http.Request) (string, bool) {
+	if r == nil || dashboardAuthorizationHeaderCount(r) != 1 {
+		return "", false
+	}
+	return r.Header.Values("Authorization")[0], true
+}
+
+func dashboardAuthorizationHeaderCount(r *http.Request) int {
+	if r == nil {
+		return 0
+	}
+	return len(r.Header.Values("Authorization"))
 }
 
 // dashboardRuntimeHasFeature wraps the boot-time-verified license's feature

--- a/enterprise/cli/dashboard_oidc.go
+++ b/enterprise/cli/dashboard_oidc.go
@@ -698,7 +698,11 @@ func walkDashboardJSONValue(decoder *json.Decoder, depth int) error {
 }
 
 func dashboardBearerToken(r *http.Request) (string, error) {
-	parts := strings.Fields(r.Header.Get("Authorization"))
+	authorization, ok := dashboardAuthorizationHeader(r)
+	if !ok {
+		return "", errors.New("OIDC bearer token is missing")
+	}
+	parts := strings.Fields(authorization)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || parts[1] == "" {
 		return "", errors.New("OIDC bearer token is missing")
 	}
@@ -879,7 +883,11 @@ func (a *dashboardOIDCAuthenticator) middleware(next http.Handler) http.Handler 
 }
 
 func dashboardBearerAttempted(r *http.Request) bool {
-	parts := strings.Fields(r.Header.Get("Authorization"))
+	authorization, ok := dashboardAuthorizationHeader(r)
+	if !ok {
+		return false
+	}
+	parts := strings.Fields(authorization)
 	return len(parts) > 0 && strings.EqualFold(parts[0], "Bearer")
 }
 
@@ -964,6 +972,8 @@ func (a *dashboardRequestAuthorization) authAuditInfo(r *http.Request) dashboard
 		return dashboard.AuthAuditInfo{Method: "raw-access-token", Roles: []string{"raw"}}
 	case dashboardConfiguredTokenMatches(r, a.metadataToken):
 		return dashboard.AuthAuditInfo{Method: "token", Roles: []string{"metadata"}}
+	case dashboardAuthorizationHeaderCount(r) > 1:
+		return dashboard.AuthAuditInfo{Method: "none", FailureReason: "malformed"}
 	case dashboardOIDCFailureReasonFromRequest(r) != "":
 		return dashboard.AuthAuditInfo{Method: "oidc", FailureReason: dashboardOIDCFailureReasonFromRequest(r)}
 	case dashboardCredentialAttempted(r):
@@ -977,6 +987,9 @@ func (a *dashboardRequestAuthorization) authAuditInfo(r *http.Request) dashboard
 // failure state. An HTTP client cannot set that context value. OIDC takes
 // precedence because both authenticators use the Bearer scheme.
 func (a *dashboardRequestAuthorization) failedAuthMode(r *http.Request) string {
+	if dashboardAuthorizationHeaderCount(r) > 1 {
+		return "none"
+	}
 	if dashboardOIDCFailureReasonFromRequest(r) != "" {
 		return "oidc"
 	}
@@ -990,7 +1003,10 @@ func dashboardCredentialAttempted(r *http.Request) bool {
 	if r == nil {
 		return false
 	}
-	if strings.TrimSpace(r.Header.Get("Authorization")) != "" {
+	if authorization, ok := dashboardAuthorizationHeader(r); ok && strings.TrimSpace(authorization) != "" {
+		return true
+	}
+	if dashboardAuthorizationHeaderCount(r) > 1 {
 		return true
 	}
 	_, _, ok := r.BasicAuth()

--- a/enterprise/cli/dashboard_oidc_test.go
+++ b/enterprise/cli/dashboard_oidc_test.go
@@ -597,6 +597,12 @@ func TestDashboardRequestAuthorization_AuthAuditInfoTokenMethodsAndFailures(t *t
 	}
 }
 
+func TestDashboardBearerAttemptedNilRequest(t *testing.T) {
+	if dashboardBearerAttempted(nil) {
+		t.Fatal("nil request reported a bearer credential attempt")
+	}
+}
+
 func TestDashboardCredentialAttemptedNilRequest(t *testing.T) {
 	if dashboardCredentialAttempted(nil) {
 		t.Fatal("nil request reported a credential attempt")
@@ -738,12 +744,16 @@ func TestDashboardOIDC_AuthenticationEventAttributesFailureMode(t *testing.T) {
 		{name: "basic header before bearer header", setHeaders: func(h http.Header) {
 			h.Add("Authorization", "Basic dXNlcjp3cm9uZy10b2tlbg==")
 			h.Add("Authorization", "Bearer not-a-jwt")
-		}, wantStatus: http.StatusUnauthorized, wantAuthMode: "operator_token"},
+		}, wantStatus: http.StatusUnauthorized, wantAuthMode: "none"},
 		{name: "bearer header before basic header", setHeaders: func(h http.Header) {
 			h.Add("Authorization", "Bearer not-a-jwt")
 			h.Add("Authorization", "Basic dXNlcjp3cm9uZy10b2tlbg==")
-		}, wantStatus: http.StatusUnauthorized, wantAuthMode: "oidc"},
+		}, wantStatus: http.StatusUnauthorized, wantAuthMode: "none"},
 		{name: "valid oidc credential", setHeaders: func(h http.Header) { h.Set("Authorization", "Bearer "+validToken) }, wantStatus: http.StatusNoContent},
+		{name: "valid oidc credential with second authorization header", setHeaders: func(h http.Header) {
+			h.Add("Authorization", "Bearer "+validToken)
+			h.Add("Authorization", "Basic dXNlcjp3cm9uZy10b2tlbg==")
+		}, wantStatus: http.StatusUnauthorized, wantAuthMode: "none"},
 	}
 
 	for _, tt := range tests {

--- a/enterprise/cli/dashboard_test.go
+++ b/enterprise/cli/dashboard_test.go
@@ -889,6 +889,7 @@ func TestDashboardAuthFailureReason(t *testing.T) {
 		{name: "bearer missing value", request: requestWithDashboardAuthorization(t, "Bearer"), want: "malformed"},
 		{name: "invalid basic encoding", request: requestWithDashboardAuthorization(t, "Basic not-base64"), want: "malformed"},
 		{name: "unsupported scheme", request: requestWithDashboardAuthorization(t, "Digest credentials"), want: "malformed"},
+		{name: "multiple authorization headers", request: requestWithDashboardAuthorizations(t, "Bearer valid-token", "Basic dXNlcjp3cm9uZy10b2tlbg=="), want: "malformed"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := dashboardAuthFailureReason(tt.request); got != tt.want {
@@ -903,6 +904,65 @@ func requestWithDashboardAuthorization(t *testing.T, authorization string) *http
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://dashboard.example/", nil)
 	req.Header.Set("Authorization", authorization)
 	return req
+}
+
+func requestWithDashboardAuthorizations(t *testing.T, authorizations ...string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://dashboard.example/", nil)
+	for _, authorization := range authorizations {
+		req.Header.Add("Authorization", authorization)
+	}
+	return req
+}
+
+func TestDashboardAuthorizationHeaderCardinality(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    *http.Request
+		wantCount  int
+		wantHeader string
+		wantOK     bool
+	}{
+		{name: "nil request"},
+		{name: "missing header", request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://dashboard.example/", nil)},
+		{name: "single header", request: requestWithDashboardAuthorization(t, "Bearer operator-token"), wantCount: 1, wantHeader: "Bearer operator-token", wantOK: true},
+		{name: "multiple headers", request: requestWithDashboardAuthorizations(t, "Bearer operator-token", "Basic dXNlcjp3OnRva2Vu"), wantCount: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dashboardAuthorizationHeaderCount(tt.request); got != tt.wantCount {
+				t.Fatalf("header count = %d, want %d", got, tt.wantCount)
+			}
+			gotHeader, gotOK := dashboardAuthorizationHeader(tt.request)
+			if gotHeader != tt.wantHeader || gotOK != tt.wantOK {
+				t.Fatalf("header = (%q, %t), want (%q, %t)", gotHeader, gotOK, tt.wantHeader, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestDashboardAuthDeniedAuditClassifiesMultipleAuthorizationHeadersAsMalformed(t *testing.T) {
+	authorization := newDashboardRequestAuthorization(dashTestToken, "", nil)
+	var audit strings.Builder
+	handler := dashboardAuthHandler(
+		authorization.authenticated,
+		authorization.authAuditInfo,
+		&audit,
+		nil,
+		authorization.failedAuthMode,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("next called") }),
+	)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, requestWithDashboardAuthorizations(t, "Bearer "+dashTestToken, "Basic dXNlcjp3cm9uZy10b2tlbg=="))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	log := audit.String()
+	for _, want := range []string{"auth_method=none", "reason=malformed"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("audit log missing %q: %s", want, log)
+		}
+	}
 }
 
 func TestDashboardAuthDeniedDoesNotWaitForBlockedEventEmitter(t *testing.T) {
@@ -1165,6 +1225,14 @@ func TestDashboardTokenMatches(t *testing.T) {
 		}, true},
 		{"basic password mismatch", dashTestToken, func(r *http.Request) {
 			r.SetBasicAuth("whoever", "nope")
+		}, false},
+		{"multiple bearer values fail closed", dashTestToken, func(r *http.Request) {
+			r.Header.Add("Authorization", "Bearer "+dashTestToken)
+			r.Header.Add("Authorization", "Bearer other-token")
+		}, false},
+		{"basic and bearer values fail closed", dashTestToken, func(r *http.Request) {
+			r.SetBasicAuth("whoever", dashTestToken)
+			r.Header.Add("Authorization", "Bearer "+dashTestToken)
 		}, false},
 		{"token as basic username does not count", dashTestToken, func(r *http.Request) {
 			r.SetBasicAuth(dashTestToken, "")


### PR DESCRIPTION
## What changed
Require exactly one Authorization header for dashboard authentication and report ambiguous credentials as malformed without selecting an authentication method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dashboard authentication now rejects requests with missing or duplicate `Authorization` headers.
  - Duplicate credentials are classified as malformed and no longer attributed to a specific authentication method.
  - Authentication failures now return `401 Unauthorized` and record a neutral authentication method.
  - Token matching fails closed when credentials are absent or duplicated.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->