### PR TITLE
fix(pr-review): show an unfinished review on the current PR head

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: Optional model override for /review deep.
     required: false
   operation:
-    description: claim creates the status marker; review performs the provider calls.
+    description: claim creates the status marker; review performs provider calls; coverage publishes the current-head verdict.
     required: false
     default: review
   base-sha:
@@ -60,6 +60,18 @@ inputs:
     required: false
   status-comment-id:
     description: Comment identifier from the admission step.
+    required: false
+  review-identity:
+    description: Unique identity emitted by the admission step for this review run.
+    required: false
+  coverage-state:
+    description: Terminal review state whose coverage verdict is being published.
+    required: false
+  coverage-complete:
+    description: Whether the terminal review covered the whole admitted pull-request range.
+    required: false
+  coverage-run-url:
+    description: Workflow run URL attached to the coverage commit status.
     required: false
   reviewed-repository-path:
     description: Immutable checkout of the target repository at the captured head.
@@ -104,6 +116,10 @@ runs:
         BASE_SHA: ${{ inputs.base-sha }}
         HEAD_SHA: ${{ inputs.head-sha }}
         STATUS_COMMENT_ID: ${{ inputs.status-comment-id }}
+        REVIEW_IDENTITY: ${{ inputs.review-identity }}
+        COVERAGE_STATE: ${{ inputs.coverage-state }}
+        COVERAGE_COMPLETE: ${{ inputs.coverage-complete }}
+        COVERAGE_RUN_URL: ${{ inputs.coverage-run-url }}
         REVIEWED_REPOSITORY_PATH: ${{ inputs.reviewed-repository-path }}
         REVIEWED_MERGE_BASE_SHA: ${{ inputs.reviewed-merge-base-sha }}
       run: python "$GITHUB_ACTION_PATH/pr_review.py"

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -2949,6 +2949,11 @@ def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, 
 
 def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None, repository: str | None = None, pr_number: str | None = None, review_identity: str | None = None) -> str:
     seen_before = seen_before or set()
+    # Resolve the fallback ONCE, so the rendered label and the marker below
+    # carry the same value. The stale-writer check compares this identity, so a
+    # comment showing one value while the marker stores another leaves a reader
+    # unable to tell which review a published verdict belongs to.
+    review_identity = review_identity or uuid.uuid4().hex
     # `full` means base..head. `delta` means a prior completed review's head
     # ..head, which is a smaller question and must never be read as a
     # verdict on the whole pull request.
@@ -3066,7 +3071,7 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
                 if delta
                 else f"**Reviewed range:** `{binding.base_sha}`..`{binding.head_sha}` (whole pull request)"
             ),
-            f"**Review identity:** `{binding.correlation}`",
+            f"**Review identity:** `{review_identity}`",
             f"**Classification:** {', '.join(classification) if classification else 'empty diff'}",
             f"**Completeness:** {progress.reviewed_units}/{progress.expected_units} representable units reviewed; {len(omitted)} omitted or unrepresentable; {len(collapsed)} deletion-collapsed.",
             "",
@@ -3134,7 +3139,7 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     fingerprints = ",".join(sorted({finding_fingerprint(finding) for finding in findings}))
     marker = {
         "state": state,
-        "identity": review_identity or uuid.uuid4().hex,
+        "identity": review_identity,
         # The unique admission identity prevents stale terminal writers from
         # clobbering a later review. This binding remains the stable key used
         # only to decide whether the same immutable review can be skipped.

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -2728,13 +2728,20 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
         lines.append("**The whole diff was reviewed, but this is not clean: manual verification is required.**")
     elif state == "superseded":
         lines.append("**This is historical only because the pull request head changed before completion.**")
-    lines.extend(
-        [
-            f"**Findings:** high {counts['high']}, medium {counts['medium']}, low {counts['low']}.",
-            "",
-            "### Findings",
-        ]
-    )
+    # Say what the count MEANS when the review did not finish. A bare
+    # "Findings: high 0, medium 0, low 0" on a partial run reads as a clean
+    # result to anyone who does not open the collapsed sections, and that is
+    # exactly how a timed-out review gets mistaken for a passing one.
+    if state == "partial":
+        lines.append(
+            f"**Findings:** high {counts['high']}, medium {counts['medium']}, low {counts['low']} "
+            "VERIFIED. The review did not finish, so this is not a count of what is in the diff."
+        )
+    else:
+        lines.append(
+            f"**Findings:** high {counts['high']}, medium {counts['medium']}, low {counts['low']}."
+        )
+    lines.extend(["", "### Findings"])
     if not findings:
         lines.append("No verified material findings were published.")
     else:

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -160,8 +160,10 @@ NOTICE_MARKER = "pr-review-notice:v1"
 STATUS_MARKER_REQUIRED_FIELDS = frozenset({"state", "identity", "mode", "findings"})
 # Older markers carry fewer fields. They are still readable, and simply do
 # not qualify as a baseline, which is the safe direction.
-STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"model", "reviewed_head", "scope", "coverage_base"}
+STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"binding", "model", "reviewed_head", "scope", "coverage_base"}
 FINDING_FINGERPRINTS_RE = re.compile(r"(?:[0-9a-f]{12}(?:,[0-9a-f]{12})*)?")
+COVERAGE_CONTEXT = "pr-review/coverage"
+COVERAGE_POST_ATTEMPTS = 3
 
 PUBLISHED_REVIEW_STATES = frozenset(
     {"already-running", "clean", "failed", "findings", "inconclusive", "partial", "superseded"}
@@ -213,6 +215,24 @@ class PullBinding:
         return ":".join(
             (self.base_sha[:12], self.head_sha[:12], self.reviewer_sha[:12], self.rubric_version)
         )
+
+
+@dataclass(frozen=True)
+class CoveragePlan:
+    """The one status write a terminal review is allowed to make."""
+
+    target_head: str
+    status: str
+    description: str
+    gate_exit: int
+
+
+@dataclass(frozen=True)
+class CoveragePublication:
+    """The terminal writer's outcome, including a deliberate stale rejection."""
+
+    outcome: str
+    plan: CoveragePlan | None = None
 
 
 @dataclass
@@ -1329,6 +1349,183 @@ def update_comment(repo: str, comment_id: int, token: str, body: str, correlatio
     response.raise_for_status()
 
 
+def coverage_plan(state: str, complete: bool, admitted: PullBinding, current: PullBinding) -> CoveragePlan:
+    """Choose the current-head status without publishing it.
+
+    A terminal review may be accurate for the head it read and still be stale
+    by publication time. GitHub evaluates a pull request against its current
+    head, so a moved head (or base) is an explicit failure on that current
+    commit rather than a historical green on the captured commit.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", admitted.head_sha):
+        raise ReviewError("coverage status has no immutable admitted head")
+    if not re.fullmatch(r"[0-9a-f]{40}", current.head_sha):
+        raise ReviewError("coverage status has no immutable current head")
+    if current.head_sha != admitted.head_sha:
+        return CoveragePlan(
+            current.head_sha,
+            "failure",
+            "Review was superseded by a newer head; re-run it",
+            1,
+        )
+    if current.base_sha != admitted.base_sha:
+        return CoveragePlan(
+            current.head_sha,
+            "failure",
+            "Review no longer matches the current base; re-run it",
+            1,
+        )
+    if complete:
+        return CoveragePlan(current.head_sha, "success", f"Review covered the whole diff ({state})", 0)
+    if state in COMPLETE_REVIEW_STATES:
+        return CoveragePlan(current.head_sha, "failure", "Review did not reach the current base; re-run it", 1)
+    return CoveragePlan(current.head_sha, "failure", f"Review did NOT finish (state={state or 'none'})", 1)
+
+
+def post_coverage_status(repo: str, token: str, plan: CoveragePlan, run_url: str, correlation: str) -> bool:
+    """Publish exactly three times, pausing only before a real retry."""
+    for attempt in range(1, COVERAGE_POST_ATTEMPTS + 1):
+        try:
+            response = requests.post(
+                f"https://api.github.com/repos/{repo}/statuses/{plan.target_head}",
+                headers=github_headers(token),
+                json={
+                    "state": plan.status,
+                    "context": COVERAGE_CONTEXT,
+                    "description": plan.description,
+                    "target_url": run_url,
+                },
+                timeout=30,
+            )
+        except requests.RequestException:
+            log_phase("coverage-status", attempt=attempt, status="request-error", correlation=correlation)
+        else:
+            log_phase("coverage-status", attempt=attempt, status=response.status_code, correlation=correlation)
+            if 200 <= response.status_code < 300:
+                return True
+        if attempt < COVERAGE_POST_ATTEMPTS:
+            time.sleep(attempt * 5)
+    return False
+
+
+def _coverage_publication_failure_body(body: str, review_identity: str, reason: str) -> str:
+    """Turn this review's terminal comment into an honest unpublished result."""
+    marker = parse_status_marker(body)
+    if marker is None or marker.get("identity") != review_identity:
+        raise ReviewError("coverage failure comment no longer belongs to this review")
+    verdict = re.search(r"\*\*Verdict:\*\* `[^`]+`", body)
+    if verdict is None:
+        raise ReviewError("coverage failure comment had no terminal verdict")
+    notice = (
+        f"**Coverage status:** {reason} "
+        "The pull request cannot show this review's coverage verdict, so it must not be treated as green."
+    )
+    replacement = "**Verdict:** `failed`\n" + notice
+    body = body[: verdict.start()] + replacement + body[verdict.end() :]
+    updated, changes = re.subn(
+        rf"(<!-- {re.escape(STATUS_MARKER)} [^>]*?\bstate=){re.escape(marker['state'])}(?=\s|-->)",
+        r"\1failed",
+        body,
+        count=1,
+    )
+    if changes != 1:
+        raise ReviewError("coverage failure comment marker could not be made terminal")
+    return updated
+
+
+def mark_coverage_unpublished(
+    repo: str,
+    comment_id: int,
+    token: str,
+    review_identity: str,
+    correlation: str,
+    reason: str = "could not be published after three attempts.",
+) -> None:
+    """Make an unpublished status visible where the reviewer result lives."""
+    try:
+        response = requests.get(
+            f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}",
+            headers=github_headers(token),
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        log_phase("coverage-comment-read", status="request-error", correlation=correlation)
+        raise ReviewError("coverage failure comment could not be read") from exc
+    log_phase("coverage-comment-read", status=response.status_code, correlation=correlation)
+    if response.status_code != 200:
+        raise ReviewError("coverage failure comment could not be read")
+    try:
+        body = response.json()["body"]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ReviewError("coverage failure comment had no body") from exc
+    if not isinstance(body, str):
+        raise ReviewError("coverage failure comment had no body")
+    update_comment(
+        repo,
+        comment_id,
+        token,
+        _coverage_publication_failure_body(body, review_identity, reason),
+        correlation,
+    )
+
+
+def publish_review_coverage(
+    repo: str,
+    pr_number: str,
+    token: str,
+    reviewer_sha: str,
+    admitted: PullBinding,
+    comment_id: int,
+    review_identity: str,
+    state: str,
+    complete: bool,
+    run_url: str,
+) -> CoveragePublication:
+    """Publish a current-head verdict, rejecting stale terminal writers."""
+    try:
+        current = get_pull_binding(repo, pr_number, token, reviewer_sha)
+    except (FetchError, requests.RequestException):
+        mark_coverage_unpublished(
+            repo,
+            comment_id,
+            token,
+            review_identity,
+            review_identity,
+            "could not be published because the current pull request could not be read.",
+        )
+        raise
+    newest, scanned = newest_admitted_review(repo, pr_number, token, review_identity)
+    if not scanned or newest is None:
+        mark_coverage_unpublished(
+            repo,
+            comment_id,
+            token,
+            review_identity,
+            review_identity,
+            "could not be published because the newest admitted review could not be confirmed.",
+        )
+        raise ReviewError("could not prove the newest admitted review before publishing coverage")
+    if newest.get("identity") != review_identity:
+        log_phase("coverage-status", status="stale-writer-rejected", correlation=review_identity)
+        return CoveragePublication("stale")
+    try:
+        plan = coverage_plan(state, complete, admitted, current)
+    except ReviewError:
+        mark_coverage_unpublished(
+            repo,
+            comment_id,
+            token,
+            review_identity,
+            review_identity,
+            "could not be published because the admitted review binding was invalid.",
+        )
+        raise
+    if post_coverage_status(repo, token, plan, run_url, review_identity):
+        return CoveragePublication("published", plan)
+    mark_coverage_unpublished(repo, comment_id, token, review_identity, review_identity)
+    raise ReviewError("coverage status could not be published")
+
+
 def _running_marker_is_stale(comment: dict[str, Any]) -> bool:
     """Whether a running marker is too old to belong to a live review job."""
     created = comment.get("created_at")
@@ -1678,6 +1875,9 @@ def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str
                 fields["html_url"] = comment.get("html_url") if isinstance(comment.get("html_url"), str) else ""
                 # Recorded so a baseline can be chosen by when it was written.
                 fields["created_at"] = comment.get("created_at") if isinstance(comment.get("created_at"), str) else ""
+                # GitHub comment IDs increase monotonically. They break a
+                # same-second timestamp tie without trusting API page order.
+                fields["comment_id"] = comment.get("id") if isinstance(comment.get("id"), int) else 0
                 # The ledger rides in the same comment. Absent or malformed, the
                 # marker still counts as a verdict; it simply cannot serve as a
                 # baseline to re-check, which falls back to a full review.
@@ -1692,6 +1892,50 @@ def scan_status_comments(repo: str, pr_number: str, token: str, correlation: str
         if len(comments) < 100:
             return markers, notices, True
     return markers, notices, False
+
+
+def _running_admission_marker(body: str) -> dict[str, str] | None:
+    """Read the minimal marker a freshly admitted review has written."""
+    matches = re.findall(rf"<!-- {re.escape(STATUS_MARKER)} ([^>\r\n]*?)-->", body)
+    if len(matches) != 1:
+        return None
+    fields: dict[str, str] = {}
+    for token in matches[0].split():
+        key, separator, value = token.partition("=")
+        if not separator or not key or key in fields:
+            return None
+        fields[key] = value
+    if fields.get("state") != "running" or not fields.get("identity"):
+        return None
+    return fields
+
+
+def newest_admitted_review(
+    repo: str, pr_number: str, token: str, correlation: str
+) -> tuple[dict[str, Any] | None, bool]:
+    """Return the newest known admission, or incomplete evidence.
+
+    Coverage writers run after reviews have become terminal, so an older writer
+    can overlap a later admission. The comment creation time is the admission
+    order; terminal edit time must not be used because it is exactly the race
+    this check prevents.
+    """
+    terminal, _, terminal_complete = scan_status_comments(repo, pr_number, token, correlation)
+    running, running_complete = find_running_comment(repo, pr_number, token, correlation)
+    if not terminal_complete or not running_complete:
+        return None, False
+    candidates: list[dict[str, Any]] = list(terminal)
+    if isinstance(running, dict):
+        body = running.get("body")
+        fields = _running_admission_marker(body) if isinstance(body, str) else None
+        if fields is None:
+            return None, False
+        fields["created_at"] = running.get("created_at") if isinstance(running.get("created_at"), str) else ""
+        fields["comment_id"] = running.get("id") if isinstance(running.get("id"), int) else 0
+        candidates.append(fields)
+    if not candidates:
+        return None, True
+    return max(candidates, key=lambda marker: (str(marker.get("created_at") or ""), int(marker.get("comment_id") or 0))), True
 
 
 def previously_reported(markers: list[dict[str, str]]) -> set[str]:
@@ -1726,7 +1970,12 @@ def completed_identical_review(markers: list[dict[str, str]], correlation: str, 
     """
     for marker in markers:
         if (
-            marker.get("identity") == correlation
+            # New markers use a fresh per-admission identity so an older
+            # terminal writer cannot impersonate a later admission. The
+            # immutable binding remains the de-duplication key. Older markers
+            # used that binding as their identity and are accepted only for
+            # this optimization.
+            marker.get("binding", marker.get("identity")) == correlation
             and marker.get("mode") == mode
             and marker.get("model") == model_binding(mode)
             and marker.get("state") in COMPLETE_REVIEW_STATES
@@ -2698,7 +2947,7 @@ def head_has_moved(repo: str, pr_number: str, token: str, binding: PullBinding, 
         return False
 
 
-def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None, repository: str | None = None, pr_number: str | None = None) -> str:
+def render_status(binding: PullBinding, mode: str, classification: list[str], progress: ReviewProgress, state: str, manifest: list[dict[str, Any]], seen_before: set[str] | None = None, scope: str = "full", scope_base: str | None = None, repository: str | None = None, pr_number: str | None = None, review_identity: str | None = None) -> str:
     seen_before = seen_before or set()
     # `full` means base..head. `delta` means a prior completed review's head
     # ..head, which is a smaller question and must never be read as a
@@ -2885,7 +3134,11 @@ def render_status(binding: PullBinding, mode: str, classification: list[str], pr
     fingerprints = ",".join(sorted({finding_fingerprint(finding) for finding in findings}))
     marker = {
         "state": state,
-        "identity": binding.correlation,
+        "identity": review_identity or uuid.uuid4().hex,
+        # The unique admission identity prevents stale terminal writers from
+        # clobbering a later review. This binding remains the stable key used
+        # only to decide whether the same immutable review can be skipped.
+        "binding": binding.correlation,
         "mode": mode,
         "model": model_binding(mode),
         "findings": fingerprints,
@@ -2926,8 +3179,9 @@ def workflow_run_url() -> str | None:
     return f"{server}/{repository}/actions/runs/{run_id}"
 
 
-def _initial_status(binding: PullBinding, mode: str) -> str:
+def _initial_status(binding: PullBinding, mode: str, review_identity: str | None = None) -> str:
     deep = mode == "deep"
+    review_identity = review_identity or uuid.uuid4().hex
     run_url = workflow_run_url()
     lines = [
         "## AI PR Review",
@@ -2958,12 +3212,12 @@ def _initial_status(binding: PullBinding, mode: str) -> str:
                 else []
             ),
             f"**Binding:** base `{binding.base_sha}` head `{binding.head_sha}`",
-            f"**Review identity:** `{binding.correlation}`",
+            f"**Review identity:** `{review_identity}`",
             "**Classification:** pending immutable diff fetch",
             "",
             "</details>",
             "",
-            f"<!-- {STATUS_MARKER} state=running identity={binding.correlation} -->",
+            f"<!-- {STATUS_MARKER} state=running identity={review_identity} binding={binding.correlation} mode={mode} model={model_binding(mode)} -->",
         ]
     )
     return "\n".join(lines)
@@ -3035,16 +3289,16 @@ def claim_review(repo: str, pr_number: str, token: str, mode: str, reviewer_sha:
             )
         write_action_outputs(claimed="false")
         return
-    comment = create_comment(repo, pr_number, token, _initial_status(binding, mode), binding.correlation)
+    review_identity = uuid.uuid4().hex
+    comment = create_comment(repo, pr_number, token, _initial_status(binding, mode, review_identity), binding.correlation)
     write_action_outputs(
         claimed="true",
         base_sha=binding.base_sha,
         head_sha=binding.head_sha,
         status_comment_id=str(comment["id"]),
-        # Published so the workflow finalizer matches this exact review identity
-        # instead of rebuilding the string in shell, where it would drift from
-        # the correlation this module writes.
-        correlation=binding.correlation,
+        # Published so finalizers and coverage writers can match this exact
+        # admission rather than a reusable base/head binding.
+        correlation=review_identity,
     )
 
 
@@ -3057,16 +3311,18 @@ def run_review(
     *,
     binding: PullBinding | None = None,
     status_comment_id: int | None = None,
+    review_identity: str | None = None,
 ) -> tuple[str, ReviewProgress]:
     deadline = time.monotonic() + REVIEW_WALL_CLOCK_SECONDS
     binding = binding or get_pull_binding(repo, pr_number, token, reviewer_sha)
+    review_identity = review_identity or uuid.uuid4().hex
     if status_comment_id is None:
         active, scanned = find_running_comment(repo, pr_number, token, binding.correlation)
         if active or not scanned:
             link = active.get("html_url") if isinstance(active, dict) and isinstance(active.get("html_url"), str) else "the existing review status"
             create_comment(repo, pr_number, token, f"A review is already running: {link}", binding.correlation)
             return "already-running", ReviewProgress()
-        comment = create_comment(repo, pr_number, token, _initial_status(binding, mode), binding.correlation)
+        comment = create_comment(repo, pr_number, token, _initial_status(binding, mode, review_identity), binding.correlation)
     else:
         comment = {"id": status_comment_id}
     progress = ReviewProgress()
@@ -3392,6 +3648,7 @@ def run_review(
                     scope_base,
                     repo,
                     pr_number,
+                    review_identity,
                 ),
                 binding.correlation,
             )
@@ -3425,7 +3682,7 @@ def main() -> None:
         or not REPO_PATTERN.fullmatch(repo)
         or not pr_number.isdigit()
         or mode not in {"default", "deep"}
-        or operation not in {"claim", "review"}
+        or operation not in {"claim", "coverage", "review"}
     ):
         print("pr-review phase=configuration attempt=1 status=invalid correlation=pending", file=sys.stderr)
         raise SystemExit(2)
@@ -3433,11 +3690,54 @@ def main() -> None:
         if operation == "claim":
             claim_review(repo, pr_number, github_token, mode, reviewer_sha)
             return
+        if operation == "coverage":
+            base_sha = os.environ.get("BASE_SHA", "")
+            head_sha = os.environ.get("HEAD_SHA", "")
+            comment_id = os.environ.get("STATUS_COMMENT_ID", "")
+            review_identity = os.environ.get("REVIEW_IDENTITY", "")
+            state = os.environ.get("COVERAGE_STATE", "")
+            complete_value = os.environ.get("COVERAGE_COMPLETE", "")
+            run_url = os.environ.get("COVERAGE_RUN_URL", "")
+            if (
+                not all((base_sha, head_sha, comment_id, review_identity, run_url))
+                or not comment_id.isdigit()
+                or not re.fullmatch(r"[0-9a-f]{32}", review_identity)
+                or complete_value not in {"", "true", "false"}
+            ):
+                raise ReviewError("coverage operation received incomplete admission data")
+            publication = publish_review_coverage(
+                repo,
+                pr_number,
+                github_token,
+                reviewer_sha,
+                binding_from_values(base_sha, head_sha, reviewer_sha),
+                int(comment_id),
+                review_identity,
+                state or "failed",
+                complete_value == "true",
+                run_url,
+            )
+            if publication.outcome == "stale":
+                print("pr-review phase=coverage attempt=1 status=stale-writer-rejected correlation=published")
+                return
+            if publication.plan is None:
+                raise ReviewError("coverage publication had no plan")
+            print(
+                f"pr-review phase=coverage attempt=1 status={publication.plan.status} correlation=published"
+            )
+            if publication.plan.gate_exit:
+                raise SystemExit(1)
+            return
         base_sha = os.environ.get("BASE_SHA", "")
         head_sha = os.environ.get("HEAD_SHA", "")
         comment_id = os.environ.get("STATUS_COMMENT_ID", "")
-        if any((base_sha, head_sha, comment_id)):
-            if not all((base_sha, head_sha, comment_id)) or not comment_id.isdigit():
+        review_identity = os.environ.get("REVIEW_IDENTITY", "")
+        if any((base_sha, head_sha, comment_id, review_identity)):
+            if (
+                not all((base_sha, head_sha, comment_id, review_identity))
+                or not comment_id.isdigit()
+                or not re.fullmatch(r"[0-9a-f]{32}", review_identity)
+            ):
                 raise ReviewError("review operation received incomplete admission data")
             state, progress = run_review(
                 repo,
@@ -3447,6 +3747,7 @@ def main() -> None:
                 reviewer_sha,
                 binding=binding_from_values(base_sha, head_sha, reviewer_sha),
                 status_comment_id=int(comment_id),
+                review_identity=review_identity,
             )
         else:
             state, progress = run_review(repo, pr_number, github_token, mode, reviewer_sha)

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -32,6 +32,14 @@ permissions:
   # /review in the repository failed until it was restored. Do not narrow it
   # again without running a real /review against a pull request.
   pull-requests: write
+  # A comment-triggered run contributes NO check to the pull request, because
+  # its workflow run is attached to the default branch rather than the PR. The
+  # completeness job below therefore publishes its verdict as a COMMIT STATUS on
+  # the reviewed head, which does appear in the PR's merge box. Without this a
+  # review that timed out fails its own run while the pull request still reads
+  # all green, and the only surface saying otherwise is prose inside a comment
+  # whose headline is "Findings: 0". Observed on #1523, 2026-09-09.
+  statuses: write
 
 jobs:
   admit:
@@ -258,6 +266,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Publish the verdict where a merge decision is actually made. This runs
+      # BEFORE the gate below so an incomplete review is visible on the pull
+      # request even though the gate then fails this job. A status is used
+      # rather than a check run because a comment-triggered run cannot add a
+      # check to a pull request it is not attached to.
+      #
+      # Failure direction: if the status POST itself fails, this step does not
+      # fail the job. The gate below is still authoritative, and losing the
+      # visibility improvement must not convert into losing the gate.
+      - name: Publish review coverage as a commit status
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATE: ${{ needs.review.outputs.state }}
+          COMPLETE: ${{ needs.review.outputs.complete }}
+          HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          if [ -z "${HEAD_SHA}" ]; then
+            echo "no reviewed head recorded; skipping status" >&2
+            exit 0
+          fi
+          if [ "${COMPLETE}" = "true" ]; then
+            STATUS_STATE=success
+            DESCRIPTION="Review covered the whole diff (${STATE})"
+          else
+            STATUS_STATE=failure
+            DESCRIPTION="Review did NOT cover the whole diff (state=${STATE:-none})"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="${STATUS_STATE}" \
+            -f context="pr-review/coverage" \
+            -f description="${DESCRIPTION}" \
+            -f target_url="${RUN_URL}" >/dev/null
+
       - name: Require a review that covered the whole diff
         env:
           STATE: ${{ needs.review.outputs.state }}

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -49,6 +49,13 @@ jobs:
     concurrency:
       group: pr-review-${{ github.repository }}-${{ inputs.pr_number }}
       cancel-in-progress: false
+      # Without this GitHub keeps only ONE pending job per group and a newly
+      # queued run cancels the pending one, so a second /review can cancel a
+      # queued completeness job before it publishes the coverage status or
+      # finalizes the review comment. That is the same silent-verdict failure
+      # the status exists to remove. `queue: max` is compatible here only
+      # because cancel-in-progress is false; the two cannot be combined.
+      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -274,6 +281,13 @@ jobs:
     concurrency:
       group: pr-review-${{ github.repository }}-${{ inputs.pr_number }}
       cancel-in-progress: false
+      # Without this GitHub keeps only ONE pending job per group and a newly
+      # queued run cancels the pending one, so a second /review can cancel a
+      # queued completeness job before it publishes the coverage status or
+      # finalizes the review comment. That is the same silent-verdict failure
+      # the status exists to remove. `queue: max` is compatible here only
+      # because cancel-in-progress is false; the two cannot be combined.
+      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -266,51 +266,76 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Publish the verdict where a merge decision is actually made. This runs
-      # BEFORE the gate below so an incomplete review is visible on the pull
-      # request even though the gate then fails this job. A status is used
-      # rather than a check run because a comment-triggered run cannot add a
-      # check to a pull request it is not attached to.
+      # ONE step, because splitting them forces a bad trade. A separate
+      # status step that fails would skip the gate entirely, since a failed
+      # step ends the job; making it continue-on-error instead buys the gate
+      # back by hiding a failed publish, and an unnoticed publish failure
+      # recreates the exact invisibility this status exists to remove.
       #
-      # Failure direction: if the status POST itself fails, this step does not
-      # fail the job. The gate below is still authoritative, and losing the
-      # visibility improvement must not convert into losing the gate.
-      - name: Publish review coverage as a commit status
+      # So: compute the verdict, publish it, then exit on the verdict.
+      #
+      # FAILURE DIRECTION, chosen deliberately: if the status cannot be
+      # published after bounded retries, the job FAILS even when the review
+      # itself was complete. An unpublished verdict on a merge-relevant gate
+      # is an unknown verdict, and the honest report of an unknown is red.
+      # The retries exist so a transient API blip does not spend that.
+      - name: Publish review coverage, then require it
         if: always()
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           STATE: ${{ needs.review.outputs.state }}
           COMPLETE: ${{ needs.review.outputs.complete }}
+          REVIEW_RESULT: ${{ needs.review.result }}
           HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          if [ -z "${HEAD_SHA}" ]; then
-            echo "no reviewed head recorded; skipping status" >&2
-            exit 0
-          fi
+
           if [ "${COMPLETE}" = "true" ]; then
             STATUS_STATE=success
             DESCRIPTION="Review covered the whole diff (${STATE})"
+            GATE_EXIT=0
+          elif [ "${STATE}" = "clean" ] || [ "${STATE}" = "findings" ]; then
+            STATUS_STATE=failure
+            DESCRIPTION="Review did not reach the current base; re-run it"
+            GATE_EXIT=1
           else
             STATUS_STATE=failure
-            DESCRIPTION="Review did NOT cover the whole diff (state=${STATE:-none})"
+            DESCRIPTION="Review did NOT finish (state=${STATE:-none})"
+            GATE_EXIT=1
           fi
-          gh api "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="${STATUS_STATE}" \
-            -f context="pr-review/coverage" \
-            -f description="${DESCRIPTION}" \
-            -f target_url="${RUN_URL}" >/dev/null
 
-      - name: Require a review that covered the whole diff
-        env:
-          STATE: ${{ needs.review.outputs.state }}
-          COMPLETE: ${{ needs.review.outputs.complete }}
-          REVIEW_RESULT: ${{ needs.review.result }}
-        run: |
-          set -euo pipefail
-          if [ "${COMPLETE}" = "true" ]; then
+          # A comment-triggered run attaches to the default branch and so
+          # contributes no check to the pull request. A commit status is keyed
+          # to the SHA instead, which is why it reaches the merge box at all.
+          if [ -n "${HEAD_SHA}" ]; then
+            PUBLISHED=false
+            for attempt in 1 2 3; do
+              if gh api "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+                  -f state="${STATUS_STATE}" \
+                  -f context="pr-review/coverage" \
+                  -f description="${DESCRIPTION}" \
+                  -f target_url="${RUN_URL}" >/dev/null; then
+                PUBLISHED=true
+                break
+              fi
+              echo "status publish attempt ${attempt} failed" >&2
+              sleep $((attempt * 5))
+            done
+            if [ "${PUBLISHED}" != "true" ]; then
+              echo "pr-review coverage: could NOT publish the coverage status for ${HEAD_SHA}" >&2
+              echo "The verdict was ${STATUS_STATE} (${DESCRIPTION}), and the pull request will not show it." >&2
+              echo "A verdict nobody can see is the defect this status exists to remove, so this fails." >&2
+              echo "Check that the CALLING workflow grants statuses: write; a called workflow cannot" >&2
+              echo "hold a permission its caller withheld." >&2
+              exit 1
+            fi
+          else
+            echo "no reviewed head recorded; cannot publish a coverage status" >&2
+            exit 1
+          fi
+
+          if [ "${GATE_EXIT}" = "0" ]; then
             echo "pr-review coverage: complete (${STATE})"
             exit 0
           fi

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -176,6 +176,7 @@ jobs:
           base-sha: ${{ needs.admit.outputs.base_sha }}
           head-sha: ${{ needs.admit.outputs.head_sha }}
           status-comment-id: ${{ needs.admit.outputs.status_comment_id }}
+          review-identity: ${{ needs.admit.outputs.correlation }}
           openai-api-key: ${{ secrets.openai_api_key }}
           model-fast: ${{ vars.PR_REVIEW_MODEL_FAST }}
           model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
@@ -196,6 +197,7 @@ jobs:
           base-sha: ${{ needs.admit.outputs.base_sha }}
           head-sha: ${{ needs.admit.outputs.head_sha }}
           status-comment-id: ${{ needs.admit.outputs.status_comment_id }}
+          review-identity: ${{ needs.admit.outputs.correlation }}
           model-fast: ${{ vars.PR_REVIEW_MODEL_FAST }}
           model-deep: ${{ vars.PR_REVIEW_MODEL_DEEP }}
 
@@ -238,7 +240,7 @@ jobs:
           # alone, and the identity check makes this edit only ever land on the
           # comment this run claimed, never on a newer review's.
           case "${body}" in
-            *"<!-- pr-review-status:v1 state=running identity=${IDENTITY} -->"*) ;;
+            *"<!-- pr-review-status:v1 state=running identity=${IDENTITY} "*) ;;
             *) echo "pr-review phase=finalize status=not-ours-or-already-final"; exit 0 ;;
           esac
           profile=""
@@ -261,90 +263,46 @@ jobs:
           echo "pr-review phase=finalize status=closed"
 
   completeness:
-    needs: [admit, review]
+    # The finalizer owns the terminal comment when a review job never reaches
+    # its own final write. Coverage follows it so a publication failure can
+    # always replace a terminal result with an honest visible failure.
+    needs: [admit, review, finalize]
     if: always() && needs.admit.outputs.claimed == 'true'
+    # Share admission's key so its newest-identity read and status write cannot
+    # race a new claim. The Python publisher still rejects stale identities;
+    # the lock narrows the interval and the identity check protects ordering.
+    concurrency:
+      group: pr-review-${{ github.repository }}-${{ inputs.pr_number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # ONE step, because splitting them forces a bad trade. A separate
-      # status step that fails would skip the gate entirely, since a failed
-      # step ends the job; making it continue-on-error instead buys the gate
-      # back by hiding a failed publish, and an unnoticed publish failure
-      # recreates the exact invisibility this status exists to remove.
-      #
-      # So: compute the verdict, publish it, then exit on the verdict.
-      #
-      # FAILURE DIRECTION, chosen deliberately: if the status cannot be
-      # published after bounded retries, the job FAILS even when the review
-      # itself was complete. An unpublished verdict on a merge-relevant gate
-      # is an unknown verdict, and the honest report of an unknown is red.
-      # The retries exist so a transient API blip does not spend that.
+      # The action contains the state-table-tested publisher. It first reads
+      # the current pull binding and newest admission, so an old terminal job
+      # either writes a re-run-needed failure on the current head or rejects
+      # itself without clobbering a newer review's context.
+      - name: Check out immutable Pipelock review source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: luckyPipewrench/pipelock
+          ref: ${{ inputs.reviewer_sha }}
+          path: trusted-pr-review
+          persist-credentials: false
+
       - name: Publish review coverage, then require it
         if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          STATE: ${{ needs.review.outputs.state }}
-          COMPLETE: ${{ needs.review.outputs.complete }}
-          REVIEW_RESULT: ${{ needs.review.result }}
-          HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -uo pipefail
-
-          if [ "${COMPLETE}" = "true" ]; then
-            STATUS_STATE=success
-            DESCRIPTION="Review covered the whole diff (${STATE})"
-            GATE_EXIT=0
-          elif [ "${STATE}" = "clean" ] || [ "${STATE}" = "findings" ]; then
-            STATUS_STATE=failure
-            DESCRIPTION="Review did not reach the current base; re-run it"
-            GATE_EXIT=1
-          else
-            STATUS_STATE=failure
-            DESCRIPTION="Review did NOT finish (state=${STATE:-none})"
-            GATE_EXIT=1
-          fi
-
-          # A comment-triggered run attaches to the default branch and so
-          # contributes no check to the pull request. A commit status is keyed
-          # to the SHA instead, which is why it reaches the merge box at all.
-          if [ -n "${HEAD_SHA}" ]; then
-            PUBLISHED=false
-            for attempt in 1 2 3; do
-              if gh api "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-                  -f state="${STATUS_STATE}" \
-                  -f context="pr-review/coverage" \
-                  -f description="${DESCRIPTION}" \
-                  -f target_url="${RUN_URL}" >/dev/null; then
-                PUBLISHED=true
-                break
-              fi
-              echo "status publish attempt ${attempt} failed" >&2
-              sleep $((attempt * 5))
-            done
-            if [ "${PUBLISHED}" != "true" ]; then
-              echo "pr-review coverage: could NOT publish the coverage status for ${HEAD_SHA}" >&2
-              echo "The verdict was ${STATUS_STATE} (${DESCRIPTION}), and the pull request will not show it." >&2
-              echo "A verdict nobody can see is the defect this status exists to remove, so this fails." >&2
-              echo "Check that the CALLING workflow grants statuses: write; a called workflow cannot" >&2
-              echo "hold a permission its caller withheld." >&2
-              exit 1
-            fi
-          else
-            echo "no reviewed head recorded; cannot publish a coverage status" >&2
-            exit 1
-          fi
-
-          if [ "${GATE_EXIT}" = "0" ]; then
-            echo "pr-review coverage: complete (${STATE})"
-            exit 0
-          fi
-          if [ "${STATE}" = "clean" ] || [ "${STATE}" = "findings" ]; then
-            echo "pr-review coverage: ${STATE}, but the reviewed range does not reach the current base" >&2
-            echo "A review chain covers the whole pull request only while the base it started from is still the base." >&2
-            echo "Re-run the review to cover the range whole." >&2
-            exit 1
-          fi
-          echo "pr-review coverage: NOT complete (state=${STATE:-none}, review job ${REVIEW_RESULT})" >&2
-          echo "The review comment carries the verdict and the reasons it is incomplete." >&2
-          exit 1
+        uses: ./trusted-pr-review/.github/actions/pr-review
+        with:
+          github-token: ${{ secrets.review_token }}
+          repo: ${{ github.repository }}
+          pr-number: ${{ inputs.pr_number }}
+          review-mode: ${{ inputs.review_mode }}
+          reviewer-sha: ${{ inputs.reviewer_sha }}
+          operation: coverage
+          base-sha: ${{ needs.admit.outputs.base_sha }}
+          head-sha: ${{ needs.admit.outputs.head_sha }}
+          status-comment-id: ${{ needs.admit.outputs.status_comment_id }}
+          review-identity: ${{ needs.admit.outputs.correlation }}
+          coverage-state: ${{ needs.review.outputs.state }}
+          coverage-complete: ${{ needs.review.outputs.complete }}
+          coverage-run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -14,6 +14,13 @@ permissions:
   # /review in the repository failed until it was restored. Do not narrow it
   # again without running a real /review against a pull request.
   pull-requests: write
+  # A called workflow cannot hold a permission its caller withheld, so this
+  # must be granted HERE as well as in the reusable workflow. The completeness
+  # job posts a pr-review/coverage commit status on the reviewed head, which is
+  # the only surface a comment-triggered run has on the pull request. Granting
+  # it in one file only means the POST 403s and the status silently never
+  # appears, which is the same invisibility the status exists to remove.
+  statuses: write
 
 jobs:
   review:

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -71,6 +71,10 @@ uses strict JSON output, a cross-file synthesis pass, and a second actual-code
 judge pass before publishing findings. It strips mentions and command-shaped
 text from model-supplied fields.
 
+The coverage status is written against the pull request head that GitHub reports when the review finishes. If the head or base moved, it marks that current head as needing another review. A terminal writer publishes only when its admission is still the newest one, so an older job can't replace a newer verdict.
+
+The publisher makes three total status requests and waits only between attempts. If all three fail, it changes the review comment to `failed` and says the pull request can't show the coverage verdict. That result isn't green.
+
 ## Setup
 
 ### Required GitHub Secret

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -263,10 +263,14 @@ code under the pin. Replace `YOUR_GITHUB_LOGIN` with the login allowed to
 trigger a review, or drop those clauses and rely on `author_association ==
 'OWNER'` alone.
 
-Grant both `issues: write` and `pull-requests: write`. A called workflow cannot
-hold a permission its caller withheld, so dropping either one silently strips it
-from the reviewer rather than failing at load, and the review then ends on a
-permission error when it tries to post.
+Grant `issues: write`, `pull-requests: write`, and `statuses: write`. A called
+workflow cannot hold a permission its caller withheld, so dropping any one of
+them silently strips it from the reviewer rather than failing at load, and the
+review then ends on a permission error when it tries to use it. The first two
+carry the review comment. `statuses: write` carries the `pr-review/coverage`
+commit status, which is the only surface a comment-triggered run has on the pull
+request itself: without it a review that did not finish fails its own run while
+the pull request still shows every check passing.
 
 Personal-account repositories must map each named secret explicitly, because
 `secrets: inherit` is not available to them.
@@ -286,6 +290,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  statuses: write
 
 jobs:
   review:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -290,6 +290,17 @@ class WorkflowPackagingTest(unittest.TestCase):
                 "write",
                 f"{path.name} must set permissions.issues to write",
             )
+            # Same rule, third scope. The completeness job posts a coverage
+            # commit status, which is the only surface a comment-triggered run
+            # has on the pull request. A called workflow cannot hold a
+            # permission its caller withheld, so granting this in the reusable
+            # file alone makes the POST 403 and the status silently never
+            # appear, which is exactly the invisibility it exists to remove.
+            self.assertEqual(
+                permissions.get("statuses"),
+                "write",
+                f"{path.name} must set permissions.statuses to write",
+            )
 
     def test_composite_action_owns_runner_requirements_and_single_provider_inputs(self) -> None:
         action = load_yaml(ACTION_YAML)

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -222,8 +222,9 @@ class WorkflowPackagingTest(unittest.TestCase):
         # review look crashed, or lets an incomplete review show an all-green
         # pull request, which reads as reviewed when it was not.
         completeness = workflow["jobs"]["completeness"]
-        self.assertEqual(completeness["needs"], ["admit", "review"])
+        self.assertEqual(completeness["needs"], ["admit", "review", "finalize"])
         self.assertIn("always()", completeness["if"])
+        self.assertEqual(completeness["concurrency"], admit["concurrency"])
         # Every step that can run a review must feed both outputs. A hard-coded
         # count went stale the moment a provider was removed, and a count is the
         # wrong assertion anyway: it cannot tell which step was dropped. Derive
@@ -312,6 +313,10 @@ class WorkflowPackagingTest(unittest.TestCase):
             "openai-api-key",
             "model-fast",
             "model-deep",
+            "review-identity",
+            "coverage-state",
+            "coverage-complete",
+            "coverage-run-url",
             "reviewed-repository-path",
             "reviewed-merge-base-sha",
         ):
@@ -505,6 +510,108 @@ class ExitSemanticsTest(unittest.TestCase):
             self.assertIsNone(pr_review.main())
             output.seek(0)
             self.assertIn("complete=false", output.read().decode("utf-8"))
+
+
+class CoveragePublicationStateTableTest(unittest.TestCase):
+    """Exercise the terminal publisher rather than only rendering its shell."""
+
+    REVIEWER = "c" * 40
+    IDENTITY = "d" * 32
+
+    @staticmethod
+    def response(status: int) -> object:
+        result = mock.Mock()
+        result.status_code = status
+        return result
+
+    def binding(self, *, base: str = "a" * 40, head: str = "b" * 40) -> object:
+        return pr_review.PullBinding(base, head, self.REVIEWER, pr_review.RUBRIC_VERSION)
+
+    def test_coverage_publication_state_table(self) -> None:
+        admitted = self.binding()
+        cases = (
+            ("success", admitted, "clean", True, self.IDENTITY, "published", "success", "b" * 40, False),
+            ("partial", admitted, "partial", False, self.IDENTITY, "published", "failure", "b" * 40, False),
+            ("moved head", self.binding(), "clean", True, self.IDENTITY, "published", "failure", "e" * 40, False),
+            ("stale terminal writer", admitted, "clean", True, "e" * 32, "stale", None, None, False),
+            ("empty admitted head", self.binding(head=""), "clean", True, self.IDENTITY, "error", None, None, True),
+            ("POST failure", admitted, "clean", True, self.IDENTITY, "error", None, None, True),
+        )
+        for name, captured, state, complete, newest_identity, expected, status, target, raises in cases:
+            with self.subTest(name=name), mock.patch.object(
+                pr_review,
+                "get_pull_binding",
+                return_value=self.binding(head="e" * 40) if name == "moved head" else admitted,
+            ), mock.patch.object(
+                pr_review,
+                "newest_admitted_review",
+                return_value=({"identity": newest_identity}, True),
+            ), mock.patch.object(
+                pr_review,
+                "post_coverage_status",
+                return_value=name != "POST failure",
+            ) as post, mock.patch.object(pr_review, "mark_coverage_unpublished") as mark:
+                if raises:
+                    with self.assertRaises(pr_review.ReviewError):
+                        pr_review.publish_review_coverage(
+                            "owner/repo", "42", "token", self.REVIEWER, captured, 7, self.IDENTITY, state, complete, "https://ci.example/run"
+                        )
+                    mark.assert_called_once()
+                    if name == "empty admitted head":
+                        post.assert_not_called()
+                    continue
+                result = pr_review.publish_review_coverage(
+                    "owner/repo", "42", "token", self.REVIEWER, captured, 7, self.IDENTITY, state, complete, "https://ci.example/run"
+                )
+                self.assertEqual(result.outcome, expected)
+                if expected == "stale":
+                    post.assert_not_called()
+                    mark.assert_not_called()
+                    continue
+                self.assertIsNotNone(result.plan)
+                self.assertEqual(result.plan.status, status)
+                self.assertEqual(result.plan.target_head, target)
+                if name == "moved head":
+                    self.assertIn("superseded", result.plan.description)
+                post.assert_called_once()
+                mark.assert_not_called()
+
+    def test_coverage_retries_exactly_three_times_without_a_final_sleep(self) -> None:
+        plan = pr_review.CoveragePlan("b" * 40, "failure", "Review did NOT finish", 1)
+        with mock.patch.object(
+            pr_review.requests,
+            "post",
+            side_effect=[self.response(503), self.response(502), self.response(201)],
+        ) as post, mock.patch.object(pr_review.time, "sleep") as sleep:
+            self.assertTrue(pr_review.post_coverage_status("owner/repo", "token", plan, "https://ci.example/run", self.IDENTITY))
+        self.assertEqual(post.call_count, 3)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [5, 10])
+
+    def test_status_publication_failure_rewrites_the_terminal_comment(self) -> None:
+        binding = self.binding()
+        progress = pr_review.ReviewProgress(expected_units=1, reviewed_units=1)
+        body = pr_review.render_status(
+            binding,
+            "default",
+            [],
+            progress,
+            "clean",
+            [],
+            review_identity=self.IDENTITY,
+        )
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"body": body}
+        with mock.patch.object(pr_review.requests, "get", return_value=response), mock.patch.object(
+            pr_review, "update_comment"
+        ) as update:
+            pr_review.mark_coverage_unpublished("owner/repo", 7, "token", self.IDENTITY, self.IDENTITY)
+        rewritten = update.call_args.args[3]
+        self.assertIn("**Verdict:** `failed`", rewritten)
+        self.assertIn("could not be published after three attempts", rewritten)
+        marker = pr_review.parse_status_marker(rewritten)
+        self.assertIsNotNone(marker)
+        self.assertEqual(marker["state"], "failed")
 
 
 class CompressionAndClassificationTest(unittest.TestCase):
@@ -1085,11 +1192,12 @@ printf '%s' "$FAKE_BODY"
     def test_finalizer_does_not_depend_on_the_review_checkout(self) -> None:
         # A failed checkout is one of the cases the finalizer exists to survive,
         # so it must not resolve the locally checked-out action.
-        workflow = REUSABLE_WORKFLOW.read_text(encoding="utf-8")
-        finalize = workflow.split("Finalize an abandoned review", 1)[1]
-        self.assertIn("if: always()", finalize)
-        self.assertNotIn("trusted-pr-review", finalize)
-        self.assertIn("needs.admit.outputs.status_comment_id", finalize)
+        workflow = load_yaml(REUSABLE_WORKFLOW)
+        finalizer = workflow["jobs"]["finalize"]
+        rendered = finalizer["steps"][0]["run"]
+        self.assertIn("always()", finalizer["if"])
+        self.assertNotIn("trusted-pr-review", rendered)
+        self.assertEqual(finalizer["steps"][0]["env"]["COMMENT_ID"], "${{ needs.admit.outputs.status_comment_id }}")
 
     def test_finalizer_matches_the_claimed_identity_not_a_rebuilt_one(self) -> None:
         # Rebuilding the identity in shell would drift from PullBinding.correlation,
@@ -3210,7 +3318,8 @@ class RepeatReviewTest(unittest.TestCase):
         fields = pr_review.parse_status_marker(body)
         self.assertIsNotNone(fields)
         self.assertEqual(fields["state"], "findings")
-        self.assertEqual(fields["identity"], binding.correlation)
+        self.assertRegex(fields["identity"], r"^[0-9a-f]{32}$")
+        self.assertEqual(fields["binding"], binding.correlation)
         self.assertEqual(fields["mode"], "deep")
         self.assertEqual(fields["model"], pr_review.model_binding("deep"))
         self.assertEqual(

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2774,6 +2774,31 @@ class StatusPresentationTest(unittest.TestCase):
         self.assertIn("- and 163 more", status)
         self.assertLess(len(status.encode("utf-8")), 2_500)
 
+    def test_partial_findings_count_says_it_is_not_a_count_of_the_diff(self) -> None:
+        # A bare "Findings: high 0, medium 0, low 0" on a review that did not
+        # finish reads as a clean result. On #1523 that is exactly how a
+        # timed-out review was mistaken for a passing one, so the count must
+        # say what it means without opening a collapsed section.
+        progress = pr_review.ReviewProgress(
+            expected_units=10,
+            reviewed_units=4,
+            incomplete_reasons=["wall-clock budget exhausted before the judge pass"],
+        )
+        status = pr_review.render_status(self._binding(), "deep", ["source:go"], progress, "partial", [])
+        lead = status[: status.index("<details>")]
+        self.assertIn("VERIFIED", lead)
+        self.assertIn("did not finish", lead)
+        self.assertNotIn("low 0.", lead)
+
+    def test_complete_findings_count_stays_plain(self) -> None:
+        # The qualifier belongs only on an unfinished review; a completed one
+        # must not acquire hedging that makes a real clean result read as doubt.
+        progress = pr_review.ReviewProgress(expected_units=1, reviewed_units=1)
+        status = pr_review.render_status(self._binding(), "default", ["source:go"], progress, "clean", [])
+        lead = status[: status.index("<details>")]
+        self.assertIn("Findings:** high 0, medium 0, low 0.", lead)
+        self.assertNotIn("VERIFIED", lead)
+
     def test_no_findings_status_is_compact_but_keeps_details_available(self) -> None:
         progress = pr_review.ReviewProgress(expected_units=1, reviewed_units=1)
         status = pr_review.render_status(self._binding(), "default", ["source:go"], progress, "clean", [])


### PR DESCRIPTION
## What changed

A review that could not finish now shows on the pull request, on the commit the pull request currently points at.

The completeness job already computed the right verdict and already failed, and that signal reached nothing. A comment-triggered run is attached to the default branch, so it contributes no check to the pull request, and nothing published a status on the head. The result was a pull request showing every check passing while the review body reported that it had not covered the diff, under a headline reading zero findings.

The job now publishes a `pr-review/coverage` commit status and exits on the same verdict. Publishing and gating are one operation on purpose: a separate status step that fails would end the job before the gate runs, and letting that step tolerate its own failure would hide a failed publish, which is the same invisibility this exists to remove.

Three properties matter more than the status itself.

The status goes to the CURRENT pull-request head rather than the head captured when the review was admitted. A terminal review can be accurate for the commit it read and stale by the time it publishes, and a pull request is evaluated against its current head, so a moved head or base is published as an explicit re-run-needed failure on that current commit instead of leaving it unmarked.

Terminal publication is serialized and checks its own identity against the newest admitted review, so an older queued job rejects itself rather than overwriting a newer verdict on the shared status context.

Every path that cannot publish updates the review comment to say coverage could not be published and must not be read as green. Failing a workflow run that nobody can see is not a fallback, which was the original defect one level up. The publisher also fails closed when it cannot prove it is the newest writer, rather than assuming it is.

Supporting changes: the permission is granted on all three copies of the contract, the caller workflow, the reusable workflow, and the documented stub other repositories copy, because a called workflow cannot hold a permission its caller withheld. A review that ends incomplete now states in its findings line that the count is of verified findings and that the review did not finish. The status is deliberately not a required check, so a red coverage status is visible without blocking a merge.

One reviewer note. This change cannot be exercised by this pull request, because a comment trigger runs the default-branch copy of the workflow. It takes effect on the first `/review` after merge, and the thing to watch is whether the status appears on the head at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coverage verdict reporting for pull request reviews, including whether the review fully covered the current changes.
  * Coverage results are published against the reviewed commit and automatically retried when publication fails.
  * Reviews now identify and reject outdated coverage updates from superseded review runs.
* **Bug Fixes**
  * Partial review results now clearly identify findings counts as unverified.
  * Coverage publication failures mark the review as failed for clearer status visibility.
* **Documentation**
  * Updated setup guidance with required permissions and coverage-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->