### PR TITLE
test: reject completion caused by expired deadlines

### DIFF
--- a/internal/contract/runtime/loader_test.go
+++ b/internal/contract/runtime/loader_test.go
@@ -982,23 +982,73 @@ func waitForLoaderReady(t *testing.T, loader *Loader) {
 }
 
 // waitFor polls cond until it returns true or watchTestTimeout elapses.
-// Returns true on success, false on timeout. Used by Watch tests where
+// Returns true on completion before the deadline, false on timeout. Used by Watch tests where
 // the signal is the watcher goroutine landing a Reload outcome: poll
 // the metric to increment rather than guess a fixed sleep.
 func waitFor(cond func() bool) bool {
-	timer := time.NewTimer(watchTestTimeout)
+	return waitForWithNow(watchTestTimeout, time.Now, cond)
+}
+
+func waitForWithNow(timeout time.Duration, now func() time.Time, cond func() bool) bool {
+	deadline := now().Add(timeout)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
+		if !now().Before(deadline) {
+			return false
+		}
 		if cond() {
-			return true
+			return now().Before(deadline)
 		}
 		select {
 		case <-timer.C:
-			return cond()
+			return false
 		case <-ticker.C:
 		}
+	}
+}
+
+func TestWaitFor_DoesNotAcceptConditionAfterDeadline(t *testing.T) {
+	base := time.Unix(0, 0)
+	now := sequenceClock(base, base, base.Add(time.Second))
+	calls := 0
+	if waitForWithNow(time.Second, now, func() bool {
+		calls++
+		return true
+	}) {
+		t.Fatal("waitFor accepted a condition that became true after its deadline")
+	}
+	if calls != 1 {
+		t.Fatalf("condition calls = %d, want 1", calls)
+	}
+}
+
+func TestWaitFor_DoesNotEvaluateConditionAfterDeadline(t *testing.T) {
+	base := time.Unix(0, 0)
+	now := sequenceClock(base, base.Add(time.Second))
+	calls := 0
+	if waitForWithNow(time.Second, now, func() bool {
+		calls++
+		return true
+	}) {
+		t.Fatal("waitFor accepted an already-expired deadline")
+	}
+	if calls != 0 {
+		t.Fatalf("condition calls = %d, want 0 after deadline", calls)
+	}
+}
+
+func sequenceClock(values ...time.Time) func() time.Time {
+	index := 0
+	return func() time.Time {
+		if index >= len(values) {
+			return values[len(values)-1]
+		}
+		value := values[index]
+		index++
+		return value
 	}
 }
 

--- a/internal/mcp/proxy_sandbox_gate_linux_test.go
+++ b/internal/mcp/proxy_sandbox_gate_linux_test.go
@@ -101,6 +101,9 @@ func TestRunProxyWithSandbox_AllowsUnmappedCommand(t *testing.T) {
 	var err error
 	select {
 	case err = <-errCh:
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			t.Fatalf("unmapped command completed after the watchdog expired: %v", ctxErr)
+		}
 	case <-ctx.Done():
 		t.Fatal("unmapped command did not complete; proxy flow blocked")
 	}

--- a/internal/mcp/proxy_sandbox_gate_linux_test.go
+++ b/internal/mcp/proxy_sandbox_gate_linux_test.go
@@ -94,19 +94,31 @@ func TestRunProxyWithSandbox_AllowsUnmappedCommand(t *testing.T) {
 	cmd := exec.CommandContext(t.Context(), "/bin/true")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), &strings.Builder{}, &strings.Builder{}, MCPProxyOpts{})
-	}()
-	var err error
-	select {
-	case err = <-errCh:
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			t.Fatalf("unmapped command completed after the watchdog expired: %v", ctxErr)
-		}
-	case <-ctx.Done():
-		t.Fatal("unmapped command did not complete; proxy flow blocked")
+	type completion struct {
+		err         error
+		completedAt time.Time
 	}
+	done := make(chan completion, 1)
+	go func() {
+		err := RunProxyWithSandbox(ctx, cmd, strings.NewReader(""), &strings.Builder{}, &strings.Builder{}, MCPProxyOpts{})
+		done <- completion{err: err, completedAt: time.Now()}
+	}()
+	var result completion
+	select {
+	case result = <-done:
+	case <-ctx.Done():
+		// The receiver may resume after both channels became ready.
+		select {
+		case result = <-done:
+		default:
+			t.Fatal("unmapped command did not complete; proxy flow blocked")
+		}
+	}
+	deadline, _ := ctx.Deadline()
+	if !result.completedAt.Before(deadline) {
+		t.Fatal("unmapped command completed after the watchdog expired")
+	}
+	err := result.err
 	if err != nil && strings.Contains(err.Error(), "RunProxyWithSandboxLaunch") {
 		t.Fatalf("unmapped command must not hit the mapped-launch refusal: %v", err)
 	}

--- a/internal/mcp/reaper_linux_test.go
+++ b/internal/mcp/reaper_linux_test.go
@@ -135,22 +135,73 @@ func TestReaper_ProtectedDirectPIDRegistry(t *testing.T) {
 }
 
 // waitForCondition polls cond every 25 ms until it returns true or the
-// deadline passes. Returns the final value of cond().
+// deadline passes. Completion after the deadline is a timeout.
 func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) bool {
 	t.Helper()
+	return waitForConditionWithNow(t, timeout, time.Now, cond)
+}
+
+func waitForConditionWithNow(t *testing.T, timeout time.Duration, now func() time.Time, cond func() bool) bool {
+	t.Helper()
+	deadline := now().Add(timeout)
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
 	for {
+		if !now().Before(deadline) {
+			return false
+		}
 		if cond() {
-			return true
+			return now().Before(deadline)
 		}
 		select {
 		case <-timer.C:
-			return cond()
+			return false
 		case <-ticker.C:
 		}
+	}
+}
+
+func TestWaitForCondition_DoesNotAcceptConditionAfterDeadline(t *testing.T) {
+	base := time.Unix(0, 0)
+	now := reaperSequenceClock(base, base, base.Add(time.Second))
+	calls := 0
+	if waitForConditionWithNow(t, time.Second, now, func() bool {
+		calls++
+		return true
+	}) {
+		t.Fatal("waitForCondition accepted a condition that became true after its deadline")
+	}
+	if calls != 1 {
+		t.Fatalf("condition calls = %d, want 1", calls)
+	}
+}
+
+func TestWaitForCondition_DoesNotEvaluateConditionAfterDeadline(t *testing.T) {
+	base := time.Unix(0, 0)
+	now := reaperSequenceClock(base, base.Add(time.Second))
+	calls := 0
+	if waitForConditionWithNow(t, time.Second, now, func() bool {
+		calls++
+		return true
+	}) {
+		t.Fatal("waitForCondition accepted an already-expired deadline")
+	}
+	if calls != 0 {
+		t.Fatalf("condition calls = %d, want 0 after deadline", calls)
+	}
+}
+
+func reaperSequenceClock(values ...time.Time) func() time.Time {
+	index := 0
+	return func() time.Time {
+		if index >= len(values) {
+			return values[len(values)-1]
+		}
+		value := values[index]
+		index++
+		return value
 	}
 }
 

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -817,8 +817,20 @@ func TestWaitForPathRequiresCompletionBeforeDeadline(t *testing.T) {
 }
 
 func TestWaitForPathMissingFileExpires(t *testing.T) {
-	if waitForPath(filepath.Join(t.TempDir(), "missing"), 0) {
+	start := time.Unix(0, 0)
+	reads := 0
+	now := func() time.Time {
+		reads++
+		if reads < 3 {
+			return start
+		}
+		return start.Add(time.Second)
+	}
+	if waitForPathWithNow(filepath.Join(t.TempDir(), "missing"), time.Second, now) {
 		t.Fatal("missing file satisfied the wait")
+	}
+	if reads != 3 {
+		t.Fatalf("clock reads = %d, want 3 across the retry", reads)
 	}
 }
 

--- a/internal/proxy/baseline/baseline_test.go
+++ b/internal/proxy/baseline/baseline_test.go
@@ -769,17 +769,56 @@ func rewriteProfileToolCallsMean(t *testing.T, path string) {
 }
 
 func waitForPath(path string, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
+	return waitForPathWithNow(path, timeout, time.Now)
+}
+
+func waitForPathWithNow(path string, timeout time.Duration, now func() time.Time) bool {
+	deadline := now().Add(timeout)
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if _, err := os.Stat(filepath.Clean(path)); err == nil {
-			return true
-		}
-		if time.Now().After(deadline) {
+		if !now().Before(deadline) {
 			return false
 		}
+		if _, err := os.Stat(filepath.Clean(path)); err == nil {
+			return now().Before(deadline)
+		}
 		<-ticker.C
+	}
+}
+
+func TestWaitForPathRequiresCompletionBeforeDeadline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Unix(0, 0)
+	for _, tt := range []struct {
+		name  string
+		times []time.Time
+		want  bool
+	}{
+		{"early", []time.Time{base, base, base}, true},
+		{"completed at deadline", []time.Time{base, base, base.Add(time.Second)}, false},
+		{"already expired", []time.Time{base, base.Add(time.Second)}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			i := 0
+			now := func() time.Time {
+				value := tt.times[min(i, len(tt.times)-1)]
+				i++
+				return value
+			}
+			if got := waitForPathWithNow(path, time.Second, now); got != tt.want {
+				t.Fatalf("completion = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForPathMissingFileExpires(t *testing.T) {
+	if waitForPath(filepath.Join(t.TempDir(), "missing"), 0) {
+		t.Fatal("missing file satisfied the wait")
 	}
 }
 

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -852,9 +852,11 @@ func TestSessionAPI_ResetUnderConcurrentTraffic(t *testing.T) {
 
 	select {
 	case <-done:
-		// Success - completed without deadlock.
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("concurrent traffic ended after the watchdog expired: %v", err)
+		}
 	case <-ctx.Done():
-		t.Fatal("deadlock detected: test did not complete within timeout")
+		t.Fatal("concurrent traffic did not complete before the watchdog expired")
 	}
 }
 

--- a/internal/proxy/session_api_test.go
+++ b/internal/proxy/session_api_test.go
@@ -802,9 +802,9 @@ func TestSessionAPI_ResetUnderConcurrentTraffic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	done := make(chan struct{})
+	done := make(chan time.Time, 1)
 	go func() {
-		defer close(done)
+		defer func() { done <- time.Now() }()
 
 		var wg sync.WaitGroup
 
@@ -850,13 +850,20 @@ func TestSessionAPI_ResetUnderConcurrentTraffic(t *testing.T) {
 		wg.Wait()
 	}()
 
+	var completedAt time.Time
 	select {
-	case <-done:
-		if err := ctx.Err(); err != nil {
-			t.Fatalf("concurrent traffic ended after the watchdog expired: %v", err)
-		}
+	case completedAt = <-done:
 	case <-ctx.Done():
-		t.Fatal("concurrent traffic did not complete before the watchdog expired")
+		// The receiver may resume after both channels became ready.
+		select {
+		case completedAt = <-done:
+		default:
+			t.Fatal("concurrent traffic did not complete before the watchdog expired")
+		}
+	}
+	deadline, _ := ctx.Deadline()
+	if !completedAt.Before(deadline) {
+		t.Fatal("concurrent traffic ended after the watchdog expired")
 	}
 }
 


### PR DESCRIPTION
## What changed
Require polling waits to finish before their deadlines and reject watchdog-expired completion in the session-reset and MCP launch tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so operations are not treated as successful after their deadlines have expired.
  * Prevented condition checks from running after a timeout, improving reliability for waiting and file-detection workflows.
  * Strengthened watchdog behavior to detect proxy and concurrent-session operations that exceed their allowed time.

* **Tests**
  * Added deterministic coverage for deadline-boundary scenarios, expired waits, and watchdog expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->