### PR TITLE
fix(proxy): honor source CIDR identity on reverse requests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2138,6 +2138,8 @@ Pipelock resolves the agent name for each request using this priority order:
 
 Listener-based resolution is the only method that cannot be spoofed by the agent. It injects a context override that takes priority over header and query param. Header and query param methods are convenient but trust the caller. Use listeners when isolation matters.
 
+On the reverse-proxy listener, a `source_cidrs` match sets the agent identity used for attribution and the outbound mediation envelope. It does not select per-agent scanner, budget, or policy overrides: reverse-proxy enforcement uses that listener's configured generic policy or `profile: submit` policy.
+
 For MCP proxy mode, the `--agent` flag resolves the profile directly at startup (not through the HTTP resolution chain).
 
 ### Override Fields

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -1083,6 +1083,7 @@ func (s *Server) Start(ctx context.Context) (startErr error) {
 		rpHandler.SetReceiptEmitter(s.proxy.ReceiptEmitterPtr())
 		rpHandler.SetV2ReceiptEmitter(s.proxy.V2EmitterPtr())
 		rpHandler.SetContractLoader(s.proxy.ContractLoaderPtr())
+		s.proxy.BindReverseProxyIdentity(rpHandler)
 		rpHandler.SetReloadLock(s.proxy.ReloadLock())
 		rpHandler.SetRequestPolicyFn(s.proxy.ApplyRequestPolicy)
 		rpHandler.SetRequestPolicyPrepareFn(s.proxy.PrepareRequestPolicyBody)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1759,6 +1759,15 @@ func (p *Proxy) ScannerPtr() *atomic.Pointer[scanner.Scanner] {
 	return &p.scannerPtr
 }
 
+// BindReverseProxyIdentity makes a reverse-proxy handler resolve identities
+// from the same edition snapshot as the main proxy, including enterprise
+// source CIDR bindings across reloads.
+func (p *Proxy) BindReverseProxyIdentity(handler *ReverseProxyHandler) {
+	if handler != nil {
+		handler.setEditionPtr(&p.editionPtr)
+	}
+}
+
 // SessionMgrPtr returns the atomic pointer to the session manager.
 // Used by run.go to construct the session API handler for the dedicated port.
 func (p *Proxy) SessionMgrPtr() *atomic.Pointer[SessionManager] {

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -83,6 +83,8 @@ type ReverseProxyHandler struct {
 	receiptEmitterPtr    *atomic.Pointer[receipt.Emitter]
 	v2EmitterPtr         *atomic.Pointer[proxydecision.Emitter]
 	contractLoaderPtr    *atomic.Pointer[contractruntime.Loader]
+	editionPtr           *atomic.Pointer[editionSnapshot]
+	agentResolver        func(*http.Request) edition.AgentIdentity
 	reqPolicyFn          func(requestPolicyInput) requestPolicyResult                 // nil = disabled
 	reqPolicyPrepareFn   func(*http.Request, *requestPolicyInput) requestPolicyResult // nil = no body pre-read
 	sizeExemptScanBudget sizeExemptScanBudget
@@ -261,6 +263,26 @@ func (rp *ReverseProxyHandler) SetV2ReceiptEmitter(ptr *atomic.Pointer[proxydeci
 // SetContractLoader sets the atomic pointer to the learn-lock loader.
 func (rp *ReverseProxyHandler) SetContractLoader(ptr *atomic.Pointer[contractruntime.Loader]) {
 	rp.contractLoaderPtr = ptr
+}
+
+// setAgentResolver is a test seam for the OSS fallback resolution path.
+func (rp *ReverseProxyHandler) setAgentResolver(resolver func(*http.Request) edition.AgentIdentity) {
+	rp.agentResolver = resolver
+}
+
+func (rp *ReverseProxyHandler) setEditionPtr(ptr *atomic.Pointer[editionSnapshot]) {
+	rp.editionPtr = ptr
+}
+
+func (rp *ReverseProxyHandler) resolveAgentIdentity(r *http.Request, cfg *config.Config, ed edition.Edition) edition.AgentIdentity {
+	if ed != nil {
+		_, identity := ed.ResolveAgent(r.Context(), r)
+		return identity
+	}
+	if rp.agentResolver != nil {
+		return rp.agentResolver(r)
+	}
+	return edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
 }
 
 // SetRequestPolicyFn wires the request_policy evaluation into the
@@ -514,6 +536,7 @@ func (rp *ReverseProxyHandler) SetRedactionRuntimePtr(ptr *atomic.Pointer[redact
 type reverseRuntimeSnapshot struct {
 	cfg              *config.Config
 	sc               *scanner.Scanner
+	edition          edition.Edition
 	admissionEmitter *envelope.Emitter
 	inboundVerifier  *envelope.Verifier
 	contractLoader   *contractruntime.Loader
@@ -527,6 +550,11 @@ func (rp *ReverseProxyHandler) snapshotRuntime() reverseRuntimeSnapshot {
 	snap := reverseRuntimeSnapshot{
 		cfg: rp.cfgPtr.Load(),
 		sc:  rp.scPtr.Load(),
+	}
+	if rp.editionPtr != nil {
+		if editionSnap := rp.editionPtr.Load(); editionSnap != nil {
+			snap.edition = editionSnap.Edition
+		}
 	}
 	if rp.envelopeEmitterPtr != nil {
 		snap.admissionEmitter = rp.envelopeEmitterPtr.Load()
@@ -603,10 +631,11 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	clientIP, requestID := requestMeta(r)
 	agent, _ := r.Context().Value(ctxKeyAgent).(string)
 	agentAuth := agentAuthFromContext(r.Context())
+	resolvedIdentity := edition.AgentIdentity{Name: agent, Auth: envelope.ActorAuth(agentAuth)}
 	if agent == "" {
-		resolved := edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
-		agent = resolved.Name
-		agentAuth = string(resolved.Auth)
+		resolvedIdentity = rp.resolveAgentIdentity(r, cfg, snap.edition)
+		agent = resolvedIdentity.Name
+		agentAuth = string(resolvedIdentity.Auth)
 	}
 	// Put the grade on the request as soon as identity resolves. The collision
 	// audit below builds its context from r.Context(), and the reverse handler
@@ -615,15 +644,18 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// bound agent.
 	r = r.WithContext(context.WithValue(r.Context(), ctxKeyAgentAuth, agentAuth))
 	targetURL := reverseTargetURL(rp.upstream, r)
-	if reservedAgent, ok := edition.RejectedSelfDeclaredReservedControlActor(r, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity); ok {
-		auditAgent := agent
-		if auditAgent == "" {
-			auditAgent = agentAnonymous
+	if envelope.NormalizeActorAuth(agentAuth) != envelope.ActorAuthBound {
+		reservedAgent, ok := edition.RejectedSelfDeclaredReservedControlActor(r, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
+		if ok {
+			auditAgent := agent
+			if auditAgent == "" {
+				auditAgent = agentAnonymous
+			}
+			rp.logger.LogAgentIdentityCollision(
+				newHTTPAuditContext(r.Context(), rp.logger, httpAuditEvent{Method: r.Method, TargetURL: audit.RedactContentBearingURL(targetURL), ClientIP: clientIP, RequestID: requestID, Agent: auditAgent}),
+				reservedAgent,
+			)
 		}
-		rp.logger.LogAgentIdentityCollision(
-			newHTTPAuditContext(r.Context(), rp.logger, httpAuditEvent{Method: r.Method, TargetURL: audit.RedactContentBearingURL(targetURL), ClientIP: clientIP, RequestID: requestID, Agent: auditAgent}),
-			reservedAgent,
-		)
 	}
 	var reverseGate ContractGateOutput
 	withReverseContractReceipt := func(opts receipt.EmitOpts) receipt.EmitOpts {
@@ -1105,8 +1137,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// same signing decision that ServeHTTP made. Without this, a reload
 	// between here and RoundTrip could flip signing on/off mid-request.
 	if admissionEmitter != nil {
-		actorIdentity := edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
-		actor := actorIdentity.Name
+		actor := resolvedIdentity.Name
 		if actor == "" {
 			actor = "anonymous"
 		}
@@ -1116,7 +1147,7 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			Verdict:    forwardedVerdict,
 			SideEffect: string(receipt.SideEffectFromMethod(r.Method)),
 			Actor:      actor,
-			ActorAuth:  actorIdentity.Auth,
+			ActorAuth:  resolvedIdentity.Auth,
 			PolicyHash: envelope.PolicyHashFromHex(cfg.CanonicalPolicyHash()),
 		}
 		ctx := context.WithValue(r.Context(), ctxKeyReverseEnvelopeOpts, opts)

--- a/internal/proxy/reverse.go
+++ b/internal/proxy/reverse.go
@@ -282,6 +282,9 @@ func (rp *ReverseProxyHandler) resolveAgentIdentity(r *http.Request, cfg *config
 	if rp.agentResolver != nil {
 		return rp.agentResolver(r)
 	}
+	if cfg == nil {
+		return edition.ResolveAgentIdentity(r, nil, "", false)
+	}
 	return edition.ResolveAgentIdentity(r, nil, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
 }
 
@@ -595,6 +598,16 @@ func (rp *ReverseProxyHandler) snapshotAndAcquire() (reverseRuntimeSnapshot, fun
 func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	snap, releaseScanner, scOK := rp.snapshotAndAcquire()
 	defer releaseScanner()
+	cfg := snap.cfg
+	clientIP, requestID := requestMeta(r)
+	agent, _ := r.Context().Value(ctxKeyAgent).(string)
+	agentAuth := agentAuthFromContext(r.Context())
+	resolvedIdentity := edition.AgentIdentity{Name: agent, Auth: envelope.ActorAuth(agentAuth)}
+	if agent == "" {
+		resolvedIdentity = rp.resolveAgentIdentity(r, cfg, snap.edition)
+		agent = resolvedIdentity.Name
+		agentAuth = string(resolvedIdentity.Auth)
+	}
 	emitReverseReceipt := func(opts receipt.EmitOpts) {
 		if snap.cfg != nil {
 			opts = withReceiptPolicyHash(opts, snap.cfg.CanonicalPolicyHash())
@@ -606,8 +619,6 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		// level rather than scan on an unpinned, possibly-closed scanner.
 		// Attest the deny so an operator reconstructing the enforcement
 		// timeline from receipts sees the request resolved to a verdict.
-		_, requestID := requestMeta(r)
-		agent, _ := r.Context().Value(ctxKeyAgent).(string)
 		rp.metrics.RecordReverseProxyRequest(r.Method, "503")
 		emitReverseReceipt(receipt.EmitOpts{
 			ActionID:  receipt.NewActionID(),
@@ -625,18 +636,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			scannerPatternUnavailable)
 		return
 	}
-	cfg := snap.cfg
 	sc := snap.sc
 	admissionEmitter := snap.admissionEmitter
-	clientIP, requestID := requestMeta(r)
-	agent, _ := r.Context().Value(ctxKeyAgent).(string)
-	agentAuth := agentAuthFromContext(r.Context())
-	resolvedIdentity := edition.AgentIdentity{Name: agent, Auth: envelope.ActorAuth(agentAuth)}
-	if agent == "" {
-		resolvedIdentity = rp.resolveAgentIdentity(r, cfg, snap.edition)
-		agent = resolvedIdentity.Name
-		agentAuth = string(resolvedIdentity.Auth)
-	}
 	// Put the grade on the request as soon as identity resolves. The collision
 	// audit below builds its context from r.Context(), and the reverse handler
 	// otherwise attaches the grade much further down, so the one event that
@@ -644,6 +645,8 @@ func (rp *ReverseProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// bound agent.
 	r = r.WithContext(context.WithValue(r.Context(), ctxKeyAgentAuth, agentAuth))
 	targetURL := reverseTargetURL(rp.upstream, r)
+	// Bound identities ignore request labels, as bound defaults do. Only
+	// rejected self-declared identities produce a reserved-name collision.
 	if envelope.NormalizeActorAuth(agentAuth) != envelope.ActorAuthBound {
 		reservedAgent, ok := edition.RejectedSelfDeclaredReservedControlActor(r, cfg.DefaultAgentIdentity, cfg.BindDefaultAgentIdentity)
 		if ok {

--- a/internal/proxy/reverse_agent_resolution_enterprise_test.go
+++ b/internal/proxy/reverse_agent_resolution_enterprise_test.go
@@ -44,9 +44,9 @@ func TestReverseProxySourceCIDRIdentityOverridesAgentHeader(t *testing.T) {
 	var emitterPtr atomic.Pointer[envelope.Emitter]
 	emitterPtr.Store(emitter)
 	handler.SetEnvelopeEmitter(&emitterPtr)
-	var editionPtr atomic.Pointer[editionSnapshot]
-	editionPtr.Store(&editionSnapshot{Edition: ed})
-	handler.setEditionPtr(&editionPtr)
+	identityProxy := &Proxy{}
+	identityProxy.editionPtr.Store(&editionSnapshot{Edition: ed})
+	identityProxy.BindReverseProxyIdentity(handler)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/resource", nil)
 	if err != nil {
@@ -84,7 +84,7 @@ func TestReverseProxySourceCIDRIdentityOverridesAgentHeader(t *testing.T) {
 		t.Fatalf("new reloaded edition: %v", err)
 	}
 	defer reloadedEdition.Close()
-	editionPtr.Store(&editionSnapshot{Edition: reloadedEdition})
+	identityProxy.editionPtr.Store(&editionSnapshot{Edition: reloadedEdition})
 
 	req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/resource", nil)
 	if err != nil {

--- a/internal/proxy/reverse_agent_resolution_enterprise_test.go
+++ b/internal/proxy/reverse_agent_resolution_enterprise_test.go
@@ -7,12 +7,15 @@ package proxy
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/edition"
 	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/receipt"
 	"github.com/luckyPipewrench/pipelock/internal/scanner"
 
 	_ "github.com/luckyPipewrench/pipelock/enterprise/testinit"
@@ -52,7 +55,8 @@ func TestReverseProxySourceCIDRIdentityOverridesAgentHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	req.Header.Set(AgentHeader, "spoofed-header-agent")
+	// Reserved request labels are ignored when the network identity is bound.
+	req.Header.Set(AgentHeader, "pipelock")
 	resp, err := proxySrv.Client().Do(req)
 	if err != nil {
 		t.Fatalf("reverse request: %v", err)
@@ -109,5 +113,134 @@ func TestReverseProxySourceCIDRIdentityOverridesAgentHeader(t *testing.T) {
 	}
 	if got.ActorAuth != envelope.ActorAuthBound {
 		t.Errorf("reloaded envelope actor auth = %q, want %q", got.ActorAuth, envelope.ActorAuthBound)
+	}
+}
+
+func TestReverseProxySourceCIDRScannerUnavailableReceipt(t *testing.T) {
+	for _, unavailable := range []string{"nil", "closed"} {
+		t.Run(unavailable, func(t *testing.T) {
+			cfg := reverseTestConfig()
+			cfg.Agents = map[string]config.AgentProfile{
+				"network-agent": {SourceCIDRs: []string{"127.0.0.0/8"}},
+			}
+			identityScanner := scanner.MustNew(cfg)
+			defer identityScanner.Close()
+			ed, err := edition.NewEditionFunc(cfg, identityScanner)
+			if err != nil {
+				t.Fatalf("new edition: %v", err)
+			}
+			defer ed.Close()
+			var upstreamCalls atomic.Int32
+			srv, handler := reverseTestSetupWithHandler(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+				upstreamCalls.Add(1)
+				w.WriteHeader(http.StatusOK)
+			})
+			identityProxy := &Proxy{}
+			identityProxy.editionPtr.Store(&editionSnapshot{Edition: ed})
+			identityProxy.BindReverseProxyIdentity(handler)
+			if unavailable == "nil" {
+				handler.scPtr.Store(nil)
+			} else {
+				handler.scPtr.Load().Close()
+			}
+			dir := t.TempDir()
+			emitter, rec, _ := newCoverageEmitter(t, dir)
+			t.Cleanup(func() { _ = rec.Close() })
+			var emitterPtr atomic.Pointer[receipt.Emitter]
+			emitterPtr.Store(emitter)
+			handler.SetReceiptEmitter(&emitterPtr)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/resource", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set(AgentHeader, "header-agent")
+			resp, err := srv.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503", resp.StatusCode)
+			}
+			if upstreamCalls.Load() != 0 {
+				t.Fatal("unavailable scanner forwarded request")
+			}
+			if err := rec.Close(); err != nil {
+				t.Fatal(err)
+			}
+			assertScannerUnavailableReceipt(t, dir, TransportReverse)
+			got := findReceiptByLayer(t, extractReceiptsFromDir(t, dir), scannerLabelUnavailable)
+			if got.ActionRecord.Actor != "network-agent" {
+				t.Fatalf("receipt agent = %q, want network-agent", got.ActionRecord.Actor)
+			}
+		})
+	}
+}
+
+func TestReverseProxySourceCIDRPreservesListenerPolicy(t *testing.T) {
+	cfg := reverseTestConfig()
+	cfg.RequestBodyScanning.ContentEntropyEnabled = false
+	cfg.DLP.Patterns = []config.DLPPattern{{Name: "listener marker", Regex: "listener-only-marker", Severity: config.SeverityHigh}}
+	cfg.Agents = map[string]config.AgentProfile{
+		"network-agent": {SourceCIDRs: []string{"127.0.0.0/8"}, DLP: &config.AgentDLP{Patterns: []config.DLPPattern{{Name: "network marker", Regex: "network-only-marker", Severity: config.SeverityHigh}}}},
+		"header-agent":  {DLP: &config.AgentDLP{Patterns: []config.DLPPattern{{Name: "header marker", Regex: "header-only-marker", Severity: config.SeverityHigh}}}},
+	}
+	identityScanner := scanner.MustNew(cfg)
+	defer identityScanner.Close()
+	ed, err := edition.NewEditionFunc(cfg, identityScanner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ed.Close()
+	// Prove both profile-only rules are active before testing the reverse
+	// listener. A missing profile must not make this policy assertion pass.
+	for _, tt := range []struct{ remote, actor, marker string }{
+		{"127.0.0.1:1234", "network-agent", "network-only-marker"},
+		{"203.0.113.1:1234", "header-agent", "header-only-marker"},
+	} {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "http://api.vendor.example/resource", nil)
+		req.RemoteAddr = tt.remote
+		req.Header.Set(AgentHeader, "header-agent")
+		resolved, identity := ed.ResolveAgent(t.Context(), req)
+		if identity.Name != tt.actor {
+			t.Fatalf("profile actor = %q, want %q", identity.Name, tt.actor)
+		}
+		if len(resolved.Scanner.ScanTextForDLP(t.Context(), tt.marker).Matches) == 0 {
+			t.Fatalf("profile %s did not detect its marker", tt.actor)
+		}
+	}
+	var upstreamCalls atomic.Int32
+	srv, handler := reverseTestSetupWithHandler(t, cfg, func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	identityProxy := &Proxy{}
+	identityProxy.editionPtr.Store(&editionSnapshot{Edition: ed})
+	identityProxy.BindReverseProxyIdentity(handler)
+	for _, tt := range []struct {
+		body   string
+		status int
+	}{
+		{"listener-only-marker", http.StatusForbidden},
+		{"network-only-marker", http.StatusOK},
+		{"header-only-marker", http.StatusOK},
+	} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/resource", strings.NewReader(tt.body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set(AgentHeader, "header-agent")
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != tt.status {
+			t.Errorf("body %q: status = %d, want %d", tt.body, resp.StatusCode, tt.status)
+		}
+	}
+	if upstreamCalls.Load() != 2 {
+		t.Fatalf("upstream calls = %d, want 2", upstreamCalls.Load())
 	}
 }

--- a/internal/proxy/reverse_agent_resolution_enterprise_test.go
+++ b/internal/proxy/reverse_agent_resolution_enterprise_test.go
@@ -1,0 +1,113 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package proxy
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+
+	_ "github.com/luckyPipewrench/pipelock/enterprise/testinit"
+)
+
+func TestReverseProxySourceCIDRIdentityOverridesAgentHeader(t *testing.T) {
+	var mediationHeader headerCapture
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.MediationEnvelope.Enabled = true
+	cfg.Agents = map[string]config.AgentProfile{
+		"reverse-cidr-agent": {SourceCIDRs: []string{"127.0.0.0/8"}},
+	}
+
+	identityScanner := scanner.MustNew(cfg)
+	defer identityScanner.Close()
+	ed, err := edition.NewEditionFunc(cfg, identityScanner)
+	if err != nil {
+		t.Fatalf("new edition: %v", err)
+	}
+	defer ed.Close()
+
+	proxySrv, handler := reverseTestSetupWithHandler(t, cfg, func(w http.ResponseWriter, r *http.Request) {
+		mediationHeader.Set(r.Header.Get(envelope.HeaderName))
+		w.WriteHeader(http.StatusOK)
+	})
+	emitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: testEnvelopeConfigHash})
+	var emitterPtr atomic.Pointer[envelope.Emitter]
+	emitterPtr.Store(emitter)
+	handler.SetEnvelopeEmitter(&emitterPtr)
+	var editionPtr atomic.Pointer[editionSnapshot]
+	editionPtr.Store(&editionSnapshot{Edition: ed})
+	handler.setEditionPtr(&editionPtr)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/resource", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set(AgentHeader, "spoofed-header-agent")
+	resp, err := proxySrv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("reverse request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	_ = resp.Body.Close()
+
+	got, err := envelope.Parse(mediationHeader.Get())
+	if err != nil {
+		t.Fatalf("parse mediation envelope: %v", err)
+	}
+	if got.Actor != "reverse-cidr-agent" {
+		t.Errorf("envelope actor = %q, want reverse-cidr-agent", got.Actor)
+	}
+	if got.ActorAuth != envelope.ActorAuthBound {
+		t.Errorf("envelope actor auth = %q, want %q", got.ActorAuth, envelope.ActorAuthBound)
+	}
+
+	cfg2 := *cfg
+	cfg2.Agents = map[string]config.AgentProfile{
+		"reloaded-cidr-agent": {SourceCIDRs: []string{"127.0.0.0/8"}},
+	}
+	reloadedScanner := scanner.MustNew(&cfg2)
+	defer reloadedScanner.Close()
+	reloadedEdition, err := edition.NewEditionFunc(&cfg2, reloadedScanner)
+	if err != nil {
+		t.Fatalf("new reloaded edition: %v", err)
+	}
+	defer reloadedEdition.Close()
+	editionPtr.Store(&editionSnapshot{Edition: reloadedEdition})
+
+	req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/resource", nil)
+	if err != nil {
+		t.Fatalf("new reloaded request: %v", err)
+	}
+	req.Header.Set(AgentHeader, "spoofed-header-agent")
+	resp, err = proxySrv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("reloaded reverse request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("reloaded status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	got, err = envelope.Parse(mediationHeader.Get())
+	if err != nil {
+		t.Fatalf("parse reloaded mediation envelope: %v", err)
+	}
+	if got.Actor != "reloaded-cidr-agent" {
+		t.Errorf("reloaded envelope actor = %q, want reloaded-cidr-agent", got.Actor)
+	}
+	if got.ActorAuth != envelope.ActorAuthBound {
+		t.Errorf("reloaded envelope actor auth = %q, want %q", got.ActorAuth, envelope.ActorAuthBound)
+	}
+}

--- a/internal/proxy/reverse_agent_resolution_test.go
+++ b/internal/proxy/reverse_agent_resolution_test.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
@@ -63,5 +64,20 @@ func TestReverseProxyUsesConfiguredAgentResolverForMediationEnvelope(t *testing.
 	}
 	if got.ActorAuth != envelope.ActorAuthBound {
 		t.Errorf("envelope actor auth = %q, want %q", got.ActorAuth, envelope.ActorAuthBound)
+	}
+}
+
+func TestReverseProxyUnavailableWithoutConfigFailsClosed(t *testing.T) {
+	_, handler := reverseTestSetupWithHandler(t, reverseTestConfig(), func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("request reached upstream without config or scanner")
+	})
+	handler.cfgPtr.Store(nil)
+	handler.scPtr.Store(nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://api.vendor.example/resource", nil)
+	req.Header.Set(AgentHeader, "header-agent")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", response.Code)
 	}
 }

--- a/internal/proxy/reverse_agent_resolution_test.go
+++ b/internal/proxy/reverse_agent_resolution_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/edition"
+	"github.com/luckyPipewrench/pipelock/internal/envelope"
+)
+
+func TestReverseProxyUsesConfiguredAgentResolverForMediationEnvelope(t *testing.T) {
+	var mediationHeader headerCapture
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
+	cfg.MediationEnvelope.Enabled = true
+
+	proxySrv, handler := reverseTestSetupWithHandler(t, cfg, func(w http.ResponseWriter, r *http.Request) {
+		mediationHeader.Set(r.Header.Get(envelope.HeaderName))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	emitter := envelope.NewEmitter(envelope.EmitterConfig{ConfigHash: testEnvelopeConfigHash})
+	var emitterPtr atomic.Pointer[envelope.Emitter]
+	emitterPtr.Store(emitter)
+	handler.SetEnvelopeEmitter(&emitterPtr)
+
+	var resolveCalls atomic.Int32
+	handler.setAgentResolver(func(*http.Request) edition.AgentIdentity {
+		resolveCalls.Add(1)
+		return edition.AgentIdentity{Name: "cidr-bound-agent", Auth: envelope.ActorAuthBound}
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxySrv.URL+"/resource", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// The resolver's infrastructure identity must win over an untrusted hint.
+	req.Header.Set(AgentHeader, "caller-supplied-agent")
+	resp, err := proxySrv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("reverse request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resolveCalls.Load(); got != 1 {
+		t.Fatalf("agent resolver calls = %d, want 1", got)
+	}
+
+	got, err := envelope.Parse(mediationHeader.Get())
+	if err != nil {
+		t.Fatalf("parse mediation envelope: %v", err)
+	}
+	if got.Actor != "cidr-bound-agent" {
+		t.Errorf("envelope actor = %q, want cidr-bound-agent", got.Actor)
+	}
+	if got.ActorAuth != envelope.ActorAuthBound {
+		t.Errorf("envelope actor auth = %q, want %q", got.ActorAuth, envelope.ActorAuthBound)
+	}
+}


### PR DESCRIPTION
## What changed
Use source CIDR bindings for reverse-proxy attribution and mediation envelopes, while retaining the reverse listener's configured enforcement policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reverse-proxy requests now reliably attribute activity to the configured infrastructure identity, even when a caller supplies a conflicting agent header.
  - Identity resolution remains accurate after configuration reloads.
  - Mediation envelopes now include the resolved actor and authentication status.

- **Bug Fixes**
  - Requests now fail safely with a service-unavailable response when identity scanning is unavailable.

- **Documentation**
  - Clarified how reverse-proxy source CIDR matching affects identity attribution and policy selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->