### PR TITLE
fix: preserve evidence auditor targets across init reruns

### DIFF
--- a/internal/cli/setup/evidence_auditor.go
+++ b/internal/cli/setup/evidence_auditor.go
@@ -98,14 +98,27 @@ func installEvidenceCorpusAuditor(ctx context.Context, recorderDir string) (evid
 		AlertPath:   filepath.Join(configDir, "pipelock", "prometheus", "rules", evidenceCorpusAuditorAlert),
 		MetricPath:  filepath.Join(configDir, "pipelock", "prometheus", "textfile", "pipelock_evidence_corpus.prom"),
 	}
-	for _, rendered := range []struct {
+	renderedFiles := []struct {
 		path string
 		body string
 	}{
 		{install.ServicePath, renderEvidenceCorpusAuditorService(pipelockPath, recorderDir, install.MetricPath)},
 		{install.TimerPath, renderEvidenceCorpusAuditorTimer()},
 		{install.AlertPath, renderEvidenceCorpusAuditorAlert()},
-	} {
+	}
+	// Validate the whole managed set before replacing anything. In particular,
+	// init may be running from a temporary binary with a temporary recorder
+	// directory; replacing a durable service with that target makes its next
+	// timer run silently stop producing fresh evidence.
+	for _, rendered := range renderedFiles {
+		if err := validateManagedEvidenceAuditorFile(rendered.path, rendered.body); err != nil {
+			return evidenceCorpusAuditorInstall{}, err
+		}
+	}
+	if err := validateEvidenceCorpusAuditorServiceTarget(renderedFiles[0].path, renderedFiles[0].body); err != nil {
+		return evidenceCorpusAuditorInstall{}, err
+	}
+	for _, rendered := range renderedFiles {
 		if err := writeManagedEvidenceAuditorFile(rendered.path, rendered.body); err != nil {
 			return evidenceCorpusAuditorInstall{}, err
 		}
@@ -123,7 +136,19 @@ func writeManagedEvidenceAuditorFile(path, body string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("creating evidence corpus auditor directory: %w", err)
 	}
-	data := []byte(body)
+	if existing, err := os.ReadFile(filepath.Clean(path)); err == nil && string(existing) == body {
+		return nil
+	}
+	if err := validateManagedEvidenceAuditorFile(path, body); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("writing evidence corpus auditor file %s: %w", path, err)
+	}
+	return nil
+}
+
+func validateManagedEvidenceAuditorFile(path, body string) error {
 	if existing, err := os.ReadFile(filepath.Clean(path)); err == nil {
 		if string(existing) == body {
 			return nil
@@ -134,10 +159,46 @@ func writeManagedEvidenceAuditorFile(path, body string) error {
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("reading evidence corpus auditor file %s: %w", path, err)
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return fmt.Errorf("writing evidence corpus auditor file %s: %w", path, err)
+	return nil
+}
+
+func validateEvidenceCorpusAuditorServiceTarget(path, desired string) error {
+	existing, err := os.ReadFile(filepath.Clean(path))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading evidence corpus auditor file %s: %w", path, err)
+	}
+	if !strings.HasPrefix(string(existing), managedEvidenceAuditorHeader) {
+		return fmt.Errorf("refusing to overwrite unmanaged evidence corpus auditor file %s", path)
+	}
+	desiredTarget, ok := evidenceCorpusAuditorServiceTarget(desired)
+	if !ok {
+		return fmt.Errorf("rendering evidence corpus auditor service target for %s", path)
+	}
+	existingTarget, ok := evidenceCorpusAuditorServiceTarget(string(existing))
+	if !ok {
+		return fmt.Errorf("refusing to replace managed evidence corpus auditor service %s because its executable and flight recorder directory cannot be determined", path)
+	}
+	if existingTarget != desiredTarget {
+		return fmt.Errorf("refusing to replace managed evidence corpus auditor service target in %s; rerun the binary and flight_recorder.dir already configured there; to migrate, stop %s with systemctl --user, update this service's ExecStart to the intended binary and recorder directory, run systemctl --user daemon-reload, then rerun init", path, evidenceCorpusAuditorTimer)
 	}
 	return nil
+}
+
+func evidenceCorpusAuditorServiceTarget(service string) (string, bool) {
+	for _, line := range strings.Split(service, "\n") {
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		textfileFlag := strings.LastIndex(line, " --prometheus-textfile ")
+		if textfileFlag == -1 {
+			return "", false
+		}
+		return line[:textfileFlag], true
+	}
+	return "", false
 }
 
 func renderEvidenceCorpusAuditorService(pipelockPath, recorderDir, metricPath string) string {
@@ -153,6 +214,7 @@ func renderEvidenceCorpusAuditorAlert() string {
 }
 
 func systemdArgument(value string) string {
-	replacer := strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "%", "%%")
+	replacer := strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "%", "%%",
+		"\a", "\\a", "\b", "\\b", "\f", "\\f", "\n", "\\n", "\r", "\\r", "\t", "\\t", "\v", "\\v")
 	return "\"" + replacer.Replace(value) + "\""
 }

--- a/internal/cli/setup/evidence_auditor_test.go
+++ b/internal/cli/setup/evidence_auditor_test.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,6 +18,7 @@ func TestInitCmdInstallsEvidenceCorpusAuditorWithRenderedConsumer(t *testing.T) 
 		t.Skip("init installs the auditor only on linux")
 	}
 
+	configDir := isolatedEvidenceAuditorInstall(t)
 	home := t.TempDir()
 	configPath := filepath.Join(home, "cfg", "pipelock.yaml")
 	cmd := InitCmd()
@@ -27,10 +29,6 @@ func TestInitCmdInstallsEvidenceCorpusAuditorWithRenderedConsumer(t *testing.T) 
 		t.Fatalf("init: %v", err)
 	}
 
-	configDir, err := evidenceAuditorUserConfigDir()
-	if err != nil {
-		t.Fatal(err)
-	}
 	servicePath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorService)
 	timerPath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer)
 	alertPath := filepath.Join(configDir, "pipelock", "prometheus", "rules", evidenceCorpusAuditorAlert)
@@ -69,6 +67,49 @@ func TestEvidenceCorpusAuditorRenderersQuotePathsAndRemainOutOfBand(t *testing.T
 	}
 }
 
+func TestEvidenceCorpusAuditorServiceTargetKeepsQuotedTargetPaths(t *testing.T) {
+	service := renderEvidenceCorpusAuditorService(
+		"/opt/one evidence doctor two/pipelock",
+		"/var/one --prometheus-textfile two/recorder",
+		"/var/lib/pipelock/pipelock.prom",
+	)
+	target, ok := evidenceCorpusAuditorServiceTarget(service)
+	if !ok {
+		t.Fatal("rendered service has no target")
+	}
+	want := `ExecStart="/opt/one evidence doctor two/pipelock" evidence doctor "/var/one --prometheus-textfile two/recorder"`
+	if target != want {
+		t.Fatalf("target = %q, want %q", target, want)
+	}
+}
+
+func TestEvidenceCorpusAuditorServiceKeepsControlCharactersInArguments(t *testing.T) {
+	for _, tt := range []struct {
+		name, value, escaped string
+	}{
+		{"newline", "\n", `\n`},
+		{"carriage return", "\r", `\r`},
+		{"tab", "\t", `\t`},
+		{"vertical tab", "\v", `\v`},
+		{"form feed", "\f", `\f`},
+		{"bell", "\a", `\a`},
+		{"backspace", "\b", `\b`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			service := renderEvidenceCorpusAuditorService("/opt/"+tt.value+"/pipelock", "/var/"+tt.value+"/recorder", "/var/"+tt.value+"/metric.prom")
+			if strings.Count(service, tt.escaped) != 3 {
+				t.Fatalf("service did not escape each argument with %q: %q", tt.escaped, service)
+			}
+			if strings.Count(service, "\n") != strings.Count(renderEvidenceCorpusAuditorService("/bin/pipelock", "/recorder", "/metric"), "\n") {
+				t.Fatalf("argument introduced a new unit directive: %q", service)
+			}
+			if _, ok := evidenceCorpusAuditorServiceTarget(service); !ok {
+				t.Fatalf("rendered target cannot be read on rerun: %q", service)
+			}
+		})
+	}
+}
+
 // TestEvidenceCorpusAuditorAlertRemediationNamesAShippedSurface keeps the
 // annotation honest. It previously told the operator to "stop evidence export",
 // and Pipelock ships no evidence-export surface to stop: `pipelock evidence`
@@ -99,13 +140,10 @@ func TestEvidenceCorpusAuditorAlertRemediationNamesAShippedSurface(t *testing.T)
 }
 
 func TestEvidenceCorpusAuditorRerunRepairsManagedTimerButRefusesUnmanagedFile(t *testing.T) {
+	configDir := isolatedEvidenceAuditorInstall(t)
 	home := t.TempDir()
 	configPath := filepath.Join(home, "pipelock.yaml")
 	runInitForEvidenceAuditorTest(t, home, configPath)
-	configDir, err := evidenceAuditorUserConfigDir()
-	if err != nil {
-		t.Fatal(err)
-	}
 	timerPath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer)
 	if err := os.WriteFile(timerPath, []byte(managedEvidenceAuditorHeader+"broken\n"), 0o600); err != nil {
 		t.Fatalf("damage managed timer: %v", err)
@@ -125,6 +163,133 @@ func TestEvidenceCorpusAuditorRerunRepairsManagedTimerButRefusesUnmanagedFile(t 
 	if _, err := installEvidenceCorpusAuditor(t.Context(), filepath.Join(home, "recorder")); err == nil {
 		t.Fatal("unmanaged service was overwritten")
 	}
+}
+
+func TestInstallEvidenceCorpusAuditorPreservesExistingManagedTarget(t *testing.T) {
+	configDir := isolatedEvidenceAuditorInstall(t)
+	recorderDir := filepath.Join(t.TempDir(), "persistent-recorder")
+	if _, err := installEvidenceCorpusAuditor(t.Context(), recorderDir); err != nil {
+		t.Fatalf("install persistent auditor: %v", err)
+	}
+
+	paths := []string{
+		filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorService),
+		filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer),
+		filepath.Join(configDir, "pipelock", "prometheus", "rules", evidenceCorpusAuditorAlert),
+	}
+	before := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			t.Fatalf("read installed %s: %v", path, err)
+		}
+		before[path] = data
+	}
+
+	for _, tt := range []struct {
+		name        string
+		executable  string
+		recorderDir string
+	}{
+		{
+			name:        "different executable",
+			executable:  "/tmp/pipelock-candidate",
+			recorderDir: recorderDir,
+		},
+		{
+			name:        "different recorder directory",
+			executable:  "/usr/bin/pipelock",
+			recorderDir: filepath.Join(t.TempDir(), "temporary-recorder"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stub(t, &evidenceAuditorExecutable, func() (string, error) { return tt.executable, nil })
+
+			_, err := installEvidenceCorpusAuditor(t.Context(), tt.recorderDir)
+			if err == nil {
+				t.Fatal("install replaced an existing managed auditor target")
+			}
+			if !strings.Contains(err.Error(), "refusing to replace managed evidence corpus auditor service target") {
+				t.Fatalf("error = %v, want target-preservation refusal", err)
+			}
+
+			for _, path := range paths {
+				data, readErr := os.ReadFile(filepath.Clean(path))
+				if readErr != nil {
+					t.Fatalf("read preserved %s: %v", path, readErr)
+				}
+				if string(data) != string(before[path]) {
+					t.Fatalf("refused install changed %s:\n%s", path, data)
+				}
+			}
+		})
+	}
+}
+
+func TestEvidenceCorpusAuditorServiceTargetRefusesUnverifiableUnits(t *testing.T) {
+	valid := renderEvidenceCorpusAuditorService("/usr/bin/pipelock", "/var/lib/recorder", "/var/lib/metric.prom")
+	for _, tt := range []struct {
+		name, existing, desired, want string
+		directory                     bool
+	}{
+		{name: "unreadable file", desired: valid, directory: true, want: "reading evidence corpus auditor file"},
+		{name: "unmanaged unit", existing: "[Service]\nExecStart=/usr/bin/true\n", desired: valid, want: "refusing to overwrite unmanaged"},
+		{name: "missing command", existing: managedEvidenceAuditorHeader + "[Service]\n", desired: valid, want: "cannot be determined"},
+		{name: "incomplete command", existing: managedEvidenceAuditorHeader + "[Service]\nExecStart=/usr/bin/pipelock evidence doctor /var/lib/recorder\n", desired: valid, want: "cannot be determined"},
+		{name: "invalid replacement", existing: valid, desired: "[Service]\n", want: "rendering evidence corpus auditor service target"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "auditor.service")
+			if tt.directory {
+				if err := os.Mkdir(path, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(path, []byte(tt.existing), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateEvidenceCorpusAuditorServiceTarget(path, tt.desired); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallEvidenceCorpusAuditorPreflightsSecondaryManagedFiles(t *testing.T) {
+	configDir := isolatedEvidenceAuditorInstall(t)
+	recorderDir := filepath.Join(t.TempDir(), "recorder")
+	if _, err := installEvidenceCorpusAuditor(t.Context(), recorderDir); err != nil {
+		t.Fatalf("install auditor: %v", err)
+	}
+	servicePath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorService)
+	before, err := os.ReadFile(filepath.Clean(servicePath))
+	if err != nil {
+		t.Fatalf("read service before failed install: %v", err)
+	}
+	timerPath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer)
+	if err := os.WriteFile(timerPath, []byte("[Timer]\nOnCalendar=daily\n"), 0o600); err != nil {
+		t.Fatalf("write unmanaged timer: %v", err)
+	}
+
+	_, err = installEvidenceCorpusAuditor(t.Context(), recorderDir)
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite unmanaged evidence corpus auditor file") {
+		t.Fatalf("error = %v, want unmanaged secondary-file refusal", err)
+	}
+	after, err := os.ReadFile(filepath.Clean(servicePath))
+	if err != nil {
+		t.Fatalf("read service after failed install: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("unmanaged timer refusal changed service:\n%s", after)
+	}
+}
+
+func isolatedEvidenceAuditorInstall(t *testing.T) string {
+	t.Helper()
+	configDir := t.TempDir()
+	stub(t, &evidenceAuditorUserConfigDir, func() (string, error) { return configDir, nil })
+	stub(t, &evidenceAuditorExecutable, func() (string, error) { return "/usr/bin/pipelock", nil })
+	stub(t, &evidenceAuditorSystemctl, func(context.Context, systemctlOp) error { return nil })
+	return configDir
 }
 
 func runInitForEvidenceAuditorTest(t *testing.T, home, configPath string) {

--- a/internal/cli/setup/evidence_auditor_test.go
+++ b/internal/cli/setup/evidence_auditor_test.go
@@ -265,6 +265,10 @@ func TestInstallEvidenceCorpusAuditorPreflightsSecondaryManagedFiles(t *testing.
 	if err != nil {
 		t.Fatalf("read service before failed install: %v", err)
 	}
+	before = append(before, []byte("# preflight sentinel\n")...)
+	if err := os.WriteFile(servicePath, before, 0o600); err != nil {
+		t.Fatalf("write managed service sentinel: %v", err)
+	}
 	timerPath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer)
 	if err := os.WriteFile(timerPath, []byte("[Timer]\nOnCalendar=daily\n"), 0o600); err != nil {
 		t.Fatalf("write unmanaged timer: %v", err)

--- a/internal/cli/setup/evidence_auditor_test.go
+++ b/internal/cli/setup/evidence_auditor_test.go
@@ -255,35 +255,51 @@ func TestEvidenceCorpusAuditorServiceTargetRefusesUnverifiableUnits(t *testing.T
 }
 
 func TestInstallEvidenceCorpusAuditorPreflightsSecondaryManagedFiles(t *testing.T) {
-	configDir := isolatedEvidenceAuditorInstall(t)
-	recorderDir := filepath.Join(t.TempDir(), "recorder")
-	if _, err := installEvidenceCorpusAuditor(t.Context(), recorderDir); err != nil {
-		t.Fatalf("install auditor: %v", err)
-	}
-	servicePath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorService)
-	before, err := os.ReadFile(filepath.Clean(servicePath))
-	if err != nil {
-		t.Fatalf("read service before failed install: %v", err)
-	}
-	before = append(before, []byte("# preflight sentinel\n")...)
-	if err := os.WriteFile(servicePath, before, 0o600); err != nil {
-		t.Fatalf("write managed service sentinel: %v", err)
-	}
-	timerPath := filepath.Join(configDir, "systemd", "user", evidenceCorpusAuditorTimer)
-	if err := os.WriteFile(timerPath, []byte("[Timer]\nOnCalendar=daily\n"), 0o600); err != nil {
-		t.Fatalf("write unmanaged timer: %v", err)
-	}
+	for _, unmanaged := range []string{"timer", "alert"} {
+		t.Run(unmanaged, func(t *testing.T) {
+			isolatedEvidenceAuditorInstall(t)
+			recorderDir := filepath.Join(t.TempDir(), "recorder")
+			installed, err := installEvidenceCorpusAuditor(t.Context(), recorderDir)
+			if err != nil {
+				t.Fatalf("install auditor: %v", err)
+			}
+			files := []struct {
+				name, path string
+				before     []byte
+			}{
+				{name: "service", path: installed.ServicePath},
+				{name: "timer", path: installed.TimerPath},
+				{name: "alert", path: installed.AlertPath},
+			}
+			for i := range files {
+				file := &files[i]
+				data, err := os.ReadFile(filepath.Clean(file.path))
+				if err != nil {
+					t.Fatalf("read %s before failed install: %v", file.name, err)
+				}
+				file.before = append(data, []byte("# preflight sentinel\n")...)
+				if file.name == unmanaged {
+					file.before = []byte("# unmanaged preflight sentinel\n")
+				}
+				if err := os.WriteFile(file.path, file.before, 0o600); err != nil {
+					t.Fatalf("write %s sentinel: %v", file.name, err)
+				}
+			}
 
-	_, err = installEvidenceCorpusAuditor(t.Context(), recorderDir)
-	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite unmanaged evidence corpus auditor file") {
-		t.Fatalf("error = %v, want unmanaged secondary-file refusal", err)
-	}
-	after, err := os.ReadFile(filepath.Clean(servicePath))
-	if err != nil {
-		t.Fatalf("read service after failed install: %v", err)
-	}
-	if string(after) != string(before) {
-		t.Fatalf("unmanaged timer refusal changed service:\n%s", after)
+			_, err = installEvidenceCorpusAuditor(t.Context(), recorderDir)
+			if err == nil || !strings.Contains(err.Error(), "refusing to overwrite unmanaged evidence corpus auditor file") {
+				t.Fatalf("error = %v, want unmanaged secondary-file refusal", err)
+			}
+			for _, file := range files {
+				after, err := os.ReadFile(filepath.Clean(file.path))
+				if err != nil {
+					t.Fatalf("read %s after failed install: %v", file.name, err)
+				}
+				if !bytes.Equal(after, file.before) {
+					t.Errorf("unmanaged %s refusal changed %s:\n%s", unmanaged, file.name, after)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/setup/install_config_test.go
+++ b/internal/cli/setup/install_config_test.go
@@ -22,7 +22,10 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("PIPELOCK_CONFIG", cfgPath); err != nil {
 		panic(err)
 	}
-	evidenceAuditorUserConfigDir = func() (string, error) { return filepath.Join(dir, "user-config"), nil }
+	// Each init command needs its own auditor directory. Sharing one directory
+	// makes independent test configs look like attempts to replace a durable
+	// auditor target, which is precisely what production must reject.
+	evidenceAuditorUserConfigDir = func() (string, error) { return os.MkdirTemp(dir, "user-config-") }
 	evidenceAuditorExecutable = func() (string, error) { return "/usr/bin/pipelock", nil }
 	evidenceAuditorSystemctl = func(_ context.Context, _ systemctlOp) error { return nil }
 


### PR DESCRIPTION
## What changed
- Refuse init reruns that would change an existing auditor's executable or recorder directory, validating the managed files before replacing them.
- Escape control characters in unit-file arguments and explain how to migrate an auditor deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Evidence Auditor installation safety by validating all generated configuration before applying changes.
  - Installations now stop without modifying existing files when service targets or managed settings do not match the expected configuration.
  - Reinstallations preserve valid existing service targets and unchanged files.
  - Improved handling of special and control characters in service configuration values.
  - Added safeguards to prevent partial installations when required configuration is unmanaged or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->