### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,12 @@ Production recipes for Docker Compose, Kubernetes sidecar + NetworkPolicy, iptab
 
 ---
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/pipelock/)
+
+---
+
 ## CI Integration
 
 ```yaml


### PR DESCRIPTION
Added a "One-Click Deploy" section with a RepoCloud deploy button to the README, placed between the Deployment and CI Integration sections.

 - New `## ☁️ One-Click Deploy` section added after Deployment
 - Button links to https://repocloud.io/details/pipelock/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “One-Click Deploy” section to the README.
  - Included a deployment badge linking to the project’s RepoCloud page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->