### PR TITLE
test: cover fail-closed paths in the signed-evidence chain

### DIFF
--- a/internal/coveragecert/completeness_coupling_test.go
+++ b/internal/coveragecert/completeness_coupling_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package coveragecert
+
+import (
+	"strings"
+	"testing"
+)
+
+// A coverage certificate's completeness_status and completeness_reason are a
+// coupled pair: the status says how much of the window is accounted for and
+// the reason says why. validateCompletenessCoupling is what stops a signed
+// certificate from claiming a pair that is not in the vocabulary, for example
+// LIMITED/chain_broken, which would understate a broken chain as a mere gap.
+//
+// This covers the whole invalid class rather than one instance: every status
+// paired with a reason belonging to a different status, an out-of-vocabulary
+// status, and both directions of the receipt_count coupling.
+func TestValidateCompletenessCoupling(t *testing.T) {
+	t.Parallel()
+
+	// Reasons grouped by the status that may legitimately carry them.
+	limitedReasons := []string{reasonBoundedClosed, reasonAbnormalEnd, reasonOpenAction, reasonHeartbeatGap}
+	brokenReasons := []string{reasonChainBroken}
+	unverifiedReasons := []string{reasonNoOpen, reasonNoLifecycle, reasonRecorderDisabled, reasonNoReceipts}
+
+	// session returns a coupling-valid session so each case changes exactly
+	// one thing. receipt_count is positive except where the case needs zero.
+	session := func(status, reason string, receipts uint64) SessionCoverage {
+		return SessionCoverage{
+			ID:                 "session-001",
+			ReceiptCount:       receipts,
+			ChainIntact:        status != completenessBroken,
+			Anchored:           "local",
+			CompletenessStatus: status,
+			CompletenessReason: reason,
+		}
+	}
+
+	t.Run("valid pairs are accepted", func(t *testing.T) {
+		t.Parallel()
+		for status, reasons := range map[string][]string{
+			completenessLimited:    limitedReasons,
+			completenessBroken:     brokenReasons,
+			completenessUnverified: {reasonNoOpen, reasonNoLifecycle, reasonRecorderDisabled},
+		} {
+			for _, reason := range reasons {
+				if err := validateCompletenessCoupling(session(status, reason, 7)); err != nil {
+					t.Errorf("validateCompletenessCoupling(%s/%s) = %v, want nil", status, reason, err)
+				}
+			}
+		}
+		// UNVERIFIED/no_receipts is only valid at zero receipts.
+		if err := validateCompletenessCoupling(session(completenessUnverified, reasonNoReceipts, 0)); err != nil {
+			t.Errorf("validateCompletenessCoupling(UNVERIFIED/no_receipts, 0 receipts) = %v, want nil", err)
+		}
+	})
+
+	t.Run("a reason belonging to another status is rejected", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			status  string
+			reasons []string
+			wantErr string
+		}{
+			{completenessLimited, append(append([]string{}, brokenReasons...), unverifiedReasons...), "LIMITED completeness cannot use reason"},
+			{completenessBroken, append(append([]string{}, limitedReasons...), unverifiedReasons...), "BROKEN completeness cannot use reason"},
+			{completenessUnverified, append(append([]string{}, limitedReasons...), brokenReasons...), "UNVERIFIED completeness cannot use reason"},
+		}
+		for _, tc := range cases {
+			for _, reason := range tc.reasons {
+				err := validateCompletenessCoupling(session(tc.status, reason, 7))
+				if err == nil {
+					t.Errorf("validateCompletenessCoupling(%s/%s) = nil, want a coupling rejection", tc.status, reason)
+					continue
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("validateCompletenessCoupling(%s/%s) = %v, want substring %q", tc.status, reason, err, tc.wantErr)
+				}
+			}
+		}
+	})
+
+	t.Run("a status outside the vocabulary is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Includes COMPLETE, which reads like it should be valid and is not
+		// part of this certificate's vocabulary, and an injection-shaped value
+		// to confirm the message quotes rather than interpolates it raw.
+		for _, status := range []string{"", "COMPLETE", "limited", "OK", "LIMITED\nBROKEN"} {
+			err := validateCompletenessCoupling(session(status, reasonBoundedClosed, 7))
+			if err == nil {
+				t.Errorf("validateCompletenessCoupling(status=%q) = nil, want rejection", status)
+				continue
+			}
+			if !strings.Contains(err.Error(), "not in the coverage certificate vocabulary") {
+				t.Errorf("validateCompletenessCoupling(status=%q) = %v, want a vocabulary rejection", status, err)
+			}
+		}
+	})
+
+	t.Run("receipt_count and no_receipts must agree in both directions", func(t *testing.T) {
+		t.Parallel()
+
+		// Zero receipts under any reason other than no_receipts: the
+		// certificate would claim a verified-ish window it observed nothing in.
+		for _, reason := range limitedReasons {
+			err := validateCompletenessCoupling(session(completenessLimited, reason, 0))
+			if err == nil || !strings.Contains(err.Error(), "zero receipt_count requires UNVERIFIED/no_receipts") {
+				t.Errorf("validateCompletenessCoupling(LIMITED/%s, 0 receipts) = %v, want the zero-count rejection", reason, err)
+			}
+		}
+
+		// The opposite direction: no_receipts while receipts exist would
+		// understate evidence that is present.
+		err := validateCompletenessCoupling(session(completenessUnverified, reasonNoReceipts, 1))
+		if err == nil || !strings.Contains(err.Error(), "cannot have positive receipt_count") {
+			t.Errorf("validateCompletenessCoupling(UNVERIFIED/no_receipts, 1 receipt) = %v, want the positive-count rejection", err)
+		}
+	})
+}
+
+// Sign refuses an ill-formed or over-claiming body, so a coupling violation
+// must be unsignable end to end and not merely rejected by the internal
+// helper. Naming the consumer is the point: a validator nothing calls on the
+// signing path would prove nothing.
+func TestSignRefusesCompletenessCouplingViolation(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := genTestKey(t)
+
+	// Control: the valid fixture signs, so a later refusal is attributable to
+	// the coupling violation rather than to the fixture or the key.
+	if _, err := Sign(validBody(pub), priv); err != nil {
+		t.Fatalf("Sign(validBody) = %v, want a signed certificate", err)
+	}
+
+	body := validBody(pub)
+	// LIMITED/chain_broken is the understatement that matters: it would
+	// present a broken chain as a bounded gap in a signed artifact.
+	body.Sessions[0].CompletenessStatus = completenessLimited
+	body.Sessions[0].CompletenessReason = reasonChainBroken
+
+	if _, err := Sign(body, priv); err == nil {
+		t.Fatal("Sign accepted LIMITED/chain_broken; a signed certificate must not understate a broken chain")
+	}
+}

--- a/internal/coveragecert/completeness_coupling_test.go
+++ b/internal/coveragecert/completeness_coupling_test.go
@@ -68,6 +68,17 @@ func TestValidateCompletenessCoupling(t *testing.T) {
 			{completenessBroken, append(append([]string{}, limitedReasons...), unverifiedReasons...), "BROKEN completeness cannot use reason"},
 			{completenessUnverified, append(append([]string{}, limitedReasons...), brokenReasons...), "UNVERIFIED completeness cannot use reason"},
 		}
+		// A reason outside the vocabulary entirely, not merely one belonging to
+		// a different status. Each status's inner switch has its own default
+		// arm, so all three need the case.
+		unknownReasons := []string{"", "bogus", "BOUNDED_CLOSED", "chain_broken\nbounded_closed"}
+		for _, status := range []string{completenessLimited, completenessBroken, completenessUnverified} {
+			for _, reason := range unknownReasons {
+				if err := validateCompletenessCoupling(session(status, reason, 7)); err == nil {
+					t.Errorf("validateCompletenessCoupling(%s/%q) = nil, want rejection of an unknown reason", status, reason)
+				}
+			}
+		}
 		for _, tc := range cases {
 			for _, reason := range tc.reasons {
 				err := validateCompletenessCoupling(session(tc.status, reason, 7))
@@ -104,10 +115,20 @@ func TestValidateCompletenessCoupling(t *testing.T) {
 
 		// Zero receipts under any reason other than no_receipts: the
 		// certificate would claim a verified-ish window it observed nothing in.
-		for _, reason := range limitedReasons {
-			err := validateCompletenessCoupling(session(completenessLimited, reason, 0))
-			if err == nil || !strings.Contains(err.Error(), "zero receipt_count requires UNVERIFIED/no_receipts") {
-				t.Errorf("validateCompletenessCoupling(LIMITED/%s, 0 receipts) = %v, want the zero-count rejection", reason, err)
+		// The zero-count check is reason-agnostic, so covering only LIMITED
+		// would pass a validator that rejected zero receipts for LIMITED
+		// alone. Walk every status with each of its own valid reasons.
+		zeroCases := map[string][]string{
+			completenessLimited:    limitedReasons,
+			completenessBroken:     brokenReasons,
+			completenessUnverified: {reasonNoOpen, reasonNoLifecycle, reasonRecorderDisabled},
+		}
+		for status, reasons := range zeroCases {
+			for _, reason := range reasons {
+				err := validateCompletenessCoupling(session(status, reason, 0))
+				if err == nil || !strings.Contains(err.Error(), "zero receipt_count requires UNVERIFIED/no_receipts") {
+					t.Errorf("validateCompletenessCoupling(%s/%s, 0 receipts) = %v, want the zero-count rejection", status, reason, err)
+				}
 			}
 		}
 

--- a/internal/posturebinding/binding_load_paths_test.go
+++ b/internal/posturebinding/binding_load_paths_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package posturebinding
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A relative PIPELOCK_POSTURE_PROOF is refused rather than resolved against
+// whatever directory the process happens to be in. Resolving it would make the
+// proof a runtime attacker or a stray working directory could redirect, and
+// the outcome would look attested. The refusal must carry both the invalid
+// availability and an error, since callers that require containment evidence
+// branch on availability while ordinary callers branch on the error.
+func TestLoadRuntime_RejectsRelativeProofPath(t *testing.T) {
+	for _, path := range []string{"proof.json", "./proof.json", "../proof.json", "relative/dir/proof.json"} {
+		t.Run(path, func(t *testing.T) {
+			t.Setenv(RuntimeProofEnv, path)
+
+			result, err := loadRuntime(nil)
+			if err == nil {
+				t.Fatalf("loadRuntime with %s=%q returned no error; a relative proof path must be refused", RuntimeProofEnv, path)
+			}
+			if result.Availability != AvailabilityInvalid {
+				t.Errorf("availability = %q, want %q", result.Availability, AvailabilityInvalid)
+			}
+			if result.Cause == nil {
+				t.Error("result.Cause is nil; the refusal must be explainable to an operator")
+			}
+			if !strings.Contains(err.Error(), "absolute path") {
+				t.Errorf("error = %v, want it to name the absolute-path requirement", err)
+			}
+			if result.HasContainmentAttestation() {
+				t.Error("a refused relative path reported a containment attestation")
+			}
+		})
+	}
+}
+
+// Surrounding whitespace must not smuggle a relative path past the absolute
+// check, and a wholly blank value falls back to the default path rather than
+// being treated as a configured one.
+func TestLoadRuntime_TrimsProofPathBeforeDeciding(t *testing.T) {
+	t.Run("padded relative path is still refused", func(t *testing.T) {
+		t.Setenv(RuntimeProofEnv, "  proof.json  ")
+		result, err := loadRuntime(nil)
+		if err == nil {
+			t.Fatal("a whitespace-padded relative path was accepted")
+		}
+		if result.Availability != AvailabilityInvalid {
+			t.Errorf("availability = %q, want %q", result.Availability, AvailabilityInvalid)
+		}
+	})
+
+	t.Run("blank value falls back to the default path", func(t *testing.T) {
+		t.Setenv(RuntimeProofEnv, "   ")
+		result, _ := loadRuntime(nil)
+		if result.Path != DefaultContainRunProofPath {
+			t.Errorf("path = %q, want the default %q", result.Path, DefaultContainRunProofPath)
+		}
+	})
+}
+
+// An empty path is "no proof configured", which is absent and not an error.
+// Reporting it as invalid would make an unconfigured deployment look like a
+// tampered one; reporting an error would break callers that do not require
+// containment evidence.
+func TestLoadFile_EmptyPathIsAbsentWithoutError(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"", "   ", "\t"} {
+		result, err := loadFile(path, nil)
+		if err != nil {
+			t.Errorf("loadFile(%q) = error %v, want nil", path, err)
+		}
+		if result.Availability != AvailabilityAbsent {
+			t.Errorf("loadFile(%q) availability = %q, want %q", path, result.Availability, AvailabilityAbsent)
+		}
+		if result.HasContainmentAttestation() {
+			t.Errorf("loadFile(%q) reported a containment attestation", path)
+		}
+	}
+}
+
+// A missing proof file is absent, not invalid: nothing was tampered with, the
+// file simply is not there.
+func TestLoadFile_MissingPathIsAbsentWithoutError(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "absent-proof.json")
+	result, err := loadFile(path, nil)
+	if err != nil {
+		t.Fatalf("loadFile on a missing path = error %v, want nil", err)
+	}
+	if result.Availability != AvailabilityAbsent {
+		t.Errorf("availability = %q, want %q", result.Availability, AvailabilityAbsent)
+	}
+	if result.Path != path {
+		t.Errorf("path = %q, want %q", result.Path, path)
+	}
+}

--- a/internal/posturebinding/binding_load_paths_test.go
+++ b/internal/posturebinding/binding_load_paths_test.go
@@ -57,9 +57,19 @@ func TestLoadRuntime_TrimsProofPathBeforeDeciding(t *testing.T) {
 
 	t.Run("blank value falls back to the default path", func(t *testing.T) {
 		t.Setenv(RuntimeProofEnv, "   ")
-		result, _ := loadRuntime(nil)
+		result, err := loadRuntime(nil)
 		if result.Path != DefaultContainRunProofPath {
 			t.Errorf("path = %q, want the default %q", result.Path, DefaultContainRunProofPath)
+		}
+		// Checking the path alone would pass even if the fallback had taken
+		// the refusal branch and returned that same path as invalid. Assert
+		// it did NOT, without asserting which valid outcome it reached: the
+		// default proof file may or may not exist on the host running this.
+		if err != nil {
+			t.Errorf("loadRuntime after a blank value = error %v, want the fallback to be accepted", err)
+		}
+		if result.Availability == AvailabilityInvalid {
+			t.Errorf("availability = %q, want the fallback not to be treated as a refused path", result.Availability)
 		}
 	})
 }

--- a/internal/receipt/emitter_lifecycle_test.go
+++ b/internal/receipt/emitter_lifecycle_test.go
@@ -133,8 +133,18 @@ func TestEmitter_RetireNativeAELBricksFurtherEmission(t *testing.T) {
 	}
 
 	// Retiring twice must stay safe: reload paths can race a second rotation.
+	// Safe means still terminal, not merely a nil return. A second retirement
+	// that reactivated the emitter would satisfy a nil-error check and then
+	// let the next caller append under the rotated-out key, so re-assert the
+	// refusal and the receipt count afterwards.
 	if err := e.RetireNativeAEL(); err != nil {
 		t.Fatalf("second RetireNativeAEL: %v", err)
+	}
+	if err := emit(); err == nil {
+		t.Fatal("Emit succeeded after a second RetireNativeAEL; retirement must stay terminal")
+	}
+	if after := len(readReceiptsRaw(t, dir)); after != before {
+		t.Fatalf("receipt count went %d -> %d after a second retirement; the emitter was reactivated", before, after)
 	}
 }
 

--- a/internal/receipt/emitter_lifecycle_test.go
+++ b/internal/receipt/emitter_lifecycle_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// SignerKeyHex is how reload code decides whether a config change is a
+// policy-only reload or a signer rotation, and a rotation retires the live
+// emitter. A wrong answer in either direction is consequential: a missed
+// rotation keeps signing under a key the operator replaced, and a spurious
+// rotation retires a healthy emitter. It had no test.
+func TestEmitter_SignerKeyHex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil emitter reports empty", func(t *testing.T) {
+		t.Parallel()
+		var e *Emitter
+		if got := e.SignerKeyHex(); got != "" {
+			t.Errorf("SignerKeyHex() on nil emitter = %q, want empty", got)
+		}
+	})
+
+	t.Run("short key reports empty rather than a truncated key", func(t *testing.T) {
+		t.Parallel()
+		e := &Emitter{privKey: ed25519.PrivateKey("too-short")}
+		if got := e.SignerKeyHex(); got != "" {
+			t.Errorf("SignerKeyHex() with a short key = %q, want empty", got)
+		}
+	})
+
+	t.Run("reports the public key matching the signing key", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		pub, priv := generateTestKey(t)
+		rec := newTestRecorder(t, dir, priv)
+		defer func() { _ = rec.Close() }()
+
+		e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv})
+		if e == nil {
+			t.Fatal("NewEmitter returned nil")
+		}
+
+		want := hex.EncodeToString(pub)
+		if got := e.SignerKeyHex(); got != want {
+			t.Fatalf("SignerKeyHex() = %q, want %q", got, want)
+		}
+		// A different key must produce a different answer, or the comparison
+		// reload relies on could never detect a rotation.
+		otherPub, otherPriv := generateTestKey(t)
+		other := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: otherPriv})
+		if other == nil {
+			t.Fatal("NewEmitter returned nil for the second key")
+		}
+		if got := other.SignerKeyHex(); got != hex.EncodeToString(otherPub) {
+			t.Fatalf("second emitter SignerKeyHex() = %q, want %q", got, hex.EncodeToString(otherPub))
+		}
+		if e.SignerKeyHex() == other.SignerKeyHex() {
+			t.Fatal("two distinct signing keys reported the same hex; a rotation would be invisible")
+		}
+	})
+}
+
+// RetireNativeAEL bricks the emitter after a signer rotation so that a stale
+// caller, or one already admitted past the policy check, cannot append a
+// receipt signed by the retired key. The brick is the security property; that
+// the call returns nil is not. Assert the refusal.
+func TestEmitter_RetireNativeAELBricksFurtherEmission(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec.Close() }()
+
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv})
+	if e == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+
+	emit := func() error {
+		return e.Emit(EmitOpts{
+			ActionID:  NewActionID(),
+			Target:    testTarget,
+			Verdict:   config.ActionAllow,
+			Transport: testTransport,
+			Method:    http.MethodGet,
+		})
+	}
+
+	// Control: emission works before retirement, so a later failure is
+	// attributable to the retirement and not to a broken fixture.
+	if err := emit(); err != nil {
+		t.Fatalf("Emit before retirement failed: %v", err)
+	}
+
+	if err := e.RetireNativeAEL(); err != nil {
+		t.Fatalf("RetireNativeAEL: %v", err)
+	}
+
+	err := emit()
+	if err == nil {
+		t.Fatal("Emit succeeded after RetireNativeAEL; a retired emitter must not append under the rotated-out key")
+	}
+	if !strings.Contains(err.Error(), "unhealthy") {
+		t.Fatalf("Emit error after retirement = %v, want it to report the emitter unhealthy", err)
+	}
+	if !strings.Contains(err.Error(), "retired") {
+		t.Fatalf("Emit error after retirement = %v, want it to name retirement as the cause", err)
+	}
+
+	// Retiring twice must stay safe: reload paths can race a second rotation.
+	if err := e.RetireNativeAEL(); err != nil {
+		t.Fatalf("second RetireNativeAEL: %v", err)
+	}
+}
+
+// The nil-receiver contracts are load-bearing because receipt emission is
+// optional: with the flight recorder off, every call site holds a nil emitter
+// and must not panic or report a false failure.
+func TestEmitter_NilReceiverLifecycleContracts(t *testing.T) {
+	t.Parallel()
+
+	var e *Emitter
+
+	if got := e.DurabilityBlocks(); got != 0 {
+		t.Errorf("DurabilityBlocks() on nil emitter = %d, want 0", got)
+	}
+	if err := e.AbortNativeAEL(); err != nil {
+		t.Errorf("AbortNativeAEL() on nil emitter = %v, want nil", err)
+	}
+	if err := e.RetireNativeAEL(); err != nil {
+		t.Errorf("RetireNativeAEL() on nil emitter = %v, want nil", err)
+	}
+	if err := e.EmitHeartbeat(); err != nil {
+		t.Errorf("EmitHeartbeat() on nil emitter = %v, want nil", err)
+	}
+}
+
+// A configured emitter with no staged native run has nothing to abort. This is
+// the ordinary path when native AEL is not enabled, and it must not be
+// reported as a failure.
+func TestEmitter_AbortNativeAELWithoutStagedRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, priv := generateTestKey(t)
+	rec := newTestRecorder(t, dir, priv)
+	defer func() { _ = rec.Close() }()
+
+	e := NewEmitter(EmitterConfig{Recorder: rec, PrivKey: priv})
+	if e == nil {
+		t.Fatal("NewEmitter returned nil")
+	}
+	if err := e.AbortNativeAEL(); err != nil {
+		t.Fatalf("AbortNativeAEL() with no staged native run = %v, want nil", err)
+	}
+	if got := e.DurabilityBlocks(); got != 0 {
+		t.Fatalf("DurabilityBlocks() on a fresh emitter = %d, want 0", got)
+	}
+}

--- a/internal/receipt/emitter_lifecycle_test.go
+++ b/internal/receipt/emitter_lifecycle_test.go
@@ -101,14 +101,29 @@ func TestEmitter_RetireNativeAELBricksFurtherEmission(t *testing.T) {
 	if err := emit(); err != nil {
 		t.Fatalf("Emit before retirement failed: %v", err)
 	}
+	// Calibrate the counter used below. A reader that always returned the same
+	// number would make the no-append assertion vacuous, so require it to
+	// observe this known-good emit before trusting it to observe an absence.
+	if got := len(readReceiptsRaw(t, dir)); got == 0 {
+		t.Fatal("receipt reader saw 0 receipts after a successful emit; it cannot detect an append, so the assertion below would be vacuous")
+	}
 
 	if err := e.RetireNativeAEL(); err != nil {
 		t.Fatalf("RetireNativeAEL: %v", err)
 	}
 
+	// Count what is on disk before the refused emit. Asserting only that Emit
+	// returns an error would still pass an implementation that appended the
+	// receipt and reported unhealthy afterwards, and the receipt landing is
+	// the thing retirement exists to prevent.
+	before := len(readReceiptsRaw(t, dir))
+
 	err := emit()
 	if err == nil {
 		t.Fatal("Emit succeeded after RetireNativeAEL; a retired emitter must not append under the rotated-out key")
+	}
+	if after := len(readReceiptsRaw(t, dir)); after != before {
+		t.Fatalf("receipt count went %d -> %d after a refused emit; a retired emitter appended under the rotated-out key", before, after)
 	}
 	if !strings.Contains(err.Error(), "unhealthy") {
 		t.Fatalf("Emit error after retirement = %v, want it to report the emitter unhealthy", err)

--- a/internal/receipt/sanitize_exported_test.go
+++ b/internal/receipt/sanitize_exported_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"strings"
+	"testing"
+)
+
+// SanitizeTarget and CleanOrRedacted are the exported pre-sign sanitization
+// boundary that internal/contract/proxydecision reuses instead of duplicating
+// this logic (#676), plus internal/cli explain rendering. Ten production call
+// sites stamp their results into a SIGNED payload, so the guarantee those
+// callers depend on is that the returned value is DLP-clean under the same
+// predicate they passed in. These tests assert that property directly rather
+// than asserting a fixed output string, which would only restate the
+// implementation.
+
+// exportedClean adapts dlpLike to the plain func(string) bool that the
+// exported wrappers accept. true means clean.
+func exportedClean(secrets ...string) func(string) bool {
+	return dlpLike(secrets...)
+}
+
+func TestSanitizeTargetExportedOutputIsClean(t *testing.T) {
+	t.Parallel()
+
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"userinfo credential", "https://user:" + secret + "@api.vendor.example/v1/things"},
+		{"query value secret", "https://api.vendor.example/v1?token=" + secret},
+		{"secret split across query values", "https://api.vendor.example/v1?a=" + secret[:10] + "&b=" + secret[10:]},
+		{"path segment secret", "https://api.vendor.example/v1/" + secret + "/read"},
+		{"fragment secret", "https://api.vendor.example/v1#" + secret},
+		{"secret in host label", "https://" + strings.ToLower(secret) + ".vendor.example/v1"},
+		{"connect authority", "api.vendor.example:443"},
+		{"connect authority carrying secret", secret + ".vendor.example:443"},
+		{"mcp tool name", "@vendor/integrity_checker"},
+		{"mcp tool name carrying secret", "@vendor/" + secret},
+		{"clean url is preserved", "https://api.vendor.example/v1/things?page=2"},
+		{"empty target", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clean := exportedClean(secret)
+			got := SanitizeTarget(tt.target, clean)
+
+			if !clean(got) {
+				t.Fatalf("SanitizeTarget(%q) = %q, which is NOT DLP-clean; a signed receipt would carry the secret", tt.target, got)
+			}
+			if strings.Contains(got, secret) {
+				t.Fatalf("SanitizeTarget(%q) = %q, still contains the secret verbatim", tt.target, got)
+			}
+		})
+	}
+}
+
+// A target that is already clean must survive byte-for-byte. Coarsening a
+// clean target would destroy forensic detail for no security gain, and the
+// callers stamp this value into evidence an operator later reads.
+func TestSanitizeTargetExportedPreservesCleanTarget(t *testing.T) {
+	t.Parallel()
+
+	const target = "https://api.vendor.example/v1/things?page=2&sort=desc"
+	clean := exportedClean("AKIAIOSFODNN7EXAMPLE")
+
+	if got := SanitizeTarget(target, clean); got != target {
+		t.Fatalf("SanitizeTarget(%q) = %q, want it unchanged", target, got)
+	}
+}
+
+// The nil predicate means flight-recorder redaction is DISABLED, and the
+// documented contract is that the target passes through unchanged. That is a
+// deliberate fail-direction, not an oversight: with redaction off there is no
+// scanner to decide what is secret. Pinning it keeps a later change from
+// quietly turning redaction-off into redaction-on (which would rewrite signed
+// evidence operators did not ask to be rewritten) or from assuming this call
+// sanitizes when it does not.
+func TestSanitizeTargetExportedNilPredicatePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	targets := []string{
+		"https://user:AKIAIOSFODNN7EXAMPLE@api.vendor.example/v1",
+		"https://api.vendor.example/v1?token=AKIAIOSFODNN7EXAMPLE",
+		"api.vendor.example:443",
+		"",
+	}
+
+	for _, target := range targets {
+		if got := SanitizeTarget(target, nil); got != target {
+			t.Errorf("SanitizeTarget(%q, nil) = %q, want the target unchanged when redaction is off", target, got)
+		}
+	}
+}
+
+func TestCleanOrRedactedExported(t *testing.T) {
+	t.Parallel()
+
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"clean rule label is preserved", "dlp.aws_access_key_id", "dlp.aws_access_key_id"},
+		{"label echoing matched bytes is redacted", "matched " + secret, redactedTarget},
+		{"bare secret is redacted", secret, redactedTarget},
+		{"empty value is clean", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clean := exportedClean(secret)
+			got := CleanOrRedacted(tt.value, clean)
+
+			if got != tt.want {
+				t.Fatalf("CleanOrRedacted(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+			if !clean(got) {
+				t.Fatalf("CleanOrRedacted(%q) = %q, which is NOT DLP-clean", tt.value, got)
+			}
+		})
+	}
+}
+
+// Same deliberate fail-direction as SanitizeTarget's nil case: redaction off
+// means the non-URL field is signed as sent.
+func TestCleanOrRedactedExportedNilPredicatePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	values := []string{"AKIAIOSFODNN7EXAMPLE", "dlp.aws_access_key_id", ""}
+	for _, value := range values {
+		if got := CleanOrRedacted(value, nil); got != value {
+			t.Errorf("CleanOrRedacted(%q, nil) = %q, want the value unchanged when redaction is off", value, got)
+		}
+	}
+}

--- a/internal/receipt/sanitize_exported_test.go
+++ b/internal/receipt/sanitize_exported_test.go
@@ -27,37 +27,56 @@ func TestSanitizeTargetExportedOutputIsClean(t *testing.T) {
 	t.Parallel()
 
 	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
+	// A host label cannot carry uppercase, so the host case needs the lowered
+	// form AND the predicate has to flag it. Without both, the raw target is
+	// already clean, the sanitizer does nothing, and the subtest passes while
+	// the secret survives. That exact subtest was vacuous before this guard.
+	lowered := strings.ToLower(secret)
 
 	tests := []struct {
-		name   string
-		target string
+		name string
+		// target is the input. secretForm is the byte sequence that must not
+		// survive; empty means the case is a deliberately-clean control.
+		target     string
+		secretForm string
 	}{
-		{"userinfo credential", "https://user:" + secret + "@api.vendor.example/v1/things"},
-		{"query value secret", "https://api.vendor.example/v1?token=" + secret},
-		{"secret split across query values", "https://api.vendor.example/v1?a=" + secret[:10] + "&b=" + secret[10:]},
-		{"path segment secret", "https://api.vendor.example/v1/" + secret + "/read"},
-		{"fragment secret", "https://api.vendor.example/v1#" + secret},
-		{"secret in host label", "https://" + strings.ToLower(secret) + ".vendor.example/v1"},
-		{"connect authority", "api.vendor.example:443"},
-		{"connect authority carrying secret", secret + ".vendor.example:443"},
-		{"mcp tool name", "@vendor/integrity_checker"},
-		{"mcp tool name carrying secret", "@vendor/" + secret},
-		{"clean url is preserved", "https://api.vendor.example/v1/things?page=2"},
-		{"empty target", ""},
+		{"userinfo credential", "https://user:" + secret + "@api.vendor.example/v1/things", secret},
+		{"query value secret", "https://api.vendor.example/v1?token=" + secret, secret},
+		{"secret split across query values", "https://api.vendor.example/v1?a=" + secret[:10] + "&b=" + secret[10:], secret},
+		{"path segment secret", "https://api.vendor.example/v1/" + secret + "/read", secret},
+		{"fragment secret", "https://api.vendor.example/v1#" + secret, secret},
+		{"secret in host label", "https://" + lowered + ".vendor.example/v1", lowered},
+		{"connect authority carrying secret", secret + ".vendor.example:443", secret},
+		{"mcp tool name carrying secret", "@vendor/" + secret, secret},
+		{"connect authority", "api.vendor.example:443", ""},
+		{"mcp tool name", "@vendor/integrity_checker", ""},
+		{"clean url is preserved", "https://api.vendor.example/v1/things?page=2", ""},
+		{"empty target", "", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			clean := exportedClean(secret)
+			clean := exportedClean(secret, lowered)
+
+			// Establish the case is meaningful before trusting its result. A
+			// secret-bearing input the predicate reports as already clean
+			// exercises nothing, and the assertions below would pass anyway.
+			if tt.secretForm != "" && clean(tt.target) {
+				t.Fatalf("fixture is vacuous: raw target %q is already clean under the predicate, so this case tests nothing", tt.target)
+			}
+
 			got := SanitizeTarget(tt.target, clean)
 
 			if !clean(got) {
 				t.Fatalf("SanitizeTarget(%q) = %q, which is NOT DLP-clean; a signed receipt would carry the secret", tt.target, got)
 			}
-			if strings.Contains(got, secret) {
+			if tt.secretForm != "" && strings.Contains(got, tt.secretForm) {
 				t.Fatalf("SanitizeTarget(%q) = %q, still contains the secret verbatim", tt.target, got)
+			}
+			if tt.secretForm == "" && got != tt.target {
+				t.Fatalf("SanitizeTarget(%q) = %q, want a clean target preserved byte for byte", tt.target, got)
 			}
 		})
 	}

--- a/internal/receipt/sanitize_exported_test.go
+++ b/internal/receipt/sanitize_exported_test.go
@@ -26,7 +26,7 @@ func exportedClean(secrets ...string) func(string) bool {
 func TestSanitizeTargetExportedOutputIsClean(t *testing.T) {
 	t.Parallel()
 
-	const secret = "AKIAIOSFODNN7EXAMPLE"
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
 
 	tests := []struct {
 		name   string
@@ -70,7 +70,7 @@ func TestSanitizeTargetExportedPreservesCleanTarget(t *testing.T) {
 	t.Parallel()
 
 	const target = "https://api.vendor.example/v1/things?page=2&sort=desc"
-	clean := exportedClean("AKIAIOSFODNN7EXAMPLE")
+	clean := exportedClean("AKIA" + "IOSFODNN7EXAMPLE")
 
 	if got := SanitizeTarget(target, clean); got != target {
 		t.Fatalf("SanitizeTarget(%q) = %q, want it unchanged", target, got)
@@ -87,9 +87,10 @@ func TestSanitizeTargetExportedPreservesCleanTarget(t *testing.T) {
 func TestSanitizeTargetExportedNilPredicatePassesThrough(t *testing.T) {
 	t.Parallel()
 
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
 	targets := []string{
-		"https://user:AKIAIOSFODNN7EXAMPLE@api.vendor.example/v1",
-		"https://api.vendor.example/v1?token=AKIAIOSFODNN7EXAMPLE",
+		"https://user:" + secret + "@api.vendor.example/v1",
+		"https://api.vendor.example/v1?token=" + secret,
 		"api.vendor.example:443",
 		"",
 	}
@@ -104,7 +105,7 @@ func TestSanitizeTargetExportedNilPredicatePassesThrough(t *testing.T) {
 func TestCleanOrRedactedExported(t *testing.T) {
 	t.Parallel()
 
-	const secret = "AKIAIOSFODNN7EXAMPLE"
+	const secret = "AKIA" + "IOSFODNN7EXAMPLE"
 
 	tests := []struct {
 		name  string
@@ -139,7 +140,7 @@ func TestCleanOrRedactedExported(t *testing.T) {
 func TestCleanOrRedactedExportedNilPredicatePassesThrough(t *testing.T) {
 	t.Parallel()
 
-	values := []string{"AKIAIOSFODNN7EXAMPLE", "dlp.aws_access_key_id", ""}
+	values := []string{"AKIA" + "IOSFODNN7EXAMPLE", "dlp.aws_access_key_id", ""}
 	for _, value := range values {
 		if got := CleanOrRedacted(value, nil); got != value {
 			t.Errorf("CleanOrRedacted(%q, nil) = %q, want the value unchanged when redaction is off", value, got)

--- a/internal/receipt/session_restart_open_test.go
+++ b/internal/receipt/session_restart_open_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package receipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+)
+
+// validateRestartOpen guards the seam where one run's chain hands off to the
+// next: a restart session_open must reference the real prior tail and must not
+// impersonate a bound genesis. Only the prior_chain_head mismatch had a
+// regression; the remaining fail-closed branches are covered here.
+//
+// Each case must FAIL verification. A restart open that verified while
+// misdescribing its own position would let an operator read a continuous chain
+// across a gap that was never proven continuous.
+func TestVerifyChain_RestartSessionOpenRejections(t *testing.T) {
+	t.Parallel()
+
+	// restartChain builds a valid bound-genesis open plus one action receipt,
+	// then appends a restart open at seq 2 whose payload the caller corrupts.
+	restartChain := func(t *testing.T, priv ed25519.PrivateKey, corrupt func(open *SessionOpen, priorHash string, priorSeq uint64), prevHash func(priorHash string) string) []Receipt {
+		t.Helper()
+		base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+		boundOpen := signBoundOpen(t, priv, base)
+		tail := signRunReceipt(t, priv, 1, mustHash(t, boundOpen), sessionOpenTestRunA, base.Add(time.Second))
+		priorHash := mustHash(t, tail)
+		priorSeq := tail.ActionRecord.ChainSeq
+
+		open := testSessionOpen(sessionOpenTestRunB, "open-b", 2)
+		open.PriorChainHead = priorHash
+		open.PriorChainSeq = priorSeq
+		corrupt(&open, priorHash, priorSeq)
+
+		restart := signSessionReceipt(t, priv, 2, prevHash(priorHash), base.Add(2*time.Second), sessionOpenTestRunB, &SessionControl{
+			Kind: SessionControlOpen,
+			Open: &open,
+		}, nil)
+		return []Receipt{boundOpen, tail, restart}
+	}
+
+	unchangedPrev := func(priorHash string) string { return priorHash }
+
+	tests := map[string]struct {
+		build   func(t *testing.T, priv ed25519.PrivateKey) []Receipt
+		wantErr string
+	}{
+		// A restart open that claims the g1 genesis prefix is asserting it
+		// begins a chain rather than continuing one, which would detach it
+		// from the prior tail it is supposed to be anchored to.
+		"restart_open_claims_g1_chain_prev_hash": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return restartChain(t, priv,
+					func(open *SessionOpen, _ string, _ uint64) {},
+					func(string) string { return genesisSessionOpenPrefix + strings.Repeat("0", 64) },
+				)
+			},
+			wantErr: "must not use g1 chain_prev_hash",
+		},
+		// Carrying a genesis_hash is the bound-genesis form's marker. A
+		// restart open carrying one is claiming two mutually exclusive
+		// positions at once.
+		"restart_open_carries_genesis_hash": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return restartChain(t, priv, func(open *SessionOpen, _ string, _ uint64) {
+					open.GenesisHash = ComputeSessionOpenGenesis(*open)
+				}, unchangedPrev)
+			},
+			wantErr: "must not carry genesis_hash",
+		},
+		// chain_open_seq is the payload's own claim about where this open
+		// sits. If it disagrees with the receipt's chain_seq, the signed
+		// payload and the signed envelope describe different positions.
+		"restart_open_chain_open_seq_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return restartChain(t, priv, func(open *SessionOpen, _ string, _ uint64) {
+					open.ChainOpenSeq = 99
+				}, unchangedPrev)
+			},
+			wantErr: "chain_open_seq does not match receipt chain_seq",
+		},
+		// The prior tail's hash and its seq are two independent claims about
+		// the same handoff point. A correct hash with a wrong seq still
+		// misdescribes the gap, so both are checked.
+		"restart_open_prior_chain_seq_mismatch": {
+			build: func(t *testing.T, priv ed25519.PrivateKey) []Receipt {
+				return restartChain(t, priv, func(open *SessionOpen, _ string, priorSeq uint64) {
+					open.PriorChainSeq = priorSeq + 7
+				}, unchangedPrev)
+			},
+			wantErr: "prior_chain_seq does not match prior tail seq",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			pub, priv := generateTestKey(t)
+			res := VerifyChain(tc.build(t, priv), hex.EncodeToString(pub))
+			if res.Valid {
+				t.Fatal("malformed restart session_open chain verified")
+			}
+			if !strings.Contains(res.Error, tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", res.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+// VerifyChainIntegrity's empty-key form is trust-on-first-use: the genesis
+// segment's key becomes the sole trusted key. It is the entry point offline
+// verification uses when the operator has no pinned key, so the difference
+// between it and the pinned form is worth pinning.
+func TestVerifyChainIntegrity_TrustOnFirstUse(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := generateTestKey(t)
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	boundOpen := signBoundOpen(t, priv, base)
+	tail := signRunReceipt(t, priv, 1, mustHash(t, boundOpen), sessionOpenTestRunA, base.Add(time.Second))
+	chain := []Receipt{boundOpen, tail}
+
+	tofu := VerifyChainIntegrity(chain, "")
+	if !tofu.Valid {
+		t.Fatalf("trust-on-first-use integrity verify failed: %s", tofu.Error)
+	}
+
+	pinned := VerifyChainIntegrity(chain, hex.EncodeToString(pub))
+	if !pinned.Valid {
+		t.Fatalf("pinned-key integrity verify failed: %s", pinned.Error)
+	}
+	if tofu.RootHash != pinned.RootHash {
+		t.Fatalf("root hash differs between trust-on-first-use (%q) and pinned (%q)", tofu.RootHash, pinned.RootHash)
+	}
+
+	// A key the operator did not pin must be rejected even though the chain is
+	// internally consistent. This is the direction that matters: an attacker
+	// with write access can produce a self-consistent chain under their own
+	// key, and only the trusted set rejects it.
+	otherPub, _ := generateTestKey(t)
+	if res := VerifyChainIntegrity(chain, hex.EncodeToString(otherPub)); res.Valid {
+		t.Fatal("integrity verify accepted a chain signed by an untrusted key")
+	}
+}

--- a/internal/receipt/session_restart_open_test.go
+++ b/internal/receipt/session_restart_open_test.go
@@ -97,6 +97,21 @@ func TestVerifyChain_RestartSessionOpenRejections(t *testing.T) {
 		},
 	}
 
+	// Availability control. Every case above is deliberately corrupt, so a
+	// change that rejected EVERY restart open, valid handoffs included, would
+	// pass all of them. This builds the same shape with nothing corrupted and
+	// requires it to verify, so over-strictness at the chain boundary fails
+	// here rather than shipping as a refusal an operator has to debug.
+	t.Run("control_valid_restart_open_verifies", func(t *testing.T) {
+		t.Parallel()
+		pub, priv := generateTestKey(t)
+		chain := restartChain(t, priv, func(*SessionOpen, string, uint64) {}, unchangedPrev)
+		res := VerifyChain(chain, hex.EncodeToString(pub))
+		if !res.Valid {
+			t.Fatalf("a valid restart session_open chain failed to verify: %s", res.Error)
+		}
+	})
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## What changed

Tests only, across the packages that produce and validate signed evidence. No production code changed.

The exported pre-sign sanitization boundary in `internal/receipt` had no direct tests, though ten production call sites stamp its results into a signed payload. These assert the property those callers depend on, which is that the returned value is clean under the predicate they supplied. The target shapes covered are a credential in userinfo, in a query value, split across two query values, in a path segment, in a fragment, in a host label, in a CONNECT authority, and in an MCP tool name. The documented redaction-off pass-through is pinned too, so it can't drift in either direction.

`validateRestartOpen` guards the seam where one run's receipt chain hands off to the next, and only its prior-tail-hash mismatch had a regression. A restart open that claims the genesis prefix, carries a genesis hash, or disagrees with its own receipt about where it sits now has to fail verification. Verifying any of those would present a gap as proven continuity.

`SignerKeyHex` is how reload decides whether a config change is a policy reload or a signer rotation, and it had no test. Two distinct keys have to report distinct values or a rotation is invisible. Retirement after a rotation has to brick the emitter so a stale caller can't append under the retired key, so the tests assert that refusal rather than the call's return value.

A coverage certificate's completeness status and reason are a coupled pair. Every status paired with another status's reason is rejected, along with a status outside the vocabulary and both directions of the receipt-count coupling. The violation has to be unsignable through `Sign`, not merely caught by the internal helper.

A relative posture-proof path is refused rather than resolved against the process working directory, which would leave the proof redirectable while still reading as attested. The two absent outcomes stay absent: an unconfigured path and a missing file must not read as tampering.

Every rejection case fails when the guard it covers is disabled, so none of them can pass vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for completeness statuses, receipt counts, and signing safeguards.
  * Added checks for proof-path handling and availability reporting, including invalid, missing, and default paths.
  * Added lifecycle coverage for receipt emitters, key handling, retirement, abort behavior, and nil-safe operations.
  * Added sanitization tests covering clean values, detected secrets, URLs, authorities, and tool targets.
  * Added chain verification tests for restart-session integrity, trust-on-first-use, and untrusted signing keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->