### PR TITLE
fix(emit): publish consistent sink failure snapshots

### DIFF
--- a/internal/emit/otlp.go
+++ b/internal/emit/otlp.go
@@ -424,15 +424,14 @@ func (s *OTLPSink) Stats() OTLPStats {
 		return OTLPStats{}
 	}
 	s.lastErrMu.Lock()
-	lastErr := s.lastErr
-	s.lastErrMu.Unlock()
+	defer s.lastErrMu.Unlock()
 	stats := OTLPStats{
 		Delivered: s.delivered.Load(),
 		Failed:    s.failed.Load(),
 		Dropped:   s.dropped.Load(),
 		Abandoned: s.abandoned.Load(),
 		Degraded:  s.degraded.Load(),
-		LastError: lastErr,
+		LastError: s.lastErr,
 	}
 	if s.queue != nil {
 		stats.QueueLen = len(s.queue)
@@ -443,13 +442,13 @@ func (s *OTLPSink) Stats() OTLPStats {
 
 func (s *OTLPSink) recordFailure(reason string, event Event, err error) {
 	lastErr := safeOTLPErrorString(err)
+	s.lastErrMu.Lock()
 	s.failed.Add(1)
 	s.degraded.Store(true)
 	if lastErr != "" {
-		s.lastErrMu.Lock()
 		s.lastErr = lastErr
-		s.lastErrMu.Unlock()
 	}
+	s.lastErrMu.Unlock()
 	s.logDiagnostic("delivery_failed", reason, event, lastErr, 0)
 }
 
@@ -461,13 +460,13 @@ func (s *OTLPSink) recordFailure(reason string, event Event, err error) {
 // backpressure into request-path blocking. The drop is observable via
 // Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
 func (s *OTLPSink) recordDropped(reason string, err error) {
-	s.dropped.Add(1)
-	s.degraded.Store(true)
 	lastErr := reason
 	if err != nil {
 		lastErr = safeOTLPErrorString(err)
 	}
 	s.lastErrMu.Lock()
+	s.dropped.Add(1)
+	s.degraded.Store(true)
 	s.lastErr = lastErr
 	s.lastErrMu.Unlock()
 }
@@ -476,9 +475,9 @@ func (s *OTLPSink) recordAbandoned(reason string, event Event, count int) {
 	if count < 1 {
 		count = 1
 	}
+	s.lastErrMu.Lock()
 	s.abandoned.Add(uint64(count))
 	s.degraded.Store(true)
-	s.lastErrMu.Lock()
 	s.lastErr = reason
 	s.lastErrMu.Unlock()
 	s.logDiagnostic("events_abandoned", reason, event, "", count)

--- a/internal/emit/sink_health_snapshot_syslog_unix_test.go
+++ b/internal/emit/sink_health_snapshot_syslog_unix_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import "errors"
+
+func syslogHealthTransitionCases() []sinkHealthTransitionCase {
+	newSink := func() *SyslogSink { return &SyslogSink{queue: make(chan syslogMessage, 1)} }
+
+	failure := newSink()
+	drop := newSink()
+	abandon := newSink()
+	return []sinkHealthTransitionCase{
+		{
+			name: "syslog failure", lock: failure.lastErrMu.Lock, unlock: failure.lastErrMu.Unlock,
+			transition: func() { failure.recordFailure("write_error", syslogMessage{}, errors.New("write failed")) }, blockedOn: "(*SyslogSink).recordFailure", count: failure.failed.Load, stats: failure.Stats, health: failure.SinkHealth,
+		},
+		{
+			name: "syslog drop", lock: drop.lastErrMu.Lock, unlock: drop.lastErrMu.Unlock,
+			transition: func() { drop.recordDropped("queue_full", nil) }, blockedOn: "(*SyslogSink).recordDropped", count: drop.dropped.Load, stats: drop.Stats, health: drop.SinkHealth,
+		},
+		{
+			name: "syslog abandon", lock: abandon.lastErrMu.Lock, unlock: abandon.lastErrMu.Unlock,
+			transition: func() { abandon.recordAbandoned("close_timeout", syslogMessage{}, 1) }, blockedOn: "(*SyslogSink).recordAbandoned", count: abandon.abandoned.Load, stats: abandon.Stats, health: abandon.SinkHealth,
+		},
+	}
+}

--- a/internal/emit/sink_health_snapshot_syslog_unix_test.go
+++ b/internal/emit/sink_health_snapshot_syslog_unix_test.go
@@ -20,7 +20,7 @@ func syslogHealthTransitionCases() []sinkHealthTransitionCase {
 		},
 		{
 			name: "syslog drop", lock: drop.lastErrMu.Lock, unlock: drop.lastErrMu.Unlock,
-			transition: func() { drop.recordDropped("queue_full", nil) }, blockedOn: "(*SyslogSink).recordDropped", count: drop.dropped.Load, stats: drop.Stats, health: drop.SinkHealth,
+			transition: func() { drop.recordDropped() }, blockedOn: "(*SyslogSink).recordDropped", count: drop.dropped.Load, stats: drop.Stats, health: drop.SinkHealth,
 		},
 		{
 			name: "syslog abandon", lock: abandon.lastErrMu.Lock, unlock: abandon.lastErrMu.Unlock,

--- a/internal/emit/sink_health_snapshot_syslog_windows_test.go
+++ b/internal/emit/sink_health_snapshot_syslog_windows_test.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+func syslogHealthTransitionCases() []sinkHealthTransitionCase { return nil }

--- a/internal/emit/sink_health_snapshot_test.go
+++ b/internal/emit/sink_health_snapshot_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package emit
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/testwait"
+)
+
+type sinkHealthTransitionCase struct {
+	name       string
+	lock       func()
+	unlock     func()
+	transition func()
+	blockedOn  string
+	count      func() uint64
+	stats      func() sinkStats
+	health     func() SinkHealth
+}
+
+// TestSinkHealthTransitionsPublishAtomically holds a sink's health mutex while
+// each degraded transition starts. A transition must not expose its counter
+// before it has also published Degraded and LastError. Otherwise a scrape can
+// report delivery failure while hiding the reason, which is inconsistent
+// telemetry for an unhealthy audit sink.
+func TestSinkHealthTransitionsPublishAtomically(t *testing.T) {
+	for _, tt := range sinkHealthTransitionCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.lock()
+			locked := true
+			t.Cleanup(func() {
+				if locked {
+					tt.unlock()
+				}
+			})
+			done := make(chan struct{})
+			transitionID := make(chan string, 1)
+			go func() {
+				transitionID <- currentGoroutineID()
+				tt.transition()
+				close(done)
+			}()
+
+			waitForSinkHealthTransitionBlock(t, <-transitionID, tt.blockedOn)
+			if got := tt.count(); got != 0 {
+				t.Fatalf("counter became visible before degraded health details: %d", got)
+			}
+
+			tt.unlock()
+			locked = false
+			testwait.For(t, 2*time.Second, func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, "health transition completion")
+			stats := tt.stats()
+			if tt.count() == 0 || !stats.Degraded || stats.LastError == "" {
+				t.Fatalf("stats = %+v, want published degraded transition", stats)
+			}
+			health := tt.health()
+			if !health.Degraded || !health.LastErrorPresent {
+				t.Fatalf("SinkHealth() = %+v, want degraded state and error presence", health)
+			}
+		})
+	}
+}
+
+func currentGoroutineID() string {
+	stack := make([]byte, 64)
+	for {
+		n := runtime.Stack(stack, false)
+		if n < len(stack) {
+			fields := strings.Fields(string(stack[:n]))
+			if len(fields) >= 2 {
+				return fields[1]
+			}
+			return ""
+		}
+		stack = make([]byte, len(stack)*2)
+	}
+}
+
+func allGoroutineStacks() string {
+	stack := make([]byte, 64<<10)
+	for {
+		n := runtime.Stack(stack, true)
+		if n < len(stack) {
+			return string(stack[:n])
+		}
+		stack = make([]byte, len(stack)*2)
+	}
+}
+
+func waitForSinkHealthTransitionBlock(t *testing.T, id, function string) {
+	t.Helper()
+	testwait.For(t, 2*time.Second, func() bool {
+		header := "goroutine " + id + " "
+		for _, goroutine := range strings.Split(allGoroutineStacks(), "\n\n") {
+			if strings.HasPrefix(goroutine, header) && strings.Contains(goroutine, function) && strings.Contains(goroutine, "sync.runtime_SemacquireMutex") {
+				return true
+			}
+		}
+		return false
+	}, "transition %s blocked on lastErrMu (%s)", id, function)
+}
+
+func sinkHealthTransitionCases() []sinkHealthTransitionCase {
+	var tests []sinkHealthTransitionCase
+	for _, newSink := range []func() sinkHealthTransitionCase{
+		func() sinkHealthTransitionCase {
+			sink := newManualOTLPSink()
+			return sinkHealthTransitionCase{
+				name: "otlp failure", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordFailure("send_error", Event{}, errors.New("send failed")) }, blockedOn: "(*OTLPSink).recordFailure", count: sink.failed.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+		func() sinkHealthTransitionCase {
+			sink := newManualOTLPSink()
+			return sinkHealthTransitionCase{
+				name: "otlp drop", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordDropped("queue_full", nil) }, blockedOn: "(*OTLPSink).recordDropped", count: sink.dropped.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+		func() sinkHealthTransitionCase {
+			sink := newManualOTLPSink()
+			return sinkHealthTransitionCase{
+				name: "otlp abandon", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordAbandoned("drain_timeout", Event{}, 1) }, blockedOn: "(*OTLPSink).recordAbandoned", count: sink.abandoned.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+		func() sinkHealthTransitionCase {
+			sink := &WebhookSink{queue: make(chan Event, 1)}
+			return sinkHealthTransitionCase{
+				name: "webhook failure", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordFailure("send_error", Event{}, errors.New("send failed")) }, blockedOn: "(*WebhookSink).recordFailure", count: sink.failed.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+		func() sinkHealthTransitionCase {
+			sink := &WebhookSink{queue: make(chan Event, 1)}
+			return sinkHealthTransitionCase{
+				name: "webhook drop", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordDropped("queue_full", nil) }, blockedOn: "(*WebhookSink).recordDropped", count: sink.dropped.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+		func() sinkHealthTransitionCase {
+			sink := &WebhookSink{queue: make(chan Event, 1)}
+			return sinkHealthTransitionCase{
+				name: "webhook abandon", lock: sink.lastErrMu.Lock, unlock: sink.lastErrMu.Unlock,
+				transition: func() { sink.recordAbandoned(1) }, blockedOn: "(*WebhookSink).recordAbandoned", count: sink.abandoned.Load, stats: sink.Stats, health: sink.SinkHealth,
+			}
+		},
+	} {
+		tests = append(tests, newSink())
+	}
+	return append(tests, syslogHealthTransitionCases()...)
+}

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -448,16 +448,14 @@ func (s *SyslogSink) Stats() SyslogStats {
 		return SyslogStats{}
 	}
 	s.lastErrMu.Lock()
-	lastErr := s.lastErr
-	degraded := s.degraded.Load()
-	s.lastErrMu.Unlock()
+	defer s.lastErrMu.Unlock()
 	stats := SyslogStats{
 		Delivered: s.delivered.Load(),
 		Failed:    s.failed.Load(),
 		Dropped:   s.dropped.Load(),
 		Abandoned: s.abandoned.Load(),
-		Degraded:  degraded,
-		LastError: lastErr,
+		Degraded:  s.degraded.Load(),
+		LastError: s.lastErr,
 	}
 	if s.queue != nil {
 		stats.QueueLen = len(s.queue)
@@ -467,11 +465,15 @@ func (s *SyslogSink) Stats() SyslogStats {
 }
 
 func (s *SyslogSink) recordFailure(reason string, msg syslogMessage, err error) {
-	s.failed.Add(1)
+	lastErr := ""
+	if err != nil {
+		lastErr = err.Error()
+	}
 	s.lastErrMu.Lock()
+	s.failed.Add(1)
 	s.degraded.Store(true)
 	if err != nil {
-		s.lastErr = err.Error()
+		s.lastErr = lastErr
 	}
 	s.lastErrMu.Unlock()
 	s.logDiagnostic("delivery_failed", reason, msg, err, 0)
@@ -485,12 +487,12 @@ func (s *SyslogSink) recordFailure(reason string, msg syslogMessage, err error) 
 // backpressure into request-path blocking. The drop is observable via
 // Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
 func (s *SyslogSink) recordDropped(reason string, err error) {
-	s.dropped.Add(1)
 	lastErr := reason
 	if err != nil {
 		lastErr = err.Error()
 	}
 	s.lastErrMu.Lock()
+	s.dropped.Add(1)
 	s.degraded.Store(true)
 	s.lastErr = lastErr
 	s.lastErrMu.Unlock()
@@ -500,8 +502,8 @@ func (s *SyslogSink) recordAbandoned(reason string, msg syslogMessage, count int
 	if count < 1 {
 		count = 1
 	}
-	s.abandoned.Add(uint64(count))
 	s.lastErrMu.Lock()
+	s.abandoned.Add(uint64(count))
 	s.degraded.Store(true)
 	s.lastErr = reason
 	s.lastErrMu.Unlock()

--- a/internal/emit/syslog.go
+++ b/internal/emit/syslog.go
@@ -307,7 +307,7 @@ func (s *SyslogSink) Emit(_ context.Context, event Event) error {
 		return nil
 	default:
 		s.closeMu.Unlock()
-		s.recordDropped("queue_full", nil)
+		s.recordDropped()
 		return ErrSyslogQueueFull
 	}
 }
@@ -486,15 +486,11 @@ func (s *SyslogSink) recordFailure(reason string, msg syslogMessage, err error) 
 // stderr write (which can block on a stalled pipe/journald) could turn that
 // backpressure into request-path blocking. The drop is observable via
 // Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
-func (s *SyslogSink) recordDropped(reason string, err error) {
-	lastErr := reason
-	if err != nil {
-		lastErr = err.Error()
-	}
+func (s *SyslogSink) recordDropped() {
 	s.lastErrMu.Lock()
 	s.dropped.Add(1)
 	s.degraded.Store(true)
-	s.lastErr = lastErr
+	s.lastErr = "queue_full"
 	s.lastErrMu.Unlock()
 }
 

--- a/internal/emit/syslog_test.go
+++ b/internal/emit/syslog_test.go
@@ -546,7 +546,7 @@ func TestSyslogSink_SuccessHealthTransitionIsAtomic(t *testing.T) {
 func TestSyslogSink_SuccessDoesNotEraseConcurrentDropDegraded(t *testing.T) {
 	var sink *SyslogSink
 	writer := &callbackSyslogWriter{writeFn: func() {
-		sink.recordDropped("queue_full", nil)
+		sink.recordDropped()
 	}}
 	sink = &SyslogSink{writer: writer, queue: make(chan syslogMessage, 1)}
 
@@ -568,7 +568,7 @@ func TestSyslogSink_RepeatedDegradeRecoverCycles(t *testing.T) {
 	}
 
 	for cycle := 1; cycle <= 3; cycle++ {
-		sink.recordDropped("queue_full", nil)
+		sink.recordDropped()
 		if stats := sink.Stats(); !stats.Degraded || stats.LastError != "queue_full" {
 			t.Fatalf("cycle %d degraded stats = %+v", cycle, stats)
 		}

--- a/internal/emit/webhook.go
+++ b/internal/emit/webhook.go
@@ -282,16 +282,14 @@ func (w *WebhookSink) Stats() WebhookStats {
 		return WebhookStats{}
 	}
 	w.lastErrMu.Lock()
-	lastErr := w.lastErr
-	degraded := w.degraded.Load()
-	w.lastErrMu.Unlock()
+	defer w.lastErrMu.Unlock()
 	stats := WebhookStats{
 		Delivered: w.delivered.Load(),
 		Failed:    w.failed.Load(),
 		Dropped:   w.dropped.Load(),
 		Abandoned: w.abandoned.Load(),
-		Degraded:  degraded,
-		LastError: lastErr,
+		Degraded:  w.degraded.Load(),
+		LastError: w.lastErr,
 	}
 	if w.queue != nil {
 		stats.QueueLen = len(w.queue)
@@ -320,11 +318,15 @@ func sanitizeWebhookErr(err error) string {
 }
 
 func (w *WebhookSink) recordFailure(reason string, event Event, err error) {
-	w.failed.Add(1)
+	lastErr := ""
+	if err != nil {
+		lastErr = sanitizeWebhookErr(err)
+	}
 	w.lastErrMu.Lock()
+	w.failed.Add(1)
 	w.degraded.Store(true)
 	if err != nil {
-		w.lastErr = sanitizeWebhookErr(err)
+		w.lastErr = lastErr
 	}
 	w.lastErrMu.Unlock()
 	w.logDiagnostic("delivery_failed", reason, event, err, 0)
@@ -338,12 +340,12 @@ func (w *WebhookSink) recordFailure(reason string, event Event, err error) {
 // backpressure into request-path blocking. The drop is observable via
 // Stats().Dropped / LastError / Degraded (and, once wired, sink health metrics).
 func (w *WebhookSink) recordDropped(reason string, err error) {
-	w.dropped.Add(1)
 	lastErr := reason
 	if err != nil {
 		lastErr = sanitizeWebhookErr(err)
 	}
 	w.lastErrMu.Lock()
+	w.dropped.Add(1)
 	w.degraded.Store(true)
 	w.lastErr = lastErr
 	w.lastErrMu.Unlock()
@@ -354,8 +356,8 @@ func (w *WebhookSink) recordAbandoned(count int) {
 		return
 	}
 	const reason = "drain_timeout" // the only path that abandons webhook events is a drain deadline
-	w.abandoned.Add(uint64(count))
 	w.lastErrMu.Lock()
+	w.abandoned.Add(uint64(count))
 	w.degraded.Store(true)
 	w.lastErr = reason
 	w.lastErrMu.Unlock()


### PR DESCRIPTION
## What changed
Publish failure counters, degraded state and error details together in each OTLP, webhook and syslog health snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health reporting for OTLP, webhook, and syslog outputs.
  * Ensured health status, error details, and failure counters remain consistent during concurrent activity.
  * Prevented snapshots from showing updated counters alongside stale or missing health details.

* **Tests**
  * Added coverage for concurrent failure, drop, and abandonment transitions across supported sink types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->