### PR TITLE
test(envelope): cover request signature failure states

### DIFF
--- a/internal/envelope/coverage_gaps_test.go
+++ b/internal/envelope/coverage_gaps_test.go
@@ -59,16 +59,16 @@ func TestEmitter_InjectAndSign_StripsHeadersOnSignError(t *testing.T) {
 		t.Fatal("InjectAndSign should have returned an error for nil URL")
 	}
 
-	if v := req.Header.Get("Pipelock-Mediation"); v != "" {
+	if v := req.Header.Values("Pipelock-Mediation"); len(v) != 0 {
 		t.Errorf("Pipelock-Mediation should be stripped on error, got %q", v)
 	}
-	if v := req.Header.Get("Signature"); v != "" {
+	if v := req.Header.Values("Signature"); len(v) != 0 {
 		t.Errorf("Signature should be stripped on error, got %q", v)
 	}
-	if v := req.Header.Get("Signature-Input"); v != "" {
+	if v := req.Header.Values("Signature-Input"); len(v) != 0 {
 		t.Errorf("Signature-Input should be stripped on error, got %q", v)
 	}
-	if v := req.Header.Get("Content-Digest"); v != "" {
+	if v := req.Header.Values("Content-Digest"); len(v) != 0 {
 		t.Errorf("Content-Digest should be stripped on error, got %q", v)
 	}
 }
@@ -110,7 +110,7 @@ func TestEmitter_InjectAndSign_NilEmitterIsNoOp(t *testing.T) {
 	if err := em.InjectAndSign(req, nil, BuildOpts{Action: testActionRead, Verdict: testVerdictAllow}); err != nil {
 		t.Errorf("nil emitter should no-op, got err = %v", err)
 	}
-	if v := req.Header.Get("Pipelock-Mediation"); v != "" {
+	if v := req.Header.Values("Pipelock-Mediation"); len(v) != 0 {
 		t.Errorf("nil emitter should not write headers, got %q", v)
 	}
 }
@@ -135,7 +135,7 @@ func TestEmitter_InjectAndSign_NoSignerHeaderOnly(t *testing.T) {
 	if v := req.Header.Get("Pipelock-Mediation"); v == "" {
 		t.Error("header-only path must still set Pipelock-Mediation")
 	}
-	if v := req.Header.Get("Signature"); v != "" {
+	if v := req.Header.Values("Signature"); len(v) != 0 {
 		t.Errorf("header-only path must not sign, got Signature = %q", v)
 	}
 }

--- a/internal/envelope/emitter_test.go
+++ b/internal/envelope/emitter_test.go
@@ -330,10 +330,10 @@ func TestEmitter_InjectAndSign_NoSigner(t *testing.T) {
 	if req.Header.Get(HeaderName) == "" {
 		t.Error("Pipelock-Mediation header not set")
 	}
-	if req.Header.Get("Signature") != "" {
+	if len(req.Header.Values("Signature")) != 0 {
 		t.Error("Signature should be absent when signer is nil")
 	}
-	if req.Header.Get("Signature-Input") != "" {
+	if len(req.Header.Values("Signature-Input")) != 0 {
 		t.Error("Signature-Input should be absent when signer is nil")
 	}
 }

--- a/internal/envelope/signer_test.go
+++ b/internal/envelope/signer_test.go
@@ -4,12 +4,14 @@
 package envelope
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -150,6 +152,118 @@ func TestSignRequest_NilRequest(t *testing.T) {
 	s := newTestSigner(t, priv)
 	if err := s.SignRequest(nil, nil); err == nil {
 		t.Error("nil request should fail")
+	}
+}
+
+func TestSignRequest_NonceFailureRestoresContentDigest(t *testing.T) {
+	pub, priv := testSignerKey(t)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{"action":"write"}`)
+
+	tests := []struct {
+		name       string
+		prevDigest string
+	}{
+		{
+			name:       "nonempty digest",
+			prevDigest: "sha-256=:previous=:",
+		},
+		{
+			name: "empty digest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signer, err := NewSigner(SignerConfig{
+				PrivKey:          priv,
+				KeyID:            testKeyIDTrusted,
+				SignedComponents: []string{derivedMethod, derivedTargetURI, headerContentDigest, headerPipelockMediation},
+				NowFn:            func() time.Time { return now },
+				RandReader:       bytes.NewReader([]byte("short")),
+			})
+			if err != nil {
+				t.Fatalf("NewSigner: %v", err)
+			}
+
+			req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(string(body)))
+			req.Header.Set(HeaderName, `v=1, act="write", vd="allow"`)
+			req.Header.Set("Content-Digest", tt.prevDigest)
+			req.Header.Set("Signature-Input", `sig1=("@method");keyid="upstream"`)
+			req.Header.Set("Signature", "sig1=:dXBzdHJlYW0=:")
+
+			err = signer.SignRequest(req, body)
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("SignRequest error = %v, want nonce short-reader error", err)
+			}
+			if got := req.Header.Get("Content-Digest"); got != tt.prevDigest {
+				t.Errorf("Content-Digest = %q, want prior value %q", got, tt.prevDigest)
+			}
+			if got := req.Header.Get("Signature-Input"); got != `sig1=("@method");keyid="upstream"` {
+				t.Errorf("Signature-Input = %q, want existing upstream signature only", got)
+			}
+			if got := req.Header.Get("Signature"); got != "sig1=:dXBzdHJlYW0=:" {
+				t.Errorf("Signature = %q, want existing upstream signature only", got)
+			}
+		})
+	}
+
+	t.Run("same key with complete nonce signs and verifies", func(t *testing.T) {
+		signer, err := NewSigner(SignerConfig{
+			PrivKey:          priv,
+			KeyID:            testKeyIDTrusted,
+			SignedComponents: []string{derivedMethod, derivedTargetURI, headerContentDigest, headerPipelockMediation},
+			NowFn:            func() time.Time { return now },
+			RandReader:       bytes.NewReader([]byte("0123456789abcdef")),
+		})
+		if err != nil {
+			t.Fatalf("NewSigner: %v", err)
+		}
+		emitter := NewEmitter(EmitterConfig{
+			ConfigHash:  strings.Repeat("a", 64),
+			Signer:      signer,
+			ActorFormat: ActorFormatSPIFFE,
+			TrustDomain: testTrustDomain,
+		})
+		req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(string(body)))
+		if err := emitter.InjectAndSign(req, body, BuildOpts{
+			ActionID:  testReceiptID1,
+			Action:    testActionWrite,
+			Verdict:   testVerdictAllow,
+			Actor:     testActorAlpha,
+			ActorAuth: ActorAuthBound,
+		}); err != nil {
+			t.Fatalf("InjectAndSign: %v", err)
+		}
+		if _, err := newTestVerifier(t, pub, now).VerifyRequest(req, body); err != nil {
+			t.Fatalf("VerifyRequest: %v", err)
+		}
+	})
+}
+
+func TestSignRequest_SignatureMergeFailureRestoresDigest(t *testing.T) {
+	t.Parallel()
+	_, priv := testSignerKey(t)
+	body := []byte("request body")
+	req := newTestRequest(t, http.MethodPost, "https://upstream.example/api", strings.NewReader(string(body)))
+	req.Header.Set(HeaderName, `v=1, act="write", vd="allow"`)
+	const priorDigest = "prior digest"
+	const invalidSignature = "not a structured dictionary"
+	req.Header.Set("Content-Digest", priorDigest)
+	req.Header.Set("Signature", invalidSignature)
+
+	err := newTestSigner(t, priv).SignRequest(req, body)
+	if err == nil || !strings.Contains(err.Error(), "merging Signature:") {
+		t.Fatalf("SignRequest error = %v, want signature merge error", err)
+	}
+	if got := req.Header.Get("Content-Digest"); got != priorDigest {
+		t.Errorf("Content-Digest = %q, want %q", got, priorDigest)
+	}
+	if got := req.Header.Get("Signature-Input"); got != "" {
+		t.Errorf("partial Signature-Input remained after failure: %q", got)
+	}
+	if got := req.Header.Get("Signature"); got != invalidSignature {
+		t.Errorf("Signature = %q, want original input %q", got, invalidSignature)
 	}
 }
 

--- a/internal/envelope/signer_test.go
+++ b/internal/envelope/signer_test.go
@@ -259,7 +259,7 @@ func TestSignRequest_SignatureMergeFailureRestoresDigest(t *testing.T) {
 	if got := req.Header.Get("Content-Digest"); got != priorDigest {
 		t.Errorf("Content-Digest = %q, want %q", got, priorDigest)
 	}
-	if got := req.Header.Get("Signature-Input"); got != "" {
+	if got := req.Header.Values("Signature-Input"); len(got) != 0 {
 		t.Errorf("partial Signature-Input remained after failure: %q", got)
 	}
 	if got := req.Header.Get("Signature"); got != invalidSignature {

--- a/internal/envelope/signer_test.go
+++ b/internal/envelope/signer_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -192,18 +193,15 @@ func TestSignRequest_NonceFailureRestoresContentDigest(t *testing.T) {
 			req.Header.Set("Signature-Input", `sig1=("@method");keyid="upstream"`)
 			req.Header.Set("Signature", "sig1=:dXBzdHJlYW0=:")
 
+			priorHeaders := req.Header.Clone()
 			err = signer.SignRequest(req, body)
 			if !errors.Is(err, io.ErrUnexpectedEOF) {
 				t.Fatalf("SignRequest error = %v, want nonce short-reader error", err)
 			}
-			if got := req.Header.Get("Content-Digest"); got != tt.prevDigest {
-				t.Errorf("Content-Digest = %q, want prior value %q", got, tt.prevDigest)
-			}
-			if got := req.Header.Get("Signature-Input"); got != `sig1=("@method");keyid="upstream"` {
-				t.Errorf("Signature-Input = %q, want existing upstream signature only", got)
-			}
-			if got := req.Header.Get("Signature"); got != "sig1=:dXBzdHJlYW0=:" {
-				t.Errorf("Signature = %q, want existing upstream signature only", got)
+			for _, name := range []string{"Content-Digest", "Signature-Input", "Signature"} {
+				if got, want := req.Header.Values(name), priorHeaders.Values(name); !slices.Equal(got, want) {
+					t.Errorf("%s = %q, want prior values %q", name, got, want)
+				}
 			}
 		})
 	}
@@ -252,18 +250,15 @@ func TestSignRequest_SignatureMergeFailureRestoresDigest(t *testing.T) {
 	req.Header.Set("Content-Digest", priorDigest)
 	req.Header.Set("Signature", invalidSignature)
 
+	priorHeaders := req.Header.Clone()
 	err := newTestSigner(t, priv).SignRequest(req, body)
 	if err == nil || !strings.Contains(err.Error(), "merging Signature:") {
 		t.Fatalf("SignRequest error = %v, want signature merge error", err)
 	}
-	if got := req.Header.Get("Content-Digest"); got != priorDigest {
-		t.Errorf("Content-Digest = %q, want %q", got, priorDigest)
-	}
-	if got := req.Header.Values("Signature-Input"); len(got) != 0 {
-		t.Errorf("partial Signature-Input remained after failure: %q", got)
-	}
-	if got := req.Header.Get("Signature"); got != invalidSignature {
-		t.Errorf("Signature = %q, want original input %q", got, invalidSignature)
+	for _, name := range []string{"Content-Digest", "Signature-Input", "Signature"} {
+		if got, want := req.Header.Values(name), priorHeaders.Values(name); !slices.Equal(got, want) {
+			t.Errorf("%s = %q, want prior values %q", name, got, want)
+		}
 	}
 }
 

--- a/internal/envelope/verify_test.go
+++ b/internal/envelope/verify_test.go
@@ -564,6 +564,121 @@ func TestVerifierRejectsMalformedRequestsWithCodes(t *testing.T) {
 	checkCode(t, err, VerificationFailureParse)
 }
 
+func TestVerifier_RejectsMalformedSignatureParametersWithoutConsumingNonce(t *testing.T) {
+	t.Parallel()
+
+	checkCode := func(t *testing.T, err error, want VerificationFailureCode) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("error = nil, want %s", want)
+		}
+		got, ok := VerificationFailureCodeOf(err)
+		if !ok || got != want {
+			t.Fatalf("code = %q, %v; want %s", got, ok, want)
+		}
+	}
+
+	parameterCases := []struct {
+		name  string
+		param string
+		value any
+		omit  bool
+	}{
+		{name: "missing key ID", param: "keyid", omit: true},
+		{name: "non-string key ID", param: "keyid", value: int64(1)},
+		{name: "missing algorithm", param: "alg", omit: true},
+		{name: "non-string algorithm", param: "alg", value: int64(1)},
+		{name: "missing tag", param: "tag", omit: true},
+		{name: "non-string tag", param: "tag", value: int64(1)},
+		{name: "missing created", param: "created", omit: true},
+		{name: "non-integer created", param: "created", value: "now"},
+		{name: "missing expires", param: "expires", omit: true},
+		{name: "non-integer expires", param: "expires", value: "later"},
+		{name: "missing nonce", param: "nonce", omit: true},
+		{name: "non-string nonce", param: "nonce", value: int64(1)},
+	}
+
+	type mutationCase struct {
+		name   string
+		mutate func(httpsfv.InnerList) httpsfv.InnerList
+	}
+	cases := make([]mutationCase, 0, len(parameterCases)+3)
+	for _, tc := range parameterCases {
+		cases = append(cases, mutationCase{
+			name: tc.name,
+			mutate: func(inner httpsfv.InnerList) httpsfv.InnerList {
+				if tc.omit {
+					inner.Params.Del(tc.param)
+				} else {
+					inner.Params.Add(tc.param, tc.value)
+				}
+				return inner
+			},
+		})
+	}
+
+	cases = append(cases,
+		mutationCase{
+			name: "empty component list",
+			mutate: func(inner httpsfv.InnerList) httpsfv.InnerList {
+				inner.Items = nil
+				return inner
+			},
+		},
+		mutationCase{
+			name: "non-string component",
+			mutate: func(inner httpsfv.InnerList) httpsfv.InnerList {
+				inner.Items = []httpsfv.Item{httpsfv.NewItem(int64(1))}
+				return inner
+			},
+		},
+		mutationCase{
+			name: "unsupported component",
+			mutate: func(inner httpsfv.InnerList) httpsfv.InnerList {
+				inner.Items = []httpsfv.Item{httpsfv.NewItem("unsupported")}
+				return inner
+			},
+		},
+	)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pub, priv := testSignerKey(t)
+			now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+			req := signedVerifierRequest(t, priv, now, "")
+			validInput := req.Header.Get("Signature-Input")
+
+			dict, err := httpsfv.UnmarshalDictionary(req.Header.Values("Signature-Input"))
+			if err != nil {
+				t.Fatalf("Signature-Input parse: %v", err)
+			}
+			member, ok := dict.Get(pipelockSigLabel)
+			if !ok {
+				t.Fatal("pipelock signature input is missing")
+			}
+			inner, ok := member.(httpsfv.InnerList)
+			if !ok {
+				t.Fatalf("pipelock signature input is %T, want inner list", member)
+			}
+			dict.Add(pipelockSigLabel, tc.mutate(inner))
+			mutatedInput, err := httpsfv.Marshal(dict)
+			if err != nil {
+				t.Fatalf("Signature-Input marshal: %v", err)
+			}
+			req.Header.Set("Signature-Input", mutatedInput)
+
+			verifier := newTestVerifier(t, pub, now)
+			_, err = verifier.VerifyRequest(req, nil)
+			checkCode(t, err, VerificationFailureParse)
+
+			req.Header.Set("Signature-Input", validInput)
+			if _, err := verifier.VerifyRequest(req, nil); err != nil {
+				t.Fatalf("valid request after parse failure: %v", err)
+			}
+		})
+	}
+}
+
 func TestVerifierValidateTimeBranches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Cover request-signing failures restoring the prior digest and removing partial signature headers.
- Verify malformed signature parameters are rejected before consuming replay-cache state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for signing failures, confirming existing signature headers remain intact and incomplete signature data is removed.
  * Added verification coverage ensuring malformed signature parameters and components are rejected without consuming the nonce.
  * Confirmed valid requests remain verifiable after malformed-input failures.
  * Added coverage for recovery from nonce-generation and signature-merge failures.
  * Improved header-absence assertions across signing and injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->