### PR TITLE
feat(licenseservice): pin Polar API requests to a dated version

### DIFF
--- a/cmd/license-service/admin.go
+++ b/cmd/license-service/admin.go
@@ -83,7 +83,7 @@ func adminHandler(ctx context.Context, log zerolog.Logger) (*licenseservice.Webh
 		_ = db.Close()
 		return nil, nil, fmt.Errorf("open audit ledger: %w", err)
 	}
-	polar := licenseservice.NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
+	polar := licenseservice.NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)
 	email := licenseservice.NewEmailSender(cfg.ResendAPIKey, cfg.FromEmail)
 	handler, err := licenseservice.NewWebhookHandler(cfg, db, polar, email, ledger, privateKey, log)
 	if err != nil {

--- a/cmd/license-service/main.go
+++ b/cmd/license-service/main.go
@@ -127,7 +127,7 @@ func run(log zerolog.Logger) error {
 	log.Info().Str("ledger_path", cfg.LedgerPath).Msg("audit ledger ready")
 
 	// Create subsystem clients.
-	polar := licenseservice.NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
+	polar := licenseservice.NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)
 	email := licenseservice.NewEmailSender(cfg.ResendAPIKey, cfg.FromEmail)
 
 	// Create the webhook handler (loads founding count from DB).

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -82,6 +83,14 @@ type Config struct {
 	// PolarAPIBase is the base URL for the Polar API. Defaults to production.
 	PolarAPIBase string
 
+	// PolarAPIVersion pins every Polar API request to a dated contract via the
+	// Polar-Version header. Polar releases a new version each quarter and an
+	// unpinned request silently follows whatever "Current" is, so the response
+	// shape can change under us at a release boundary. A removed or malformed
+	// version is a 404 from Polar, not a fallback, so this is validated at
+	// startup rather than discovered on the first webhook.
+	PolarAPIVersion string
+
 	// EvalProductIDs is the allowlist of Polar product IDs that fulfill the
 	// Enterprise Eval. An order only mints an eval token if its product ID is in
 	// this list AND its tier metadata is enterprise_eval (defense in depth against
@@ -134,7 +143,12 @@ const (
 	defaultLedgerPath       = "audit.jsonl"
 	defaultFromEmail        = "licenses@mail.pipelab.org"
 	defaultPolarAPIBase     = "https://api.polar.sh"
-	defaultEvalCurrency     = "usd"
+	// defaultPolarAPIVersion is the dated Polar API contract this code was
+	// written against. Polar removes a version roughly nine months after
+	// release, at which point every request pinned to it returns 404, so this
+	// must be re-pinned to a supported version before then.
+	defaultPolarAPIVersion = "2026-04"
+	defaultEvalCurrency    = "usd"
 )
 
 // LoadConfig reads configuration from environment variables with sensible
@@ -156,6 +170,7 @@ func LoadConfig() (*Config, error) {
 		ListenAddr:        envOrDefault("LISTEN_ADDR", defaultListenAddr),
 		FromEmail:         envOrDefault("FROM_EMAIL", defaultFromEmail),
 		PolarAPIBase:      envOrDefault("POLAR_API_BASE", defaultPolarAPIBase),
+		PolarAPIVersion:   envOrDefault("POLAR_API_VERSION", defaultPolarAPIVersion),
 	}
 
 	// Parse founding pro cap.
@@ -251,6 +266,10 @@ func LoadConfig() (*Config, error) {
 		seenOrderProducts[product.ProductID] = struct{}{}
 	}
 
+	if !polarAPIVersionPattern.MatchString(cfg.PolarAPIVersion) {
+		return nil, fmt.Errorf("POLAR_API_VERSION must be YYYY-MM (e.g. %s), got %q", defaultPolarAPIVersion, cfg.PolarAPIVersion)
+	}
+
 	// Validate required secrets.
 	if cfg.PolarWebhookSecret == "" {
 		return nil, fmt.Errorf("POLAR_WEBHOOK_SECRET is required")
@@ -270,6 +289,9 @@ func LoadConfig() (*Config, error) {
 
 	return cfg, nil
 }
+
+// polarAPIVersionPattern matches Polar's dated version format, YYYY-MM.
+var polarAPIVersionPattern = regexp.MustCompile(`^[0-9]{4}-(0[1-9]|1[0-2])$`)
 
 func envOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {

--- a/enterprise/licenseservice/config.go
+++ b/enterprise/licenseservice/config.go
@@ -86,9 +86,13 @@ type Config struct {
 	// PolarAPIVersion pins every Polar API request to a dated contract via the
 	// Polar-Version header. Polar releases a new version each quarter and an
 	// unpinned request silently follows whatever "Current" is, so the response
-	// shape can change under us at a release boundary. A removed or malformed
-	// version is a 404 from Polar, not a fallback, so this is validated at
-	// startup rather than discovered on the first webhook.
+	// shape can change under us at a release boundary.
+	//
+	// Only the YYYY-MM SHAPE is checked at startup. Whether Polar still serves
+	// that version is not knowable without calling Polar, and a version it has
+	// retired is answered with 404 on every request rather than a fallback, so
+	// a syntactically valid but retired pin presents at runtime as every
+	// subscription and order read failing.
 	PolarAPIVersion string
 
 	// EvalProductIDs is the allowlist of Polar product IDs that fulfill the
@@ -144,9 +148,10 @@ const (
 	defaultFromEmail        = "licenses@mail.pipelab.org"
 	defaultPolarAPIBase     = "https://api.polar.sh"
 	// defaultPolarAPIVersion is the dated Polar API contract this code was
-	// written against. Polar removes a version roughly nine months after
-	// release, at which point every request pinned to it returns 404, so this
-	// must be re-pinned to a supported version before then.
+	// written against. Polar retires a version roughly nine months after
+	// release, at which point every request pinned to it returns 404. Nothing
+	// in this process can detect that in advance, so this constant must be
+	// re-pinned to a supported version before the pinned one is retired.
 	defaultPolarAPIVersion = "2026-04"
 	defaultEvalCurrency    = "usd"
 )
@@ -267,7 +272,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	if !polarAPIVersionPattern.MatchString(cfg.PolarAPIVersion) {
-		return nil, fmt.Errorf("POLAR_API_VERSION must be YYYY-MM (e.g. %s), got %q", defaultPolarAPIVersion, cfg.PolarAPIVersion)
+		return nil, fmt.Errorf("POLAR_API_VERSION must be a YYYY-MM date (e.g. %s), got %q", defaultPolarAPIVersion, cfg.PolarAPIVersion)
 	}
 
 	// Validate required secrets.

--- a/enterprise/licenseservice/config_test.go
+++ b/enterprise/licenseservice/config_test.go
@@ -328,3 +328,48 @@ func TestLoadConfig_ZeroFoundingCap(t *testing.T) {
 		t.Errorf("FoundingProCap = %d, want 0", cfg.FoundingProCap)
 	}
 }
+
+// TestLoadConfig_PolarAPIVersion covers the three states the pin can be in:
+// omitted (default), explicitly set to another supported version, and
+// malformed. A malformed version must be refused at startup, because Polar
+// answers an unknown version with 404 on every request rather than falling
+// back, so an unvalidated typo would present as a total fulfillment outage.
+func TestLoadConfig_PolarAPIVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{name: "omitted uses the pinned default", env: "", want: defaultPolarAPIVersion},
+		{name: "explicit version is honored", env: "2026-10", want: "2026-10"},
+		{name: "not a date is refused", env: "latest", wantErr: true},
+		{name: "month out of range is refused", env: "2026-13", wantErr: true},
+		{name: "zero month is refused", env: "2026-00", wantErr: true},
+		{name: "day-precision is refused", env: "2026-04-01", wantErr: true},
+		{name: "short year is refused", env: "26-04", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setRequiredConfigEnv(t)
+			if tt.env != "" {
+				t.Setenv("POLAR_API_VERSION", tt.env)
+			}
+
+			cfg, err := LoadConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("LoadConfig() accepted %q, want an error", tt.env)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if cfg.PolarAPIVersion != tt.want {
+				t.Errorf("PolarAPIVersion = %q, want %q", cfg.PolarAPIVersion, tt.want)
+			}
+		})
+	}
+}

--- a/enterprise/licenseservice/cron_test.go
+++ b/enterprise/licenseservice/cron_test.go
@@ -95,7 +95,7 @@ func TestRefreshCron_Tick_SkipsCanceledSubscription(t *testing.T) {
 		}`, testSubscriptionID, testCustomerEmail, testProductID, testProductName)
 	}))
 	defer canceledPolar.Close()
-	ts.handler.polar = NewPolarClient(testPolarAPIToken, canceledPolar.URL)
+	ts.handler.polar = NewPolarClient(testPolarAPIToken, canceledPolar.URL, defaultPolarAPIVersion)
 
 	// Insert an entitlement due for refresh.
 	past := time.Now().Add(-1 * time.Hour)
@@ -166,7 +166,7 @@ func TestRefreshCron_RefreshOne_PolarError(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient(testPolarAPIToken, errorPolar.URL)
+	polar := NewPolarClient(testPolarAPIToken, errorPolar.URL, defaultPolarAPIVersion)
 	email := NewEmailSender("re_"+"key", "from@test.com")
 
 	handler, err := NewWebhookHandler(cfg, db, polar, email, ledger, priv, zerolog.Nop())
@@ -249,7 +249,7 @@ func TestRefreshCron_RefreshOne_CanceledSub(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient(testPolarAPIToken, canceledPolar.URL)
+	polar := NewPolarClient(testPolarAPIToken, canceledPolar.URL, defaultPolarAPIVersion)
 	email := NewEmailSender("re_"+"key", "from@test.com")
 
 	handler, err := NewWebhookHandler(cfg, db, polar, email, ledger, priv, zerolog.Nop())

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -53,7 +53,13 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 	def := defaultEvalOrderJSON(orderStatusPaidJSON())
 	orderJSON.Store(&def)
 
-	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every production Polar read must carry the version pin; these
+		// end-to-end fixtures are the ones that would otherwise let an
+		// unpinned client through.
+		if got := r.Header.Get("Polar-Version"); got != defaultPolarAPIVersion {
+			t.Errorf("Polar-Version = %q, want %q", got, defaultPolarAPIVersion)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(*orderJSON.Load()))
 	}))
@@ -88,6 +94,7 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 		ListenAddr:          ":0",
 		FromEmail:           "test@pipelock.dev",
 		PolarAPIBase:        polarSrv.URL,
+		PolarAPIVersion:     defaultPolarAPIVersion,
 		EvalProductIDs:      []string{testEvalProductID},
 		EvalAmountCents:     testEvalAmount,
 		EvalCurrency:        "usd",

--- a/enterprise/licenseservice/eval_test.go
+++ b/enterprise/licenseservice/eval_test.go
@@ -93,7 +93,7 @@ func newEvalTestSetup(t *testing.T) *evalTestSetup {
 		EvalCurrency:        "usd",
 	}
 	email := &EmailSender{apiKey: cfg.ResendAPIKey, fromEmail: cfg.FromEmail, client: emailSrv.Client(), apiURL: emailSrv.URL}
-	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
+	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)
 	handler, err := NewWebhookHandler(cfg, db, polar, email, ledger, priv, zerolog.Nop())
 	if err != nil {
 		t.Fatalf("NewWebhookHandler: %v", err)

--- a/enterprise/licenseservice/polar.go
+++ b/enterprise/licenseservice/polar.go
@@ -75,16 +75,21 @@ type PolarSubscription struct {
 
 // PolarClient handles communication with the Polar API.
 type PolarClient struct {
-	apiToken string
-	baseURL  string
-	client   *http.Client
+	apiToken   string
+	baseURL    string
+	apiVersion string
+	client     *http.Client
 }
 
-// NewPolarClient creates a Polar API client with the given token and base URL.
-func NewPolarClient(apiToken, baseURL string) *PolarClient {
+// NewPolarClient creates a Polar API client with the given token, base URL, and
+// dated API version. The version is sent as the Polar-Version header on every
+// request so a quarterly Polar release cannot change the response contract
+// under a running deployment.
+func NewPolarClient(apiToken, baseURL, apiVersion string) *PolarClient {
 	return &PolarClient{
-		apiToken: apiToken,
-		baseURL:  baseURL,
+		apiToken:   apiToken,
+		baseURL:    baseURL,
+		apiVersion: apiVersion,
 		client: &http.Client{
 			Timeout: 15 * time.Second, // 15s: generous for external API, prevents hanging
 		},
@@ -102,6 +107,11 @@ func (p *PolarClient) getJSON(ctx context.Context, path, label string, out any) 
 	}
 	req.Header.Set("Authorization", "Bearer "+p.apiToken)
 	req.Header.Set("Accept", "application/json")
+	// Pin the response contract. Without this header Polar serves whatever
+	// version is Current, which rolls forward every quarter.
+	if p.apiVersion != "" {
+		req.Header.Set("Polar-Version", p.apiVersion)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/enterprise/licenseservice/polar.go
+++ b/enterprise/licenseservice/polar.go
@@ -130,6 +130,14 @@ func (p *PolarClient) getJSON(ctx context.Context, path, label string, out any) 
 		return fmt.Errorf("read %s response: exceeds %d bytes", label, maxResponseBody)
 	}
 	if resp.StatusCode != http.StatusOK {
+		// Polar answers a retired or unrecognized Polar-Version with 404, which
+		// is otherwise indistinguishable from "this subscription does not
+		// exist". Name the pin in the error so the operator has a control to
+		// reach for; POLAR_API_VERSION is the knob that changes it.
+		if resp.StatusCode == http.StatusNotFound && p.apiVersion != "" {
+			return fmt.Errorf("polar API returned 404 for %s (pinned to API version %s via POLAR_API_VERSION; a retired version returns 404 for every request): %s",
+				label, p.apiVersion, string(body))
+		}
 		return fmt.Errorf("polar API returned %d for %s: %s", resp.StatusCode, label, string(body))
 	}
 	if err := decodeVendorJSON(body, out); err != nil {

--- a/enterprise/licenseservice/polar_test.go
+++ b/enterprise/licenseservice/polar_test.go
@@ -415,7 +415,7 @@ func TestPolarClient_GetSubscription(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewPolarClient(testPolarAPIToken, srv.URL)
+			client := NewPolarClient(testPolarAPIToken, srv.URL, defaultPolarAPIVersion)
 			sub, err := client.GetSubscription(t.Context(), testSubscriptionID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetSubscription() error = %v, wantErr %v", err, tt.wantErr)
@@ -521,7 +521,7 @@ func TestPolarClient_GetOrder(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client := NewPolarClient(testPolarAPIToken, srv.URL)
+			client := NewPolarClient(testPolarAPIToken, srv.URL, defaultPolarAPIVersion)
 			order, err := client.GetOrder(t.Context(), testOrderID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetOrder() error = %v, wantErr %v", err, tt.wantErr)
@@ -570,7 +570,7 @@ func TestPolarClient_GetSubscription_NetworkError(t *testing.T) {
 	}))
 	srv.Close()
 
-	client := NewPolarClient(testPolarAPIToken, srv.URL)
+	client := NewPolarClient(testPolarAPIToken, srv.URL, defaultPolarAPIVersion)
 	_, err := client.GetSubscription(t.Context(), testSubscriptionID)
 	if err == nil {
 		t.Fatal("expected network error for closed server, got nil")
@@ -600,5 +600,66 @@ func TestIsSubscriptionEvent(t *testing.T) {
 				t.Errorf("isSubscriptionEvent(%q) = %v, want %v", tt.eventType, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPolarClient_SendsVersionHeader proves every API read pins its contract.
+// Polar serves whatever version is Current to an unpinned request, and Current
+// rolls forward each quarter, so a missing header here means the response shape
+// can change under a running deployment without any code change.
+func TestPolarClient_SendsVersionHeader(t *testing.T) {
+	calls := []struct {
+		name     string
+		wantPath string
+		body     string
+		invoke   func(*PolarClient) error
+	}{
+		{
+			name:     "GetSubscription",
+			wantPath: "/v1/subscriptions/" + testSubscriptionID,
+			body:     `{"id":"` + testSubscriptionID + `","status":"active"}`,
+			invoke: func(c *PolarClient) error {
+				_, err := c.GetSubscription(t.Context(), testSubscriptionID)
+				return err
+			},
+		},
+		{
+			name:     "GetOrder",
+			wantPath: "/v1/orders/order_123",
+			body:     `{"id":"order_123","status":"paid"}`,
+			invoke: func(c *PolarClient) error {
+				_, err := c.GetOrder(t.Context(), "order_123")
+				return err
+			},
+		},
+	}
+
+	for _, call := range calls {
+		for _, version := range []string{defaultPolarAPIVersion, "2026-10"} {
+			t.Run(call.name+"/"+version, func(t *testing.T) {
+				var got string
+				var seen bool
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					seen = true
+					got = r.Header.Get("Polar-Version")
+					if r.URL.Path != call.wantPath {
+						t.Errorf("got path %q, want %q", r.URL.Path, call.wantPath)
+					}
+					_, _ = w.Write([]byte(call.body))
+				}))
+				defer srv.Close()
+
+				client := NewPolarClient(testPolarAPIToken, srv.URL, version)
+				if err := call.invoke(client); err != nil {
+					t.Fatalf("%s: %v", call.name, err)
+				}
+				if !seen {
+					t.Fatal("upstream was never called")
+				}
+				if got != version {
+					t.Errorf("Polar-Version = %q, want %q", got, version)
+				}
+			})
+		}
 	}
 }

--- a/enterprise/licenseservice/polar_test.go
+++ b/enterprise/licenseservice/polar_test.go
@@ -663,3 +663,42 @@ func TestPolarClient_SendsVersionHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestPolarClient_404NamesVersionPin covers the operability direction. A
+// retired Polar-Version is answered with 404 on every request, which otherwise
+// reads exactly like "no such subscription". The error must name the pin, or
+// the operator has a total fulfillment outage and no control to reach for.
+func TestPolarClient_404NamesVersionPin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	client := NewPolarClient(testPolarAPIToken, srv.URL, "2026-01")
+	_, err := client.GetSubscription(t.Context(), testSubscriptionID)
+	if err == nil {
+		t.Fatal("expected an error on 404")
+	}
+	for _, want := range []string{"2026-01", "POLAR_API_VERSION"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("404 error %q does not mention %q", err.Error(), want)
+		}
+	}
+
+	// A non-404 failure keeps the plain shape: the version pin is not a
+	// plausible remedy for a 500, and suggesting it would misdirect.
+	srv500 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv500.Close()
+
+	client500 := NewPolarClient(testPolarAPIToken, srv500.URL, "2026-01")
+	_, err = client500.GetSubscription(t.Context(), testSubscriptionID)
+	if err == nil {
+		t.Fatal("expected an error on 500")
+	}
+	if strings.Contains(err.Error(), "POLAR_API_VERSION") {
+		t.Errorf("500 error should not suggest the version pin: %q", err.Error())
+	}
+}

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -89,7 +89,7 @@ func newTestServer(t *testing.T) *Server {
 		PolarAPIBase:        polarSrv.URL,
 	}
 
-	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
+	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)
 	email := &EmailSender{
 		apiKey:    cfg.ResendAPIKey,
 		fromEmail: cfg.FromEmail,
@@ -422,7 +422,7 @@ func TestServer_WebhookProcessingError_Returns500(t *testing.T) {
 	defer badPolarSrv.Close()
 
 	// Rewire the handler's Polar client.
-	srv.handler.polar = NewPolarClient(testPolarAPIToken, badPolarSrv.URL)
+	srv.handler.polar = NewPolarClient(testPolarAPIToken, badPolarSrv.URL, defaultPolarAPIVersion)
 
 	body := `{"type":"subscription.created","data":{"id":"sub_bad"}}`
 	req := signedWebhookRequest(t, srv, body)

--- a/enterprise/licenseservice/server_test.go
+++ b/enterprise/licenseservice/server_test.go
@@ -50,7 +50,13 @@ func newTestServer(t *testing.T) *Server {
 	}
 
 	// Polar mock returns active pro subscription.
-	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every production Polar read must carry the version pin; these
+		// end-to-end fixtures are the ones that would otherwise let an
+		// unpinned client through.
+		if got := r.Header.Get("Polar-Version"); got != defaultPolarAPIVersion {
+			t.Errorf("Polar-Version = %q, want %q", got, defaultPolarAPIVersion)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintf(w, `{
 			"id": "%s",
@@ -87,6 +93,7 @@ func newTestServer(t *testing.T) *Server {
 		ListenAddr:          ":0",
 		FromEmail:           "test@pipelock.dev",
 		PolarAPIBase:        polarSrv.URL,
+		PolarAPIVersion:     defaultPolarAPIVersion,
 	}
 
 	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -95,6 +95,12 @@ func newTestSetup(t *testing.T) *testSetup {
 
 	// Default Polar mock: returns an active pro subscription.
 	polarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every production Polar read must carry the version pin; these
+		// end-to-end fixtures are the ones that would otherwise let an
+		// unpinned client through.
+		if got := r.Header.Get("Polar-Version"); got != defaultPolarAPIVersion {
+			t.Errorf("Polar-Version = %q, want %q", got, defaultPolarAPIVersion)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if strings.HasPrefix(r.URL.Path, "/v1/orders/") {
 			orderID := strings.TrimPrefix(r.URL.Path, "/v1/orders/")
@@ -211,6 +217,7 @@ func newTestSetup(t *testing.T) *testSetup {
 		ListenAddr:          ":0",
 		FromEmail:           "test@pipelock.dev",
 		PolarAPIBase:        polarSrv.URL,
+		PolarAPIVersion:     defaultPolarAPIVersion,
 		OrderProducts: []OrderProductConfig{
 			{ProductID: "prod_trial", Tier: tierTrial, AmountCents: 100, Currency: "usd"},
 			{ProductID: "prod_trial_test", Tier: tierTrial, AmountCents: 100, Currency: "usd"},

--- a/enterprise/licenseservice/webhook_test.go
+++ b/enterprise/licenseservice/webhook_test.go
@@ -219,7 +219,7 @@ func newTestSetup(t *testing.T) *testSetup {
 		},
 	}
 
-	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase)
+	polar := NewPolarClient(cfg.PolarAPIToken, cfg.PolarAPIBase, cfg.PolarAPIVersion)
 	email := &EmailSender{
 		apiKey:    cfg.ResendAPIKey,
 		fromEmail: cfg.FromEmail,
@@ -795,7 +795,7 @@ func TestProcessSubscription_ExpiryClampedToIntermediateNotAfter(t *testing.T) {
 	handler, err := NewWebhookHandler(
 		cfg,
 		db,
-		NewPolarClient("token", "http://localhost"),
+		NewPolarClient("token", "http://localhost", defaultPolarAPIVersion),
 		&EmailSender{apiKey: "re_" + "test", fromEmail: "test@pipelock.dev", client: emailSrv.Client(), apiURL: emailSrv.URL},
 		ledger,
 		signingPriv,
@@ -1434,7 +1434,7 @@ func TestNewWebhookHandler_InitializesFoundingCount(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient("token", "http://localhost")
+	polar := NewPolarClient("token", "http://localhost", defaultPolarAPIVersion)
 	email := NewEmailSender("key", "from@test.com")
 
 	handler, err := NewWebhookHandler(cfg, db, polar, email, ledger, priv, zerolog.Nop())
@@ -1467,7 +1467,7 @@ func TestNewWebhookHandler_RejectsIntermediateSigningKeyMismatch(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient("token", "http://localhost")
+	polar := NewPolarClient("token", "http://localhost", defaultPolarAPIVersion)
 	email := NewEmailSender("key", "from@test.com")
 
 	_, err = NewWebhookHandler(cfg, db, polar, email, ledger, signingPriv, zerolog.Nop())
@@ -1498,7 +1498,7 @@ func TestNewWebhookHandler_RejectsMalformedIntermediate(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient("token", "http://localhost")
+	polar := NewPolarClient("token", "http://localhost", defaultPolarAPIVersion)
 	email := NewEmailSender("key", "from@test.com")
 
 	_, err = NewWebhookHandler(cfg, db, polar, email, ledger, signingPriv, zerolog.Nop())
@@ -1576,7 +1576,7 @@ func TestNewWebhookHandler_VerifiesIntermediateAtStartup(t *testing.T) {
 				FoundingProCap:      50,
 				FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 			}
-			_, err = NewWebhookHandler(cfg, db, NewPolarClient("token", "http://localhost"), NewEmailSender("key", "from@test.com"), ledger, signingPriv, zerolog.Nop())
+			_, err = NewWebhookHandler(cfg, db, NewPolarClient("token", "http://localhost", defaultPolarAPIVersion), NewEmailSender("key", "from@test.com"), ledger, signingPriv, zerolog.Nop())
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewWebhookHandler() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1610,7 +1610,7 @@ func TestHandleEvent_PolarFetchError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"down"}`))
 	}))
 	defer errorPolar.Close()
-	ts.handler.polar = NewPolarClient(testPolarAPIToken, errorPolar.URL)
+	ts.handler.polar = NewPolarClient(testPolarAPIToken, errorPolar.URL, defaultPolarAPIVersion)
 
 	event := &PolarWebhookEvent{
 		Type: EventSubscriptionCreated,
@@ -2145,7 +2145,7 @@ func TestNewWebhookHandler_DBError(t *testing.T) {
 		FoundingProCap:      50,
 		FoundingProDeadline: time.Date(2099, 6, 30, 0, 0, 0, 0, time.UTC),
 	}
-	polar := NewPolarClient("token", "http://localhost")
+	polar := NewPolarClient("token", "http://localhost", defaultPolarAPIVersion)
 	email := NewEmailSender("key", "from@test.com")
 
 	_, err = NewWebhookHandler(cfg, db, polar, email, ledger, priv, zerolog.Nop())
@@ -2712,7 +2712,7 @@ func TestHandleOrderEvent_RejectsCurrentlyRefundedOrder(t *testing.T) {
 		}`))
 	}))
 	t.Cleanup(orderSrv.Close)
-	ts.handler.polar = NewPolarClient(testPolarAPIToken, orderSrv.URL)
+	ts.handler.polar = NewPolarClient(testPolarAPIToken, orderSrv.URL, defaultPolarAPIVersion)
 
 	event := &PolarWebhookEvent{Type: EventOrderCreated, Data: json.RawMessage(`{
 		"id":"order_refunded",


### PR DESCRIPTION
## What changed

Every license-service read of a subscription or order now sends a Polar-Version header pinning the response contract to a dated version, defaulting to 2026-04 and overridable with POLAR_API_VERSION. An unpinned request follows whichever version the payment provider currently treats as default, and that default rolls forward each quarter, so the response shape could change under a running deployment with no code change.

Startup validates the YYYY-MM shape only. Whether the provider still serves a given version cannot be known without calling it, and a retired version is answered with 404 on every request rather than a fallback, so a 404 now names the pinned version and the variable that changes it. A retired pin otherwise reads exactly like a missing subscription, which leaves the operator a total fulfillment outage and no control to reach for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Polar API requests now use a configurable, date-based API version.
  - The version can be set through `POLAR_API_VERSION`, with a default provided automatically.
  - API version settings must follow the required year-and-month format.
  - Errors for unavailable or retired API versions now identify the configured version and setting, making configuration issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->