### PR TITLE
fix(ci): retain complete timeout diagnostics before retry

### DIFF
--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -454,6 +454,20 @@ if [ "${#retry_packages[@]}" -eq 0 ]; then
   retry_scope="whole shard; no failed package list was isolated"
 fi
 
+if [ "$retry_kind" = "timeout" ]; then
+  echo "GO TEST TIMEOUT DIAGNOSTICS: first-attempt output follows before retry" >&2
+  # The live formatter intentionally suppresses raw JSON output. Print this
+  # summary before retry can overwrite its JSON file or the job can be canceled.
+  python3 scripts/summarize_go_test_json.py --allow-failed-packages --full-failed-output --label "first-attempt timeout" <"$first_stdout" >&2 || {
+    summary_status=$?
+    echo "ci-test-with-retry: failed to summarize first-attempt timeout diagnostics (status ${summary_status})" >&2
+    echo "GO TEST TIMEOUT DIAGNOSTICS: sanitized raw first-attempt JSON follows" >&2
+    if ! python3 scripts/summarize_go_test_json.py --sanitize-raw <"$first_stdout" >&2; then
+      echo "ci-test-with-retry: failed to sanitize first-attempt timeout diagnostics" >&2
+    fi
+  }
+fi
+
 coverage_profile=""
 first_coverage_profile=""
 cmd_args=("$@")

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -11,6 +11,8 @@ import collections
 import json
 import math
 import sys
+import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 
@@ -54,7 +56,7 @@ class TestResult(_ActionResult):
 
 
 def parse_events(
-    lines: list[str], *, output_limit: int | None = FAILED_OUTPUT_LIMIT
+    lines: Iterable[str], *, output_limit: int = FAILED_OUTPUT_LIMIT
 ) -> dict[str, PackageResult]:
     results: dict[str, PackageResult] = {}
 
@@ -213,6 +215,61 @@ def print_summary(
                 print(escape_terminal_text(line), file=out)
 
 
+def print_full_failed_output(lines: Iterable[str], results: dict[str, PackageResult]) -> None:
+    """Replay failed diagnostics from disk without retaining output in memory."""
+    previous = None
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Go and its toolchain may write text around the JSON stream. Keep
+            # that evidence too; silently dropping it hides formatter failures.
+            print("unparsed diagnostic: " + escape_terminal_text(line.rstrip("\n")))
+            continue
+        if not isinstance(event, dict):
+            continue
+        package = event.get("Package")
+        if not isinstance(package, str):
+            continue
+        result = results.get(package)
+        output = event.get("Output")
+        if result is None or result.action != "fail" or not isinstance(output, str):
+            continue
+        test = event.get("Test")
+        test = test if isinstance(test, str) else ""
+        if test:
+            test_result = result.tests.get(test)
+            if test_result is None or test_result.action not in {"fail", "run"}:
+                continue
+            heading = "interrupted test output:" if test_result.action == "run" else "failed tests:"
+        else:
+            heading = "failed package output:"
+        key = (package, test)
+        if key != previous:
+            print(heading)
+            name = package + (" " + test if test else "")
+            print(f"--- {escape_terminal_text(name)} ---")
+            previous = key
+        print(escape_terminal_text(output.rstrip("\n")))
+
+
+def summarize_full_output(lines: Iterable[str], *, label: str, top: int, top_tests: int) -> dict[str, PackageResult]:
+    """Spool input once, then replay selected output after final states are known."""
+    with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as captured:
+        def capture():
+            for line in lines:
+                captured.write(line)
+                if not line.endswith("\n"):
+                    captured.write("\n")
+                yield line
+
+        results = parse_events(capture(), output_limit=0)
+        print_summary(results, label=label, top=top, top_tests=top_tests)
+        captured.seek(0)
+        print_full_failed_output(captured, results)
+        return results
+
+
 def has_failed_packages(results: dict[str, PackageResult]) -> bool:
     return any(result.action == "fail" for result in results.values())
 
@@ -253,9 +310,11 @@ def main() -> int:
             print(escape_terminal_text(line.rstrip("\n")))
         return 0
 
-    output_limit = None if args.full_failed_output else FAILED_OUTPUT_LIMIT
-    results = parse_events(sys.stdin.readlines(), output_limit=output_limit)
-    print_summary(results, label=args.label, top=args.top, top_tests=args.top_tests)
+    if args.full_failed_output:
+        results = summarize_full_output(sys.stdin, label=args.label, top=args.top, top_tests=args.top_tests)
+    else:
+        results = parse_events(sys.stdin)
+        print_summary(results, label=args.label, top=args.top, top_tests=args.top_tests)
     if has_failed_packages(results) and not args.allow_failed_packages:
         return 1
     return 0

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -253,8 +253,35 @@ def print_full_failed_output(lines: Iterable[str], results: dict[str, PackageRes
         print(escape_terminal_text(output.rstrip("\n")))
 
 
+def rewind_position(lines: Iterable[str]) -> int | None:
+    """Return a replayable input position, or None when the input is a pipe."""
+    seekable = getattr(lines, "seekable", None)
+    if not callable(seekable):
+        return None
+    try:
+        if not seekable():
+            return None
+        position = lines.tell()
+        # Check rewinding before consuming the stream, when a fallback can
+        # still capture it if this is an unusual file-like object.
+        lines.seek(position)
+    except (AttributeError, OSError, ValueError):
+        return None
+    return position
+
+
 def summarize_full_output(lines: Iterable[str], *, label: str, top: int, top_tests: int) -> dict[str, PackageResult]:
-    """Spool input once, then replay selected output after final states are known."""
+    """Replay failed diagnostics without retaining all output in memory."""
+    position = rewind_position(lines)
+    if position is not None:
+        results = parse_events(lines, output_limit=0)
+        print_summary(results, label=label, top=top, top_tests=top_tests)
+        lines.seek(position)
+        print_full_failed_output(lines, results)
+        return results
+
+    # Pipes cannot be rewound, so capture exactly one temporary copy for the
+    # second pass after package terminal states are known.
     with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as captured:
         def capture():
             for line in lines:

--- a/scripts/summarize_go_test_json.py
+++ b/scripts/summarize_go_test_json.py
@@ -53,7 +53,9 @@ class TestResult(_ActionResult):
     pass
 
 
-def parse_events(lines: list[str]) -> dict[str, PackageResult]:
+def parse_events(
+    lines: list[str], *, output_limit: int | None = FAILED_OUTPUT_LIMIT
+) -> dict[str, PackageResult]:
     results: dict[str, PackageResult] = {}
 
     for line in lines:
@@ -68,12 +70,16 @@ def parse_events(lines: list[str]) -> dict[str, PackageResult]:
         if not isinstance(package, str) or package == "":
             continue
 
-        result = results.setdefault(package, PackageResult())
+        result = results.setdefault(
+            package, PackageResult(output=collections.deque(maxlen=output_limit))
+        )
         action = event.get("Action")
         test = event.get("Test")
         test_result = None
         if isinstance(test, str) and test != "":
-            test_result = result.tests.setdefault(test, TestResult())
+            test_result = result.tests.setdefault(
+                test, TestResult(output=collections.deque(maxlen=output_limit))
+            )
 
         if action == "output":
             output = event.get("Output")
@@ -83,6 +89,10 @@ def parse_events(lines: list[str]) -> dict[str, PackageResult]:
                     test_result.output.append(output_line)
                 else:
                     result.output.append(output_line)
+            continue
+
+        if action == "run" and test_result is not None:
+            test_result.action = action
             continue
 
         if action in {"pass", "fail", "skip"}:
@@ -111,8 +121,10 @@ def print_summary(
     label: str,
     top: int,
     top_tests: int = 25,
-    out: object = sys.stdout,
+    out: object | None = None,
 ) -> None:
+    if out is None:
+        out = sys.stdout
     packages = [
         (package, result)
         for package, result in results.items()
@@ -174,6 +186,22 @@ def print_summary(
             for line in test_result.output:
                 print(escape_terminal_text(line), file=out)
 
+    interrupted_tests = [
+        (package, test, test_result)
+        for package, result in failures
+        for test, test_result in sorted(result.tests.items())
+        if test_result.action == "run" and test_result.output
+    ]
+    if interrupted_tests:
+        print("interrupted test output:", file=out)
+        for package, test, test_result in interrupted_tests:
+            print(
+                f"--- {escape_terminal_text(package)} {escape_terminal_text(test)} ---",
+                file=out,
+            )
+            for line in test_result.output:
+                print(escape_terminal_text(line), file=out)
+
     package_output_failures = [
         (package, result) for package, result in failures if result.output
     ]
@@ -198,6 +226,21 @@ def main() -> int:
     parser.add_argument(
         "--top-tests", type=int, default=25, help="number of slow tests to print"
     )
+    parser.add_argument(
+        "--full-failed-output",
+        action="store_true",
+        help="retain complete output for failed packages instead of bounded tails",
+    )
+    parser.add_argument(
+        "--allow-failed-packages",
+        action="store_true",
+        help="return success after reporting failed packages",
+    )
+    parser.add_argument(
+        "--sanitize-raw",
+        action="store_true",
+        help="escape captured input without parsing it",
+    )
     args = parser.parse_args()
 
     if args.top < 1:
@@ -205,9 +248,15 @@ def main() -> int:
     if args.top_tests < 1:
         parser.error("--top-tests must be at least 1")
 
-    results = parse_events(sys.stdin.readlines())
+    if args.sanitize_raw:
+        for line in sys.stdin:
+            print(escape_terminal_text(line.rstrip("\n")))
+        return 0
+
+    output_limit = None if args.full_failed_output else FAILED_OUTPUT_LIMIT
+    results = parse_events(sys.stdin.readlines(), output_limit=output_limit)
     print_summary(results, label=args.label, top=args.top, top_tests=args.top_tests)
-    if has_failed_packages(results):
+    if has_failed_packages(results) and not args.allow_failed_packages:
         return 1
     return 0
 

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -6,6 +6,7 @@
 import io
 import json
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -181,8 +182,20 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         )
 
         out = io.StringIO()
-        with mock.patch.object(sys, "stdout", out):
-            summarize_go_test_json.summarize_full_output(lines, label="unit", top=1, top_tests=25)
+        with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as captured:
+            captured.write("\n".join(lines) + "\n")
+            captured.seek(0)
+            with (
+                mock.patch.object(sys, "stdout", out),
+                mock.patch.object(
+                    summarize_go_test_json.tempfile,
+                    "TemporaryFile",
+                    side_effect=AssertionError("regular input must be replayed directly"),
+                ),
+            ):
+                summarize_go_test_json.summarize_full_output(
+                    captured, label="unit", top=1, top_tests=25
+                )
 
         summary = out.getvalue()
         self.assertIn("stack line 0", summary)
@@ -207,13 +220,23 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
 
         tracemalloc.start()
         try:
-            with mock.patch.object(sys, "stdout", DiscardOutput()):
-                results = summarize_go_test_json.summarize_full_output(events(), label="unit", top=1, top_tests=1)
+            with (
+                mock.patch.object(sys, "stdout", DiscardOutput()),
+                mock.patch.object(
+                    summarize_go_test_json.tempfile,
+                    "TemporaryFile",
+                    wraps=tempfile.TemporaryFile,
+                ) as captured,
+            ):
+                results = summarize_go_test_json.summarize_full_output(
+                    events(), label="unit", top=1, top_tests=1
+                )
             _, peak = tracemalloc.get_traced_memory()
         finally:
             tracemalloc.stop()
         self.assertLess(peak, 4 * 1024 * 1024)
         self.assertFalse(results["example.com/pass"].output)
+        captured.assert_called_once_with(mode="w+t", encoding="utf-8")
 
     def test_full_output_preserves_malformed_text_and_escapes_controls(self):
         lines = [

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -52,6 +52,13 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         self.assertIn("failed package output tails:", summary)
         self.assertIn("useful failure line", summary)
 
+    def test_default_output_uses_current_stdout(self):
+        out = io.StringIO()
+        with mock.patch.object(sys, "stdout", out):
+            summarize_go_test_json.print_summary({}, label="unit", top=1)
+
+        self.assertIn("Go test package timing (unit)", out.getvalue())
+
     def test_preserves_failed_test_output_when_package_tail_evicted(self):
         lines = [
             json.dumps(
@@ -106,6 +113,81 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
         self.assertIn("failed tests:", summary)
         self.assertIn("--- example.com/proxy TestFlaky (0.8s) ---", summary)
         self.assertIn("lost early failure", summary)
+
+    def test_preserves_running_test_output_when_package_times_out(self):
+        lines = [
+            json.dumps(
+                {
+                    "Action": "run",
+                    "Package": "example.com/conductor",
+                    "Test": "TestServe",
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "output",
+                    "Package": "example.com/conductor",
+                    "Test": "TestServe",
+                    "Output": "goroutine 42 [chan receive]:\\n",
+                }
+            ),
+            json.dumps(
+                {
+                    "Action": "fail",
+                    "Package": "example.com/conductor",
+                    "Elapsed": 900,
+                }
+            ),
+        ]
+
+        results = summarize_go_test_json.parse_events(lines)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(results, label="unit", top=1, out=out)
+
+        summary = out.getvalue()
+        self.assertIn("interrupted test output:", summary)
+        self.assertIn("--- example.com/conductor TestServe ---", summary)
+        self.assertIn("goroutine 42 [chan receive]:", summary)
+
+    def test_full_failed_output_preserves_complete_timeout_stack(self):
+        lines = [
+            json.dumps(
+                {
+                    "Action": "run",
+                    "Package": "example.com/conductor",
+                    "Test": "TestServe",
+                }
+            )
+        ]
+        for index in range(summarize_go_test_json.FAILED_OUTPUT_LIMIT + 21):
+            lines.append(
+                json.dumps(
+                    {
+                        "Action": "output",
+                        "Package": "example.com/conductor",
+                        "Test": "TestServe",
+                        "Output": f"stack line {index}\\n",
+                    }
+                )
+            )
+        lines.append(
+            json.dumps(
+                {
+                    "Action": "fail",
+                    "Package": "example.com/conductor",
+                    "Elapsed": 900,
+                }
+            )
+        )
+
+        results = summarize_go_test_json.parse_events(lines, output_limit=None)
+        out = io.StringIO()
+        summarize_go_test_json.print_summary(results, label="unit", top=1, out=out)
+
+        summary = out.getvalue()
+        self.assertIn("stack line 0", summary)
+        self.assertIn("stack line 50", summary)
+        self.assertIn("stack line 100", summary)
 
     def test_omits_failed_tests_header_for_package_only_failure(self):
         lines = [
@@ -351,6 +433,38 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
             status = summarize_go_test_json.main()
 
         self.assertEqual(status, 1)
+
+    def test_main_allows_failed_packages_when_requested(self):
+        lines = json.dumps(
+            {"Action": "fail", "Package": "example.com/pkg", "Elapsed": 1}
+        )
+
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                ["summarize_go_test_json.py", "--allow-failed-packages"],
+            ),
+            mock.patch.object(sys, "stdin", io.StringIO(lines)),
+            mock.patch.object(sys, "stdout", io.StringIO()),
+        ):
+            status = summarize_go_test_json.main()
+
+        self.assertEqual(status, 0)
+
+    def test_main_sanitizes_raw_controls_without_parsing(self):
+        out = io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", ["summarize_go_test_json.py", "--sanitize-raw"]),
+            mock.patch.object(sys, "stdin", io.StringIO("bad\x1b[2J\rline\n")),
+            mock.patch.object(sys, "stdout", out),
+        ):
+            status = summarize_go_test_json.main()
+
+        self.assertEqual(status, 0)
+        self.assertNotIn("\x1b", out.getvalue())
+        self.assertNotIn("\r", out.getvalue())
+        self.assertIn("bad\\u001b[2J\\u000dline", out.getvalue())
 
     def test_main_allows_retry_stream_when_final_package_action_passes(self):
         lines = "\n".join(

--- a/scripts/summarize_go_test_json_test.py
+++ b/scripts/summarize_go_test_json_test.py
@@ -180,14 +180,56 @@ class SummarizeGoTestJSONTest(unittest.TestCase):
             )
         )
 
-        results = summarize_go_test_json.parse_events(lines, output_limit=None)
         out = io.StringIO()
-        summarize_go_test_json.print_summary(results, label="unit", top=1, out=out)
+        with mock.patch.object(sys, "stdout", out):
+            summarize_go_test_json.summarize_full_output(lines, label="unit", top=1, top_tests=25)
 
         summary = out.getvalue()
         self.assertIn("stack line 0", summary)
         self.assertIn("stack line 50", summary)
         self.assertIn("stack line 100", summary)
+
+    def test_full_output_streams_large_passed_output_without_retaining_it(self):
+        import tracemalloc
+
+        class DiscardOutput:
+            def write(self, value):
+                return len(value)
+            def flush(self):
+                pass
+
+        def events():
+            payload = json.dumps({"Action": "output", "Package": "example.com/pass", "Output": "x" * 8192})
+            for _ in range(2048):
+                yield payload
+            yield json.dumps({"Action": "pass", "Package": "example.com/pass"})
+            yield json.dumps({"Action": "fail", "Package": "example.com/fail"})
+
+        tracemalloc.start()
+        try:
+            with mock.patch.object(sys, "stdout", DiscardOutput()):
+                results = summarize_go_test_json.summarize_full_output(events(), label="unit", top=1, top_tests=1)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        self.assertLess(peak, 4 * 1024 * 1024)
+        self.assertFalse(results["example.com/pass"].output)
+
+    def test_full_output_preserves_malformed_text_and_escapes_controls(self):
+        lines = [
+            "toolchain prelude\x1b[2J\n",
+            json.dumps({"Action": "output", "Package": "example.com/fail", "Output": "stack\x1b[2J\n"}),
+            json.dumps({"Action": "fail", "Package": "example.com/fail"}),
+            json.dumps({"Action": "output", "Package": "example.com/pass", "Output": "unrelated passed output"}),
+            json.dumps({"Action": "pass", "Package": "example.com/pass"}),
+        ]
+        out = io.StringIO()
+        with mock.patch.object(sys, "stdout", out):
+            summarize_go_test_json.summarize_full_output(lines, label="unit", top=1, top_tests=1)
+        self.assertIn("unparsed diagnostic: toolchain prelude", out.getvalue())
+        self.assertIn("stack\\u001b[2J", out.getvalue())
+        self.assertNotIn("\x1b", out.getvalue())
+        self.assertNotIn("unrelated passed output", out.getvalue())
 
     def test_omits_failed_tests_header_for_package_only_failure(self):
         lines = [

--- a/scripts/test_ci_test_with_retry.py
+++ b/scripts/test_ci_test_with_retry.py
@@ -781,7 +781,9 @@ exit 0
 state=${CI_RETRY_STATE:?}
 if [ ! -e "$state" ]; then
   : >"$state"
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestHang"}'
   printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"panic: test timed out after 15m0s\n"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"goroutine 42 [chan receive]:\n"}'
   printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":900}'
   exit 1
 fi
@@ -791,7 +793,82 @@ exit 0
         )
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("GO TEST TIMEOUT DIAGNOSTICS", result.stderr)
+        self.assertIn("interrupted test output:", result.stderr)
+        self.assertIn("--- example.com/p/pkg TestHang ---", result.stderr)
+        self.assertIn("goroutine 42 [chan receive]:", result.stderr)
+        self.assertIn("panic: test timed out after 15m0s", result.stderr)
         self.assertIn("failed then passed on rerun", result.stderr)
+
+    def test_timeout_diagnostics_retain_complete_stack_before_retry(self) -> None:
+        result = run_wrapper(
+            r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestHang"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"panic: test timed out after 15m0s\n"}'
+  for i in $(seq 0 100); do
+    printf '{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"stack line %s\\n"}\n' "$i"
+  done
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":900}'
+  exit 1
+fi
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+'''
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("stack line 0", result.stderr)
+        self.assertIn("stack line 50", result.stderr)
+        self.assertIn("stack line 100", result.stderr)
+        self.assertLess(
+            result.stderr.index("GO TEST TIMEOUT DIAGNOSTICS"),
+            result.stderr.index("FLAKE RETRY: first pass failed"),
+        )
+
+    def test_timeout_summary_failure_uses_sanitized_raw_fallback(self) -> None:
+        real_python = shutil.which("python3")
+        self.assertIsNotNone(real_python)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_python = Path(tmp) / "python3"
+            fake_python.write_text(
+                f'''#!/bin/sh
+case " $* " in
+  *" --sanitize-raw "*) exec "{real_python}" "$@" ;;
+esac
+if [ "$1" = "scripts/summarize_go_test_json.py" ]; then
+  exit 1
+fi
+exec "{real_python}" "$@"
+''',
+                encoding="utf-8",
+            )
+            fake_python.chmod(0o700)
+            result = run_wrapper(
+                r'''
+state=${CI_RETRY_STATE:?}
+if [ ! -e "$state" ]; then
+  : >"$state"
+  printf '\033[2Jmalformed\n'
+  printf '%s\n' '{"Action":"run","Package":"example.com/p/pkg","Test":"TestHang"}'
+  printf '%s\n' '{"Action":"output","Package":"example.com/p/pkg","Test":"TestHang","Output":"panic: test timed out after 15m0s\n"}'
+  printf '%s\n' '{"Action":"fail","Package":"example.com/p/pkg","Elapsed":900}'
+  exit 1
+fi
+printf '%s\n' '{"Action":"pass","Package":"example.com/p/pkg","Elapsed":1}'
+''',
+                env_overrides={"PATH": f"{tmp}:{os.environ['PATH']}"},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("failed to summarize first-attempt timeout diagnostics (status 1)", result.stderr)
+        self.assertIn("sanitized raw first-attempt JSON follows", result.stderr)
+        self.assertIn("\\u001b[2Jmalformed", result.stderr)
+        self.assertNotIn("\x1b", result.stderr)
+        self.assertNotIn("\r", result.stderr)
+        self.assertIn("FLAKE RETRY: first pass failed", result.stderr)
 
     def test_coverage_retry_requires_recreated_profile(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed
Preserve complete first-attempt timeout diagnostics before retry, including interrupted-test output, and report formatter failures with sanitized fallback output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout diagnostics for failed test runs, including interrupted test output and complete stack traces.
  * Added a sanitized fallback summary when detailed diagnostics cannot be generated.
  * Ensured timeout information is captured before retries begin.
  * Improved handling of large test outputs and malformed diagnostic data.

* **Tests**
  * Expanded coverage for timeout reporting, output preservation, retry ordering, output limits, and sanitized fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->