### PR TITLE
fix(gauntlet): authenticate the pinned release lookup

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -91,6 +91,16 @@ jobs:
 
       - name: Run portable canonical benchmark
         shell: bash
+        # The runner resolves the pinned Pipelock release through the GitHub
+        # API. Unauthenticated calls are rate-limited per source IP, which on a
+        # hosted runner is shared with every other job on that machine, so the
+        # lookup returns 403 and the whole scheduled run produces no score. The
+        # run on 2026-09-07 failed exactly this way. GITHUB_TOKEN raises the
+        # limit to a per-repository budget; contents:read is enough to read a
+        # public release, and the runner still works without a token, so an
+        # exhausted limit fails the run loudly rather than scoring silently.
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           job_deadline=$((JOB_STARTED_EPOCH + JOB_TIMEOUT_MINUTES * 60))


### PR DESCRIPTION
## What changed

The scheduled Gauntlet resolves its pinned Pipelock release through the GitHub API without credentials, so the request draws on a per-IP rate limit shared with every other job on the hosted runner.
The 2026-09-07 scheduled run returned 403 at that call and produced no score at all.

The benchmark step now passes the workflow token, which moves the lookup onto a per-repository budget.
The runner still functions without a token, so an exhausted budget fails the run rather than reporting an empty result as success.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of scheduled benchmark runs by using authenticated access for GitHub release lookups, reducing failures caused by API rate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->