### PR TITLE
fix(mcp): component-wise containment check, untrusted-input tests

### DIFF
--- a/internal/mcp/integrity/containment_test.go
+++ b/internal/mcp/integrity/containment_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package integrity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isInsideDir answers one containment question: is this resolved binary inside
+// the agent's own working directory? Callers set VerifyResult.Suspicious from
+// the answer, and false means "not suspicious", so every false is a warning
+// the operator does not see. The direction matters more than usual here.
+func TestIsInsideDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	if err := os.MkdirAll(filepath.Join(workDir, "bin"), 0o750); err != nil {
+		t.Fatalf("MkdirAll bin: %v", err)
+	}
+	// A directory whose name begins with two dots but is an ordinary child.
+	// A prefix test against ".." misreads this as an escape.
+	dotDot := filepath.Join(workDir, "..cache")
+	if err := os.MkdirAll(dotDot, 0o750); err != nil {
+		t.Fatalf("MkdirAll ..cache: %v", err)
+	}
+	// A sibling whose name shares workDir's prefix, which a naive string
+	// prefix comparison on absolute paths would misread as inside.
+	sibling := filepath.Join(root, "workother")
+	if err := os.MkdirAll(sibling, 0o750); err != nil {
+		t.Fatalf("MkdirAll sibling: %v", err)
+	}
+
+	write := func(t *testing.T, path string) string {
+		t.Helper()
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", path, err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"binary directly in the work dir", write(t, filepath.Join(workDir, "server")), true},
+		{"binary nested in the work dir", write(t, filepath.Join(workDir, "bin", "server")), true},
+		{"binary in a child whose name starts with two dots", write(t, filepath.Join(dotDot, "server")), true},
+		{"the work dir itself", workDir, true},
+		{"binary in a prefix-sharing sibling", write(t, filepath.Join(sibling, "server")), false},
+		{"binary outside the root", write(t, filepath.Join(root, "server")), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInsideDir(tt.path, workDir); got != tt.want {
+				t.Fatalf("isInsideDir(%q, %q) = %v, want %v", tt.path, workDir, got, tt.want)
+			}
+		})
+	}
+}
+
+// A symlink is resolved before the comparison, so where the link LIVES does
+// not decide the answer; where it POINTS does. Both directions matter: a link
+// inside the work dir pointing out is not the agent's own binary, and a link
+// outside pointing in is.
+func TestIsInsideDirResolvesSymlinksBeforeComparing(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	outside := filepath.Join(root, "outside")
+	for _, d := range []string{workDir, outside} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatalf("MkdirAll %s: %v", d, err)
+		}
+	}
+
+	outsideBin := filepath.Join(outside, "server")
+	insideBin := filepath.Join(workDir, "real-server")
+	for _, f := range []string{outsideBin, insideBin} {
+		if err := os.WriteFile(f, []byte("#!/bin/sh\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+
+	linkInsidePointingOut := filepath.Join(workDir, "link-out")
+	if err := os.Symlink(outsideBin, linkInsidePointingOut); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+	linkOutsidePointingIn := filepath.Join(outside, "link-in")
+	if err := os.Symlink(insideBin, linkOutsidePointingIn); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	if isInsideDir(linkInsidePointingOut, workDir) {
+		t.Error("a link inside the work dir pointing outside was reported inside; the target decides, not the link")
+	}
+	if !isInsideDir(linkOutsidePointingIn, workDir) {
+		t.Error("a link outside the work dir pointing inside was reported outside; the target decides, not the link")
+	}
+}
+
+// Every error path returns false, which means "not suspicious". That is a
+// deliberate direction on an advisory signal, and it is worth pinning so a
+// later change does not start reporting unresolvable paths as suspicious (a
+// warning an operator cannot act on) or, worse, as an error that breaks
+// verification.
+func TestIsInsideDirUnresolvablePathsReportNotInside(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	if err := os.MkdirAll(workDir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Control: a real binary inside resolves and reports inside, so a false
+	// below is attributable to the unresolvable path rather than the fixture.
+	insideBin := filepath.Join(workDir, "server")
+	if err := os.WriteFile(insideBin, []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !isInsideDir(insideBin, workDir) {
+		t.Fatal("control failed: a real binary inside the work dir was reported outside")
+	}
+
+	if isInsideDir(filepath.Join(workDir, "does-not-exist"), workDir) {
+		t.Error("a nonexistent path was reported inside")
+	}
+	if isInsideDir(insideBin, filepath.Join(root, "no-such-workdir")) {
+		t.Error("a nonexistent work dir was reported as containing the binary")
+	}
+
+	dangling := filepath.Join(workDir, "dangling")
+	if err := os.Symlink(filepath.Join(root, "missing-target"), dangling); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+	if isInsideDir(dangling, workDir) {
+		t.Error("a dangling symlink was reported inside")
+	}
+}

--- a/internal/mcp/integrity/integrity.go
+++ b/internal/mcp/integrity/integrity.go
@@ -754,5 +754,12 @@ func isInsideDir(path, dir string) bool {
 		return false
 	}
 
-	return !strings.HasPrefix(rel, "..")
+	// Compare against ".." as a whole path component, not as a string prefix.
+	// A bare prefix test also matches an ordinary name that merely starts with
+	// two dots, so a binary at <dir>/..name would be reported as OUTSIDE dir.
+	// Callers set Suspicious from this result, and false means not suspicious,
+	// so the loose form drops the warning for a binary an agent can write
+	// inside its own working directory. internal/securefile already uses this
+	// component-wise form for the same containment question.
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/mcp/integrity/parse_manifest_test.go
+++ b/internal/mcp/integrity/parse_manifest_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package integrity
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A manifest file is untrusted input: it pins the hashes an MCP server binary
+// is checked against, so whoever can edit it decides what counts as
+// unmodified. ParseManifest is the gate, and each of its rejections is
+// reachable only from a file we did not write. It had no direct test; the
+// rejections were exercised through the file-loading wrapper instead.
+func TestParseManifestRejections(t *testing.T) {
+	t.Parallel()
+
+	// Control first: a well-formed manifest parses, so every rejection below
+	// is attributable to the one thing that case changes.
+	t.Run("control_well_formed_manifest_parses", func(t *testing.T) {
+		t.Parallel()
+		good := fmt.Sprintf(`{"version":%d,"entries":{"/opt/server":"abc"}}`, ManifestVersion)
+		m, err := ParseManifest([]byte(good))
+		if err != nil {
+			t.Fatalf("ParseManifest(control) = %v, want a parsed manifest", err)
+		}
+		if got := m.Entries["/opt/server"]; got != "abc" {
+			t.Fatalf("entries[/opt/server] = %q, want %q", got, "abc")
+		}
+	})
+
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "not json",
+			data:    `{"version":`,
+			wantErr: "parsing manifest",
+		},
+		{
+			// An unsupported version must not be parsed on a best-effort
+			// basis: field meanings can change between versions, so a hash
+			// read under the wrong schema pins the wrong thing.
+			name:    "future version",
+			data:    fmt.Sprintf(`{"version":%d,"entries":{}}`, ManifestVersion+1),
+			wantErr: "unsupported manifest version",
+		},
+		{
+			name:    "zero version",
+			data:    `{"entries":{}}`,
+			wantErr: "unsupported manifest version",
+		},
+		{
+			// Explicit null entries is the case with no other coverage. An
+			// empty pin set means nothing is pinned, so accepting a null
+			// entries field would let a truncated or blanked manifest read as
+			// a valid one that happens to pin nothing.
+			name:    "null entries",
+			data:    fmt.Sprintf(`{"version":%d,"entries":null}`, ManifestVersion),
+			wantErr: "missing or null 'entries' field",
+		},
+		{
+			name:    "absent entries",
+			data:    fmt.Sprintf(`{"version":%d}`, ManifestVersion),
+			wantErr: "missing or null 'entries' field",
+		},
+		{
+			// Duplicate keys are a parser-differential defense. Go's decoder
+			// keeps the last occurrence while other JSON readers keep the
+			// first, so a manifest with two entries maps could pin one set of
+			// hashes for this verifier and show a different set to anyone
+			// auditing the same file.
+			name:    "duplicate entries key",
+			data:    fmt.Sprintf(`{"version":%d,"entries":{"/opt/a":"1"},"entries":{"/opt/a":"2"}}`, ManifestVersion),
+			wantErr: "parsing manifest",
+		},
+		{
+			name:    "duplicate key nested inside entries",
+			data:    fmt.Sprintf(`{"version":%d,"entries":{"/opt/a":"1","/opt/a":"2"}}`, ManifestVersion),
+			wantErr: "parsing manifest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, err := ParseManifest([]byte(tt.data))
+			if err == nil {
+				t.Fatalf("ParseManifest accepted %s; got manifest %+v", tt.name, m)
+			}
+			if m != nil {
+				t.Errorf("ParseManifest returned a non-nil manifest alongside an error, which a caller could use")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// The size cap bounds a manifest before it is decoded, so an oversized file
+// cannot be used to make the verifier do unbounded work at startup.
+func TestParseManifestRejectsOversizedInput(t *testing.T) {
+	t.Parallel()
+
+	// One byte over the cap, built as valid JSON so the rejection is
+	// attributable to the size check rather than to a decode failure.
+	filler := strings.Repeat("a", maxManifestFileSize)
+	data := fmt.Sprintf(`{"version":%d,"entries":{"/opt/server":"%s"}}`, ManifestVersion, filler)
+	if len(data) <= maxManifestFileSize {
+		t.Fatalf("fixture is %d bytes, which does not exceed the %d cap, so this case tests nothing", len(data), maxManifestFileSize)
+	}
+	if !json.Valid([]byte(data)) {
+		t.Fatal("fixture is not valid JSON, so a rejection would not prove the size check fired")
+	}
+
+	if _, err := ParseManifest([]byte(data)); err == nil {
+		t.Fatal("ParseManifest accepted input over the size cap")
+	} else if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %v, want it to name the size cap", err)
+	}
+}

--- a/internal/mcp/provenance/message_untrusted_shapes_test.go
+++ b/internal/mcp/provenance/message_untrusted_shapes_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package provenance
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The message a verifier receives is attacker-shaped: the signer is not
+// necessarily ours, so VerifyMessage cannot assume SignMessage produced the
+// _meta it is reading. These cover the branches reached only by a message
+// built outside the signing path.
+
+// verifyConfigFor returns a config whose only variable is the trust anchor, so
+// each case below changes exactly one thing about the message.
+func verifyConfigFor(t *testing.T, pub []byte, now time.Time) MessageVerifyConfig {
+	t.Helper()
+	return MessageVerifyConfig{
+		PublicKey: pub,
+		KeyID:     testMessageKeyID,
+		MaxAge:    5 * time.Minute,
+		Clock:     func() time.Time { return now },
+	}
+}
+
+// extractSignedMessage has four distinct routes to "no signature found", and
+// each one makes VerifyMessage report the message as UNSIGNED rather than
+// invalid. That classification is the fail-direction that matters: an attacker
+// who can corrupt signature extraction downgrades a signed message to an
+// unsigned one, and the caller's policy decides what unsigned means. The
+// property worth pinning is that no corrupted shape is ever reported as
+// verified, and that the downgrade is reported honestly as unsigned rather
+// than silently accepted.
+func TestVerifyMessage_CorruptSignatureShapesReportUnsigned(t *testing.T) {
+	t.Parallel()
+
+	pub, priv := newTestKeypair(t)
+	now := time.Unix(1_780_000_000, 0).UTC()
+
+	// Control: a genuinely signed message verifies under this config, so a
+	// later "unsigned" result is attributable to the corrupted shape rather
+	// than to the fixture, the key, or the clock.
+	t.Run("control_valid_signature_verifies", func(t *testing.T) {
+		t.Parallel()
+		sig, err := SignMessage("tools/call", nil, nil, priv, testMessageKeyID, newTestNonce(t), now)
+		if err != nil {
+			t.Fatalf("SignMessage: %v", err)
+		}
+		signed, err := EmbedMessageSignature([]byte(`{"jsonrpc":"2.0","method":"tools/call"}`), sig)
+		if err != nil {
+			t.Fatalf("EmbedMessageSignature: %v", err)
+		}
+		if res := VerifyMessage(signed, verifyConfigFor(t, pub, now)); res.Status != MessageSigVerified {
+			t.Fatalf("control status = %q (%s), want %q", res.Status, res.Reason, MessageSigVerified)
+		}
+	})
+
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{"meta absent", `{"jsonrpc":"2.0","method":"tools/call"}`},
+		{"meta null", `{"jsonrpc":"2.0","method":"tools/call","_meta":null}`},
+		{"meta is a string not an object", `{"jsonrpc":"2.0","method":"tools/call","_meta":"nope"}`},
+		{"meta is an array not an object", `{"jsonrpc":"2.0","method":"tools/call","_meta":[1,2]}`},
+		{"meta object without the signature key", `{"jsonrpc":"2.0","method":"tools/call","_meta":{"other":"value"}}`},
+		{"signature value is a string not an object", `{"jsonrpc":"2.0","method":"tools/call","_meta":{"` + MessageMetaKey + `":"nope"}}`},
+		{"signature value is an array", `{"jsonrpc":"2.0","method":"tools/call","_meta":{"` + MessageMetaKey + `":[]}}`},
+		{"signature object carries neither alg nor signature", `{"jsonrpc":"2.0","method":"tools/call","_meta":{"` + MessageMetaKey + `":{"kid":"x","ts":1}}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The fixture must be a valid JSON envelope, or the case would be
+			// testing the envelope parser instead of signature extraction.
+			var probe map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tt.msg), &probe); err != nil {
+				t.Fatalf("fixture is not a valid JSON envelope, so this case tests the wrong branch: %v", err)
+			}
+
+			res := VerifyMessage([]byte(tt.msg), verifyConfigFor(t, pub, now))
+			if res.Status == MessageSigVerified {
+				t.Fatalf("a corrupted signature shape was reported VERIFIED (reason %q)", res.Reason)
+			}
+			if res.Status != MessageSigUnsigned {
+				t.Fatalf("status = %q (%s), want %q", res.Status, res.Reason, MessageSigUnsigned)
+			}
+		})
+	}
+}
+
+// A malformed envelope is distinct from a corrupted signature: it cannot be
+// classified as unsigned, because nothing about it was parseable. It must
+// report malformed so an operator can tell a broken sender from an unsigned
+// one.
+func TestVerifyMessage_UnparseableEnvelopeReportsMalformed(t *testing.T) {
+	t.Parallel()
+
+	pub, _ := newTestKeypair(t)
+	now := time.Unix(1_780_000_000, 0).UTC()
+
+	for _, msg := range []string{``, `{`, `not json`, `[1,2,3]`} {
+		res := VerifyMessage([]byte(msg), verifyConfigFor(t, pub, now))
+		if res.Status != MessageSigMalformed {
+			t.Errorf("VerifyMessage(%q) status = %q (%s), want %q", msg, res.Status, res.Reason, MessageSigMalformed)
+		}
+	}
+}
+
+// SignMessage refuses to produce a bad nonce, so the verifier's own nonce
+// check is only reachable from a message built outside our signing path. That
+// is exactly the untrusted case: a verifier that trusted the signer to have
+// validated would accept a nonce too short to resist replay inside the
+// max-age window.
+func TestVerifyMessage_RejectsMalformedNonceFromAnUntrustedSigner(t *testing.T) {
+	t.Parallel()
+
+	pub, _ := newTestKeypair(t)
+	now := time.Unix(1_780_000_000, 0).UTC()
+
+	tests := []struct {
+		name  string
+		nonce string
+	}{
+		{"empty", ""},
+		{"not base64", "not!!base64"},
+		{"decodes below MinNonceLen", base64.StdEncoding.EncodeToString([]byte("12345678"))},
+		{"decodes to a single byte", base64.StdEncoding.EncodeToString([]byte("x"))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Built as a struct rather than through SignMessage, because
+			// SignMessage rejects these before they can reach a verifier.
+			sig := SignedMessage{
+				Algorithm: MessageSigAlgEd25519,
+				KeyID:     testMessageKeyID,
+				Timestamp: now.Unix(),
+				Nonce:     tt.nonce,
+				Signature: base64.StdEncoding.EncodeToString([]byte("irrelevant, the nonce is checked first")),
+			}
+			msg, err := EmbedMessageSignature([]byte(`{"jsonrpc":"2.0","method":"tools/call"}`), sig)
+			if err != nil {
+				t.Fatalf("EmbedMessageSignature: %v", err)
+			}
+
+			res := VerifyMessage(msg, verifyConfigFor(t, pub, now))
+			if res.Status == MessageSigVerified {
+				t.Fatalf("a message with nonce %q was reported VERIFIED", tt.nonce)
+			}
+			if res.Status != MessageSigMalformed {
+				t.Fatalf("status = %q (%s), want %q", res.Status, res.Reason, MessageSigMalformed)
+			}
+			if !strings.Contains(res.Reason, "nonce") {
+				t.Errorf("reason = %q, want it to name the nonce so an operator can act on it", res.Reason)
+			}
+		})
+	}
+}
+
+// EmbedMessageSignature is given caller-supplied bytes, so its parse failures
+// must surface as errors rather than producing an envelope that silently drops
+// the signature or the caller's existing _meta keys.
+func TestEmbedMessageSignature_RejectsUnusableEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	sig := SignedMessage{
+		Algorithm: MessageSigAlgEd25519,
+		KeyID:     testMessageKeyID,
+		Timestamp: 1,
+		Nonce:     base64.StdEncoding.EncodeToString(make([]byte, MinNonceLen)),
+		Signature: base64.StdEncoding.EncodeToString([]byte("sig")),
+	}
+
+	t.Run("envelope is not JSON", func(t *testing.T) {
+		t.Parallel()
+		if _, err := EmbedMessageSignature([]byte(`not json`), sig); err == nil {
+			t.Fatal("EmbedMessageSignature accepted a non-JSON envelope")
+		}
+	})
+
+	t.Run("existing _meta is not an object", func(t *testing.T) {
+		t.Parallel()
+		if _, err := EmbedMessageSignature([]byte(`{"jsonrpc":"2.0","_meta":"scalar"}`), sig); err == nil {
+			t.Fatal("EmbedMessageSignature accepted a scalar _meta, which would discard it")
+		}
+	})
+
+	// The documented contract is that existing _meta keys survive. A signature
+	// that silently dropped a caller's progress token would break the caller
+	// while still verifying.
+	t.Run("existing _meta keys are preserved", func(t *testing.T) {
+		t.Parallel()
+		out, err := EmbedMessageSignature([]byte(`{"jsonrpc":"2.0","_meta":{"progressToken":"abc"}}`), sig)
+		if err != nil {
+			t.Fatalf("EmbedMessageSignature: %v", err)
+		}
+		var env struct {
+			Meta map[string]json.RawMessage `json:"_meta"`
+		}
+		if err := json.Unmarshal(out, &env); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		if _, ok := env.Meta["progressToken"]; !ok {
+			t.Error("embedding the signature dropped the caller's existing _meta key")
+		}
+		if _, ok := env.Meta[MessageMetaKey]; !ok {
+			t.Error("embedding the signature did not add the signature key")
+		}
+	})
+}

--- a/internal/mcp/provenance/message_untrusted_shapes_test.go
+++ b/internal/mcp/provenance/message_untrusted_shapes_test.go
@@ -210,8 +210,12 @@ func TestEmbedMessageSignature_RejectsUnusableEnvelopes(t *testing.T) {
 		if err := json.Unmarshal(out, &env); err != nil {
 			t.Fatalf("unmarshal result: %v", err)
 		}
-		if _, ok := env.Meta["progressToken"]; !ok {
-			t.Error("embedding the signature dropped the caller's existing _meta key")
+		// Compare the value, not just the key's presence. Checking presence
+		// alone passes an implementation that rewrites the caller's token to
+		// null or to anything else, which breaks the caller just as surely as
+		// dropping the key would.
+		if got := string(env.Meta["progressToken"]); got != `"abc"` {
+			t.Errorf("progressToken = %s, want %q: embedding the signature must preserve the caller's existing _meta value", got, `"abc"`)
 		}
 		if _, ok := env.Meta[MessageMetaKey]; !ok {
 			t.Error("embedding the signature did not add the signature key")


### PR DESCRIPTION
## What changed

`isInsideDir` compared the relative path with a bare two-dot prefix test, so an ordinary child directory whose name begins with two dots read as outside the directory. Callers set the integrity report's suspicious flag from that result, and false means not suspicious, so a binary written to a path like `<workDir>/..cache/server` lost its warning. It now compares the parent reference as a whole path component, which is the form `internal/securefile` already uses for the same containment question.

That signal is advisory rather than enforcing. It's surfaced in the integrity report, it's deliberately zeroed when generating a manifest, and the proxy path passes an empty working directory so the comparison doesn't run there. The change restores a missing operator warning and moves toward reporting more rather than less.

The rest is coverage for input a verifier doesn't control. Message-signature extraction has several routes to not-found, and each one downgrades a signed message to unsigned instead of rejecting it, so these pin that no corrupted shape reports as verified and that the downgrade is reported as unsigned rather than passed over. The verifier's own nonce check can't be reached through our signing path, which refuses to emit a bad nonce, so it's covered from a message built as a struct instead.

Manifest parsing gained a rejection matrix. A null or absent entries field is rejected rather than read as a valid manifest that pins nothing. Duplicate JSON keys stay rejected because Go keeps the last occurrence while other readers keep the first, so one file could pin one set of hashes for this verifier and show a different set to anyone auditing it.

Every rejection case fails when the guard it covers is disabled, and the containment case fails against the previous prefix comparison, so none of them can pass vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved directory-boundary checks for similarly named paths, nested locations, and symbolic links.
  - Strengthened manifest validation by rejecting malformed, unsupported, duplicated, missing, or oversized data.
  - Improved handling of invalid or corrupted message signatures and envelopes so they are not treated as trusted.
  - Added validation for malformed security nonces while preserving existing metadata when adding signatures.

- **Tests**
  - Expanded coverage for path containment, manifest parsing, and untrusted message scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->