### PR TITLE
fix(anchor): verify non-Rekor auto-anchor proofs before persisting

### DIFF
--- a/internal/anchor/anchor_bundle_format_test.go
+++ b/internal/anchor/anchor_bundle_format_test.go
@@ -6,6 +6,7 @@ package anchor
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -172,6 +173,55 @@ func TestAnchorBundleV1SchemaForbidsRekorOnNonRekorProof(t *testing.T) {
 	}
 	if !forbidden {
 		t.Fatal("proof schema must forbid the rekor property when backend is not rekor")
+	}
+}
+
+// TestAnchorBundleV1SchemaTypesEveryPropertiesNode asserts every schema node that
+// carries a "properties" keyword also declares "type": "object". Draft 2020-12
+// does not require this, and the santhosh-tekuri validator used by the other
+// conformance tests accepts the schema either way, but AJV strict-mode consumers
+// reject a properties node that lacks an object type (strictTypes). This guard
+// keeps the published schema strict-mode clean so a future edit cannot silently
+// reintroduce the untyped-properties tell. It is semantically a no-op for every
+// bundle instance, which is always an object.
+func TestAnchorBundleV1SchemaTypesEveryPropertiesNode(t *testing.T) {
+	data, err := os.ReadFile(filepath.Clean(anchorBundleSchemaPath))
+	if err != nil {
+		t.Fatalf("read anchor bundle schema: %v", err)
+	}
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse anchor bundle schema: %v", err)
+	}
+
+	checked := 0
+	var walk func(node any, path string)
+	walk = func(node any, path string) {
+		switch v := node.(type) {
+		case map[string]any:
+			if _, hasProps := v["properties"]; hasProps {
+				checked++
+				if typ, _ := v["type"].(string); typ != "object" {
+					t.Errorf("schema node %s carries \"properties\" but type = %q, want \"object\" (AJV strictTypes)", path, typ)
+				}
+			}
+			for k, child := range v {
+				walk(child, path+"/"+k)
+			}
+		case []any:
+			for i, child := range v {
+				walk(child, fmt.Sprintf("%s[%d]", path, i))
+			}
+		}
+	}
+	walk(doc, "#")
+
+	// Calibrate the walk so a silent miss (or a schema-shape change) is caught: the
+	// five object definitions (root, checkpoint, proof, rekor_proof,
+	// rekor_inclusion_proof) plus the seven conditional subschemas that carry
+	// "properties" total twelve nodes.
+	if checked != 12 {
+		t.Fatalf("walked %d nodes carrying \"properties\", want 12; the walk missed nodes or the schema shape changed", checked)
 	}
 }
 

--- a/internal/cli/runtime/auto_anchor.go
+++ b/internal/cli/runtime/auto_anchor.go
@@ -421,17 +421,30 @@ func (m *autoAnchorMonitor) submitOrReusePending(anchorCfg config.FlightRecorder
 }
 
 // verifyAutoAnchorProof checks a freshly returned anchor proof before it is
-// persisted, so a misconfigured or buggy backend that returns a syntactically
-// accepted but invalid proof cannot make the chain look anchored. The local
-// backend verifies deterministically. A Rekor submission is witnessed
-// independently by the offline verifier against the log's public key, which the
-// runtime does not hold, so it is recorded without an immediate
-// self-verification (the documented submit-and-audit-offline model).
+// persisted, so a misconfigured, buggy, or hostile backend that returns a
+// syntactically accepted but invalid proof cannot make the chain look anchored.
+//
+// Verification is the DEFAULT: every backend is asked to verify its own proof.
+// The choice of whether to verify keys off the CONCRETE backend type, which the
+// runtime built from local config (autoAnchorBackend), not off proof.Backend.
+// The backend controls proof.Backend, so trusting that field would let a hostile
+// backend label its proof "rekor" to dodge verification — the exact gap this
+// closes.
+//
+// Rekor is the one exception: its proofs are witnessed offline against the log's
+// public key, which the runtime does not hold (autoAnchorBackend builds RekorLog
+// without TrustedLogKeys), so an immediate self-verification here would always
+// fail with "trusted Rekor log public key required". Recording it without a
+// local self-verification is the documented submit-and-audit-offline model.
+//
+// Failure direction: fail closed. A non-Rekor backend (LocalLog today, any
+// future custom backend tomorrow) whose Verify errors keeps its proof out of the
+// persisted anchor state. Only the named Rekor type is exempt.
 func verifyAutoAnchorProof(backend anchorpkg.Backend, proof anchorpkg.Proof, checkpoint anchorpkg.Checkpoint) error {
-	if local, ok := backend.(anchorpkg.LocalLog); ok {
-		return local.Verify(proof, checkpoint)
+	if _, ok := backend.(anchorpkg.RekorLog); ok {
+		return nil
 	}
-	return nil
+	return backend.Verify(proof, checkpoint)
 }
 
 func (m *autoAnchorMonitor) checkpointAdvanced(receiptCount uint64) bool {

--- a/internal/cli/runtime/auto_anchor.go
+++ b/internal/cli/runtime/auto_anchor.go
@@ -385,6 +385,9 @@ func (m *autoAnchorMonitor) submitOrReusePending(anchorCfg config.FlightRecorder
 		m.pendingCheckpoint.ReceiptCount == checkpoint.ReceiptCount &&
 		m.pendingCheckpoint.RootHash == checkpoint.RootHash &&
 		m.pendingCheckpoint.FinalSeq == checkpoint.FinalSeq {
+		// The retained proof was verified by verifyAutoAnchorProof before it was
+		// stored below; keep that ordering if this reuse path is ever refactored,
+		// or an unverified proof could reach persistence through the retry.
 		proof := m.pendingProof
 		m.mu.Unlock()
 		return proof, false, nil
@@ -425,11 +428,14 @@ func (m *autoAnchorMonitor) submitOrReusePending(anchorCfg config.FlightRecorder
 // syntactically accepted but invalid proof cannot make the chain look anchored.
 //
 // Verification is the DEFAULT: every backend is asked to verify its own proof.
-// The choice of whether to verify keys off the CONCRETE backend type, which the
-// runtime built from local config (autoAnchorBackend), not off proof.Backend.
-// The backend controls proof.Backend, so trusting that field would let a hostile
-// backend label its proof "rekor" to dodge verification — the exact gap this
-// closes.
+// This is fail-closed on the backend's own verifier error; it is not an
+// independent check of an arbitrary backend implementation, whose Verify remains
+// its own trust mechanism. The choice of whether to verify keys off the CONCRETE
+// backend type, which the runtime built from local config (autoAnchorBackend),
+// not off proof.Backend. The backend controls proof.Backend, so trusting that
+// field would let a buggy or mislabelled backend mark its proof "rekor" to dodge
+// verification. Both the value and pointer Rekor forms are exempt so a future
+// factory change cannot silently turn Rekor into an always-failing verify.
 //
 // Rekor is the one exception: its proofs are witnessed offline against the log's
 // public key, which the runtime does not hold (autoAnchorBackend builds RekorLog
@@ -441,7 +447,8 @@ func (m *autoAnchorMonitor) submitOrReusePending(anchorCfg config.FlightRecorder
 // future custom backend tomorrow) whose Verify errors keeps its proof out of the
 // persisted anchor state. Only the named Rekor type is exempt.
 func verifyAutoAnchorProof(backend anchorpkg.Backend, proof anchorpkg.Proof, checkpoint anchorpkg.Checkpoint) error {
-	if _, ok := backend.(anchorpkg.RekorLog); ok {
+	switch backend.(type) {
+	case anchorpkg.RekorLog, *anchorpkg.RekorLog:
 		return nil
 	}
 	return backend.Verify(proof, checkpoint)

--- a/internal/cli/runtime/auto_anchor_test.go
+++ b/internal/cli/runtime/auto_anchor_test.go
@@ -768,6 +768,15 @@ func TestVerifyAutoAnchorProof(t *testing.T) {
 			t.Fatal("verifyAutoAnchorProof(local, tampered) = nil, want error")
 		}
 	})
+	t.Run("pointer rekor backend is exempt like the value form", func(t *testing.T) {
+		// A factory change to *RekorLog must not turn Rekor into an always-failing
+		// verify (the runtime holds no Rekor log key), which would be an
+		// availability failure disguised as hardening.
+		rekor := &anchorpkg.RekorLog{}
+		if err := verifyAutoAnchorProof(rekor, anchorpkg.Proof{Backend: anchorpkg.RekorBackend}, checkpoint); err != nil {
+			t.Fatalf("verifyAutoAnchorProof(*RekorLog) = %v, want nil (exempt)", err)
+		}
+	})
 	t.Run("non-rekor backend is verified by default and its error surfaces", func(t *testing.T) {
 		sentinel := errors.New("backend rejected the proof")
 		backend := &verifyCountingAnchorBackend{verifyErr: sentinel}

--- a/internal/cli/runtime/auto_anchor_test.go
+++ b/internal/cli/runtime/auto_anchor_test.go
@@ -56,6 +56,24 @@ func (b errorAnchorBackend) Submit(anchorpkg.Checkpoint) (anchorpkg.Proof, error
 
 func (errorAnchorBackend) Verify(anchorpkg.Proof, anchorpkg.Checkpoint) error { return nil }
 
+// verifyCountingAnchorBackend is a non-Rekor backend that accepts every Submit
+// and records how many times Verify was called, optionally returning a fixed
+// verify error. It proves the verify-by-default path both runs Verify and fails
+// closed when Verify rejects the proof.
+type verifyCountingAnchorBackend struct {
+	verifies  atomic.Int64
+	verifyErr error
+}
+
+func (b *verifyCountingAnchorBackend) Submit(anchorpkg.Checkpoint) (anchorpkg.Proof, error) {
+	return anchorpkg.Proof{Backend: anchorpkg.LocalBackend, LogID: "verify-counting-log"}, nil
+}
+
+func (b *verifyCountingAnchorBackend) Verify(anchorpkg.Proof, anchorpkg.Checkpoint) error {
+	b.verifies.Add(1)
+	return b.verifyErr
+}
+
 type autoAnchorTestRig struct {
 	monitor  *autoAnchorMonitor
 	metrics  *metrics.Metrics
@@ -750,10 +768,70 @@ func TestVerifyAutoAnchorProof(t *testing.T) {
 			t.Fatal("verifyAutoAnchorProof(local, tampered) = nil, want error")
 		}
 	})
+	t.Run("non-rekor backend is verified by default and its error surfaces", func(t *testing.T) {
+		sentinel := errors.New("backend rejected the proof")
+		backend := &verifyCountingAnchorBackend{verifyErr: sentinel}
+		err := verifyAutoAnchorProof(backend, anchorpkg.Proof{Backend: anchorpkg.LocalBackend}, checkpoint)
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("verifyAutoAnchorProof(custom backend) = %v, want %v", err, sentinel)
+		}
+		if got := backend.verifies.Load(); got != 1 {
+			t.Fatalf("custom backend Verify calls = %d, want 1 (verify is the default)", got)
+		}
+	})
 	t.Run("rekor records without immediate self-verification", func(t *testing.T) {
+		// The RekorLog carries no TrustedLogKeys (as autoAnchorBackend builds it),
+		// so RekorLog.Verify would fail with "trusted Rekor log public key
+		// required" if it were called. A nil result therefore proves the Rekor
+		// type is skipped, not that a permissive Verify passed.
 		if err := verifyAutoAnchorProof(anchorpkg.RekorLog{URL: "https://rekor.internal.example"}, anchorpkg.Proof{Backend: anchorpkg.RekorBackend}, checkpoint); err != nil {
 			t.Fatalf("verifyAutoAnchorProof(rekor) = %v, want nil", err)
 		}
+	})
+}
+
+// TestAutoAnchorVerifiesEveryBackendBeforePersist proves the verify-by-default
+// rule end to end: a non-Rekor backend is verified before its proof is persisted.
+// When Verify rejects the proof, nothing is written and the failure surfaces
+// through the same fail() path a LocalLog verify failure uses; when Verify
+// accepts it, the anchor persists normally.
+func TestAutoAnchorVerifiesEveryBackendBeforePersist(t *testing.T) {
+	t.Run("verify failure keeps the proof out of persisted state", func(t *testing.T) {
+		trig := newAutoAnchorTestRig(t)
+		backend := &verifyCountingAnchorBackend{verifyErr: errors.New("bogus proof material")}
+		trig.monitor.backendFn = func(config.FlightRecorderAnchor) (anchorpkg.Backend, error) { return backend, nil }
+		emitAutoAnchorReceipt(t, trig.emitter, "https://api.vendor.example/rejected")
+
+		trig.monitor.runPass()
+
+		if got := backend.verifies.Load(); got != 1 {
+			t.Fatalf("Verify calls = %d, want exactly 1 before persistence", got)
+		}
+		if state, found, err := readAnchorStateForSession(trig.recorder.Dir()); found || err != nil {
+			t.Fatalf("readAnchorStateForSession = (%+v, %v, %v), want no persisted marker", state, found, err)
+		}
+		bundles, err := filepath.Glob(filepath.Join(trig.recorder.Dir(), autoAnchorBundleDir, "*.json"))
+		if err != nil || len(bundles) != 0 {
+			t.Fatalf("anchor bundles = %v err=%v, want none written on verify failure", bundles, err)
+		}
+		assertAutoAnchorStats(t, trig.metrics, 1, 0, 1, "verify live receipt anchor proof")
+	})
+	t.Run("verify success persists the anchor", func(t *testing.T) {
+		trig := newAutoAnchorTestRig(t)
+		backend := &verifyCountingAnchorBackend{}
+		trig.monitor.backendFn = func(config.FlightRecorderAnchor) (anchorpkg.Backend, error) { return backend, nil }
+		emitAutoAnchorReceipt(t, trig.emitter, "https://api.vendor.example/accepted")
+
+		trig.monitor.runPass()
+
+		if got := backend.verifies.Load(); got != 1 {
+			t.Fatalf("Verify calls = %d, want exactly 1 on the success path", got)
+		}
+		state, found, err := readAnchorStateForSession(trig.recorder.Dir())
+		if err != nil || !found {
+			t.Fatalf("readAnchorStateForSession = (%+v, %v, %v), want a persisted marker", state, found, err)
+		}
+		assertAutoAnchorStats(t, trig.metrics, 1, 1, 0, "")
 	})
 }
 

--- a/sdk/anchor-bundle/README.md
+++ b/sdk/anchor-bundle/README.md
@@ -10,6 +10,8 @@ package.
 | `v1.json` | JSON Schema draft 2020-12 description of the emitted v1 shape. |
 | `example.json` | Fully populated structural fixture. Its placeholder proof is not cryptographically valid. |
 
+Every schema object that declares `properties` also declares `"type": "object"`, so strict-mode validators such as AJV (`strict: true`) accept `v1.json` without a `strictTypes` error.
+
 ## Stability status
 
 **Experimental compatibility notice:** This document and `v1.json` describe the

--- a/sdk/anchor-bundle/v1.json
+++ b/sdk/anchor-bundle/v1.json
@@ -106,6 +106,7 @@
       "allOf": [
         {
           "if": {
+            "type": "object",
             "properties": {
               "backend": {
                 "const": "rekor"
@@ -273,6 +274,7 @@
   "allOf": [
     {
       "if": {
+        "type": "object",
         "properties": {
           "backend": {
             "const": "local"
@@ -283,8 +285,10 @@
         ]
       },
       "then": {
+        "type": "object",
         "properties": {
           "proof": {
+            "type": "object",
             "properties": {
               "backend": {
                 "const": "local"
@@ -296,6 +300,7 @@
     },
     {
       "if": {
+        "type": "object",
         "properties": {
           "backend": {
             "const": "rekor"
@@ -306,8 +311,10 @@
         ]
       },
       "then": {
+        "type": "object",
         "properties": {
           "proof": {
+            "type": "object",
             "properties": {
               "backend": {
                 "const": "rekor"


### PR DESCRIPTION
## What changed

The auto-anchor loop now asks every anchor backend to verify the proof it just returned before that proof is persisted. Only the Rekor backend is exempt, because its proofs are witnessed offline against a log key the runtime does not hold. The exemption keys off the concrete backend type the runtime built from config, not the label the backend puts on its own proof, so a backend cannot skip verification by calling itself rekor. A non-Rekor backend whose verify fails keeps its proof out of the anchor state, which is the fail-closed direction, and Rekor behavior is unchanged.

The published anchor-bundle schema now declares `type: object` on the seven conditional subschemas that carry `properties`, so strict-mode validators accept it. A walk test pins every properties node to that type, and the existing conformance fixtures pass unchanged.

Still open: authenticating the on-disk anchor-state marker itself is a separate follow-up and is not in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-anchoring now verifies proofs for all supported backend types before persisting them, preventing invalid proofs from being stored.
  * Rekor-based proofs remain exempt from this verification step.
  * Improved handling of verification failures so unsuccessful anchors do not leave behind partial records.

* **Documentation**
  * Clarified schema compatibility with strict JSON Schema validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->