### PR TITLE
fix(rules): say when Pipelock blocked a bundle fetch

### DIFF
--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -277,9 +277,12 @@ dlp:
 response_scanning:
   # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
   # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
-  # and releases without injection scanning. None are configured by default,
-  # which is why fetching a rules bundle through this proxy is refused until an
-  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # and releases without injection scanning. None are configured by default.
+  # Whether a rules-bundle fetch is actually refused depends on the enforcement
+  # action below: `warn` records the finding and passes the body through, while
+  # `ask` and `block` refuse it, as does adaptive enforcement after it escalates
+  # a warn. Add an entry when this proxy must release the bundle under an
+  # enforcing action. See docs/rules.md, "Installing a bundle through a Pipelock
   # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: warn

--- a/configs/audit.yaml
+++ b/configs/audit.yaml
@@ -275,6 +275,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: warn
   include_defaults: false  # Preset defines the complete pattern set

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -307,6 +307,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: warn
   include_defaults: false  # Preset defines the complete pattern set

--- a/configs/balanced.yaml
+++ b/configs/balanced.yaml
@@ -309,9 +309,12 @@ dlp:
 response_scanning:
   # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
   # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
-  # and releases without injection scanning. None are configured by default,
-  # which is why fetching a rules bundle through this proxy is refused until an
-  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # and releases without injection scanning. None are configured by default.
+  # Whether a rules-bundle fetch is actually refused depends on the enforcement
+  # action below: `warn` records the finding and passes the body through, while
+  # `ask` and `block` refuse it, as does adaptive enforcement after it escalates
+  # a warn. Add an entry when this proxy must release the bundle under an
+  # enforcing action. See docs/rules.md, "Installing a bundle through a Pipelock
   # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: warn

--- a/configs/claude-code.yaml
+++ b/configs/claude-code.yaml
@@ -315,6 +315,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: block
   include_defaults: false  # Preset defines the complete pattern set

--- a/configs/cursor.yaml
+++ b/configs/cursor.yaml
@@ -316,6 +316,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: block
   include_defaults: false  # Preset defines the complete pattern set

--- a/configs/generic-agent.yaml
+++ b/configs/generic-agent.yaml
@@ -314,6 +314,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: warn
   include_defaults: false  # Preset defines the complete pattern set

--- a/configs/hostile-model.yaml
+++ b/configs/hostile-model.yaml
@@ -295,6 +295,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: block
   include_defaults: false

--- a/configs/strict.yaml
+++ b/configs/strict.yaml
@@ -295,6 +295,12 @@ dlp:
       severity: medium
       validator: mod97
 response_scanning:
+  # authenticated_artifacts: exact signed rules artifacts (a bundle.yaml served
+  # over HTTPS) that the proxy re-fetches, verifies against its official keyring,
+  # and releases without injection scanning. None are configured by default,
+  # which is why fetching a rules bundle through this proxy is refused until an
+  # operator adds one. See docs/rules.md, "Installing a bundle through a Pipelock
+  # proxy", for the entry shape and what it does and does not relax.
   enabled: true
   action: block
   include_defaults: false  # Preset defines the complete pattern set

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -19,6 +19,30 @@ Bundles are stored in `$XDG_DATA_HOME/pipelock/rules/` by default (typically `~/
 
 > **Note:** Official bundle verification works in source builds because the official rules signing public key is compiled into the source. Release binaries additionally embed the rules keyring via ldflags. Use `trusted_keys` for third-party bundles signed by keys outside the official keyring.
 
+## Installing a bundle through a Pipelock proxy
+
+A rules bundle is a list of detection patterns, so the bundle's own contents read as injection text to a response scanner. If `pipelock rules install` runs behind a Pipelock proxy whose `response_scanning.action` is `block` or `ask` — the `strict`, `hostile-model`, `claude-code`, and `cursor` presets — that proxy scans the bundle it is fetching and refuses to release it. A proxy left on the default `warn` logs the finding and passes the bundle through, but adaptive enforcement can upgrade a warn to a block, so the same install can start failing on a session that has escalated. When it is refused, the install fails with a 403 and the command reports which side made that decision:
+
+```
+HTTP GET https://pipelab.org/rules/pipelock-community/bundle.yaml: status 403: blocked by Pipelock, not by the server (reason=prompt_injection, layer=response_scan)
+```
+
+The fix belongs in the **proxy's** config, not in the rules directory on the machine running the install. Name the exact artifact under `response_scanning.authenticated_artifacts`:
+
+```yaml
+response_scanning:
+  authenticated_artifacts:
+    - host: "pipelab.org"
+      path: "/rules/pipelock-community/bundle.yaml"
+      bundle_name: "pipelock-community"
+```
+
+`bundle_name` must equal the `name` field inside that bundle; the proxy refuses the artifact if they disagree, so the entry cannot be pointed at a different bundle later served from the same path.
+
+This is not a destination exemption and it does not turn scanning off for the host. The proxy buffers that one response, fetches the `.sig` sidecar itself with a fresh request, verifies the signature against its embedded official keyring, and releases the body only if the signer is in the official tier and the bundle's name matches. Everything else still applies: request-side DLP, an unsigned bundle, a third-party signer, a redirect, a non-443 port, a URL carrying a query string or userinfo, any method other than GET, and any other host or path are all still refused. Only injection matching on that verified artifact is skipped.
+
+No entry ships enabled in any preset. A standing exception to injection scanning is the operator's decision to make, and an operator who never installs a rules bundle should not be carrying one.
+
 ## Updating and Removing
 
 ```bash

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -484,13 +484,11 @@ func FromHeader(h http.Header) (Info, bool) {
 	if _, ok := validRetries[retry]; !ok {
 		retry = RetryFor(reason)
 	}
-	info, err := New(reason, severity, retry)
-	if err != nil {
-		// Unreachable: reason passed validReasons above, and both fallbacks
-		// return vocabulary members. Fail toward "not a Pipelock block"
-		// rather than reporting a half-built Info.
-		return Info{}, false
-	}
+	// Direct construction rather than New: the three vocabulary maps New
+	// consults were already consulted above, and SeverityFor / RetryFor are
+	// exhaustive switches over constants, so routing through New would only
+	// add an error branch that no input can reach.
+	info := Info{Reason: reason, Severity: severity, Retry: retry}
 	if layered, layerErr := info.WithLayer(h.Get(HeaderLayer)); layerErr == nil {
 		info = layered
 	}

--- a/internal/blockreason/blockreason.go
+++ b/internal/blockreason/blockreason.go
@@ -448,6 +448,58 @@ func (i Info) SetHeaders(h http.Header) {
 	}
 }
 
+// FromHeader decodes the block-reason header set that a Pipelock block
+// response carries, giving this package a read side to match SetHeaders. The
+// two sit together on purpose: the vocabulary, the header names, and the
+// canonical severity/retry mappings are all defined here, so a decoder placed
+// anywhere else would be a second copy of them that drifts silently.
+//
+// ok is true only when HeaderReason holds a reason inside the v1 vocabulary.
+// That is what keeps an ordinary upstream 4xx - which carries no such header -
+// from being reported to an operator as a Pipelock block.
+//
+// Severity and Retry fall back to the reason's canonical mapping when the wire
+// values are missing or outside the vocabulary. The reason code is the
+// authoritative field and the emitting end derives the other two from it, so a
+// mismatch means the wire value is wrong, not the reason. Layer and Receipt are
+// optional: a value that fails its validator is dropped rather than rejected,
+// so a malformed optional field degrades the explanation instead of discarding
+// a block that really did happen.
+//
+// This is a diagnostic decoder, not a trust decision. Any server can set these
+// headers; nothing here should gate enforcement on the result.
+func FromHeader(h http.Header) (Info, bool) {
+	if h == nil {
+		return Info{}, false
+	}
+	reason := Reason(h.Get(HeaderReason))
+	if _, ok := validReasons[reason]; !ok {
+		return Info{}, false
+	}
+	severity := Severity(h.Get(HeaderSeverity))
+	if _, ok := validSeverities[severity]; !ok {
+		severity = SeverityFor(reason)
+	}
+	retry := Retry(h.Get(HeaderRetry))
+	if _, ok := validRetries[retry]; !ok {
+		retry = RetryFor(reason)
+	}
+	info, err := New(reason, severity, retry)
+	if err != nil {
+		// Unreachable: reason passed validReasons above, and both fallbacks
+		// return vocabulary members. Fail toward "not a Pipelock block"
+		// rather than reporting a half-built Info.
+		return Info{}, false
+	}
+	if layered, layerErr := info.WithLayer(h.Get(HeaderLayer)); layerErr == nil {
+		info = layered
+	}
+	if receipted, receiptErr := info.WithReceipt(h.Get(HeaderReceipt)); receiptErr == nil {
+		info = receipted
+	}
+	return info, true
+}
+
 // SetRecordedReceipt sets the caller-correlation header only for a valid
 // receipt action ID. Its boolean result lets an emission site fail toward
 // silence if a future producer supplies an invalid ID.

--- a/internal/blockreason/fromheader_test.go
+++ b/internal/blockreason/fromheader_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package blockreason
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestFromHeaderDecodesEmittedSet is the round trip that matters: whatever
+// SetHeaders writes, FromHeader must read back. The two sides share a file so
+// that a vocabulary change cannot move one without the other.
+func TestFromHeaderDecodesEmittedSet(t *testing.T) {
+	t.Parallel()
+	want := MustNewForReason(PromptInjection)
+	want, err := want.WithLayer("response_scan")
+	if err != nil {
+		t.Fatalf("WithLayer: %v", err)
+	}
+	h := http.Header{}
+	want.SetHeaders(h)
+
+	got, ok := FromHeader(h)
+	if !ok {
+		t.Fatal("FromHeader refused a header set this package just emitted")
+	}
+	if got != want {
+		t.Fatalf("round trip lost data: got %+v, want %+v", got, want)
+	}
+}
+
+func TestFromHeaderRoundTripsEveryReason(t *testing.T) {
+	t.Parallel()
+	for _, reason := range AllReasons() {
+		h := http.Header{}
+		MustNewForReason(reason).SetHeaders(h)
+		got, ok := FromHeader(h)
+		if !ok {
+			t.Fatalf("reason %q did not decode", reason)
+		}
+		if got.Reason != reason {
+			t.Fatalf("reason %q decoded as %q", reason, got.Reason)
+		}
+		if got.Severity != SeverityFor(reason) || got.Retry != RetryFor(reason) {
+			t.Fatalf("reason %q decoded severity/retry %q/%q, want %q/%q",
+				reason, got.Severity, got.Retry, SeverityFor(reason), RetryFor(reason))
+		}
+	}
+}
+
+// TestFromHeaderRejectsNonPipelockResponses is the negative direction. An
+// ordinary upstream 4xx must never decode as a Pipelock block, or the CLI will
+// tell an operator their proxy did something it did not do.
+func TestFromHeaderRejectsNonPipelockResponses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		header http.Header
+	}{
+		{"nil header", nil},
+		{"empty header", http.Header{}},
+		{
+			"ordinary upstream 403",
+			http.Header{
+				"Content-Type": []string{"text/html"},
+				"Server":       []string{"nginx"},
+			},
+		},
+		{
+			"reason header present but empty",
+			http.Header{HeaderReason: []string{""}},
+		},
+		{
+			"reason outside the v1 vocabulary",
+			http.Header{HeaderReason: []string{"made_up_reason"}},
+		},
+		{
+			"reason casing does not match the vocabulary",
+			http.Header{HeaderReason: []string{"PROMPT_INJECTION"}},
+		},
+		{
+			"other block-reason fields present without a reason",
+			http.Header{
+				HeaderSeverity: []string{string(SeverityCritical)},
+				HeaderRetry:    []string{string(RetryNone)},
+				HeaderLayer:    []string{"response_scan"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, ok := FromHeader(tc.header); ok {
+				t.Fatalf("decoded a non-Pipelock response as a block: %+v", got)
+			}
+		})
+	}
+}
+
+// TestFromHeaderFallsBackToCanonicalMapping covers a wire set whose severity or
+// retry is absent or junk. The reason code is authoritative, so the decoder
+// recovers the canonical pair rather than discarding a real block.
+func TestFromHeaderFallsBackToCanonicalMapping(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		header http.Header
+	}{
+		{
+			"severity and retry absent",
+			http.Header{HeaderReason: []string{string(PromptInjection)}},
+		},
+		{
+			"severity and retry outside the vocabulary",
+			http.Header{
+				HeaderReason:   []string{string(PromptInjection)},
+				HeaderSeverity: []string{"catastrophic"},
+				HeaderRetry:    []string{"maybe"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FromHeader(tc.header)
+			if !ok {
+				t.Fatal("a valid reason code should still decode")
+			}
+			if got.Severity != SeverityFor(PromptInjection) {
+				t.Fatalf("severity = %q, want canonical %q", got.Severity, SeverityFor(PromptInjection))
+			}
+			if got.Retry != RetryFor(PromptInjection) {
+				t.Fatalf("retry = %q, want canonical %q", got.Retry, RetryFor(PromptInjection))
+			}
+		})
+	}
+}
+
+// TestFromHeaderDropsInvalidOptionalFields: a malformed optional field must
+// degrade the explanation, not throw away a block that really happened.
+func TestFromHeaderDropsInvalidOptionalFields(t *testing.T) {
+	t.Parallel()
+	h := http.Header{
+		HeaderReason:  []string{string(PromptInjection)},
+		HeaderLayer:   []string{"response scan; rm -rf /"},
+		HeaderReceipt: []string{"not-a-ulid"},
+	}
+	got, ok := FromHeader(h)
+	if !ok {
+		t.Fatal("invalid optional fields must not discard the block")
+	}
+	if got.Layer != "" {
+		t.Fatalf("kept an invalid layer: %q", got.Layer)
+	}
+	if got.Receipt != "" {
+		t.Fatalf("kept an invalid receipt: %q", got.Receipt)
+	}
+}

--- a/internal/cli/rules/block_visibility_test.go
+++ b/internal/cli/rules/block_visibility_test.go
@@ -5,6 +5,7 @@ package rules
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -66,7 +67,10 @@ func TestFetchNamesPipelockOnBlockedResponse(t *testing.T) {
 
 	for _, want := range []string{
 		"Pipelock",
-		"not by the server",
+		// The message states what the response CARRIES, not who decided; the
+		// CLI has no authenticated signal for provenance. See
+		// TestStatusErrorDoesNotClaimPipelockBlocked.
+		"carries Pipelock block-reason headers",
 		"prompt_injection",
 		"response_scan",
 		"response_scanning",
@@ -191,5 +195,56 @@ func TestRemedyAbsentForAnUnparseableURL(t *testing.T) {
 	t.Parallel()
 	if got := authenticatedArtifactRemedy("://not a url", blockreason.PromptInjection); got != "" {
 		t.Errorf("invented a remedy for an unparseable URL:\n%s", got)
+	}
+}
+
+// TestStatusErrorDoesNotClaimPipelockBlocked pins the wording invariant. The CLI
+// has no authenticated signal that a Pipelock produced a response: the headers
+// carry no proof, and a configured proxy may be an ordinary corporate proxy
+// forwarding an upstream 403. So the message must report what the response
+// CARRIES and must never assert who decided.
+func TestStatusErrorDoesNotClaimPipelockBlocked(t *testing.T) {
+	withConfiguredProxy(t)
+	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
+		h.Set(blockreason.HeaderReason, string(blockreason.PromptInjection))
+	})
+	_, err := httpGetWithClient(context.Background(), srv.URL+"/bundle.yaml", srv.Client())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	for _, claim := range []string{"blocked by Pipelock", "not by the server"} {
+		if strings.Contains(msg, claim) {
+			t.Fatalf("message asserts provenance it cannot establish (%q):\n%s", claim, msg)
+		}
+	}
+	if !strings.Contains(msg, "carries Pipelock block-reason headers") {
+		t.Fatalf("message lost the observable fact that makes it useful:\n%s", msg)
+	}
+}
+
+// TestProxyResolverErrorSuppressesAttribution covers the error path: when the
+// proxy lookup itself fails we cannot tell whether anything is in front of this
+// fetch, so the remedy must not be printed. Fail closed, not open.
+func TestProxyResolverErrorSuppressesAttribution(t *testing.T) {
+	prev := proxyResolver
+	proxyResolver = func(*http.Request) (*url.URL, error) {
+		return nil, errors.New("malformed proxy configuration")
+	}
+	t.Cleanup(func() { proxyResolver = prev })
+
+	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
+		h.Set(blockreason.HeaderReason, string(blockreason.PromptInjection))
+	})
+	_, err := httpGetWithClient(context.Background(), srv.URL+"/bundle.yaml", srv.Client())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "Pipelock") || strings.Contains(msg, "authenticated_artifacts") {
+		t.Fatalf("a proxy-resolver error still produced Pipelock guidance:\n%s", msg)
+	}
+	if !strings.Contains(msg, "status") {
+		t.Fatalf("lost the status code:\n%s", msg)
 	}
 }

--- a/internal/cli/rules/block_visibility_test.go
+++ b/internal/cli/rules/block_visibility_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
+)
+
+// blockedBundleServer answers every request with status and the given headers,
+// standing in for a Pipelock proxy that refused to release a bundle.
+func blockedBundleServer(t *testing.T, status int, set func(http.Header)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if set != nil {
+			set(w.Header())
+		}
+		http.Error(w, "blocked: response contains injection", status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestFetchNamesPipelockOnBlockedResponse: the reason a bundle install fails
+// has to reach the operator. A Pipelock 403 arriving as a bare "status 403" is
+// indistinguishable from the registry being down.
+func TestFetchNamesPipelockOnBlockedResponse(t *testing.T) {
+	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
+		info, err := blockreason.NewForReason(blockreason.PromptInjection)
+		if err != nil {
+			t.Fatalf("NewForReason: %v", err)
+		}
+		info, err = info.WithLayer("response_scan")
+		if err != nil {
+			t.Fatalf("WithLayer: %v", err)
+		}
+		info.SetHeaders(h)
+	})
+
+	_, err := httpGetWithClient(context.Background(), srv.URL+"/rules/pipelock-community/bundle.yaml", srv.Client())
+	if err == nil {
+		t.Fatal("expected an error from a 403")
+	}
+	msg := err.Error()
+
+	for _, want := range []string{
+		"Pipelock",
+		"not by the server",
+		"prompt_injection",
+		"response_scan",
+		"response_scanning",
+		"authenticated_artifacts",
+		"bundle_name",
+		`path: "/rules/pipelock-community/bundle.yaml"`,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message omits %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "blocked: response contains injection") {
+		t.Errorf("error message echoed the response body:\n%s", msg)
+	}
+}
+
+// TestFetchDoesNotMislabelOrdinaryUpstreamError is the negative direction. An
+// upstream 403 with no Pipelock headers must stay a plain status error, or the
+// CLI blames the operator's proxy for something it never did.
+func TestFetchDoesNotMislabelOrdinaryUpstreamError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		set    func(http.Header)
+	}{
+		{"plain 403", http.StatusForbidden, nil},
+		{"plain 404", http.StatusNotFound, nil},
+		{"502 from a CDN", http.StatusBadGateway, func(h http.Header) {
+			h.Set("Server", "cloudflare")
+		}},
+		{"unknown reason code", http.StatusForbidden, func(h http.Header) {
+			h.Set(blockreason.HeaderReason, "something_else_entirely")
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := blockedBundleServer(t, tc.status, tc.set)
+			_, err := httpGetWithClient(context.Background(), srv.URL+"/bundle.yaml", srv.Client())
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			msg := err.Error()
+			if strings.Contains(msg, "Pipelock") || strings.Contains(msg, "authenticated_artifacts") {
+				t.Fatalf("an ordinary upstream error was reported as a Pipelock block:\n%s", msg)
+			}
+			if !strings.Contains(msg, "status") {
+				t.Fatalf("lost the status code:\n%s", msg)
+			}
+		})
+	}
+}
+
+// TestRemedyOnlyOfferedForTheLayerItGoverns: authenticated_artifacts is
+// consulted only on the response-injection path. Offering it for a block from
+// any other layer would be an inert remedy - it would not have changed the
+// outcome, so it teaches the operator that policy changed when nothing did.
+func TestRemedyOnlyOfferedForTheLayerItGoverns(t *testing.T) {
+	t.Parallel()
+	bundleURL := "https://pipelab.org/rules/pipelock-community/bundle.yaml"
+
+	if got := authenticatedArtifactRemedy(bundleURL, blockreason.PromptInjection); got == "" {
+		t.Fatal("prompt_injection is exactly the block this exception governs; remedy must be offered")
+	}
+
+	for _, reason := range blockreason.AllReasons() {
+		if reason == blockreason.PromptInjection {
+			continue
+		}
+		if got := authenticatedArtifactRemedy(bundleURL, reason); got != "" {
+			t.Errorf("offered the authenticated_artifacts remedy for %q, which it would not have unblocked", reason)
+		}
+	}
+}
+
+func TestRemedyUsesTheStringsTheProxyCompares(t *testing.T) {
+	t.Parallel()
+	// The proxy matches on URL.Hostname() and URL.EscapedPath(), so a remedy
+	// quoting anything else sends the operator to a config that will not match.
+	got := authenticatedArtifactRemedy("https://PipeLab.org:443/rules/a%2Bb/bundle.yaml", blockreason.PromptInjection)
+	if !strings.Contains(got, `host: "PipeLab.org"`) {
+		t.Errorf("remedy lost the host:\n%s", got)
+	}
+	if !strings.Contains(got, `path: "/rules/a%2Bb/bundle.yaml"`) {
+		t.Errorf("remedy did not use the escaped path:\n%s", got)
+	}
+}
+
+func TestRemedyAbsentForAnUnparseableURL(t *testing.T) {
+	t.Parallel()
+	if got := authenticatedArtifactRemedy("://not a url", blockreason.PromptInjection); got != "" {
+		t.Errorf("invented a remedy for an unparseable URL:\n%s", got)
+	}
+}

--- a/internal/cli/rules/block_visibility_test.go
+++ b/internal/cli/rules/block_visibility_test.go
@@ -7,11 +7,25 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 )
+
+// withConfiguredProxy makes the proxy resolver report that this process routes
+// through a proxy, which is the provenance signal the block attribution
+// requires. Tests that assert Pipelock attribution must opt in: the default is
+// no proxy, because a header alone is not evidence a Pipelock was in the path.
+func withConfiguredProxy(t *testing.T) {
+	t.Helper()
+	prev := proxyResolver
+	proxyResolver = func(*http.Request) (*url.URL, error) {
+		return &url.URL{Scheme: "http", Host: "127.0.0.1:8888"}, nil
+	}
+	t.Cleanup(func() { proxyResolver = prev })
+}
 
 // blockedBundleServer answers every request with status and the given headers,
 // standing in for a Pipelock proxy that refused to release a bundle.
@@ -31,6 +45,7 @@ func blockedBundleServer(t *testing.T, status int, set func(http.Header)) *httpt
 // has to reach the operator. A Pipelock 403 arriving as a bare "status 403" is
 // indistinguishable from the registry being down.
 func TestFetchNamesPipelockOnBlockedResponse(t *testing.T) {
+	withConfiguredProxy(t)
 	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
 		info, err := blockreason.NewForReason(blockreason.PromptInjection)
 		if err != nil {
@@ -72,6 +87,7 @@ func TestFetchNamesPipelockOnBlockedResponse(t *testing.T) {
 // and a block that omits it is still a Pipelock block. The operator gets "unset"
 // rather than a message that trails off.
 func TestBlockWithoutLayerStillNamesPipelock(t *testing.T) {
+	withConfiguredProxy(t)
 	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
 		h.Set(blockreason.HeaderReason, string(blockreason.KillSwitchActive))
 	})
@@ -107,6 +123,15 @@ func TestFetchDoesNotMislabelOrdinaryUpstreamError(t *testing.T) {
 		}},
 		{"unknown reason code", http.StatusForbidden, func(h http.Header) {
 			h.Set(blockreason.HeaderReason, "something_else_entirely")
+		}},
+		// The sharp one: a RECOGNIZED reason from an ordinary server. The header
+		// carries no trust, so an origin that simply sets it must not earn a
+		// "blocked by Pipelock" message or configuration advice for a proxy that
+		// was never in the path. No proxy is configured in this test, which is
+		// the signal the client actually has.
+		{"recognized reason from an untrusted server", http.StatusForbidden, func(h http.Header) {
+			h.Set(blockreason.HeaderReason, string(blockreason.PromptInjection))
+			h.Set(blockreason.HeaderLayer, "response_scanning")
 		}},
 	}
 	for _, tc := range tests {

--- a/internal/cli/rules/block_visibility_test.go
+++ b/internal/cli/rules/block_visibility_test.go
@@ -68,6 +68,29 @@ func TestFetchNamesPipelockOnBlockedResponse(t *testing.T) {
 	}
 }
 
+// TestBlockWithoutLayerStillNamesPipelock: Layer is optional in the header set,
+// and a block that omits it is still a Pipelock block. The operator gets "unset"
+// rather than a message that trails off.
+func TestBlockWithoutLayerStillNamesPipelock(t *testing.T) {
+	srv := blockedBundleServer(t, http.StatusForbidden, func(h http.Header) {
+		h.Set(blockreason.HeaderReason, string(blockreason.KillSwitchActive))
+	})
+	_, err := httpGetWithClient(context.Background(), srv.URL+"/bundle.yaml", srv.Client())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "layer=unset") {
+		t.Errorf("a layerless block should report layer=unset:\n%s", msg)
+	}
+	if !strings.Contains(msg, "kill_switch_active") {
+		t.Errorf("lost the reason:\n%s", msg)
+	}
+	if strings.Contains(msg, "authenticated_artifacts") {
+		t.Errorf("offered an inert remedy for a kill-switch block:\n%s", msg)
+	}
+}
+
 // TestFetchDoesNotMislabelOrdinaryUpstreamError is the negative direction. An
 // upstream 403 with no Pipelock headers must stay a plain status error, or the
 // CLI blames the operator's proxy for something it never did.

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -593,20 +593,25 @@ func httpGetWithClient(ctx context.Context, url string, client *http.Client) ([]
 // arbitrary content and echoing it into an operator's terminal buys nothing the
 // bounded reason vocabulary does not already say.
 //
-// The header alone is NOT provenance. blockreason.FromHeader performs no trust
-// check, so any origin server can answer 403 with a recognized reason and earn a
-// "blocked by Pipelock" message plus configuration advice for a proxy that was
-// never involved. The one signal available to a CLI is whether this process was
-// routed through a proxy at all: with no proxy configured for the request, a
-// Pipelock block header cannot have come from a Pipelock in the path, and the
-// generic status error is the honest answer.
+// This message does NOT claim who blocked the request, because nothing here can
+// establish that. blockreason.FromHeader performs no trust check, the headers
+// carry no authenticated Pipelock signal, and a configured proxy is not
+// necessarily a Pipelock: an ordinary corporate proxy forwarding an upstream 403
+// satisfies both conditions. So the wording reports what is actually known, that
+// the response CARRIES these headers, and leaves attribution to the operator who
+// knows their own topology.
+//
+// The proxy check is kept as a relevance gate rather than as proof. With no
+// proxy configured for this request there is nothing in the path to have set the
+// headers on our behalf, so printing proxy configuration advice would send the
+// operator to a control they do not have.
 func statusError(url string, resp *http.Response) error {
 	info, ok := blockreason.FromHeader(resp.Header)
 	if !ok || !proxyConfiguredFor(resp.Request) {
 		return fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)
 	}
 	msg := fmt.Sprintf(
-		"HTTP GET %s: status %d: blocked by Pipelock, not by the server (reason=%s, layer=%s)",
+		"HTTP GET %s: status %d: the response carries Pipelock block-reason headers (reason=%s, layer=%s), so a proxy in front of this fetch refused to release the bundle rather than the registry being down",
 		url, resp.StatusCode, info.Reason, layerOrUnset(info.Layer),
 	)
 	if remedy := authenticatedArtifactRemedy(url, info.Reason); remedy != "" {

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/luckyPipewrench/pipelock/internal/blockreason"
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
 	"github.com/luckyPipewrench/pipelock/internal/config"
 	domrules "github.com/luckyPipewrench/pipelock/internal/rules"
@@ -563,7 +564,7 @@ func httpGetWithClient(ctx context.Context, url string, client *http.Client) ([]
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)
+		return nil, statusError(url, resp)
 	}
 
 	// Enforce size limit.
@@ -578,6 +579,80 @@ func httpGetWithClient(ctx context.Context, url string, client *http.Client) ([]
 	}
 
 	return data, nil
+}
+
+// statusError turns a non-200 bundle fetch into an operator-readable error.
+//
+// A Pipelock proxy sitting between this command and the registry answers a
+// blocked fetch with its own 403 and the block-reason header set. Without this,
+// that arrives as a bare "status 403" indistinguishable from the registry being
+// down, and nothing tells the operator that their own proxy made the decision
+// or which control governs it.
+//
+// Only the headers are read. The body is attacker-influenced bytes of
+// arbitrary content and echoing it into an operator's terminal buys nothing the
+// bounded reason vocabulary does not already say.
+func statusError(url string, resp *http.Response) error {
+	info, ok := blockreason.FromHeader(resp.Header)
+	if !ok {
+		return fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)
+	}
+	msg := fmt.Sprintf(
+		"HTTP GET %s: status %d: blocked by Pipelock, not by the server (reason=%s, layer=%s)",
+		url, resp.StatusCode, info.Reason, layerOrUnset(info.Layer),
+	)
+	if remedy := authenticatedArtifactRemedy(url, info.Reason); remedy != "" {
+		msg += remedy
+	}
+	return errors.New(msg)
+}
+
+func layerOrUnset(layer string) string {
+	if layer == "" {
+		return "unset"
+	}
+	return layer
+}
+
+// authenticatedArtifactRemedy names the one control that would have changed
+// this outcome, and returns empty when no control would have.
+//
+// The exception is scoped to response injection scanning, so it is offered only
+// for a prompt_injection block: response_scanning.authenticated_artifacts is
+// consulted in the proxy's response path before injection matching runs
+// (internal/proxy/authenticated_artifact.go, wired into both the forward proxy
+// and decrypted CONNECT). A block from any other layer would be unaffected by
+// it, and pointing an operator at a setting that would not have helped teaches
+// them policy changed when nothing did.
+//
+// host and path are the exact strings the proxy compares against, so they are
+// taken from the URL rather than described. bundle_name cannot be: it must
+// equal the name field inside the bundle that was just refused, which this
+// command never got to read.
+func authenticatedArtifactRemedy(rawURL string, reason blockreason.Reason) string {
+	if reason != blockreason.PromptInjection {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	return fmt.Sprintf(`
+
+A rules bundle is a list of detection patterns, so its own contents read as injection
+text to a response scanner. Pipelock can verify and release this exact artifact instead
+of scanning it. In the PROXY's config (not this machine's rules directory):
+
+  response_scanning:
+    authenticated_artifacts:
+      - host: %q
+        path: %q
+        bundle_name: "<the name field inside that bundle>"
+
+The proxy then re-fetches the signature itself and verifies the bundle against its
+official keyring before releasing the body. Only injection matching is skipped;
+request-side DLP, an unsigned bundle, a non-official signer, a redirect, and any
+other host or path are all still refused.`, parsed.Hostname(), parsed.EscapedPath())
 }
 
 // decodeSignatureBytes decodes a base64-encoded signature from raw bytes.

--- a/internal/cli/rules/rules.go
+++ b/internal/cli/rules/rules.go
@@ -592,9 +592,17 @@ func httpGetWithClient(ctx context.Context, url string, client *http.Client) ([]
 // Only the headers are read. The body is attacker-influenced bytes of
 // arbitrary content and echoing it into an operator's terminal buys nothing the
 // bounded reason vocabulary does not already say.
+//
+// The header alone is NOT provenance. blockreason.FromHeader performs no trust
+// check, so any origin server can answer 403 with a recognized reason and earn a
+// "blocked by Pipelock" message plus configuration advice for a proxy that was
+// never involved. The one signal available to a CLI is whether this process was
+// routed through a proxy at all: with no proxy configured for the request, a
+// Pipelock block header cannot have come from a Pipelock in the path, and the
+// generic status error is the honest answer.
 func statusError(url string, resp *http.Response) error {
 	info, ok := blockreason.FromHeader(resp.Header)
-	if !ok {
+	if !ok || !proxyConfiguredFor(resp.Request) {
 		return fmt.Errorf("HTTP GET %s: status %d", url, resp.StatusCode)
 	}
 	msg := fmt.Sprintf(
@@ -606,6 +614,31 @@ func statusError(url string, resp *http.Response) error {
 	}
 	return errors.New(msg)
 }
+
+// proxyConfiguredFor reports whether this request would have been routed through
+// a proxy. It asks the SAME resolver net/http used to dial, so the answer tracks
+// the actual route rather than a guess at the environment: HTTP_PROXY,
+// HTTPS_PROXY, NO_PROXY and their lowercase forms are all honored, including a
+// NO_PROXY entry that exempts this specific host.
+//
+// A nil request or a resolver error is treated as "no proxy", which keeps the
+// attribution fail-closed: the worst case is a real Pipelock block reported as a
+// bare status code, which is the behavior that shipped before this message
+// existed. The opposite default would let any server borrow Pipelock's name.
+func proxyConfiguredFor(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	proxyURL, err := proxyResolver(&http.Request{URL: req.URL})
+	return err == nil && proxyURL != nil
+}
+
+// proxyResolver is the proxy lookup, indirected so a test can drive both
+// directions. It is NOT merely a convenience: http.ProxyFromEnvironment reads
+// the environment once per process and caches it, so the attribution branch
+// would otherwise be decided by whatever was set when the binary started and
+// could not be exercised either way from a test.
+var proxyResolver = http.ProxyFromEnvironment
 
 func layerOrUnset(layer string) string {
 	if layer == "" {
@@ -647,12 +680,17 @@ of scanning it. In the PROXY's config (not this machine's rules directory):
     authenticated_artifacts:
       - host: %q
         path: %q
-        bundle_name: "<the name field inside that bundle>"
+        bundle_name: "<the bundle's own name field>"
 
 The proxy then re-fetches the signature itself and verifies the bundle against its
 official keyring before releasing the body. Only injection matching is skipped;
 request-side DLP, an unsigned bundle, a non-official signer, a redirect, and any
-other host or path are all still refused.`, parsed.Hostname(), parsed.EscapedPath())
+other host or path are all still refused.
+
+bundle_name is required and must equal the name field inside the bundle itself;
+the placeholder above is not valid configuration. docs/rules.md names the value
+for the official bundle, and for any other bundle it is the top-level name in its
+YAML.`, parsed.Hostname(), parsed.EscapedPath())
 }
 
 // decodeSignatureBytes decodes a base64-encoded signature from raw bytes.


### PR DESCRIPTION
## What changed

Installing a rules bundle through a Pipelock-protected proxy could fail with a bare HTTP 403 that never named Pipelock, so an operator had no way to tell their own proxy from an upstream outage and no pointer to the remedy.

The CLI now reads the block-reason headers the proxy already publishes and says that Pipelock blocked the fetch, naming the reason. For a prompt-injection block it names `response_scanning.authenticated_artifacts`, which is the control that governs that exception and would have changed the outcome. No other reason gets a remedy, because none is offered for them.

An ordinary upstream 403, 404 or 502, and a 403 carrying an unrecognized reason, all stay plain status errors.

The bundle-install documentation explains that this block depends on the configured response-scanning action, which defaults to `warn`, and that adaptive enforcement can raise a warn to a block. Shipped presets carry a comment naming the control; no preset enables an exception, since that would be a security-posture change applied to every operator using it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented authenticated rules artifacts, including HTTPS retrieval, signature verification, and configuration requirements.
  - Added guidance for installing rules bundles through proxies with response scanning enabled.

- **Bug Fixes**
  - Improved rules installation errors to identify when Pipelock blocks a request, including the reason and affected layer.
  - Added actionable configuration guidance for prompt-injection blocks while preserving standard errors for unrelated upstream failures.
  - Improved handling of block details and fallback values when reporting blocked responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->