### PR TITLE
test(config): preserve explicit zero evidence anchor lag

### DIFF
--- a/internal/cli/runtime/evidence_anchor_lag_test.go
+++ b/internal/cli/runtime/evidence_anchor_lag_test.go
@@ -43,19 +43,25 @@ func TestEvidenceHealthZeroAnchorLagDisablesOnlyAgeRequirement(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h.currentConfig().FlightRecorder.EvidenceHealth.MaxAnchorLag = tt.lag
-			stats, ok := h.stats()
-			if !ok || stats.Anchor == nil {
-				t.Fatalf("valid anchor stats unavailable: ok=%v anchor=%+v", ok, stats.Anchor)
+			checkStats := func() {
+				t.Helper()
+				stats, ok := h.stats()
+				if !ok || stats.Anchor == nil {
+					t.Fatalf("valid anchor stats unavailable: ok=%v anchor=%+v", ok, stats.Anchor)
+				}
+				if got := stats.Requirements[metrics.EvidenceRequirementAnchoringFresh]; got != tt.wantFresh {
+					t.Errorf("anchoring_fresh = %v, want %v", got, tt.wantFresh)
+				}
+				if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+					t.Errorf("age setting raised current AEL to %q", stats.CurrentAEL)
+				}
+				if !stats.LocalRecorderOperational {
+					t.Error("age setting degraded local recorder operation")
+				}
 			}
-			if got := stats.Requirements[metrics.EvidenceRequirementAnchoringFresh]; got != tt.wantFresh {
-				t.Errorf("anchoring_fresh = %v, want %v", got, tt.wantFresh)
-			}
-			if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
-				t.Errorf("age setting raised current AEL to %q", stats.CurrentAEL)
-			}
-			if !stats.LocalRecorderOperational {
-				t.Error("age setting degraded local recorder operation")
-			}
+			checkStats()
+			h.runPass()
+			checkStats()
 		})
 	}
 }

--- a/internal/cli/runtime/evidence_anchor_lag_test.go
+++ b/internal/cli/runtime/evidence_anchor_lag_test.go
@@ -25,6 +25,9 @@ func TestEvidenceHealthZeroAnchorLagDisablesOnlyAgeRequirement(t *testing.T) {
 	if !ok || withoutAnchor.Anchor != nil || withoutAnchor.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
 		t.Fatalf("zero age limit accepted missing anchor evidence: ok=%v stats=%+v", ok, withoutAnchor)
 	}
+	if _, present := withoutAnchor.Requirements[metrics.EvidenceRequirementAnchoringFresh]; !present {
+		t.Fatal("missing anchoring_fresh requirement without anchor")
+	}
 	state := validEvidenceHealthAnchorState()
 	state.FinalSeq = 1
 	state.SignerKey = emitter.SignerKeyHex()
@@ -49,7 +52,18 @@ func TestEvidenceHealthZeroAnchorLagDisablesOnlyAgeRequirement(t *testing.T) {
 				if !ok || stats.Anchor == nil {
 					t.Fatalf("valid anchor stats unavailable: ok=%v anchor=%+v", ok, stats.Anchor)
 				}
-				if got := stats.Requirements[metrics.EvidenceRequirementAnchoringFresh]; got != tt.wantFresh {
+				if stats.Anchor.AnchoredAt != state.AnchoredAt.Format(time.RFC3339Nano) || stats.Anchor.FinalSeq != state.FinalSeq || stats.Anchor.RootHash != state.RootHash {
+					t.Fatalf("loaded anchor does not match stale fixture: %+v", stats.Anchor)
+				}
+				if want := float64(state.AnchoredAt.UnixNano()) / 1e9; stats.Anchor.LastTimestampSeconds != want {
+					t.Fatalf("anchor age timestamp = %v, want %v", stats.Anchor.LastTimestampSeconds, want)
+				}
+				if time.Since(state.AnchoredAt) <= config.DefaultEvidenceHealthMaxAnchorLag {
+					t.Fatal("anchor fixture is not stale")
+				}
+				if got, present := stats.Requirements[metrics.EvidenceRequirementAnchoringFresh]; !present {
+					t.Error("missing anchoring_fresh requirement with stale anchor")
+				} else if got != tt.wantFresh {
 					t.Errorf("anchoring_fresh = %v, want %v", got, tt.wantFresh)
 				}
 				if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {

--- a/internal/cli/runtime/evidence_anchor_lag_test.go
+++ b/internal/cli/runtime/evidence_anchor_lag_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+)
+
+func TestEvidenceHealthZeroAnchorLagDisablesOnlyAgeRequirement(t *testing.T) {
+	h, _, emitter, _ := newEvidenceHealthTestMonitor(t, nil)
+	t.Cleanup(func() {
+		if err := h.recorder.Close(); err != nil {
+			t.Errorf("recorder.Close: %v", err)
+		}
+	})
+	emitEvidenceHealthTestReceipt(t, emitter, "https://api.vendor.example/baseline")
+	emitEvidenceHealthTestReceipt(t, emitter, "https://api.vendor.example/current-head")
+	h.currentConfig().FlightRecorder.EvidenceHealth.MaxAnchorLag = "0s"
+	withoutAnchor, ok := h.stats()
+	if !ok || withoutAnchor.Anchor != nil || withoutAnchor.Requirements[metrics.EvidenceRequirementAnchoringFresh] {
+		t.Fatalf("zero age limit accepted missing anchor evidence: ok=%v stats=%+v", ok, withoutAnchor)
+	}
+	state := validEvidenceHealthAnchorState()
+	state.FinalSeq = 1
+	state.SignerKey = emitter.SignerKeyHex()
+	state.AnchoredAt = time.Now().UTC().Add(-2 * config.DefaultEvidenceHealthMaxAnchorLag)
+	writeEvidenceHealthAnchorState(t, h.recorder.Dir(), state)
+	h.runPass()
+
+	for _, tt := range []struct {
+		name      string
+		lag       string
+		wantFresh bool
+	}{
+		{name: "default rejects stale anchor"},
+		{name: "zero accepts valid stale anchor", lag: "0s", wantFresh: true},
+		{name: "restored limit rejects stale anchor", lag: "1h"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h.currentConfig().FlightRecorder.EvidenceHealth.MaxAnchorLag = tt.lag
+			stats, ok := h.stats()
+			if !ok || stats.Anchor == nil {
+				t.Fatalf("valid anchor stats unavailable: ok=%v anchor=%+v", ok, stats.Anchor)
+			}
+			if got := stats.Requirements[metrics.EvidenceRequirementAnchoringFresh]; got != tt.wantFresh {
+				t.Errorf("anchoring_fresh = %v, want %v", got, tt.wantFresh)
+			}
+			if stats.CurrentAEL != metrics.EvidenceCurrentAELUnavailable {
+				t.Errorf("age setting raised current AEL to %q", stats.CurrentAEL)
+			}
+			if !stats.LocalRecorderOperational {
+				t.Error("age setting degraded local recorder operation")
+			}
+		})
+	}
+}

--- a/internal/config/evidence_health_test.go
+++ b/internal/config/evidence_health_test.go
@@ -64,7 +64,7 @@ func TestLoad_FlightRecorderEvidenceMaxAnchorLagDuration(t *testing.T) {
 			want: DefaultEvidenceHealthMaxAnchorLag,
 		},
 		{
-			name: "explicit zero disables age check",
+			name: "explicit zero is preserved",
 			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: 0s\n",
 			want: 0,
 		},

--- a/internal/config/evidence_health_test.go
+++ b/internal/config/evidence_health_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLoad_FlightRecorderEvidenceHealthEnabledStates(t *testing.T) {
@@ -43,6 +44,76 @@ func TestLoad_FlightRecorderEvidenceHealthReloadStates(t *testing.T) {
 	if third.FlightRecorder.EvidenceHealthEnabled() != second.FlightRecorder.EvidenceHealthEnabled() {
 		t.Fatalf("reload without change EvidenceHealthEnabled = %v, want %v",
 			third.FlightRecorder.EvidenceHealthEnabled(), second.FlightRecorder.EvidenceHealthEnabled())
+	}
+}
+
+func TestLoad_FlightRecorderEvidenceMaxAnchorLagDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want time.Duration
+	}{
+		{
+			name: "omitted uses default",
+			yaml: "flight_recorder:\n  enabled: true\n",
+			want: DefaultEvidenceHealthMaxAnchorLag,
+		},
+		{
+			name: "null uses default",
+			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: null\n",
+			want: DefaultEvidenceHealthMaxAnchorLag,
+		},
+		{
+			name: "explicit zero disables age check",
+			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: 0s\n",
+			want: 0,
+		},
+		{
+			name: "whitespace-padded duration",
+			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: ' 90m '\n",
+			want: 90 * time.Minute,
+		},
+		{
+			name: "blank uses default",
+			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: ''\n",
+			want: DefaultEvidenceHealthMaxAnchorLag,
+		},
+		{
+			name: "valid duration",
+			yaml: "flight_recorder:\n  enabled: true\n  evidence_health:\n    max_anchor_lag: 90m\n",
+			want: 90 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := loadEvidenceHealthYAML(t, tt.yaml)
+			if got := cfg.FlightRecorder.EvidenceMaxAnchorLagDuration(); got != tt.want {
+				t.Fatalf("EvidenceMaxAnchorLagDuration = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlightRecorderEvidenceMaxAnchorLagDurationFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "blank", raw: " \t", want: DefaultEvidenceHealthMaxAnchorLag},
+		{name: "trimmed valid duration", raw: " 90m ", want: 90 * time.Minute},
+		{name: "malformed", raw: "not-a-duration", want: DefaultEvidenceHealthMaxAnchorLag},
+		{name: "negative", raw: "-1s", want: DefaultEvidenceHealthMaxAnchorLag},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := FlightRecorder{EvidenceHealth: FlightRecorderEvidenceHealth{MaxAnchorLag: tt.raw}}
+			if got := f.EvidenceMaxAnchorLagDuration(); got != tt.want {
+				t.Fatalf("EvidenceMaxAnchorLagDuration(%q) = %s, want %s", tt.raw, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

Test that an explicit zero anchor-age limit survives configuration loading, while omitted and blank values retain the default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for evidence-health anchor-lag settings, including defaults, whitespace, zero values, valid durations, and invalid or negative inputs.
  * Verified that disabling the freshness threshold does not bypass required anchor evidence.
  * Confirmed that valid stale evidence is handled according to configured limits.
  * Confirmed that anchor-lag evaluation does not alter operational status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->