### PR TITLE
fix(ci): keep AI review verdicts informational

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: Optional model override for /review deep.
     required: false
   operation:
-    description: claim creates the status marker; review performs provider calls; coverage publishes the current-head verdict.
+    description: claim creates the status marker; review performs provider calls.
     required: false
     default: review
   base-sha:
@@ -63,15 +63,6 @@ inputs:
     required: false
   review-identity:
     description: Unique identity emitted by the admission step for this review run.
-    required: false
-  coverage-state:
-    description: Terminal review state whose coverage verdict is being published.
-    required: false
-  coverage-complete:
-    description: Whether the terminal review covered the whole admitted pull-request range.
-    required: false
-  coverage-run-url:
-    description: Workflow run URL attached to the coverage commit status.
     required: false
   reviewed-repository-path:
     description: Immutable checkout of the target repository at the captured head.
@@ -117,9 +108,6 @@ runs:
         HEAD_SHA: ${{ inputs.head-sha }}
         STATUS_COMMENT_ID: ${{ inputs.status-comment-id }}
         REVIEW_IDENTITY: ${{ inputs.review-identity }}
-        COVERAGE_STATE: ${{ inputs.coverage-state }}
-        COVERAGE_COMPLETE: ${{ inputs.coverage-complete }}
-        COVERAGE_RUN_URL: ${{ inputs.coverage-run-url }}
         REVIEWED_REPOSITORY_PATH: ${{ inputs.reviewed-repository-path }}
         REVIEWED_MERGE_BASE_SHA: ${{ inputs.reviewed-merge-base-sha }}
       run: python "$GITHUB_ACTION_PATH/pr_review.py"

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -162,9 +162,6 @@ STATUS_MARKER_REQUIRED_FIELDS = frozenset({"state", "identity", "mode", "finding
 # not qualify as a baseline, which is the safe direction.
 STATUS_MARKER_FIELDS = STATUS_MARKER_REQUIRED_FIELDS | {"binding", "model", "reviewed_head", "scope", "coverage_base"}
 FINDING_FINGERPRINTS_RE = re.compile(r"(?:[0-9a-f]{12}(?:,[0-9a-f]{12})*)?")
-COVERAGE_CONTEXT = "pr-review/coverage"
-COVERAGE_POST_ATTEMPTS = 3
-
 PUBLISHED_REVIEW_STATES = frozenset(
     {"already-running", "clean", "failed", "findings", "inconclusive", "partial", "superseded"}
 )
@@ -215,24 +212,6 @@ class PullBinding:
         return ":".join(
             (self.base_sha[:12], self.head_sha[:12], self.reviewer_sha[:12], self.rubric_version)
         )
-
-
-@dataclass(frozen=True)
-class CoveragePlan:
-    """The one status write a terminal review is allowed to make."""
-
-    target_head: str
-    status: str
-    description: str
-    gate_exit: int
-
-
-@dataclass(frozen=True)
-class CoveragePublication:
-    """The terminal writer's outcome, including a deliberate stale rejection."""
-
-    outcome: str
-    plan: CoveragePlan | None = None
 
 
 @dataclass
@@ -1347,183 +1326,6 @@ def update_comment(repo: str, comment_id: int, token: str, body: str, correlatio
     )
     log_phase("comment-update", status=response.status_code, correlation=correlation)
     response.raise_for_status()
-
-
-def coverage_plan(state: str, complete: bool, admitted: PullBinding, current: PullBinding) -> CoveragePlan:
-    """Choose the current-head status without publishing it.
-
-    A terminal review may be accurate for the head it read and still be stale
-    by publication time. GitHub evaluates a pull request against its current
-    head, so a moved head (or base) is an explicit failure on that current
-    commit rather than a historical green on the captured commit.
-    """
-    if not re.fullmatch(r"[0-9a-f]{40}", admitted.head_sha):
-        raise ReviewError("coverage status has no immutable admitted head")
-    if not re.fullmatch(r"[0-9a-f]{40}", current.head_sha):
-        raise ReviewError("coverage status has no immutable current head")
-    if current.head_sha != admitted.head_sha:
-        return CoveragePlan(
-            current.head_sha,
-            "failure",
-            "Review was superseded by a newer head; re-run it",
-            1,
-        )
-    if current.base_sha != admitted.base_sha:
-        return CoveragePlan(
-            current.head_sha,
-            "failure",
-            "Review no longer matches the current base; re-run it",
-            1,
-        )
-    if complete:
-        return CoveragePlan(current.head_sha, "success", f"Review covered the whole diff ({state})", 0)
-    if state in COMPLETE_REVIEW_STATES:
-        return CoveragePlan(current.head_sha, "failure", "Review did not reach the current base; re-run it", 1)
-    return CoveragePlan(current.head_sha, "failure", f"Review did NOT finish (state={state or 'none'})", 1)
-
-
-def post_coverage_status(repo: str, token: str, plan: CoveragePlan, run_url: str, correlation: str) -> bool:
-    """Publish exactly three times, pausing only before a real retry."""
-    for attempt in range(1, COVERAGE_POST_ATTEMPTS + 1):
-        try:
-            response = requests.post(
-                f"https://api.github.com/repos/{repo}/statuses/{plan.target_head}",
-                headers=github_headers(token),
-                json={
-                    "state": plan.status,
-                    "context": COVERAGE_CONTEXT,
-                    "description": plan.description,
-                    "target_url": run_url,
-                },
-                timeout=30,
-            )
-        except requests.RequestException:
-            log_phase("coverage-status", attempt=attempt, status="request-error", correlation=correlation)
-        else:
-            log_phase("coverage-status", attempt=attempt, status=response.status_code, correlation=correlation)
-            if 200 <= response.status_code < 300:
-                return True
-        if attempt < COVERAGE_POST_ATTEMPTS:
-            time.sleep(attempt * 5)
-    return False
-
-
-def _coverage_publication_failure_body(body: str, review_identity: str, reason: str) -> str:
-    """Turn this review's terminal comment into an honest unpublished result."""
-    marker = parse_status_marker(body)
-    if marker is None or marker.get("identity") != review_identity:
-        raise ReviewError("coverage failure comment no longer belongs to this review")
-    verdict = re.search(r"\*\*Verdict:\*\* `[^`]+`", body)
-    if verdict is None:
-        raise ReviewError("coverage failure comment had no terminal verdict")
-    notice = (
-        f"**Coverage status:** {reason} "
-        "The pull request cannot show this review's coverage verdict, so it must not be treated as green."
-    )
-    replacement = "**Verdict:** `failed`\n" + notice
-    body = body[: verdict.start()] + replacement + body[verdict.end() :]
-    updated, changes = re.subn(
-        rf"(<!-- {re.escape(STATUS_MARKER)} [^>]*?\bstate=){re.escape(marker['state'])}(?=\s|-->)",
-        r"\1failed",
-        body,
-        count=1,
-    )
-    if changes != 1:
-        raise ReviewError("coverage failure comment marker could not be made terminal")
-    return updated
-
-
-def mark_coverage_unpublished(
-    repo: str,
-    comment_id: int,
-    token: str,
-    review_identity: str,
-    correlation: str,
-    reason: str = "could not be published after three attempts.",
-) -> None:
-    """Make an unpublished status visible where the reviewer result lives."""
-    try:
-        response = requests.get(
-            f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}",
-            headers=github_headers(token),
-            timeout=30,
-        )
-    except requests.RequestException as exc:
-        log_phase("coverage-comment-read", status="request-error", correlation=correlation)
-        raise ReviewError("coverage failure comment could not be read") from exc
-    log_phase("coverage-comment-read", status=response.status_code, correlation=correlation)
-    if response.status_code != 200:
-        raise ReviewError("coverage failure comment could not be read")
-    try:
-        body = response.json()["body"]
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ReviewError("coverage failure comment had no body") from exc
-    if not isinstance(body, str):
-        raise ReviewError("coverage failure comment had no body")
-    update_comment(
-        repo,
-        comment_id,
-        token,
-        _coverage_publication_failure_body(body, review_identity, reason),
-        correlation,
-    )
-
-
-def publish_review_coverage(
-    repo: str,
-    pr_number: str,
-    token: str,
-    reviewer_sha: str,
-    admitted: PullBinding,
-    comment_id: int,
-    review_identity: str,
-    state: str,
-    complete: bool,
-    run_url: str,
-) -> CoveragePublication:
-    """Publish a current-head verdict, rejecting stale terminal writers."""
-    try:
-        current = get_pull_binding(repo, pr_number, token, reviewer_sha)
-    except (FetchError, requests.RequestException):
-        mark_coverage_unpublished(
-            repo,
-            comment_id,
-            token,
-            review_identity,
-            review_identity,
-            "could not be published because the current pull request could not be read.",
-        )
-        raise
-    newest, scanned = newest_admitted_review(repo, pr_number, token, review_identity)
-    if not scanned or newest is None:
-        mark_coverage_unpublished(
-            repo,
-            comment_id,
-            token,
-            review_identity,
-            review_identity,
-            "could not be published because the newest admitted review could not be confirmed.",
-        )
-        raise ReviewError("could not prove the newest admitted review before publishing coverage")
-    if newest.get("identity") != review_identity:
-        log_phase("coverage-status", status="stale-writer-rejected", correlation=review_identity)
-        return CoveragePublication("stale")
-    try:
-        plan = coverage_plan(state, complete, admitted, current)
-    except ReviewError:
-        mark_coverage_unpublished(
-            repo,
-            comment_id,
-            token,
-            review_identity,
-            review_identity,
-            "could not be published because the admitted review binding was invalid.",
-        )
-        raise
-    if post_coverage_status(repo, token, plan, run_url, review_identity):
-        return CoveragePublication("published", plan)
-    mark_coverage_unpublished(repo, comment_id, token, review_identity, review_identity)
-    raise ReviewError("coverage status could not be published")
 
 
 def _running_marker_is_stale(comment: dict[str, Any]) -> bool:
@@ -3687,51 +3489,13 @@ def main() -> None:
         or not REPO_PATTERN.fullmatch(repo)
         or not pr_number.isdigit()
         or mode not in {"default", "deep"}
-        or operation not in {"claim", "coverage", "review"}
+        or operation not in {"claim", "review"}
     ):
         print("pr-review phase=configuration attempt=1 status=invalid correlation=pending", file=sys.stderr)
         raise SystemExit(2)
     try:
         if operation == "claim":
             claim_review(repo, pr_number, github_token, mode, reviewer_sha)
-            return
-        if operation == "coverage":
-            base_sha = os.environ.get("BASE_SHA", "")
-            head_sha = os.environ.get("HEAD_SHA", "")
-            comment_id = os.environ.get("STATUS_COMMENT_ID", "")
-            review_identity = os.environ.get("REVIEW_IDENTITY", "")
-            state = os.environ.get("COVERAGE_STATE", "")
-            complete_value = os.environ.get("COVERAGE_COMPLETE", "")
-            run_url = os.environ.get("COVERAGE_RUN_URL", "")
-            if (
-                not all((base_sha, head_sha, comment_id, review_identity, run_url))
-                or not comment_id.isdigit()
-                or not re.fullmatch(r"[0-9a-f]{32}", review_identity)
-                or complete_value not in {"", "true", "false"}
-            ):
-                raise ReviewError("coverage operation received incomplete admission data")
-            publication = publish_review_coverage(
-                repo,
-                pr_number,
-                github_token,
-                reviewer_sha,
-                binding_from_values(base_sha, head_sha, reviewer_sha),
-                int(comment_id),
-                review_identity,
-                state or "failed",
-                complete_value == "true",
-                run_url,
-            )
-            if publication.outcome == "stale":
-                print("pr-review phase=coverage attempt=1 status=stale-writer-rejected correlation=published")
-                return
-            if publication.plan is None:
-                raise ReviewError("coverage publication had no plan")
-            print(
-                f"pr-review phase=coverage attempt=1 status={publication.plan.status} correlation=published"
-            )
-            if publication.plan.gate_exit:
-                raise SystemExit(1)
             return
         base_sha = os.environ.get("BASE_SHA", "")
         head_sha = os.environ.get("HEAD_SHA", "")

--- a/.github/workflows/pr-review-reusable.yaml
+++ b/.github/workflows/pr-review-reusable.yaml
@@ -32,14 +32,6 @@ permissions:
   # /review in the repository failed until it was restored. Do not narrow it
   # again without running a real /review against a pull request.
   pull-requests: write
-  # A comment-triggered run contributes NO check to the pull request, because
-  # its workflow run is attached to the default branch rather than the PR. The
-  # completeness job below therefore publishes its verdict as a COMMIT STATUS on
-  # the reviewed head, which does appear in the PR's merge box. Without this a
-  # review that timed out fails its own run while the pull request still reads
-  # all green, and the only surface saying otherwise is prose inside a comment
-  # whose headline is "Findings: 0". Observed on #1523, 2026-09-09.
-  statuses: write
 
 jobs:
   admit:
@@ -268,55 +260,3 @@ jobs:
             "${profile}" "${BASE_SHA}" "${HEAD_SHA}" "${IDENTITY}" "${IDENTITY}" "${REVIEW_MODE}" "${HEAD_SHA}" "${BASE_SHA}" > /tmp/pr-review-finalize.md
           gh api --method PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" -F body=@/tmp/pr-review-finalize.md >/dev/null
           echo "pr-review phase=finalize status=closed"
-
-  completeness:
-    # The finalizer owns the terminal comment when a review job never reaches
-    # its own final write. Coverage follows it so a publication failure can
-    # always replace a terminal result with an honest visible failure.
-    needs: [admit, review, finalize]
-    if: always() && needs.admit.outputs.claimed == 'true'
-    # Share admission's key so its newest-identity read and status write cannot
-    # race a new claim. The Python publisher still rejects stale identities;
-    # the lock narrows the interval and the identity check protects ordering.
-    concurrency:
-      group: pr-review-${{ github.repository }}-${{ inputs.pr_number }}
-      cancel-in-progress: false
-      # Without this GitHub keeps only ONE pending job per group and a newly
-      # queued run cancels the pending one, so a second /review can cancel a
-      # queued completeness job before it publishes the coverage status or
-      # finalizes the review comment. That is the same silent-verdict failure
-      # the status exists to remove. `queue: max` is compatible here only
-      # because cancel-in-progress is false; the two cannot be combined.
-      queue: max
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # The action contains the state-table-tested publisher. It first reads
-      # the current pull binding and newest admission, so an old terminal job
-      # either writes a re-run-needed failure on the current head or rejects
-      # itself without clobbering a newer review's context.
-      - name: Check out immutable Pipelock review source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: luckyPipewrench/pipelock
-          ref: ${{ inputs.reviewer_sha }}
-          path: trusted-pr-review
-          persist-credentials: false
-
-      - name: Publish review coverage, then require it
-        if: always()
-        uses: ./trusted-pr-review/.github/actions/pr-review
-        with:
-          github-token: ${{ secrets.review_token }}
-          repo: ${{ github.repository }}
-          pr-number: ${{ inputs.pr_number }}
-          review-mode: ${{ inputs.review_mode }}
-          reviewer-sha: ${{ inputs.reviewer_sha }}
-          operation: coverage
-          base-sha: ${{ needs.admit.outputs.base_sha }}
-          head-sha: ${{ needs.admit.outputs.head_sha }}
-          status-comment-id: ${{ needs.admit.outputs.status_comment_id }}
-          review-identity: ${{ needs.admit.outputs.correlation }}
-          coverage-state: ${{ needs.review.outputs.state }}
-          coverage-complete: ${{ needs.review.outputs.complete }}
-          coverage-run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -14,13 +14,6 @@ permissions:
   # /review in the repository failed until it was restored. Do not narrow it
   # again without running a real /review against a pull request.
   pull-requests: write
-  # A called workflow cannot hold a permission its caller withheld, so this
-  # must be granted HERE as well as in the reusable workflow. The completeness
-  # job posts a pr-review/coverage commit status on the reviewed head, which is
-  # the only surface a comment-triggered run has on the pull request. Granting
-  # it in one file only means the POST 403s and the status silently never
-  # appears, which is the same invisibility the status exists to remove.
-  statuses: write
 
 jobs:
   review:

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -208,13 +208,11 @@ The `pr-review-tests` job in `ci.yaml` runs the same command. A suite that runs
 only inside a review cannot gate a change to the reviewer, because a review runs
 the default-branch copy.
 
-**Two signals, and they mean different things.** The `review` job reports
-whether the runner published a verdict, so `partial` and `inconclusive` are
-successful runner outcomes. The `completeness` job reports whether the reviewer
-settled the whole pull request. It fails when the reviewer missed work or a
-candidate still needs human verification. Read the comment for the exact cause.
-Combining these signals would make a working review look crashed or give an
-unsettled review a green check.
+**The signed comment is the review signal.** The `review` job reports whether
+the runner published a verdict, so `partial` and `inconclusive` are successful
+runner outcomes. Automation reads the signed marker in the comment to decide
+whether the reviewer settled the whole pull request; review verdicts do not
+publish commit statuses or CI checks.
 
 **Deletions are a security change.** Removing a guard reads as a deletion hunk.
 Deep mode reads deletion hunks in full and splits an oversized one into bounded

--- a/docs/guides/pr-review.md
+++ b/docs/guides/pr-review.md
@@ -267,14 +267,12 @@ code under the pin. Replace `YOUR_GITHUB_LOGIN` with the login allowed to
 trigger a review, or drop those clauses and rely on `author_association ==
 'OWNER'` alone.
 
-Grant `issues: write`, `pull-requests: write`, and `statuses: write`. A called
-workflow cannot hold a permission its caller withheld, so dropping any one of
-them silently strips it from the reviewer rather than failing at load, and the
-review then ends on a permission error when it tries to use it. The first two
-carry the review comment. `statuses: write` carries the `pr-review/coverage`
-commit status, which is the only surface a comment-triggered run has on the pull
-request itself: without it a review that did not finish fails its own run while
-the pull request still shows every check passing.
+Grant `issues: write` and `pull-requests: write`. A called workflow cannot hold
+a permission its caller withheld, so dropping either one silently strips it
+from the reviewer rather than failing at load, and the review then ends on a
+permission error when it tries to update its pull-request comment. Review
+verdicts are informational and do not publish commit statuses or CI checks;
+automation must read the signed review marker in the comment.
 
 Personal-account repositories must map each named secret explicitly, because
 `secrets: inherit` is not available to them.
@@ -294,7 +292,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  statuses: write
 
 jobs:
   review:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -217,14 +217,9 @@ class WorkflowPackagingTest(unittest.TestCase):
         self.assertIn("always()", finalize["if"])
         self.assertNotIn("Finalize an abandoned review", [step.get("name") for step in review["steps"]])
 
-        # Coverage is a separate check from whether the runner published. One
-        # signal cannot carry both: collapsing them either makes a working
-        # review look crashed, or lets an incomplete review show an all-green
-        # pull request, which reads as reviewed when it was not.
-        completeness = workflow["jobs"]["completeness"]
-        self.assertEqual(completeness["needs"], ["admit", "review", "finalize"])
-        self.assertIn("always()", completeness["if"])
-        self.assertEqual(completeness["concurrency"], admit["concurrency"])
+        # Review verdicts stay in the signed comment marker. They must not be
+        # projected onto the pull request as a CI-style commit status.
+        self.assertNotIn("completeness", workflow["jobs"])
         # Every step that can run a review must feed both outputs. A hard-coded
         # count went stale the moment a provider was removed, and a count is the
         # wrong assertion anyway: it cannot tell which step was dropped. Derive
@@ -291,17 +286,7 @@ class WorkflowPackagingTest(unittest.TestCase):
                 "write",
                 f"{path.name} must set permissions.issues to write",
             )
-            # Same rule, third scope. The completeness job posts a coverage
-            # commit status, which is the only surface a comment-triggered run
-            # has on the pull request. A called workflow cannot hold a
-            # permission its caller withheld, so granting this in the reusable
-            # file alone makes the POST 403 and the status silently never
-            # appear, which is exactly the invisibility it exists to remove.
-            self.assertEqual(
-                permissions.get("statuses"),
-                "write",
-                f"{path.name} must set permissions.statuses to write",
-            )
+            self.assertNotIn("statuses", permissions)
 
     def test_composite_action_owns_runner_requirements_and_single_provider_inputs(self) -> None:
         action = load_yaml(ACTION_YAML)
@@ -314,9 +299,6 @@ class WorkflowPackagingTest(unittest.TestCase):
             "model-fast",
             "model-deep",
             "review-identity",
-            "coverage-state",
-            "coverage-complete",
-            "coverage-run-url",
             "reviewed-repository-path",
             "reviewed-merge-base-sha",
         ):
@@ -510,108 +492,6 @@ class ExitSemanticsTest(unittest.TestCase):
             self.assertIsNone(pr_review.main())
             output.seek(0)
             self.assertIn("complete=false", output.read().decode("utf-8"))
-
-
-class CoveragePublicationStateTableTest(unittest.TestCase):
-    """Exercise the terminal publisher rather than only rendering its shell."""
-
-    REVIEWER = "c" * 40
-    IDENTITY = "d" * 32
-
-    @staticmethod
-    def response(status: int) -> object:
-        result = mock.Mock()
-        result.status_code = status
-        return result
-
-    def binding(self, *, base: str = "a" * 40, head: str = "b" * 40) -> object:
-        return pr_review.PullBinding(base, head, self.REVIEWER, pr_review.RUBRIC_VERSION)
-
-    def test_coverage_publication_state_table(self) -> None:
-        admitted = self.binding()
-        cases = (
-            ("success", admitted, "clean", True, self.IDENTITY, "published", "success", "b" * 40, False),
-            ("partial", admitted, "partial", False, self.IDENTITY, "published", "failure", "b" * 40, False),
-            ("moved head", self.binding(), "clean", True, self.IDENTITY, "published", "failure", "e" * 40, False),
-            ("stale terminal writer", admitted, "clean", True, "e" * 32, "stale", None, None, False),
-            ("empty admitted head", self.binding(head=""), "clean", True, self.IDENTITY, "error", None, None, True),
-            ("POST failure", admitted, "clean", True, self.IDENTITY, "error", None, None, True),
-        )
-        for name, captured, state, complete, newest_identity, expected, status, target, raises in cases:
-            with self.subTest(name=name), mock.patch.object(
-                pr_review,
-                "get_pull_binding",
-                return_value=self.binding(head="e" * 40) if name == "moved head" else admitted,
-            ), mock.patch.object(
-                pr_review,
-                "newest_admitted_review",
-                return_value=({"identity": newest_identity}, True),
-            ), mock.patch.object(
-                pr_review,
-                "post_coverage_status",
-                return_value=name != "POST failure",
-            ) as post, mock.patch.object(pr_review, "mark_coverage_unpublished") as mark:
-                if raises:
-                    with self.assertRaises(pr_review.ReviewError):
-                        pr_review.publish_review_coverage(
-                            "owner/repo", "42", "token", self.REVIEWER, captured, 7, self.IDENTITY, state, complete, "https://ci.example/run"
-                        )
-                    mark.assert_called_once()
-                    if name == "empty admitted head":
-                        post.assert_not_called()
-                    continue
-                result = pr_review.publish_review_coverage(
-                    "owner/repo", "42", "token", self.REVIEWER, captured, 7, self.IDENTITY, state, complete, "https://ci.example/run"
-                )
-                self.assertEqual(result.outcome, expected)
-                if expected == "stale":
-                    post.assert_not_called()
-                    mark.assert_not_called()
-                    continue
-                self.assertIsNotNone(result.plan)
-                self.assertEqual(result.plan.status, status)
-                self.assertEqual(result.plan.target_head, target)
-                if name == "moved head":
-                    self.assertIn("superseded", result.plan.description)
-                post.assert_called_once()
-                mark.assert_not_called()
-
-    def test_coverage_retries_exactly_three_times_without_a_final_sleep(self) -> None:
-        plan = pr_review.CoveragePlan("b" * 40, "failure", "Review did NOT finish", 1)
-        with mock.patch.object(
-            pr_review.requests,
-            "post",
-            side_effect=[self.response(503), self.response(502), self.response(201)],
-        ) as post, mock.patch.object(pr_review.time, "sleep") as sleep:
-            self.assertTrue(pr_review.post_coverage_status("owner/repo", "token", plan, "https://ci.example/run", self.IDENTITY))
-        self.assertEqual(post.call_count, 3)
-        self.assertEqual([call.args[0] for call in sleep.call_args_list], [5, 10])
-
-    def test_status_publication_failure_rewrites_the_terminal_comment(self) -> None:
-        binding = self.binding()
-        progress = pr_review.ReviewProgress(expected_units=1, reviewed_units=1)
-        body = pr_review.render_status(
-            binding,
-            "default",
-            [],
-            progress,
-            "clean",
-            [],
-            review_identity=self.IDENTITY,
-        )
-        response = mock.Mock()
-        response.status_code = 200
-        response.json.return_value = {"body": body}
-        with mock.patch.object(pr_review.requests, "get", return_value=response), mock.patch.object(
-            pr_review, "update_comment"
-        ) as update:
-            pr_review.mark_coverage_unpublished("owner/repo", 7, "token", self.IDENTITY, self.IDENTITY)
-        rewritten = update.call_args.args[3]
-        self.assertIn("**Verdict:** `failed`", rewritten)
-        self.assertIn("could not be published after three attempts", rewritten)
-        marker = pr_review.parse_status_marker(rewritten)
-        self.assertIsNotNone(marker)
-        self.assertEqual(marker["state"], "failed")
 
 
 class CompressionAndClassificationTest(unittest.TestCase):


### PR DESCRIPTION
## What changed
- Keep AI review verdicts in the signed pull-request comment without publishing a CI-style commit status.
- Preserve incomplete-review enforcement in the sweep while preventing review findings, timeouts, and inconclusive results from turning pull requests red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Pull request reviews no longer publish coverage results as commit statuses.
  - The review workflow now requires fewer permissions and supports only review and claim operations.
  - Review verdicts are provided through comments and signed review markers.
  - Removed coverage-related workflow inputs and completeness processing.

- **Documentation**
  - Updated workflow permission guidance to remove status-writing access and clarify review verdict usage.

- **Tests**
  - Updated validation to confirm coverage inputs, completeness jobs, and status permissions are no longer present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->