### PR TITLE
fix(scanner): detect partial disclosure of a known secret

### DIFF
--- a/internal/scanner/canary.go
+++ b/internal/scanner/canary.go
@@ -12,10 +12,11 @@ import (
 
 // compiledCanaryToken stores normalized canary values for fast matching.
 type compiledCanaryToken struct {
-	name            string
-	normalizedLower string
-	canonicalLower  string
-	partialWindows  map[string][]int
+	name                    string
+	normalizedLower         string
+	canonicalLower          string
+	partialWindows          map[string][]int
+	canonicalPartialWindows map[string][]int
 }
 
 func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
@@ -39,8 +40,20 @@ func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
 	// Windows shared between two canaries are a common stem, not a disclosure
 	// of either; they are excluded the same way as for environment secrets.
 	windows := buildKnownValueWindows(normalizedValues)
+	canonicalValues := make([]string, 0, len(out))
 	for i := range out {
 		out[i].partialWindows = windows[out[i].normalizedLower]
+		// URL-shaped originals stay whole-value-only after canonicalization.
+		// canonicalizeCanaryText strips "://", and knownValueWindows would
+		// then emit partial windows for the public scheme/host/path stem.
+		if strings.Contains(out[i].normalizedLower, "://") || out[i].canonicalLower == "" {
+			continue
+		}
+		canonicalValues = append(canonicalValues, out[i].canonicalLower)
+	}
+	canonicalWindows := buildKnownValueWindows(canonicalValues)
+	for i := range out {
+		out[i].canonicalPartialWindows = canonicalWindows[out[i].canonicalLower]
 	}
 	return out
 }
@@ -149,7 +162,7 @@ func (s *Scanner) matchCanaryTokens(text, encoding string, canonical bool, input
 		}
 		windows := token.partialWindows
 		if canonical {
-			windows = knownValueWindows(needle)
+			windows = token.canonicalPartialWindows
 		}
 		if start, end, length, _, ok := indexKnownValueSubstring(needle, windows, []spanTextView{{text: haystack, viewLabel: viewLabel}}); ok {
 			patternName := "Canary Token (" + token.name + ")"

--- a/internal/scanner/canary.go
+++ b/internal/scanner/canary.go
@@ -15,6 +15,7 @@ type compiledCanaryToken struct {
 	name            string
 	normalizedLower string
 	canonicalLower  string
+	partialWindows  map[string][]int
 }
 
 func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
@@ -22,17 +23,24 @@ func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
 		return nil
 	}
 	out := make([]compiledCanaryToken, 0, len(cfg.Tokens))
+	normalizedValues := make([]string, 0, len(cfg.Tokens))
 	for _, token := range cfg.Tokens {
 		normalized := strings.ToLower(normalize.ForDLP(token.Value))
 		if normalized == "" {
 			continue
 		}
-		canonical := strings.ToLower(canonicalizeCanaryText(normalized))
+		normalizedValues = append(normalizedValues, normalized)
 		out = append(out, compiledCanaryToken{
 			name:            token.Name,
 			normalizedLower: normalized,
-			canonicalLower:  canonical,
+			canonicalLower:  strings.ToLower(canonicalizeCanaryText(normalized)),
 		})
+	}
+	// Windows shared between two canaries are a common stem, not a disclosure
+	// of either; they are excluded the same way as for environment secrets.
+	windows := buildKnownValueWindows(normalizedValues)
+	for i := range out {
+		out[i].partialWindows = windows[out[i].normalizedLower]
 	}
 	return out
 }
@@ -55,6 +63,9 @@ func (s *Scanner) scanCanaryText(text string) []TextDLPMatch {
 
 	if decoded := IterativeDecode(cleaned); decoded != cleaned {
 		matches = append(matches, s.matchCanaryTokens(decoded, "url", false, spanViewLabel("url_decoded", ViewDLPNormalized))...)
+	}
+	if decoded := decodeHTMLEntities(cleaned); decoded != cleaned {
+		matches = append(matches, s.matchCanaryTokens(decoded, encodingHTML, false, spanViewLabel("html_decoded", ViewDLPNormalized))...)
 	}
 	if strings.Contains(cleaned, ".") {
 		dotless := removeHostnameDots(cleaned)
@@ -132,6 +143,21 @@ func (s *Scanner) matchCanaryTokens(text, encoding string, canonical bool, input
 				PatternName: patternName,
 				Severity:    "critical",
 				Encoded:     encoding,
+				span:        newMatchSpan(start, end, viewLabel, patternName, "", ""),
+			})
+			continue
+		}
+		windows := token.partialWindows
+		if canonical {
+			windows = knownValueWindows(needle)
+		}
+		if start, end, length, _, ok := indexKnownValueSubstring(needle, windows, []spanTextView{{text: haystack, viewLabel: viewLabel}}); ok {
+			patternName := "Canary Token (" + token.name + ")"
+			matches = append(matches, TextDLPMatch{
+				PatternName: patternName,
+				Severity:    "critical",
+				Encoded:     encoding,
+				PartialLen:  length,
 				span:        newMatchSpan(start, end, viewLabel, patternName, "", ""),
 			})
 		}

--- a/internal/scanner/canary.go
+++ b/internal/scanner/canary.go
@@ -40,7 +40,7 @@ func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
 	// Windows shared between two canaries are a common stem, not a disclosure
 	// of either; they are excluded the same way as for environment secrets.
 	windows := buildKnownValueWindows(normalizedValues)
-	canonicalValues := make([]string, 0, len(out))
+	canonicalCount := make(map[string]int, len(out))
 	for i := range out {
 		out[i].partialWindows = windows[out[i].normalizedLower]
 		// URL-shaped originals stay whole-value-only after canonicalization.
@@ -49,10 +49,22 @@ func compileCanaryTokens(cfg config.CanaryTokens) []compiledCanaryToken {
 		if strings.Contains(out[i].normalizedLower, "://") || out[i].canonicalLower == "" {
 			continue
 		}
-		canonicalValues = append(canonicalValues, out[i].canonicalLower)
+		canonicalCount[out[i].canonicalLower]++
+	}
+	canonicalValues := make([]string, 0, len(canonicalCount))
+	for value, n := range canonicalCount {
+		if n == 1 {
+			canonicalValues = append(canonicalValues, value)
+		}
 	}
 	canonicalWindows := buildKnownValueWindows(canonicalValues)
 	for i := range out {
+		if strings.Contains(out[i].normalizedLower, "://") || out[i].canonicalLower == "" {
+			continue
+		}
+		if canonicalCount[out[i].canonicalLower] != 1 {
+			continue
+		}
 		out[i].canonicalPartialWindows = canonicalWindows[out[i].canonicalLower]
 	}
 	return out

--- a/internal/scanner/canary_test.go
+++ b/internal/scanner/canary_test.go
@@ -331,6 +331,52 @@ func TestScanTextForDLP_CanonicalCanaryKeepsURLAndSharedStemExclusions(t *testin
 	}
 }
 
+func TestScanTextForDLP_CanonicalCanaryCollisionDropsPartialWindows(t *testing.T) {
+	stem := "Q7vP2mK9xR4nT8wB6cD3"
+	hyphen := stem + "-fG1hJ5sL0zA"
+	underscore := stem + "_fG1hJ5sL0zA"
+
+	cfg := testConfig()
+	cfg.DLP.Patterns = nil
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{
+		{Name: "hyphen", Value: hyphen},
+		{Name: "underscore", Value: underscore},
+	}
+	s := MustNew(cfg)
+	defer s.Close()
+
+	frag := (stem + "fG1hJ5sL0zA")[:20]
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+frag[:10]+"-"+frag[10:]); !r.Clean {
+		t.Fatalf("canonical -/_ collision must not partial-match, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "token is "+hyphen); r.Clean {
+		t.Fatal("whole hyphen canary must still match")
+	}
+	for _, tok := range compileCanaryTokens(cfg.CanaryTokens) {
+		if tok.canonicalPartialWindows != nil {
+			t.Fatalf("colliding canonical canary %q kept partial windows", tok.name)
+		}
+	}
+}
+
+func TestCompileCanaryTokens_URLTokenDoesNotInheritTwinWindows(t *testing.T) {
+	stem := "Q7vP2mK9xR4nT8wB6cD3"
+	urlCanary := "https://example.com/a/" + stem
+	cfg := config.CanaryTokens{
+		Enabled: true,
+		Tokens: []config.CanaryToken{
+			{Name: "url_canary", Value: urlCanary},
+			{Name: "url_canonical_twin", Value: canonicalizeCanaryText(urlCanary)},
+		},
+	}
+	for _, tok := range compileCanaryTokens(cfg) {
+		if strings.Contains(tok.normalizedLower, "://") && tok.canonicalPartialWindows != nil {
+			t.Fatalf("URL-shaped canary %q inherited canonical partial windows", tok.name)
+		}
+	}
+}
+
 // BenchmarkScanCanaryText_Clean measures the canary path on ordinary text with
 // canary tokens configured. benchConfig deliberately has none, so the existing
 // text-DLP benchmarks never enter this code.

--- a/internal/scanner/canary_test.go
+++ b/internal/scanner/canary_test.go
@@ -350,8 +350,10 @@ func TestScanTextForDLP_CanonicalCanaryCollisionDropsPartialWindows(t *testing.T
 	if r := s.ScanTextForDLP(context.Background(), "checksum: "+frag[:10]+"-"+frag[10:]); !r.Clean {
 		t.Fatalf("canonical -/_ collision must not partial-match, got %+v", r.Matches)
 	}
-	if r := s.ScanTextForDLP(context.Background(), "token is "+hyphen); r.Clean {
-		t.Fatal("whole hyphen canary must still match")
+	for _, canary := range []string{hyphen, underscore} {
+		if r := s.ScanTextForDLP(context.Background(), "token is "+canary); r.Clean {
+			t.Fatalf("whole canary %q must still match", canary)
+		}
 	}
 	for _, tok := range compileCanaryTokens(cfg.CanaryTokens) {
 		if tok.canonicalPartialWindows != nil {

--- a/internal/scanner/canary_test.go
+++ b/internal/scanner/canary_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -174,6 +175,76 @@ func TestScanTextForDLP_CanaryDisabled(t *testing.T) {
 		if strings.Contains(m.PatternName, "Canary Token") {
 			t.Fatalf("unexpected canary match when canary scanning is disabled: %+v", result.Matches)
 		}
+	}
+}
+
+func TestScanTextForDLP_CanaryPartialDisclosure(t *testing.T) {
+	const canary = "Q7vP2mK9xR4nT8wB6cD3fG1hJ5sL0zA"
+	cfg := testConfig()
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{{Name: "partial_canary", Value: canary}}
+	s := MustNew(cfg)
+	defer s.Close()
+
+	htmlEntity := func(value string) string {
+		var b strings.Builder
+		for _, r := range value {
+			b.WriteString("&#")
+			b.WriteString(strconv.Itoa(int(r)))
+			b.WriteString(";")
+		}
+		return b.String()
+	}
+
+	tests := []struct {
+		name        string
+		text        string
+		wantClean   bool
+		wantPartial int
+	}{
+		{name: "full", text: canary},
+		{name: "prefix", text: "checksum: " + canary[:20], wantPartial: 20},
+		{name: "middle", text: "checksum: " + canary[6:27], wantPartial: 21},
+		{name: "suffix", text: "checksum: " + canary[len(canary)-20:], wantPartial: 20},
+		{name: "below_floor", text: "checksum: " + canary[:15], wantClean: true},
+		{name: "html_entity", text: htmlEntity(canary)},
+		{name: "unrelated_high_entropy", text: "checksum: mV4xJ9qR2sT7wK3p", wantClean: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.ScanTextForDLP(context.Background(), tt.text)
+			if result.Clean != tt.wantClean {
+				t.Fatalf("Clean = %t, want %t; matches=%+v", result.Clean, tt.wantClean, result.Matches)
+			}
+			if !tt.wantClean {
+				if result.Matches[0].PatternName != "Canary Token (partial_canary)" {
+					t.Fatalf("pattern=%q must stay stable for name-keyed consumers", result.Matches[0].PatternName)
+				}
+				if result.Matches[0].PartialLen != tt.wantPartial {
+					t.Fatalf("partial=%d, want %d; matches=%+v", result.Matches[0].PartialLen, tt.wantPartial, result.Matches)
+				}
+			}
+			if !tt.wantClean {
+				span := result.Matches[0].Span()
+				if !span.Valid() || span.ByteEnd-span.ByteStart < minKnownSecretSubstringLen {
+					t.Fatalf("partial canary span=%+v must retain the matched region", span)
+				}
+			}
+		})
+	}
+}
+
+func TestScanTextForDLP_LowEntropyCanaryPartialDisclosureIgnored(t *testing.T) {
+	cfg := testConfig()
+	cfg.DLP.Patterns = nil
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{{Name: "low_entropy", Value: "passwordpasswordpasswordpassword"}}
+	s := MustNew(cfg)
+	defer s.Close()
+
+	result := s.ScanTextForDLP(context.Background(), "checksum: passwordpassword")
+	if !result.Clean {
+		t.Fatalf("low-entropy partial canary must remain clean, got %+v", result.Matches)
 	}
 }
 

--- a/internal/scanner/canary_test.go
+++ b/internal/scanner/canary_test.go
@@ -295,6 +295,42 @@ func TestCanary_NestedEncodingInQuerySegment(t *testing.T) {
 	}
 }
 
+func TestScanTextForDLP_CanonicalCanaryKeepsURLAndSharedStemExclusions(t *testing.T) {
+	stem := "Q7vP2mK9xR4nT8wB6cD3"
+	first := stem + "-fG1hJ5sL0zAqW2eR"
+	second := stem + "_9uY6tR3eW1qZ8xC7"
+	urlCanary := strings.Join([]string{"https://example.com/a/", stem, "fG1hJ5sL0zA"}, "")
+
+	cfg := testConfig()
+	cfg.DLP.Patterns = nil
+	cfg.CanaryTokens.Enabled = true
+	cfg.CanaryTokens.Tokens = []config.CanaryToken{
+		{Name: "first", Value: first},
+		{Name: "second", Value: second},
+		{Name: "url_canary", Value: urlCanary},
+	}
+	s := MustNew(cfg)
+	defer s.Close()
+
+	// Hyphens force the canonical path. The shared stem is 20 bytes after
+	// separators are stripped; that is not a disclosure of either canary.
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+stem[:10]+"-"+stem[10:]); !r.Clean {
+		t.Fatalf("shared canonical stem must stay clean, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+first); r.Clean {
+		t.Fatal("whole first canary must still match")
+	}
+
+	// Canonicalization strips ://, so a URL-shaped canary would otherwise get
+	// partial windows on the public host path. Naming that path is not a leak.
+	if r := s.ScanTextForDLP(context.Background(), "docs live at https://example.com/a/readme"); !r.Clean {
+		t.Fatalf("URL-shaped canary public prefix must stay clean, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "token is "+urlCanary); r.Clean {
+		t.Fatal("whole URL-shaped canary must still be detected")
+	}
+}
+
 // BenchmarkScanCanaryText_Clean measures the canary path on ordinary text with
 // canary tokens configured. benchConfig deliberately has none, so the existing
 // text-DLP benchmarks never enter this code.

--- a/internal/scanner/scan_env_test.go
+++ b/internal/scanner/scan_env_test.go
@@ -46,6 +46,24 @@ func TestScan_EnvLeakDetection_RawValue(t *testing.T) {
 	}
 }
 
+func TestScanTextForDLP_EnvLeakPartialValue(t *testing.T) {
+	cfg := testConfig()
+	cfg.DLP.ScanEnv = true
+	cfg.DLP.Patterns = nil
+	secret := strings.Join([]string{"Q7vP2mK9xR4nT8wB", "6cD3fG1hJ5sL0zA"}, "")
+	t.Setenv("PIPELOCK_PARTIAL_SECRET", secret)
+	s := MustNew(cfg)
+	defer s.Close()
+
+	result := s.ScanTextForDLP(context.Background(), "checksum: "+secret[:20])
+	if result.Clean || len(result.Matches) != 1 {
+		t.Fatalf("partial environment value must be blocked, got %+v", result)
+	}
+	if result.Matches[0].PartialLen != 20 || result.Matches[0].PatternName != "Environment Variable Leak" || result.Matches[0].Encoded != "env" {
+		t.Fatalf("match=%+v, want partial environment leak attribution", result.Matches[0])
+	}
+}
+
 func TestScan_EnvLeakDetection_Base64Encoded(t *testing.T) {
 	cfg := testConfig()
 	cfg.DLP.ScanEnv = true

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2817,9 +2817,22 @@ func knownValueWindows(value string) map[string][]int {
 		return nil
 	}
 	windows := make(map[string][]int, len(value)-minKnownSecretSubstringLen+1)
+	repeated := make(map[string]struct{})
 	for start := 0; start <= len(value)-minKnownSecretSubstringLen; start++ {
 		window := value[start : start+minKnownSecretSubstringLen]
-		windows[window] = append(windows[window], start)
+		// The whole-value entropy floor does not protect a low-entropy prefix
+		// or a repeated 16-byte block inside an otherwise high-entropy secret.
+		if ShannonEntropy(window) <= envLeakMinEntropy {
+			continue
+		}
+		if _, seen := windows[window]; seen {
+			repeated[window] = struct{}{}
+			continue
+		}
+		windows[window] = []int{start}
+	}
+	for window := range repeated {
+		delete(windows, window)
 	}
 	return windows
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1964,11 +1964,12 @@ type decodedResult struct {
 
 // Encoding labels for decoded results.
 const (
-	encodingHex    = "hex"
-	encodingBase64 = "base64"
-	encodingBase32 = "base32"
-	encodingURL    = "url"
-	encodingHTML   = "html_entity"
+	encodingHex     = "hex"
+	encodingBase64  = "base64"
+	encodingBase32  = "base32"
+	encodingURL     = "url"
+	encodingHTML    = "html_entity"
+	encodingDecimal = "decimal_character_codes"
 )
 
 const (
@@ -2731,11 +2732,14 @@ func (s *Scanner) checkSecretsInURL(secrets []string, parsed *url.URL, reasonPre
 		{text: strings.ToLower(decodedURL), viewLabel: lowerViewLabel("control_stripped_url:url_decoded")},
 	}
 
+	windows := buildKnownValueWindows(s.envSecrets, s.fileSecrets)
 	for _, secret := range secrets {
-		if matched, enc, start, end, viewLabel := matchSecretEncodingSpan(secret, texts, lowerTexts); matched {
+		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, windows[secret], texts, lowerTexts); matched {
 			reason := reasonPrefix
-			if enc != "" {
-				reason += " (" + enc + "-encoded)"
+			if match.partialLen > 0 {
+				reason += fmt.Sprintf(" (partial %d)", match.partialLen)
+			} else if match.encoding != "" {
+				reason += " (" + match.encoding + "-encoded)"
 			}
 			return Result{
 				Allowed: false,
@@ -2780,6 +2784,119 @@ func indexAnyView(needle string, views []spanTextView) (int, int, string, bool) 
 		}
 	}
 	return 0, 0, "", false
+}
+
+// minKnownSecretSubstringLen is long enough that, at the 3-bit/character
+// entropy floor, a contiguous match carries at least 48 bits of evidence.
+// That keeps accidental matches unlikely while detecting meaningful disclosure.
+const minKnownSecretSubstringLen = 16
+
+type knownSecretMatch struct {
+	encoding   string
+	partialLen int
+}
+
+// knownValueWindows returns the fixed-size windows of one known value that are
+// eligible for partial matching, or nil when the value gets whole-value
+// matching only. A value is skipped when it is too short, when its own entropy
+// is below the leak floor (a low-entropy value's fragments are ordinary text),
+// or when it is URL-shaped: a connection string or webhook URL carries a long
+// public stem (scheme, host, path) that is not the secret part, and matching
+// that stem would block ordinary text that merely names the service.
+func knownValueWindows(value string) map[string][]int {
+	if len(value) < minKnownSecretSubstringLen || ShannonEntropy(value) <= envLeakMinEntropy || strings.Contains(value, "://") {
+		return nil
+	}
+	windows := make(map[string][]int, len(value)-minKnownSecretSubstringLen+1)
+	for start := 0; start <= len(value)-minKnownSecretSubstringLen; start++ {
+		window := value[start : start+minKnownSecretSubstringLen]
+		windows[window] = append(windows[window], start)
+	}
+	return windows
+}
+
+// knownValueWindowSet holds, per known value, the windows unique to that value.
+type knownValueWindowSet map[string]map[string][]int
+
+// buildKnownValueWindows computes partial-match windows for every value across
+// the given lists and drops any window that appears in more than one distinct
+// value. Two secrets that share a sixteen-byte run share a structural stem (a
+// vendor prefix, an account path, a common template), and a stem is not a
+// disclosure of either secret; matching it would attribute one secret's text
+// to the other and would block text that only contains the shared part.
+func buildKnownValueWindows(lists ...[]string) knownValueWindowSet {
+	set := make(knownValueWindowSet)
+	owners := make(map[string]string) // window -> first value seen with it
+	shared := make(map[string]struct{})
+	for _, list := range lists {
+		for _, value := range list {
+			if _, done := set[value]; done {
+				continue
+			}
+			windows := knownValueWindows(value)
+			set[value] = windows
+			for window := range windows {
+				if owner, seen := owners[window]; seen && owner != value {
+					shared[window] = struct{}{}
+					continue
+				}
+				owners[window] = value
+			}
+		}
+	}
+	for _, windows := range set {
+		for window := range shared {
+			delete(windows, window)
+		}
+	}
+	return set
+}
+
+// indexKnownValueSubstring scans each candidate view once with fixed-size
+// windows, then extends only matching windows. It avoids constructing every
+// possible substring needle while retaining the longest contiguous disclosure.
+func indexKnownValueSubstring(value string, windows map[string][]int, views []spanTextView) (int, int, int, string, bool) {
+	if len(windows) == 0 {
+		return 0, 0, 0, "", false
+	}
+	bestLen := 0
+	bestStart, bestEnd := 0, 0
+	bestView := ""
+	for _, view := range views {
+		for textStart := 0; textStart <= len(view.text)-minKnownSecretSubstringLen; textStart++ {
+			for _, valueStart := range windows[view.text[textStart:textStart+minKnownSecretSubstringLen]] {
+				leftText, leftValue := textStart, valueStart
+				for leftText > 0 && leftValue > 0 && view.text[leftText-1] == value[leftValue-1] {
+					leftText--
+					leftValue--
+				}
+				rightText := textStart + minKnownSecretSubstringLen
+				rightValue := valueStart + minKnownSecretSubstringLen
+				for rightText < len(view.text) && rightValue < len(value) && view.text[rightText] == value[rightValue] {
+					rightText++
+					rightValue++
+				}
+				if length := rightText - leftText; length > bestLen {
+					bestLen, bestStart, bestEnd, bestView = length, leftText, rightText, view.viewLabel
+				}
+			}
+		}
+	}
+	if bestLen < minKnownSecretSubstringLen {
+		return 0, 0, 0, "", false
+	}
+	return bestStart, bestEnd, bestLen, bestView, true
+}
+
+func decimalCharacterCodes(value, separator string) string {
+	var b strings.Builder
+	for i, r := range value {
+		if i > 0 {
+			b.WriteString(separator)
+		}
+		b.WriteString(strconv.Itoa(int(r)))
+	}
+	return b.String()
 }
 
 func indexEncodedTokenView(needle string, views []spanTextView, kind encodedTokenKind) (int, int, string, bool) {
@@ -2876,29 +2993,35 @@ func indexHexTokenView(needle string, views []spanTextView) (int, int, string, b
 	return 0, 0, "", false
 }
 
-func matchSecretEncodingSpan(secret string, texts, lowerTexts []spanTextView) (bool, string, int, int, string) {
+// matchSecretEncodingSpan finds a known secret in the candidate views as a
+// whole value, as a contiguous partial disclosure using the caller-provided
+// windows (nil disables partial matching), or under a supported encoding.
+func matchSecretEncodingSpan(secret string, windows map[string][]int, texts, lowerTexts []spanTextView) (knownSecretMatch, int, int, string, bool) {
 	// Raw match.
 	if start, end, viewLabel, ok := indexAnyView(secret, texts); ok {
-		return true, "", start, end, viewLabel
+		return knownSecretMatch{}, start, end, viewLabel, true
+	}
+	if start, end, length, viewLabel, ok := indexKnownValueSubstring(secret, windows, texts); ok {
+		return knownSecretMatch{partialLen: length}, start, end, viewLabel, true
 	}
 
 	// Base64 standard (padded + unpadded).
 	b64Std := base64.StdEncoding.EncodeToString([]byte(secret))
 	b64StdNoPad := strings.TrimRight(b64Std, "=")
 	if start, end, viewLabel, ok := indexAnyView(b64Std, texts); ok {
-		return true, encodingBase64, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingBase64}, start, end, viewLabel, true
 	}
 	if b64StdNoPad != b64Std {
 		if start, end, viewLabel, ok := indexAnyView(b64StdNoPad, texts); ok {
-			return true, encodingBase64, start, end, viewLabel
+			return knownSecretMatch{encoding: encodingBase64}, start, end, viewLabel, true
 		}
 	}
 	if start, end, viewLabel, ok := indexEncodedTokenView(b64Std, texts, encodedTokenBase64Std); ok {
-		return true, encodingBase64, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingBase64}, start, end, viewLabel, true
 	}
 	if b64StdNoPad != b64Std {
 		if start, end, viewLabel, ok := indexEncodedTokenView(b64StdNoPad, texts, encodedTokenBase64Std); ok {
-			return true, encodingBase64, start, end, viewLabel
+			return knownSecretMatch{encoding: encodingBase64}, start, end, viewLabel, true
 		}
 	}
 
@@ -2907,29 +3030,29 @@ func matchSecretEncodingSpan(secret string, texts, lowerTexts []spanTextView) (b
 	b64URLNoPad := strings.TrimRight(b64URL, "=")
 	if b64URL != b64Std {
 		if start, end, viewLabel, ok := indexAnyView(b64URL, texts); ok {
-			return true, "base64url", start, end, viewLabel
+			return knownSecretMatch{encoding: "base64url"}, start, end, viewLabel, true
 		}
 	}
 	if b64URLNoPad != b64StdNoPad {
 		if start, end, viewLabel, ok := indexAnyView(b64URLNoPad, texts); ok {
-			return true, "base64url", start, end, viewLabel
+			return knownSecretMatch{encoding: "base64url"}, start, end, viewLabel, true
 		}
 	}
 	if b64URL != b64Std {
 		if start, end, viewLabel, ok := indexEncodedTokenView(b64URL, texts, encodedTokenBase64URL); ok {
-			return true, "base64url", start, end, viewLabel
+			return knownSecretMatch{encoding: "base64url"}, start, end, viewLabel, true
 		}
 	}
 	if b64URLNoPad != b64StdNoPad {
 		if start, end, viewLabel, ok := indexEncodedTokenView(b64URLNoPad, texts, encodedTokenBase64URL); ok {
-			return true, "base64url", start, end, viewLabel
+			return knownSecretMatch{encoding: "base64url"}, start, end, viewLabel, true
 		}
 	}
 
 	// Hex (case-insensitive via pre-lowered texts).
 	hexEnc := hex.EncodeToString([]byte(secret))
 	if start, end, viewLabel, ok := indexAnyView(hexEnc, lowerTexts); ok {
-		return true, encodingHex, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingHex}, start, end, viewLabel, true
 	}
 
 	// Delimiter-separated hex variants for env/file secret detection.
@@ -2942,34 +3065,40 @@ func matchSecretEncodingSpan(secret string, texts, lowerTexts []spanTextView) (b
 	zxHex := hexBytePrefix(hexEnc, "0x")
 	for _, candidate := range []string{colonHex, spaceHex, hyphenHex, commaHex, bsxHex, zxHex} {
 		if start, end, viewLabel, ok := indexAnyView(candidate, lowerTexts); ok {
-			return true, encodingHex, start, end, viewLabel
+			return knownSecretMatch{encoding: encodingHex}, start, end, viewLabel, true
 		}
 	}
 	if start, end, viewLabel, ok := indexHexTokenView(hexEnc, lowerTexts); ok {
-		return true, encodingHex, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingHex}, start, end, viewLabel, true
+	}
+
+	for _, candidate := range []string{decimalCharacterCodes(secret, ","), decimalCharacterCodes(secret, " ")} {
+		if start, end, viewLabel, ok := indexAnyView(candidate, texts); ok {
+			return knownSecretMatch{encoding: encodingDecimal}, start, end, viewLabel, true
+		}
 	}
 
 	// Base32 standard (padded + unpadded).
 	b32Std := base32.StdEncoding.EncodeToString([]byte(secret))
 	b32NoPad := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(secret))
 	if start, end, viewLabel, ok := indexAnyView(b32Std, texts); ok {
-		return true, encodingBase32, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingBase32}, start, end, viewLabel, true
 	}
 	if b32NoPad != b32Std {
 		if start, end, viewLabel, ok := indexAnyView(b32NoPad, texts); ok {
-			return true, encodingBase32, start, end, viewLabel
+			return knownSecretMatch{encoding: encodingBase32}, start, end, viewLabel, true
 		}
 	}
 	if start, end, viewLabel, ok := indexEncodedTokenView(b32Std, texts, encodedTokenBase32); ok {
-		return true, encodingBase32, start, end, viewLabel
+		return knownSecretMatch{encoding: encodingBase32}, start, end, viewLabel, true
 	}
 	if b32NoPad != b32Std {
 		if start, end, viewLabel, ok := indexEncodedTokenView(b32NoPad, texts, encodedTokenBase32); ok {
-			return true, encodingBase32, start, end, viewLabel
+			return knownSecretMatch{encoding: encodingBase32}, start, end, viewLabel, true
 		}
 	}
 
-	return false, "", 0, 0, ""
+	return knownSecretMatch{}, 0, 0, "", false
 }
 
 // nonSecretEnvNames lists environment variable names that are never secrets.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -203,26 +203,32 @@ func IsHostnameExfilResult(r Result) bool {
 
 // Scanner checks URLs for suspicious content before fetching.
 type Scanner struct {
-	core                       *compiledCoreScanner // immutable safety floor - always runs, no config knobs
-	allowlist                  []string
-	blocklist                  []string
-	dlpPatterns                []*compiledPattern
-	canaryTokens               []compiledCanaryToken
-	dlpPreFilter               *dlpPreFilter
-	entropyThreshold           float64
-	subdomainEntropyThreshold  float64
-	entropyMinLen              int
-	maxURLLength               int
-	internalCIDRs              []*net.IPNet
-	ipAllowlistCIDRs           []*net.IPNet // SSRF-exempt IP ranges (ssrf.ip_allowlist)
-	trustedDomains             []string     // SSRF-exempt domains (wildcard via MatchDomain)
-	destinationGrants          destination.GrantSet
-	rawAPIAllowlist            []string // full api_allowlist for SSRF hint generation (all modes)
-	rateLimiter                *RateLimiter
-	dataBudget                 *DataBudget
-	envSecrets                 []string // filtered high-entropy env var values
-	fileSecrets                []string // loaded from secrets_file config
-	minEnvSecretLen            int      // minimum env var length for leak detection
+	core                      *compiledCoreScanner // immutable safety floor - always runs, no config knobs
+	allowlist                 []string
+	blocklist                 []string
+	dlpPatterns               []*compiledPattern
+	canaryTokens              []compiledCanaryToken
+	dlpPreFilter              *dlpPreFilter
+	entropyThreshold          float64
+	subdomainEntropyThreshold float64
+	entropyMinLen             int
+	maxURLLength              int
+	internalCIDRs             []*net.IPNet
+	ipAllowlistCIDRs          []*net.IPNet // SSRF-exempt IP ranges (ssrf.ip_allowlist)
+	trustedDomains            []string     // SSRF-exempt domains (wildcard via MatchDomain)
+	destinationGrants         destination.GrantSet
+	rawAPIAllowlist           []string // full api_allowlist for SSRF hint generation (all modes)
+	rateLimiter               *RateLimiter
+	dataBudget                *DataBudget
+	envSecrets                []string // filtered high-entropy env var values
+	fileSecrets               []string // loaded from secrets_file config
+	// knownSecretWindows holds the partial-match windows for every configured
+	// env and file secret, keyed by the secret. It is built once here because
+	// the lists are fixed for a scanner's lifetime (a reload builds a new
+	// scanner), and rebuilding it per scan cost more than the scan itself once
+	// a host had a realistic number of high-entropy environment values.
+	knownSecretWindows         knownValueWindowSet
+	minEnvSecretLen            int // minimum env var length for leak detection
 	responsePatterns           []*compiledPattern
 	responseOptSpacePatterns   []*compiledPattern // \s+ → \s* variants for ZW-stripped pass
 	responseVowelFoldPatterns  []*compiledPattern // vowel-folded variants for confusable vowel attacks
@@ -526,6 +532,10 @@ func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
 				cfg.DLP.SecretsFile)
 		}
 	}
+
+	// Build partial-match windows across both known-value lists together, so a
+	// stem shared by an env secret and a file secret is excluded from both.
+	s.knownSecretWindows = buildKnownValueWindows(s.envSecrets, s.fileSecrets)
 
 	// Compile response scanning patterns - must succeed since config.Validate checks these
 	if cfg.ResponseScanning.Enabled {
@@ -2732,9 +2742,8 @@ func (s *Scanner) checkSecretsInURL(secrets []string, parsed *url.URL, reasonPre
 		{text: strings.ToLower(decodedURL), viewLabel: lowerViewLabel("control_stripped_url:url_decoded")},
 	}
 
-	windows := buildKnownValueWindows(s.envSecrets, s.fileSecrets)
 	for _, secret := range secrets {
-		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, windows[secret], texts, lowerTexts); matched {
+		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, s.knownSecretWindows[secret], texts, lowerTexts); matched {
 			reason := reasonPrefix
 			if match.partialLen > 0 {
 				reason += fmt.Sprintf(" (partial %d)", match.partialLen)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2807,15 +2807,63 @@ type knownSecretMatch struct {
 
 // knownValueWindows returns the fixed-size windows of one known value that are
 // eligible for partial matching, or nil when the value gets whole-value
-// matching only. A value is skipped when it is too short, when its own entropy
-// is below the leak floor (a low-entropy value's fragments are ordinary text),
-// or when it is URL-shaped: a connection string or webhook URL carries a long
-// public stem (scheme, host, path) that is not the secret part, and matching
-// that stem would block ordinary text that merely names the service.
+// matching only. A value is skipped when it is too short or when its own
+// entropy is below the leak floor. URL-shaped values skip public scheme, host,
+// and path stems; only credential-bearing parts (password, query, fragment,
+// and a high-entropy final path segment) are windowed.
 func knownValueWindows(value string) map[string][]int {
-	if len(value) < minKnownSecretSubstringLen || ShannonEntropy(value) <= envLeakMinEntropy || strings.Contains(value, "://") {
+	if len(value) < minKnownSecretSubstringLen || ShannonEntropy(value) <= envLeakMinEntropy {
 		return nil
 	}
+	if strings.Contains(value, "://") {
+		return urlCredentialWindows(value)
+	}
+	return collectValueWindows(value, 0)
+}
+
+func urlCredentialWindows(value string) map[string][]int {
+	u, err := url.Parse(value)
+	if err != nil {
+		return nil
+	}
+	var parts []string
+	if u.User != nil {
+		if password, ok := u.User.Password(); ok && password != "" {
+			parts = append(parts, password)
+		}
+	}
+	for _, vs := range u.Query() {
+		parts = append(parts, vs...)
+	}
+	if u.Fragment != "" {
+		parts = append(parts, u.Fragment)
+	}
+	if path := strings.Trim(u.Path, "/"); path != "" {
+		seg := path
+		if i := strings.LastIndexByte(path, '/'); i >= 0 {
+			seg = path[i+1:]
+		}
+		if seg != "" {
+			parts = append(parts, seg)
+		}
+	}
+	out := make(map[string][]int)
+	for _, part := range parts {
+		if len(part) < minKnownSecretSubstringLen || ShannonEntropy(part) <= envLeakMinEntropy {
+			continue
+		}
+		idx := strings.Index(value, part)
+		if idx < 0 {
+			continue
+		}
+		for window, offsets := range collectValueWindows(part, idx) {
+			out[window] = append(out[window], offsets...)
+		}
+	}
+	return out
+}
+
+func collectValueWindows(value string, base int) map[string][]int {
 	windows := make(map[string][]int, len(value)-minKnownSecretSubstringLen+1)
 	repeated := make(map[string]struct{})
 	for start := 0; start <= len(value)-minKnownSecretSubstringLen; start++ {
@@ -2829,7 +2877,7 @@ func knownValueWindows(value string) map[string][]int {
 			repeated[window] = struct{}{}
 			continue
 		}
-		windows[window] = []int{start}
+		windows[window] = []int{base + start}
 	}
 	for window := range repeated {
 		delete(windows, window)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2824,7 +2824,10 @@ func knownValueWindows(value string) map[string][]int {
 func urlCredentialWindows(value string) map[string][]int {
 	u, err := url.Parse(value)
 	if err != nil {
-		return nil
+		// Unparseable URL-shaped secrets still have to partial-match as a
+		// blob. Skipping them would hide a leaked token that happens to
+		// sit next to "://".
+		return collectValueWindows(value, 0)
 	}
 	var parts []string
 	if u.User != nil {
@@ -2839,12 +2842,10 @@ func urlCredentialWindows(value string) map[string][]int {
 		parts = append(parts, u.Fragment)
 	}
 	if path := strings.Trim(u.Path, "/"); path != "" {
-		seg := path
-		if i := strings.LastIndexByte(path, '/'); i >= 0 {
-			seg = path[i+1:]
-		}
-		if seg != "" {
-			parts = append(parts, seg)
+		for _, seg := range strings.Split(path, "/") {
+			if seg != "" {
+				parts = append(parts, seg)
+			}
 		}
 	}
 	out := make(map[string][]int)
@@ -2852,15 +2853,35 @@ func urlCredentialWindows(value string) map[string][]int {
 		if len(part) < minKnownSecretSubstringLen || ShannonEntropy(part) <= envLeakMinEntropy {
 			continue
 		}
-		idx := strings.Index(value, part)
+		idx, raw := locateURLPart(value, part)
 		if idx < 0 {
 			continue
 		}
 		for window, offsets := range collectValueWindows(part, idx) {
 			out[window] = append(out[window], offsets...)
 		}
+		if raw != part {
+			for window, offsets := range collectValueWindows(raw, idx) {
+				out[window] = append(out[window], offsets...)
+			}
+		}
 	}
 	return out
+}
+
+func locateURLPart(value, part string) (int, string) {
+	if i := strings.Index(value, part); i >= 0 {
+		return i, part
+	}
+	for _, enc := range []string{url.QueryEscape(part), url.PathEscape(part)} {
+		if enc == part {
+			continue
+		}
+		if i := strings.Index(value, enc); i >= 0 {
+			return i, enc
+		}
+	}
+	return -1, ""
 }
 
 func collectValueWindows(value string, base int) map[string][]int {

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -904,11 +904,8 @@ func (s *Scanner) checkSecretsInText(secrets []string, text, patternName, encode
 	texts := []spanTextView{{text: text, viewLabel: ViewDLPNormalized}}
 	lowerTexts := []spanTextView{{text: strings.ToLower(text), viewLabel: lowerViewLabel(ViewDLPNormalized)}}
 
-	// Windows are built over every known value, not only this list, so a stem
-	// shared between an environment secret and a file secret is excluded.
-	windows := buildKnownValueWindows(s.envSecrets, s.fileSecrets, secrets)
 	for _, secret := range secrets {
-		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, windows[secret], texts, lowerTexts); matched {
+		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, s.knownSecretWindows[secret], texts, lowerTexts); matched {
 			m := TextDLPMatch{PatternName: patternName, Severity: "critical", PartialLen: match.partialLen}
 			if encodedOverride != "" {
 				m.Encoded = encodedOverride

--- a/internal/scanner/text_dlp.go
+++ b/internal/scanner/text_dlp.go
@@ -288,7 +288,12 @@ type TextDLPMatch struct {
 	BundleVersion  string `json:"bundle_version,omitempty"`
 	Warn           bool   `json:"warn,omitempty"`            // true for warn-mode patterns (informational only)
 	ProviderOpaque bool   `json:"provider_opaque,omitempty"` // true when proxy scoped this match to trusted provider opaque ciphertext
-	span           MatchSpan
+	// PartialLen is the number of contiguous bytes of a known value (canary or
+	// environment/file secret) found when the whole value was absent. Zero
+	// means a whole-value match. It lives in its own field so PatternName stays
+	// stable for suppression rules and core-pattern checks that match by name.
+	PartialLen int `json:"partial_len,omitempty"`
+	span       MatchSpan
 }
 
 // Span returns retained coordinates for this match in the normalized scanner
@@ -899,13 +904,16 @@ func (s *Scanner) checkSecretsInText(secrets []string, text, patternName, encode
 	texts := []spanTextView{{text: text, viewLabel: ViewDLPNormalized}}
 	lowerTexts := []spanTextView{{text: strings.ToLower(text), viewLabel: lowerViewLabel(ViewDLPNormalized)}}
 
+	// Windows are built over every known value, not only this list, so a stem
+	// shared between an environment secret and a file secret is excluded.
+	windows := buildKnownValueWindows(s.envSecrets, s.fileSecrets, secrets)
 	for _, secret := range secrets {
-		if matched, enc, start, end, viewLabel := matchSecretEncodingSpan(secret, texts, lowerTexts); matched {
-			m := TextDLPMatch{PatternName: patternName, Severity: "critical"}
+		if match, start, end, viewLabel, matched := matchSecretEncodingSpan(secret, windows[secret], texts, lowerTexts); matched {
+			m := TextDLPMatch{PatternName: patternName, Severity: "critical", PartialLen: match.partialLen}
 			if encodedOverride != "" {
 				m.Encoded = encodedOverride
 			} else {
-				m.Encoded = enc
+				m.Encoded = match.encoding
 			}
 			m.span = newMatchSpan(start, end, viewLabel, patternName, "", "")
 			return []TextDLPMatch{m}

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -5,6 +5,7 @@ package scanner
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/hex"
@@ -3968,9 +3969,9 @@ func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
 		t.Fatalf("whole first secret must match as a whole value, got %+v", r)
 	}
 
-	// A URL-shaped secret gets whole-value matching only: its scheme, host and
-	// path are a public stem that ordinary text may name. Built at runtime from
-	// parts so the test binary carries no URL-shaped credential literal.
+	// A URL-shaped secret windows credential-bearing parts only. Scheme, host
+	// and public path stay unmatched. Built at runtime from parts so the test
+	// binary carries no URL-shaped credential literal.
 	dsn := strings.Join([]string{"postgres://app:", stem, "fG1hJ5sL0zA", "@db.internal.example:5432/prod"}, "")
 	dsnPath := filepath.Join(dir, "dsn.txt")
 	if err := os.WriteFile(dsnPath, []byte(dsn+"\n"), 0o600); err != nil {
@@ -3993,6 +3994,61 @@ func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
 	}
 	if r := dsnScanner.ScanTextForDLP(context.Background(), "checksum: "+password[:18]); r.Clean || r.Matches[0].PartialLen != 18 {
 		t.Fatalf("leaked DSN password must partial-match, got %+v", r)
+	}
+}
+
+func TestCheckSecretsInText_PartialMatchURLEncodedComponents(t *testing.T) {
+	// Derived at runtime so the PR never contains a high-entropy secret
+	// literal for GitGuardian to reconstruct from concatenations or bytes.
+	sum := sha256.Sum256([]byte(t.Name()))
+	token := hex.EncodeToString(sum[:10]) + "/" + hex.EncodeToString(sum[10:14])
+	escaped := url.QueryEscape(token)
+	if escaped == token {
+		t.Fatal("test token must contain a character that percent-encodes")
+	}
+
+	dir := t.TempDir()
+	writeSecret := func(name, value string) *Scanner {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(value+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := testConfig()
+		cfg.DLP.SecretsFile = path
+		s := MustNew(cfg)
+		t.Cleanup(s.Close)
+		return s
+	}
+
+	queryURL := "https://api.vendor.example/v1?token=" + escaped
+	qs := writeSecret("query.txt", queryURL)
+	if r := qs.ScanTextForDLP(context.Background(), "checksum: "+token[:18]); r.Clean {
+		t.Fatalf("decoded query token must partial-match, got %+v", r)
+	}
+	if r := qs.ScanTextForDLP(context.Background(), "checksum: "+escaped[:18]); r.Clean {
+		t.Fatalf("escaped query token must partial-match, got %+v", r)
+	}
+
+	pathURL := "https://api.vendor.example/hooks/" + url.PathEscape(token)
+	ps := writeSecret("path.txt", pathURL)
+	if r := ps.ScanTextForDLP(context.Background(), "checksum: "+token[:18]); r.Clean {
+		t.Fatalf("decoded path token must partial-match, got %+v", r)
+	}
+
+	fragURL := "https://api.vendor.example/v1#" + escaped
+	fs := writeSecret("frag.txt", fragURL)
+	if r := fs.ScanTextForDLP(context.Background(), "checksum: "+token[:18]); r.Clean {
+		t.Fatalf("decoded fragment token must partial-match, got %+v", r)
+	}
+
+	malformed := "http://[" + token
+	if _, err := url.Parse(malformed); err == nil {
+		t.Fatal("malformed fixture must fail url.Parse")
+	}
+	ms := writeSecret("malformed.txt", malformed)
+	if r := ms.ScanTextForDLP(context.Background(), "checksum: "+token[:18]); r.Clean {
+		t.Fatalf("unparseable URL-shaped secret must still partial-match, got %+v", r)
 	}
 }
 

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1732,6 +1732,45 @@ func TestCheckSecretsInText_NoEnvSecrets(t *testing.T) {
 	}
 }
 
+func TestCheckSecretsInText_KnownSecretRepresentations(t *testing.T) {
+	cfg := testConfig()
+	cfg.DLP.Patterns = nil
+	s := MustNew(cfg)
+	defer s.Close()
+
+	secret := strings.Join([]string{"Q7vP2mK9xR4nT8wB", "6cD3fG1hJ5sL0zA"}, "")
+	tests := []struct {
+		name        string
+		text        string
+		wantPartial int
+		wantEnc     string
+	}{
+		{name: "full", text: secret},
+		{name: "prefix", text: secret[:20], wantPartial: 20},
+		{name: "middle", text: secret[6:27], wantPartial: 21},
+		{name: "suffix", text: secret[len(secret)-20:], wantPartial: 20},
+		{name: "decimal_comma", text: decimalCharacterCodes(secret, ","), wantEnc: encodingDecimal},
+		{name: "decimal_space", text: decimalCharacterCodes(secret, " "), wantEnc: encodingDecimal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := s.checkSecretsInText([]string{secret}, tt.text, "Known Secret Leak", "")
+			if len(matches) != 1 {
+				t.Fatalf("matches=%+v, want one known-secret match", matches)
+			}
+			if matches[0].PatternName != "Known Secret Leak" {
+				t.Fatalf("pattern=%q must stay stable for suppression rules", matches[0].PatternName)
+			}
+			if matches[0].PartialLen != tt.wantPartial {
+				t.Fatalf("partial=%d, want %d", matches[0].PartialLen, tt.wantPartial)
+			}
+			if matches[0].Encoded != tt.wantEnc {
+				t.Fatalf("encoded=%q, want %q", matches[0].Encoded, tt.wantEnc)
+			}
+		})
+	}
+}
+
 func TestCheckSecretsInText_HexEncodedEnvSecret(t *testing.T) {
 	cfg := testConfig()
 	cfg.DLP.ScanEnv = true
@@ -3888,5 +3927,43 @@ func TestScanTextForDLP_CredentialInURLGrammarFromPresetYAML(t *testing.T) {
 	}
 	if result := s.ScanTextForDLP(context.Background(), "token=abcdef123456"); result.Clean || !hasTextDLPMatch(result.Matches, "Credential in URL", "") {
 		t.Fatalf("preset-loaded pattern must still detect the adjacent form: %+v", result.Matches)
+	}
+}
+
+func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
+	cfg := testConfig()
+	s := MustNew(cfg)
+	defer s.Close()
+
+	// Two secrets sharing a 20-byte stem: the stem alone is not a disclosure
+	// of either, while each unique tail still is.
+	stem := "Q7vP2mK9xR4nT8wB6cD3"
+	first := stem + "fG1hJ5sL0zAqW2eR"
+	second := stem + "9uY6tR3eW1qZ8xC7"
+	s.envSecrets = []string{first, second}
+
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+stem); !r.Clean {
+		t.Fatalf("shared stem alone must stay clean, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+first[len(first)-18:]); r.Clean || r.Matches[0].PartialLen != 18 {
+		t.Fatalf("unique tail of first secret must partial-match, got %+v", r)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+first); r.Clean || r.Matches[0].PartialLen != 0 {
+		t.Fatalf("whole first secret must match as a whole value, got %+v", r)
+	}
+
+	// A URL-shaped secret gets whole-value matching only: its scheme, host and
+	// path are a public stem that ordinary text may name.
+	// Built at runtime from parts so the test binary carries no URL-shaped credential literal.
+	dsn := strings.Join([]string{"postgres://app:", stem, "fG1hJ5sL0zA", "@db.internal.example:5432/prod"}, "")
+	s.envSecrets = []string{dsn}
+	if r := s.ScanTextForDLP(context.Background(), "connect to postgres://app:@db.internal.example:5432/prod first"); !r.Clean {
+		t.Fatalf("URL stem without the credential must stay clean, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "dsn is "+dsn); r.Clean {
+		t.Fatal("whole URL-shaped secret must still be detected")
+	}
+	if got := knownValueWindows(dsn); got != nil {
+		t.Fatalf("URL-shaped value must not get partial windows, got %d", len(got))
 	}
 }

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -3991,3 +3991,29 @@ func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
 		t.Fatalf("URL-shaped value must not get partial windows, got %d", len(got))
 	}
 }
+
+func TestCheckSecretsInText_PartialMatchSkipsLowEntropyWindows(t *testing.T) {
+	prefix := strings.Repeat("a", minKnownSecretSubstringLen)
+	tail := "Q7vP2mK9xR4nT8wB6cD3fG1hJ5sL0zAqW2eR9uY6tR3eW1qZ8xC7"
+	secret := prefix + tail
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.txt")
+	if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig()
+	cfg.DLP.SecretsFile = path
+	s := MustNew(cfg)
+	defer s.Close()
+
+	if r := s.ScanTextForDLP(context.Background(), "padding: "+prefix); !r.Clean {
+		t.Fatalf("low-entropy prefix window must stay clean, got %+v", r.Matches)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "checksum: "+tail[:18]); r.Clean || r.Matches[0].PartialLen != 18 {
+		t.Fatalf("high-entropy tail must partial-match, got %+v", r)
+	}
+	if r := s.ScanTextForDLP(context.Background(), "secret is "+secret); r.Clean {
+		t.Fatal("whole secret must still be detected")
+	}
+}

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -1733,12 +1733,21 @@ func TestCheckSecretsInText_NoEnvSecrets(t *testing.T) {
 }
 
 func TestCheckSecretsInText_KnownSecretRepresentations(t *testing.T) {
+	secret := strings.Join([]string{"Q7vP2mK9xR4nT8wB", "6cD3fG1hJ5sL0zA"}, "")
+	// Configure the secret through the shipped secrets_file path, so the
+	// partial-match windows under test are the ones the scanner precomputes
+	// rather than a set assembled by the test.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.txt")
+	if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	cfg := testConfig()
 	cfg.DLP.Patterns = nil
+	cfg.DLP.SecretsFile = path
 	s := MustNew(cfg)
 	defer s.Close()
 
-	secret := strings.Join([]string{"Q7vP2mK9xR4nT8wB", "6cD3fG1hJ5sL0zA"}, "")
 	tests := []struct {
 		name        string
 		text        string
@@ -3931,16 +3940,23 @@ func TestScanTextForDLP_CredentialInURLGrammarFromPresetYAML(t *testing.T) {
 }
 
 func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
-	cfg := testConfig()
-	s := MustNew(cfg)
-	defer s.Close()
-
 	// Two secrets sharing a 20-byte stem: the stem alone is not a disclosure
-	// of either, while each unique tail still is.
+	// of either, while each unique tail still is. They are configured through
+	// the shipped secrets_file path so the test exercises the windows the
+	// scanner precomputes at construction, not a hand-built set.
 	stem := "Q7vP2mK9xR4nT8wB6cD3"
 	first := stem + "fG1hJ5sL0zAqW2eR"
 	second := stem + "9uY6tR3eW1qZ8xC7"
-	s.envSecrets = []string{first, second}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.txt")
+	if err := os.WriteFile(path, []byte(first+"\n"+second+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig()
+	cfg.DLP.SecretsFile = path
+	s := MustNew(cfg)
+	defer s.Close()
 
 	if r := s.ScanTextForDLP(context.Background(), "checksum: "+stem); !r.Clean {
 		t.Fatalf("shared stem alone must stay clean, got %+v", r.Matches)
@@ -3953,14 +3969,22 @@ func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
 	}
 
 	// A URL-shaped secret gets whole-value matching only: its scheme, host and
-	// path are a public stem that ordinary text may name.
-	// Built at runtime from parts so the test binary carries no URL-shaped credential literal.
+	// path are a public stem that ordinary text may name. Built at runtime from
+	// parts so the test binary carries no URL-shaped credential literal.
 	dsn := strings.Join([]string{"postgres://app:", stem, "fG1hJ5sL0zA", "@db.internal.example:5432/prod"}, "")
-	s.envSecrets = []string{dsn}
-	if r := s.ScanTextForDLP(context.Background(), "connect to postgres://app:@db.internal.example:5432/prod first"); !r.Clean {
+	dsnPath := filepath.Join(dir, "dsn.txt")
+	if err := os.WriteFile(dsnPath, []byte(dsn+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dsnCfg := testConfig()
+	dsnCfg.DLP.SecretsFile = dsnPath
+	dsnScanner := MustNew(dsnCfg)
+	defer dsnScanner.Close()
+
+	if r := dsnScanner.ScanTextForDLP(context.Background(), "connect to postgres://app:@db.internal.example:5432/prod first"); !r.Clean {
 		t.Fatalf("URL stem without the credential must stay clean, got %+v", r.Matches)
 	}
-	if r := s.ScanTextForDLP(context.Background(), "dsn is "+dsn); r.Clean {
+	if r := dsnScanner.ScanTextForDLP(context.Background(), "dsn is "+dsn); r.Clean {
 		t.Fatal("whole URL-shaped secret must still be detected")
 	}
 	if got := knownValueWindows(dsn); got != nil {

--- a/internal/scanner/text_dlp_test.go
+++ b/internal/scanner/text_dlp_test.go
@@ -3987,8 +3987,12 @@ func TestCheckSecretsInText_PartialMatchSkipsSharedStemsAndURLs(t *testing.T) {
 	if r := dsnScanner.ScanTextForDLP(context.Background(), "dsn is "+dsn); r.Clean {
 		t.Fatal("whole URL-shaped secret must still be detected")
 	}
-	if got := knownValueWindows(dsn); got != nil {
-		t.Fatalf("URL-shaped value must not get partial windows, got %d", len(got))
+	password := stem + "fG1hJ5sL0zA"
+	if got := knownValueWindows(dsn); len(got) == 0 {
+		t.Fatal("URL-shaped secret must window the password")
+	}
+	if r := dsnScanner.ScanTextForDLP(context.Background(), "checksum: "+password[:18]); r.Clean || r.Matches[0].PartialLen != 18 {
+		t.Fatalf("leaked DSN password must partial-match, got %+v", r)
 	}
 }
 


### PR DESCRIPTION
## What changed
- Detect a contiguous partial disclosure of a canary token or a configured environment or file secret, above a length floor and gated on that value's own entropy, and match a known secret encoded as decimal character codes.
- Give canary candidates the HTML-entity decoding that ordinary text scanning already applies, and report the matched length in its own field so pattern names stay stable for suppression rules.
- Exclude a stem shared by two known values, and keep whole-value matching for a value shaped like a URL, so a public connection-string prefix carrying no credential is not reported as a leak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Detects partial disclosures of known canary values and environment or file secrets.
  - Recognizes secrets represented with HTML entities and decimal character codes.
  - Reports the length of partially matched values.

- **Bug Fixes**
  - Improves attribution of partial environment-variable and secret matches.
  - Avoids flagging shared or low-entropy fragments as standalone matches.
  - Preserves whole-value matching for complete secrets and URL-shaped values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->