### PR TITLE
fix(scanner): resolve ordinary document-sharing links out of the box

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,7 @@ fetch_proxy:
 | `monitoring.subdomain_entropy_exclusions` | `files.pythonhosted.org`, `pypi.org`, `objects.githubusercontent.com` | Domains excluded from subdomain and path entropy checks; override to replace defaults, or set an empty list to disable exclusions entirely (query entropy still checked) |
 | `monitoring.scan_nested_urls` | `true` (nil) | Evaluate URL-shaped query parameter values as destinations |
 | `monitoring.query_entropy_exclusions` | `[]` | Host-wide query-string entropy exclusions for hosts whose query values are broadly opaque by contract |
-| `monitoring.path_entropy_exclusions` | `[]` | Host plus literal path-prefix exemptions for the URL-path entropy gate only; subdomain entropy, query entropy, DLP and SSRF still apply |
+| `monitoring.path_entropy_exclusions` | 5 document-sharing routes | Host plus literal path-prefix exemptions for the URL-path entropy gate only; subdomain entropy, query entropy, DLP and SSRF still apply. Ships with Google Docs, Sheets, Slides, Forms and Drive file routes; override to replace the defaults, or set an empty list to disable them |
 | `monitoring.query_entropy_param_exclusions` | `[]` | Exact HTTPS endpoint+parameter query-value entropy exclusions; DLP, SSRF, query-key entropy, adjacent parameters, path/subdomain entropy, rate limits, and data budgets still apply |
 
 **Entropy guidance:**
@@ -191,7 +191,24 @@ fetch_proxy:
 
 An entry asserts that on that exact route the opaque segment is a service-issued resource identifier. It is a policy assertion rather than a classifier, and it does not make the route safe: before exempting one, confirm an agent cannot place a chosen opaque segment there and later read that value back, because such a route can carry data out. `https` only, and an entry with no host, no path prefix, or the bare root prefix `/` is refused at load rather than treated as a wildcard, because each of those three would exempt far more than one route. The prefix must be a canonical path: an encoded slash or backslash, a query or fragment delimiter in either literal or percent-encoded form, a wildcard, a dot segment, and a traversal segment are all refused. Matching compares the prefix against the request's escaped path, so a request that spells the route differently, such as `/document%2Fd/`, is a different route and stays subject to path entropy. **End `path_prefix` with `/` when you mean one path segment.** The prefix is matched literally, so `/document/d` also exempts `/document/de`, `/document/detail`, and every other path starting with those characters, while `/document/d/` does not. Dropping one character widens the exemption. `reason`, `owner` and `expires` are governance metadata. Editing any of them does not change the policy hash a receipt carries. Nothing revokes an entry when its `expires` date passes; `pipelock doctor` reports the expired, unowned, unexplained and inert entries so a standing exemption gets revisited instead of quietly outliving its reason.
 
-This ships empty. A vendor route enters the shipped defaults only with that vendor's own published route contract behind it.
+**Shipped defaults.** Five document-sharing routes ship enabled, because an ordinary Google Docs, Sheets, Slides, Forms or Drive link carries an opaque service-issued file ID by construction and was otherwise blocked on a fresh install:
+
+```yaml
+- host: docs.google.com
+  path_prefix: /document/d/
+- host: docs.google.com
+  path_prefix: /spreadsheets/d/
+- host: docs.google.com
+  path_prefix: /presentation/d/
+- host: docs.google.com
+  path_prefix: /forms/d/e/
+- host: drive.google.com
+  path_prefix: /file/d/
+```
+
+What a shipped entry encodes is the vendor's published route shape, never the identifier format. Google documents these product URL shapes; it documents the file ID itself as opaque, with no charset or length, so keying on the ID would be an invented value. A vendor route enters the shipped defaults only on that basis. Setting the field to an empty list removes them; setting your own list replaces them.
+
+Each entry still exempts only the path-entropy gate for that one host and prefix. It does not make the route safe to send secrets to, and the warning above applies with equal force to a shipped entry: an agent that can place a chosen opaque segment on one of these routes and read it back later can carry data out over it.
 
 **Query entropy parameter exclusions** skip only the raw query-value entropy gate for one exact HTTPS endpoint and one exact parameter key. Subdomain entropy, path entropy, query-key entropy, adjacent parameters, DLP, SSRF, rate limits, and data budgets still apply. Use this first when a structured query language or endpoint contract creates a false positive in one parameter.
 

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -741,6 +741,21 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 	var findings []ConfigSemanticFinding
 	for _, entry := range entries {
 		tuple := pathEntropyAdvisoryTuple(entry)
+		// Every advisory in this loop asks the OPERATOR to act on an exemption
+		// they chose: own it, review it, remove it while entropy is off, or
+		// narrow it. A Pipelock-shipped default is none of those things. The
+		// operator did not add the route, cannot meaningfully own it, and
+		// "remove the path exemption" names a control they do not hold, so the
+		// advisory is an instruction that cannot be followed. Emitting them
+		// would put five to ten warnings in front of every operator on a fresh
+		// install, which is how a diagnostic trains people to ignore it.
+		//
+		// A shipped entry is still governed - just not here. It is pinned by a
+		// defaults test, validated by the same validator an operator's config
+		// passes, and moves the canonical policy hash when it changes.
+		if isShippedPathEntropyDefault(entry) {
+			continue
+		}
 		if cfg.FetchProxy.Monitoring.EntropyThreshold <= 0 {
 			findings = append(findings, newPathEntropyFinding(
 				ConfigSemanticKindInert,
@@ -792,6 +807,22 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 	}
 	sortConfigSemanticFindings(findings)
 	return findings
+}
+
+// isShippedPathEntropyDefault reports whether an entry is one Pipelock ships in
+// Defaults(). It compares against the live default set rather than a second
+// hardcoded list, so adding or removing a shipped route cannot leave this
+// predicate out of date. An operator who types the same host and prefix by hand
+// is indistinguishable here and is treated as shipped, which is the safe
+// direction: the worst case is one missing advisory on a route we already
+// consider correct.
+func isShippedPathEntropyDefault(entry config.PathEntropyExclusion) bool {
+	for _, def := range config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions {
+		if strings.EqualFold(entry.Host, def.Host) && entry.PathPrefix == def.PathPrefix {
+			return true
+		}
+	}
+	return false
 }
 
 func pathEntropyLifecycleCheck(tuple, field, next string) ConfigSemanticFinding {

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -843,7 +843,18 @@ func pathEntropyExclusionsAreInherited(cfg *config.Config) bool {
 		return false
 	}
 	for i := range got {
-		if !strings.EqualFold(got[i].Host, want[i].Host) || got[i].PathPrefix != want[i].PathPrefix {
+		// Compare the WHOLE entry, not just the route. Comparing host and prefix
+		// alone let an operator write all five routes with their own governance
+		// metadata - including a past Expires - and still read as inherited, so
+		// the expiry advisory was skipped on an exemption that had lapsed. The
+		// field is inherited only when it is byte-for-byte what ApplyDefaults
+		// would have written, which is the same test ApplyDefaults itself makes.
+		if !strings.EqualFold(got[i].Host, want[i].Host) {
+			return false
+		}
+		a, b := got[i], want[i]
+		a.Host, b.Host = "", ""
+		if a != b {
 			return false
 		}
 	}

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -836,6 +836,15 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 // An operator who hand-writes precisely the shipped set is indistinguishable and
 // is treated as inherited. That is the one remaining ambiguity and it is benign:
 // the entries are ours either way.
+// normalizedExclusionScheme folds an omitted scheme to the value Load fills in,
+// so a comparison does not turn a defaulting difference into a provenance one.
+func normalizedExclusionScheme(scheme string) string {
+	if scheme == "" {
+		return "https"
+	}
+	return scheme
+}
+
 func pathEntropyExclusionsAreInherited(cfg *config.Config) bool {
 	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
 	want := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions
@@ -852,8 +861,15 @@ func pathEntropyExclusionsAreInherited(cfg *config.Config) bool {
 		if !strings.EqualFold(got[i].Host, want[i].Host) {
 			return false
 		}
+		// Compare against the NORMALIZED default, not the raw one. Load fills an
+		// omitted Scheme with https, so a config that inherited the defaults
+		// carries https while Defaults() leaves the field empty. Comparing the
+		// raw structs made every inherited entry look operator-authored, which
+		// would have greeted a fresh install with an advisory per shipped route
+		// telling the operator to own a route they never added.
 		a, b := got[i], want[i]
 		a.Host, b.Host = "", ""
+		a.Scheme, b.Scheme = normalizedExclusionScheme(a.Scheme), normalizedExclusionScheme(b.Scheme)
 		if a != b {
 			return false
 		}

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -738,6 +738,10 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 	if len(entries) == 0 {
 		return nil
 	}
+	// Decide provenance ONCE for the list, not per entry: ApplyDefaults fills
+	// the whole field or none of it.
+	inherited := pathEntropyExclusionsAreInherited(cfg)
+
 	var findings []ConfigSemanticFinding
 	for _, entry := range entries {
 		tuple := pathEntropyAdvisoryTuple(entry)
@@ -752,7 +756,7 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 		// also lists the host in subdomain_entropy_exclusions has given up
 		// subdomain-entropy coverage for it, and suppressing that warning would
 		// hide a real detection downgrade behind a route we shipped.
-		shipped := isShippedPathEntropyDefault(entry)
+		shipped := inherited
 		// The inert-while-entropy-disabled notice is skipped for shipped routes:
 		// its remedy is "remove the path exemption", which the operator does not
 		// own, and repeating it once per shipped route buries the one signal
@@ -817,20 +821,33 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 	return findings
 }
 
-// isShippedPathEntropyDefault reports whether an entry is one Pipelock ships in
-// Defaults(). It compares against the live default set rather than a second
-// hardcoded list, so adding or removing a shipped route cannot leave this
-// predicate out of date. An operator who types the same host and prefix by hand
-// is indistinguishable here and is treated as shipped, which is the safe
-// direction: the worst case is one missing advisory on a route we already
-// consider correct.
-func isShippedPathEntropyDefault(entry config.PathEntropyExclusion) bool {
-	for _, def := range config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions {
-		if strings.EqualFold(entry.Host, def.Host) && entry.PathPrefix == def.PathPrefix {
-			return true
+// pathEntropyExclusionsAreInherited reports whether this config's exclusion list
+// is the one Pipelock materialized, rather than one the operator wrote.
+//
+// This is PROVENANCE, not resemblance, and the distinction is the point.
+// ApplyDefaults fills the field only when it is nil, so an operator who writes
+// any list at all owns every entry in it, including one that happens to name a
+// shipped route. Matching an entry by host and prefix alone would strip the
+// reason, owner and expiry advisories from that operator's own exemption, and
+// would hide an EXPIRED operator entry that merely shares a route with a
+// default. Comparing the whole list against Defaults() reproduces exactly what
+// ApplyDefaults did and cannot drift from it.
+//
+// An operator who hand-writes precisely the shipped set is indistinguishable and
+// is treated as inherited. That is the one remaining ambiguity and it is benign:
+// the entries are ours either way.
+func pathEntropyExclusionsAreInherited(cfg *config.Config) bool {
+	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
+	want := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if !strings.EqualFold(got[i].Host, want[i].Host) || got[i].PathPrefix != want[i].PathPrefix {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func pathEntropyLifecycleCheck(tuple, field, next string) ConfigSemanticFinding {

--- a/internal/cli/diag/doctor_config_semantics.go
+++ b/internal/cli/diag/doctor_config_semantics.go
@@ -741,22 +741,24 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 	var findings []ConfigSemanticFinding
 	for _, entry := range entries {
 		tuple := pathEntropyAdvisoryTuple(entry)
-		// Every advisory in this loop asks the OPERATOR to act on an exemption
-		// they chose: own it, review it, remove it while entropy is off, or
-		// narrow it. A Pipelock-shipped default is none of those things. The
-		// operator did not add the route, cannot meaningfully own it, and
-		// "remove the path exemption" names a control they do not hold, so the
-		// advisory is an instruction that cannot be followed. Emitting them
-		// would put five to ten warnings in front of every operator on a fresh
-		// install, which is how a diagnostic trains people to ignore it.
+		// A shipped default is not an exemption the operator chose, so the
+		// LIFECYCLE advisories below (own it, give it a reason, set and renew an
+		// expiry) name actions they cannot take on a route Pipelock maintains.
+		// Emitting those would put ten warnings in front of every operator on a
+		// fresh install, which is how a diagnostic trains people to ignore it.
 		//
-		// A shipped entry is still governed - just not here. It is pinned by a
-		// defaults test, validated by the same validator an operator's config
-		// passes, and moves the canonical policy hash when it changes.
-		if isShippedPathEntropyDefault(entry) {
-			continue
-		}
-		if cfg.FetchProxy.Monitoring.EntropyThreshold <= 0 {
+		// The CROSS-FIELD checks are a different thing and still run on shipped
+		// entries, because their remedy IS operator-controlled: an operator who
+		// also lists the host in subdomain_entropy_exclusions has given up
+		// subdomain-entropy coverage for it, and suppressing that warning would
+		// hide a real detection downgrade behind a route we shipped.
+		shipped := isShippedPathEntropyDefault(entry)
+		// The inert-while-entropy-disabled notice is skipped for shipped routes:
+		// its remedy is "remove the path exemption", which the operator does not
+		// own, and repeating it once per shipped route buries the one signal
+		// that matters (entropy is off) under five copies about our own
+		// defaults. An operator's own entry still gets it.
+		if cfg.FetchProxy.Monitoring.EntropyThreshold <= 0 && !shipped {
 			findings = append(findings, newPathEntropyFinding(
 				ConfigSemanticKindInert,
 				tuple,
@@ -774,6 +776,12 @@ func analyzeDoctorPathEntropyExclusions(cfg *config.Config) []ConfigSemanticFind
 				fmt.Sprintf("path_entropy_exclusions entry %s is redundant because subdomain_entropy_exclusions already exempts host %s from path entropy", tuple, entry.Host),
 				"keep the narrow path exemption and remove the host from subdomain_entropy_exclusions, which also disables subdomain entropy for that host",
 			))
+		}
+		if shipped {
+			// Lifecycle metadata stops here for a shipped route. Everything
+			// above is either a correctness problem or has an operator-owned
+			// remedy; everything below asks them to own a route they did not add.
+			continue
 		}
 		if strings.TrimSpace(entry.Reason) == "" {
 			findings = append(findings, pathEntropyLifecycleCheck(tuple, "reason", "add a short reason so future operators know why this route is exempt"))

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -45,4 +45,25 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 			t.Errorf("advisory targeted a shipped default rather than the operator entry: %s", f.Detail)
 		}
 	}
+	// Each lifecycle field is a SEPARATE check, so assert each one by name. A
+	// bare len(got) != 0 passes when only one of the three still fires, which
+	// would let two of them silently go missing while the calibration above
+	// still reported the analyzer as live.
+	for _, field := range []string{"reason", "owner", "expires"} {
+		want := "is missing advisory " + field
+		found := false
+		for _, f := range got {
+			if strings.Contains(f.Detail, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			var details []string
+			for _, f := range got {
+				details = append(details, f.Detail)
+			}
+			t.Errorf("operator entry produced no %q advisory; got:\n%s", field, strings.Join(details, "\n"))
+		}
+	}
 }

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -128,3 +128,35 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 		}
 	}
 }
+
+// TestExplicitShippedRoutesWithExpiryStillWarn is the YAML-provenance case: an
+// operator writes the five shipped routes verbatim but adds their own expiry,
+// which has lapsed. ApplyDefaults leaves that list alone, so those entries are
+// operator-owned and the expiry advisory must fire. Comparing only host and
+// path prefix treated them as inherited and silenced it.
+func TestExplicitShippedRoutesWithExpiryStillWarn(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	operatorCopy := make([]config.PathEntropyExclusion, 0, len(cfg.FetchProxy.Monitoring.PathEntropyExclusions))
+	for _, def := range cfg.FetchProxy.Monitoring.PathEntropyExclusions {
+		def.Reason = "operator copy"
+		def.Owner = "ops"
+		def.Expires = "2020-01-01"
+		operatorCopy = append(operatorCopy, def)
+	}
+	cfg.FetchProxy.Monitoring.PathEntropyExclusions = operatorCopy
+
+	if pathEntropyExclusionsAreInherited(cfg) {
+		t.Fatal("an operator list carrying its own lifecycle metadata was read as inherited")
+	}
+	expired := 0
+	for _, f := range analyzeDoctorPathEntropyExclusions(cfg) {
+		if strings.Contains(f.Detail, "expired on") {
+			expired++
+		}
+	}
+	if expired != len(operatorCopy) {
+		t.Fatalf("expiry advisories = %d, want %d; a lapsed operator exemption was silenced", expired, len(operatorCopy))
+	}
+}

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -31,39 +31,58 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 	// Calibration: the analyzer is NOT inert. An operator's own entry still
 	// gets the full lifecycle treatment, so the silence above is scoping and
 	// not a disabled check.
-	// The NEAR matches are the load-bearing cases. An unrelated host alone
-	// cannot distinguish an exact (host, prefix) match from a matcher that keys
-	// on host only, or on a prefix-of-a-prefix: either would silently suppress
-	// a real operator exemption's advisories while this test still passed. Each
-	// entry below differs from a SHIPPED one in exactly one field.
+	// PROVENANCE, not resemblance. An operator who writes their own list owns
+	// every entry in it, because ApplyDefaults fills the field only when it is
+	// nil. So a config carrying a shipped route PLUS an operator route is
+	// entirely operator-owned and every entry must get its advisories, and an
+	// operator entry that merely duplicates a shipped route must not have its
+	// governance stripped. Matching by host and prefix alone got both wrong.
 	shipped := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions[0]
-	for _, near := range []config.PathEntropyExclusion{
-		{Host: shipped.Host, PathPrefix: "/operator/d/"},
-		{Host: "vendor.example", PathPrefix: shipped.PathPrefix},
-		{Host: shipped.Host, PathPrefix: shipped.PathPrefix + "extra/"},
-	} {
-		if isShippedPathEntropyDefault(near) {
-			t.Errorf("a near match was treated as shipped, so its lifecycle advisories are suppressed: %s%s", near.Host, near.PathPrefix)
-		}
-		cfg := config.Defaults()
-		cfg.FetchProxy.Monitoring.PathEntropyExclusions = append(cfg.FetchProxy.Monitoring.PathEntropyExclusions, near)
-		if len(analyzeDoctorPathEntropyExclusions(cfg)) == 0 {
-			t.Errorf("near match %s%s produced no advisory; a broader matcher is swallowing operator entries", near.Host, near.PathPrefix)
-		}
+
+	explicitDuplicate := config.Defaults()
+	explicitDuplicate.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{
+		{Host: shipped.Host, PathPrefix: shipped.PathPrefix},
+	}
+	if len(analyzeDoctorPathEntropyExclusions(explicitDuplicate)) == 0 {
+		t.Error("an operator entry duplicating a shipped route lost its lifecycle advisories; provenance was decided by resemblance")
 	}
 
-	// Host matching is case-insensitive, so an EQUIVALENT spelling of a shipped
-	// host is still shipped. Without this, a regression from EqualFold to strict
-	// equality passes every case above while telling an operator to own and
-	// renew a route Pipelock ships, under a host DNS considers identical.
-	mixedCase := config.PathEntropyExclusion{Host: strings.ToUpper(shipped.Host), PathPrefix: shipped.PathPrefix}
-	if !isShippedPathEntropyDefault(mixedCase) {
-		t.Errorf("%s%s is an equivalent spelling of a shipped route but was not treated as shipped", mixedCase.Host, mixedCase.PathPrefix)
+	// An expired operator entry on a shipped route must still be reported.
+	expired := config.Defaults()
+	expired.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{
+		{Host: shipped.Host, PathPrefix: shipped.PathPrefix, Reason: "r", Owner: "o", Expires: "2020-01-01"},
 	}
-	mixedCfg := config.Defaults()
-	mixedCfg.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{mixedCase}
-	for _, f := range analyzeDoctorPathEntropyExclusions(mixedCfg) {
-		t.Errorf("an equivalent-cased shipped route produced an advisory the operator cannot act on: %s", f.Detail)
+	sawExpiry := false
+	for _, f := range analyzeDoctorPathEntropyExclusions(expired) {
+		if strings.Contains(f.Detail, "expired on") {
+			sawExpiry = true
+		}
+	}
+	if !sawExpiry {
+		t.Error("an EXPIRED operator entry on a shipped route was silenced; that is the worst case of matching by value")
+	}
+
+	// Adding one operator route alongside the shipped set makes the whole list
+	// operator-owned, so the operator entry is advised.
+	mixedList := config.Defaults()
+	mixedList.FetchProxy.Monitoring.PathEntropyExclusions = append(
+		append([]config.PathEntropyExclusion(nil), config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions...),
+		config.PathEntropyExclusion{Host: "vendor.example", PathPrefix: "/assets/d/"},
+	)
+	if len(analyzeDoctorPathEntropyExclusions(mixedList)) == 0 {
+		t.Error("a list the operator extended produced no advisories; an added entry must not inherit shipped status")
+	}
+
+	// Case-insensitive host matching is still required for the inherited list.
+	mixedCase := config.Defaults()
+	upper := append([]config.PathEntropyExclusion(nil), config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions...)
+	upper[0].Host = strings.ToUpper(upper[0].Host)
+	mixedCase.FetchProxy.Monitoring.PathEntropyExclusions = upper
+	if !pathEntropyExclusionsAreInherited(mixedCase) {
+		t.Error("an equivalent-cased spelling of the shipped list was not recognized as inherited")
+	}
+	for _, f := range analyzeDoctorPathEntropyExclusions(mixedCase) {
+		t.Errorf("an equivalent-cased shipped list produced an advisory the operator cannot act on: %s", f.Detail)
 	}
 
 	operator := config.Defaults()
@@ -75,10 +94,17 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 	if len(got) == 0 {
 		t.Fatal("an operator-added entry with no reason/owner/expires produced no advisory; the analyzer is inert")
 	}
+	// Every entry in an operator-written list is operator-owned, including ones
+	// naming a shipped route, so advisories on those are CORRECT here. What
+	// matters is that the operator's own entry is among them.
+	sawOperatorEntry := false
 	for _, f := range got {
-		if !strings.Contains(f.Subject, "vendor.example") {
-			t.Errorf("advisory targeted a shipped default rather than the operator entry: %s", f.Detail)
+		if strings.Contains(f.Subject, "vendor.example") {
+			sawOperatorEntry = true
 		}
+	}
+	if !sawOperatorEntry {
+		t.Error("the operator's own entry produced no advisory")
 	}
 	// Each lifecycle field is a SEPARATE check, so assert each one by name. A
 	// bare len(got) != 0 passes when only one of the three still fires, which
@@ -88,7 +114,7 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 		want := "is missing advisory " + field
 		found := false
 		for _, f := range got {
-			if strings.Contains(f.Detail, want) {
+			if strings.Contains(f.Subject, "vendor.example") && strings.Contains(f.Detail, want) {
 				found = true
 				break
 			}

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -52,6 +52,20 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 		}
 	}
 
+	// Host matching is case-insensitive, so an EQUIVALENT spelling of a shipped
+	// host is still shipped. Without this, a regression from EqualFold to strict
+	// equality passes every case above while telling an operator to own and
+	// renew a route Pipelock ships, under a host DNS considers identical.
+	mixedCase := config.PathEntropyExclusion{Host: strings.ToUpper(shipped.Host), PathPrefix: shipped.PathPrefix}
+	if !isShippedPathEntropyDefault(mixedCase) {
+		t.Errorf("%s%s is an equivalent spelling of a shipped route but was not treated as shipped", mixedCase.Host, mixedCase.PathPrefix)
+	}
+	mixedCfg := config.Defaults()
+	mixedCfg.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{mixedCase}
+	for _, f := range analyzeDoctorPathEntropyExclusions(mixedCfg) {
+		t.Errorf("an equivalent-cased shipped route produced an advisory the operator cannot act on: %s", f.Detail)
+	}
+
 	operator := config.Defaults()
 	operator.FetchProxy.Monitoring.PathEntropyExclusions = append(
 		operator.FetchProxy.Monitoring.PathEntropyExclusions,

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -4,6 +4,8 @@
 package diag
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -158,5 +160,37 @@ func TestExplicitShippedRoutesWithExpiryStillWarn(t *testing.T) {
 	}
 	if expired != len(operatorCopy) {
 		t.Fatalf("expiry advisories = %d, want %d; a lapsed operator exemption was silenced", expired, len(operatorCopy))
+	}
+}
+
+// TestLoadedDefaultsAreStillInherited asserts provenance through config.Load,
+// the seam every deployment actually goes through, rather than Defaults().
+//
+// This is the case the Defaults()-only tests could not see: Load fills an
+// omitted Scheme with https while Defaults() leaves it empty, so a raw struct
+// comparison classified an inherited list as operator-authored and would have
+// greeted a fresh install with one advisory per shipped route. Testing a state
+// production never occupies is how that reached a push.
+func TestLoadedDefaultsAreStillInherited(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	if err := os.WriteFile(path, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.FetchProxy.Monitoring.PathEntropyExclusions) == 0 {
+		t.Fatal("a loaded config inherited no shipped routes; this test is calibrated against a non-empty set")
+	}
+	if !pathEntropyExclusionsAreInherited(cfg) {
+		t.Fatalf("a loaded config that omitted the field was not recognized as inherited: %+v",
+			cfg.FetchProxy.Monitoring.PathEntropyExclusions)
+	}
+	for _, f := range analyzeDoctorPathEntropyExclusions(cfg) {
+		t.Errorf("a fresh install produced an advisory the operator cannot act on: %s", f.Detail)
 	}
 }

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -31,6 +31,27 @@ func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
 	// Calibration: the analyzer is NOT inert. An operator's own entry still
 	// gets the full lifecycle treatment, so the silence above is scoping and
 	// not a disabled check.
+	// The NEAR matches are the load-bearing cases. An unrelated host alone
+	// cannot distinguish an exact (host, prefix) match from a matcher that keys
+	// on host only, or on a prefix-of-a-prefix: either would silently suppress
+	// a real operator exemption's advisories while this test still passed. Each
+	// entry below differs from a SHIPPED one in exactly one field.
+	shipped := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions[0]
+	for _, near := range []config.PathEntropyExclusion{
+		{Host: shipped.Host, PathPrefix: "/operator/d/"},
+		{Host: "vendor.example", PathPrefix: shipped.PathPrefix},
+		{Host: shipped.Host, PathPrefix: shipped.PathPrefix + "extra/"},
+	} {
+		if isShippedPathEntropyDefault(near) {
+			t.Errorf("a near match was treated as shipped, so its lifecycle advisories are suppressed: %s%s", near.Host, near.PathPrefix)
+		}
+		cfg := config.Defaults()
+		cfg.FetchProxy.Monitoring.PathEntropyExclusions = append(cfg.FetchProxy.Monitoring.PathEntropyExclusions, near)
+		if len(analyzeDoctorPathEntropyExclusions(cfg)) == 0 {
+			t.Errorf("near match %s%s produced no advisory; a broader matcher is swallowing operator entries", near.Host, near.PathPrefix)
+		}
+	}
+
 	operator := config.Defaults()
 	operator.FetchProxy.Monitoring.PathEntropyExclusions = append(
 		operator.FetchProxy.Monitoring.PathEntropyExclusions,

--- a/internal/cli/diag/shipped_path_entropy_advisory_test.go
+++ b/internal/cli/diag/shipped_path_entropy_advisory_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package diag
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestShippedPathEntropyDefaultsProduceNoAdvisories pins the operability
+// direction of shipping vendor route defaults: a fresh install must not greet
+// the operator with advisories about routes Pipelock itself shipped. Every
+// advisory in this analyzer asks the operator to own, review, narrow or remove
+// an exemption they chose; none of those is an action they can take on a
+// shipped default, and an instruction that cannot be followed teaches an
+// operator to ignore the whole diagnostic.
+func TestShippedPathEntropyDefaultsProduceNoAdvisories(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	if len(cfg.FetchProxy.Monitoring.PathEntropyExclusions) == 0 {
+		t.Fatal("defaults ship no path_entropy_exclusions; this test is calibrated against a non-empty shipped set")
+	}
+	for _, f := range analyzeDoctorPathEntropyExclusions(cfg) {
+		t.Errorf("fresh install emits a path-entropy advisory the operator cannot act on: %s || next: %s", f.Detail, f.Next)
+	}
+
+	// Calibration: the analyzer is NOT inert. An operator's own entry still
+	// gets the full lifecycle treatment, so the silence above is scoping and
+	// not a disabled check.
+	operator := config.Defaults()
+	operator.FetchProxy.Monitoring.PathEntropyExclusions = append(
+		operator.FetchProxy.Monitoring.PathEntropyExclusions,
+		config.PathEntropyExclusion{Host: "vendor.example", PathPrefix: "/assets/d/"},
+	)
+	got := analyzeDoctorPathEntropyExclusions(operator)
+	if len(got) == 0 {
+		t.Fatal("an operator-added entry with no reason/owner/expires produced no advisory; the analyzer is inert")
+	}
+	for _, f := range got {
+		if !strings.Contains(f.Subject, "vendor.example") {
+			t.Errorf("advisory targeted a shipped default rather than the operator entry: %s", f.Detail)
+		}
+	}
+}

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -402,7 +402,13 @@ const (
 	// removed. It had no consumer, but SessionProfiling is part of the policy
 	// view, so dropping the field changes the canonical JSON shape and shifts
 	// the hash. Effective enforcement is unchanged.
-	goldenHashDefaults = "18a0abfed63f3277805971cde5412b94742b0d76aed5930cd1b9cb8d1456ca8e"
+	// Re-bumped 2026-09-11 for the shipped document-sharing route exclusions.
+	// Defaults() now carries five path_entropy_exclusions entries, which IS a
+	// policy-semantics change: every deployment's reported policy identity moves
+	// on upgrade, and a conductor strict-mode reload will see it. That
+	// visibility is the intended behavior, not a side effect - an operator's
+	// detection posture changed and the hash is what says so.
+	goldenHashDefaults = "09c3838715f14d36effe3ba7790a40a2295d68dadfc76ba12b585f9495d9927e"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,

--- a/internal/config/canonical_golden_test.go
+++ b/internal/config/canonical_golden_test.go
@@ -402,13 +402,15 @@ const (
 	// removed. It had no consumer, but SessionProfiling is part of the policy
 	// view, so dropping the field changes the canonical JSON shape and shifts
 	// the hash. Effective enforcement is unchanged.
-	// Re-bumped 2026-09-11 for the shipped document-sharing route exclusions.
+	// Re-bumped 2026-09-11 for the shipped document-sharing route exclusions,
+	// and again the same day when the Slides route was corrected to Google's
+	// published singular /presentation/d/ (the plural was an invented value).
 	// Defaults() now carries five path_entropy_exclusions entries, which IS a
 	// policy-semantics change: every deployment's reported policy identity moves
 	// on upgrade, and a conductor strict-mode reload will see it. That
 	// visibility is the intended behavior, not a side effect - an operator's
 	// detection posture changed and the hash is what says so.
-	goldenHashDefaults = "09c3838715f14d36effe3ba7790a40a2295d68dadfc76ba12b585f9495d9927e"
+	goldenHashDefaults = "c6264fe6ff02adfcab114ed9575298e46d72608cbeb0e6f74c6f8d6ea801afe7"
 
 	// goldenHashRichConfig pins the hash for goldenRichYAML loaded via
 	// config.Load, post-ApplyDefaults + Validate. Covers a broad,
@@ -621,7 +623,13 @@ const (
 	// Re-bumped for the session_profiling.volume_spike_ratio removal: see
 	// goldenHashDefaults note above. The rich fixture inherits SessionProfiling
 	// defaults, so the hash shifts in lockstep.
-	goldenHashRichConfig = "e9afed0409969eee5acf87a9b2ae6a9cbf072eb90033a41e0824ca707bda09b6"
+	// Re-bumped 2026-09-11 alongside goldenHashDefaults. This one moving is the
+	// POINT rather than a side effect: the rich fixture is YAML-backed, and it
+	// only inherits the shipped document-sharing routes because ApplyDefaults
+	// now materializes them. Before that fix the defaults hash moved and this
+	// one did not, which is exactly the shape of a default that reaches the
+	// no-config CLI path and no real deployment.
+	goldenHashRichConfig = "e5c4d6a5b87d66803c06ac88b976f414b9c793d270e3ad50a314e9d7a1d7c16c"
 )
 
 // goldenRichYAML is the canonical fixture for goldenHashRichConfig. It

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -263,6 +263,33 @@ func Defaults() *Config {
 					"pypi.org",
 					"objects.githubusercontent.com",
 				},
+				// Document-sharing routes whose path carries an opaque vendor
+				// file identifier by construction. Without these, an operator
+				// sent an ordinary Google Doc, Sheet, Slide, Form or Drive link
+				// is blocked on a fresh install, and the remedy an operator
+				// reaches for first is disabling path entropy entirely - which
+				// is the only control that catches an unrecognizable payload in
+				// a URL path.
+				//
+				// What these encode is the vendor's ROUTE SHAPE, never the
+				// identifier format. The route prefix is directly observable
+				// and stable; Google's Drive API guide calls the file ID opaque
+				// and publishes no charset or length, so keying on the ID would
+				// be the invented value this mechanism exists to avoid.
+				//
+				// Scope, and why this is not a host exemption: each entry binds
+				// ONE host to ONE literal path prefix and suppresses ONLY the
+				// path-entropy gate. Subdomain entropy, query entropy, DLP,
+				// the core credential floor and SSRF all still run on the same
+				// request. docs.google.com/<anything-else> stays checked, and a
+				// lookalike host matches nothing here.
+				PathEntropyExclusions: []PathEntropyExclusion{
+					{Host: "docs.google.com", PathPrefix: "/document/d/", Reason: "Google Docs document route; opaque vendor file id"},
+					{Host: "docs.google.com", PathPrefix: "/spreadsheets/d/", Reason: "Google Sheets route; opaque vendor file id"},
+					{Host: "docs.google.com", PathPrefix: "/presentations/d/", Reason: "Google Slides route; opaque vendor file id"},
+					{Host: "docs.google.com", PathPrefix: "/forms/d/e/", Reason: "Google Forms published-response route; opaque vendor form id"},
+					{Host: "drive.google.com", PathPrefix: "/file/d/", Reason: "Google Drive file route; opaque vendor file id"},
+				},
 			},
 		},
 		ForwardProxy: ForwardProxy{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -286,7 +286,7 @@ func Defaults() *Config {
 				PathEntropyExclusions: []PathEntropyExclusion{
 					{Host: "docs.google.com", PathPrefix: "/document/d/", Reason: "Google Docs document route; opaque vendor file id"},
 					{Host: "docs.google.com", PathPrefix: "/spreadsheets/d/", Reason: "Google Sheets route; opaque vendor file id"},
-					{Host: "docs.google.com", PathPrefix: "/presentations/d/", Reason: "Google Slides route; opaque vendor file id"},
+					{Host: "docs.google.com", PathPrefix: "/presentation/d/", Reason: "Google Slides route; opaque vendor file id"},
 					{Host: "docs.google.com", PathPrefix: "/forms/d/e/", Reason: "Google Forms published-response route; opaque vendor form id"},
 					{Host: "drive.google.com", PathPrefix: "/file/d/", Reason: "Google Drive file route; opaque vendor file id"},
 				},

--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -261,6 +261,15 @@ func (c *Config) ApplyDefaults() {
 	if c.FetchProxy.Monitoring.SubdomainEntropyExclusions == nil {
 		c.FetchProxy.Monitoring.SubdomainEntropyExclusions = append([]string(nil), Defaults().FetchProxy.Monitoring.SubdomainEntropyExclusions...)
 	}
+	// The shipped document-sharing routes must reach a YAML-backed deployment,
+	// which is every real operator: Load() decodes into an EMPTY config and then
+	// calls this, so a default that is only present in Defaults() covers the
+	// no-config CLI path and nothing else. nil means the operator omitted the
+	// field and gets the shipped set; an explicitly empty list is a deliberate
+	// opt-out and is preserved, matching the sibling above.
+	if c.FetchProxy.Monitoring.PathEntropyExclusions == nil {
+		c.FetchProxy.Monitoring.PathEntropyExclusions = append([]PathEntropyExclusion(nil), Defaults().FetchProxy.Monitoring.PathEntropyExclusions...)
+	}
 	if c.FetchProxy.Monitoring.MaxReqPerMinute <= 0 {
 		c.FetchProxy.Monitoring.MaxReqPerMinute = 60
 	}

--- a/internal/config/path_entropy_exclusion_test.go
+++ b/internal/config/path_entropy_exclusion_test.go
@@ -209,7 +209,7 @@ func TestPathEntropyExclusionDefaults(t *testing.T) {
 	want := []PathEntropyExclusion{
 		{Host: "docs.google.com", PathPrefix: "/document/d/"},
 		{Host: "docs.google.com", PathPrefix: "/spreadsheets/d/"},
-		{Host: "docs.google.com", PathPrefix: "/presentations/d/"},
+		{Host: "docs.google.com", PathPrefix: "/presentation/d/"},
 		{Host: "docs.google.com", PathPrefix: "/forms/d/e/"},
 		{Host: "drive.google.com", PathPrefix: "/file/d/"},
 	}

--- a/internal/config/path_entropy_exclusion_test.go
+++ b/internal/config/path_entropy_exclusion_test.go
@@ -189,12 +189,53 @@ func TestValidatePathEntropyExclusions(t *testing.T) {
 	})
 }
 
-// The field ships empty. That is what makes adding it behaviour-preserving, so
-// it is worth pinning rather than assuming.
-func TestPathEntropyExclusionsDefaultEmpty(t *testing.T) {
+// The field shipped EMPTY when the mechanism landed, and this test pinned that.
+// Josh overruled it on 2026-09-11: the five document-sharing routes below now
+// ship as defaults, because an operator sent an ordinary Google Doc, Sheet,
+// Slide, Form or Drive link was blocked on a fresh install and the remedy they
+// reach for first is disabling path entropy outright.
+//
+// The distinction that changed the answer: a shipped default here encodes the
+// vendor's ROUTE PREFIX, which is directly observable and stable, NOT the
+// identifier format, which Google documents as opaque. The earlier "needs a
+// published route contract" bar was applied to the ID format and then used to
+// refuse the route prefix, which was never the thing in question.
+//
+// This test is rewritten rather than deleted so the shipped set stays pinned:
+// an entry added without a deliberate edit here fails.
+func TestPathEntropyExclusionDefaults(t *testing.T) {
 	t.Parallel()
-	if got := Defaults().FetchProxy.Monitoring.PathEntropyExclusions; len(got) != 0 {
-		t.Fatalf("default path_entropy_exclusions = %+v, want empty; a shipped default needs the vendor's published route contract behind it", got)
+	got := Defaults().FetchProxy.Monitoring.PathEntropyExclusions
+	want := []PathEntropyExclusion{
+		{Host: "docs.google.com", PathPrefix: "/document/d/"},
+		{Host: "docs.google.com", PathPrefix: "/spreadsheets/d/"},
+		{Host: "docs.google.com", PathPrefix: "/presentations/d/"},
+		{Host: "docs.google.com", PathPrefix: "/forms/d/e/"},
+		{Host: "drive.google.com", PathPrefix: "/file/d/"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("default path_entropy_exclusions has %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Host != w.Host || got[i].PathPrefix != w.PathPrefix {
+			t.Fatalf("entry %d = %s%s, want %s%s", i, got[i].Host, got[i].PathPrefix, w.Host, w.PathPrefix)
+		}
+		// Every shipped entry must stay narrow. A wildcard host or a bare "/"
+		// prefix would turn a route exemption into a host-wide one, which is
+		// the thing this mechanism exists to avoid.
+		if strings.HasPrefix(got[i].Host, "*") {
+			t.Fatalf("entry %d ships a wildcard host %q; a shipped default must name an exact host", i, got[i].Host)
+		}
+		if got[i].PathPrefix == "/" || !strings.HasPrefix(got[i].PathPrefix, "/") || len(got[i].PathPrefix) < 4 {
+			t.Fatalf("entry %d ships an over-broad path prefix %q", i, got[i].PathPrefix)
+		}
+		if got[i].Reason == "" {
+			t.Fatalf("entry %d ships without a reason an operator can read", i)
+		}
+	}
+	// The shipped set must satisfy the same validator an operator's config does.
+	if err := validatePathEntropyExclusions(got); err != nil {
+		t.Fatalf("shipped defaults fail their own validator: %v", err)
 	}
 }
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1079,8 +1079,12 @@ type Monitoring struct {
 	// SSRF enforced for the same request. Prefer this over adding a host to
 	// SubdomainEntropyExclusions for a path false positive: that list governs
 	// BOTH the path and subdomain gates, so it gives up a second detection.
-	// Ships empty; a route enters the defaults only with the vendor's own
-	// published route contract behind it.
+	// Ships with five document-sharing routes (Google Docs, Sheets, Slides,
+	// Forms and Drive file), because those carry an opaque service-issued file
+	// ID by construction and were otherwise blocked on a fresh install. A route
+	// enters the defaults on the vendor's PUBLISHED ROUTE SHAPE only, never on
+	// the identifier format, which Google documents as opaque. An operator's
+	// own list replaces the shipped set; an explicitly empty list removes it.
 	PathEntropyExclusions []PathEntropyExclusion `yaml:"path_entropy_exclusions"`
 
 	// QueryEntropyParamExclusions lists exact HTTPS endpoint+parameter tuples

--- a/internal/config/vendor_route_defaults_test.go
+++ b/internal/config/vendor_route_defaults_test.go
@@ -135,13 +135,28 @@ func TestYAMLExplicitShippedRoutesKeepTheirGovernance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
+	// Assert the FULL round trip, not just the expiry. The YAML supplies five
+	// fields; checking two would let a loader silently drop the reason or the
+	// owner while this test still reported the operator's list as preserved,
+	// and those two fields are exactly what the governance advisories read.
+	defaults := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions
 	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
-	if len(got) != len(config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions) {
+	if len(got) != len(defaults) {
 		t.Fatalf("operator list was not preserved: %+v", got)
 	}
 	for i, e := range got {
-		if e.Expires != "2020-01-01" {
-			t.Fatalf("entry %d lost the operator's expiry: %+v", i, e)
+		want := config.PathEntropyExclusion{
+			// Load fills an omitted scheme with https; asserting it here pins
+			// that normalization rather than letting it drift unnoticed.
+			Scheme:     "https",
+			Host:       defaults[i].Host,
+			PathPrefix: defaults[i].PathPrefix,
+			Reason:     "operator copy",
+			Owner:      "ops",
+			Expires:    "2020-01-01",
+		}
+		if e != want {
+			t.Fatalf("entry %d round-tripped as %+v, want %+v", i, e, want)
 		}
 	}
 }

--- a/internal/config/vendor_route_defaults_test.go
+++ b/internal/config/vendor_route_defaults_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestVendorRouteDefaults pins BOTH directions of the shipped document-sharing
+// route exclusions. The allow cases prove an operator sent an ordinary Google
+// Docs, Sheets, Slides, Forms or Drive link is not blocked on a fresh install.
+// The block cases are the ones that matter more: each shipped entry binds ONE
+// host to ONE literal path prefix, so a different route on the same host, the
+// same route shape on another host, and a lookalike host that merely carries
+// the vendor host as a leading label must all still be blocked. Removing any
+// entry makes its allow case fail with the real entropy reason, so neither
+// direction is vacuous.
+func TestVendorRouteDefaults(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	sc := scanner.MustNew(cfg)
+	t.Cleanup(sc.Close)
+
+	const id = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+	const formID = "1FAIpQLSf1xQ2mGh7kVJd0pWqYxNzR3TbLcMnOpQrStUvWxYz012345"
+
+	cases := []struct {
+		name      string
+		url       string
+		wantAllow bool
+	}{
+		{"docs document", "https://docs.google.com/document/d/" + id + "/edit", true},
+		{"docs spreadsheet", "https://docs.google.com/spreadsheets/d/" + id + "/edit", true},
+		{"docs presentation", "https://docs.google.com/presentations/d/" + id + "/edit", true},
+		{"docs form", "https://docs.google.com/forms/d/e/" + formID + "/viewform", true},
+		{"drive file", "https://drive.google.com/file/d/" + id + "/view", true},
+
+		// Must STILL block: same host, route not on the list.
+		{"same host other route", "https://docs.google.com/random/" + id, false},
+		// Must STILL block: listed route shape on an unlisted host.
+		{"route on evil host", "https://evil.test/document/d/" + id, false},
+		// Must STILL block: lookalike host with the vendor host as a prefix label.
+		{"lookalike host", "https://docs.google.com.evil.test/document/d/" + id, false},
+		// Must STILL block: listed prefix but the blob is elsewhere in the path.
+		{"prefix then unrelated blob segment", "https://docs.google.com/random/d/" + id, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := sc.Scan(context.Background(), tc.url)
+			if res.Allowed != tc.wantAllow {
+				t.Fatalf("allowed=%v want %v (reason=%q scanner=%q)", res.Allowed, tc.wantAllow, res.Reason, res.Scanner)
+			}
+		})
+	}
+}

--- a/internal/config/vendor_route_defaults_test.go
+++ b/internal/config/vendor_route_defaults_test.go
@@ -5,6 +5,8 @@ package config_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -36,7 +38,7 @@ func TestVendorRouteDefaults(t *testing.T) {
 	}{
 		{"docs document", "https://docs.google.com/document/d/" + id + "/edit", true},
 		{"docs spreadsheet", "https://docs.google.com/spreadsheets/d/" + id + "/edit", true},
-		{"docs presentation", "https://docs.google.com/presentations/d/" + id + "/edit", true},
+		{"docs presentation", "https://docs.google.com/presentation/d/" + id + "/edit", true},
 		{"docs form", "https://docs.google.com/forms/d/e/" + formID + "/viewform", true},
 		{"drive file", "https://drive.google.com/file/d/" + id + "/view", true},
 
@@ -56,5 +58,47 @@ func TestVendorRouteDefaults(t *testing.T) {
 				t.Fatalf("allowed=%v want %v (reason=%q scanner=%q)", res.Allowed, tc.wantAllow, res.Reason, res.Scanner)
 			}
 		})
+	}
+}
+
+// TestVendorRouteDefaultsReachAYAMLBackedConfig covers the state every real
+// operator occupies and the original tests missed: a config LOADED FROM YAML.
+//
+// Load() decodes into an empty config and then calls ApplyDefaults, so a value
+// present only in Defaults() reaches the no-config CLI path and no deployment.
+// The first version of this change had exactly that shape: the five routes were
+// in Defaults(), the defaults hash moved, and a configured operator still got
+// the block. Asserting through Load is what makes the default real.
+func TestVendorRouteDefaultsReachAYAMLBackedConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+	// A minimal config that says nothing about path_entropy_exclusions.
+	if err := os.WriteFile(path, []byte("mode: balanced\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := len(config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions)
+	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
+	if len(got) != want {
+		t.Fatalf("a YAML-backed config inherited %d shipped routes, want %d; the default never reaches a real deployment: %+v",
+			len(got), want, got)
+	}
+
+	// An explicitly empty list is a deliberate opt-out and must be preserved,
+	// not silently refilled with the shipped set.
+	optOut := filepath.Join(dir, "optout.yaml")
+	body := "mode: balanced\nfetch_proxy:\n  monitoring:\n    path_entropy_exclusions: []\n"
+	if err := os.WriteFile(optOut, []byte(body), 0o600); err != nil {
+		t.Fatalf("write opt-out config: %v", err)
+	}
+	cfg2, err := config.Load(optOut)
+	if err != nil {
+		t.Fatalf("config.Load(opt-out): %v", err)
+	}
+	if n := len(cfg2.FetchProxy.Monitoring.PathEntropyExclusions); n != 0 {
+		t.Fatalf("an explicit empty list was refilled with %d shipped routes; the operator's opt-out was overridden", n)
 	}
 }

--- a/internal/config/vendor_route_defaults_test.go
+++ b/internal/config/vendor_route_defaults_test.go
@@ -5,8 +5,10 @@ package config_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/config"
@@ -108,5 +110,38 @@ func TestVendorRouteDefaultsReachAYAMLBackedConfig(t *testing.T) {
 	}
 	if n := len(cfg2.FetchProxy.Monitoring.PathEntropyExclusions); n != 0 {
 		t.Fatalf("an explicit empty list was refilled with %d shipped routes; the operator's opt-out was overridden", n)
+	}
+}
+
+// TestYAMLExplicitShippedRoutesKeepTheirGovernance is the provenance case that
+// route-value comparison could not see. An operator may write all five shipped
+// routes in YAML with their OWN lifecycle metadata, including a past expiry.
+// ApplyDefaults leaves that list alone because it is not nil, so those entries
+// are operator-owned and must keep their advisories. Treating them as inherited
+// silences the expiry warning on an exemption that has already lapsed.
+func TestYAMLExplicitShippedRoutesKeepTheirGovernance(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipelock.yaml")
+
+	var b strings.Builder
+	b.WriteString("mode: balanced\nfetch_proxy:\n  monitoring:\n    path_entropy_exclusions:\n")
+	for _, def := range config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions {
+		fmt.Fprintf(&b, "      - host: %q\n        path_prefix: %q\n        reason: \"operator copy\"\n        owner: \"ops\"\n        expires: \"2020-01-01\"\n", def.Host, def.PathPrefix)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
+	if len(got) != len(config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions) {
+		t.Fatalf("operator list was not preserved: %+v", got)
+	}
+	for i, e := range got {
+		if e.Expires != "2020-01-01" {
+			t.Fatalf("entry %d lost the operator's expiry: %+v", i, e)
+		}
 	}
 }

--- a/internal/config/vendor_route_defaults_test.go
+++ b/internal/config/vendor_route_defaults_test.go
@@ -80,11 +80,19 @@ func TestVendorRouteDefaultsReachAYAMLBackedConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	want := len(config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions)
+	// Compare CONTENT, not just the count. A count-only check passes for a
+	// wrong set of the same length, which would report the enforcement path as
+	// working while a deployment inherited routes nobody shipped.
+	want := config.Defaults().FetchProxy.Monitoring.PathEntropyExclusions
 	got := cfg.FetchProxy.Monitoring.PathEntropyExclusions
-	if len(got) != want {
+	if len(got) != len(want) {
 		t.Fatalf("a YAML-backed config inherited %d shipped routes, want %d; the default never reaches a real deployment: %+v",
-			len(got), want, got)
+			len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Host != want[i].Host || got[i].PathPrefix != want[i].PathPrefix {
+			t.Fatalf("inherited route %d = %s%s, want %s%s", i, got[i].Host, got[i].PathPrefix, want[i].Host, want[i].PathPrefix)
+		}
 	}
 
 	// An explicitly empty list is a deliberate opt-out and must be preserved,


### PR DESCRIPTION
## What changed

The path-entropy scanner blocked ordinary Google Docs, Sheets, Slides, Forms and Drive links, because those routes carry an opaque service-issued file ID that reads as a high-entropy path segment. An operator sent any of them could not open it, and the remedy closest to hand is disabling path entropy altogether: it is the only control that catches an unrecognizable payload in a URL path.

Five document-sharing routes now ship in the default `fetch_proxy.monitoring.path_entropy_exclusions`. Each binds one exact host to one literal path prefix and suppresses only the path-entropy gate; subdomain entropy, query entropy, DLP, the core credential floor and SSRF still run on the same request. A different route on the same host, the same route shape on another host, and a lookalike host all remain blocked. What a shipped entry encodes is the vendor's published route shape, never the identifier format, which Google documents as opaque.

`ApplyDefaults` now materializes the list, so a YAML-backed deployment inherits the routes rather than only a no-config run. An explicitly empty list remains a deliberate opt-out.

`pipelock doctor` no longer asks an operator to own, renew or remove a route Pipelock ships, since none of those is an action they can take. Cross-field warnings still fire on shipped entries, including the one that says a host-wide subdomain exclusion gives up subdomain-entropy coverage.

The canonical policy hash moves. That is deliberate: an operator's detection posture changed and the reported policy identity is what says so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five default path-entropy exemptions for Google Docs, Sheets, Slides, Forms, and Drive sharing routes.
  * Empty configurations disable these defaults; custom lists replace them.
  * Other security checks remain active for exempted routes.

* **Bug Fixes**
  * Diagnostics now distinguish shipped defaults from operator-defined exclusions.
  * Unrelated, malformed, or lookalike routes remain blocked.

* **Documentation**
  * Documented defaults, customization behavior, and YAML examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->