### PR TITLE
feat(contain): show a session contract before launch and expire grants

### DIFF
--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -74,7 +74,7 @@ Flags:
 
 Exit codes:
 
-- **0** — preflight passed, posture capsule was written, and the agent process exited successfully.
+- **0** — preflight passed and either `--dry-run` printed the session contract, or the posture capsule was written and the agent process exited successfully.
 - **1** — containment was broken, posture emission failed, or the launched agent exited non-zero.
 - **2** — usage/precondition error, such as not running as root, an invalid tool name, or an invalid port.
 
@@ -450,6 +450,8 @@ Flags:
 | Flag | Default | Purpose |
 |---|---|---|
 | `--agent-user` | `pipelock-agent` | Contained agent user whose grants to list. |
+
+Grants recorded by this version carry the agent user they were granted to and are listed only for that `--agent-user`; grants written by an earlier version carry none and are listed for every agent user. The table includes the reason recorded at grant time.
 
 ## `pipelock contain revoke-workspace`
 

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -9,13 +9,14 @@ The subcommands are:
 | `install` | Create users, systemd unit, nftables rules, wrappers, sudoers entry, CA bundle, runtime contract | yes (root only) |
 | `upgrade` | Download, verify, replace, re-pin integrity, restart, and verify in one fail-closed command | yes (root only) |
 | `run` | Verify the containment boundary, emit a signed posture capsule, then launch a registered tool as `pipelock-agent` | writes proof + starts process |
-| `verify` | Read-only probes that report pass / fail / skip for the 12 invariants below | no |
+| `verify` | Read-only probes that report pass / fail / skip for the invariants below | no |
 | `doctor` | Live self-test that proves common tooling reaches the internet *through* the proxy, with per-check remediation | no |
 | `rollback` | Idempotently undo `install`. Restores the prior state and removes wrappers, users, unit, rules | yes (root only) |
 | `add-tool` | Register an additional tool wrapper under `/usr/local/bin/plk-<name>` after install | yes (root only) |
 | `explain` | Explain a contain egress block event and print remediation | no |
 | `grant-workspace` | Grant the contained agent user ACL access to one project workspace | yes (root only) |
 | `revoke-workspace` | Revoke a previously granted workspace ACL and clean unused parent traversal ACLs | yes (root only) |
+| `list-workspaces` | List recorded workspace grants (path, mode, owner, expiry, status) | no |
 | `ca-refresh` | Rebuild the combined CA bundle at `/etc/pipelock/combined-ca.pem` after a CA rotation | yes (root only) |
 
 Each mutating subcommand accepts `--dry-run` to print the planned actions without touching state.
@@ -45,7 +46,22 @@ Before it starts the tool, `contain run` fails closed unless every containment p
 - the direct-egress canary from `pipelock-agent` must fail while the operator can still reach the internet, proving the negative probe is meaningful rather than a generic outage;
 - `pipelock-agent` must not be able to run `sudo -n true`, so the launch path refuses a host where the agent can trivially sudo back out.
 
-If preflight passes, the command emits a signed posture capsule using `flight_recorder.signing_key_path` from the config, then launches `/usr/local/bin/plk-launch <tool> ...` directly as `pipelock-agent`. Pipelock does not read or store the agent's API keys; the launched tool loads its own credentials from the contained user's environment and config, the same as the `plk-*` wrappers.
+After preflight, and before it launches, `contain run` prints a **session contract**: the exact boundary the agent is about to receive, derived from the same preflight state the launch uses. It lists the agent user, the proxy egress posture, the posture-capsule destination, whether the agent's `/tmp` is private, the registered tools, and every workspace grant with its owner, creation time, expiry, and status:
+
+```text
+pipelock contain run: session contract for claude
+  agent user:       pipelock-agent
+  proxy egress:     http://127.0.0.1:8888 (loopback proxy only; direct egress denied by nftables)
+  posture capsule:  /var/lib/pipelock/contain/posture/proof.json
+  agent /tmp:       shared with the operator (not private)
+  registered tools: claude, codex
+  workspaces:
+    /home/alice/src/proj  read-write  owner=alice  created=2026-06-01T12:00:00Z  expires=never  [active]
+```
+
+Use `--dry-run` to run preflight, print the contract, and exit without emitting a posture capsule or launching — the way to review what a launch would grant before running it.
+
+If preflight passes and no recorded workspace grant has expired, the command emits a signed posture capsule using `flight_recorder.signing_key_path` from the config, then launches `/usr/local/bin/plk-launch <tool> ...` directly as `pipelock-agent`. An expired grant is refused fail-closed (re-grant or `revoke-workspace` first). Pipelock does not read or store the agent's API keys; the launched tool loads its own credentials from the contained user's environment and config, the same as the `plk-*` wrappers.
 
 Flags:
 
@@ -54,6 +70,7 @@ Flags:
 | `--config` | `/etc/pipelock/pipelock.yaml` | Config used to sign the posture capsule. Must include `flight_recorder.signing_key_path`. |
 | `--port` | `8888` | Loopback proxy port to verify before launch. |
 | `--posture-output` | `/var/lib/pipelock/contain/posture` | Directory where the signed posture capsule is written. |
+| `--dry-run` | off | Run preflight and print the session contract, then exit without emitting a posture capsule or launching. |
 
 Exit codes:
 
@@ -159,8 +176,11 @@ Exit codes:
 
 ## `pipelock contain verify`
 
-Verify is read-only. It walks 13 probes in order and prints pass / fail / skip /
-unknown per probe. It does not require root.
+Verify is read-only. It walks 14 fixed probes in order (plus a conditional
+workspace probe, numbered 15, when workspaces are configured) and prints pass /
+fail / skip / unknown per probe. It does not require root. Probe numbers are an
+operator contract; new probes are appended above the existing range rather than
+renumbering the ones already published.
 
 ```bash
 pipelock contain verify
@@ -181,6 +201,8 @@ pipelock contain verify
 | 11 | `cc_launch_allow_list_enforced` | `plk-launch` rejects tools that are not in the registered allow-list. |
 | 12 | `listed_tool_targets_resolvable` | Every entry in `tools.list` resolves to an executable absolute path in the agent user's PATH. |
 | 13 | `managed_config_metrics` | The managed config keeps metrics on a dedicated numeric loopback port or verifies a current, source-scoped remote metrics exception. It skips only when the config file is missing or permission is denied, and reports unknown for any other read failure. |
+| 14 | `launch_env_allow_list` | `plk-launch` clears the operator environment with `env -i` before exec, so operator variables sudo leaves standing (e.g. `DISPLAY`, `XAUTHORITY`, `SUDO_*`) do not reach the contained agent. Fails if the launcher reverted to plain `env` or dropped the posture-proof forward. |
+| 15 | `workspace_access` (conditional) | Present when `--workspace` paths are passed or recorded grants exist: each path is readable/traversable by the agent user, and no recorded grant has expired. |
 
 ### Managed metrics invariant
 
@@ -240,6 +262,8 @@ The containment boundary is security-correct, but a tool that ignores the proxy 
 
 The contract has four parts:
 
+`plk-launch` builds this environment with `env -i` — it starts from an empty environment and rebuilds only the identity block, the matrix below, the posture-proof binding, and the agent PATH. This is deliberate: `plk-launch` runs after `sudo`, which leaves operator variables standing (`DISPLAY`, `XAUTHORITY`, `XDG_RUNTIME_DIR`, `SUDO_*`), and plain `env` would pass every one of them through to the contained agent. `env -i` closes that leak, and it uses the same environment set as the `contain run` Go launcher so the two launch paths cannot drift (verify probe 14 fails if the launcher reverts to plain `env`). The tradeoff is that ambient niceties like `TERM`/`LANG` are not forwarded either; this already matched the `contain run` path, so it is not a new regression there.
+
 1. **Full environment matrix.** `plk-launch` (and the login-shell script below) export the complete proxy + CA set, because different ecosystems read different variables:
 
    - Proxy (upper- and lower-case): `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` and their lowercase forms, all pointing at `http://127.0.0.1:<proxy-port>`.
@@ -256,6 +280,10 @@ The contract has four parts:
 A login-shell script at `/etc/profile.d/pipelock-contain.sh` exports the same matrix so an interactive `sudo -iu pipelock-agent` session inherits it too. Because `/etc/profile.d` is sourced by all login shells, the script returns immediately for every user except `pipelock-agent`.
 
 This makes compatible tooling work; it does **not** widen egress. Direct (proxy-bypassing) connections from the agent user remain blocked by the nftables owner-match rule.
+
+### Filesystem sharing
+
+The contained agent runs as its own system user, but `contain run` does not currently give it a private `/tmp`: the agent and the operator share `/tmp` and `/var/tmp`, so at the usual `umask 022` the agent can read operator scratch files. The session contract reports this as `agent /tmp: shared with the operator (not private)`. Do not use `/tmp` to hand secrets to or from the agent. The supported, audited way to share a directory with the agent is a workspace grant (`contain grant-workspace`), which is recorded, listable, and revocable.
 
 ## `pipelock contain doctor`
 
@@ -386,6 +414,12 @@ sudo pipelock contain grant-workspace /home/alice/src/my-project --mode read-wri
 
 The command resolves symlinks, requires the target to be an existing directory, rejects protected system prefixes such as `/`, `/etc`, `/usr`, `/var`, `/proc`, `/sys`, and `/root` by default, and records the grant in `/etc/pipelock/contain/workspaces.json` so later revocation knows which parent traversal ACLs are still needed.
 
+Each grant is recorded with lifecycle metadata: the owner (the operator behind `sudo`, else the current user), an optional `--reason`, the creation timestamp, and an optional expiry from `--expires`. `--expires` accepts either a Go duration (for example `720h`) or an absolute RFC3339 timestamp. An **expired** grant is refused fail-closed by `contain run` and fails the `workspace_access` verify probe; the ACL itself is not auto-removed, so `revoke-workspace` (or a fresh grant) is still how you take the access away. In other words, expiry gates the launch, it does not unset the ACL. Inventories written by an older Pipelock (path and mode only) still load and are shown as legacy grants with no metadata. Use `list-workspaces` to see every recorded grant and its status.
+
+```bash
+sudo pipelock contain grant-workspace /home/alice/src/my-project --mode read-write --reason "sprint-42 refactor" --expires 336h
+```
+
 Default ACLs are applied only below the granted directory, not on the directory root. That keeps config roots such as `~/.codex` or `~/.claude` traversable without making future root-level credential files inherit agent-read. During every grant, credential-shaped files named `auth.json`, `.claude.json`, `.credentials.json`, or `*.token` are stripped of the contained agent ACL and chmodded to `0600`.
 
 `pipelock contain install` also installs a root-managed credential guard (`pipelock-cred-guard.path` / `.service`). The path unit uses `PathChanged` watches on exact credential-shaped files under the operator's home directory, `.claude`, `.claude-cc2`, and `.codex` roots so systemd can catch atomic temp-file plus rename rewrites through leaf-path watching. It also keeps `PathChanged` watches on those roots because systemd has no `PathChangedGlob`, and dynamic `*.token` files must still be discovered without level-triggered `PathExistsGlob` loops. The service filters each rescan to credential-shaped files only and re-applies the same credential lock if a later tool recreates, replaces, or widens them. The home-directory pass is depth-limited to top-level credential files such as `~/.claude.json`.
@@ -398,6 +432,24 @@ Flags:
 | `--mode` | `read-only` | Workspace ACL mode: `read-only` or `read-write`. |
 | `--agent-user` | `pipelock-agent` | Contained agent user to grant access to. |
 | `--allow-system-path` | false | Allow grants under protected system path prefixes. Use only for deliberate admin workflows. |
+| `--reason` | (none) | Optional justification recorded with the grant. |
+| `--expires` | (none) | Grant expiry as a Go duration (e.g. `720h`) or an RFC3339 timestamp. An expired grant is refused at launch and fails verify. |
+
+## `pipelock contain list-workspaces`
+
+Lists every recorded workspace grant so "what can the agent reach today, and why" is one command. Read-only; safe without root.
+
+```bash
+pipelock contain list-workspaces
+```
+
+Prints a table of path, mode, owner, creation time, expiry, and status (`active`, `expired`, `legacy`, or `invalid-expiry`). An `expired` grant still has its ACLs on disk — clear them with `revoke-workspace`.
+
+Flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--agent-user` | `pipelock-agent` | Contained agent user whose grants to list. |
 
 ## `pipelock contain revoke-workspace`
 

--- a/docs/contain-cli.md
+++ b/docs/contain-cli.md
@@ -59,7 +59,7 @@ pipelock contain run: session contract for claude
     /home/alice/src/proj  read-write  owner=alice  created=2026-06-01T12:00:00Z  expires=never  [active]
 ```
 
-Use `--dry-run` to run preflight, print the contract, and exit without emitting a posture capsule or launching — the way to review what a launch would grant before running it.
+Use `--dry-run` to run preflight, print the contract, and exit without emitting a posture capsule or launching. This is the way to review what a launch would grant before running it. It applies the same expiry gate as a real launch, so an expired grant prints `[expired]` and exits non-zero.
 
 If preflight passes and no recorded workspace grant has expired, the command emits a signed posture capsule using `flight_recorder.signing_key_path` from the config, then launches `/usr/local/bin/plk-launch <tool> ...` directly as `pipelock-agent`. An expired grant is refused fail-closed (re-grant or `revoke-workspace` first). Pipelock does not read or store the agent's API keys; the launched tool loads its own credentials from the contained user's environment and config, the same as the `plk-*` wrappers.
 

--- a/internal/cli/contain/cmd.go
+++ b/internal/cli/contain/cmd.go
@@ -31,6 +31,8 @@ Subcommands:
               Grant pipelock-agent ACL access to a project directory.
   revoke-workspace
               Revoke pipelock-agent ACL access from a project directory.
+  list-workspaces
+              List recorded workspace grants (path, mode, owner, expiry, status).
   ca-refresh  Rebuild the combined CA bundle after a CA rotation.
 
 All mutating subcommands except 'upgrade' accept --dry-run to print the
@@ -49,6 +51,7 @@ planned actions without touching state.`,
 		explainCmd(),
 		grantWorkspaceCmd(),
 		revokeWorkspaceCmd(),
+		listWorkspacesCmd(),
 		caRefreshCmd(),
 		reloadNFTRulesCmd(),
 		upgradeCmd(),

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
 package contain
 
 import (

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -94,6 +94,15 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 			wantDetail: "CA bundle",
 		},
 		{
+			// Without the trailing backslash the shell ends the command there,
+			// so the tool never starts. The probe must not read on and report
+			// a complete variable set the shell would never apply.
+			name:       "a missing line continuation fails",
+			body:       strings.Replace(canonical, "    SHELL=/bin/bash \\\n", "    SHELL=/bin/bash\n", 1),
+			wantStatus: statusFail,
+			wantDetail: "never reaches the tool",
+		},
+		{
 			name:       "a dropped posture forward fails",
 			body:       strings.Replace(canonical, "    "+posturebinding.RuntimeProofEnv+"=", "    IGNORED_PROOF=", 1),
 			wantStatus: statusFail,

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -100,7 +100,24 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 			name:       "a missing line continuation fails",
 			body:       strings.Replace(canonical, "    SHELL=/bin/bash \\\n", "    SHELL=/bin/bash\n", 1),
 			wantStatus: statusFail,
-			wantDetail: "never reaches the tool",
+			wantDetail: "does not match the installed launcher grammar",
+		},
+		{
+			// `# \` looks like a continued line to a line-based reader, but the
+			// shell treats it as a comment and runs env -i with no target, so
+			// the agent never starts while every variable still looks correct.
+			name:       "an inline comment before the target fails",
+			body:       strings.Replace(canonical, "    SHELL=/bin/bash \\\n", "    SHELL=/bin/bash # \\\n", 1),
+			wantStatus: statusFail,
+			wantDetail: "does not match the installed launcher grammar",
+		},
+		{
+			// A control operator is rejected for the same reason: the shell may
+			// not read the block the way this probe does.
+			name:       "a control operator before the target fails",
+			body:       strings.Replace(canonical, "    SHELL=/bin/bash \\\n", "    SHELL=/bin/bash ; true \\\n", 1),
+			wantStatus: statusFail,
+			wantDetail: "does not match the installed launcher grammar",
 		},
 		{
 			name:       "a dropped posture forward fails",

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -18,6 +18,7 @@ import (
 // probe can return. The probe reads the installed plk-launch text, so each case
 // writes a launcher and asserts the status plus the operator-facing detail.
 func TestProbeLaunchEnvAllowList(t *testing.T) {
+	canonical := canonicalLaunchScript(8888)
 	posture := posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + `:-/var/lib/pipelock/proof.json}"`
 	cases := []struct {
 		name       string
@@ -26,10 +27,10 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 		wantDetail string
 	}{
 		{
-			name:       "env -i with posture forward passes",
-			body:       "#!/bin/bash\nexec env -i \\\n    HOME=/home/agent \\\n    " + posture + " \\\n    PATH=\"$AGENT_PATH\" \\\n    \"$TARGET\" \"$@\"\n",
+			name:       "canonical env -i block passes",
+			body:       canonical,
 			wantStatus: statusPass,
-			wantDetail: "env -i",
+			wantDetail: "rebuilds exactly",
 		},
 		{
 			name:       "plain env leaks the operator environment",
@@ -44,16 +45,28 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 			wantDetail: "does not clear the environment",
 		},
 		{
-			name:       "env -i without the posture forward grades containment unknown",
-			body:       "#!/bin/bash\nexec env -i \\\n    HOME=/home/agent \\\n    \"$TARGET\" \"$@\"\n",
+			name:       "a decoy comment does not satisfy the probe",
+			body:       "#!/bin/bash\n# exec env -i " + posture + "\nexec env HOME=/home/agent \"$TARGET\" \"$@\"\n",
 			wantStatus: statusFail,
-			wantDetail: "does not forward " + posturebinding.RuntimeProofEnv,
+			wantDetail: "plain `env`",
 		},
 		{
-			name:       "explicit operator variable passthrough fails even under env -i",
-			body:       "#!/bin/bash\nexec env -i \\\n    " + posture + " \\\n    DISPLAY=\"$DISPLAY\" \\\n    \"$TARGET\" \"$@\"\n",
+			name:       "a missing contract variable fails",
+			body:       strings.Replace(canonical, "    NO_PROXY=", "    NOT_PROXY=", 1),
 			wantStatus: statusFail,
-			wantDetail: "explicitly forwards an operator variable",
+			wantDetail: "missing: NO_PROXY",
+		},
+		{
+			name:       "an extra operator variable fails even under env -i",
+			body:       strings.Replace(canonical, "    PATH=", "    DISPLAY=\"$DISPLAY\" \\\n    PATH=", 1),
+			wantStatus: statusFail,
+			wantDetail: "unexpected: DISPLAY",
+		},
+		{
+			name:       "a dropped posture forward fails",
+			body:       strings.Replace(canonical, "    "+posturebinding.RuntimeProofEnv+"=", "    IGNORED_PROOF=", 1),
+			wantStatus: statusFail,
+			wantDetail: "missing: " + posturebinding.RuntimeProofEnv,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -18,7 +18,7 @@ import (
 // probe can return. The probe reads the installed plk-launch text, so each case
 // writes a launcher and asserts the status plus the operator-facing detail.
 func TestProbeLaunchEnvAllowList(t *testing.T) {
-	canonical := canonicalLaunchScript(8888)
+	canonical := canonicalLaunchScript(8888, defaultCABundlePath)
 	posture := posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + `:-/var/lib/pipelock/proof.json}"`
 	cases := []struct {
 		name       string
@@ -63,6 +63,37 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 			wantDetail: "unexpected: DISPLAY",
 		},
 		{
+			// env applies the LAST assignment of a repeated name, so a wrapper
+			// that sets HTTPS_PROXY twice runs with a value a reader scanning
+			// from the top never sees.
+			name:       "a duplicated assignment fails",
+			body:       strings.Replace(canonical, "    PATH=", "    HTTPS_PROXY=http://127.0.0.1:9 \\\n    PATH=", 1),
+			wantStatus: statusFail,
+			wantDetail: "assigns HTTPS_PROXY more than once",
+		},
+		{
+			// Two exec blocks make the effective environment depend on which one
+			// the shell reaches, so a canonical decoy could front a leaky block.
+			name:       "two exec env -i blocks are ambiguous",
+			body:       canonical + "\n" + canonical,
+			wantStatus: statusFail,
+			wantDetail: "contains 2 `exec env -i` blocks",
+		},
+		{
+			// The name-only check passes here: every expected variable is
+			// present. Only the value check catches the redirected proxy.
+			name:       "a redirected proxy value fails",
+			body:       strings.Replace(canonical, "    HTTPS_PROXY=http://127.0.0.1:8888", "    HTTPS_PROXY=http://127.0.0.1:9999", 1),
+			wantStatus: statusFail,
+			wantDetail: "expected http://127.0.0.1:8888",
+		},
+		{
+			name:       "a swapped CA bundle fails",
+			body:       strings.Replace(canonical, "SSL_CERT_FILE="+defaultCABundlePath, "SSL_CERT_FILE=/tmp/attacker-ca.pem", 1),
+			wantStatus: statusFail,
+			wantDetail: "CA bundle",
+		},
+		{
 			name:       "a dropped posture forward fails",
 			body:       strings.Replace(canonical, "    "+posturebinding.RuntimeProofEnv+"=", "    IGNORED_PROOF=", 1),
 			wantStatus: statusFail,
@@ -72,6 +103,12 @@ func TestProbeLaunchEnvAllowList(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := makeProbeEnv(t)
+			// This probe reads only the launcher text, never the bundle file.
+			// Production renders the wrapper and runs verify from one install
+			// state, where both carry the default CA path; pin the probe env to
+			// it so the fixture exercises that state rather than an impossible
+			// one where the two disagree.
+			env.caBundlePath = defaultCABundlePath
 			if err := os.WriteFile(env.launchPath, []byte(tc.body), 0o600); err != nil {
 				t.Fatalf("write launcher: %v", err)
 			}

--- a/internal/cli/contain/launch_env_probe_test.go
+++ b/internal/cli/contain/launch_env_probe_test.go
@@ -1,0 +1,119 @@
+package contain
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
+)
+
+// TestProbeLaunchEnvAllowList walks every verdict the launcher-environment
+// probe can return. The probe reads the installed plk-launch text, so each case
+// writes a launcher and asserts the status plus the operator-facing detail.
+func TestProbeLaunchEnvAllowList(t *testing.T) {
+	posture := posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + `:-/var/lib/pipelock/proof.json}"`
+	cases := []struct {
+		name       string
+		body       string
+		wantStatus string
+		wantDetail string
+	}{
+		{
+			name:       "env -i with posture forward passes",
+			body:       "#!/bin/bash\nexec env -i \\\n    HOME=/home/agent \\\n    " + posture + " \\\n    PATH=\"$AGENT_PATH\" \\\n    \"$TARGET\" \"$@\"\n",
+			wantStatus: statusPass,
+			wantDetail: "env -i",
+		},
+		{
+			name:       "plain env leaks the operator environment",
+			body:       "#!/bin/bash\nexec env \\\n    HOME=/home/agent \\\n    \"$TARGET\" \"$@\"\n",
+			wantStatus: statusFail,
+			wantDetail: "plain `env`",
+		},
+		{
+			name:       "no env at all does not clear the environment",
+			body:       "#!/bin/bash\nexec \"$TARGET\" \"$@\"\n",
+			wantStatus: statusFail,
+			wantDetail: "does not clear the environment",
+		},
+		{
+			name:       "env -i without the posture forward grades containment unknown",
+			body:       "#!/bin/bash\nexec env -i \\\n    HOME=/home/agent \\\n    \"$TARGET\" \"$@\"\n",
+			wantStatus: statusFail,
+			wantDetail: "does not forward " + posturebinding.RuntimeProofEnv,
+		},
+		{
+			name:       "explicit operator variable passthrough fails even under env -i",
+			body:       "#!/bin/bash\nexec env -i \\\n    " + posture + " \\\n    DISPLAY=\"$DISPLAY\" \\\n    \"$TARGET\" \"$@\"\n",
+			wantStatus: statusFail,
+			wantDetail: "explicitly forwards an operator variable",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := makeProbeEnv(t)
+			if err := os.WriteFile(env.launchPath, []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write launcher: %v", err)
+			}
+			status, detail := probeLaunchEnvAllowList(context.Background(), env)
+			if status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q (detail=%q)", status, tc.wantStatus, detail)
+			}
+			if !strings.Contains(detail, tc.wantDetail) {
+				t.Fatalf("detail = %q, want substring %q", detail, tc.wantDetail)
+			}
+		})
+	}
+
+	t.Run("missing launcher skips rather than passing", func(t *testing.T) {
+		env := makeProbeEnv(t)
+		_ = os.Remove(env.launchPath)
+		status, detail := probeLaunchEnvAllowList(context.Background(), env)
+		if status != statusSkip {
+			t.Fatalf("status = %q, want skip (detail=%q)", status, detail)
+		}
+		if !strings.Contains(detail, "install never ran") {
+			t.Fatalf("detail = %q", detail)
+		}
+	})
+}
+
+// TestRunGrantWorkspace_RejectsBadExpiry proves an unparseable or already-past
+// --expires is a configuration error, never a silently ignored expiry.
+func TestRunGrantWorkspace_RejectsBadExpiry(t *testing.T) {
+	for _, bad := range []string{"soon", "-1h", "2020-01-01T00:00:00Z"} {
+		t.Run(bad, func(t *testing.T) {
+			env, _, _ := newFakeEnv(t)
+			env.now = func() time.Time { return testNow }
+			env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+			err := runGrantWorkspace(context.Background(), env, t.TempDir(), workspaceOpts{mode: workspaceModeReadOnly, expires: bad})
+			if err == nil || !strings.Contains(err.Error(), "invalid --expires") {
+				t.Fatalf("err = %v, want invalid --expires", err)
+			}
+			inv, loadErr := loadWorkspaceInventory(env)
+			if loadErr != nil {
+				t.Fatalf("load: %v", loadErr)
+			}
+			if len(inv.Workspaces) != 0 {
+				t.Fatalf("a rejected grant must not be recorded: %+v", inv.Workspaces)
+			}
+		})
+	}
+}
+
+// TestListWorkspacesCmd_RejectsInvalidAgentUser covers the command wiring's
+// fail-closed username validation without touching the host inventory.
+func TestListWorkspacesCmd_RejectsInvalidAgentUser(t *testing.T) {
+	cmd := listWorkspacesCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--agent-user", "bad user!"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "agent user") {
+		t.Fatalf("err = %v, want agent user validation error", err)
+	}
+}

--- a/internal/cli/contain/osops.go
+++ b/internal/cli/contain/osops.go
@@ -66,6 +66,11 @@ type installEnv struct {
 	out    io.Writer
 	errOut io.Writer
 
+	// now returns the current time. Abstracted so workspace-grant metadata
+	// (created/expires timestamps) is deterministic in tests. Defaults to
+	// time.Now.
+	now func() time.Time
+
 	// Static configuration. These mirror the constants in verify.go so the
 	// two subsystems agree on filesystem layout. Made fields rather than
 	// constants so the install subcommand can accept flag overrides.
@@ -146,6 +151,7 @@ func defaultInstallEnv(out io.Writer) *installEnv {
 		hashFile:           sha256HexOfFile,
 		out:                out,
 		errOut:             os.Stderr,
+		now:                time.Now,
 		operatorUser:       os.Getenv("SUDO_USER"),
 		proxyUserName:      defaultProxyUser,
 		agentUserName:      defaultAgentUser,

--- a/internal/cli/contain/review_sweep_fixes_test.go
+++ b/internal/cli/contain/review_sweep_fixes_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+// TestRunContainRun_RefusesWhenContractCannotBeWritten proves an unwritable
+// stdout stops the run before posture emission and launch: a boundary the
+// operator never saw is not launched.
+func TestRunContainRun_RefusesWhenContractCannotBeWritten(t *testing.T) {
+	env := allPassEnv(t)
+	var launched, posture bool
+	runEnv := containRunEnv{
+		probe: env,
+		launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+			launched = true
+			return nil
+		},
+		emitPosture: func(string, string, *probeEnv, []string) (string, error) {
+			posture = true
+			return "/unused", nil
+		},
+	}
+	sentinel := errors.New("stdout closed")
+	err := runContainRun(context.Background(), nil, failingWriter{err: sentinel}, io.Discard, runEnv, containRunOptions{}, []string{"claude"})
+	if err == nil || !strings.Contains(err.Error(), "write session contract") || !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want session-contract write failure wrapping the writer error", err)
+	}
+	if launched || posture {
+		t.Fatalf("launched=%v posture=%v after an unwritten contract, want neither", launched, posture)
+	}
+	if err := renderSessionContract(&bytes.Buffer{}, sessionContract{Tool: "claude"}); err != nil {
+		t.Fatalf("render to a healthy writer = %v, want nil", err)
+	}
+}
+
+// TestProbeWorkspaceAccess_ChecksRecordedGrantPaths proves a recorded grant is
+// readability-checked even when no --workspace path was given, and that an
+// unreadable grant fails the probe rather than passing with zero paths.
+func TestProbeWorkspaceAccess_ChecksRecordedGrantPaths(t *testing.T) {
+	dir := t.TempDir()
+	env := makeProbeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.workspaceGrants = []workspaceGrant{{Path: dir, Mode: workspaceModeReadOnly, Owner: "josh", Created: "2026-05-01T00:00:00Z"}}
+
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		if name == "sudo" && strings.Contains(strings.Join(args, " "), dir) {
+			return "", 1, nil
+		}
+		return "", 0, nil
+	}
+	status, detail := probeWorkspaceAccess(context.Background(), env)
+	if status != statusFail || !strings.Contains(detail, "not readable") {
+		t.Fatalf("status=%q detail=%q, want fail on an unreadable recorded grant", status, detail)
+	}
+
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+	env.workspacePaths = []string{dir} // duplicate of the grant path: checked once
+	status, detail = probeWorkspaceAccess(context.Background(), env)
+	if status != statusPass || !strings.Contains(detail, "1 workspace path(s) readable") {
+		t.Fatalf("status=%q detail=%q, want pass over one deduplicated path", status, detail)
+	}
+}
+
+// TestProbeWorkspaceAccess_FailsOnUnreadableInventory proves a permission or
+// parse error on the recorded inventory is a probe failure, not an empty grant
+// set that lets verify pass.
+func TestProbeWorkspaceAccess_FailsOnUnreadableInventory(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.workspaceInvErr = errors.New("permission denied")
+	probes := probesForEnv(env)
+	if probes[len(probes)-1].name != "workspace_access" {
+		t.Fatalf("workspace_access probe must run when the inventory is unreadable; got %q", probes[len(probes)-1].name)
+	}
+	status, detail := probeWorkspaceAccess(context.Background(), env)
+	if status != statusFail || !strings.Contains(detail, "could not be read") {
+		t.Fatalf("status=%q detail=%q, want fail on an unreadable inventory", status, detail)
+	}
+}
+
+// TestLoadWorkspaceInventoryFrom_ParseErrorIsAnError pins the loader contract
+// the verify command relies on: absence is empty, corruption is an error.
+func TestLoadWorkspaceInventoryFrom_ParseErrorIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "workspaces.json")
+	if _, err := loadWorkspaceInventoryFrom(os.ReadFile, path); err != nil {
+		t.Fatalf("missing inventory = %v, want empty and nil", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadWorkspaceInventoryFrom(os.ReadFile, path); err == nil {
+		t.Fatal("corrupt inventory loaded as empty; want an error")
+	}
+}
+
+// TestRunListWorkspaces_FiltersByAgentUserAndShowsReason proves the listing
+// honors --agent-user for grants that record one, keeps legacy rows visible to
+// every agent user, and renders the recorded reason.
+func TestRunListWorkspaces_FiltersByAgentUserAndShowsReason(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: "/a/mine", Mode: "read-write", Owner: "josh", Created: "2026-05-01T00:00:00Z", Reason: "sprint work", AgentUser: env.agentUserName},
+		{Path: "/b/other", Mode: "read-only", Owner: "josh", Created: "2026-05-01T00:00:00Z", AgentUser: "other-agent"},
+		{Path: "/c/legacy", Mode: "read-only"},
+	}}); err != nil {
+		t.Fatalf("seed inventory: %v", err)
+	}
+	var buf bytes.Buffer
+	env.out = &buf
+	if err := runListWorkspaces(env); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"REASON", "/a/mine", "sprint work", "/c/legacy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "/b/other") {
+		t.Errorf("list showed another agent user's grant:\n%s", out)
+	}
+
+	env.agentUserName = "nobody-here"
+	buf.Reset()
+	if err := runListWorkspaces(env); err != nil {
+		t.Fatalf("list for unknown agent: %v", err)
+	}
+	if !strings.Contains(buf.String(), "/c/legacy") || strings.Contains(buf.String(), "/a/mine") {
+		t.Fatalf("legacy row must stay visible and recorded rows must filter:\n%s", buf.String())
+	}
+}
+
+// TestRunGrantWorkspace_RecordsAgentUser proves a new grant records the agent
+// user it was granted to so list-workspaces can filter on it.
+func TestRunGrantWorkspace_RecordsAgentUser(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+	if err := runGrantWorkspace(context.Background(), env, t.TempDir(), workspaceOpts{mode: workspaceModeReadOnly}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil || len(inv.Workspaces) != 1 {
+		t.Fatalf("load: %v (%d grants)", err, len(inv.Workspaces))
+	}
+	if inv.Workspaces[0].AgentUser != env.agentUserName {
+		t.Fatalf("agent_user = %q, want %q", inv.Workspaces[0].AgentUser, env.agentUserName)
+	}
+}

--- a/internal/cli/contain/run.go
+++ b/internal/cli/contain/run.go
@@ -131,6 +131,17 @@ func runContainRun(
 		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf("invalid tool name %q (must match %s)", tool, containToolNameRegex))
 	}
 
+	// Read the workspace inventory ONCE, before preflight, so the workspace probe
+	// checks readability and expiry of every recorded grant in the same pass, and
+	// the contract and the expiry gate below derive from the same read the launch
+	// enforces. A grant the agent cannot actually read, or one past its expiry,
+	// fails preflight (fail closed) rather than launching against a stale record.
+	inv, err := loadWorkspaceInventoryFrom(env.probe.readFile, env.probe.workspaceInvPath)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
+	}
+	env.probe.workspaceGrants = inv.Workspaces
+
 	_, _ = fmt.Fprintln(stdout, "pipelock contain run: verifying containment preflight")
 	entries, err := containRunPreflight(ctx, stdout, env.probe, tool)
 	if err != nil {
@@ -148,16 +159,13 @@ func runContainRun(
 	}
 	env.probe.postureProofPath = proofPath
 
-	// Read the workspace inventory ONCE and derive both the contract's workspace
-	// rows and the expiry gate from it, so what the operator is shown is what the
-	// launch enforces.
-	inv, err := loadWorkspaceInventoryFrom(env.probe.readFile, env.probe.workspaceInvPath)
-	if err != nil {
-		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
-	}
-
 	contract := buildSessionContract(env.probe, tool, entries, inv.Workspaces, proofPath)
-	renderSessionContract(stdout, contract)
+	// The contract is the operator's review surface. If it cannot be written
+	// (closed pipe, failed writer) nobody saw the boundary, so refuse to go on
+	// rather than emit a capsule and launch unreviewed (fail closed).
+	if err := renderSessionContract(stdout, contract); err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("write session contract: %w", err))
+	}
 
 	// Fail CLOSED on an expired grant: the recorded window has passed while the
 	// ACL is still live, so refuse the launch until the operator re-grants or
@@ -262,9 +270,29 @@ func buildSessionContract(env *probeEnv, tool string, tools []toolsListEntry, gr
 	}
 }
 
+// firstErrWriter records the first write error so a multi-line render can
+// report whether the whole block reached the operator.
+type firstErrWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (f *firstErrWriter) Write(p []byte) (int, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	n, err := f.w.Write(p)
+	if err != nil {
+		f.err = err
+	}
+	return n, err
+}
+
 // renderSessionContract prints the contract as an operator-facing block. Pure
-// over the struct so tests assert exact text.
-func renderSessionContract(out io.Writer, c sessionContract) {
+// over the struct so tests assert exact text. It returns the first write error
+// so a caller can refuse to launch a boundary the operator never saw.
+func renderSessionContract(w io.Writer, c sessionContract) error {
+	out := &firstErrWriter{w: w}
 	_, _ = fmt.Fprintf(out, "pipelock contain run: session contract for %s\n", c.Tool)
 	_, _ = fmt.Fprintf(out, "  agent user:       %s\n", c.AgentUser)
 	_, _ = fmt.Fprintf(out, "  proxy egress:     %s (loopback proxy only; direct egress denied by nftables)\n", c.ProxyURL)
@@ -288,6 +316,7 @@ func renderSessionContract(out io.Writer, c sessionContract) {
 				w.Path, w.Mode, w.Owner, w.Created, w.Expires, w.Status)
 		}
 	}
+	return out.err
 }
 
 func containRunPostureProofPath(postureOutput string) (string, error) {

--- a/internal/cli/contain/run.go
+++ b/internal/cli/contain/run.go
@@ -159,13 +159,11 @@ func runContainRun(
 	contract := buildSessionContract(env.probe, tool, entries, inv.Workspaces, proofPath)
 	renderSessionContract(stdout, contract)
 
-	if opts.dryRun {
-		return nil
-	}
-
 	// Fail CLOSED on an expired grant: the recorded window has passed while the
 	// ACL is still live, so refuse the launch until the operator re-grants or
-	// revokes. Expiry gates the launch; it does not remove the ACL.
+	// revokes. Dry-runs use this same gate so their outcome cannot claim a launch
+	// is possible when a real launch would refuse it. Expiry gates the launch; it
+	// does not remove the ACL.
 	expired, err := expiredWorkspaceGrants(inv.Workspaces, containRunNow(env.probe))
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
@@ -175,7 +173,9 @@ func runContainRun(
 			"refusing to launch: %d workspace grant(s) have expired: %s; re-grant with `pipelock contain grant-workspace` or remove with `pipelock contain revoke-workspace`",
 			len(expired), strings.Join(expired, ", ")))
 	}
-
+	if opts.dryRun {
+		return nil
+	}
 	posturePath, err := env.emitPosture(opts.configFile, opts.postureOutput, env.probe, args)
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("emit contain-run posture capsule: %w", err))

--- a/internal/cli/contain/run.go
+++ b/internal/cli/contain/run.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -34,6 +35,7 @@ type containRunOptions struct {
 	configFile    string
 	port          int
 	postureOutput string
+	dryRun        bool
 }
 
 type containRunEnv struct {
@@ -95,6 +97,7 @@ Pipelock does not read or store agent secrets.`,
 	cmd.Flags().StringVarP(&opts.configFile, "config", "c", opts.configFile, "pipelock config file for the signed posture capsule")
 	cmd.Flags().IntVar(&opts.port, "port", opts.port, "pipelock listen port to probe on loopback")
 	cmd.Flags().StringVar(&opts.postureOutput, "posture-output", opts.postureOutput, "directory for the signed contain-run posture capsule")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "run preflight and print the session contract, then exit without emitting a posture capsule or launching")
 
 	return cmd
 }
@@ -129,7 +132,8 @@ func runContainRun(
 	}
 
 	_, _ = fmt.Fprintln(stdout, "pipelock contain run: verifying containment preflight")
-	if err := containRunPreflight(ctx, stdout, env.probe, tool); err != nil {
+	entries, err := containRunPreflight(ctx, stdout, env.probe, tool)
+	if err != nil {
 		return err
 	}
 
@@ -144,6 +148,34 @@ func runContainRun(
 	}
 	env.probe.postureProofPath = proofPath
 
+	// Read the workspace inventory ONCE and derive both the contract's workspace
+	// rows and the expiry gate from it, so what the operator is shown is what the
+	// launch enforces.
+	inv, err := loadWorkspaceInventoryFrom(env.probe.readFile, env.probe.workspaceInvPath)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
+	}
+
+	contract := buildSessionContract(env.probe, tool, entries, inv.Workspaces, proofPath)
+	renderSessionContract(stdout, contract)
+
+	if opts.dryRun {
+		return nil
+	}
+
+	// Fail CLOSED on an expired grant: the recorded window has passed while the
+	// ACL is still live, so refuse the launch until the operator re-grants or
+	// revokes. Expiry gates the launch; it does not remove the ACL.
+	expired, err := expiredWorkspaceGrants(inv.Workspaces, containRunNow(env.probe))
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+	}
+	if len(expired) > 0 {
+		return cliutil.ExitCodeError(cliutil.ExitConfig, fmt.Errorf(
+			"refusing to launch: %d workspace grant(s) have expired: %s; re-grant with `pipelock contain grant-workspace` or remove with `pipelock contain revoke-workspace`",
+			len(expired), strings.Join(expired, ", ")))
+	}
+
 	posturePath, err := env.emitPosture(opts.configFile, opts.postureOutput, env.probe, args)
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("emit contain-run posture capsule: %w", err))
@@ -156,6 +188,106 @@ func runContainRun(
 		return err
 	}
 	return nil
+}
+
+// containRunNow returns the probe environment's clock, defaulting to time.Now
+// so production callers need not wire it.
+func containRunNow(env *probeEnv) time.Time {
+	if env.now != nil {
+		return env.now()
+	}
+	return time.Now()
+}
+
+// sessionContract is the set of boundaries `contain run` is about to grant the
+// agent, rendered for the operator before launch. Every field is derived from
+// the SAME preflight state the launch itself uses (the same probe environment,
+// the single tools.list read from preflight, the single workspace-inventory
+// read), so the printed contract can never describe a boundary different from
+// the one that is enforced.
+type sessionContract struct {
+	Tool            string
+	AgentUser       string
+	ProxyURL        string
+	ProxyPort       int
+	PostureCapsule  string
+	RegisteredTools []string
+	Workspaces      []contractWorkspace
+	// PrivateTmp reports whether the agent's /tmp is isolated from the operator.
+	// It is false today: contain run shares /tmp with the operator (see the
+	// "private /tmp" item in the containment guide). The field exists so the
+	// contract stops advertising a boundary the moment one is added.
+	PrivateTmp bool
+}
+
+type contractWorkspace struct {
+	Path    string
+	Mode    string
+	Owner   string
+	Created string
+	Expires string
+	Status  string
+}
+
+// buildSessionContract assembles the contract from preflight state. tools are
+// the entries preflight already parsed and the launcher's allow-list relies on;
+// grants are the single workspace-inventory read; proofPath is the exact capsule
+// destination threaded into the launch environment.
+func buildSessionContract(env *probeEnv, tool string, tools []toolsListEntry, grants []workspaceGrant, proofPath string) sessionContract {
+	names := make([]string, 0, len(tools))
+	for _, e := range tools {
+		names = append(names, e.name)
+	}
+	now := containRunNow(env)
+	workspaces := make([]contractWorkspace, 0, len(grants))
+	for _, g := range grants {
+		workspaces = append(workspaces, contractWorkspace{
+			Path:    g.Path,
+			Mode:    valueOrDash(g.Mode),
+			Owner:   valueOrDash(g.Owner),
+			Created: valueOrDash(g.Created),
+			Expires: grantExpiryLabel(g),
+			Status:  g.grantStatus(now),
+		})
+	}
+	return sessionContract{
+		Tool:            tool,
+		AgentUser:       env.agentUserName,
+		ProxyURL:        proxyURLFor(env.port),
+		ProxyPort:       env.port,
+		PostureCapsule:  proofPath,
+		RegisteredTools: names,
+		Workspaces:      workspaces,
+		PrivateTmp:      false,
+	}
+}
+
+// renderSessionContract prints the contract as an operator-facing block. Pure
+// over the struct so tests assert exact text.
+func renderSessionContract(out io.Writer, c sessionContract) {
+	_, _ = fmt.Fprintf(out, "pipelock contain run: session contract for %s\n", c.Tool)
+	_, _ = fmt.Fprintf(out, "  agent user:       %s\n", c.AgentUser)
+	_, _ = fmt.Fprintf(out, "  proxy egress:     %s (loopback proxy only; direct egress denied by nftables)\n", c.ProxyURL)
+	_, _ = fmt.Fprintf(out, "  posture capsule:  %s\n", c.PostureCapsule)
+	if c.PrivateTmp {
+		_, _ = fmt.Fprintln(out, "  agent /tmp:       private (isolated from the operator)")
+	} else {
+		_, _ = fmt.Fprintln(out, "  agent /tmp:       shared with the operator (not private)")
+	}
+	if len(c.RegisteredTools) == 0 {
+		_, _ = fmt.Fprintln(out, "  registered tools: (none)")
+	} else {
+		_, _ = fmt.Fprintf(out, "  registered tools: %s\n", strings.Join(c.RegisteredTools, ", "))
+	}
+	if len(c.Workspaces) == 0 {
+		_, _ = fmt.Fprintln(out, "  workspaces:       (none granted)")
+	} else {
+		_, _ = fmt.Fprintln(out, "  workspaces:")
+		for _, w := range c.Workspaces {
+			_, _ = fmt.Fprintf(out, "    %s  %s  owner=%s  created=%s  expires=%s  [%s]\n",
+				w.Path, w.Mode, w.Owner, w.Created, w.Expires, w.Status)
+		}
+	}
 }
 
 func containRunPostureProofPath(postureOutput string) (string, error) {
@@ -188,33 +320,39 @@ func warnCustomPostureOutput(stderr io.Writer, postureOutput, posturePath string
 		posturebinding.RuntimeProofEnv, posturePath)
 }
 
-func containRunPreflight(ctx context.Context, out io.Writer, env *probeEnv, tool string) error {
+// containRunPreflight runs every containment probe, the privilege-escape
+// canary, and the requested-tool registration check. It returns the parsed
+// tools.list entries it read for the registration check so the caller renders
+// the session contract from the SAME read the launch path relies on, never a
+// second, possibly-divergent read.
+func containRunPreflight(ctx context.Context, out io.Writer, env *probeEnv, tool string) ([]toolsListEntry, error) {
 	for _, p := range probesForEnv(env) {
 		status, detail := p.fn(ctx, env)
 		writeTextLine(out, p, status, detail)
 		if status != statusPass {
-			return cliutil.ExitCodeError(cliutil.ExitGeneral,
+			return nil, cliutil.ExitCodeError(cliutil.ExitGeneral,
 				fmt.Errorf("containment preflight failed at probe %d (%s): %s: %s", p.n, p.name, status, detail))
 		}
 	}
 
-	// Numbered above the verify probe range (max 13, the conditional
-	// workspace_access probe) so these run-only checks never collide with a
-	// verify probe number operators may key off.
+	// Numbered above the verify probe range (allProbes tops out at 14 after the
+	// launch-environment allow-list probe; the conditional workspace_access
+	// probe is 15) so these run-only checks never collide with a verify probe
+	// number operators may key off.
 	status, detail := probeAgentPrivilegeEscapeDenied(ctx, env)
-	writeTextLine(out, probe{n: 14, name: containRunPrivilegeProbe, desc: "pipelock-agent cannot sudo back out"}, status, detail)
+	writeTextLine(out, probe{n: 16, name: containRunPrivilegeProbe, desc: "pipelock-agent cannot sudo back out"}, status, detail)
 	if status != statusPass {
-		return cliutil.ExitCodeError(cliutil.ExitGeneral,
+		return nil, cliutil.ExitCodeError(cliutil.ExitGeneral,
 			fmt.Errorf("containment preflight failed at %s: %s: %s", containRunPrivilegeProbe, status, detail))
 	}
 
-	status, detail = probeRequestedToolRegistered(env, tool)
-	writeTextLine(out, probe{n: 15, name: "requested_tool_registered", desc: "requested tool is registered in tools.list"}, status, detail)
+	entries, status, detail := probeRequestedToolRegistered(env, tool)
+	writeTextLine(out, probe{n: 17, name: "requested_tool_registered", desc: "requested tool is registered in tools.list"}, status, detail)
 	if status != statusPass {
-		return cliutil.ExitCodeError(cliutil.ExitGeneral,
+		return nil, cliutil.ExitCodeError(cliutil.ExitGeneral,
 			fmt.Errorf("containment preflight failed at requested_tool_registered: %s: %s", status, detail))
 	}
-	return nil
+	return entries, nil
 }
 
 func probeAgentPrivilegeEscapeDenied(ctx context.Context, env *probeEnv) (string, string) {
@@ -231,21 +369,24 @@ func probeAgentPrivilegeEscapeDenied(ctx context.Context, env *probeEnv) (string
 	return statusPass, fmt.Sprintf("sudo escape denied (exit=%d): %s", code, oneLine(out))
 }
 
-func probeRequestedToolRegistered(env *probeEnv, tool string) (string, string) {
+// probeRequestedToolRegistered confirms the requested tool is present in the
+// runtime allow-list and returns the parsed entries so the caller can render
+// them in the session contract without a second read of tools.list.
+func probeRequestedToolRegistered(env *probeEnv, tool string) ([]toolsListEntry, string, string) {
 	data, err := env.readFile(env.toolsListPath)
 	if err != nil {
-		return statusFail, fmt.Sprintf("read %s: %v", env.toolsListPath, err)
+		return nil, statusFail, fmt.Sprintf("read %s: %v", env.toolsListPath, err)
 	}
 	entries, err := parseToolsList(data)
 	if err != nil {
-		return statusFail, fmt.Sprintf("parse %s: %v", env.toolsListPath, err)
+		return nil, statusFail, fmt.Sprintf("parse %s: %v", env.toolsListPath, err)
 	}
 	for _, entry := range entries {
 		if entry.name == tool {
-			return statusPass, fmt.Sprintf("%s is registered", tool)
+			return entries, statusPass, fmt.Sprintf("%s is registered", tool)
 		}
 	}
-	return statusFail, fmt.Sprintf("%s is not registered; run `pipelock contain add-tool %s` first", tool, tool)
+	return entries, statusFail, fmt.Sprintf("%s is not registered; run `pipelock contain add-tool %s` first", tool, tool)
 }
 
 // parseAgentGIDs converts the agent's group-id strings (primary plus

--- a/internal/cli/contain/run.go
+++ b/internal/cli/contain/run.go
@@ -140,7 +140,11 @@ func runContainRun(
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
 	}
-	env.probe.workspaceGrants = inv.Workspaces
+	// Only the grants governing THIS agent user gate this launch; another
+	// contained user's expired grant must not refuse it, and its paths must not
+	// be probed as though this agent could read them.
+	grants := grantsForAgent(inv.Workspaces, env.probe.agentUserName)
+	env.probe.workspaceGrants = grants
 
 	_, _ = fmt.Fprintln(stdout, "pipelock contain run: verifying containment preflight")
 	entries, err := containRunPreflight(ctx, stdout, env.probe, tool)
@@ -159,7 +163,7 @@ func runContainRun(
 	}
 	env.probe.postureProofPath = proofPath
 
-	contract := buildSessionContract(env.probe, tool, entries, inv.Workspaces, proofPath)
+	contract := buildSessionContract(env.probe, tool, entries, grants, proofPath)
 	// The contract is the operator's review surface. If it cannot be written
 	// (closed pipe, failed writer) nobody saw the boundary, so refuse to go on
 	// rather than emit a capsule and launch unreviewed (fail closed).
@@ -172,7 +176,7 @@ func runContainRun(
 	// revokes. Dry-runs use this same gate so their outcome cannot claim a launch
 	// is possible when a real launch would refuse it. Expiry gates the launch; it
 	// does not remove the ACL.
-	expired, err := expiredWorkspaceGrants(inv.Workspaces, containRunNow(env.probe))
+	expired, err := expiredWorkspaceGrants(grants, containRunNow(env.probe))
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}

--- a/internal/cli/contain/run_test.go
+++ b/internal/cli/contain/run_test.go
@@ -499,7 +499,7 @@ func TestProbeRequestedToolRegistered_FailureDetails(t *testing.T) {
 			env := allPassEnv(t)
 			env.readFile = tt.read
 
-			status, detail := probeRequestedToolRegistered(env, "claude")
+			_, status, detail := probeRequestedToolRegistered(env, "claude")
 			if status != statusFail {
 				t.Fatalf("status = %s, want %s (%s)", status, statusFail, detail)
 			}

--- a/internal/cli/contain/runtime_contract.go
+++ b/internal/cli/contain/runtime_contract.go
@@ -158,10 +158,26 @@ func runtimeContractVars(env *installEnv) []contractVar {
 	}
 }
 
+// containedLaunchIdentityVars returns the identity block that LEADS the
+// contained launch environment. It is the single source of truth for that
+// block, consumed by both containLaunchEnv (the `contain run` Go launcher) and
+// launchExecEnvLines (the installed plk-launch wrapper) so the two launch paths
+// can never disagree on who the tool runs as.
+func containedLaunchIdentityVars(agentUserName, homeDir string) []contractVar {
+	return []contractVar{
+		{"HOME", homeDir},
+		{"USER", agentUserName},
+		{"LOGNAME", agentUserName},
+		{"SHELL", "/bin/bash"},
+	}
+}
+
 // containLaunchEnv returns the exact environment used by `pipelock contain
-// run` when it execs plk-launch directly, bypassing sudo's env filtering. Keep
-// this in lockstep with launchExecEnvLines so the verified run launcher and the
-// installed wrapper do not drift.
+// run` when it execs plk-launch directly, bypassing sudo's env filtering. It is
+// derived from the same building blocks the installed wrapper renders
+// (containedLaunchIdentityVars + runtimeContractVars + the posture-proof export
+// + PATH); TestLaunchPathsShareEnvNameSet enforces that the two paths export the
+// same ordered set of names so they cannot drift.
 //
 // postureProofPath is the resolved path this run wrote its signed posture
 // capsule to; it is exported as PIPELOCK_POSTURE_PROOF so an emitter running in
@@ -170,11 +186,9 @@ func runtimeContractVars(env *installEnv) []contractVar {
 // when --posture-output points elsewhere. An empty value falls back to the
 // default proof path.
 func containLaunchEnv(agentUserName, homeDir string, proxyPort int, postureProofPath string) []string {
-	env := []string{
-		"HOME=" + homeDir,
-		"USER=" + agentUserName,
-		"LOGNAME=" + agentUserName,
-		"SHELL=/bin/bash",
+	var env []string
+	for _, v := range containedLaunchIdentityVars(agentUserName, homeDir) {
+		env = append(env, v.name+"="+v.value)
 	}
 	for _, v := range runtimeContractVars(&installEnv{
 		proxyPort:    proxyPort,
@@ -230,19 +244,37 @@ func envAssign(name, value string) string {
 	return name + "=" + shellQuote(value)
 }
 
-// launchExecEnvLines renders the `exec env \`-style block that plk-launch uses
-// to run the resolved tool under the full runtime contract. HOME and PATH are
-// handled specially (HOME is fixed, PATH expands the AGENT_PATH shell var), so
-// they bracket the generated contract assignments.
+// launchExecEnvLines renders the `exec env -i`-style block that plk-launch uses
+// to run the resolved tool under the full runtime contract.
+//
+// `env -i` (not plain `env`) is deliberate and is the fix for the operator->agent
+// env leak: plk-launch runs after sudo, which leaves ~two dozen operator
+// variables standing (DISPLAY, XAUTHORITY, XDG_RUNTIME_DIR, SUDO_*, ...). Plain
+// `env` would pass every one of them through to the contained tool. `env -i`
+// starts from an empty environment and rebuilds ONLY the identity block, the
+// proxy/CA runtime contract, the posture-proof binding, and PATH - the same set
+// containLaunchEnv assembles for the `contain run` Go path, so the two launch
+// paths agree. This is fail-closed for confidentiality: a variable not on this
+// list never reaches the agent. The availability tradeoff is that ambient
+// niceties like TERM/LANG are not forwarded either; this already matches the
+// `contain run` path (containLaunchEnv never set them), so it is not a new
+// regression relative to the primary path.
+//
+// HOME and PATH are rendered specially (HOME is fixed, PATH expands the
+// AGENT_PATH shell var); PIPELOCK_POSTURE_PROOF is forwarded from the caller
+// when set (contain run sets it) or bound to the default, because `env -i`
+// clears the caller's value and it must be re-asserted here or the child grades
+// containment UNKNOWN.
 func launchExecEnvLines(env *installEnv) []string {
-	lines := []string{
-		"exec env \\",
-		"    " + envAssign("HOME", agentHomeDir(env)) + " \\",
+	lines := []string{"exec env -i \\"}
+	for _, v := range containedLaunchIdentityVars(env.agentUserName, agentHomeDir(env)) {
+		lines = append(lines, "    "+envAssign(v.name, v.value)+" \\")
 	}
 	for _, v := range runtimeContractVars(env) {
 		lines = append(lines, "    "+envAssign(v.name, v.value)+" \\")
 	}
 	lines = append(lines,
+		"    "+posturebinding.RuntimeProofEnv+`="${`+posturebinding.RuntimeProofEnv+":-"+posturebinding.DefaultContainRunProofPath+`}" \`,
 		`    PATH="$AGENT_PATH" \`,
 		`    "$TARGET" "$@"`,
 	)

--- a/internal/cli/contain/runtime_contract_test.go
+++ b/internal/cli/contain/runtime_contract_test.go
@@ -123,11 +123,19 @@ func TestLaunchExecEnvLines_Shape(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	lines := launchExecEnvLines(env)
 	joined := strings.Join(lines, "\n")
-	if lines[0] != "exec env \\" {
-		t.Errorf("first line = %q, want 'exec env \\'", lines[0])
+	// env -i (not plain env) is the operator->agent leak fix: the wrapper must
+	// start from an empty environment and rebuild only the contract.
+	if lines[0] != "exec env -i \\" {
+		t.Errorf("first line = %q, want 'exec env -i \\'", lines[0])
+	}
+	if strings.Contains(joined, "exec env \\") {
+		t.Errorf("launch wrapper still uses plain `env` (ambient operator env would leak):\n%s", joined)
 	}
 	for _, want := range []string{
 		"HOME=" + agentHomeDir(env),
+		"USER=" + env.agentUserName,
+		"LOGNAME=" + env.agentUserName,
+		"SHELL=/bin/bash",
 		"HTTPS_PROXY=http://127.0.0.1:8888",
 		`PATH="$AGENT_PATH"`,
 		`"$TARGET" "$@"`,
@@ -139,8 +147,12 @@ func TestLaunchExecEnvLines_Shape(t *testing.T) {
 			t.Errorf("launch exec env missing %q", want)
 		}
 	}
-	if strings.Contains(joined, posturebinding.RuntimeProofEnv+"=") {
-		t.Fatalf("launch wrapper must preserve caller-provided %s, got:\n%s", posturebinding.RuntimeProofEnv, joined)
+	// Under env -i the caller's PIPELOCK_POSTURE_PROOF is cleared, so it must be
+	// explicitly forwarded (preserving a run-provided value, else the default) or
+	// the child grades containment UNKNOWN.
+	wantForward := posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + ":-" + posturebinding.DefaultContainRunProofPath + `}"`
+	if !strings.Contains(joined, wantForward) {
+		t.Fatalf("launch wrapper must forward %s under env -i, want %q, got:\n%s", posturebinding.RuntimeProofEnv, wantForward, joined)
 	}
 	// Every continuation line except the last must end with a backslash.
 	for i, l := range lines[:len(lines)-1] {

--- a/internal/cli/contain/runtime_contract_test.go
+++ b/internal/cli/contain/runtime_contract_test.go
@@ -844,3 +844,82 @@ func TestStepWriteUtilityWrappers_WriteErrorRollsBack(t *testing.T) {
 		t.Fatalf("expected write error to surface")
 	}
 }
+
+// TestLaunchPathsShareEnvNameSet is the anti-drift check named in
+// containLaunchEnv's doc: the `contain run` Go launcher and the installed
+// plk-launch wrapper must export the SAME ordered set of environment variable
+// names, so the two contained-launch paths can never disagree on what the tool
+// sees.
+func TestLaunchPathsShareEnvNameSet(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+
+	goEnv := containLaunchEnv(env.agentUserName, agentHomeDir(env), env.proxyPort, "")
+	goNames := make([]string, 0, len(goEnv))
+	for _, e := range goEnv {
+		name, _, ok := strings.Cut(e, "=")
+		if !ok {
+			t.Fatalf("malformed go env entry %q", e)
+		}
+		goNames = append(goNames, name)
+	}
+
+	wrapperNames := make([]string, 0, len(goNames))
+	for _, l := range launchExecEnvLines(env) {
+		l = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(l), `\`))
+		if l == "" || strings.HasPrefix(l, "exec env") || strings.HasPrefix(l, `"$TARGET"`) {
+			continue
+		}
+		name, _, ok := strings.Cut(l, "=")
+		if !ok {
+			continue
+		}
+		wrapperNames = append(wrapperNames, strings.TrimSpace(name))
+	}
+
+	if !slices.Equal(goNames, wrapperNames) {
+		t.Fatalf("launch env name sets diverged:\n  go     =%v\n  wrapper=%v", goNames, wrapperNames)
+	}
+}
+
+// TestLaunchExecEnvLines_EnvIClearsLeakAndForwardsPosture proves the rendered
+// plk-launch env block, run through a real bash, (a) forwards a caller-provided
+// PIPELOCK_POSTURE_PROOF, (b) falls back to the default when it is unset, and
+// (c) drops operator variables that were standing in the wrapper's own
+// environment (the leak `env -i` closes).
+func TestLaunchExecEnvLines_EnvIClearsLeakAndForwardsPosture(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("bash unavailable")
+	}
+	if _, err := os.Stat("/usr/bin/env"); err != nil {
+		t.Skip("/usr/bin/env unavailable")
+	}
+	env, _, _ := newFakeEnv(t)
+	body := "#!/bin/bash\nset -euo pipefail\nAGENT_PATH=/usr/bin:/bin\nTARGET=/usr/bin/env\n" +
+		strings.Join(launchExecEnvLines(env), "\n") + "\n"
+	tmp := filepath.Join(t.TempDir(), "plk-launch")
+	writeScriptFixture(t, tmp, body)
+
+	// Caller (sudo) leaves operator variables standing AND a run-specific proof.
+	res := execRealCommand(t, "/bin/bash", "-c",
+		"PIPELOCK_POSTURE_PROOF=/custom/run/proof.json DISPLAY=:0 XAUTHORITY=/x SUDO_USER=josh bash "+shellQuote(tmp))
+	if res.exit != 0 {
+		t.Fatalf("run: exit=%d out=%s", res.exit, res.output)
+	}
+	if !strings.Contains(res.output, posturebinding.RuntimeProofEnv+"=/custom/run/proof.json") {
+		t.Fatalf("posture proof not forwarded under env -i:\n%s", res.output)
+	}
+	for _, leak := range []string{"DISPLAY=", "XAUTHORITY=", "SUDO_USER="} {
+		if strings.Contains(res.output, leak) {
+			t.Fatalf("env -i leaked operator variable %q:\n%s", leak, res.output)
+		}
+	}
+
+	// With no caller-provided proof, the default binds.
+	res2 := execRealCommand(t, "/bin/bash", "-c", "unset PIPELOCK_POSTURE_PROOF; bash "+shellQuote(tmp))
+	if res2.exit != 0 {
+		t.Fatalf("run (default): exit=%d out=%s", res2.exit, res2.output)
+	}
+	if !strings.Contains(res2.output, posturebinding.RuntimeProofEnv+"="+posturebinding.DefaultContainRunProofPath) {
+		t.Fatalf("posture proof did not fall back to default:\n%s", res2.output)
+	}
+}

--- a/internal/cli/contain/session_contract_test.go
+++ b/internal/cli/contain/session_contract_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRenderSessionContract_ExactText(t *testing.T) {
 	var buf bytes.Buffer
-	renderSessionContract(&buf, sessionContract{
+	_ = renderSessionContract(&buf, sessionContract{
 		Tool:            "claude",
 		AgentUser:       "pipelock-agent",
 		ProxyURL:        "http://127.0.0.1:8888",
@@ -45,7 +45,7 @@ func TestRenderSessionContract_ExactText(t *testing.T) {
 
 func TestRenderSessionContract_EmptyToolsAndWorkspaces(t *testing.T) {
 	var buf bytes.Buffer
-	renderSessionContract(&buf, sessionContract{Tool: "claude", AgentUser: "pipelock-agent", ProxyURL: "http://127.0.0.1:8888"})
+	_ = renderSessionContract(&buf, sessionContract{Tool: "claude", AgentUser: "pipelock-agent", ProxyURL: "http://127.0.0.1:8888"})
 	out := buf.String()
 	if !strings.Contains(out, "registered tools: (none)") {
 		t.Errorf("empty tools not rendered: %q", out)

--- a/internal/cli/contain/session_contract_test.go
+++ b/internal/cli/contain/session_contract_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderSessionContract_ExactText(t *testing.T) {
+	var buf bytes.Buffer
+	renderSessionContract(&buf, sessionContract{
+		Tool:            "claude",
+		AgentUser:       "pipelock-agent",
+		ProxyURL:        "http://127.0.0.1:8888",
+		ProxyPort:       8888,
+		PostureCapsule:  "/var/lib/pipelock/contain/posture/proof.json",
+		RegisteredTools: []string{"claude", "codex"},
+		Workspaces: []contractWorkspace{
+			{Path: "/home/dev/proj", Mode: "read-write", Owner: "josh", Created: "2026-01-02T03:04:05Z", Expires: "never", Status: "active"},
+		},
+		PrivateTmp: false,
+	})
+	want := strings.Join([]string{
+		"pipelock contain run: session contract for claude",
+		"  agent user:       pipelock-agent",
+		"  proxy egress:     http://127.0.0.1:8888 (loopback proxy only; direct egress denied by nftables)",
+		"  posture capsule:  /var/lib/pipelock/contain/posture/proof.json",
+		"  agent /tmp:       shared with the operator (not private)",
+		"  registered tools: claude, codex",
+		"  workspaces:",
+		"    /home/dev/proj  read-write  owner=josh  created=2026-01-02T03:04:05Z  expires=never  [active]",
+		"",
+	}, "\n")
+	if got := buf.String(); got != want {
+		t.Fatalf("contract text mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRenderSessionContract_EmptyToolsAndWorkspaces(t *testing.T) {
+	var buf bytes.Buffer
+	renderSessionContract(&buf, sessionContract{Tool: "claude", AgentUser: "pipelock-agent", ProxyURL: "http://127.0.0.1:8888"})
+	out := buf.String()
+	if !strings.Contains(out, "registered tools: (none)") {
+		t.Errorf("empty tools not rendered: %q", out)
+	}
+	if !strings.Contains(out, "workspaces:       (none granted)") {
+		t.Errorf("empty workspaces not rendered: %q", out)
+	}
+}
+
+func TestBuildSessionContract_DerivesFromPreflightState(t *testing.T) {
+	env := &probeEnv{agentUserName: "pipelock-agent", port: 8888, now: func() time.Time {
+		return time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	}}
+	tools := []toolsListEntry{{name: "claude"}, {name: "codex", target: "/usr/bin/codex"}}
+	grants := []workspaceGrant{
+		{Path: "/home/dev/proj", Mode: "read-write", Owner: "josh", Created: "2026-01-01T00:00:00Z", Expires: "2026-02-01T00:00:00Z"},
+		{Path: "/legacy/only"}, // legacy: no metadata
+	}
+	c := buildSessionContract(env, "claude", tools, grants, "/var/lib/pipelock/contain/posture/proof.json")
+
+	if c.Tool != "claude" || c.AgentUser != "pipelock-agent" || c.ProxyURL != "http://127.0.0.1:8888" {
+		t.Fatalf("scalar fields wrong: %+v", c)
+	}
+	if c.PrivateTmp {
+		t.Fatal("PrivateTmp must be false until private-tmp isolation ships")
+	}
+	if strings.Join(c.RegisteredTools, ",") != "claude,codex" {
+		t.Fatalf("registered tools = %v, want claude,codex", c.RegisteredTools)
+	}
+	if len(c.Workspaces) != 2 {
+		t.Fatalf("workspaces len = %d, want 2", len(c.Workspaces))
+	}
+	if c.Workspaces[0].Status != "active" || c.Workspaces[0].Owner != "josh" {
+		t.Fatalf("grant 0 = %+v, want active/josh", c.Workspaces[0])
+	}
+	if c.Workspaces[1].Status != "legacy" || c.Workspaces[1].Owner != "-" || c.Workspaces[1].Expires != "never" {
+		t.Fatalf("legacy grant should render as legacy with dashes: %+v", c.Workspaces[1])
+	}
+}
+
+// TestRunContainRun_DryRunPrintsContractWithoutLaunchOrPosture proves --dry-run
+// runs preflight, prints the contract, and neither emits a posture capsule nor
+// launches.
+func TestRunContainRun_DryRunPrintsContractWithoutLaunchOrPosture(t *testing.T) {
+	env := allPassEnv(t)
+	var launched, posture bool
+	runEnv := containRunEnv{
+		probe: env,
+		launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+			launched = true
+			return nil
+		},
+		emitPosture: func(string, string, *probeEnv, []string) (string, error) {
+			posture = true
+			return "/unused", nil
+		},
+	}
+	var buf bytes.Buffer
+	err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{dryRun: true}, []string{"claude"})
+	if err != nil {
+		t.Fatalf("dry-run err = %v", err)
+	}
+	if launched {
+		t.Fatal("dry-run launched the tool")
+	}
+	if posture {
+		t.Fatal("dry-run emitted a posture capsule")
+	}
+	if !strings.Contains(buf.String(), "session contract for claude") {
+		t.Fatalf("dry-run did not print the contract: %q", buf.String())
+	}
+}
+
+// TestRunContainRun_ContractReflectsTheToolsTheLauncherAccepts is the
+// display/action anti-divergence check: the contract's registered-tools list is
+// exactly what the registration check (which the launch relies on) parsed from
+// tools.list, from the same read.
+func TestRunContainRun_ContractReflectsTheToolsTheLauncherAccepts(t *testing.T) {
+	env := allPassEnv(t)
+	// Both tools resolve to one real executable so probe 12 (target resolvable)
+	// passes; the point of the test is that the contract lists exactly what the
+	// registration read parsed.
+	toolTarget := filepath.Join(t.TempDir(), "tool")
+	writeFakeWrapper(t, toolTarget, 0o755)
+	base := env.readFile
+	env.readFile = func(path string) ([]byte, error) {
+		if path == env.toolsListPath {
+			return []byte("claude\t" + toolTarget + "\ncodex\t" + toolTarget + "\n"), nil
+		}
+		return base(path)
+	}
+	var launched bool
+	runEnv := containRunEnv{
+		probe: env,
+		launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+			launched = true
+			return nil
+		},
+		emitPosture: func(string, string, *probeEnv, []string) (string, error) { return "/unused", nil },
+	}
+	var buf bytes.Buffer
+	if err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{}, []string{"claude"}); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if !launched {
+		t.Fatal("launch did not run for a registered tool")
+	}
+	if !strings.Contains(buf.String(), "registered tools: claude, codex") {
+		t.Fatalf("contract tool list did not match the launcher's tools.list read: %q", buf.String())
+	}
+}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -634,12 +634,31 @@ func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) 
 	// must rebuild EXACTLY the runtime contract, nothing missing and nothing
 	// extra. Both directions fail: a missing variable breaks the proxy/CA
 	// contract, an extra one is an operator-environment passthrough.
-	names, found := parseLaunchExecEnvNames(script)
-	if !found {
-		if strings.Contains(script, "exec env ") {
-			return statusFail, "plk-launch execs the tool with plain `env`; operator environment (DISPLAY, XAUTHORITY, SUDO_*, ...) leaks into the contained agent - reinstall with `pipelock contain install`"
-		}
+	if plainExecEnvLine(script) {
+		return statusFail, "plk-launch execs the tool with plain `env`; operator environment (DISPLAY, XAUTHORITY, SUDO_*, ...) leaks into the contained agent - reinstall with `pipelock contain install`"
+	}
+	blocks := parseLaunchExecEnvBlocks(script)
+	switch len(blocks) {
+	case 0:
 		return statusFail, fmt.Sprintf("plk-launch at %s does not clear the environment (no `exec env -i` block) before exec", env.launchPath)
+	case 1:
+	default:
+		// A correctly rendered wrapper execs exactly once. More than one block
+		// means the block this probe reads is not necessarily the one the shell
+		// reaches, so a canonical decoy could stand in front of a leaky block
+		// that actually runs. Refuse to guess which is effective.
+		return statusFail, fmt.Sprintf("plk-launch at %s contains %d `exec env -i` blocks; exactly one is expected, so the effective launch environment is ambiguous - reinstall with `pipelock contain install`",
+			env.launchPath, len(blocks))
+	}
+	assigns := blocks[0]
+	names := make([]string, 0, len(assigns))
+	for _, a := range assigns {
+		names = append(names, a.name)
+	}
+	if dup := firstDuplicateName(names); dup != "" {
+		// env applies the LAST assignment of a repeated name, so a duplicate
+		// makes the effective value differ from the one a reader sees first.
+		return statusFail, fmt.Sprintf("plk-launch env -i block assigns %s more than once; the effective value is not the one it appears to set - reinstall with `pipelock contain install`", dup)
 	}
 	expected := expectedLaunchEnvNames()
 	missing, extra := diffNameSets(expected, names)
@@ -647,41 +666,157 @@ func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) 
 		return statusFail, fmt.Sprintf("plk-launch env -i block does not match the runtime contract (missing: %s; unexpected: %s); reinstall with `pipelock contain install`",
 			listOrNone(missing), listOrNone(extra))
 	}
-	return statusPass, fmt.Sprintf("plk-launch clears the environment (env -i) and rebuilds exactly the %d-variable runtime contract", len(expected))
+	// Names alone are not the contract. A wrapper that assigns every expected
+	// name and points HTTPS_PROXY somewhere else, or SSL_CERT_FILE at an
+	// attacker-writable bundle, passes a name-only check while defeating exactly
+	// what containment buys. Values are checked for the variables whose correct
+	// value this probe can derive with certainty from the verified install
+	// (proxy endpoint, no-proxy list, CA bundle, agent identity); the rest
+	// (NODE_OPTIONS shim path, NODE_EXTRA_CA_CERTS, PATH, posture proof) depend
+	// on install-time paths this probe does not rediscover, so demanding a value
+	// for them would refuse legitimate non-default installs.
+	if name, want, got, ok := firstLaunchEnvValueMismatch(assigns, env); !ok {
+		return statusFail, fmt.Sprintf("plk-launch env -i block sets %s=%s, expected %s; the contained agent would not be bound to this install's %s - reinstall with `pipelock contain install`",
+			name, got, want, launchEnvValueSubject(name))
+	}
+	return statusPass, fmt.Sprintf("plk-launch clears the environment (env -i) and rebuilds exactly the %d-variable runtime contract, with the proxy, no-proxy, CA and identity values bound to this install", len(expected))
+}
+
+// launchEnvAssign is one NAME=VALUE assignment read from a launcher's exec
+// block, with surrounding shell quoting stripped from the value.
+type launchEnvAssign struct {
+	name  string
+	value string
+}
+
+// plainExecEnvLine reports whether the script execs the tool through `env`
+// WITHOUT -i anywhere, which passes the whole operator environment through.
+// Checked independently of the -i parse so a leaky exec line is caught even
+// when a canonical block also exists.
+func plainExecEnvLine(script string) bool {
+	for _, raw := range strings.Split(script, "\n") {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, "exec env ") {
+			continue
+		}
+		if !strings.HasPrefix(line, "exec env -i") {
+			return true
+		}
+	}
+	return false
+}
+
+// firstDuplicateName returns the first name assigned more than once, or "".
+func firstDuplicateName(names []string) string {
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		if seen[n] {
+			return n
+		}
+		seen[n] = true
+	}
+	return ""
+}
+
+// launchEnvValueSubject names, in operator words, what a mismatched variable
+// would have bound the agent to, so the failure line says what broke.
+func launchEnvValueSubject(name string) string {
+	switch name {
+	case "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy":
+		return "proxy endpoint"
+	case "NO_PROXY", "no_proxy":
+		return "proxy bypass list"
+	case "USER", "LOGNAME", "SHELL":
+		return "agent identity"
+	default:
+		return "CA bundle"
+	}
+}
+
+// firstLaunchEnvValueMismatch checks the assignments whose correct value is
+// derivable from the verified install state. ok is false on the first mismatch.
+func firstLaunchEnvValueMismatch(assigns []launchEnvAssign, env *probeEnv) (name, want, got string, ok bool) {
+	proxy := proxyURLFor(env.port)
+	expect := map[string]string{
+		"HTTP_PROXY":  proxy,
+		"http_proxy":  proxy,
+		"HTTPS_PROXY": proxy,
+		"https_proxy": proxy,
+		"ALL_PROXY":   proxy,
+		"all_proxy":   proxy,
+		"NO_PROXY":    contractNoProxy,
+		"no_proxy":    contractNoProxy,
+	}
+	if env.caBundlePath != "" {
+		for _, n := range []string{"SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO", "CARGO_HTTP_CAINFO", "PIP_CERT"} {
+			expect[n] = env.caBundlePath
+		}
+	}
+	// SHELL is a fixed literal in the contract, so it is always checkable.
+	expect["SHELL"] = "/bin/bash"
+	if env.agentUserName != "" {
+		expect["USER"] = env.agentUserName
+		expect["LOGNAME"] = env.agentUserName
+	}
+	for _, a := range assigns {
+		if w, checked := expect[a.name]; checked && a.value != w {
+			return a.name, w, a.value, false
+		}
+	}
+	return "", "", "", true
 }
 
 var launchEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// parseLaunchExecEnvNames finds the executed `exec env -i` command in a
-// launcher script (comment lines are skipped) and returns the variable names it
-// assigns, reading line continuations up to the "$TARGET" token. found is false
-// when no such command exists.
-func parseLaunchExecEnvNames(script string) (names []string, found bool) {
+// parseLaunchExecEnvBlocks finds EVERY `exec env -i` command in a launcher
+// script (comment lines are skipped) and returns each one's assignments,
+// reading line continuations up to the "$TARGET" token. All blocks are returned
+// rather than the first, because a script with more than one has no
+// determinable effective environment and the caller refuses it.
+func parseLaunchExecEnvBlocks(script string) [][]launchEnvAssign {
+	var blocks [][]launchEnvAssign
 	lines := strings.Split(script, "\n")
 	for i := 0; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
 		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, "exec env -i") {
 			continue
 		}
+		var assigns []launchEnvAssign
 		rest := strings.TrimPrefix(line, "exec env -i")
 		for {
 			rest = strings.TrimSuffix(strings.TrimSpace(rest), "\\")
+			done := false
 			for _, tok := range strings.Fields(rest) {
 				if tok == `"$TARGET"` || tok == "$TARGET" {
-					return names, true
+					done = true
+					break
 				}
 				if eq := strings.IndexByte(tok, '='); eq > 0 && launchEnvNamePattern.MatchString(tok[:eq]) {
-					names = append(names, tok[:eq])
+					assigns = append(assigns, launchEnvAssign{name: tok[:eq], value: unquoteShellValue(tok[eq+1:])})
 				}
 			}
 			i++
-			if i >= len(lines) {
-				return names, true
+			if done || i >= len(lines) {
+				break
 			}
 			rest = lines[i]
 		}
+		blocks = append(blocks, assigns)
 	}
-	return nil, false
+	return blocks
+}
+
+// unquoteShellValue strips one layer of matching single or double quotes from a
+// rendered assignment value so it can be compared with the literal it must
+// carry. envAssign quotes only when the value is not shell-safe, so an unquoted
+// value is returned unchanged.
+func unquoteShellValue(v string) string {
+	if len(v) >= 2 {
+		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
+			return v[1 : len(v)-1]
+		}
+	}
+	return v
 }
 
 // expectedLaunchEnvNames is the exact variable-name set a correctly rendered
@@ -993,7 +1128,9 @@ Exit codes:
 			if inv, err := loadWorkspaceInventoryFrom(env.readFile, env.workspaceInvPath); err != nil {
 				env.workspaceInvErr = err
 			} else {
-				env.workspaceGrants = inv.Workspaces
+				// Scope to this agent user: another contained user's grant is not
+				// part of this verification's boundary and must not fail it.
+				env.workspaceGrants = grantsForAgent(inv.Workspaces, env.agentUserName)
 			}
 			return runVerify(cmd, env, opts)
 		},

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -637,7 +637,10 @@ func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) 
 	if plainExecEnvLine(script) {
 		return statusFail, "plk-launch execs the tool with plain `env`; operator environment (DISPLAY, XAUTHORITY, SUDO_*, ...) leaks into the contained agent - reinstall with `pipelock contain install`"
 	}
-	blocks := parseLaunchExecEnvBlocks(script)
+	blocks, malformed := parseLaunchExecEnvBlocks(script)
+	if malformed {
+		return statusFail, fmt.Sprintf("plk-launch at %s has an `exec env -i` block that never reaches the tool (a line before \"$TARGET\" is missing its trailing continuation), so the launcher would not start the agent - reinstall with `pipelock contain install`", env.launchPath)
+	}
 	switch len(blocks) {
 	case 0:
 		return statusFail, fmt.Sprintf("plk-launch at %s does not clear the environment (no `exec env -i` block) before exec", env.launchPath)
@@ -773,8 +776,7 @@ var launchEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // reading line continuations up to the "$TARGET" token. All blocks are returned
 // rather than the first, because a script with more than one has no
 // determinable effective environment and the caller refuses it.
-func parseLaunchExecEnvBlocks(script string) [][]launchEnvAssign {
-	var blocks [][]launchEnvAssign
+func parseLaunchExecEnvBlocks(script string) (blocks [][]launchEnvAssign, malformed bool) {
 	lines := strings.Split(script, "\n")
 	for i := 0; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
@@ -783,12 +785,19 @@ func parseLaunchExecEnvBlocks(script string) [][]launchEnvAssign {
 		}
 		var assigns []launchEnvAssign
 		rest := strings.TrimPrefix(line, "exec env -i")
+		reachedTarget := false
 		for {
-			rest = strings.TrimSuffix(strings.TrimSpace(rest), "\\")
-			done := false
-			for _, tok := range strings.Fields(rest) {
+			trimmed := strings.TrimSpace(rest)
+			// The shell ends the command at the first physical line that is NOT
+			// continued. A block whose continuation is missing therefore never
+			// reaches "$TARGET" and never starts the tool, so reading on past
+			// that line would let the probe collect a complete-looking variable
+			// set from lines the shell would never pass to env.
+			continued := strings.HasSuffix(trimmed, "\\")
+			trimmed = strings.TrimSuffix(trimmed, "\\")
+			for _, tok := range strings.Fields(trimmed) {
 				if tok == `"$TARGET"` || tok == "$TARGET" {
-					done = true
+					reachedTarget = true
 					break
 				}
 				if eq := strings.IndexByte(tok, '='); eq > 0 && launchEnvNamePattern.MatchString(tok[:eq]) {
@@ -796,14 +805,21 @@ func parseLaunchExecEnvBlocks(script string) [][]launchEnvAssign {
 				}
 			}
 			i++
-			if done || i >= len(lines) {
+			if reachedTarget || !continued || i >= len(lines) {
 				break
 			}
 			rest = lines[i]
 		}
+		if !reachedTarget {
+			// Ran off a broken continuation or off the end of the file: this
+			// launcher does not exec the tool at all. Fail rather than report a
+			// variable set the shell never applies.
+			malformed = true
+			continue
+		}
 		blocks = append(blocks, assigns)
 	}
-	return blocks
+	return blocks, malformed
 }
 
 // unquoteShellValue strips one layer of matching single or double quotes from a

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
 )
 
 // Probe environment defaults. These match the layout produced by
@@ -144,7 +145,9 @@ type probeEnv struct {
 	wrapperInvPath     string
 	toolsListPath      string
 	configPath         string
+	workspaceInvPath   string
 	workspacePaths     []string
+	workspaceGrants    []workspaceGrant
 	pipelockTarget     string
 	verifyRunningImage bool
 	// postureProofPath is the resolved path the current `contain run` writes its
@@ -152,6 +155,8 @@ type probeEnv struct {
 	// PIPELOCK_POSTURE_PROOF so an in-child emitter binds the exact capsule this
 	// run produced, even when --posture-output points off the default path.
 	postureProofPath string
+
+	now func() time.Time
 
 	runCmd      runCommand
 	dropCounter dropCounterFunc
@@ -191,9 +196,11 @@ func defaultProbeEnv() *probeEnv {
 		pinPath:            defaultIntegrityPin,
 		wrapperInvPath:     defaultWrapperInvPath,
 		toolsListPath:      defaultToolsListPath,
+		workspaceInvPath:   defaultWorkspaceInvPath,
 		configPath:         filepath.Join(defaultConfigDir, "pipelock.yaml"),
 		pipelockTarget:     defaultPipelockTarget,
 		verifyRunningImage: true,
+		now:                time.Now,
 		runCmd:             realRunCommand,
 		dropCounter:        readContainmentDropCounter,
 		dialCtx:            realDial,
@@ -337,6 +344,7 @@ func allProbes() []probe {
 		{11, "cc_launch_allow_list_enforced", "plk-launch rejects tools missing from the allow-list", probeCCLaunchAllowList},
 		{12, "listed_tool_targets_resolvable", "tools.list entries resolve for pipelock-agent", probeListedToolTargets},
 		{13, "managed_config_metrics", "managed config keeps metrics on loopback or a current, source-scoped exception", probeManagedConfigMetrics},
+		{14, "launch_env_allow_list", "plk-launch clears the operator environment (env -i) before exec", probeLaunchEnvAllowList},
 	}
 }
 
@@ -350,13 +358,34 @@ func probesForEnv(env *probeEnv) []probe {
 			}
 		}
 	}
-	if len(env.workspacePaths) > 0 {
-		probes = append(probes, probe{14, "workspace_access", "pipelock-agent can read configured workspace paths", probeWorkspaceAccess})
+	// Conditional workspace probe. Numbered 15 (above the fixed allProbes range,
+	// which now tops out at 14) so adding the launch-env probe did not renumber
+	// any fixed probe. Appears when workspaces are passed via --workspace or when
+	// the recorded inventory has grants to check for readability and expiry.
+	if len(env.workspacePaths) > 0 || len(env.workspaceGrants) > 0 {
+		probes = append(probes, probe{15, "workspace_access", "pipelock-agent can read configured workspace paths and no grant has expired", probeWorkspaceAccess})
 	}
 	return probes
 }
 
 func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
+	// Expiry gate first: a recorded grant past its window means the ACL is still
+	// live after the operator's intended lifetime, which is a posture failure
+	// even if the path is still readable. Fail CLOSED, including on a malformed
+	// expiry value.
+	now := time.Now()
+	if env.now != nil {
+		now = env.now()
+	}
+	expired, err := expiredWorkspaceGrants(env.workspaceGrants, now)
+	if err != nil {
+		return statusFail, err.Error()
+	}
+	if len(expired) > 0 {
+		return statusFail, fmt.Sprintf("%d workspace grant(s) expired: %s; re-grant with `pipelock contain grant-workspace` or remove with `pipelock contain revoke-workspace`",
+			len(expired), strings.Join(expired, "; "))
+	}
+
 	var bad []string
 	for _, path := range env.workspacePaths {
 		clean, err := filepath.Abs(filepath.Clean(path))
@@ -391,7 +420,8 @@ func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
 	if len(bad) > 0 {
 		return statusFail, strings.Join(bad, "; ")
 	}
-	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s", len(env.workspacePaths), env.agentUserName)
+	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s; %d recorded grant(s) within expiry",
+		len(env.workspacePaths), env.agentUserName, len(env.workspaceGrants))
 }
 
 // probeListedToolTargets verifies each configured wrapper target exists and is
@@ -534,6 +564,51 @@ func probeCCLaunchAllowList(ctx context.Context, env *probeEnv) (string, string)
 		// exit-code table.
 		return statusFail, fmt.Sprintf("plk-launch exit %d (expected 5): %s", code, oneLine(out))
 	}
+}
+
+// probeLaunchEnvAllowList confirms the installed plk-launch clears the operator
+// environment before exec'ing the tool. plk-launch runs after sudo, which leaves
+// operator variables standing (DISPLAY, XAUTHORITY, XDG_RUNTIME_DIR, SUDO_*);
+// plain `env` would pass them all through to the contained agent, and a sudoers
+// change could widen that further. The launcher is rendered with `env -i` so it
+// rebuilds ONLY the identity block, the proxy/CA contract, the posture-proof
+// binding, and PATH. This probe fails CLOSED: a plk-launch that reverted to
+// plain `env`, or that no longer forwards the posture proof, is a boundary
+// regression the operator must see, not a silent leak.
+//
+// It is a read-only check of the rendered launcher artifact rather than a live
+// env dump: with `env -i` the child's environment is fully determined by the
+// script text, and there is no default-registered tool that prints its
+// environment to exec through the allow-list, so reading the artifact is both
+// sufficient and the only path that does not depend on install-specific tools.
+func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) {
+	// Read the on-disk launcher artifact the same way probeNoProxyEnv does, so
+	// both probes inspect the exact script the operator will exec.
+	data, err := os.ReadFile(filepath.Clean(env.launchPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return statusSkip, fmt.Sprintf("plk-launch missing at %s (install never ran)", env.launchPath)
+		}
+		return statusSkip, fmt.Sprintf("read %s: %v (rerun as root)", env.launchPath, err)
+	}
+	script := string(data)
+	if !strings.Contains(script, "exec env -i") {
+		if strings.Contains(script, "exec env ") {
+			return statusFail, "plk-launch execs the tool with plain `env`; operator environment (DISPLAY, XAUTHORITY, SUDO_*, ...) leaks into the contained agent - reinstall with `pipelock contain install`"
+		}
+		return statusFail, fmt.Sprintf("plk-launch at %s does not clear the environment (no `env -i`) before exec", env.launchPath)
+	}
+	if !strings.Contains(script, posturebinding.RuntimeProofEnv+`="${`+posturebinding.RuntimeProofEnv) {
+		return statusFail, fmt.Sprintf("plk-launch does not forward %s under env -i; a contained launch would grade containment UNKNOWN", posturebinding.RuntimeProofEnv)
+	}
+	// Guard against a future edit re-introducing an explicit operator-variable
+	// passthrough (e.g. DISPLAY="$DISPLAY") that env -i would otherwise defeat.
+	for _, leak := range []string{`DISPLAY="$DISPLAY"`, `XAUTHORITY=`, `SUDO_`} {
+		if strings.Contains(script, leak) {
+			return statusFail, fmt.Sprintf("plk-launch explicitly forwards an operator variable (%s); remove it so env -i keeps the boundary closed", leak)
+		}
+	}
+	return statusPass, "plk-launch clears the environment (env -i) and rebuilds only the runtime contract"
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
@@ -790,6 +865,12 @@ Exit codes:
 			env := defaultProbeEnv()
 			env.port = opts.port
 			env.workspacePaths = append([]string(nil), opts.workspacePaths...)
+			// Load recorded grants so the workspace probe can enforce expiry, not
+			// just the ad-hoc --workspace paths. A missing inventory is empty (no
+			// grants), not an error.
+			if inv, err := loadWorkspaceInventoryFrom(env.readFile, env.workspaceInvPath); err == nil {
+				env.workspaceGrants = inv.Workspaces
+			}
 			return runVerify(cmd, env, opts)
 		},
 	}

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -639,7 +639,7 @@ func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) 
 	}
 	blocks, malformed := parseLaunchExecEnvBlocks(script)
 	if malformed {
-		return statusFail, fmt.Sprintf("plk-launch at %s has an `exec env -i` block that never reaches the tool (a line before \"$TARGET\" is missing its trailing continuation), so the launcher would not start the agent - reinstall with `pipelock contain install`", env.launchPath)
+		return statusFail, fmt.Sprintf("plk-launch at %s has an `exec env -i` block that does not match the installed launcher grammar (a token before \"$TARGET\" is not a NAME=VALUE assignment, or a line is missing its trailing continuation), so the launcher may not start the agent under the runtime contract - reinstall with `pipelock contain install`", env.launchPath)
 	}
 	switch len(blocks) {
 	case 0:
@@ -786,6 +786,7 @@ func parseLaunchExecEnvBlocks(script string) (blocks [][]launchEnvAssign, malfor
 		var assigns []launchEnvAssign
 		rest := strings.TrimPrefix(line, "exec env -i")
 		reachedTarget := false
+		unsupported := ""
 		for {
 			trimmed := strings.TrimSpace(rest)
 			// The shell ends the command at the first physical line that is NOT
@@ -795,14 +796,30 @@ func parseLaunchExecEnvBlocks(script string) (blocks [][]launchEnvAssign, malfor
 			// set from lines the shell would never pass to env.
 			continued := strings.HasSuffix(trimmed, "\\")
 			trimmed = strings.TrimSuffix(trimmed, "\\")
-			for _, tok := range strings.Fields(trimmed) {
+			for _, tok := range splitLaunchEnvTokens(trimmed) {
 				if tok == `"$TARGET"` || tok == "$TARGET" {
 					reachedTarget = true
 					break
 				}
-				if eq := strings.IndexByte(tok, '='); eq > 0 && launchEnvNamePattern.MatchString(tok[:eq]) {
-					assigns = append(assigns, launchEnvAssign{name: tok[:eq], value: unquoteShellValue(tok[eq+1:])})
+				// Parse ONLY the grammar the renderer emits: every token before
+				// the target is a NAME=VALUE assignment. Anything else means the
+				// installed script is not the script `contain install` writes,
+				// and the shell may not read it the way this probe does. An
+				// inline `#` is the sharp case: `PATH="$PATH" # \` looks
+				// continued to a line-based reader, while the shell treats the
+				// rest as a comment and runs `env -i` with no target, so the
+				// probe would certify a runtime contract for a launcher that
+				// never starts the agent. Control operators (;, &, |, redirects,
+				// command substitution) are rejected for the same reason.
+				eq := strings.IndexByte(tok, '=')
+				if eq <= 0 || !launchEnvNamePattern.MatchString(tok[:eq]) {
+					unsupported = tok
+					break
 				}
+				assigns = append(assigns, launchEnvAssign{name: tok[:eq], value: unquoteShellValue(tok[eq+1:])})
+			}
+			if unsupported != "" {
+				break
 			}
 			i++
 			if reachedTarget || !continued || i >= len(lines) {
@@ -810,16 +827,59 @@ func parseLaunchExecEnvBlocks(script string) (blocks [][]launchEnvAssign, malfor
 			}
 			rest = lines[i]
 		}
-		if !reachedTarget {
-			// Ran off a broken continuation or off the end of the file: this
-			// launcher does not exec the tool at all. Fail rather than report a
-			// variable set the shell never applies.
+		if unsupported != "" || !reachedTarget {
+			// Either a token outside the renderer's grammar, or the block ran
+			// off a broken continuation or the end of the file. Both mean this
+			// launcher does not reliably exec the tool under the contract, so
+			// fail rather than report a variable set the shell may never apply.
 			malformed = true
 			continue
 		}
 		blocks = append(blocks, assigns)
 	}
 	return blocks, malformed
+}
+
+// splitLaunchEnvTokens splits a rendered launcher line into shell words,
+// honoring double and single quotes. strings.Fields cannot be used here: the
+// renderer quotes any value that is not shell-safe, so a value containing a
+// space (NODE_OPTIONS="--require /path/shim.js") would split into two words and
+// the second would look like a token outside the grammar.
+func splitLaunchEnvTokens(line string) []string {
+	var (
+		tokens []string
+		cur    strings.Builder
+		quote  byte
+		inTok  bool
+	)
+	flush := func() {
+		if inTok {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+			inTok = false
+		}
+	}
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+			cur.WriteByte(c)
+		case c == '"' || c == '\'':
+			quote = c
+			inTok = true
+			cur.WriteByte(c)
+		case c == ' ' || c == '\t':
+			flush()
+		default:
+			inTok = true
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	return tokens
 }
 
 // unquoteShellValue strips one layer of matching single or double quotes from a

--- a/internal/cli/contain/verify.go
+++ b/internal/cli/contain/verify.go
@@ -19,6 +19,8 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -148,6 +150,10 @@ type probeEnv struct {
 	workspaceInvPath   string
 	workspacePaths     []string
 	workspaceGrants    []workspaceGrant
+	// workspaceInvErr records a recorded-inventory read that failed for any
+	// reason other than absence. The workspace probe fails on it so a permission
+	// or parse error cannot make verify pass with the grant set silently empty.
+	workspaceInvErr    error
 	pipelockTarget     string
 	verifyRunningImage bool
 	// postureProofPath is the resolved path the current `contain run` writes its
@@ -362,13 +368,18 @@ func probesForEnv(env *probeEnv) []probe {
 	// which now tops out at 14) so adding the launch-env probe did not renumber
 	// any fixed probe. Appears when workspaces are passed via --workspace or when
 	// the recorded inventory has grants to check for readability and expiry.
-	if len(env.workspacePaths) > 0 || len(env.workspaceGrants) > 0 {
+	if len(env.workspacePaths) > 0 || len(env.workspaceGrants) > 0 || env.workspaceInvErr != nil {
 		probes = append(probes, probe{15, "workspace_access", "pipelock-agent can read configured workspace paths and no grant has expired", probeWorkspaceAccess})
 	}
 	return probes
 }
 
 func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
+	// An unreadable inventory is a failure, not an empty grant set: verify must
+	// not pass while the recorded grants are unknown (fail closed).
+	if env.workspaceInvErr != nil {
+		return statusFail, fmt.Sprintf("workspace inventory %s could not be read: %v; repair it before trusting recorded grants", env.workspaceInvPath, env.workspaceInvErr)
+	}
 	// Expiry gate first: a recorded grant past its window means the ACL is still
 	// live after the operator's intended lifetime, which is a posture failure
 	// even if the path is still readable. Fail CLOSED, including on a malformed
@@ -386,8 +397,12 @@ func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
 			len(expired), strings.Join(expired, "; "))
 	}
 
+	// Check readability of every path the agent is supposed to reach: ad-hoc
+	// --workspace paths AND every recorded grant, deduplicated, so a recorded
+	// grant is never silently skipped when no --workspace flag is given.
+	paths := workspaceProbePaths(env)
 	var bad []string
-	for _, path := range env.workspacePaths {
+	for _, path := range paths {
 		clean, err := filepath.Abs(filepath.Clean(path))
 		if err != nil {
 			bad = append(bad, fmt.Sprintf("%s resolve: %v", path, err))
@@ -421,7 +436,29 @@ func probeWorkspaceAccess(ctx context.Context, env *probeEnv) (string, string) {
 		return statusFail, strings.Join(bad, "; ")
 	}
 	return statusPass, fmt.Sprintf("%d workspace path(s) readable by %s; %d recorded grant(s) within expiry",
-		len(env.workspacePaths), env.agentUserName, len(env.workspaceGrants))
+		len(paths), env.agentUserName, len(env.workspaceGrants))
+}
+
+// workspaceProbePaths returns the deduplicated union of ad-hoc --workspace
+// paths and recorded grant paths, in first-seen order.
+func workspaceProbePaths(env *probeEnv) []string {
+	seen := make(map[string]bool, len(env.workspacePaths)+len(env.workspaceGrants))
+	var paths []string
+	add := func(p string) {
+		p = strings.TrimSpace(p)
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		paths = append(paths, p)
+	}
+	for _, p := range env.workspacePaths {
+		add(p)
+	}
+	for _, g := range env.workspaceGrants {
+		add(g.Path)
+	}
+	return paths
 }
 
 // probeListedToolTargets verifies each configured wrapper target exists and is
@@ -592,23 +629,107 @@ func probeLaunchEnvAllowList(_ context.Context, env *probeEnv) (string, string) 
 		return statusSkip, fmt.Sprintf("read %s: %v (rerun as root)", env.launchPath, err)
 	}
 	script := string(data)
-	if !strings.Contains(script, "exec env -i") {
+	// Parse the executed `exec env -i` block rather than substring-matching the
+	// file: a comment or a decoy line must not satisfy the probe, and the block
+	// must rebuild EXACTLY the runtime contract, nothing missing and nothing
+	// extra. Both directions fail: a missing variable breaks the proxy/CA
+	// contract, an extra one is an operator-environment passthrough.
+	names, found := parseLaunchExecEnvNames(script)
+	if !found {
 		if strings.Contains(script, "exec env ") {
 			return statusFail, "plk-launch execs the tool with plain `env`; operator environment (DISPLAY, XAUTHORITY, SUDO_*, ...) leaks into the contained agent - reinstall with `pipelock contain install`"
 		}
-		return statusFail, fmt.Sprintf("plk-launch at %s does not clear the environment (no `env -i`) before exec", env.launchPath)
+		return statusFail, fmt.Sprintf("plk-launch at %s does not clear the environment (no `exec env -i` block) before exec", env.launchPath)
 	}
-	if !strings.Contains(script, posturebinding.RuntimeProofEnv+`="${`+posturebinding.RuntimeProofEnv) {
-		return statusFail, fmt.Sprintf("plk-launch does not forward %s under env -i; a contained launch would grade containment UNKNOWN", posturebinding.RuntimeProofEnv)
+	expected := expectedLaunchEnvNames()
+	missing, extra := diffNameSets(expected, names)
+	if len(missing) > 0 || len(extra) > 0 {
+		return statusFail, fmt.Sprintf("plk-launch env -i block does not match the runtime contract (missing: %s; unexpected: %s); reinstall with `pipelock contain install`",
+			listOrNone(missing), listOrNone(extra))
 	}
-	// Guard against a future edit re-introducing an explicit operator-variable
-	// passthrough (e.g. DISPLAY="$DISPLAY") that env -i would otherwise defeat.
-	for _, leak := range []string{`DISPLAY="$DISPLAY"`, `XAUTHORITY=`, `SUDO_`} {
-		if strings.Contains(script, leak) {
-			return statusFail, fmt.Sprintf("plk-launch explicitly forwards an operator variable (%s); remove it so env -i keeps the boundary closed", leak)
+	return statusPass, fmt.Sprintf("plk-launch clears the environment (env -i) and rebuilds exactly the %d-variable runtime contract", len(expected))
+}
+
+var launchEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// parseLaunchExecEnvNames finds the executed `exec env -i` command in a
+// launcher script (comment lines are skipped) and returns the variable names it
+// assigns, reading line continuations up to the "$TARGET" token. found is false
+// when no such command exists.
+func parseLaunchExecEnvNames(script string) (names []string, found bool) {
+	lines := strings.Split(script, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "#") || !strings.HasPrefix(line, "exec env -i") {
+			continue
+		}
+		rest := strings.TrimPrefix(line, "exec env -i")
+		for {
+			rest = strings.TrimSuffix(strings.TrimSpace(rest), "\\")
+			for _, tok := range strings.Fields(rest) {
+				if tok == `"$TARGET"` || tok == "$TARGET" {
+					return names, true
+				}
+				if eq := strings.IndexByte(tok, '='); eq > 0 && launchEnvNamePattern.MatchString(tok[:eq]) {
+					names = append(names, tok[:eq])
+				}
+			}
+			i++
+			if i >= len(lines) {
+				return names, true
+			}
+			rest = lines[i]
 		}
 	}
-	return statusPass, "plk-launch clears the environment (env -i) and rebuilds only the runtime contract"
+	return nil, false
+}
+
+// expectedLaunchEnvNames is the exact variable-name set a correctly rendered
+// plk-launch assigns under env -i: the identity block, the proxy/CA runtime
+// contract, the posture-proof binding, and PATH. Names do not depend on
+// install-time values, so a zero installEnv yields the canonical set.
+func expectedLaunchEnvNames() []string {
+	var names []string
+	for _, v := range containedLaunchIdentityVars("", "") {
+		names = append(names, v.name)
+	}
+	for _, v := range runtimeContractVars(&installEnv{}) {
+		names = append(names, v.name)
+	}
+	return append(names, posturebinding.RuntimeProofEnv, "PATH")
+}
+
+// diffNameSets returns the names in want but not got (missing) and in got but
+// not want (extra), each sorted.
+func diffNameSets(want, got []string) (missing, extra []string) {
+	wantSet := make(map[string]bool, len(want))
+	for _, n := range want {
+		wantSet[n] = true
+	}
+	gotSet := make(map[string]bool, len(got))
+	for _, n := range got {
+		gotSet[n] = true
+	}
+	for n := range wantSet {
+		if !gotSet[n] {
+			missing = append(missing, n)
+		}
+	}
+	for n := range gotSet {
+		if !wantSet[n] {
+			extra = append(extra, n)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
+}
+
+func listOrNone(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ",")
 }
 
 // probeBinaryIntegrity reads the integrity pin written at install time and
@@ -831,7 +952,7 @@ func verifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Run read-only probes against the containment model",
-		Long: `Run thirteen read-only probes to verify the workstation containment model
+		Long: `Run fourteen read-only probes to verify the workstation containment model
 is installed correctly and the boundary is intact.
 
 Probes inspect system users, the pipelock systemd unit, nftables rules,
@@ -865,10 +986,13 @@ Exit codes:
 			env := defaultProbeEnv()
 			env.port = opts.port
 			env.workspacePaths = append([]string(nil), opts.workspacePaths...)
-			// Load recorded grants so the workspace probe can enforce expiry, not
-			// just the ad-hoc --workspace paths. A missing inventory is empty (no
-			// grants), not an error.
-			if inv, err := loadWorkspaceInventoryFrom(env.readFile, env.workspaceInvPath); err == nil {
+			// Load recorded grants so the workspace probe checks readability and
+			// expiry of every grant, not just the ad-hoc --workspace paths. A
+			// missing inventory is empty (no grants); any other read or parse error
+			// is recorded so the probe FAILS instead of treating grants as absent.
+			if inv, err := loadWorkspaceInventoryFrom(env.readFile, env.workspaceInvPath); err != nil {
+				env.workspaceInvErr = err
+			} else {
 				env.workspaceGrants = inv.Workspaces
 			}
 			return runVerify(cmd, env, opts)

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -3660,7 +3660,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 	toolTarget := filepath.Join(t.TempDir(), "claude")
 	writeFakeWrapper(t, toolTarget, 0o755)
-	body := canonicalLaunchScript(env.port)
+	body := canonicalLaunchScript(env.port, env.caBundlePath)
 	if err := os.WriteFile(env.launchPath, []byte(body), 0o755); err != nil { //nolint:gosec // wrapper script must be executable in test
 		t.Fatalf("rewrite launch: %v", err)
 	}
@@ -3976,11 +3976,16 @@ func TestNewFakeRunHelper(t *testing.T) {
 // canonicalLaunchScript renders the plk-launch body exactly as `contain
 // install` would for the given proxy port, so fixtures exercise the real
 // `exec env -i` contract block the launcher-environment probe validates.
-func canonicalLaunchScript(port int) string {
+// canonicalLaunchScript renders the launcher exactly as `contain install`
+// would for this port and CA bundle. Fixtures pass the SAME caBundle the
+// probeEnv under test discovers: production renders the wrapper and runs verify
+// from one install state, so a fixture whose script and probe disagree about
+// the CA path is testing a state production never occupies.
+func canonicalLaunchScript(port int, caBundle string) string {
 	env := &installEnv{
 		agentUserName: testAgentUser,
 		proxyPort:     port,
-		caBundlePath:  defaultCABundlePath,
+		caBundlePath:  caBundle,
 		caExportPath:  defaultCAExportPath,
 	}
 	return "#!/bin/bash\n" + strings.Join(launchExecEnvLines(env), "\n") + "\n"

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
 )
 
 // Test helpers ---------------------------------------------------------------
@@ -208,6 +209,7 @@ func makeProbeEnv(t *testing.T, opts ...func(*probeEnv)) *probeEnv {
 		serviceName:        testService,
 		pinPath:            filepath.Join(t.TempDir(), "binary-pin.sha256"),
 		toolsListPath:      filepath.Join(t.TempDir(), "tools.list"),
+		workspaceInvPath:   filepath.Join(t.TempDir(), "workspaces.json"),
 		configPath:         filepath.Join(t.TempDir(), "pipelock.yaml"),
 		pipelockTarget:     defaultPipelockTarget,
 		verifyRunningImage: true,
@@ -2996,10 +2998,10 @@ func TestRunVerify_TextOutput_AllPass(t *testing.T) {
 	if !strings.HasPrefix(out, "pipelock contain verify") {
 		t.Errorf("missing header: %q", out)
 	}
-	if strings.Count(out, "[PASS]") != 13 {
-		t.Errorf("want 13 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
+	if strings.Count(out, "[PASS]") != 14 {
+		t.Errorf("want 14 [PASS] lines, got %d in %q", strings.Count(out, "[PASS]"), out)
 	}
-	if !strings.Contains(out, "13 PASS / 0 FAIL / 0 SKIP") {
+	if !strings.Contains(out, "14 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing aggregate: %q", out)
 	}
 }
@@ -3016,10 +3018,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	if len(lines) != 14 {
-		t.Fatalf("expected 14 JSON records (13 probes + aggregate), got %d: %q", len(lines), buf.String())
+	if len(lines) != 15 {
+		t.Fatalf("expected 15 JSON records (14 probes + aggregate), got %d: %q", len(lines), buf.String())
 	}
-	for i := 0; i < 13; i++ {
+	for i := 0; i < 14; i++ {
 		var rec probeRecord
 		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
 			t.Fatalf("line %d: parse: %v (line=%q)", i, err, lines[i])
@@ -3032,10 +3034,10 @@ func TestRunVerify_JSONOutput_AllPass(t *testing.T) {
 		}
 	}
 	var agg aggregateRecord
-	if err := json.Unmarshal([]byte(lines[13]), &agg); err != nil {
-		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[13])
+	if err := json.Unmarshal([]byte(lines[14]), &agg); err != nil {
+		t.Fatalf("aggregate: parse: %v (line=%q)", err, lines[14])
 	}
-	if agg.Aggregate.Pass != 13 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
+	if agg.Aggregate.Pass != 14 || agg.Aggregate.Fail != 0 || agg.Aggregate.Skip != 0 {
 		t.Errorf("aggregate counts: %+v", agg.Aggregate)
 	}
 	if agg.Aggregate.ExitCode != cliutil.ExitOK {
@@ -3080,7 +3082,7 @@ func TestRunVerify_EnforcementOnlySkipsProxyLiveness(t *testing.T) {
 	if strings.Contains(out, "probe 2:") || strings.Contains(out, "probe 6:") {
 		t.Errorf("liveness probes should be omitted: %q", out)
 	}
-	if !strings.Contains(out, "11 PASS / 0 FAIL / 0 SKIP") {
+	if !strings.Contains(out, "12 PASS / 0 FAIL / 0 SKIP") {
 		t.Errorf("missing enforcement-only aggregate: %q", out)
 	}
 	if !strings.Contains(out, "probe 10: deployed pipelock binary matches TOFU pin; running-service image is not verified") ||
@@ -3296,8 +3298,8 @@ func TestRunVerify_JSONUnknownIsIncomplete(t *testing.T) {
 	}
 
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	if len(lines) != 14 {
-		t.Fatalf("JSON record count = %d, want 14: %q", len(lines), buf.String())
+	if len(lines) != 15 {
+		t.Fatalf("JSON record count = %d, want 15: %q", len(lines), buf.String())
 	}
 	var canary probeRecord
 	if err := json.Unmarshal([]byte(lines[7]), &canary); err != nil {
@@ -3307,11 +3309,11 @@ func TestRunVerify_JSONUnknownIsIncomplete(t *testing.T) {
 		t.Fatalf("canary record = %+v, want probe 8 unknown", canary)
 	}
 	var agg aggregateRecord
-	if err := json.Unmarshal([]byte(lines[13]), &agg); err != nil {
+	if err := json.Unmarshal([]byte(lines[14]), &agg); err != nil {
 		t.Fatalf("decode aggregate: %v", err)
 	}
-	if agg.Aggregate.Unknown != 1 || agg.Aggregate.Pass != 12 || agg.Aggregate.ExitCode != cliutil.ExitConfig {
-		t.Fatalf("aggregate = %+v, want 12 pass / 1 unknown / exit 2", agg.Aggregate)
+	if agg.Aggregate.Unknown != 1 || agg.Aggregate.Pass != 13 || agg.Aggregate.ExitCode != cliutil.ExitConfig {
+		t.Fatalf("aggregate = %+v, want 13 pass / 1 unknown / exit 2", agg.Aggregate)
 	}
 }
 
@@ -3348,14 +3350,14 @@ func TestRunVerify_MixedOutcomesPreserveWorstResultInTextAndJSON(t *testing.T) {
 				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &agg); err != nil {
 					t.Fatalf("decode aggregate: %v\n%s", err, out)
 				}
-				if agg.Aggregate.Pass != 9 || agg.Aggregate.Fail != 1 ||
+				if agg.Aggregate.Pass != 10 || agg.Aggregate.Fail != 1 ||
 					agg.Aggregate.Skip != 2 || agg.Aggregate.Unknown != 1 ||
 					agg.Aggregate.ExitCode != cliutil.ExitGeneral {
-					t.Fatalf("mixed aggregate = %+v, want 9 pass / 1 fail / 2 skip / 1 unknown / exit 1", agg.Aggregate)
+					t.Fatalf("mixed aggregate = %+v, want 10 pass / 1 fail / 2 skip / 1 unknown / exit 1", agg.Aggregate)
 				}
 				return
 			}
-			if !strings.Contains(out, "9 PASS / 1 FAIL / 2 SKIP / 1 UNKNOWN — exit 1") {
+			if !strings.Contains(out, "10 PASS / 1 FAIL / 2 SKIP / 1 UNKNOWN — exit 1") {
 				t.Fatalf("text lost a mixed outcome or fail precedence:\n%s", out)
 			}
 		})
@@ -3379,9 +3381,9 @@ func TestRunVerify_RecordAndAggregateWriteFailuresFailClosed(t *testing.T) {
 		want             string
 	}{
 		{name: "text probe", successfulWrites: 1, want: "writing probe 1 text"},
-		{name: "text aggregate", successfulWrites: 14, want: "writing verify aggregate"},
+		{name: "text aggregate", successfulWrites: 15, want: "writing verify aggregate"},
 		{name: "JSON probe", jsonOutput: true, want: "encoding probe 1 JSON"},
-		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 13, want: "encoding aggregate JSON"},
+		{name: "JSON aggregate", jsonOutput: true, successfulWrites: 14, want: "encoding aggregate JSON"},
 	}
 
 	for _, tc := range tests {
@@ -3659,7 +3661,8 @@ func allPassEnv(t *testing.T) *probeEnv {
 	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 	toolTarget := filepath.Join(t.TempDir(), "claude")
 	writeFakeWrapper(t, toolTarget, 0o755)
-	body := "#!/bin/bash\nexec env NO_PROXY=127.0.0.1,localhost,::1 HTTPS_PROXY=http://127.0.0.1:8888 sh\n"
+	body := "#!/bin/bash\nexec env -i NO_PROXY=127.0.0.1,localhost,::1 HTTPS_PROXY=http://127.0.0.1:8888 " +
+		posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + ":-" + posturebinding.DefaultContainRunProofPath + `}" sh` + "\n"
 	if err := os.WriteFile(env.launchPath, []byte(body), 0o755); err != nil { //nolint:gosec // wrapper script must be executable in test
 		t.Fatalf("rewrite launch: %v", err)
 	}
@@ -3685,6 +3688,11 @@ func allPassEnv(t *testing.T) *probeEnv {
 		}
 		if path == env.toolsListPath {
 			return []byte("claude\t" + toolTarget + "\n"), nil
+		}
+		if path == env.workspaceInvPath {
+			// Empty inventory: contain run's contract read and expiry gate see no
+			// grants. Tests that exercise grants override readFile after this.
+			return nil, os.ErrNotExist
 		}
 		if path == env.nftRulesPath {
 			return []byte(renderNFTRules(1000, 988, 987, env.port, env.nftTable, env.nftChain)), nil

--- a/internal/cli/contain/verify_test.go
+++ b/internal/cli/contain/verify_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
-	"github.com/luckyPipewrench/pipelock/internal/posturebinding"
 )
 
 // Test helpers ---------------------------------------------------------------
@@ -3661,8 +3660,7 @@ func allPassEnv(t *testing.T) *probeEnv {
 	writeFakeWrapper(t, filepath.Join(env.wrapperDir, "plk-claude"), 0o755)
 	toolTarget := filepath.Join(t.TempDir(), "claude")
 	writeFakeWrapper(t, toolTarget, 0o755)
-	body := "#!/bin/bash\nexec env -i NO_PROXY=127.0.0.1,localhost,::1 HTTPS_PROXY=http://127.0.0.1:8888 " +
-		posturebinding.RuntimeProofEnv + `="${` + posturebinding.RuntimeProofEnv + ":-" + posturebinding.DefaultContainRunProofPath + `}" sh` + "\n"
+	body := canonicalLaunchScript(env.port)
 	if err := os.WriteFile(env.launchPath, []byte(body), 0o755); err != nil { //nolint:gosec // wrapper script must be executable in test
 		t.Fatalf("rewrite launch: %v", err)
 	}
@@ -3973,4 +3971,17 @@ func TestNewFakeRunHelper(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for unstubbed call")
 	}
+}
+
+// canonicalLaunchScript renders the plk-launch body exactly as `contain
+// install` would for the given proxy port, so fixtures exercise the real
+// `exec env -i` contract block the launcher-environment probe validates.
+func canonicalLaunchScript(port int) string {
+	env := &installEnv{
+		agentUserName: testAgentUser,
+		proxyPort:     port,
+		caBundlePath:  defaultCABundlePath,
+		caExportPath:  defaultCAExportPath,
+	}
+	return "#!/bin/bash\n" + strings.Join(launchExecEnvLines(env), "\n") + "\n"
 }

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -356,7 +356,11 @@ func runRevokeWorkspace(ctx context.Context, env *installEnv, path string, opts 
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
 	remaining := workspaceGrantsExcept(inv.Workspaces, workspace, env.agentUserName)
-	commands := workspaceRevokeCommands(workspace, env.agentUserName, ancestorsNeededBy(remaining), workspaceExists)
+	// Ancestor traversal ACLs are per agent user, so only THIS user's remaining
+	// grants may hold one open. Passing every agent's grants here would let
+	// another user's grant on a shared ancestor preserve the revoked user's --x
+	// traversal, leaving a path walkable after its grant was revoked.
+	commands := workspaceRevokeCommands(workspace, env.agentUserName, ancestorsNeededBy(grantsForAgent(remaining, env.agentUserName)), workspaceExists)
 	if opts.dryRun {
 		_, _ = fmt.Fprintf(env.out, "pipelock contain revoke-workspace %s - planned:\n", workspace)
 		for i, c := range commands {

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -55,12 +55,15 @@ type workspaceGrant struct {
 	Reason  string `json:"reason,omitempty"`  // optional free-text justification
 	Created string `json:"created,omitempty"` // when the grant was recorded
 	Expires string `json:"expires,omitempty"` // empty = never; a grant past this is refused at launch/verify
+	// AgentUser is the contained user the ACL was granted to, so a host that
+	// contains more than one agent user can list each one's grants alone.
+	AgentUser string `json:"agent_user,omitempty"`
 }
 
 // isLegacyGrant reports whether a grant carries none of the lifecycle metadata
 // fields, i.e. it was written by a Pipelock that predates this feature.
 func (g workspaceGrant) isLegacyGrant() bool {
-	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == ""
+	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == "" && g.AgentUser == ""
 }
 
 // expired reports whether the grant's expiry (if any) is at or before now. A
@@ -228,11 +231,12 @@ func runGrantWorkspace(ctx context.Context, env *installEnv, path string, opts w
 	}
 	created := envNow(env)
 	grant := workspaceGrant{
-		Path:    workspace,
-		Mode:    mode,
-		Owner:   grantOwner(env),
-		Reason:  strings.TrimSpace(opts.reason),
-		Created: created.Format(time.RFC3339),
+		Path:      workspace,
+		Mode:      mode,
+		Owner:     grantOwner(env),
+		Reason:    strings.TrimSpace(opts.reason),
+		Created:   created.Format(time.RFC3339),
+		AgentUser: env.agentUserName,
 	}
 	if strings.TrimSpace(opts.expires) != "" {
 		expiry, err := parseGrantExpiry(opts.expires, created)
@@ -385,17 +389,26 @@ func runListWorkspaces(env *installEnv) error {
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
 	}
-	if len(inv.Workspaces) == 0 {
-		_, _ = fmt.Fprintf(env.out, "no workspace grants recorded in %s\n", env.workspaceInvPath)
+	// Legacy grants carry no agent user and are shown for every agent user;
+	// grants recorded with one are shown only for that user.
+	var rows []workspaceGrant
+	for _, g := range inv.Workspaces {
+		if g.AgentUser != "" && g.AgentUser != env.agentUserName {
+			continue
+		}
+		rows = append(rows, g)
+	}
+	if len(rows) == 0 {
+		_, _ = fmt.Fprintf(env.out, "no workspace grants recorded for %s in %s\n", env.agentUserName, env.workspaceInvPath)
 		return nil
 	}
 	now := envNow(env)
-	_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %s\n",
-		"PATH", "MODE", "OWNER", "CREATED", "EXPIRES", "STATUS")
-	for _, g := range inv.Workspaces {
-		_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %s\n",
+	_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %-14s  %s\n",
+		"PATH", "MODE", "OWNER", "CREATED", "EXPIRES", "STATUS", "REASON")
+	for _, g := range rows {
+		_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %-14s  %s\n",
 			g.Path, valueOrDash(g.Mode), valueOrDash(g.Owner),
-			valueOrDash(g.Created), grantExpiryLabel(g), g.grantStatus(now))
+			valueOrDash(g.Created), grantExpiryLabel(g), g.grantStatus(now), valueOrDash(g.Reason))
 	}
 	return nil
 }

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +30,8 @@ type workspaceOpts struct {
 	dryRun          bool
 	mode            string
 	agentUser       string
+	reason          string
+	expires         string
 }
 
 type workspaceCommand struct {
@@ -39,9 +43,57 @@ type workspaceInventory struct {
 	Workspaces []workspaceGrant `json:"workspaces"`
 }
 
+// workspaceGrant records one ACL grant plus its lifecycle metadata. The
+// metadata fields are all omitempty and optional so an inventory written by an
+// older Pipelock (path+mode only) loads unchanged and renders as a "legacy
+// grant, no metadata" row rather than failing to parse. Timestamps are RFC3339
+// in UTC.
 type workspaceGrant struct {
-	Path string `json:"path"`
-	Mode string `json:"mode"`
+	Path         string `json:"path"`
+	Mode         string `json:"mode"`
+	Owner        string `json:"owner,omitempty"`         // operator who granted it (SUDO_USER, else current user)
+	Reason       string `json:"reason,omitempty"`        // optional free-text justification
+	Created      string `json:"created,omitempty"`       // when the grant was recorded
+	Expires      string `json:"expires,omitempty"`       // empty = never; a grant past this is refused at launch/verify
+	LastVerified string `json:"last_verified,omitempty"` // set by the verify workspace probe when it runs
+}
+
+// isLegacyGrant reports whether a grant carries none of the lifecycle metadata
+// fields, i.e. it was written by a Pipelock that predates this feature.
+func (g workspaceGrant) isLegacyGrant() bool {
+	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == "" && g.LastVerified == ""
+}
+
+// expired reports whether the grant's expiry (if any) is at or before now. A
+// malformed Expires value fails CLOSED (returns an error) so a corrupted
+// timestamp is treated as a launch/verify failure, never silently as
+// "not expired".
+func (g workspaceGrant) expired(now time.Time) (bool, error) {
+	if strings.TrimSpace(g.Expires) == "" {
+		return false, nil
+	}
+	exp, err := time.Parse(time.RFC3339, g.Expires)
+	if err != nil {
+		return false, fmt.Errorf("workspace %s has a malformed expiry %q: %w", g.Path, g.Expires, err)
+	}
+	return !now.Before(exp), nil
+}
+
+// grantStatus returns a short human status for list-workspaces: "legacy",
+// "expired", or "active". A malformed expiry surfaces as "invalid-expiry" so an
+// operator sees the corruption rather than a misleading "active".
+func (g workspaceGrant) grantStatus(now time.Time) string {
+	if g.isLegacyGrant() {
+		return "legacy"
+	}
+	exp, err := g.expired(now)
+	if err != nil {
+		return "invalid-expiry"
+	}
+	if exp {
+		return "expired"
+	}
+	return "active"
 }
 
 var deniedWorkspacePrefixes = []string{
@@ -114,6 +166,8 @@ Must be run as root.`,
 	cmd.Flags().BoolVar(&opts.allowSystemPath, "allow-system-path", false, "allow granting ACLs under protected system path prefixes")
 	cmd.Flags().StringVar(&opts.mode, "mode", workspaceModeReadOnly, "workspace ACL mode: read-only or read-write")
 	cmd.Flags().StringVar(&opts.agentUser, "agent-user", defaultAgentUser, "contained agent user to grant access to")
+	cmd.Flags().StringVar(&opts.reason, "reason", "", "optional justification recorded with the grant")
+	cmd.Flags().StringVar(&opts.expires, "expires", "", "grant expiry as a Go duration (e.g. 720h) or an RFC3339 timestamp; an expired grant is refused at launch and fails verify")
 
 	return cmd
 }
@@ -173,23 +227,93 @@ func runGrantWorkspace(ctx context.Context, env *installEnv, path string, opts w
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
+	created := envNow(env)
+	grant := workspaceGrant{
+		Path:    workspace,
+		Mode:    mode,
+		Owner:   grantOwner(env),
+		Reason:  strings.TrimSpace(opts.reason),
+		Created: created.Format(time.RFC3339),
+	}
+	if strings.TrimSpace(opts.expires) != "" {
+		expiry, err := parseGrantExpiry(opts.expires, created)
+		if err != nil {
+			return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+		}
+		grant.Expires = expiry.UTC().Format(time.RFC3339)
+	}
 	commands := workspaceACLCommands(workspace, env.agentUserName, mode)
 	if opts.dryRun {
 		_, _ = fmt.Fprintf(env.out, "pipelock contain grant-workspace %s - planned:\n", workspace)
 		for i, c := range commands {
 			_, _ = fmt.Fprintf(env.out, "  %d. %s %s\n", i+1, c.name, strings.Join(shellQuoteArgs(c.args), " "))
 		}
-		_, _ = fmt.Fprintf(env.out, "  %d. record grant in %s\n", len(commands)+1, env.workspaceInvPath)
+		_, _ = fmt.Fprintf(env.out, "  %d. record grant in %s (owner %s, expires %s)\n",
+			len(commands)+1, env.workspaceInvPath, grant.Owner, grantExpiryLabel(grant))
 		return nil
 	}
 	if err := runWorkspaceCommands(ctx, env, commands); err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, err)
 	}
-	if err := recordWorkspaceGrant(env, workspaceGrant{Path: workspace, Mode: mode}); err != nil {
+	if err := recordWorkspaceGrant(env, grant); err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("record workspace grant: %w", err))
 	}
-	_, _ = fmt.Fprintf(env.out, "granted %s access to %s for %s.\n", mode, workspace, env.agentUserName)
+	_, _ = fmt.Fprintf(env.out, "granted %s access to %s for %s (owner %s, expires %s).\n",
+		mode, workspace, env.agentUserName, grant.Owner, grantExpiryLabel(grant))
 	return nil
+}
+
+// envNow returns env.now() when set, falling back to time.Now. Keeps timestamp
+// generation deterministic under test without every caller having to check.
+func envNow(env *installEnv) time.Time {
+	if env.now != nil {
+		return env.now()
+	}
+	return time.Now()
+}
+
+// grantOwner resolves who is recording the grant: SUDO_USER (the operator
+// behind sudo) first, then the current OS user, then "unknown". Never fails the
+// grant on a lookup miss - ownership metadata is advisory, not a gate.
+func grantOwner(env *installEnv) string {
+	if op := strings.TrimSpace(env.operatorUser); op != "" {
+		return op
+	}
+	if u, err := user.Current(); err == nil && strings.TrimSpace(u.Username) != "" {
+		return u.Username
+	}
+	return "unknown"
+}
+
+// parseGrantExpiry accepts either a Go duration (relative to created) or an
+// absolute RFC3339 timestamp. A duration must be positive; an absolute time
+// must be in the future relative to created. Fails CLOSED: an unparseable or
+// already-past value is a config error, never a silently-ignored expiry.
+func parseGrantExpiry(raw string, created time.Time) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if dur, err := time.ParseDuration(raw); err == nil {
+		if dur <= 0 {
+			return time.Time{}, fmt.Errorf("invalid --expires %q: duration must be positive", raw)
+		}
+		return created.Add(dur), nil
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid --expires %q: want a Go duration (e.g. 720h) or an RFC3339 timestamp", raw)
+	}
+	if !ts.After(created) {
+		return time.Time{}, fmt.Errorf("invalid --expires %q: timestamp is not in the future", raw)
+	}
+	return ts, nil
+}
+
+// grantExpiryLabel renders a grant's expiry for operator output: "never" when
+// unset, otherwise the recorded RFC3339 value.
+func grantExpiryLabel(g workspaceGrant) string {
+	if strings.TrimSpace(g.Expires) == "" {
+		return "never"
+	}
+	return g.Expires
 }
 
 func runRevokeWorkspace(ctx context.Context, env *installEnv, path string, opts workspaceOpts) error {
@@ -222,6 +346,85 @@ func runRevokeWorkspace(ctx context.Context, env *installEnv, path string, opts 
 	}
 	_, _ = fmt.Fprintf(env.out, "revoked workspace access to %s for %s.\n", workspace, env.agentUserName)
 	return nil
+}
+
+func listWorkspacesCmd() *cobra.Command {
+	var agentUser string
+	cmd := &cobra.Command{
+		Use:   "list-workspaces",
+		Short: "List recorded pipelock-agent workspace grants",
+		Long: `List the workspace grants recorded for the contained agent.
+
+Answers "what can the agent reach today, and why" from one command: each row
+shows the path, ACL mode, owner, when it was granted, when it expires, and a
+status. An EXPIRED grant is refused by contain run and fails contain verify,
+but its ACLs stay on disk until you run revoke-workspace - expiry gates the
+launch, it does not remove the ACL.
+
+Read-only; safe to run without root.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if agentUser == "" {
+				agentUser = defaultAgentUser
+			}
+			if err := validateContainUsername("agent user", agentUser); err != nil {
+				return cliutil.ExitCodeError(cliutil.ExitConfig, err)
+			}
+			env := defaultInstallEnv(cmd.OutOrStdout())
+			env.agentUserName = agentUser
+			return runListWorkspaces(env)
+		},
+	}
+	cmd.Flags().StringVar(&agentUser, "agent-user", defaultAgentUser, "contained agent user whose grants to list")
+	return cmd
+}
+
+func runListWorkspaces(env *installEnv) error {
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil {
+		return cliutil.ExitCodeError(cliutil.ExitGeneral, fmt.Errorf("read workspace inventory: %w", err))
+	}
+	if len(inv.Workspaces) == 0 {
+		_, _ = fmt.Fprintf(env.out, "no workspace grants recorded in %s\n", env.workspaceInvPath)
+		return nil
+	}
+	now := envNow(env)
+	_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %s\n",
+		"PATH", "MODE", "OWNER", "CREATED", "EXPIRES", "STATUS")
+	for _, g := range inv.Workspaces {
+		_, _ = fmt.Fprintf(env.out, "%-40s  %-10s  %-12s  %-20s  %-20s  %s\n",
+			g.Path, valueOrDash(g.Mode), valueOrDash(g.Owner),
+			valueOrDash(g.Created), grantExpiryLabel(g), g.grantStatus(now))
+	}
+	return nil
+}
+
+func valueOrDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+// expiredWorkspaceGrants returns the paths of every grant that has passed its
+// expiry as of now, plus the first malformed-expiry error if any. Callers
+// (contain run, contain verify) use it to fail CLOSED: any expired grant means
+// the recorded window has passed while the ACL is still live, so the launch is
+// refused until the operator re-grants or revokes.
+func expiredWorkspaceGrants(grants []workspaceGrant, now time.Time) ([]string, error) {
+	var expired []string
+	for _, g := range grants {
+		isExpired, err := g.expired(now)
+		if err != nil {
+			return nil, err
+		}
+		if isExpired {
+			expired = append(expired, g.Path)
+		}
+	}
+	return expired, nil
 }
 
 func resolveWorkspaceForRevoke(env *installEnv, path string, inv workspaceInventory) (string, bool, error) {
@@ -443,7 +646,15 @@ func readWorkspaceInventory(env *installEnv) workspaceInventory {
 }
 
 func loadWorkspaceInventory(env *installEnv) (workspaceInventory, error) {
-	data, err := env.readFile(env.workspaceInvPath)
+	return loadWorkspaceInventoryFrom(env.readFile, env.workspaceInvPath)
+}
+
+// loadWorkspaceInventoryFrom reads and parses the workspace inventory from an
+// arbitrary readFile/path pair so both the installEnv-based commands and the
+// probeEnv-based contain run/verify paths share one loader. A missing file is
+// an empty inventory (install never ran, or no grants yet), not an error.
+func loadWorkspaceInventoryFrom(readFile func(string) ([]byte, error), path string) (workspaceInventory, error) {
+	data, err := readFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return workspaceInventory{}, nil
@@ -452,7 +663,7 @@ func loadWorkspaceInventory(env *installEnv) (workspaceInventory, error) {
 	}
 	var inv workspaceInventory
 	if err := json.Unmarshal(data, &inv); err != nil {
-		return workspaceInventory{}, fmt.Errorf("parse %s: %w", env.workspaceInvPath, err)
+		return workspaceInventory{}, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return inv, nil
 }

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -66,6 +66,30 @@ func (g workspaceGrant) isLegacyGrant() bool {
 	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == "" && g.AgentUser == ""
 }
 
+// appliesTo reports whether this grant governs the named contained agent user.
+// A grant recorded with an explicit AgentUser belongs to that user alone; a
+// legacy grant (written before the field existed) carries no identity and is
+// therefore attributed to every agent user, because refusing to honour it would
+// silently drop an ACL that is still live on disk.
+//
+// This is the single predicate every grant consumer uses - list-workspaces,
+// `contain run` preflight, and `contain verify` - so one agent user's grant can
+// never gate, expire, or be verified against another's launch.
+func (g workspaceGrant) appliesTo(agentUser string) bool {
+	return g.AgentUser == "" || g.AgentUser == agentUser
+}
+
+// grantsForAgent filters an inventory down to the grants that govern agentUser.
+func grantsForAgent(grants []workspaceGrant, agentUser string) []workspaceGrant {
+	out := make([]workspaceGrant, 0, len(grants))
+	for _, g := range grants {
+		if g.appliesTo(agentUser) {
+			out = append(out, g)
+		}
+	}
+	return out
+}
+
 // expired reports whether the grant's expiry (if any) is at or before now. A
 // malformed Expires value fails CLOSED (returns an error) so a corrupted
 // timestamp is treated as a launch/verify failure, never silently as
@@ -331,7 +355,7 @@ func runRevokeWorkspace(ctx context.Context, env *installEnv, path string, opts 
 	if err != nil {
 		return cliutil.ExitCodeError(cliutil.ExitConfig, err)
 	}
-	remaining := workspaceGrantsExcept(inv.Workspaces, workspace)
+	remaining := workspaceGrantsExcept(inv.Workspaces, workspace, env.agentUserName)
 	commands := workspaceRevokeCommands(workspace, env.agentUserName, ancestorsNeededBy(remaining), workspaceExists)
 	if opts.dryRun {
 		_, _ = fmt.Fprintf(env.out, "pipelock contain revoke-workspace %s - planned:\n", workspace)
@@ -391,13 +415,7 @@ func runListWorkspaces(env *installEnv) error {
 	}
 	// Legacy grants carry no agent user and are shown for every agent user;
 	// grants recorded with one are shown only for that user.
-	var rows []workspaceGrant
-	for _, g := range inv.Workspaces {
-		if g.AgentUser != "" && g.AgentUser != env.agentUserName {
-			continue
-		}
-		rows = append(rows, g)
-	}
+	rows := grantsForAgent(inv.Workspaces, env.agentUserName)
 	if len(rows) == 0 {
 		_, _ = fmt.Fprintf(env.out, "no workspace grants recorded for %s in %s\n", env.agentUserName, env.workspaceInvPath)
 		return nil
@@ -632,9 +650,18 @@ func recordWorkspaceGrant(env *installEnv, grant workspaceGrant) error {
 	if err != nil {
 		return err
 	}
+	// A grant is identified by (Path, AgentUser), not by Path alone: a host that
+	// contains two agent users can hold a live ACL on the same directory for each
+	// of them, and keying on Path would make the second grant silently destroy
+	// the first one's record (including its expiry) while its ACL stayed live.
+	// A legacy row (no AgentUser) is upgraded in place by the first grant that
+	// names a user for that path, because it is the same ACL gaining an identity.
 	replaced := false
 	for i, existing := range inv.Workspaces {
-		if existing.Path == grant.Path {
+		if existing.Path != grant.Path {
+			continue
+		}
+		if existing.AgentUser == grant.AgentUser || existing.AgentUser == "" {
 			inv.Workspaces[i] = grant
 			replaced = true
 			break
@@ -695,12 +722,18 @@ func writeWorkspaceInventory(env *installEnv, inv workspaceInventory) error {
 	return backupAndWrite(env, env.workspaceInvPath, data, modeAllowListReadable)
 }
 
-func workspaceGrantsExcept(grants []workspaceGrant, path string) []workspaceGrant {
+// workspaceGrantsExcept drops the grants revoking path for agentUser removes.
+// Revocation strips the ACL for ONE agent user, so another user's grant on the
+// same path survives: dropping it would leave that user's ACL live on disk with
+// no record of it. A legacy row on that path is dropped, because it cannot be
+// attributed and the revoke may well be removing exactly it.
+func workspaceGrantsExcept(grants []workspaceGrant, path, agentUser string) []workspaceGrant {
 	out := make([]workspaceGrant, 0, len(grants))
 	for _, grant := range grants {
-		if grant.Path != path {
-			out = append(out, grant)
+		if grant.Path == path && grant.appliesTo(agentUser) {
+			continue
 		}
+		out = append(out, grant)
 	}
 	return out
 }

--- a/internal/cli/contain/workspace.go
+++ b/internal/cli/contain/workspace.go
@@ -49,19 +49,18 @@ type workspaceInventory struct {
 // grant, no metadata" row rather than failing to parse. Timestamps are RFC3339
 // in UTC.
 type workspaceGrant struct {
-	Path         string `json:"path"`
-	Mode         string `json:"mode"`
-	Owner        string `json:"owner,omitempty"`         // operator who granted it (SUDO_USER, else current user)
-	Reason       string `json:"reason,omitempty"`        // optional free-text justification
-	Created      string `json:"created,omitempty"`       // when the grant was recorded
-	Expires      string `json:"expires,omitempty"`       // empty = never; a grant past this is refused at launch/verify
-	LastVerified string `json:"last_verified,omitempty"` // set by the verify workspace probe when it runs
+	Path    string `json:"path"`
+	Mode    string `json:"mode"`
+	Owner   string `json:"owner,omitempty"`   // operator who granted it (SUDO_USER, else current user)
+	Reason  string `json:"reason,omitempty"`  // optional free-text justification
+	Created string `json:"created,omitempty"` // when the grant was recorded
+	Expires string `json:"expires,omitempty"` // empty = never; a grant past this is refused at launch/verify
 }
 
 // isLegacyGrant reports whether a grant carries none of the lifecycle metadata
 // fields, i.e. it was written by a Pipelock that predates this feature.
 func (g workspaceGrant) isLegacyGrant() bool {
-	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == "" && g.LastVerified == ""
+	return g.Owner == "" && g.Reason == "" && g.Created == "" && g.Expires == ""
 }
 
 // expired reports whether the grant's expiry (if any) is at or before now. A

--- a/internal/cli/contain/workspace_lifecycle_test.go
+++ b/internal/cli/contain/workspace_lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -336,4 +337,124 @@ func TestProbeWorkspaceAccess_FailsOnExpiredGrant(t *testing.T) {
 	if status != statusFail || !strings.Contains(detail, "expired") {
 		t.Fatalf("status=%s detail=%q, want fail on expiry", status, detail)
 	}
+}
+
+// TestMultiAgentGrantsOnOnePathStayIndependent covers the case a host that
+// contains two agent users actually occupies: both hold a live ACL on the same
+// directory. Grant identity is (Path, AgentUser), so neither one's record may
+// overwrite, revoke, or gate the other's.
+func TestMultiAgentGrantsOnOnePathStayIndependent(t *testing.T) {
+	shared := t.TempDir()
+	alphaGrant := workspaceGrant{
+		Path: shared, Mode: workspaceModeReadOnly, Owner: "josh",
+		Reason: "alpha reads it", Created: "2026-05-01T00:00:00Z",
+		Expires: "2026-07-01T00:00:00Z", AgentUser: "agent-alpha",
+	}
+	betaGrant := workspaceGrant{
+		Path: shared, Mode: workspaceModeReadWrite, Owner: "josh",
+		Reason: "beta writes it", Created: "2026-05-02T00:00:00Z",
+		Expires: "2026-08-01T00:00:00Z", AgentUser: "agent-beta",
+	}
+
+	t.Run("a second agent's grant does not overwrite the first", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		env.now = func() time.Time { return testNow }
+		if err := recordWorkspaceGrant(env, alphaGrant); err != nil {
+			t.Fatalf("record alpha: %v", err)
+		}
+		if err := recordWorkspaceGrant(env, betaGrant); err != nil {
+			t.Fatalf("record beta: %v", err)
+		}
+		inv := readWorkspaceInventory(env)
+		if len(inv.Workspaces) != 2 {
+			t.Fatalf("grants = %d, want 2 (one per agent user): %+v", len(inv.Workspaces), inv.Workspaces)
+		}
+		for _, want := range []workspaceGrant{alphaGrant, betaGrant} {
+			if !slices.Contains(inv.Workspaces, want) {
+				t.Fatalf("inventory lost %+v: %+v", want, inv.Workspaces)
+			}
+		}
+	})
+
+	t.Run("re-granting one agent leaves the other's metadata intact", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		env.now = func() time.Time { return testNow }
+		if err := recordWorkspaceGrant(env, alphaGrant); err != nil {
+			t.Fatalf("record alpha: %v", err)
+		}
+		updated := betaGrant
+		updated.Reason = "beta re-granted"
+		if err := recordWorkspaceGrant(env, betaGrant); err != nil {
+			t.Fatalf("record beta: %v", err)
+		}
+		if err := recordWorkspaceGrant(env, updated); err != nil {
+			t.Fatalf("re-record beta: %v", err)
+		}
+		inv := readWorkspaceInventory(env)
+		if len(inv.Workspaces) != 2 {
+			t.Fatalf("grants = %d, want 2: %+v", len(inv.Workspaces), inv.Workspaces)
+		}
+		if !slices.Contains(inv.Workspaces, alphaGrant) {
+			t.Fatalf("alpha's grant changed when beta was re-granted: %+v", inv.Workspaces)
+		}
+		if !slices.Contains(inv.Workspaces, updated) {
+			t.Fatalf("beta's re-grant not recorded: %+v", inv.Workspaces)
+		}
+	})
+
+	t.Run("revoking one agent leaves the other's ACL recorded", func(t *testing.T) {
+		env, _, _ := newFakeEnv(t)
+		env.now = func() time.Time { return testNow }
+		env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+		env.agentUserName = "agent-beta"
+		if err := recordWorkspaceGrant(env, alphaGrant); err != nil {
+			t.Fatalf("record alpha: %v", err)
+		}
+		if err := recordWorkspaceGrant(env, betaGrant); err != nil {
+			t.Fatalf("record beta: %v", err)
+		}
+		if err := runRevokeWorkspace(context.Background(), env, shared, workspaceOpts{}); err != nil {
+			t.Fatalf("revoke beta: %v", err)
+		}
+		inv := readWorkspaceInventory(env)
+		if len(inv.Workspaces) != 1 || inv.Workspaces[0] != alphaGrant {
+			t.Fatalf("revoking beta must leave alpha's grant alone, got %+v", inv.Workspaces)
+		}
+	})
+
+	t.Run("one agent's expired grant does not gate another's launch", func(t *testing.T) {
+		stale := alphaGrant
+		stale.Expires = "2026-05-01T00:00:00Z" // before testNow
+		grants := []workspaceGrant{stale, betaGrant}
+
+		betaScoped := grantsForAgent(grants, "agent-beta")
+		expired, err := expiredWorkspaceGrants(betaScoped, testNow)
+		if err != nil {
+			t.Fatalf("beta expiry check: %v", err)
+		}
+		if len(expired) != 0 {
+			t.Fatalf("alpha's expired grant gated beta: %v", expired)
+		}
+
+		alphaScoped := grantsForAgent(grants, "agent-alpha")
+		expired, err = expiredWorkspaceGrants(alphaScoped, testNow)
+		if err != nil {
+			t.Fatalf("alpha expiry check: %v", err)
+		}
+		if len(expired) != 1 || expired[0] != shared {
+			t.Fatalf("alpha's own expired grant must still gate alpha, got %v", expired)
+		}
+	})
+
+	t.Run("a legacy grant is honoured for every agent user", func(t *testing.T) {
+		legacy := workspaceGrant{Path: shared, Mode: workspaceModeReadOnly}
+		for _, user := range []string{"agent-alpha", "agent-beta"} {
+			if got := grantsForAgent([]workspaceGrant{legacy}, user); len(got) != 1 {
+				t.Fatalf("legacy grant hidden from %s: %+v", user, got)
+			}
+		}
+		if got := grantsForAgent([]workspaceGrant{betaGrant}, "agent-alpha"); len(got) != 0 {
+			t.Fatalf("beta's grant leaked into alpha's scope: %+v", got)
+		}
+	})
 }

--- a/internal/cli/contain/workspace_lifecycle_test.go
+++ b/internal/cli/contain/workspace_lifecycle_test.go
@@ -458,3 +458,81 @@ func TestMultiAgentGrantsOnOnePathStayIndependent(t *testing.T) {
 		}
 	})
 }
+
+// TestRevokeScopesAncestorACLCleanupToTheRevokedAgent pins the authorization
+// boundary in ancestor cleanup. Traversal (--x) ACLs on a shared ancestor are
+// per agent user, so only the revoked user's OWN remaining grants may keep one
+// open. Passing every agent's grants to the ancestor calculation would let a
+// second agent's grant under the same parent preserve the revoked agent's
+// traversal, leaving a path walkable after its grant was revoked.
+func TestRevokeScopesAncestorACLCleanupToTheRevokedAgent(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.agentUserName = "agent-alpha"
+
+	var ran []workspaceCommand
+	env.runCmd = func(_ context.Context, name string, args ...string) (string, int, error) {
+		ran = append(ran, workspaceCommand{name: name, args: args})
+		return "", 0, nil
+	}
+
+	parent := t.TempDir()
+	alphaPath := filepath.Join(parent, "alpha")
+	betaPath := filepath.Join(parent, "beta")
+	for _, dir := range []string{alphaPath, betaPath} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	// Two agents, two workspaces, one shared ancestor.
+	if err := recordWorkspaceGrant(env, workspaceGrant{
+		Path: alphaPath, Mode: workspaceModeReadOnly, Owner: "josh",
+		Created: "2026-05-01T00:00:00Z", AgentUser: "agent-alpha",
+	}); err != nil {
+		t.Fatalf("record alpha: %v", err)
+	}
+	if err := recordWorkspaceGrant(env, workspaceGrant{
+		Path: betaPath, Mode: workspaceModeReadOnly, Owner: "josh",
+		Created: "2026-05-01T00:00:00Z", AgentUser: "agent-beta",
+	}); err != nil {
+		t.Fatalf("record beta: %v", err)
+	}
+
+	ran = nil
+	if err := runRevokeWorkspace(context.Background(), env, alphaPath, workspaceOpts{}); err != nil {
+		t.Fatalf("revoke alpha: %v", err)
+	}
+
+	// agent-alpha holds no other grant, so its traversal ACL on the shared
+	// parent must be removed. agent-beta's grant lives under the same parent
+	// and must not keep alpha's traversal alive.
+	// Match the ancestor path EXACTLY as an argument. A substring match would
+	// be satisfied by the workspace command itself, since alphaPath has parent
+	// as a prefix - which made an earlier version of this test pass with the
+	// guard removed.
+	var cleared bool
+	for _, c := range ran {
+		if c.name != "setfacl" {
+			continue
+		}
+		joined := strings.Join(c.args, " ")
+		if strings.Contains(joined, "u:agent-beta") {
+			t.Fatalf("revoking agent-alpha touched agent-beta's ACL: setfacl %s", joined)
+		}
+		if !slices.Contains(c.args, "-x") || !slices.Contains(c.args, "u:agent-alpha") {
+			continue
+		}
+		if slices.Contains(c.args, parent) {
+			cleared = true
+		}
+	}
+	if !cleared {
+		var got []string
+		for _, c := range ran {
+			got = append(got, c.name+" "+strings.Join(c.args, " "))
+		}
+		t.Fatalf("agent-alpha's traversal ACL on the shared ancestor %s was not removed; another agent's grant kept it open.\ncommands:\n%s",
+			parent, strings.Join(got, "\n"))
+	}
+}

--- a/internal/cli/contain/workspace_lifecycle_test.go
+++ b/internal/cli/contain/workspace_lifecycle_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+func TestWorkspaceGrant_ExpiredAndStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		grant      workspaceGrant
+		wantExpErr bool
+		wantExp    bool
+		wantStatus string
+	}{
+		{"never", workspaceGrant{Path: "/p", Mode: "read-only", Owner: "josh", Created: "x"}, false, false, "active"},
+		{"future", workspaceGrant{Path: "/p", Owner: "josh", Expires: "2026-07-01T00:00:00Z"}, false, false, "active"},
+		{"past", workspaceGrant{Path: "/p", Owner: "josh", Expires: "2026-05-01T00:00:00Z"}, false, true, "expired"},
+		{"exact-boundary", workspaceGrant{Path: "/p", Owner: "josh", Expires: "2026-06-01T12:00:00Z"}, false, true, "expired"},
+		{"malformed", workspaceGrant{Path: "/p", Owner: "josh", Expires: "not-a-time"}, true, false, "invalid-expiry"},
+		{"legacy", workspaceGrant{Path: "/p", Mode: "read-only"}, false, false, "legacy"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exp, err := tc.grant.expired(testNow)
+			if tc.wantExpErr != (err != nil) {
+				t.Fatalf("expired err = %v, wantErr %v", err, tc.wantExpErr)
+			}
+			if err == nil && exp != tc.wantExp {
+				t.Fatalf("expired = %v, want %v", exp, tc.wantExp)
+			}
+			if got := tc.grant.grantStatus(testNow); got != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", got, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestParseGrantExpiry(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t.Run("duration", func(t *testing.T) {
+		got, err := parseGrantExpiry("720h", created)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if want := created.Add(720 * time.Hour); !got.Equal(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("rfc3339", func(t *testing.T) {
+		got, err := parseGrantExpiry("2026-03-01T00:00:00Z", created)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if want := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+	for _, bad := range []string{"0s", "-1h", "2025-01-01T00:00:00Z", "garbage", ""} {
+		t.Run("reject_"+bad, func(t *testing.T) {
+			if _, err := parseGrantExpiry(bad, created); err == nil {
+				t.Fatalf("parseGrantExpiry(%q) = nil err, want rejection", bad)
+			}
+		})
+	}
+}
+
+// TestLegacyGrantInventoryLoadsUnchanged proves an inventory written by the OLD
+// struct (path+mode only) parses without error and is recognized as legacy.
+func TestLegacyGrantInventoryLoadsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspaces.json")
+	legacy := `{"workspaces":[{"path":"/home/dev/proj","mode":"read-only"}]}`
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	inv, err := loadWorkspaceInventoryFrom(os.ReadFile, path)
+	if err != nil {
+		t.Fatalf("load legacy inventory: %v", err)
+	}
+	if len(inv.Workspaces) != 1 {
+		t.Fatalf("workspaces len = %d, want 1", len(inv.Workspaces))
+	}
+	g := inv.Workspaces[0]
+	if g.Path != "/home/dev/proj" || g.Mode != "read-only" {
+		t.Fatalf("legacy grant fields lost: %+v", g)
+	}
+	if !g.isLegacyGrant() {
+		t.Fatalf("grant with no metadata should be legacy: %+v", g)
+	}
+	if g.grantStatus(testNow) != "legacy" {
+		t.Fatalf("status = %q, want legacy", g.grantStatus(testNow))
+	}
+}
+
+func TestRunGrantWorkspace_RecordsMetadata(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+	ws := t.TempDir()
+
+	err := runGrantWorkspace(context.Background(), env, ws, workspaceOpts{
+		mode:    workspaceModeReadWrite,
+		reason:  "sprint work",
+		expires: "720h",
+	})
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	inv, err := loadWorkspaceInventory(env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(inv.Workspaces) != 1 {
+		t.Fatalf("grants = %d, want 1", len(inv.Workspaces))
+	}
+	g := inv.Workspaces[0]
+	if g.Owner != containInstallOperatorUser {
+		t.Errorf("owner = %q, want %q", g.Owner, containInstallOperatorUser)
+	}
+	if g.Reason != "sprint work" {
+		t.Errorf("reason = %q", g.Reason)
+	}
+	if g.Created != testNow.Format(time.RFC3339) {
+		t.Errorf("created = %q, want %q", g.Created, testNow.Format(time.RFC3339))
+	}
+	wantExp := testNow.Add(720 * time.Hour).UTC().Format(time.RFC3339)
+	if g.Expires != wantExp {
+		t.Errorf("expires = %q, want %q", g.Expires, wantExp)
+	}
+	if g.isLegacyGrant() {
+		t.Errorf("recorded grant should carry metadata: %+v", g)
+	}
+}
+
+func TestRunListWorkspaces_RendersRowsAndStatus(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	if err := writeWorkspaceInventory(env, workspaceInventory{Workspaces: []workspaceGrant{
+		{Path: "/a/active", Mode: "read-write", Owner: "josh", Created: "2026-05-01T00:00:00Z", Expires: "2026-07-01T00:00:00Z"},
+		{Path: "/b/expired", Mode: "read-only", Owner: "josh", Created: "2026-04-01T00:00:00Z", Expires: "2026-05-01T00:00:00Z"},
+		{Path: "/c/legacy", Mode: "read-only"},
+	}}); err != nil {
+		t.Fatalf("seed inventory: %v", err)
+	}
+	var buf bytes.Buffer
+	env.out = &buf
+	if err := runListWorkspaces(env); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"PATH", "/a/active", "active", "/b/expired", "expired", "/c/legacy", "legacy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunListWorkspaces_EmptyInventory(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	var buf bytes.Buffer
+	env.out = &buf
+	if err := runListWorkspaces(env); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no workspace grants recorded") {
+		t.Fatalf("empty inventory message missing: %q", buf.String())
+	}
+}
+
+func TestExpiredWorkspaceGrants(t *testing.T) {
+	grants := []workspaceGrant{
+		{Path: "/ok", Expires: "2026-07-01T00:00:00Z"},
+		{Path: "/gone", Expires: "2026-05-01T00:00:00Z"},
+		{Path: "/never"},
+	}
+	got, err := expiredWorkspaceGrants(grants, testNow)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0] != "/gone" {
+		t.Fatalf("expired = %v, want [/gone]", got)
+	}
+	if _, err := expiredWorkspaceGrants([]workspaceGrant{{Path: "/bad", Expires: "nope"}}, testNow); err == nil {
+		t.Fatal("malformed expiry should error (fail closed)")
+	}
+}
+
+// TestRunContainRun_RefusesExpiredGrant proves an expired grant fails the launch
+// closed, and that --dry-run still surfaces it without launching.
+func TestRunContainRun_RefusesExpiredGrant(t *testing.T) {
+	seedExpired := func(env *probeEnv) {
+		env.now = func() time.Time { return testNow }
+		base := env.readFile
+		env.readFile = func(path string) ([]byte, error) {
+			if path == env.workspaceInvPath {
+				return []byte(`{"workspaces":[{"path":"/x/expired","mode":"read-only","owner":"josh","expires":"2026-05-01T00:00:00Z"}]}`), nil
+			}
+			return base(path)
+		}
+	}
+
+	t.Run("launch refused", func(t *testing.T) {
+		env := allPassEnv(t)
+		seedExpired(env)
+		var launched bool
+		runEnv := containRunEnv{
+			probe: env,
+			launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+				launched = true
+				return nil
+			},
+			emitPosture: func(string, string, *probeEnv, []string) (string, error) { return "/unused", nil },
+		}
+		err := runContainRun(context.Background(), nil, io.Discard, io.Discard, runEnv, containRunOptions{}, []string{"claude"})
+		if err == nil || !strings.Contains(err.Error(), "expired") {
+			t.Fatalf("err = %v, want expired-grant refusal", err)
+		}
+		if launched {
+			t.Fatal("launched despite an expired grant")
+		}
+	})
+
+	t.Run("dry-run surfaces without refusing", func(t *testing.T) {
+		env := allPassEnv(t)
+		seedExpired(env)
+		var buf bytes.Buffer
+		runEnv := containRunEnv{
+			probe:       env,
+			launch:      func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error { return nil },
+			emitPosture: func(string, string, *probeEnv, []string) (string, error) { return "/unused", nil },
+		}
+		if err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{dryRun: true}, []string{"claude"}); err != nil {
+			t.Fatalf("dry-run err = %v", err)
+		}
+		if !strings.Contains(buf.String(), "[expired]") {
+			t.Fatalf("dry-run did not surface expired grant status:\n%s", buf.String())
+		}
+	})
+}
+
+func TestProbeWorkspaceAccess_FailsOnExpiredGrant(t *testing.T) {
+	env := makeProbeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.workspaceGrants = []workspaceGrant{{Path: "/x/expired", Expires: "2026-05-01T00:00:00Z"}}
+	status, detail := probeWorkspaceAccess(context.Background(), env)
+	if status != statusFail || !strings.Contains(detail, "expired") {
+		t.Fatalf("status=%s detail=%q, want fail on expiry", status, detail)
+	}
+}

--- a/internal/cli/contain/workspace_lifecycle_test.go
+++ b/internal/cli/contain/workspace_lifecycle_test.go
@@ -312,11 +312,15 @@ func TestRunContainRun_RefusesExpiredGrant(t *testing.T) {
 			},
 		}
 		err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{dryRun: true}, []string{"claude"})
-		if err == nil || !strings.Contains(err.Error(), "refusing to launch") {
+		// The recorded grants are checked by the workspace probe during
+		// preflight, so a dry run refuses at the same point a real launch does
+		// and names the remedy; the contract is never rendered for a boundary
+		// that already failed.
+		if err == nil || !strings.Contains(err.Error(), "expired") {
 			t.Fatalf("dry-run err = %v, want expired-grant refusal", err)
 		}
-		if !strings.Contains(buf.String(), "[expired]") {
-			t.Fatalf("dry-run did not surface expired grant status:\n%s", buf.String())
+		if !strings.Contains(buf.String(), "[FAIL] probe 15") || !strings.Contains(buf.String(), "revoke-workspace") {
+			t.Fatalf("dry-run did not surface the expired grant through the workspace probe:\n%s", buf.String())
 		}
 		if launched || posture {
 			t.Fatalf("dry-run launched=%v posture=%v, want neither", launched, posture)

--- a/internal/cli/contain/workspace_lifecycle_test.go
+++ b/internal/cli/contain/workspace_lifecycle_test.go
@@ -144,6 +144,69 @@ func TestRunGrantWorkspace_RecordsMetadata(t *testing.T) {
 	}
 }
 
+// TestWorkspaceMetadataSurvivesRevokeAndRegrant proves inventory rewrites keep
+// metadata on unaffected grants while a re-grant records fresh metadata.
+func TestWorkspaceMetadataSurvivesRevokeAndRegrant(t *testing.T) {
+	env, _, _ := newFakeEnv(t)
+	env.now = func() time.Time { return testNow }
+	env.runCmd = func(context.Context, string, ...string) (string, int, error) { return "", 0, nil }
+	keptPath := t.TempDir()
+	regrantPath := t.TempDir()
+	kept := workspaceGrant{
+		Path:    keptPath,
+		Mode:    workspaceModeReadOnly,
+		Owner:   "alice",
+		Reason:  "keep this grant",
+		Created: "2026-05-01T00:00:00Z",
+		Expires: "2026-07-01T00:00:00Z",
+	}
+	if err := recordWorkspaceGrant(env, kept); err != nil {
+		t.Fatalf("record kept grant: %v", err)
+	}
+	if err := recordWorkspaceGrant(env, workspaceGrant{
+		Path:    regrantPath,
+		Mode:    workspaceModeReadOnly,
+		Owner:   "bob",
+		Reason:  "old reason",
+		Created: "2026-05-01T00:00:00Z",
+		Expires: "2026-07-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("record initial grant: %v", err)
+	}
+	if err := runRevokeWorkspace(context.Background(), env, regrantPath, workspaceOpts{}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if err := runGrantWorkspace(context.Background(), env, regrantPath, workspaceOpts{
+		mode:    workspaceModeReadWrite,
+		reason:  "new reason",
+		expires: "720h",
+	}); err != nil {
+		t.Fatalf("re-grant: %v", err)
+	}
+
+	inv := readWorkspaceInventory(env)
+	if len(inv.Workspaces) != 2 {
+		t.Fatalf("grants = %d, want 2: %+v", len(inv.Workspaces), inv.Workspaces)
+	}
+	var gotKept, gotRegrant workspaceGrant
+	for _, grant := range inv.Workspaces {
+		switch grant.Path {
+		case keptPath:
+			gotKept = grant
+		case regrantPath:
+			gotRegrant = grant
+		}
+	}
+	if gotKept != kept {
+		t.Fatalf("unaffected grant metadata changed: got %+v, want %+v", gotKept, kept)
+	}
+	if gotRegrant.Mode != workspaceModeReadWrite || gotRegrant.Owner != containInstallOperatorUser ||
+		gotRegrant.Reason != "new reason" || gotRegrant.Created != testNow.Format(time.RFC3339) ||
+		gotRegrant.Expires != testNow.Add(720*time.Hour).Format(time.RFC3339) {
+		t.Fatalf("re-grant metadata = %+v, want fresh recorded metadata", gotRegrant)
+	}
+}
+
 func TestRunListWorkspaces_RendersRowsAndStatus(t *testing.T) {
 	env, _, _ := newFakeEnv(t)
 	env.now = func() time.Time { return testNow }
@@ -198,7 +261,7 @@ func TestExpiredWorkspaceGrants(t *testing.T) {
 }
 
 // TestRunContainRun_RefusesExpiredGrant proves an expired grant fails the launch
-// closed, and that --dry-run still surfaces it without launching.
+// closed, including a dry-run that must report the same refusal without launching.
 func TestRunContainRun_RefusesExpiredGrant(t *testing.T) {
 	seedExpired := func(env *probeEnv) {
 		env.now = func() time.Time { return testNow }
@@ -232,20 +295,31 @@ func TestRunContainRun_RefusesExpiredGrant(t *testing.T) {
 		}
 	})
 
-	t.Run("dry-run surfaces without refusing", func(t *testing.T) {
+	t.Run("dry-run reports refusal", func(t *testing.T) {
 		env := allPassEnv(t)
 		seedExpired(env)
 		var buf bytes.Buffer
+		var launched, posture bool
 		runEnv := containRunEnv{
-			probe:       env,
-			launch:      func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error { return nil },
-			emitPosture: func(string, string, *probeEnv, []string) (string, error) { return "/unused", nil },
+			probe: env,
+			launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+				launched = true
+				return nil
+			},
+			emitPosture: func(string, string, *probeEnv, []string) (string, error) {
+				posture = true
+				return "/unused", nil
+			},
 		}
-		if err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{dryRun: true}, []string{"claude"}); err != nil {
-			t.Fatalf("dry-run err = %v", err)
+		err := runContainRun(context.Background(), nil, &buf, io.Discard, runEnv, containRunOptions{dryRun: true}, []string{"claude"})
+		if err == nil || !strings.Contains(err.Error(), "refusing to launch") {
+			t.Fatalf("dry-run err = %v, want expired-grant refusal", err)
 		}
 		if !strings.Contains(buf.String(), "[expired]") {
 			t.Fatalf("dry-run did not surface expired grant status:\n%s", buf.String())
+		}
+		if launched || posture {
+			t.Fatalf("dry-run launched=%v posture=%v, want neither", launched, posture)
 		}
 	})
 }


### PR DESCRIPTION
## What changed

`pipelock contain run` now prints a session contract before it launches anything: the agent user, the proxy egress posture, the posture capsule path, whether the agent's /tmp is private, every registered tool, and every workspace grant with its mode, owner, creation time, expiry and status. The contract is built from the same tools.list read and the same inventory read the launch consumes, so it cannot describe a boundary other than the one enforced. A new `--dry-run` runs preflight, prints the contract, applies the same expiry gate a real launch applies, and exits without emitting a capsule or launching.

The installed `plk-launch` wrapper now execs the tool with `env -i` and rebuilds only the identity block, the proxy and CA contract, the posture-proof binding and PATH, sharing one source of truth with the Go launcher instead of inheriting whatever sudo left standing. This is fail-closed for confidentiality: an operator variable such as DISPLAY, XAUTHORITY or SUDO_USER no longer reaches the contained agent, and a new verify probe fails if the installed launcher ever reverts to plain `env` or stops forwarding the posture proof.

Workspace grants now record owner, reason, creation time and an optional expiry. `contain list-workspaces` answers what the agent can reach today and why. An expired grant makes `contain run` refuse to launch and makes the verify workspace probe fail, both naming re-grant or `revoke-workspace` as the remedy. Expiry gates the launch; it does not remove the ACL. Inventories written before this change load unchanged and list as legacy.

The contract reports the agent's /tmp as shared with the operator, because it is. Giving the agent a private /tmp needs a mount namespace, which the sandbox package already owns and which changes the containment trust model, so it is a separate decision rather than part of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `list-workspaces` to view workspace grants, ownership, reasons, and expiration status.
  - Added `--dry-run` to preview a contained session without launching the tool.
  - Added session contract output before contained sessions start.
  - Added `--reason` and `--expires` options for workspace grants.

- **Bug Fixes**
  - Expired or invalid workspace grants now prevent launches and verification.
  - Contained tools now start with a clean environment while preserving required runtime settings.
  - Verification now includes launch-environment isolation and workspace grant checks.
  - Documented shared `/tmp` access between contained sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->