### PR TITLE
fix(scanner): stop flagging spaced assignments as URL credentials

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -291,7 +291,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -323,7 +323,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -331,7 +331,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -332,7 +332,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -330,7 +330,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -311,7 +311,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: critical
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: critical
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -311,7 +311,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
     - name: "Environment Variable Secret"
       regex: '(?-i:[A-Z][A-Z0-9]*[_-](?:SECRET(?:[_-]ACCESS)?[_-]?KEY|SECRET|PASSWORD|PASSWD|TOKEN|API[_-]?KEY))\b\s*=\s*[A-Za-z0-9_+/=~.-]\S{7,}'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -872,6 +872,8 @@ Core safety-floor patterns (`AWS Access ID`, `AWS Secret Key`, `GitHub Token`, `
 | Instruction Dismissal | `set the previous instructions aside` | high |
 | Priority Override | `prioritize the (task\|current) (request\|input)` | high |
 
+`Credential in URL` treats a line-start `key=value` as a credential only when `=` has no surrounding whitespace; spaced source or configuration assignments such as `token = value` are not this pattern's target. Query-style forms beginning with `?`, `&`, or `;` retain whitespace tolerance, so `? token = value` is still detected. Tabs are removed during DLP normalization before this grammar check, so tab-aligned assignments remain a documented false-positive residual.
+
 ### Environment Variable Leak Detection
 
 When `scan_env: true`, pipelock reads all environment variables at startup and flags URLs containing any env value that is:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -872,7 +872,7 @@ Core safety-floor patterns (`AWS Access ID`, `AWS Secret Key`, `GitHub Token`, `
 | Instruction Dismissal | `set the previous instructions aside` | high |
 | Priority Override | `prioritize the (task\|current) (request\|input)` | high |
 
-`Credential in URL` treats a line-start `key=value` as a credential only when `=` has no surrounding whitespace; spaced source or configuration assignments such as `token = value` are not this pattern's target. Query-style forms beginning with `?`, `&`, or `;` retain whitespace tolerance, so `? token = value` is still detected. Tabs are removed during DLP normalization before this grammar check, so tab-aligned assignments remain a documented false-positive residual.
+`Credential in URL` treats a line-start `key=value` as a credential only when `=` has no surrounding whitespace; spaced source or configuration assignments such as `token = value` are not this pattern's target. Query-style forms beginning with `?`, `&`, or `;` retain whitespace tolerance, so `? token = value` is still detected. Tabs are removed during DLP normalization before this grammar check, so tab-aligned assignments remain a documented false-positive residual. The whitespace-view refinement belongs to the unmodified built-in pattern; a renamed copy or a rule-bundle copy of the same regex keeps only the regex-level grammar.
 
 ### Environment Variable Leak Detection
 

--- a/examples/quickstart/pipelock.yaml
+++ b/examples/quickstart/pipelock.yaml
@@ -146,7 +146,7 @@ dlp:
       regex: '[0-9]{6,}-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
       severity: medium
     - name: "Credential in URL"
-      regex: '(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}'
+      regex: '(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})'
       severity: high
 response_scanning:
   enabled: true

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -357,7 +357,10 @@ const (
 	// report the same policy identity.
 	// Re-bumped when host-set hashing adopted runtime-equivalent case,
 	// duplicate, and trailing-dot normalization.
-	goldenHashDefaults = "6013ddd31af350126da95206ec226224f6c572aa628640745141d4a9c0a55eaa"
+	// Re-bumped for Credential in URL grammar: line-start assignments require
+	// adjacency around '=', while delimiter-led query parameters retain
+	// whitespace tolerance. This detection-relevant default changes policy.
+	goldenHashDefaults = "43c689f65d90d4cd7e6a90a298df97a6b4d01150066006d37e7e618d1f968063"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -541,7 +544,9 @@ const (
 	// flows into ph identically to Defaults().
 	// Re-bumped for runtime-equivalent host-set normalization; see
 	// goldenHashDefaults above.
-	goldenHashRichConfig = "0d78b75e6e65becb10e7ed9b6b3fca2846eebc5ab52bad45aa4cbb55ca533e6b"
+	// Re-bumped for the Credential in URL grammar change above; the rich
+	// fixture inherits the built-in DLP patterns.
+	goldenHashRichConfig = "649c59d3cf9cb07e446c22dc88769316c6ea3ba3600659a669bb5ade43b7e7af"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/dlp_patterns.go
+++ b/internal/config/dlp_patterns.go
@@ -280,7 +280,10 @@ var defaultDLPPatternSet = []DLPPattern{
 	// otherwise turn into a spurious match by deleting the value's
 	// natural delimiter: command substitution (token=$(...)),
 	// backticks, and quoted variable refs (password="$VAR").
-	{Name: "Credential in URL", Regex: `(?m)(?:^|[?&;])\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,}`, Severity: SeverityHigh},
+	// The line-start branch is intentionally strict around '=': spaced source
+	// assignments are not URL credentials. Delimiter-led query parameters keep
+	// whitespace tolerance for decoded and hand-written URLs.
+	{Name: "Credential in URL", Regex: `(?m)(?:^\s*(?:password|passwd|secret|token|apikey|api_key|api-key)=[A-Za-z0-9_+/=~%.-][^\s&;]{3,}|[?&;]\s*(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[A-Za-z0-9_+/=~%.-][^\s&;]{3,})`, Severity: SeverityHigh, CredentialURLWhitespaceGrammar: true},
 	// Environment variable credential patterns: catches env var dumps
 	// where the secret-bearing keyword is the terminal segment of an
 	// UPPER_CASE name (e.g., AWS_SECRET_ACCESS_KEY=..., STRIPE_SECRET_KEY=...,

--- a/internal/config/dlp_patterns_test.go
+++ b/internal/config/dlp_patterns_test.go
@@ -24,6 +24,28 @@ func TestDefaultDLPPatternsMatchDefaults(t *testing.T) {
 	}
 }
 
+func TestMarkBuiltInCredentialURLWhitespaceGrammar(t *testing.T) {
+	patterns := DefaultDLPPatterns()
+	var credentialIndex int
+	for i := range patterns {
+		if patterns[i].CredentialURLWhitespaceGrammar {
+			credentialIndex = i
+			break
+		}
+	}
+	patterns[credentialIndex].CredentialURLWhitespaceGrammar = false
+	markBuiltInCredentialURLWhitespaceGrammar(patterns)
+	if !patterns[credentialIndex].CredentialURLWhitespaceGrammar {
+		t.Fatal("canonical Credential in URL pattern lost built-in runtime provenance")
+	}
+
+	patterns[credentialIndex].Regex += "(?:changed)"
+	markBuiltInCredentialURLWhitespaceGrammar(patterns)
+	if patterns[credentialIndex].CredentialURLWhitespaceGrammar {
+		t.Fatal("customized Credential in URL pattern received built-in runtime provenance")
+	}
+}
+
 func TestDefaultDLPPatternsMatchIssuerBackedDecodedFormats(t *testing.T) {
 	t.Parallel()
 	githubJWTHeader := strings.Join([]string{"ghs_", "eyJ", "hbG", "ciOi", "JFUz", "I1Ni", "J9."}, "")
@@ -507,6 +529,7 @@ func scrubPatternRuntimeFields(patterns []DLPPattern) []DLPPattern {
 	out := cloneDLPPatterns(patterns)
 	for i := range out {
 		out[i].Compiled = false
+		out[i].CredentialURLWhitespaceGrammar = false
 		out[i].Bundle = ""
 		out[i].BundleVersion = ""
 	}

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -289,6 +289,7 @@ func (c *Config) ApplyDefaults() {
 		c.DLP.Patterns,
 		Defaults().DLP.Patterns,
 	)
+	markBuiltInCredentialURLWhitespaceGrammar(c.DLP.Patterns)
 	c.Suppress = mergeDefaultSuppressions(c.Suppress, defaultProviderKeySuppressions())
 	// Always default OnParseError (fail-closed) regardless of enabled state,
 	// since validation checks it unconditionally.
@@ -862,6 +863,28 @@ func mergeDLPPatterns(includeDefaults *bool, user, defaults []DLPPattern) []DLPP
 	}
 	merged = append(merged, user...)
 	return merged
+}
+
+// markBuiltInCredentialURLWhitespaceGrammar restores built-in runtime
+// provenance for shipped preset YAML, which serializes DLPPattern without its
+// runtime-only marker. Only an exact copy of the canonical built-in definition
+// receives the marker; operators cannot configure it through YAML.
+func markBuiltInCredentialURLWhitespaceGrammar(patterns []DLPPattern) {
+	for _, pattern := range defaultDLPPatternSet {
+		if !pattern.CredentialURLWhitespaceGrammar {
+			continue
+		}
+		for i := range patterns {
+			candidate := &patterns[i]
+			candidate.CredentialURLWhitespaceGrammar = candidate.Bundle == "" &&
+				candidate.Name == pattern.Name &&
+				candidate.Regex == pattern.Regex &&
+				candidate.Severity == pattern.Severity &&
+				candidate.Validator == pattern.Validator &&
+				sameStrings(candidate.ExemptDomains, pattern.ExemptDomains)
+		}
+		return
+	}
 }
 
 func mergeDefaultSuppressions(user, defaults []SuppressEntry) []SuppressEntry {

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -374,3 +374,65 @@ func TestReloader_RenameReload(t *testing.T) {
 	waitForReloaderReady(t, r)
 	renameUntilReload(t, r, dir, cfgPath, ModeAudit)
 }
+
+// TestReloader_PreservesCredentialURLGrammarMarker covers the runtime-only
+// marker on the built-in Credential in URL pattern across two successive
+// reloads. The fixture serializes the pattern the way a shipped preset does
+// (include_defaults: false plus the literal regex), so the marker cannot come
+// from Defaults(); it exists after a reload only because ApplyDefaults
+// re-derives it. With that re-derivation disabled this test fails.
+func TestReloader_PreservesCredentialURLGrammarMarker(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pipelock.yaml")
+	writeCredentialPatternConfig(t, cfgPath, "balanced")
+
+	r := NewReloader(cfgPath)
+	defer r.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		if err := r.Start(ctx); err != nil {
+			t.Errorf("reloader error: %v", err)
+		}
+	}()
+	waitForReloaderReady(t, r)
+
+	assertMarker := func(cfg *Config, state string) {
+		t.Helper()
+		for _, p := range cfg.DLP.Patterns {
+			if p.Name == "Credential in URL" {
+				if !p.CredentialURLWhitespaceGrammar {
+					t.Fatalf("%s: built-in Credential in URL lost its grammar marker", state)
+				}
+				return
+			}
+		}
+		t.Fatalf("%s: Credential in URL pattern missing after reload", state)
+	}
+
+	writeCredentialPatternConfig(t, cfgPath, ModeAudit)
+	assertMarker(waitForReload(t, r, ModeAudit), "reload with change")
+	writeCredentialPatternConfig(t, cfgPath, ModeBalanced)
+	assertMarker(waitForReload(t, r, ModeBalanced), "second reload")
+}
+
+// writeCredentialPatternConfig writes a config whose DLP set is only the
+// serialized built-in Credential in URL pattern, taken from Defaults() so the
+// fixture cannot drift from the shipped regex.
+func writeCredentialPatternConfig(t *testing.T, path, mode string) {
+	t.Helper()
+	var regex string
+	for _, p := range Defaults().DLP.Patterns {
+		if p.Name == "Credential in URL" {
+			regex = p.Regex
+		}
+	}
+	if regex == "" {
+		t.Fatal("Credential in URL missing from Defaults()")
+	}
+	content := "version: 1\nmode: " + mode + "\ndlp:\n  include_defaults: false\n  patterns:\n    - name: \"Credential in URL\"\n      regex: '" + regex + "'\n      severity: high\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1113,6 +1113,9 @@ type DLPPattern struct {
 	Bundle        string   `yaml:"-"`                   // set by rules loader, not from YAML
 	BundleVersion string   `yaml:"-"`                   // set by rules loader, not from YAML
 	Compiled      bool     `yaml:"-"`                   // true for patterns created in Defaults()
+	// CredentialURLWhitespaceGrammar is set only by the built-in default
+	// registry. It is runtime provenance, not an operator-facing setting.
+	CredentialURLWhitespaceGrammar bool `yaml:"-"`
 }
 
 // AddressProtection configures crypto address poisoning detection.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -324,18 +324,19 @@ func (s *Scanner) getDLPWarnHook() func(ctx context.Context, patternName, severi
 }
 
 type compiledPattern struct {
-	name                string
-	re                  *regexp.Regexp
-	withoutLeftBoundary *regexp.Regexp
-	providerKeyPrefix   string
-	severity            string
-	validate            func(string) bool // post-match checksum (nil = regex-only)
-	exemptDomains       []string          // domains where this pattern is skipped (wildcard supported)
-	core                bool              // name belongs to the immutable floor: exemptDomains is never honored
-	bundle              string            // empty for built-in/config patterns
-	bundleVersion       string
-	warn                bool // true when pattern action is "warn" - matches are informational only
-	requiredLiteralsAny []string
+	name                           string
+	re                             *regexp.Regexp
+	withoutLeftBoundary            *regexp.Regexp
+	providerKeyPrefix              string
+	severity                       string
+	validate                       func(string) bool // post-match checksum (nil = regex-only)
+	exemptDomains                  []string          // domains where this pattern is skipped (wildcard supported)
+	core                           bool              // name belongs to the immutable floor: exemptDomains is never honored
+	bundle                         string            // empty for built-in/config patterns
+	bundleVersion                  string
+	warn                           bool // true when pattern action is "warn" - matches are informational only
+	credentialURLWhitespaceGrammar bool // built-in-only runtime provenance; never configured by operators
+	requiredLiteralsAny            []string
 }
 
 // matches returns true if text matches the regex AND passes the post-match
@@ -418,14 +419,15 @@ func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 			return nil, fmt.Errorf("compile DLP pattern %q: %w", p.Name, err)
 		}
 		cp := &compiledPattern{
-			name:          p.Name,
-			re:            re,
-			severity:      p.Severity,
-			exemptDomains: p.ExemptDomains,
-			core:          config.IsCoreDLPPatternName(p.Name),
-			bundle:        p.Bundle,
-			bundleVersion: p.BundleVersion,
-			warn:          p.Action == config.ActionWarn,
+			name:                           p.Name,
+			re:                             re,
+			severity:                       p.Severity,
+			exemptDomains:                  p.ExemptDomains,
+			core:                           config.IsCoreDLPPatternName(p.Name),
+			bundle:                         p.Bundle,
+			bundleVersion:                  p.BundleVersion,
+			warn:                           p.Action == config.ActionWarn,
+			credentialURLWhitespaceGrammar: p.CredentialURLWhitespaceGrammar,
 		}
 		body, hasProviderBoundary := strings.CutPrefix(p.Regex, config.ProviderKeyLeftBoundaryRegex)
 		if hasProviderBoundary {

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	"github.com/luckyPipewrench/pipelock/internal/normalize"
@@ -562,7 +563,8 @@ func (s *Scanner) scanTextForDLP(ctx context.Context, text string, opts textDLPO
 	}
 
 	if len(segmentViews) > 1 {
-		matches = append(matches, s.matchDLPPatternsInView(segmentViews[1].text, "whitespace", cleaned)...)
+		compacted, offsets := compactTextDLPWhitespaceWithOffsets(cleaned)
+		matches = append(matches, s.matchDLPPatternsInWhitespaceView(compacted, cleaned, offsets)...)
 	}
 
 	// Hostname exfiltration: extract URL hostnames from the text and run the
@@ -699,6 +701,66 @@ func (s *Scanner) matchDLPPatternsInView(text, encoding, proseSource string) []T
 		}
 	}
 	return matches
+}
+
+// matchDLPPatternsInWhitespaceView preserves the whitespace-compacted view and
+// its spans for every pattern. The built-in Credential in URL grammar alone
+// rejects a match that compaction manufactured from a spaced line-start
+// assignment; this is intentionally not an operator-configurable behavior.
+func (s *Scanner) matchDLPPatternsInWhitespaceView(text, proseSource string, offsets []int) []TextDLPMatch {
+	// text is already compacted from normalize.ForDLP(proseSource). Do not
+	// transform it again: offsets index this exact emitted view.
+	var matches []TextDLPMatch
+	for _, idx := range s.dlpPreFilter.patternsToCheck(text) {
+		p := s.dlpPatterns[idx]
+		if start, end, ok := p.matchSpanInView(text, proseSource); ok {
+			if p.credentialURLWhitespaceGrammar && !credentialURLWhitespaceMatchAllowed(text, proseSource, offsets, start, end) {
+				continue
+			}
+			matches = append(matches, TextDLPMatch{
+				PatternName:   p.name,
+				Severity:      p.severity,
+				Encoded:       "whitespace",
+				Bundle:        p.bundle,
+				BundleVersion: p.bundleVersion,
+				Warn:          p.warn,
+				span:          newMatchSpan(start, end, dlpViewLabel("whitespace"), p.name, p.bundle, p.bundleVersion),
+			})
+		}
+	}
+	return matches
+}
+
+func credentialURLWhitespaceMatchAllowed(compacted, source string, offsets []int, start, end int) bool {
+	if start < 0 || end > len(compacted) || start >= end || end > len(offsets) {
+		return true // Invalid context must stay fail-closed for detection.
+	}
+	if delimiter := compacted[start]; delimiter == '?' || delimiter == '&' || delimiter == ';' {
+		return true
+	}
+	equalAt := start + strings.IndexByte(compacted[start:end], '=')
+	if equalAt < start || equalAt >= len(offsets) {
+		return true
+	}
+	sourceEqualAt := offsets[equalAt]
+	if sourceEqualAt < 0 || sourceEqualAt >= len(source) || source[sourceEqualAt] != '=' {
+		return true
+	}
+	return !hasWhitespaceAdjacentToByte(source, sourceEqualAt)
+}
+
+func hasWhitespaceAdjacentToByte(text string, at int) bool {
+	if at > 0 {
+		left, _ := utf8.DecodeLastRuneInString(text[:at])
+		if unicode.IsSpace(left) {
+			return true
+		}
+	}
+	if at+1 < len(text) {
+		right, _ := utf8.DecodeRuneInString(text[at+1:])
+		return unicode.IsSpace(right)
+	}
+	return false
 }
 
 //pipelock:provenance-transform whitespace_compact

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -684,6 +684,9 @@ func (s *Scanner) matchDLPPatterns(text, encoding string) []TextDLPMatch {
 }
 
 func (s *Scanner) matchDLPPatternsInView(text, encoding, proseSource string) []TextDLPMatch {
+	// The whitespace view deliberately skips this re-normalization
+	// (matchDLPPatternsInWhitespaceView): its offsets index the emitted view
+	// bytes, and normalizing again would shift every span.
 	text = normalize.ForDLP(text)
 	var matches []TextDLPMatch
 	for _, idx := range s.dlpPreFilter.patternsToCheck(text) {

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/normalize"
 )
 
 const (
@@ -2431,6 +2432,148 @@ func TestScanTextForDLP_CredentialInURL_CatchesBodyStart(t *testing.T) {
 			result := s.ScanTextForDLP(context.Background(), s2)
 			if result.Clean {
 				t.Errorf("expected catch on %q, got clean", s2)
+			}
+		})
+	}
+}
+
+func TestScanTextForDLP_CredentialInURLGrammar(t *testing.T) {
+	s := MustNew(testConfig())
+	defer s.Close()
+
+	positives := []struct {
+		name     string
+		text     string
+		encoding string
+	}{
+		{name: "line start", text: "token=abcdef123456"},
+		{name: "query", text: "?token=abcdef123456"},
+		{name: "ampersand", text: "&secret=abcdef123456"},
+		{name: "split keyword", text: "tok en=abcdef123456", encoding: "whitespace"},
+		{name: "split value", text: "token=abcdef 123456", encoding: "whitespace"},
+		{name: "url encoded", text: "api_key%3DZ9x8y7w6v5u4", encoding: "url"},
+		{name: "spaced query", text: "GET /p? token = abcdef123456"},
+		{name: "callback", text: "https://api.vendor.example/cb?api_key=Z9x8y7w6v5u4"},
+	}
+	for _, tc := range positives {
+		t.Run("positive/"+tc.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tc.text)
+			if result.Clean || !hasTextDLPMatch(result.Matches, "Credential in URL", tc.encoding) {
+				t.Fatalf("Credential in URL missed %q: %+v", tc.text, result.Matches)
+			}
+		})
+	}
+
+	negatives := []string{
+		`secret = bytes.fromhex("0011223344556677")`,
+		`SECRET = os.Getenv("X")`,
+		"token = $(get_token)",
+		"token=${VAR}",
+	}
+	for _, text := range negatives {
+		t.Run("negative/"+text, func(t *testing.T) {
+			if result := s.ScanTextForDLP(context.Background(), text); !result.Clean {
+				t.Fatalf("spaced source assignment must stay clean: %+v", result.Matches)
+			}
+		})
+	}
+}
+
+func TestScanTextForDLP_CredentialInURLTabResidual(t *testing.T) {
+	s := MustNew(testConfig())
+	defer s.Close()
+
+	// ForDLP strips tabs before the whitespace view can preserve offsets, so
+	// tab-aligned source assignments remain a documented false positive.
+	result := s.ScanTextForDLP(context.Background(), "passwd\t=\tabcdef123456")
+	if result.Clean || !hasTextDLPMatch(result.Matches, "Credential in URL", "") {
+		t.Fatalf("tab residual must remain covered: %+v", result.Matches)
+	}
+}
+
+func TestScanTextForDLP_CredentialInURLPreservesWhitespaceViewSpans(t *testing.T) {
+	cfg := testConfig()
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, config.DLPPattern{
+		Name: "view sentinel", Regex: `VIEWSENTINEL`, Severity: config.SeverityHigh,
+	})
+	s := MustNew(cfg)
+	defer s.Close()
+
+	text := "secret = bytes.fromhex(\"00\")\nordinary note VIEWSENTINEL"
+	result := s.ScanTextForDLP(context.Background(), text)
+	cleaned := normalize.ForDLP(text)
+	compacted, offsets := compactTextDLPWhitespaceWithOffsets(cleaned)
+	sentinelStart := strings.Index(compacted, "VIEWSENTINEL")
+	if sentinelStart < 0 {
+		t.Fatal("compacted view lost VIEWSENTINEL")
+	}
+	for i := range "VIEWSENTINEL" {
+		if got := cleaned[offsets[sentinelStart+i]]; got != "VIEWSENTINEL"[i] {
+			t.Fatalf("offset[%d] indexes %q, want %q", sentinelStart+i, got, "VIEWSENTINEL"[i])
+		}
+	}
+	for _, match := range result.Matches {
+		if match.PatternName != "view sentinel" || match.Encoded != "whitespace" {
+			continue
+		}
+		assertSpanSlice(t, compacted, match.Span(), "VIEWSENTINEL")
+		return
+	}
+	t.Fatalf("missing whitespace VIEWSENTINEL match: %+v", result.Matches)
+}
+
+func TestCredentialURLWhitespaceMatchAllowed(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		start  int
+		end    int
+		want   bool
+	}{
+		{name: "adjacent line start", source: "token=abcdef123456", start: 0, end: len("token=abcdef123456"), want: true},
+		{name: "spaced line start", source: "token = abcdef123456", start: 0, end: len("token=abcdef123456"), want: false},
+		{name: "delimiter keeps whitespace", source: "? token = abcdef123456", start: 0, end: len("?token=abcdef123456"), want: true},
+		{name: "invalid span stays detected", source: "token=abcdef123456", start: -1, end: 2, want: true},
+		{name: "empty span stays detected", source: "token=abcdef123456", start: 3, end: 3, want: true},
+		{name: "missing equals stays detected", source: "tokenabcdef123456", start: 0, end: len("tokenabcdef123456"), want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			compacted, offsets := compactTextDLPWhitespaceWithOffsets(tc.source)
+			if got := credentialURLWhitespaceMatchAllowed(compacted, tc.source, offsets, tc.start, tc.end); got != tc.want {
+				t.Fatalf("credentialURLWhitespaceMatchAllowed(%q) = %v, want %v", tc.source, got, tc.want)
+			}
+		})
+	}
+
+	compacted, offsets := compactTextDLPWhitespaceWithOffsets("token=abcdef123456")
+	if !credentialURLWhitespaceMatchAllowed(compacted, "token=abcdef123456", nil, 0, len(compacted)) {
+		t.Fatal("missing offset context must stay detected")
+	}
+	badOffsets := append([]int(nil), offsets...)
+	badOffsets[strings.IndexByte(compacted, '=')] = 0
+	if !credentialURLWhitespaceMatchAllowed(compacted, "token=abcdef123456", badOffsets, 0, len(compacted)) {
+		t.Fatal("invalid source mapping must stay detected")
+	}
+}
+
+func TestHasWhitespaceAdjacentToByte(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		at   int
+		want bool
+	}{
+		{name: "left", text: "token =value", at: strings.IndexByte("token =value", '='), want: true},
+		{name: "right", text: "token= value", at: strings.IndexByte("token= value", '='), want: true},
+		{name: "unicode right", text: "token=\u00a0value", at: strings.IndexByte("token=\u00a0value", '='), want: true},
+		{name: "adjacent", text: "token=value", at: strings.IndexByte("token=value", '='), want: false},
+		{name: "edge", text: "=", at: 0, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasWhitespaceAdjacentToByte(tc.text, tc.at); got != tc.want {
+				t.Fatalf("hasWhitespaceAdjacentToByte(%q, %d) = %v, want %v", tc.text, tc.at, got, tc.want)
 			}
 		})
 	}

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -3869,3 +3869,24 @@ func TestTextDLP_DottedTokenPatterns(t *testing.T) {
 		}
 	}
 }
+
+// TestScanTextForDLP_CredentialInURLGrammarFromPresetYAML proves the
+// production seam: a shipped preset serializes the pattern without its
+// runtime-only marker, so the whitespace-view filter exists only through the
+// ApplyDefaults re-derivation. Defaults()-based tests never exercise that path.
+func TestScanTextForDLP_CredentialInURLGrammarFromPresetYAML(t *testing.T) {
+	cfg, err := config.Load("../../configs/balanced.yaml")
+	if err != nil {
+		t.Fatalf("load preset: %v", err)
+	}
+	cfg.Internal = nil
+	s := MustNew(cfg)
+	defer s.Close()
+
+	if result := s.ScanTextForDLP(context.Background(), `secret = bytes.fromhex("0011223344556677")`); !result.Clean {
+		t.Fatalf("preset-loaded pattern must suppress the spaced assignment: %+v", result.Matches)
+	}
+	if result := s.ScanTextForDLP(context.Background(), "token=abcdef123456"); result.Clean || !hasTextDLPMatch(result.Matches, "Credential in URL", "") {
+		t.Fatalf("preset-loaded pattern must still detect the adjacent form: %+v", result.Matches)
+	}
+}


### PR DESCRIPTION
## What changed

`Credential in URL` no longer flags a line-start assignment with spaces around `=`, such as `secret = bytes.fromhex(...)` or `SECRET = os.Getenv("X")`. Those are source or config assignments, not credentials in a URL. Query-style forms that begin with `?`, `&` or `;` keep their whitespace tolerance, and the adjacent form `token=value` is still detected.

- The whitespace-compacted scan view keeps its bytes and offsets intact. A built-in-only filter drops a match that compaction manufactured from a spaced assignment, so every other pattern's span still points at the right bytes. The filter belongs to the unmodified built-in pattern and isn't an operator setting.
- Every preset copy of the regex and the canonical policy hash move together, and the parity test fails if one copy is left behind. Tab-aligned assignments are still flagged because tabs are removed before this check; that residual is documented and pinned by a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Credential in URL” detection accuracy across built-in presets.
  * Prevented spaced line-start assignments from being incorrectly flagged.
  * Preserved detection for credentials in query-style URL parameters, including `?`, `&`, and `;` formats.
  * Improved handling of whitespace-normalized and URL-encoded content.

* **Documentation**
  * Clarified the whitespace rules for the built-in “Credential in URL” pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->