### PR TITLE
test: fix CI timing flakes and cover the debounce timer identity

### DIFF
--- a/internal/filesentry/watcher_impl.go
+++ b/internal/filesentry/watcher_impl.go
@@ -81,6 +81,10 @@ type fsWatcher struct {
 	// addWatch is the fsnotify registration seam. It is only replaced by tests
 	// to deterministically exercise per-subtree watch-install failures.
 	addWatch func(string) error
+	// afterFunc is the debounce timer seam. It is only replaced by tests so a
+	// stale callback can be invoked after a replacement without waiting on the
+	// wall clock. Production keeps time.AfterFunc.
+	afterFunc func(time.Duration, func()) *time.Timer
 }
 
 // DegradedPath records a configured watch_paths entry whose install failed
@@ -140,6 +144,7 @@ func NewWatcher(cfg *config.FileSentry, sc DLPScanner, lin Lineage, onError func
 		watchedPaths: make(map[string]struct{}),
 		onError:      onError,
 		addWatch:     w.Add,
+		afterFunc:    time.AfterFunc,
 	}, nil
 }
 
@@ -548,8 +553,9 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	// Timer identity check: capture the timer pointer in the closure.
 	// If a second write replaces this timer before the callback fires,
 	// the old callback sees its pointer differs from the map entry and
-	// does nothing. Without this, the old callback would delete the new
-	// timer's map entry, causing the new callback to scan without cleanup.
+	// does nothing. Without this, the old callback deletes the live
+	// timer's map entry, the live callback finds no timer, and the
+	// quiet-period scan is missed.
 	w.mu.Lock()
 	if w.closed {
 		w.mu.Unlock()
@@ -562,7 +568,7 @@ func (w *fsWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 	// Declare timer before AfterFunc so the closure can capture it.
 	// The closure uses timer identity to detect stale callbacks.
 	var timer *time.Timer
-	timer = time.AfterFunc(debounceDelay, func() {
+	timer = w.afterFunc(debounceDelay, func() {
 		w.mu.Lock()
 		if w.closed {
 			w.mu.Unlock()

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1053,12 +1053,13 @@ func TestWatcher_ClosedGuardsRejectNewWork(t *testing.T) {
 	t.Run("timer_callback", func(t *testing.T) {
 		sc := &countingDLPScanner{}
 		w := &fsWatcher{
-			cfg:      &config.FileSentry{ScanContent: ptrBool(true)},
-			scanner:  sc,
-			findings: make(chan Finding, 1),
-			overflow: make(chan Finding, 1),
-			timers:   make(map[string]*time.Timer),
-			pidSnap:  make(map[string]bool),
+			cfg:       &config.FileSentry{ScanContent: ptrBool(true)},
+			scanner:   sc,
+			findings:  make(chan Finding, 1),
+			overflow:  make(chan Finding, 1),
+			timers:    make(map[string]*time.Timer),
+			pidSnap:   make(map[string]bool),
+			afterFunc: time.AfterFunc,
 		}
 		w.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
 		w.mu.Lock()
@@ -1273,8 +1274,9 @@ func TestWatcher_CloseWaitsForInFlightDebounceScan(t *testing.T) {
 }
 
 func TestWatcher_DebounceTimerRace(t *testing.T) {
-	// Verify that rapid writes to the same file produce exactly one scan,
-	// not multiple. The timer identity check prevents stale callbacks.
+	// Smoke test over real fsnotify: a write burst still produces a finding
+	// for the written path. The identity check is covered by
+	// TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan.
 	dir := t.TempDir()
 	cfg := &config.FileSentry{
 		Enabled:     true,
@@ -1313,14 +1315,11 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 	//   produced 6 scans for 10 writes and the assertion stayed green.
 	//
 	// The count assertions this test's name implies need control over the
-	// debounce clock, which this package does not expose. Until that exists the
-	// honest position is a smoke test that cannot lie, rather than a threshold
-	// that reports contention as a timer race.
-	//
-	// In particular this does NOT guard the timer identity check. That
-	// regression deletes the live timer's map entry and produces FEWER scans,
-	// which no upper bound detects; removing the identity comparison leaves
-	// this test green.
+	// debounce clock. TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan
+	// owns that clock through the afterFunc seam. This test stays a smoke
+	// check over real fsnotify: it cannot lie about a scan happening, and it
+	// cannot police the identity check. Removing the identity comparison still
+	// leaves this test green because the missed scan is a lower count.
 	const writes = 10
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 	filePath := filepath.Join(dir, "rapid.json")
@@ -1345,6 +1344,147 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 
 	if got := sc.calls.Load(); got < 1 {
 		t.Fatalf("ScanTextForDLP calls = %d, want the debounced scan to have run", got)
+	}
+}
+
+// A stale debounce callback that lost the replacement race must not delete
+// the live timer's map entry. Without that identity check the live callback
+// finds no timer and skips the scan of the quiet-period content.
+func TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	const firstContent = "first-write-body"
+	const finalContent = "final-write-body"
+	if err := os.WriteFile(path, []byte(firstContent), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	sc := &capturingDLPScanner{}
+	clock := &manualAfterFunc{}
+	w, err := NewWatcher(&config.FileSentry{ScanContent: ptrBool(true)}, sc, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		clock.stopAll()
+		_ = w.Close()
+	})
+	fw := w.(*fsWatcher)
+	fw.afterFunc = clock.afterFunc
+
+	fw.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
+	if err := os.WriteFile(path, []byte(finalContent), 0o600); err != nil {
+		t.Fatalf("WriteFile final: %v", err)
+	}
+	fw.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
+
+	stale, live := clock.callbacks()
+	if stale == nil || live == nil {
+		t.Fatalf("armed callbacks = %d, want 2", clock.len())
+	}
+	if clock.timerAt(0) == clock.timerAt(1) {
+		t.Fatal("replacement reused the first timer pointer")
+	}
+
+	fw.mu.Lock()
+	current := fw.timers[path]
+	fw.mu.Unlock()
+	if current != clock.timerAt(1) {
+		t.Fatal("live timer is not the map entry for the path")
+	}
+
+	stale()
+	if got := sc.scanned(); len(got) != 0 {
+		t.Fatalf("stale callback scanned %#v, want no scan", got)
+	}
+	fw.mu.Lock()
+	current = fw.timers[path]
+	fw.mu.Unlock()
+	if current != clock.timerAt(1) {
+		t.Fatal("stale callback deleted the live timer map entry")
+	}
+
+	live()
+	got := sc.scanned()
+	if len(got) != 1 || got[0] != finalContent {
+		t.Fatalf("live scan = %#v, want one scan of %q", got, finalContent)
+	}
+}
+
+type capturingDLPScanner struct {
+	countingDLPScanner
+	mu    sync.Mutex
+	texts []string
+}
+
+func (s *capturingDLPScanner) ScanTextForDLP(ctx context.Context, text string) scanner.TextDLPResult {
+	s.mu.Lock()
+	s.texts = append(s.texts, text)
+	s.mu.Unlock()
+	return s.countingDLPScanner.ScanTextForDLP(ctx, text)
+}
+
+func (s *capturingDLPScanner) scanned() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.texts))
+	copy(out, s.texts)
+	return out
+}
+
+// manualAfterFunc returns real *time.Timer values that never fire on their
+// own so tests can invoke captured callbacks in a chosen order. Production
+// Stop() and pointer identity keep their exact semantics.
+type manualAfterFunc struct {
+	mu     sync.Mutex
+	fns    []func()
+	timers []*time.Timer
+}
+
+func (m *manualAfterFunc) afterFunc(_ time.Duration, cb func()) *time.Timer {
+	// Hour is longer than any test deadline; the test fires cb itself.
+	timer := time.NewTimer(time.Hour)
+	m.mu.Lock()
+	m.fns = append(m.fns, cb)
+	m.timers = append(m.timers, timer)
+	m.mu.Unlock()
+	return timer
+}
+
+func (m *manualAfterFunc) callbacks() (stale, live func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.fns) < 2 {
+		return nil, nil
+	}
+	return m.fns[0], m.fns[1]
+}
+
+func (m *manualAfterFunc) timerAt(i int) *time.Timer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if i < 0 || i >= len(m.timers) {
+		return nil
+	}
+	return m.timers[i]
+}
+
+func (m *manualAfterFunc) len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.fns)
+}
+
+func (m *manualAfterFunc) stopAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, timer := range m.timers {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
 	}
 }
 

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1349,12 +1349,19 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 	// Drain whatever the remaining windows produced. Counting beats failing on
 	// the first extra: a run that coalesced nothing and a run that split into
 	// two windows are different defects, and only the count distinguishes them.
+	// The two-value receive is load-bearing. A closed Findings channel yields
+	// immediately and forever, so a single-value receive would spin for the
+	// whole observation window and report thousands of findings -- a false
+	// failure that would read exactly like a catastrophic timer race.
 	findings := int64(1)
 	extraWindow := time.After(filesentryNegativeObservation)
 drain:
 	for {
 		select {
-		case <-w.Findings():
+		case _, open := <-w.Findings():
+			if !open {
+				break drain
+			}
 			findings++
 		case <-extraWindow:
 			break drain

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1294,91 +1294,57 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 
 	armAndStart(t, w, ctx)
 
-	// Write the same file rapidly, then assert the debouncer COALESCED the
-	// burst rather than asserting an exact scan count.
+	// Write the same file rapidly and assert what survives scheduling: the
+	// burst produces a finding, and it describes the file that was written.
 	//
-	// The timer fires debounceDelay after the last write it saw, so two writes
-	// separated by a gap of at least debounceDelay legitimately land in
-	// different windows and legitimately produce two scans. How the burst is
-	// spread across windows is decided by the OS scheduler, not by the
-	// debouncer, so "exactly 1" asserted a property this code does not own. On
-	// an idle host the loop finishes in microseconds and the answer is 1; on a
-	// contended CI runner the loop can be preempted for longer than the 50ms
-	// window, and the old assertion reported that as "unexpected extra finding
-	// (timer race?)" -- a red build caused by load rather than by the timer
-	// identity check it named.
+	// This test asserts NO scan count, and that is deliberate. Three count
+	// shapes were tried and each was unsound:
 	//
-	// The bound is derived from the burst this run actually observed: the gaps
-	// that can split it sum to at most the elapsed time, so it spans at most
-	// elapsed/debounceDelay + 1 windows. On a fast host that is 1, which keeps
-	// the original strict assertion intact where it is meaningful.
+	//   "exactly 1" asserted a property of the OS scheduler. The timer is armed
+	//   in handleEvent, so window boundaries are set by when fsnotify delivers
+	//   events, not by when the writer wrote. A burst completed in microseconds
+	//   can still span two windows, which is what reddened CI.
+	//
+	//   A bound derived from the writer's elapsed time reads a different clock
+	//   than the one arming the timers, so it is wrong in both directions.
+	//
+	//   "fewer scans than writes" is vacuous: fsnotify already coalesces the
+	//   writes into fewer events, so disabling the debouncer entirely still
+	//   produced 6 scans for 10 writes and the assertion stayed green.
+	//
+	// The count assertions this test's name implies need control over the
+	// debounce clock, which this package does not expose. Until that exists the
+	// honest position is a smoke test that cannot lie, rather than a threshold
+	// that reports contention as a timer race.
+	//
+	// In particular this does NOT guard the timer identity check. That
+	// regression deletes the live timer's map entry and produces FEWER scans,
+	// which no upper bound detects; removing the identity comparison leaves
+	// this test green.
 	const writes = 10
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 	filePath := filepath.Join(dir, "rapid.json")
-	start := time.Now()
 	for i := range writes {
 		content := fmt.Sprintf("%s-%d", secret, i)
 		if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
 			t.Fatalf("WriteFile[%d]: %v", i, err)
 		}
 	}
-	elapsed := time.Since(start)
 
-	// A burst slow enough to span every window proves nothing about
-	// coalescing, so say so rather than passing vacuously.
-	// Computed and compared as int64. A narrowing conversion here could wrap to
-	// a negative bound, which would fail every run rather than tolerate a slow
-	// one -- the exact failure direction this change exists to remove.
-	maxScans := int64(elapsed/debounceDelay) + 1
-	if maxScans >= writes {
-		t.Skipf("burst of %d writes took %v, spanning at least %d debounce windows: "+
-			"scheduling decided the scan count, so coalescing cannot be observed",
-			writes, elapsed, writes)
-	}
-
-	// Wait for the first debounced scan.
 	select {
 	case f := <-w.Findings():
 		if f.PatternName == "" {
 			t.Error("expected DLP match")
 		}
+		if f.Path != filePath {
+			t.Errorf("finding path = %q, want %q", f.Path, filePath)
+		}
 	case <-time.After(filesentryPositiveBackstop):
 		t.Fatal("timeout waiting for debounced finding")
 	}
 
-	// Drain whatever the remaining windows produced. Counting beats failing on
-	// the first extra: a run that coalesced nothing and a run that split into
-	// two windows are different defects, and only the count distinguishes them.
-	// The two-value receive is load-bearing. A closed Findings channel yields
-	// immediately and forever, so a single-value receive would spin for the
-	// whole observation window and report thousands of findings -- a false
-	// failure that would read exactly like a catastrophic timer race.
-	findings := int64(1)
-	extraWindow := time.After(filesentryNegativeObservation)
-drain:
-	for {
-		select {
-		case _, open := <-w.Findings():
-			if !open {
-				break drain
-			}
-			findings++
-		case <-extraWindow:
-			break drain
-		}
-	}
-
-	if findings > maxScans {
-		t.Errorf("findings = %d over a %v burst of %d writes, want at most %d (timer race?)",
-			findings, elapsed, writes, maxScans)
-	}
-	got := int64(sc.calls.Load())
-	if got < 1 {
+	if got := sc.calls.Load(); got < 1 {
 		t.Fatalf("ScanTextForDLP calls = %d, want the debounced scan to have run", got)
-	}
-	if got > maxScans {
-		t.Fatalf("ScanTextForDLP calls = %d over a %v burst of %d writes, want at most %d",
-			got, elapsed, writes, maxScans)
 	}
 }
 

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1315,11 +1315,13 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 	//   produced 6 scans for 10 writes and the assertion stayed green.
 	//
 	// The count assertions this test's name implies need control over the
-	// debounce clock. TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan
-	// owns that clock through the afterFunc seam. This test stays a smoke
+	// debounce clock, and two tests own that clock through the afterFunc seam:
+	// TestWatcher_BurstCoalescesToOneScan asserts a burst collapses to exactly
+	// one scan, and TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan
+	// asserts the identity check keeps the live scan. This one stays a smoke
 	// check over real fsnotify: it cannot lie about a scan happening, and it
-	// cannot police the identity check. Removing the identity comparison still
-	// leaves this test green because the missed scan is a lower count.
+	// cannot police either count. Removing the identity comparison still leaves
+	// this test green because the missed scan is a lower count.
 	const writes = 10
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 	filePath := filepath.Join(dir, "rapid.json")
@@ -1458,6 +1460,79 @@ func (m *manualAfterFunc) callbacks() (stale, live func()) {
 		return nil, nil
 	}
 	return m.fns[0], m.fns[1]
+}
+
+// A rapid burst must collapse to ONE scan, and this asserts the count without
+// touching the wall clock. The real-fsnotify test above deliberately asserts no
+// count: it observes whatever windows the scheduler happened to produce, so any
+// number it checks is a claim about scheduling rather than about the debouncer.
+// Driving handleEvent through the afterFunc seam fixes the window boundaries,
+// which is what makes a count meaningful here.
+//
+// This is the coalescing guarantee the debouncer actually owns: every event but
+// the last loses the replacement race and its callback must do nothing.
+func TestWatcher_BurstCoalescesToOneScan(t *testing.T) {
+	const writes = 10
+	const finalContent = "final-burst-body"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "burst.txt")
+	if err := os.WriteFile(path, []byte("seed-body"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	sc := &capturingDLPScanner{}
+	clock := &manualAfterFunc{}
+	w, err := NewWatcher(&config.FileSentry{ScanContent: ptrBool(true)}, sc, nil, nil)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		clock.stopAll()
+		_ = w.Close()
+	})
+	fw := w.(*fsWatcher)
+	fw.afterFunc = clock.afterFunc
+
+	for range writes {
+		fw.handleEvent(context.Background(), fsnotify.Event{Name: path, Op: fsnotify.Write})
+	}
+	if err := os.WriteFile(path, []byte(finalContent), 0o600); err != nil {
+		t.Fatalf("WriteFile final: %v", err)
+	}
+
+	if got := clock.len(); got != writes {
+		t.Fatalf("armed timers = %d, want %d", got, writes)
+	}
+	fw.mu.Lock()
+	current := fw.timers[path]
+	fw.mu.Unlock()
+	if current != clock.timerAt(writes-1) {
+		t.Fatal("map entry is not the last armed timer")
+	}
+
+	// Fire every window in the order it was armed. The first nine lost the race.
+	for i := range writes {
+		cb := clock.fnAt(i)
+		if cb == nil {
+			t.Fatalf("callback %d missing", i)
+		}
+		cb()
+	}
+
+	got := sc.scanned()
+	if len(got) != 1 || got[0] != finalContent {
+		t.Fatalf("scans = %#v, want exactly one scan of %q", got, finalContent)
+	}
+}
+
+func (m *manualAfterFunc) fnAt(i int) func() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if i < 0 || i >= len(m.fns) {
+		return nil
+	}
+	return m.fns[i]
 }
 
 func (m *manualAfterFunc) timerAt(i int) *time.Timer {

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1294,18 +1294,49 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 
 	armAndStart(t, w, ctx)
 
-	// Write the same file rapidly 10 times. Only the last write's debounce
-	// timer should fire. We should get exactly 1 finding.
+	// Write the same file rapidly, then assert the debouncer COALESCED the
+	// burst rather than asserting an exact scan count.
+	//
+	// The timer fires debounceDelay after the last write it saw, so two writes
+	// separated by a gap of at least debounceDelay legitimately land in
+	// different windows and legitimately produce two scans. How the burst is
+	// spread across windows is decided by the OS scheduler, not by the
+	// debouncer, so "exactly 1" asserted a property this code does not own. On
+	// an idle host the loop finishes in microseconds and the answer is 1; on a
+	// contended CI runner the loop can be preempted for longer than the 50ms
+	// window, and the old assertion reported that as "unexpected extra finding
+	// (timer race?)" -- a red build caused by load rather than by the timer
+	// identity check it named.
+	//
+	// The bound is derived from the burst this run actually observed: the gaps
+	// that can split it sum to at most the elapsed time, so it spans at most
+	// elapsed/debounceDelay + 1 windows. On a fast host that is 1, which keeps
+	// the original strict assertion intact where it is meaningful.
+	const writes = 10
 	secret := "sk-ant-" + "api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 	filePath := filepath.Join(dir, "rapid.json")
-	for i := range 10 {
+	start := time.Now()
+	for i := range writes {
 		content := fmt.Sprintf("%s-%d", secret, i)
 		if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
 			t.Fatalf("WriteFile[%d]: %v", i, err)
 		}
 	}
+	elapsed := time.Since(start)
 
-	// Wait for the single debounced scan.
+	// A burst slow enough to span every window proves nothing about
+	// coalescing, so say so rather than passing vacuously.
+	// Computed and compared as int64. A narrowing conversion here could wrap to
+	// a negative bound, which would fail every run rather than tolerate a slow
+	// one -- the exact failure direction this change exists to remove.
+	maxScans := int64(elapsed/debounceDelay) + 1
+	if maxScans >= writes {
+		t.Skipf("burst of %d writes took %v, spanning at least %d debounce windows: "+
+			"scheduling decided the scan count, so coalescing cannot be observed",
+			writes, elapsed, writes)
+	}
+
+	// Wait for the first debounced scan.
 	select {
 	case f := <-w.Findings():
 		if f.PatternName == "" {
@@ -1315,15 +1346,32 @@ func TestWatcher_DebounceTimerRace(t *testing.T) {
 		t.Fatal("timeout waiting for debounced finding")
 	}
 
-	// Verify no additional findings arrive (only 1 scan should fire).
-	select {
-	case f := <-w.Findings():
-		t.Errorf("unexpected extra finding (timer race?): %+v", f)
-	case <-time.After(filesentryNegativeObservation):
-		// Good - only one finding.
+	// Drain whatever the remaining windows produced. Counting beats failing on
+	// the first extra: a run that coalesced nothing and a run that split into
+	// two windows are different defects, and only the count distinguishes them.
+	findings := int64(1)
+	extraWindow := time.After(filesentryNegativeObservation)
+drain:
+	for {
+		select {
+		case <-w.Findings():
+			findings++
+		case <-extraWindow:
+			break drain
+		}
 	}
-	if got := sc.calls.Load(); got != 1 {
-		t.Fatalf("ScanTextForDLP calls = %d, want 1", got)
+
+	if findings > maxScans {
+		t.Errorf("findings = %d over a %v burst of %d writes, want at most %d (timer race?)",
+			findings, elapsed, writes, maxScans)
+	}
+	got := int64(sc.calls.Load())
+	if got < 1 {
+		t.Fatalf("ScanTextForDLP calls = %d, want the debounced scan to have run", got)
+	}
+	if got > maxScans {
+		t.Fatalf("ScanTextForDLP calls = %d over a %v burst of %d writes, want at most %d",
+			got, elapsed, writes, maxScans)
 	}
 }
 

--- a/internal/filesentry/watcher_test.go
+++ b/internal/filesentry/watcher_test.go
@@ -1413,12 +1413,18 @@ func TestWatcher_StaleDebounceCallbackDoesNotDropLiveScan(t *testing.T) {
 	}
 }
 
+// capturingDLPScanner records the text of every scan, so a test can assert
+// WHICH content was scanned rather than only how many scans ran. The debounce
+// tests turn on that distinction: a stale callback and a live one differ by the
+// file body they see, not by their count.
 type capturingDLPScanner struct {
 	countingDLPScanner
 	mu    sync.Mutex
 	texts []string
 }
 
+// ScanTextForDLP records the scanned text before delegating to the embedded
+// counting scanner, so call count and content stay consistent with each other.
 func (s *capturingDLPScanner) ScanTextForDLP(ctx context.Context, text string) scanner.TextDLPResult {
 	s.mu.Lock()
 	s.texts = append(s.texts, text)
@@ -1426,6 +1432,8 @@ func (s *capturingDLPScanner) ScanTextForDLP(ctx context.Context, text string) s
 	return s.countingDLPScanner.ScanTextForDLP(ctx, text)
 }
 
+// scanned returns a copy of the recorded texts. A copy rather than the slice
+// itself, because the watcher may still be scanning on another goroutine.
 func (s *capturingDLPScanner) scanned() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1443,6 +1451,9 @@ type manualAfterFunc struct {
 	timers []*time.Timer
 }
 
+// afterFunc stands in for time.AfterFunc. It returns a REAL timer so the
+// production pointer-identity comparison and Stop() keep their exact meaning,
+// and records the callback so the test decides when each window fires.
 func (m *manualAfterFunc) afterFunc(_ time.Duration, cb func()) *time.Timer {
 	// Hour is longer than any test deadline; the test fires cb itself.
 	timer := time.NewTimer(time.Hour)
@@ -1453,6 +1464,8 @@ func (m *manualAfterFunc) afterFunc(_ time.Duration, cb func()) *time.Timer {
 	return timer
 }
 
+// callbacks returns the first two armed callbacks, the stale one and the live
+// one, for the two-event replacement race.
 func (m *manualAfterFunc) callbacks() (stale, live func()) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1526,6 +1539,8 @@ func TestWatcher_BurstCoalescesToOneScan(t *testing.T) {
 	}
 }
 
+// fnAt returns the callback armed by the i-th event, so a burst test can fire
+// every window in the order the watcher armed them.
 func (m *manualAfterFunc) fnAt(i int) func() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1535,6 +1550,8 @@ func (m *manualAfterFunc) fnAt(i int) func() {
 	return m.fns[i]
 }
 
+// timerAt returns the timer handed back for the i-th event, which is what the
+// watcher stores in its map and compares against.
 func (m *manualAfterFunc) timerAt(i int) *time.Timer {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1544,12 +1561,15 @@ func (m *manualAfterFunc) timerAt(i int) *time.Timer {
 	return m.timers[i]
 }
 
+// len reports how many debounce windows the watcher armed.
 func (m *manualAfterFunc) len() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.fns)
 }
 
+// stopAll releases every timer the fake handed out. The timers are real, so
+// leaving them armed would keep the runtime holding them for the full hour.
 func (m *manualAfterFunc) stopAll() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -371,7 +371,7 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 	parentDied.Store(true)
 	select {
 	case <-done:
-	case <-time.After(20 * time.Second):
+	case <-time.After(testwait.Deadline(20 * time.Second)):
 		t.Fatal("sandbox proxy stayed alive after the spawning session exited")
 	}
 
@@ -427,7 +427,7 @@ func TestSessionExit_SandboxLiveSessionIsNotTornDown(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(20 * time.Second):
+	case <-time.After(testwait.Deadline(20 * time.Second)):
 		// Report the operator log and the surviving processes. This assertion
 		// has failed on CI while passing on a development host, and a bare
 		// timeout says nothing about which stage did not finish.
@@ -484,7 +484,7 @@ func TestSessionExit_SandboxCancellationWithSurvivingPipeHolder(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(20 * time.Second):
+	case <-time.After(testwait.Deadline(20 * time.Second)):
 		t.Fatalf("sandbox proxy did not stop after cancellation while a detached descendant held stdout; log: %q; surviving descendants: %s",
 			logBuf.String(), describeOwnDescendants())
 	}

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -230,7 +230,9 @@ func TestSessionExit_RealParentDeathReapsWholeTree(t *testing.T) {
 		"echo $! > " + proxyPidFile + "\n" +
 		"wait\n"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	// Scaled for the same reason as the sandbox teardown ctx below: the waits
+	// inside this test scale under CI and an unscaled ctx would expire first.
+	ctx, cancel := context.WithTimeout(context.Background(), testwait.Deadline(90*time.Second))
 	defer cancel()
 
 	session := exec.CommandContext(ctx, "/bin/sh")
@@ -316,7 +318,14 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 	sandboxFile := filepath.Join(dir, "sandbox.pid")
 	grandchildFile := filepath.Join(dir, "grandchild.pid")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	// Scaled with the waits inside it. An unscaled ctx here is not merely
+	// impatient, it inverts the result: exec.CommandContext kills the command
+	// when ctx expires, RunProxyWithSandbox returns, and the teardown select
+	// takes its <-done branch. A run whose reaping was genuinely broken would
+	// then report PASS, because the context did the killing the code under test
+	// failed to do. The scaled teardown deadline below is 80s under CI, so an
+	// unscaled 45s ctx would win every time.
+	ctx, cancel := context.WithTimeout(context.Background(), testwait.Deadline(45*time.Second))
 	defer cancel()
 	clientIn := newBlockingReader()
 	defer func() { _ = clientIn.Close() }()

--- a/internal/mcp/parentwatch_integration_linux_test.go
+++ b/internal/mcp/parentwatch_integration_linux_test.go
@@ -380,6 +380,16 @@ func TestSessionExit_SandboxTreeIsReaped(t *testing.T) {
 	parentDied.Store(true)
 	select {
 	case <-done:
+		// Scaling the deadline is not enough on its own: whichever clock fires
+		// first decides which branch runs. If the governing context deadline
+		// expired, exec.CommandContext killed the command, RunProxyWithSandbox
+		// returned, and this branch reports success for teardown the code under
+		// test never performed. Deliberate cancellation is a different thing and
+		// is not a deadline, so this checks DeadlineExceeded specifically.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatal("teardown completed only because the governing context deadline expired; " +
+				"the session-exit reaping under test never ran")
+		}
 	case <-time.After(testwait.Deadline(20 * time.Second)):
 		t.Fatal("sandbox proxy stayed alive after the spawning session exited")
 	}

--- a/internal/testwait/scale_test.go
+++ b/internal/testwait/scale_test.go
@@ -63,3 +63,48 @@ func TestScaleDeadline(t *testing.T) {
 		})
 	}
 }
+
+// TestDeadline pins the exported wrapper to the same scaling For gets. The two
+// must not drift: the select-based waits call Deadline while the polling waits
+// call For, and a wrapper that quietly stopped scaling would restore exactly the
+// unscaled twenty-second teardown deadline this function exists to remove,
+// while every test still passed on a development host.
+func TestDeadline(t *testing.T) {
+	base := 20 * time.Second
+
+	t.Run("ci scales", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("PIPELOCK_TEST_DEADLINE_SCALE", "")
+		if got, want := Deadline(base), base*ciDeadlineScale; got != want {
+			t.Errorf("Deadline(%v) under CI = %v, want %v", base, got, want)
+		}
+	})
+
+	t.Run("local is unscaled", func(t *testing.T) {
+		t.Setenv("CI", "")
+		t.Setenv("PIPELOCK_TEST_DEADLINE_SCALE", "")
+		if got := Deadline(base); got != base {
+			t.Errorf("Deadline(%v) locally = %v, want %v", base, got, base)
+		}
+	})
+
+	t.Run("matches For's scaling exactly", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("PIPELOCK_TEST_DEADLINE_SCALE", "2.5")
+		if got, want := Deadline(base), scaleDeadline(base); got != want {
+			t.Errorf("Deadline(%v) = %v, want scaleDeadline's %v", base, got, want)
+		}
+	})
+
+	// A non-positive result would expire every select immediately and report
+	// timing as product failure, which is the direction this must never fail in.
+	t.Run("stays positive under a hostile override", func(t *testing.T) {
+		for _, scale := range []string{"0", "-1", "5e-324", "bogus", "   "} {
+			t.Setenv("CI", "true")
+			t.Setenv("PIPELOCK_TEST_DEADLINE_SCALE", scale)
+			if got := Deadline(base); got <= 0 {
+				t.Errorf("Deadline(%v) with scale %q = %v, want a positive deadline", base, scale, got)
+			}
+		}
+	})
+}

--- a/internal/testwait/testwait.go
+++ b/internal/testwait/testwait.go
@@ -97,3 +97,19 @@ func ForContext(t testing.TB, ctx context.Context, cond func() bool, format stri
 		}
 	}
 }
+
+// Deadline returns d scaled for the current environment, for waits that cannot
+// use For because they block on a channel rather than poll a condition.
+//
+// A select that hard-codes its own time.After deadline opts out of the scaling
+// For already applies, so the same contended runner that For rides out fails the
+// select instead. That is not hypothetical: the two sandbox teardown waits in
+// internal/mcp scaled their startup wait through For and then blocked on a raw
+// twenty-second time.After, and both reported a loaded runner as a product
+// failure to reap a process tree.
+//
+// The failure direction is what makes this worth exporting. A deadline that is
+// too short turns scheduling noise into a red build, which trains the operator
+// to re-run rather than to read the failure; a genuine hang still fails the
+// package -timeout, which is the real backstop and is unaffected here.
+func Deadline(d time.Duration) time.Duration { return scaleDeadline(d) }


### PR DESCRIPTION
## What changed

Three tests reported CI contention as product failure. Each one failed on a deadline rather than on the behavior it guards.

The sandbox teardown waits in internal/mcp scaled their startup wait through testwait.For, then blocked on a raw twenty-second time.After, so the scaling never reached the deadline that was expiring. testwait.Deadline now covers waits that block on a channel instead of polling a condition. The context timeouts above those waits scale with them: whichever clock fires first decides which branch of the select runs, so a context that expires before the teardown wait reports success for reaping that never happened.

TestWatcher_DebounceTimerRace asserted exactly one scan for a ten-write burst. handleEvent arms the debounce timer when fsnotify delivers an event, so the number of windows a burst spans is a scheduling artifact the debouncer doesn't promise. That test is now a smoke check over real fsnotify with no scan count.

The timer identity check it was named for had no coverage. Removing the pointer comparison left the package green, because a stale callback that deletes the live timer's map entry produces fewer scans and no upper bound catches a missing one. filesentry gains an afterFunc seam next to the existing addWatch seam, and a new test fires a stale callback after its replacement, then requires the live scan of the final content. Production keeps time.AfterFunc.

Still open: roughly 280 other test waits in the tree use raw multi-second deadlines and haven't been audited against this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file monitoring reliability when rapid updates trigger overlapping debounce callbacks.
  * Ensured the latest file content is scanned correctly without stale callbacks interfering with active scans.
  * Consolidated bursts of file updates into a single scan of the final content.

* **Tests**
  * Strengthened coverage for file-change race conditions and debounce behavior.
  * Improved reliability of session-exit checks in slower or resource-constrained environments.
  * Added coverage for timing and deadline behavior across test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->