### PR TITLE
fix(scanner): allow a SigV4-signed request to its own AWS endpoint

### DIFF
--- a/internal/mcp/mcp_http_reverse.go
+++ b/internal/mcp/mcp_http_reverse.go
@@ -767,7 +767,7 @@ func RunHTTPListenerProxy(
 			recordListenerAdaptiveSignal(clientState.recorder, sig, listenerStateAuditKey())
 		}
 		blockedByForwardedHeaderDLP := func() bool {
-			headerResult := scanMCPListenerHeadersForDLP(r.Context(), r.Header, reqScanner, opts.requestBodyCfg())
+			headerResult := scanMCPListenerHeadersForTarget(r.Context(), r.Header, reqScanner, opts.requestBodyCfg(), upstreamURL)
 			if headerResult == nil {
 				return false
 			}
@@ -1351,7 +1351,7 @@ func RunHTTPListenerProxy(
 		// Scan configured sensitive listener headers for DLP patterns. The
 		// body scanner doesn't see HTTP headers, so an agent could leak
 		// credentials via MCP listener headers without triggering DLP.
-		if headerResult := scanMCPListenerHeadersForDLP(r.Context(), r.Header, reqScanner, opts.requestBodyCfg()); headerResult != nil {
+		if headerResult := scanMCPListenerHeadersForTarget(r.Context(), r.Header, reqScanner, opts.requestBodyCfg(), upstreamURL); headerResult != nil {
 			reason, pattern := listenerHeaderBlockClassification(headerResult)
 			_, _ = fmt.Fprintf(safeLogW, "pipelock: %s in %s header: %s\n", reason, headerResult.header, pattern)
 			emitListenerBlockDecision(mcpListenerBlockDecision{

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -71,7 +71,11 @@ func scanMCPListenerHeadersForTarget(
 				continue
 			}
 			scanVal := value
-			if http.CanonicalHeaderKey(name) == listenerAuthorization {
+			// Same rule as the forward-proxy header scan: a repeated
+			// Authorization header is not valid HTTP, and scrubbing each
+			// value independently would leave both the per-value and the
+			// joined scan with no access-key ID to find.
+			if http.CanonicalHeaderKey(name) == listenerAuthorization && len(values) == 1 {
 				scanVal = scanner.ScrubSigV4AuthorizationForTarget(value, target)
 			}
 			allValues = append(allValues, scanVal)

--- a/internal/mcp/proxy_http.go
+++ b/internal/mcp/proxy_http.go
@@ -39,6 +39,16 @@ func scanMCPListenerHeadersForDLP(
 	sc *scanner.Scanner,
 	cfg *config.RequestBodyScanning,
 ) *mcpListenerHeaderDLPResult {
+	return scanMCPListenerHeadersForTarget(ctx, headers, sc, cfg, "")
+}
+
+func scanMCPListenerHeadersForTarget(
+	ctx context.Context,
+	headers http.Header,
+	sc *scanner.Scanner,
+	cfg *config.RequestBodyScanning,
+	target string,
+) *mcpListenerHeaderDLPResult {
 	if sc == nil {
 		return nil
 	}
@@ -60,8 +70,12 @@ func scanMCPListenerHeadersForDLP(
 			if value == "" {
 				continue
 			}
-			allValues = append(allValues, value)
-			result := sc.ScanTextForDLP(ctx, value)
+			scanVal := value
+			if http.CanonicalHeaderKey(name) == listenerAuthorization {
+				scanVal = scanner.ScrubSigV4AuthorizationForTarget(value, target)
+			}
+			allValues = append(allValues, scanVal)
+			result := sc.ScanTextForDLP(ctx, scanVal)
 			if !result.Clean {
 				return &mcpListenerHeaderDLPResult{header: name, matches: result.Matches}
 			}
@@ -85,7 +99,7 @@ func scanMCPListenerHeadersForDLP(
 				}
 			}
 			if mcpListenerShouldScanHeaderNames(cfg) {
-				result = sc.ScanTextForDLP(ctx, name+value)
+				result = sc.ScanTextForDLP(ctx, name+scanVal)
 				if !result.Clean {
 					return &mcpListenerHeaderDLPResult{header: name, matches: result.Matches}
 				}

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -82,6 +82,11 @@ const (
 
 	invalidFormURLEncodedBody = "invalid application/x-www-form-urlencoded body"
 
+	// headerNameAuthorization is the only header whose value may carry a
+	// structurally validated SigV4 envelope. Proxy-Authorization and custom
+	// headers stay under core DLP even when they look similar.
+	headerNameAuthorization = "Authorization"
+
 	// bodyDLPJoinSeparator preserves cross-field token/key DLP because the
 	// scanner's dot-collapse pass removes dots, but it prevents phrase-based
 	// detectors like BIP-39 from synthesizing mnemonics across unrelated JSON
@@ -1876,6 +1881,17 @@ func isNoisyHeaderName(name string) bool {
 	return false
 }
 
+// headerValueForDLP returns the value that header DLP should scan. A
+// structurally valid SigV4 Authorization envelope to an AWS endpoint has
+// only its access-key ID replaced; the forwarded header is unchanged.
+// Every other header, destination, or malformed envelope is scanned as-is.
+func headerValueForDLP(name, value, target string) string {
+	if http.CanonicalHeaderKey(name) != headerNameAuthorization {
+		return value
+	}
+	return scanner.ScrubSigV4AuthorizationForTarget(value, target)
+}
+
 // scanRequestHeaders scans HTTP request headers for DLP patterns.
 // Two modes: "sensitive" scans only listed headers; "all" scans everything
 // except the ignore list. Headers are scanned regardless of destination
@@ -1990,15 +2006,16 @@ func scanRequestHeadersWithAudience(ctx context.Context, headers http.Header, cf
 		}
 
 		for _, v := range values {
-			allValues = append(allValues, v)
-			result := sc.ScanTextForDLP(ctx, v)
+			scanVal := headerValueForDLP(name, v, target)
+			allValues = append(allValues, scanVal)
+			result := sc.ScanTextForDLP(ctx, scanVal)
 			if !result.Clean {
 				addMatches(name, result.Matches)
 			}
 			// In "all" mode, scan name+value concatenation to catch secrets
 			// split across the header name:value boundary.
 			if bodyCfg.HeaderMode == config.HeaderModeAll {
-				combined := name + v
+				combined := name + scanVal
 				combinedResult := sc.ScanTextForDLP(ctx, combined)
 				if !combinedResult.Clean {
 					addMatches(name, combinedResult.Matches)

--- a/internal/proxy/bodyscan.go
+++ b/internal/proxy/bodyscan.go
@@ -1885,8 +1885,15 @@ func isNoisyHeaderName(name string) bool {
 // structurally valid SigV4 Authorization envelope to an AWS endpoint has
 // only its access-key ID replaced; the forwarded header is unchanged.
 // Every other header, destination, or malformed envelope is scanned as-is.
-func headerValueForDLP(name, value, target string) string {
+// A repeated Authorization header is not valid HTTP and no AWS SDK emits one,
+// so valueCount above one means the carve-out does not apply: scrubbing each
+// value independently would leave the per-value AND joined scans with no
+// access-key ID to find.
+func headerValueForDLP(name, value, target string, valueCount int) string {
 	if http.CanonicalHeaderKey(name) != headerNameAuthorization {
+		return value
+	}
+	if valueCount != 1 {
 		return value
 	}
 	return scanner.ScrubSigV4AuthorizationForTarget(value, target)
@@ -2006,7 +2013,7 @@ func scanRequestHeadersWithAudience(ctx context.Context, headers http.Header, cf
 		}
 
 		for _, v := range values {
-			scanVal := headerValueForDLP(name, v, target)
+			scanVal := headerValueForDLP(name, v, target, len(values))
 			allValues = append(allValues, scanVal)
 			result := sc.ScanTextForDLP(ctx, scanVal)
 			if !result.Clean {

--- a/internal/proxy/sigv4_header_test.go
+++ b/internal/proxy/sigv4_header_test.go
@@ -129,3 +129,46 @@ func TestScanRequestHeaders_SigV4CarveOutIsAuthorizationOnly(t *testing.T) {
 	requireSigV4HeaderBlocked(t, headers, sigV4HeaderAWSTarget,
 		"Proxy-Authorization is not the SigV4 signing header")
 }
+
+func TestScanRequestHeaders_SigV4CarveOutRequiresEncryptedTransport(t *testing.T) {
+	// A real AWS API call is always TLS. Over cleartext the forwarded header
+	// puts the key id on the wire in the clear, so the carve-out must not
+	// apply even though the hostname is AWS-issued.
+	for _, target := range []string{
+		"http://sts.us-east-1.amazonaws.com/",
+		"ws://sts.us-east-1.amazonaws.com/",
+		"HTTP://sts.us-east-1.amazonaws.com/",
+	} {
+		t.Run(target, func(t *testing.T) {
+			headers := http.Header{}
+			headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+			requireSigV4HeaderBlocked(t, headers, target,
+				"a cleartext destination must stay under core DLP")
+		})
+	}
+}
+
+func TestScanRequestHeaders_SigV4CarveOutRequiresASingleAuthorizationValue(t *testing.T) {
+	// Scrubbing each value independently would leave the per-value and the
+	// joined scans with no key id to find, so a repeated header disables the
+	// carve-out entirely.
+	headers := http.Header{}
+	headers.Add("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+	headers.Add("Authorization", buildSigV4Authorization(sigV4HeaderTestAltKey()))
+
+	requireSigV4HeaderBlocked(t, headers, sigV4HeaderAWSTarget,
+		"a repeated Authorization header must disable the carve-out")
+}
+
+func TestScanRequestHeaders_SigV4EnvelopeStillAllowedOverTLS(t *testing.T) {
+	// Guards against over-tightening: the single legitimate shape must still
+	// pass, or the fix above has re-broken what this change set out to fix.
+	headers := http.Header{}
+	headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+	headers.Set("X-Amz-Date", sigV4HeaderTestDate)
+
+	result := scanSigV4Headers(t, headers, sigV4HeaderAWSTarget)
+	if result != nil && !result.Clean {
+		t.Fatalf("a single TLS-bound SigV4 header was blocked: %+v", result)
+	}
+}

--- a/internal/proxy/sigv4_header_test.go
+++ b/internal/proxy/sigv4_header_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+const (
+	sigV4HeaderTestDate       = "20260512T173720Z"
+	sigV4HeaderTestScope      = "20260512/us-east-1/sts/aws4_request"
+	sigV4HeaderTestSignature  = "4667401eda326e25245738e62377c28e0bc120b1fbcab22896f1cc85eb4d2e89"
+	sigV4HeaderAWSTarget      = "https://sts.us-east-1.amazonaws.com/"
+	sigV4HeaderAttackerTarget = "https://attacker.example/exfil"
+)
+
+func sigV4HeaderTestKey() string {
+	return "AKIA" + "IOSFODNN7EXAMPLE"
+}
+
+func sigV4HeaderTestAltKey() string {
+	return "ASIA" + "Z5MHFQGAEXAMPLE1"
+}
+
+func buildSigV4Authorization(keyID string) string {
+	return "AWS4-HMAC-SHA256 Credential=" + keyID + "/" + sigV4HeaderTestScope +
+		", SignedHeaders=host;x-amz-date, Signature=" + sigV4HeaderTestSignature
+}
+
+func scanSigV4Headers(t *testing.T, headers http.Header, target string) *BodyScanResult {
+	t.Helper()
+	cfg := testScannerConfig()
+	cfg.RequestBodyScanning.Action = config.ActionBlock
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+	return scanRequestHeadersForTarget(context.Background(), headers, cfg, sc, target)
+}
+
+func TestScanRequestHeaders_SigV4AuthorizationEnvelopeAllowsAWSDestination(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+	headers.Set("X-Amz-Date", sigV4HeaderTestDate)
+
+	result := scanSigV4Headers(t, headers, sigV4HeaderAWSTarget)
+	if result != nil && !result.Clean {
+		t.Fatalf("legitimate SigV4 Authorization to AWS was blocked: %+v", result)
+	}
+}
+
+// requireSigV4HeaderBlocked asserts the header set is blocked. The allow test
+// above cannot detect a carve-out that is too broad, so every deny case below
+// is what actually constrains the change.
+func requireSigV4HeaderBlocked(t *testing.T, headers http.Header, target, why string) {
+	t.Helper()
+	result := scanSigV4Headers(t, headers, target)
+	if result == nil || result.Clean {
+		t.Fatalf("%s: expected a block, got clean (result=%+v)", why, result)
+	}
+}
+
+func TestScanRequestHeaders_SigV4EnvelopeBlockedAtNonAWSDestination(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+	headers.Set("X-Amz-Date", sigV4HeaderTestDate)
+
+	requireSigV4HeaderBlocked(t, headers, sigV4HeaderAttackerTarget,
+		"a structurally perfect envelope aimed at an attacker host is an exfiltration channel, not a signed AWS call")
+}
+
+func TestScanRequestHeaders_SigV4EnvelopeBlockedWhenTargetUnknown(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+
+	requireSigV4HeaderBlocked(t, headers, "",
+		"an unresolvable destination must fail closed rather than inherit the carve-out")
+}
+
+func TestScanRequestHeaders_MalformedSigV4EnvelopeBlockedAtAWSDestination(t *testing.T) {
+	// Reaching an AWS host is necessary but not sufficient: the envelope still
+	// has to validate, or a bare key ID could ride to AWS wearing the scheme.
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"scheme_only", "AWS4-HMAC-SHA256 Credential=" + sigV4HeaderTestKey()},
+		{"lowercase_scheme", "aws4-hmac-sha256 Credential=" + sigV4HeaderTestKey() +
+			"/" + sigV4HeaderTestScope + ", SignedHeaders=host, Signature=" + sigV4HeaderTestSignature},
+		{"truncated_signature", "AWS4-HMAC-SHA256 Credential=" + sigV4HeaderTestKey() +
+			"/" + sigV4HeaderTestScope + ", SignedHeaders=host, Signature=dead"},
+		{"bare_key_id", sigV4HeaderTestKey()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := http.Header{}
+			headers.Set("Authorization", tc.value)
+			requireSigV4HeaderBlocked(t, headers, sigV4HeaderAWSTarget,
+				"malformed envelope to AWS must stay under core DLP")
+		})
+	}
+}
+
+func TestScanRequestHeaders_SigV4CarveOutIsNotASmugglingChannel(t *testing.T) {
+	// A valid envelope must not launder a second credential travelling beside
+	// it. This is the case that distinguishes a narrow carve-out from a hole.
+	headers := http.Header{}
+	headers.Set("Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+	headers.Set("X-Amz-Date", sigV4HeaderTestDate)
+	// X-Api-Key is in the default sensitive-header set, so this exercises the
+	// carve-out rather than the header-mode config. A header outside that set
+	// is not scanned at all, which would make this test pass for the wrong
+	// reason.
+	headers.Set("X-Api-Key", sigV4HeaderTestAltKey())
+
+	requireSigV4HeaderBlocked(t, headers, sigV4HeaderAWSTarget,
+		"a second access key in another scanned header must still block")
+}
+
+func TestScanRequestHeaders_SigV4CarveOutIsAuthorizationOnly(t *testing.T) {
+	// The carve-out is scoped to Authorization. A lookalike header carrying the
+	// same envelope has no signing role and must not inherit the exemption.
+	headers := http.Header{}
+	headers.Set("Proxy-Authorization", buildSigV4Authorization(sigV4HeaderTestKey()))
+
+	requireSigV4HeaderBlocked(t, headers, sigV4HeaderAWSTarget,
+		"Proxy-Authorization is not the SigV4 signing header")
+}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -1192,7 +1192,11 @@ func (p *Proxy) dlpScanWSHeaders(ctx context.Context, headers http.Header, sc *s
 		if val == "" {
 			continue
 		}
-		result := sc.ScanTextForDLP(ctx, val)
+		scanVal := val
+		if key == "Authorization" {
+			scanVal = scanner.ScrubSigV4AuthorizationForTarget(val, targetURL)
+		}
+		result := sc.ScanTextForDLP(ctx, scanVal)
 		if !result.Clean {
 			matches, allows := sc.FilterTextDLPMatchesForDestination(result.Matches, targetURL, "header")
 			for _, allow := range allows {

--- a/internal/scanner/sigv4.go
+++ b/internal/scanner/sigv4.go
@@ -10,31 +10,44 @@ import (
 	"strings"
 )
 
-// AWS Signature Version 4 (SigV4) presigned URL carve-out.
+// AWS Signature Version 4 (SigV4) credential carve-out.
 //
-// A presigned URL embeds an AWS access-key ID inside the X-Amz-Credential
-// query parameter. The full URL is a scoped bearer capability for a single
-// S3 object until X-Amz-Expires elapses. Pipelock's core AWS Access ID DLP
-// pattern matches that AKIA and blocks the GET, even though the request is
-// going to the issuer's own S3 host and the credential is the operating
-// mechanism, not a leaked long-lived key.
+// AWS signed requests carry an access-key ID in two operating-mechanism
+// forms. A presigned URL embeds it in the X-Amz-Credential query parameter.
+// A live SDK/CLI call puts it in the Authorization header:
+//
+//	Authorization: AWS4-HMAC-SHA256 Credential=AKIA.../<scope>,
+//	               SignedHeaders=host;x-amz-date, Signature=<64 hex>
+//
+// Pipelock's core AWS Access ID DLP pattern matches that AKIA and would
+// otherwise block every signed request, even though the request is going
+// to the issuer's own AWS endpoint and the credential is the signing
+// envelope, not a leaked long-lived key.
 //
 // The carve-out is intentionally narrow:
 //
-//   - All six mandatory SigV4 query parameters must validate structurally
-//     and appear exactly once: X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date,
-//     X-Amz-Signature, X-Amz-Expires, X-Amz-SignedHeaders. The signed-header
-//     list must be well-formed and include host. Duplicate structural fields
-//     fall back to normal DLP scanning so a duplicate credential cannot be
-//     hidden by the scrub pass and an attacker cannot silence the long-expiry
-//     warn by pinning the scanner's view to a short value.
+//   - Presigned URLs: all six mandatory SigV4 query parameters must validate
+//     structurally and appear exactly once: X-Amz-Algorithm, X-Amz-Credential,
+//     X-Amz-Date, X-Amz-Signature, X-Amz-Expires, X-Amz-SignedHeaders. The
+//     signed-header list must be well-formed and include host. Duplicate
+//     structural fields fall back to normal DLP scanning so a duplicate
+//     credential cannot be hidden by the scrub pass and an attacker cannot
+//     silence the long-expiry warn by pinning the scanner's view to a short
+//     value.
+//   - Authorization headers: the value must be a well-formed AWS4-HMAC-SHA256
+//     envelope whose Credential, SignedHeaders, and Signature fields each
+//     appear exactly once and pass the same structural checks as the query
+//     form (minus X-Amz-Expires, which is a presigned-URL lifetime, not a
+//     header field). Malformed, truncated, duplicated, or partial envelopes
+//     stay under core DLP. The carve-out applies only to the Authorization
+//     header, never Proxy-Authorization or a lookalike in another header.
 //   - The destination host must match an AWS-published amazonaws.com
-//     hostname. The carve-out is for legitimate fetches to the issuer's
-//     own S3 endpoint; a SigV4-shaped URL to an attacker host is not
-//     evidence of legitimacy because pipelock cannot verify the HMAC.
+//     hostname. The carve-out is for legitimate requests to the issuer's
+//     own AWS endpoint; a SigV4-shaped URL or header to an attacker host is
+//     not evidence of legitimacy because pipelock cannot verify the HMAC.
 //   - The AKIA exemption applies ONLY to the access-key component of a
-//     parsed X-Amz-Credential value. AKIA anywhere else in the URL (path,
-//     hostname, other query params, subsequence-concatenated values) still
+//     parsed credential scope. AKIA anywhere else (path, hostname, other
+//     query params, other headers, subsequence-concatenated values) still
 //     blocks with ClassThreat.
 //   - The carve-out result is ClassStructuralExemption - adaptive-neutral,
 //     not clean-decay. A burst of legitimate presigned fetches must not
@@ -89,6 +102,13 @@ const (
 	// ASCII does not match the core AWS Access ID regex, which anchors
 	// on uppercase prefixes (AKIA, ASIA, …).
 	sigV4AccessKeyPlaceholderRune = 'a'
+
+	// SigV4 Authorization header field names. Exact case; a lowercase or
+	// mixed-case lookalike is not a well-formed envelope and stays under
+	// core DLP.
+	sigV4AuthFieldCredential    = "Credential"
+	sigV4AuthFieldSignedHeaders = "SignedHeaders"
+	sigV4AuthFieldSignature     = "Signature"
 )
 
 // sigV4CredentialQueryKey is the URL-encoded representation of the
@@ -190,27 +210,11 @@ func detectValidSigV4(parsed *url.URL) sigV4Detection {
 		return sigV4Detection{}
 	}
 
-	cred := params["X-Amz-Credential"]
-	if cred == "" {
+	keyID, credDate, ok := parseSigV4Credential(params["X-Amz-Credential"])
+	if !ok {
 		return sigV4Detection{}
 	}
-	parts := strings.Split(cred, "/")
-	if len(parts) != sigV4CredentialScopeSegments {
-		return sigV4Detection{}
-	}
-	if parts[sigV4CredentialScopeSegments-1] != sigV4CredentialScopeTerminator {
-		return sigV4Detection{}
-	}
-	if !sigV4AccessKeyAnchored.MatchString(parts[0]) {
-		return sigV4Detection{}
-	}
-	if !sigV4ScopeDateRe.MatchString(parts[1]) {
-		return sigV4Detection{}
-	}
-	if parts[1] != date[:8] {
-		return sigV4Detection{}
-	}
-	if parts[2] == "" || parts[3] == "" {
+	if credDate != date[:8] {
 		return sigV4Detection{}
 	}
 
@@ -227,7 +231,35 @@ func detectValidSigV4(parsed *url.URL) sigV4Detection {
 		return sigV4Detection{}
 	}
 
-	return sigV4Detection{Valid: true, KeyID: parts[0], Expires: expires}
+	return sigV4Detection{Valid: true, KeyID: keyID, Expires: expires}
+}
+
+// parseSigV4Credential validates the five-segment SigV4 credential scope
+// shared by X-Amz-Credential query values and Authorization Credential=
+// fields: <key>/<date>/<region>/<service>/aws4_request. Empty region or
+// service, the wrong segment count, or a non-exact access-key ID fail
+// closed so the caller leaves the value for core DLP.
+func parseSigV4Credential(cred string) (keyID, date string, ok bool) {
+	if cred == "" {
+		return "", "", false
+	}
+	parts := strings.Split(cred, "/")
+	if len(parts) != sigV4CredentialScopeSegments {
+		return "", "", false
+	}
+	if parts[sigV4CredentialScopeSegments-1] != sigV4CredentialScopeTerminator {
+		return "", "", false
+	}
+	if !sigV4AccessKeyAnchored.MatchString(parts[0]) {
+		return "", "", false
+	}
+	if !sigV4ScopeDateRe.MatchString(parts[1]) {
+		return "", "", false
+	}
+	if parts[2] == "" || parts[3] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 func validSigV4SignedHeaders(raw string) bool {
@@ -423,4 +455,124 @@ func scrubEmbeddedSigV4Credentials(text string) (string, []sigV4Detection) {
 		return scrubSigV4Credential(parsed, detection.KeyID).String()
 	})
 	return scrubbed, detections
+}
+
+// ScrubSigV4AuthorizationForTarget returns a scan-only copy of value with the
+// access-key ID replaced by a same-length lowercase placeholder when target
+// is an AWS-issued endpoint and value is a structurally valid SigV4
+// Authorization envelope. Callers must keep the original value for
+// forwarding. Any other destination or any malformed envelope is returned
+// unchanged so core DLP still sees the access-key ID.
+func ScrubSigV4AuthorizationForTarget(value, target string) string {
+	host := ""
+	if target != "" {
+		parsed, err := url.Parse(target)
+		if err == nil {
+			host = parsed.Hostname()
+		}
+	}
+	if !isAWSEndpointHost(host) {
+		return value
+	}
+	detection := detectValidSigV4Authorization(value)
+	if !detection.Valid {
+		return value
+	}
+	return scrubSigV4Authorization(value, detection.KeyID)
+}
+
+// detectValidSigV4Authorization reports whether value is a well-formed SigV4
+// Authorization envelope. Strict by design: the scheme must be the canonical
+// AWS4-HMAC-SHA256 token, and Credential, SignedHeaders, and Signature must
+// each appear exactly once with no unknown fields. This does not prove the
+// HMAC; pipelock has no AWS credentials to verify it.
+func detectValidSigV4Authorization(value string) sigV4Detection {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, sigV4AlgorithmValue) {
+		return sigV4Detection{}
+	}
+	rest := value[len(sigV4AlgorithmValue):]
+	if rest == "" {
+		return sigV4Detection{}
+	}
+	switch rest[0] {
+	case ' ', '\t':
+	default:
+		return sigV4Detection{}
+	}
+	rest = strings.TrimSpace(rest)
+	fields, ok := extractSigV4AuthorizationFields(rest)
+	if !ok || len(fields) != 3 {
+		return sigV4Detection{}
+	}
+	// extractSigV4AuthorizationFields admits only the three known keys and
+	// rejects duplicates, so exactly three fields means all three are present.
+	cred := fields[sigV4AuthFieldCredential]
+	signed := fields[sigV4AuthFieldSignedHeaders]
+	sig := fields[sigV4AuthFieldSignature]
+	if !sigV4SignatureRe.MatchString(sig) {
+		return sigV4Detection{}
+	}
+	if !validSigV4SignedHeaders(signed) {
+		return sigV4Detection{}
+	}
+	keyID, _, ok := parseSigV4Credential(cred)
+	if !ok {
+		return sigV4Detection{}
+	}
+	return sigV4Detection{Valid: true, KeyID: keyID}
+}
+
+// extractSigV4AuthorizationFields walks the comma-separated k=v tail of a
+// SigV4 Authorization value. Keys are compared byte-for-byte against the
+// canonical field names. Duplicate known fields, unknown fields, missing
+// equals, or empty names/values fail closed.
+func extractSigV4AuthorizationFields(rest string) (map[string]string, bool) {
+	known := map[string]struct{}{
+		sigV4AuthFieldCredential:    {},
+		sigV4AuthFieldSignedHeaders: {},
+		sigV4AuthFieldSignature:     {},
+	}
+	out := map[string]string{}
+	if rest == "" {
+		return nil, false
+	}
+	for _, part := range strings.Split(rest, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, false
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return nil, false
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			return nil, false
+		}
+		if _, isKnown := known[key]; !isKnown {
+			return nil, false
+		}
+		if _, dup := out[key]; dup {
+			return nil, false
+		}
+		out[key] = value
+	}
+	return out, true
+}
+
+// scrubSigV4Authorization replaces the single access-key ID span in a
+// previously validated Authorization envelope. If the key ID is absent,
+// duplicated, or the wrong length, the original value is returned so core
+// DLP still sees it.
+func scrubSigV4Authorization(value, akia string) string {
+	if value == "" || akia == "" || len(akia) != sigV4AccessKeyLength {
+		return value
+	}
+	if strings.Count(value, akia) != 1 {
+		return value
+	}
+	placeholder := strings.Repeat(string(sigV4AccessKeyPlaceholderRune), len(akia))
+	return strings.Replace(value, akia, placeholder, 1)
 }

--- a/internal/scanner/sigv4.go
+++ b/internal/scanner/sigv4.go
@@ -149,10 +149,17 @@ var (
 	// cannot verify the HMAC of a SigV4 URL, so structural validity alone
 	// is not evidence of legitimacy: a presigned-looking URL pointing at
 	// an attacker host would let an attacker exfiltrate an AKIA-shaped
-	// value via the scrub-then-fetch path. *.amazonaws.com is registered
-	// to AWS and cannot be claimed by a third party, so the suffix gate is
-	// effective. Path-style and virtual-hosted S3, FIPS, and access-point
-	// hostnames all live under this suffix.
+	// value via the scrub-then-fetch path. The suffix is registered to AWS,
+	// so a third party cannot claim the DOMAIN - but this gate is weaker
+	// than that fact suggests, and the difference matters. S3 bucket names
+	// become hostnames under it and anyone with an AWS account can register
+	// one, so a request to a bucket an attacker controls satisfies this
+	// gate. What the gate rules out is an arbitrary attacker-operated
+	// origin; it does not establish that the destination belongs to the
+	// operator. Deciding WHICH AWS destinations an agent may reach is
+	// destination policy, not DLP. Path-style and virtual-hosted S3, FIPS,
+	// and access-point hostnames all live under this suffix, which is why
+	// the gate cannot simply demand a service-shaped hostname.
 	sigV4AmazonHostSuffixes = []string{
 		".amazonaws.com",
 		".amazonaws.com.cn", // AWS China regions
@@ -341,6 +348,18 @@ func extractSigV4FieldsLiteralKeyed(rawQuery string) (map[string]string, bool) {
 // known AWS-issued DNS suffixes. The match is case-insensitive and
 // requires a true suffix (not a substring), so attacker-controlled hosts
 // like example.com.evil.tld cannot impersonate an AWS endpoint.
+// sigV4EncryptedScheme reports whether the destination scheme protects the
+// forwarded Authorization header in transit. An empty, unknown, or cleartext
+// scheme is not evidence of protection and fails closed.
+func sigV4EncryptedScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "https", "wss":
+		return true
+	default:
+		return false
+	}
+}
+
 func isAWSEndpointHost(hostname string) bool {
 	if hostname == "" {
 		return false
@@ -465,11 +484,20 @@ func scrubEmbeddedSigV4Credentials(text string) (string, []sigV4Detection) {
 // unchanged so core DLP still sees the access-key ID.
 func ScrubSigV4AuthorizationForTarget(value, target string) string {
 	host := ""
+	scheme := ""
 	if target != "" {
 		parsed, err := url.Parse(target)
 		if err == nil {
 			host = parsed.Hostname()
+			scheme = parsed.Scheme
 		}
+	}
+	// A real AWS API call is always over TLS. Over cleartext the forwarded
+	// header would put the access-key ID on the wire in the clear, so an
+	// http:// or ws:// destination keeps the value under core DLP even when
+	// the hostname is AWS-issued.
+	if !sigV4EncryptedScheme(scheme) {
+		return value
 	}
 	if !isAWSEndpointHost(host) {
 		return value

--- a/internal/scanner/sigv4_header_test.go
+++ b/internal/scanner/sigv4_header_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+func buildSigV4Authorization(keyID string) string {
+	return sigV4AlgorithmValue + " Credential=" + keyID + "/" + validSigV4Scope +
+		", SignedHeaders=host;x-amz-date, Signature=" + validSigV4Signature
+}
+
+func TestDetectValidSigV4Authorization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		value     string
+		wantValid bool
+		wantKeyID string
+	}{
+		{
+			name:      "valid_AKIA_envelope",
+			value:     buildSigV4Authorization(fakeAKIAExample),
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:      "valid_ASIA_envelope",
+			value:     buildSigV4Authorization(fakeASIAExample),
+			wantValid: true,
+			wantKeyID: fakeASIAExample,
+		},
+		{
+			name:      "leading_and_trailing_whitespace",
+			value:     "  " + buildSigV4Authorization(fakeAKIAExample) + "\t",
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:      "tab_after_scheme",
+			value:     sigV4AlgorithmValue + "\tCredential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature,
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:      "spaces_around_equals_and_commas",
+			value:     sigV4AlgorithmValue + " Credential = " + fakeAKIAExample + "/" + validSigV4Scope + " , SignedHeaders = host;x-amz-date , Signature = " + validSigV4Signature,
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:      "field_order_signature_first",
+			value:     sigV4AlgorithmValue + " Signature=" + validSigV4Signature + ", SignedHeaders=host, Credential=" + fakeAKIAExample + "/" + validSigV4Scope,
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:      "no_space_after_commas",
+			value:     sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ",SignedHeaders=host,Signature=" + validSigV4Signature,
+			wantValid: true,
+			wantKeyID: fakeAKIAExample,
+		},
+		{
+			name:  "lowercase_scheme",
+			value: "aws4-hmac-sha256 Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "missing_space_after_scheme",
+			value: sigV4AlgorithmValue + "Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "lowercase_credential_field",
+			value: sigV4AlgorithmValue + " credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "missing_signature",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host",
+		},
+		{
+			name:  "missing_credential",
+			value: sigV4AlgorithmValue + " SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "missing_signed_headers",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "scope_four_segments",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/20260512/us-east-1/sts, SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "empty_region",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/20260512//sts/aws4_request, SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "empty_service",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/20260512/us-east-1//aws4_request, SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "wrong_terminator",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/20260512/us-east-1/sts/aws3_request, SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "short_signature",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=abc123",
+		},
+		{
+			name:  "long_signature",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature + "aa",
+		},
+		{
+			name:  "non_hex_signature",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + strings.Repeat("g", 64),
+		},
+		{
+			name:  "duplicate_credential",
+			value: buildSigV4Authorization(fakeAKIAExample) + ", Credential=" + fakeASIAExample + "/" + validSigV4Scope,
+		},
+		{
+			name:  "duplicate_signature",
+			value: buildSigV4Authorization(fakeAKIAExample) + ", Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "unknown_field",
+			value: buildSigV4Authorization(fakeAKIAExample) + ", Token=extra",
+		},
+		{
+			name:  "trailing_comma",
+			value: buildSigV4Authorization(fakeAKIAExample) + ",",
+		},
+		{
+			name:  "signed_headers_without_host",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=x-amz-date, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "key_id_in_signed_headers",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "/" + validSigV4Scope + ", SignedHeaders=host;" + fakeAKIAExample + ", Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "overlong_access_key",
+			value: sigV4AlgorithmValue + " Credential=" + fakeAKIAExample + "EXTRA/" + validSigV4Scope + ", SignedHeaders=host, Signature=" + validSigV4Signature,
+		},
+		{
+			name:  "second_key_appended_after_envelope",
+			value: buildSigV4Authorization(fakeAKIAExample) + " " + fakeASIAExample,
+		},
+		{
+			name:  "bearer_not_sigv4",
+			value: "Bearer " + fakeAKIAExample,
+		},
+		{
+			name:  "empty",
+			value: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectValidSigV4Authorization(tc.value)
+			if got.Valid != tc.wantValid {
+				t.Fatalf("Valid = %v, want %v (value=%q)", got.Valid, tc.wantValid, tc.value)
+			}
+			if got.KeyID != tc.wantKeyID {
+				t.Fatalf("KeyID = %q, want %q", got.KeyID, tc.wantKeyID)
+			}
+		})
+	}
+}
+
+func TestScrubSigV4Authorization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("replaces_only_the_access_key", func(t *testing.T) {
+		t.Parallel()
+		raw := buildSigV4Authorization(fakeAKIAExample)
+		got := scrubSigV4Authorization(raw, fakeAKIAExample)
+		if strings.Contains(got, fakeAKIAExample) {
+			t.Fatalf("scrubbed value still contains access key: %q", got)
+		}
+		placeholder := strings.Repeat(string(sigV4AccessKeyPlaceholderRune), sigV4AccessKeyLength)
+		if !strings.Contains(got, "Credential="+placeholder+"/") {
+			t.Fatalf("scrubbed value missing placeholder credential: %q", got)
+		}
+		if !strings.Contains(got, validSigV4Signature) {
+			t.Fatal("scrub removed the signature")
+		}
+	})
+
+	t.Run("duplicate_key_id_refuses_to_scrub", func(t *testing.T) {
+		t.Parallel()
+		raw := buildSigV4Authorization(fakeAKIAExample) + " " + fakeAKIAExample
+		got := scrubSigV4Authorization(raw, fakeAKIAExample)
+		if got != raw {
+			t.Fatalf("duplicate key ID was scrubbed: %q", got)
+		}
+	})
+
+	t.Run("empty_or_wrong_length_key_refuses_to_scrub", func(t *testing.T) {
+		t.Parallel()
+		raw := buildSigV4Authorization(fakeAKIAExample)
+		if got := scrubSigV4Authorization(raw, ""); got != raw {
+			t.Fatalf("empty key scrubbed the value: %q", got)
+		}
+		if got := scrubSigV4Authorization(raw, fakeAKIAExample+"X"); got != raw {
+			t.Fatalf("wrong-length key scrubbed the value: %q", got)
+		}
+	})
+}
+
+func TestScrubSigV4AuthorizationForTarget(t *testing.T) {
+	t.Parallel()
+
+	raw := buildSigV4Authorization(fakeAKIAExample)
+
+	t.Run("aws_destination_scrubs", func(t *testing.T) {
+		t.Parallel()
+		got := ScrubSigV4AuthorizationForTarget(raw, "https://sts.us-east-1.amazonaws.com/")
+		if strings.Contains(got, fakeAKIAExample) {
+			t.Fatalf("AWS destination did not scrub: %q", got)
+		}
+	})
+
+	t.Run("china_destination_scrubs", func(t *testing.T) {
+		t.Parallel()
+		got := ScrubSigV4AuthorizationForTarget(raw, "https://sts.cn-north-1.amazonaws.com.cn/")
+		if strings.Contains(got, fakeAKIAExample) {
+			t.Fatalf("AWS China destination did not scrub: %q", got)
+		}
+	})
+
+	t.Run("non_aws_destination_leaves_key", func(t *testing.T) {
+		t.Parallel()
+		got := ScrubSigV4AuthorizationForTarget(raw, "https://attacker.example/exfil")
+		if got != raw {
+			t.Fatalf("non-AWS destination scrubbed: %q", got)
+		}
+	})
+
+	t.Run("empty_target_leaves_key", func(t *testing.T) {
+		t.Parallel()
+		got := ScrubSigV4AuthorizationForTarget(raw, "")
+		if got != raw {
+			t.Fatalf("empty target scrubbed: %q", got)
+		}
+	})
+
+	t.Run("malformed_envelope_on_aws_host_leaves_key", func(t *testing.T) {
+		t.Parallel()
+		malformed := "AWS4-HMAC-SHA256 Credential=" + fakeAKIAExample
+		got := ScrubSigV4AuthorizationForTarget(malformed, "https://sts.us-east-1.amazonaws.com/")
+		if got != malformed {
+			t.Fatalf("malformed envelope scrubbed: %q", got)
+		}
+	})
+}

--- a/internal/scanner/sigv4_helpers_test.go
+++ b/internal/scanner/sigv4_helpers_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import "testing"
+
+// The envelope-level tests exercise these helpers through
+// detectValidSigV4Authorization, which cannot reach every rejection branch
+// because earlier checks shadow some of them. These drive the helpers
+// directly so each fail-closed path is covered on its own terms.
+
+func TestParseSigV4CredentialRejections(t *testing.T) {
+	key := "AKIA" + "IOSFODNN7EXAMPLE"
+	for _, tc := range []struct {
+		name string
+		cred string
+	}{
+		{"empty", ""},
+		{"too_few_segments", key + "/20260910/us-east-1/aws4_request"},
+		{"too_many_segments", key + "/20260910/us-east-1/s3/extra/aws4_request"},
+		{"wrong_terminator", key + "/20260910/us-east-1/s3/aws5_request"},
+		{"key_not_access_id", "NOTAKEY/20260910/us-east-1/s3/aws4_request"},
+		{"date_not_eight_digits", key + "/2026091/us-east-1/s3/aws4_request"},
+		{"date_non_numeric", key + "/2026091x/us-east-1/s3/aws4_request"},
+		{"empty_region", key + "/20260910//s3/aws4_request"},
+		{"empty_service", key + "/20260910/us-east-1//aws4_request"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, ok := parseSigV4Credential(tc.cred); ok {
+				t.Fatalf("parseSigV4Credential(%q) accepted a malformed scope", tc.cred)
+			}
+		})
+	}
+}
+
+func TestParseSigV4CredentialAcceptsWellFormedScope(t *testing.T) {
+	key := "AKIA" + "IOSFODNN7EXAMPLE"
+	gotKey, gotDate, ok := parseSigV4Credential(key + "/20260910/us-east-1/s3/aws4_request")
+	if !ok {
+		t.Fatal("a well-formed credential scope was rejected")
+	}
+	if gotKey != key {
+		t.Fatalf("key id = %q, want %q", gotKey, key)
+	}
+	if gotDate != "20260910" {
+		t.Fatalf("scope date = %q, want 20260910", gotDate)
+	}
+}
+
+func TestExtractSigV4AuthorizationFieldsRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rest string
+	}{
+		{"empty", ""},
+		{"empty_part_between_commas", "Credential=a,,Signature=b"},
+		{"no_equals", "Credential"},
+		{"empty_key", "=value"},
+		{"empty_value", "Credential="},
+		{"unknown_field", "Credential=a, Signature=b, SignedHeaders=c, Extra=d"},
+		{"duplicate_known_field", "Credential=a, Credential=b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := extractSigV4AuthorizationFields(tc.rest); ok {
+				t.Fatalf("extractSigV4AuthorizationFields(%q) accepted a malformed tail", tc.rest)
+			}
+		})
+	}
+}
+
+func TestScrubSigV4AuthorizationRefusesAmbiguousInput(t *testing.T) {
+	key := "AKIA" + "IOSFODNN7EXAMPLE"
+	// Each of these must return the value untouched so core DLP still sees
+	// the access key id.
+	for _, tc := range []struct {
+		name  string
+		value string
+		akia  string
+	}{
+		{"empty_value", "", key},
+		{"empty_key", "AWS4-HMAC-SHA256 Credential=" + key, ""},
+		{"wrong_length_key", "AWS4-HMAC-SHA256 Credential=" + key, "AKIASHORT"},
+		{"key_appears_twice", "AWS4-HMAC-SHA256 Credential=" + key + " dup=" + key, key},
+		{"key_absent", "AWS4-HMAC-SHA256 Credential=none", key},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := scrubSigV4Authorization(tc.value, tc.akia); got != tc.value {
+				t.Fatalf("value was modified: got %q, want %q unchanged", got, tc.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

AWS Signature Version 4 puts the access key ID in the Authorization header, so header DLP matched it as a leaked credential and blocked every signed request on the first call. Any deployment running an AWS SDK, the AWS CLI, or Terraform behind Pipelock hit this immediately, and the message said a secret was leaking rather than that AWS signs requests this way.

The header envelope is now validated structurally, reusing the same credential-scope parser as the presigned-URL path rather than a second copy of it. The carve-out is scan-only: the access key ID is substituted for scanning and the forwarded header is unchanged.

It stays narrow in the directions that matter. The destination must be an AWS endpoint, the envelope must carry exactly the three expected fields with no duplicates and no unknown fields, and the exemption reaches only the key ID inside a validated credential scope. A malformed, partial, or duplicated envelope stays blocked, and so does a valid envelope accompanied by a second credential elsewhere in the request, so a well-formed envelope cannot be used to launder one.

The failure direction worth stating: this makes a blocking path stop blocking, so the risk is a carve-out that is too generous rather than too strict. Every branch that grants the exemption is gated on the destination and on structural validation, and the deny cases are covered directly rather than inferred from the allow case passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved handling of AWS Signature Version 4 credentials in `Authorization` headers.
  - Valid, properly formed SigV4 credentials for AWS destinations are no longer incorrectly flagged by sensitive-data scanning.
  - Malformed credentials, non-AWS destinations, unknown targets, and `Proxy-Authorization` headers continue to be scanned and blocked when applicable.
  - Applies consistently to HTTP, WebSocket, and MCP traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->