### PR TITLE
fix(config): check host patterns at both unvalidated boundaries

### DIFF
--- a/internal/cli/runtime/server_reload.go
+++ b/internal/cli/runtime/server_reload.go
@@ -72,6 +72,16 @@ func (s *Server) reloadLocked(newCfg *config.Config) (err error) {
 		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
 		return rejectErr
 	}
+	// Host patterns get the same treatment, for the same reason: the file
+	// reloader validates through config.Load, but the Conductor apply boundary
+	// enters here directly and this seam must stay fail-closed for every
+	// caller. A pattern that reaches the live scanner unvalidated can match a
+	// host the operator never wrote.
+	if validationErr := newCfg.ValidateHostPatterns(); validationErr != nil {
+		rejectErr := fmt.Errorf("rejected: invalid config reload: invalid host pattern: %w", validationErr)
+		s.logger.LogError(audit.NewResourceLogContext(configReloadAuditMethod, s.opts.ConfigFile), rejectErr)
+		return rejectErr
+	}
 	// Startup refuses block on this listener, so a reload that asks for it is
 	// requesting enforcement this runtime cannot provide. Reject the whole
 	// reload atomically and record it through the reload audit path; applying

--- a/internal/cli/runtime/server_reload_host_pattern_conductor_test.go
+++ b/internal/cli/runtime/server_reload_host_pattern_conductor_test.go
@@ -1,0 +1,50 @@
+//go:build enterprise
+
+// Copyright 2026 Pipelock contributors
+// Licensed under the Elastic License 2.0. See enterprise/LICENSE.
+
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestReload_HostPatternRejectionPrecedesConductorTeardown pins the ORDERING
+// that the host-pattern check actually buys.
+//
+// With the check removed the reload is still refused, because scanner
+// construction rejects the pattern further down. What the check adds is that
+// the refusal happens BEFORE teardownConductor runs. Without it, a reload
+// carrying both a revoked fleet entitlement and a bad host pattern tears the
+// follower down and only then rejects, so an operator loses a running
+// Conductor to a config that was never applied.
+//
+// A plain rejection test cannot see this: it has no live Conductor to lose.
+func TestReload_HostPatternRejectionPrecedesConductorTeardown(t *testing.T) {
+	s, _ := newConductorApplyTestServer(t)
+	_, cancel := context.WithCancel(context.Background())
+	s.setConductorCancel(cancel)
+
+	// Both conditions at once: the license loses the fleet entitlement (which
+	// alone tears the follower down, proven by
+	// TestReload_FleetDowngradeTearsDownConductor) AND the config carries an
+	// invalid host pattern.
+	proTok, proPubHex := agentsOnlyLicenseFixture(t)
+	newCfg := s.proxy.CurrentConfig().Clone()
+	newCfg.LicenseKey = proTok
+	newCfg.LicensePublicKey = proPubHex
+	newCfg.TrustedDomains = []string{"*"}
+
+	err := s.Reload(newCfg)
+	if err == nil {
+		t.Fatal("Reload accepted an invalid host pattern")
+	}
+	if !strings.Contains(err.Error(), "invalid host pattern") {
+		t.Fatalf("Reload error = %q, want the host-pattern rejection to be the reason", err)
+	}
+	if s.conductorDown.Load() {
+		t.Fatal("a rejected reload tore down the Conductor follower; validation must precede teardown, or an operator loses a running fleet to a config that was never applied")
+	}
+}

--- a/internal/cli/runtime/server_reload_host_pattern_test.go
+++ b/internal/cli/runtime/server_reload_host_pattern_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// The reload activation seam is an ingest boundary, not only the tail of the
+// file reloader: the Conductor apply path calls reloadLocked directly. A host
+// pattern that reaches the live scanner unchecked can match a host the operator
+// never wrote, so this seam refuses it the same way it already refuses reserved
+// day-of-week limits, malformed suppressions and an unenforceable file sentry.
+//
+// WHAT THE MESSAGE ASSERTION IS FOR, since the reload would be refused either
+// way. Scanner construction later in this function rejects the same pattern, so
+// removing the preamble check does not make a bad reload land. What it changes
+// is WHEN. The preamble runs before the license block can call teardownConductor
+// and before restart-only fields are preserved; scanner construction runs after
+// both. A reload carrying an invalid host pattern AND a revoked fleet
+// entitlement would therefore tear the conductor down and only then reject,
+// leaving the follower down on the strength of a reload that never applied.
+// Asserting the preamble's message rather than the constructor's is how this
+// test pins the ordering.
+func TestServer_ReloadRejectsInvalidHostPattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*config.Config)
+		wantField string
+	}{
+		{
+			name:      "api_allowlist wildcard over a public suffix",
+			mutate:    func(c *config.Config) { c.APIAllowlist = append(c.APIAllowlist, "*.co.uk") },
+			wantField: "api_allowlist",
+		},
+		{
+			// Validates as one host and matches as another, so this blocklist
+			// entry would never block.
+			name:      "blocklist entry the matcher reads differently",
+			mutate:    func(c *config.Config) { c.FetchProxy.Monitoring.Blocklist = []string{"vendor.example.."} },
+			wantField: "fetch_proxy.monitoring.blocklist",
+		},
+		{
+			name:      "trusted_domains bare wildcard",
+			mutate:    func(c *config.Config) { c.TrustedDomains = []string{"*"} },
+			wantField: "trusted_domains",
+		},
+		{
+			name: "request_policy route host with an interior wildcard",
+			mutate: func(c *config.Config) {
+				c.RequestPolicy.Rules = []config.RequestPolicyRule{{
+					Name:   "deny-uploads",
+					Action: config.ActionBlock,
+					Route:  config.RequestPolicyRoute{Hosts: []string{"*.vendor*.example"}},
+				}}
+			},
+			wantField: "request_policy.rules",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newTestServer(t, nil)
+			oldCfg := s.proxy.CurrentConfig()
+
+			newCfg := oldCfg.Clone()
+			tt.mutate(newCfg)
+
+			err := s.Reload(newCfg)
+			if err == nil {
+				t.Fatal("Reload accepted an invalid host pattern; this seam must stay fail-closed for every caller")
+			}
+			if !strings.Contains(err.Error(), "rejected: invalid config reload: invalid host pattern") {
+				t.Errorf("Reload error = %q, want a host-pattern rejection", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Errorf("Reload error = %q, does not name %q; the operator cannot act on a message that omits the field", err, tt.wantField)
+			}
+			if live := s.proxy.CurrentConfig(); live != oldCfg {
+				t.Error("a rejected reload changed the live config; the refusal must be atomic")
+			}
+		})
+	}
+}
+
+// Control for the rejections above: an ordinary reload carrying a well-formed
+// host pattern still lands. Without this the rejection test would pass against
+// a seam that refuses everything.
+func TestServer_ReloadAcceptsValidHostPattern(t *testing.T) {
+	s, _ := newTestServer(t, nil)
+	oldCfg := s.proxy.CurrentConfig()
+
+	newCfg := oldCfg.Clone()
+	newCfg.TrustedDomains = []string{"*.internal.vendor.example", "api.vendor.example"}
+
+	if err := s.Reload(newCfg); err != nil {
+		t.Fatalf("Reload(valid host patterns) = %v, want nil; the guard must not refuse working configuration", err)
+	}
+	live := s.proxy.CurrentConfig()
+	if live == oldCfg {
+		t.Fatal("a valid reload did not replace the live config, so this control proves nothing")
+	}
+	if len(live.TrustedDomains) != 2 {
+		t.Errorf("live trusted_domains = %q, want the two patterns the reload carried", live.TrustedDomains)
+	}
+}

--- a/internal/config/host_pattern_invariant.go
+++ b/internal/config/host_pattern_invariant.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// hostPatternList names one host-pattern list on a Config together with the
+// validator Validate already applies to that list.
+//
+// The check is a field, not a switch, because the directionality of a list
+// decides its rule: a GRANT list gets the wildcard breadth test, a MATCH or
+// DENY list deliberately does not, and a request_policy route gets shape only.
+// Pairing each list with its own validator here keeps that mapping in one
+// table instead of re-deciding it per call site.
+type hostPatternList struct {
+	field string
+	hosts []string
+	check func(hosts []string, label string) error
+	// single marks a row whose field already names one host, so the reported
+	// location must not gain a "[0]" the YAML has no counterpart for.
+	single bool
+}
+
+// hostPatternLists returns every host-pattern list that can reach a Scanner,
+// each paired with the validator Validate uses for it.
+//
+// Per-agent profiles are deliberately absent. A profile reaches a Scanner only
+// through the enterprise merge, which REPLACES the top-level lists rather than
+// merging them, so the merged Config handed to scanner.New carries them as
+// api_allowlist and trusted_domains and the first two rows below check them at
+// that boundary. Walking cfg.Agents here as well would refuse an inert profile
+// on a build where agent profiles are not enabled, which removes working
+// configuration without covering anything the merged walk misses.
+func (c *Config) hostPatternLists() []hostPatternList {
+	lists := []hostPatternList{
+		{field: "api_allowlist", hosts: c.APIAllowlist, check: ValidateHostGrantList},
+		{field: "trusted_domains", hosts: c.TrustedDomains, check: ValidateTrustedDomains},
+		{field: "fetch_proxy.monitoring.blocklist", hosts: c.FetchProxy.Monitoring.Blocklist, check: ValidateHostMatchList},
+		{
+			field: "fetch_proxy.monitoring.subdomain_entropy_exclusions",
+			hosts: c.FetchProxy.Monitoring.SubdomainEntropyExclusions,
+			check: hostnamePatternListCheck,
+		},
+		{
+			field: "fetch_proxy.monitoring.query_entropy_exclusions",
+			hosts: c.FetchProxy.Monitoring.QueryEntropyExclusions,
+			check: hostnamePatternListCheck,
+		},
+	}
+
+	for i := range c.FetchProxy.Monitoring.PathEntropyExclusions {
+		lists = append(lists, hostPatternList{
+			field:  fmt.Sprintf("fetch_proxy.monitoring.path_entropy_exclusions[%d].host", i),
+			hosts:  []string{c.FetchProxy.Monitoring.PathEntropyExclusions[i].Host},
+			check:  hostnamePatternListCheck,
+			single: true,
+		})
+	}
+
+	// The parameter exclusions take an EXACT host, not a wildcard, so they get
+	// their own normalizer rather than the wildcard-aware one above. Routing
+	// them through the wildcard checker would accept "*.example.com" here, which
+	// the runtime compares literally and would never match.
+	for i := range c.FetchProxy.Monitoring.QueryEntropyParamExclusions {
+		lists = append(lists, hostPatternList{
+			field:  fmt.Sprintf("fetch_proxy.monitoring.query_entropy_param_exclusions[%d].host", i),
+			hosts:  []string{c.FetchProxy.Monitoring.QueryEntropyParamExclusions[i].Host},
+			check:  queryEntropyParamHostCheck,
+			single: true,
+		})
+	}
+
+	// Route hosts get SHAPE only. Breadth on a request_policy route is the
+	// operator's policy rather than a mistake, and refusing a broad wildcard
+	// here would remove the ability to express one. Validate makes the same
+	// call at validate.go:2583.
+	//
+	// Both route-bearing shapes are walked. A batch route is a route: it
+	// reaches the same matcher, and covering only rules would leave the newer
+	// of the two shapes unguarded, which is the failure this whole walk exists
+	// to prevent.
+	for i := range c.RequestPolicy.Rules {
+		lists = append(lists, hostPatternList{
+			field: fmt.Sprintf("request_policy.rules[%q].route.hosts", c.RequestPolicy.Rules[i].Name),
+			hosts: c.RequestPolicy.Rules[i].Route.Hosts,
+			check: routeHostCheck,
+		})
+	}
+	for i := range c.RequestPolicy.Batch {
+		lists = append(lists, hostPatternList{
+			field: fmt.Sprintf("request_policy.batch[%d].route.hosts", i),
+			hosts: c.RequestPolicy.Batch[i].Route.Hosts,
+			check: routeHostCheck,
+		})
+	}
+
+	for i := range c.DLP.Patterns {
+		p := &c.DLP.Patterns[i]
+		if len(p.ExemptDomains) == 0 {
+			continue
+		}
+		lists = append(lists, hostPatternList{
+			field: fmt.Sprintf("dlp.patterns[%q].exempt_domains", p.Name),
+			hosts: p.ExemptDomains,
+			check: ValidateTrustedDomains,
+		})
+	}
+
+	return lists
+}
+
+// hostnamePatternListCheck adapts validateHostnamePatternList, whose parameters
+// are ordered label-first, to the shared check signature.
+func hostnamePatternListCheck(hosts []string, label string) error {
+	return validateHostnamePatternList(label, hosts)
+}
+
+func queryEntropyParamHostCheck(hosts []string, label string) error {
+	for i, raw := range hosts {
+		if _, err := normalizeQueryEntropyParamHost(raw); err != nil {
+			return fmt.Errorf("%s[%d] %q: %w", label, i, raw, err)
+		}
+	}
+	return nil
+}
+
+func routeHostCheck(hosts []string, label string) error {
+	for i, raw := range hosts {
+		if _, err := NormalizeAndCheckHostPattern(raw); err != nil {
+			return fmt.Errorf("%s[%d] %q: %w", label, i, raw, err)
+		}
+	}
+	return nil
+}
+
+// ValidateHostPatterns re-checks every host-pattern list on the Config against
+// the same rules Validate applies to it.
+//
+// It exists because two boundaries take a *Config without being able to tell
+// whether Validate ever ran on it: scanner.New, reached by the enterprise
+// per-agent merge among others, and the reload activation seam, which the
+// Conductor apply path enters directly rather than through the file reloader.
+// Neither is a live operator bypass today, because every production caller
+// still arrives by way of config.Load. This is the guard that keeps that true
+// when a caller arrives that does not.
+//
+// It walks the whole set rather than filtering each list at its point of use.
+// A per-list filter puts a copy of the same predicate at every site and leaves
+// the next list uncovered the moment someone adds one; the path-entropy builder
+// is exactly that shape and needed three separate repairs. One walk over one
+// table means a new list is covered by adding a row.
+//
+// It REFUSES rather than dropping. Dropping an invalid entry changes what the
+// scanner enforces while the operator still sees their configuration as
+// accepted: an exemption silently disappears and scanning becomes stricter than
+// the YAML says, or a blocklist entry disappears and it becomes looser. Either
+// way the posture moves and nothing tells them.
+//
+// It does not mutate the Config. Two of the shared validators normalize their
+// input in place, and this runs at a construction boundary where the Config may
+// already be shared with a live runtime, so every list is copied first.
+func (c *Config) ValidateHostPatterns() error {
+	for _, list := range c.hostPatternLists() {
+		for i, raw := range list.hosts {
+			// One entry at a time, on a copy, so the offending value is known
+			// exactly and an in-place normalizer cannot reach the caller's
+			// slice.
+			if err := list.check([]string{raw}, list.field); err != nil {
+				where := list.field
+				if !list.single {
+					where = fmt.Sprintf("%s[%d]", list.field, i)
+				}
+				return fmt.Errorf("%s %q (normalizes to %q): %s",
+					where, raw, NormalizeHostPattern(raw),
+					hostPatternReason(list.field, err))
+			}
+		}
+	}
+	return nil
+}
+
+// hostPatternReason strips the field/index prefix the shared validators add, so
+// the caller can print the field, the raw value and the normalized value once
+// each instead of twice.
+//
+// The prefix is deterministic rather than guessed: every list above is checked
+// one entry at a time under a label this package passed in, so a validator that
+// formats its own prefix produces exactly "<label>[0]".
+func hostPatternReason(label string, err error) string {
+	if inner := errors.Unwrap(err); inner != nil {
+		return inner.Error()
+	}
+	msg := strings.TrimPrefix(err.Error(), fmt.Sprintf("%s[0]", label))
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(msg), ":"))
+}

--- a/internal/config/host_pattern_invariant_test.go
+++ b/internal/config/host_pattern_invariant_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every host-pattern list that can reach a Scanner is refused when it carries a
+// pattern Validate would reject. One case per list, so a list that loses its
+// row in the table fails here rather than going quietly uncovered.
+func TestValidateHostPatternsRefusesEveryList(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Config)
+		wantField string
+		wantRaw   string
+		wantNorm  string
+		wantWhy   string
+	}{
+		{
+			name:      "api_allowlist wildcard over a public suffix",
+			mutate:    func(c *Config) { c.APIAllowlist = []string{"api.vendor.example", "*.co.uk"} },
+			wantField: "api_allowlist[1]",
+			wantRaw:   `"*.co.uk"`,
+			wantNorm:  `"*.co.uk"`,
+			wantWhy:   "public suffix",
+		},
+		{
+			// Validates as one host and matches as another: the matcher trims a
+			// single trailing dot, so a deny rule written this way never denies.
+			name:      "blocklist entry the matcher reads differently",
+			mutate:    func(c *Config) { c.FetchProxy.Monitoring.Blocklist = []string{"vendor.example.."} },
+			wantField: "fetch_proxy.monitoring.blocklist[0]",
+			wantRaw:   `"vendor.example.."`,
+			wantNorm:  `"vendor.example"`,
+			wantWhy:   "never agree with the validated form",
+		},
+		{
+			name:      "trusted_domains bare wildcard",
+			mutate:    func(c *Config) { c.TrustedDomains = []string{"*"} },
+			wantField: "trusted_domains[0]",
+			wantRaw:   `"*"`,
+			wantNorm:  `"*"`,
+			wantWhy:   "disables all SSRF protection",
+		},
+		{
+			// U+212A KELVIN SIGN folds to ASCII "k", so this exempts a host the
+			// operator never wrote. The normalized value in the message is what
+			// makes that visible.
+			name: "subdomain_entropy_exclusions host that folds into a different ASCII host",
+			mutate: func(c *Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"Kexample.com"}
+			},
+			wantField: "fetch_proxy.monitoring.subdomain_entropy_exclusions[0]",
+			wantNorm:  `"kexample.com"`,
+			wantWhy:   "must be ASCII",
+		},
+		{
+			name:      "query_entropy_exclusions blank entry",
+			mutate:    func(c *Config) { c.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"  "} },
+			wantField: "fetch_proxy.monitoring.query_entropy_exclusions[0]",
+			wantNorm:  `""`,
+			wantWhy:   "empty",
+		},
+		{
+			name: "path_entropy_exclusions host wildcard over a registry",
+			mutate: func(c *Config) {
+				c.FetchProxy.Monitoring.PathEntropyExclusions = []PathEntropyExclusion{
+					{Scheme: "https", Host: "*.co.uk", PathPrefix: "/document/d/"},
+				}
+			},
+			wantField: "fetch_proxy.monitoring.path_entropy_exclusions[0].host",
+			wantRaw:   `"*.co.uk"`,
+			wantWhy:   "public suffix",
+		},
+		{
+			name: "query_entropy_param_exclusions host carrying a wildcard",
+			mutate: func(c *Config) {
+				c.FetchProxy.Monitoring.QueryEntropyParamExclusions = []QueryEntropyParamExclusion{
+					{Scheme: "https", Host: "*.vendor.example", Path: "/v1", Param: "sig"},
+				}
+			},
+			wantField: "fetch_proxy.monitoring.query_entropy_param_exclusions[0].host",
+			wantRaw:   `"*.vendor.example"`,
+			wantWhy:   "without URL syntax, port, or wildcard",
+		},
+		{
+			// An interior wildcard matches no legal hostname, so a block rule
+			// carrying it denies nothing.
+			name: "request_policy rule route host with an interior wildcard",
+			mutate: func(c *Config) {
+				c.RequestPolicy.Rules = []RequestPolicyRule{
+					{Name: "deny-uploads", Route: RequestPolicyRoute{Hosts: []string{"*.vendor*.example"}}},
+				}
+			},
+			wantField: `request_policy.rules["deny-uploads"].route.hosts[0]`,
+			wantRaw:   `"*.vendor*.example"`,
+			wantWhy:   "only as the leading",
+		},
+		{
+			name: "request_policy batch route host with an interior wildcard",
+			mutate: func(c *Config) {
+				c.RequestPolicy.Batch = []RequestPolicyBatch{
+					{Route: RequestPolicyRoute{Hosts: []string{"*.vendor*.example"}}},
+				}
+			},
+			wantField: "request_policy.batch[0].route.hosts[0]",
+			wantRaw:   `"*.vendor*.example"`,
+			wantWhy:   "only as the leading",
+		},
+		{
+			name: "dlp pattern exempt_domains carrying a URL",
+			mutate: func(c *Config) {
+				c.DLP.Patterns = append(c.DLP.Patterns, DLPPattern{
+					Name:          "custom-token",
+					Regex:         "tok_[a-z]+",
+					ExemptDomains: []string{"https://vendor.example"},
+				})
+			},
+			wantField: `dlp.patterns["custom-token"].exempt_domains[0]`,
+			wantRaw:   `"https://vendor.example"`,
+			wantWhy:   "not a URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			tt.mutate(cfg)
+			err := cfg.ValidateHostPatterns()
+			if err == nil {
+				t.Fatalf("ValidateHostPatterns() = nil, want a refusal; this list reaches the Scanner unchecked")
+			}
+			msg := err.Error()
+			for _, want := range []string{tt.wantField, tt.wantRaw, tt.wantNorm, tt.wantWhy} {
+				if want == "" {
+					continue
+				}
+				if !strings.Contains(msg, want) {
+					t.Errorf("error %q does not name %q; the operator cannot act on a message that omits it", msg, want)
+				}
+			}
+		})
+	}
+}
+
+// The invariant must refuse nothing that works today. It reuses Validate's own
+// validators rather than a second copy of the rules, so this holds by
+// construction; the test is here because the construction is the security
+// property and a future row could quietly break it.
+func TestValidateHostPatternsAcceptsEveryShippedConfig(t *testing.T) {
+	if err := Defaults().ValidateHostPatterns(); err != nil {
+		t.Fatalf("Defaults() is refused by the invariant: %v", err)
+	}
+
+	// Collect first, load second. A walk callback that swallows its own error
+	// to keep going is the shape that hides a broken tree, so the walk
+	// propagates and only the LOAD is allowed to skip.
+	var paths []string
+	for _, root := range []string{"../../configs", "../../examples", "../../charts", "../../docs"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ext := filepath.Ext(path); ext == ".yaml" || ext == ".yml" {
+				paths = append(paths, path)
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+
+	var checked int
+	for _, path := range paths {
+		// Anything that does not load is not a pipelock config, or is already
+		// refused for an unrelated reason. Only configs Validate accepts are in
+		// scope: those are what "works today" means.
+		cfg, loadErr := Load(path)
+		if loadErr != nil || cfg == nil {
+			continue
+		}
+		checked++
+		if invErr := cfg.ValidateHostPatterns(); invErr != nil {
+			t.Errorf("%s passes config.Load but the invariant refuses it: %v", path, invErr)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no shipped config was checked; this test would pass without exercising anything")
+	}
+	t.Logf("checked %d shipped configs that load through config.Load", checked)
+}
+
+// Two of the shared validators normalize their input in place. The invariant
+// runs where the Config may already be serving live traffic, so it must leave
+// every list exactly as it found it.
+func TestValidateHostPatternsDoesNotMutateConfig(t *testing.T) {
+	cfg := Defaults()
+	// Values that all four normalizers WOULD rewrite: mixed case, surrounding
+	// space, a trailing dot. Each is accepted, so the walk runs to completion
+	// and any in-place write would land.
+	cfg.APIAllowlist = []string{"API.Vendor.Example"}
+	cfg.TrustedDomains = []string{" internal.Vendor.example "}
+	cfg.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example"}
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"Entropy.Vendor.Example"}
+	cfg.FetchProxy.Monitoring.QueryEntropyExclusions = []string{" Query.Vendor.Example "}
+
+	want := map[string][]string{
+		"api_allowlist":               {"API.Vendor.Example"},
+		"trusted_domains":             {" internal.Vendor.example "},
+		"blocklist":                   {"blocked.vendor.example"},
+		"subdomain_entropy_exclusion": {"Entropy.Vendor.Example"},
+		"query_entropy_exclusion":     {" Query.Vendor.Example "},
+	}
+
+	if err := cfg.ValidateHostPatterns(); err != nil {
+		t.Fatalf("ValidateHostPatterns() = %v, want nil; these are legitimate operator values", err)
+	}
+
+	got := map[string][]string{
+		"api_allowlist":               cfg.APIAllowlist,
+		"trusted_domains":             cfg.TrustedDomains,
+		"blocklist":                   cfg.FetchProxy.Monitoring.Blocklist,
+		"subdomain_entropy_exclusion": cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions,
+		"query_entropy_exclusion":     cfg.FetchProxy.Monitoring.QueryEntropyExclusions,
+	}
+	for field, wantVals := range want {
+		gotVals := got[field]
+		if len(gotVals) != len(wantVals) || gotVals[0] != wantVals[0] {
+			t.Errorf("%s = %q after the invariant, want %q unchanged; a check that rewrites a live Config is not a check",
+				field, gotVals, wantVals)
+		}
+	}
+}
+
+// A list that reaches the Scanner without a row in the table is invisible to
+// the invariant, which is the exact failure a single walk exists to prevent.
+// This pins the covered set so adding a list without covering it is a visible
+// test change rather than a silent gap.
+func TestHostPatternListsCoversTheKnownSet(t *testing.T) {
+	cfg := Defaults()
+	cfg.APIAllowlist = []string{"a.vendor.example"}
+	cfg.TrustedDomains = []string{"b.vendor.example"}
+	cfg.FetchProxy.Monitoring.Blocklist = []string{"c.vendor.example"}
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"d.vendor.example"}
+	cfg.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"e.vendor.example"}
+	cfg.FetchProxy.Monitoring.PathEntropyExclusions = []PathEntropyExclusion{
+		{Scheme: "https", Host: "f.vendor.example", PathPrefix: "/d/"},
+	}
+	cfg.FetchProxy.Monitoring.QueryEntropyParamExclusions = []QueryEntropyParamExclusion{
+		{Scheme: "https", Host: "g.vendor.example", Path: "/v1", Param: "sig"},
+	}
+	cfg.RequestPolicy.Rules = []RequestPolicyRule{
+		{Name: "r", Route: RequestPolicyRoute{Hosts: []string{"h.vendor.example"}}},
+	}
+	cfg.RequestPolicy.Batch = []RequestPolicyBatch{
+		{Route: RequestPolicyRoute{Hosts: []string{"i.vendor.example"}}},
+	}
+	cfg.DLP.Patterns = append(cfg.DLP.Patterns, DLPPattern{
+		Name: "custom", Regex: "x", ExemptDomains: []string{"j.vendor.example"},
+	})
+
+	want := []string{
+		"api_allowlist",
+		"trusted_domains",
+		"fetch_proxy.monitoring.blocklist",
+		"fetch_proxy.monitoring.subdomain_entropy_exclusions",
+		"fetch_proxy.monitoring.query_entropy_exclusions",
+		"fetch_proxy.monitoring.path_entropy_exclusions[0].host",
+		"fetch_proxy.monitoring.query_entropy_param_exclusions[0].host",
+		`request_policy.rules["r"].route.hosts`,
+		"request_policy.batch[0].route.hosts",
+		`dlp.patterns["custom"].exempt_domains`,
+	}
+
+	got := make(map[string]bool)
+	for _, list := range cfg.hostPatternLists() {
+		got[list.field] = true
+	}
+	for _, field := range want {
+		if !got[field] {
+			t.Errorf("hostPatternLists() omits %q, so that list reaches the Scanner unchecked", field)
+		}
+	}
+}

--- a/internal/proxy/bodyscan_test.go
+++ b/internal/proxy/bodyscan_test.go
@@ -3479,7 +3479,8 @@ func TestFetchHandler_HeaderScan_WarnMode(t *testing.T) {
 	defer upstream.Close()
 
 	cfg := config.Defaults()
-	cfg.APIAllowlist = []string{"*"} // allow all URLs so we reach header scanning
+	// An EMPTY allowlist is the allow-all spelling; a bare "*" is refused by
+	// validation and now by scanner construction, so it never meant this.
 	cfg.RequestBodyScanning.Enabled = true
 	cfg.RequestBodyScanning.Action = config.ActionWarn
 	cfg.RequestBodyScanning.ScanHeaders = true
@@ -3516,7 +3517,7 @@ func TestFetchHandler_HeaderScan_WarnModeCriticalDLPBlocksWhenEnforced(t *testin
 	defer upstream.Close()
 
 	cfg := config.Defaults()
-	cfg.APIAllowlist = []string{"*"}
+	// Empty allowlist = allow all; see the sibling test above.
 	cfg.RequestBodyScanning.Enabled = true
 	cfg.RequestBodyScanning.Action = config.ActionWarn
 	cfg.RequestBodyScanning.ScanHeaders = true

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -3563,8 +3563,17 @@ func TestWSProxyAuditModePassthrough(t *testing.T) {
 	backendAddr, backendCleanup := wsEchoServer(t)
 	defer backendCleanup()
 
+	// Block the backend by its exact host rather than a bare "*". A bare
+	// wildcard is not a loadable blocklist entry: config.Validate refuses it
+	// through ValidateHostMatchList, so this test was exercising a config no
+	// operator can produce. Blocking the literal backend host is the same
+	// scenario and is a pattern the validator accepts.
+	backendHost, _, err := net.SplitHostPort(backendAddr)
+	if err != nil {
+		t.Fatalf("split backend addr %q: %v", backendAddr, err)
+	}
 	proxyAddr, cleanup := setupWSProxy(t, func(cfg *config.Config) {
-		cfg.FetchProxy.Monitoring.Blocklist = []string{"*"}
+		cfg.FetchProxy.Monitoring.Blocklist = []string{backendHost}
 		cfg.Enforce = new(bool) // enforce=false (audit mode)
 	})
 	defer cleanup()
@@ -3573,8 +3582,7 @@ func TestWSProxyAuditModePassthrough(t *testing.T) {
 	conn := dialWS(t, proxyAddr, backendAddr)
 	defer conn.Close() //nolint:errcheck // test
 
-	err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(testWSHello))
-	if err != nil {
+	if err := wsutil.WriteClientMessage(conn, ws.OpText, []byte(testWSHello)); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	msg, _, err := wsutil.ReadServerData(conn)

--- a/internal/proxy/websocket_test.go
+++ b/internal/proxy/websocket_test.go
@@ -276,6 +276,15 @@ func setupWSProxyDefaultWithCaptureAndProxy(t *testing.T, cfgMod func(*config.Co
 func setupWSProxyWithHandlerDone(t *testing.T, cfgMod func(*config.Config), obs capture.CaptureObserver, handlerDone func()) (string, *Proxy, func()) {
 	t.Helper()
 
+	return setupWSProxyWithLogger(t, nil, cfgMod, obs, handlerDone)
+}
+
+// setupWSProxyWithLogger is setupWSProxyWithHandlerDone with a caller-supplied
+// audit logger, so a test can assert what the WebSocket path RECORDED and not
+// only what it returned. A nil logger keeps the no-op default.
+func setupWSProxyWithLogger(t *testing.T, logger *audit.Logger, cfgMod func(*config.Config), obs capture.CaptureObserver, handlerDone func()) (string, *Proxy, func()) {
+	t.Helper()
+
 	cfg := config.Defaults()
 	cfg.Internal = nil
 	cfg.SSRF.IPAllowlist = []string{"127.0.0.0/8", "::1/128"}
@@ -291,7 +300,9 @@ func setupWSProxyWithHandlerDone(t *testing.T, cfgMod func(*config.Config), obs 
 		cfgMod(cfg)
 	}
 
-	logger := audit.NewNop()
+	if logger == nil {
+		logger = audit.NewNop()
+	}
 	sc := scanner.MustNew(cfg)
 	m := metrics.New()
 	var opts []Option
@@ -3572,10 +3583,20 @@ func TestWSProxyAuditModePassthrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split backend addr %q: %v", backendAddr, err)
 	}
-	proxyAddr, cleanup := setupWSProxy(t, func(cfg *config.Config) {
+	// A capturing audit sink, not the no-op default. Echo passthrough alone
+	// proves only that the frame made it through; it is equally satisfied by a
+	// blocklist matcher that never fired, which is the regression this test
+	// exists to catch. The recorded block is what proves audit mode SAW the
+	// match and chose not to enforce it.
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.New("json", "file", logPath, true, true)
+	if err != nil {
+		t.Fatalf("audit.New: %v", err)
+	}
+	proxyAddr, _, cleanup := setupWSProxyWithLogger(t, logger, func(cfg *config.Config) {
 		cfg.FetchProxy.Monitoring.Blocklist = []string{backendHost}
 		cfg.Enforce = new(bool) // enforce=false (audit mode)
-	})
+	}, nil, nil)
 	defer cleanup()
 
 	// In audit mode, the blocked URL should pass through.
@@ -3591,6 +3612,21 @@ func TestWSProxyAuditModePassthrough(t *testing.T) {
 	}
 	if string(msg) != testWSHello {
 		t.Errorf("expected echo 'hello', got %q", string(msg))
+	}
+
+	logger.Close()
+	data, err := os.ReadFile(filepath.Clean(logPath))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	// Assert the SCANNER LABEL, not the host. The host appears in ordinary
+	// request logging whether or not the blocklist matched, so a host-only
+	// check is satisfied by a matcher that never fired. Verified: pointing the
+	// blocklist at an unrelated host leaves this assertion failing and the
+	// host-only version passing.
+	if !strings.Contains(string(data), scanner.ScannerBlocklist) {
+		t.Fatalf("audit mode passed the frame through but recorded no %q scanner event; a disabled blocklist matcher would look identical:\n%s",
+			scanner.ScannerBlocklist, data)
 	}
 }
 

--- a/internal/scanner/host_pattern_boundary_test.go
+++ b/internal/scanner/host_pattern_boundary_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// Scanner construction is an ingest boundary. Several callers reach it with a
+// Config that never passed through config.Validate: the enterprise per-agent
+// merge builds one, and the assess and sandbox paths assemble one in code. A
+// host pattern that arrives that way would otherwise be installed verbatim and
+// matched against live traffic.
+func TestNew_RefusesInvalidHostPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mutate    func(*config.Config)
+		wantField string
+		why       string
+	}{
+		{
+			name:      "api_allowlist wildcard over a public suffix",
+			mutate:    func(c *config.Config) { c.APIAllowlist = []string{"*.co.uk"} },
+			wantField: "api_allowlist",
+			why:       "in strict mode this grants every domain under an entire registry, which is strict mode spelled as if it were enabled",
+		},
+		{
+			name:      "blocklist entry the matcher reads differently",
+			mutate:    func(c *config.Config) { c.FetchProxy.Monitoring.Blocklist = []string{"vendor.example.."} },
+			wantField: "fetch_proxy.monitoring.blocklist",
+			why:       "the matcher trims one trailing dot, so this deny rule would compare two strings that never agree and would never deny",
+		},
+		{
+			name:      "trusted_domains bare wildcard",
+			mutate:    func(c *config.Config) { c.TrustedDomains = []string{"*"} },
+			wantField: "trusted_domains",
+			why:       "a bare wildcard exempts every host from the SSRF internal-IP check",
+		},
+		{
+			name: "subdomain_entropy_exclusions host that folds into a different ASCII host",
+			mutate: func(c *config.Config) {
+				c.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"Kexample.com"}
+			},
+			wantField: "fetch_proxy.monitoring.subdomain_entropy_exclusions",
+			why:       "U+212A folds to ASCII k, so this would exempt kexample.com, a host the operator never wrote",
+		},
+		{
+			name: "query_entropy_param_exclusions host carrying a wildcard",
+			mutate: func(c *config.Config) {
+				c.FetchProxy.Monitoring.QueryEntropyParamExclusions = []config.QueryEntropyParamExclusion{
+					{Scheme: "https", Host: "*.vendor.example", Path: "/v1", Param: "sig"},
+				}
+			},
+			wantField: "fetch_proxy.monitoring.query_entropy_param_exclusions[0].host",
+			why:       "this list is matched literally, so a wildcard here is an exemption that can never fire",
+		},
+		{
+			name: "dlp pattern exempt_domains carrying a URL",
+			mutate: func(c *config.Config) {
+				c.DLP.Patterns = append(c.DLP.Patterns, config.DLPPattern{
+					Name:          "custom-token",
+					Regex:         "tok_[a-z]+",
+					ExemptDomains: []string{"https://vendor.example"},
+				})
+			},
+			wantField: `dlp.patterns["custom-token"].exempt_domains`,
+			why:       "a URL is not a hostname pattern, so this exemption would never match and the operator would think it had",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Control: the same config without the mutation builds, so a
+			// failure below is attributable to the pattern and not to the
+			// fixture.
+			base := config.Defaults()
+			base.Internal = nil
+			control, err := New(base)
+			if err != nil {
+				t.Fatalf("control failed: an unmutated Defaults() config did not build: %v", err)
+			}
+			control.Close()
+
+			cfg := config.Defaults()
+			cfg.Internal = nil
+			tt.mutate(cfg)
+
+			s, err := New(cfg)
+			if err == nil {
+				s.Close()
+				t.Fatalf("New accepted the config; %s", tt.why)
+			}
+			if !strings.Contains(err.Error(), "invalid host pattern") {
+				t.Errorf("New error = %q, want it prefixed as a host-pattern refusal", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantField) {
+				t.Errorf("New error = %q, does not name %q; the operator cannot fix a field the message never mentions", err, tt.wantField)
+			}
+		})
+	}
+}
+
+// The refusal must not cost a working configuration. Defaults plus ordinary
+// operator patterns, including the wildcard shapes this repository ships, still
+// build.
+func TestNew_AcceptsWorkingHostPatterns(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Internal = nil
+	cfg.APIAllowlist = []string{"api.anthropic.com", "*.googleapis.com", "*.vendor.example"}
+	cfg.TrustedDomains = []string{"internal.vendor.example", "*.internal.vendor.example"}
+	cfg.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example", "*.co.uk", "10.0.0.1"}
+	cfg.FetchProxy.Monitoring.SubdomainEntropyExclusions = []string{"*.cdn.vendor.example"}
+	cfg.FetchProxy.Monitoring.QueryEntropyExclusions = []string{"s3.vendor.example"}
+
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New refused a working configuration: %v", err)
+	}
+	defer s.Close()
+
+	// A broad wildcard on the DENY list is policy, not a mistake, and the two
+	// directions must stay distinguishable: the same pattern is refused on the
+	// allowlist above and accepted here.
+	if s.checkBlocklist("anything.co.uk").Allowed {
+		t.Error("the *.co.uk block rule did not survive construction; breadth on a deny list is policy and must stay expressible")
+	}
+	if !s.checkBlocklist("allowed.vendor.example").Allowed {
+		t.Error("an unrelated host was blocked, so the assertion above proves nothing about the rule")
+	}
+}

--- a/internal/scanner/path_entropy_escaped_test.go
+++ b/internal/scanner/path_entropy_escaped_test.go
@@ -170,6 +170,12 @@ func TestPathEntropyExclusion_ConstructionCompilesTheCurrentList(t *testing.T) {
 // empty prefix and let a bare / prefix and a cleartext scheme through, which
 // are the same over-broad exemption in different spellings. These construct the
 // scanner directly, bypassing Validate exactly as the gap required.
+//
+// Only the SCHEME and PREFIX spellings remain here. An over-broad HOST no
+// longer reaches the builder through New, which now refuses it outright rather
+// than dropping it; those cases moved to the two tests below, which assert the
+// refusal and then exercise the builder's drop directly so the second line is
+// still proven rather than assumed.
 func TestPathEntropyExclusion_BuilderDropsOverBroadEntries(t *testing.T) {
 	t.Parallel()
 
@@ -219,60 +225,6 @@ func TestPathEntropyExclusion_BuilderDropsOverBroadEntries(t *testing.T) {
 			probe:  exempted,
 			reason: "an unrecognized scheme must not default into the https slot",
 		},
-		{
-			name:   "a public-suffix wildcard exempts most of the internet",
-			entry:  config.PathEntropyExclusion{Host: "*.com", PathPrefix: "/document/d/"},
-			probe:  "https://evil.com/document/d/" + highEntropyID,
-			reason: "MatchDomain matches *.com against every .com host, so the route prefix would exempt requests far outside the intended domain",
-		},
-		{
-			name:   "repeated trailing dots must not survive the breadth check",
-			entry:  config.PathEntropyExclusion{Host: "*.com..", PathPrefix: "/document/d/"},
-			probe:  "https://evil.com/document/d/" + highEntropyID,
-			reason: "one TrimSuffix left *.com. whose remaining dot read as a domain label, and runtime matching then stripped it and matched every .com host",
-		},
-		{
-			name:   "a single trailing dot is the same host and is still refused",
-			entry:  config.PathEntropyExclusion{Host: "*.com.", PathPrefix: "/document/d/"},
-			probe:  "https://evil.com/document/d/" + highEntropyID,
-			reason: "trailing dots are DNS-equivalent, so this is *.com by another spelling",
-		},
-		{
-			name:   "a bare dot host normalizes to nothing and is dropped",
-			entry:  config.PathEntropyExclusion{Host: ".", PathPrefix: "/document/d/"},
-			probe:  exempted,
-			reason: "an entry that cannot name a host is dead config, and the builder claims to drop dead config",
-		},
-		{
-			name:   "a bare wildcard host is not a scoped route",
-			entry:  config.PathEntropyExclusion{Host: "*", PathPrefix: "/document/d/"},
-			probe:  exempted,
-			reason: "a bare wildcard names no domain at all",
-		},
-		{
-			name:   "a wildcard in the middle is not a supported pattern",
-			entry:  config.PathEntropyExclusion{Host: "docs.*.example", PathPrefix: "/document/d/"},
-			probe:  exempted,
-			reason: "only exact hosts and leading *. wildcards are supported",
-		},
-		{
-			// U+212A KELVIN SIGN lowercases to ASCII "k", so a host checked for
-			// ASCII only AFTER case folding reads as clean and installs an
-			// exemption for kexample.com. Written as a Go escape on purpose:
-			// an earlier version of this input lost the rune to a shell
-			// heredoc and became a plain ASCII "K", which is legitimately
-			// accepted and asserted nothing.
-			name:   "a rune that folds into ASCII must not install a retargeted exemption",
-			entry:  config.PathEntropyExclusion{Host: "\u212Aexample.com", PathPrefix: "/document/d/"},
-			probe:  "https://kexample.com/document/d/" + highEntropyID,
-			reason: "the raw host is gated before folding, so the folded ASCII host is never exempted",
-		},
-		{
-			name:   "a host:port is not a hostname",
-			entry:  config.PathEntropyExclusion{Host: "docs.vendor.example:443", PathPrefix: "/document/d/"},
-			probe:  exempted,
-			reason: "a port makes the pattern unmatchable and is refused rather than trimmed",
-		},
 	}
 
 	for _, tt := range tests {
@@ -300,6 +252,122 @@ func TestPathEntropyExclusion_BuilderDropsOverBroadEntries(t *testing.T) {
 				t.Fatalf("entry %+v was installed and exempted %q; it must be dropped (%s)", tt.entry, tt.probe, tt.reason)
 			}
 		})
+	}
+}
+
+// The over-broad HOST spellings the builder used to absorb are now refused at
+// construction. Each one names a host whose pattern would match well outside
+// the route the operator wrote, so installing it quietly and dropping it
+// quietly are both worse than refusing loudly: the operator can only fix what
+// they are told about.
+func TestPathEntropyExclusion_OverBroadHostIsRefusedAtConstruction(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range overBroadPathEntropyHosts() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Defaults()
+			cfg.Internal = nil
+			cfg.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{tt.entry}
+
+			s, err := New(cfg)
+			if err == nil {
+				s.Close()
+				t.Fatalf("New accepted host %q; %s", tt.entry.Host, tt.reason)
+			}
+			if !strings.Contains(err.Error(), "fetch_proxy.monitoring.path_entropy_exclusions[0].host") {
+				t.Errorf("New error %q does not name the field the operator has to edit", err)
+			}
+		})
+	}
+}
+
+// The builder's drop for those same hosts stays proven. Construction refuses
+// them first, so this is the only way left to exercise the second line, and
+// deleting it on the strength of the first is how a defense quietly rots.
+func TestPathEntropyExclusion_BuilderStillDropsOverBroadHost(t *testing.T) {
+	t.Parallel()
+
+	// Calibrate: the builder KEEPS a well-formed entry, so a zero-length result
+	// below means the entry was dropped rather than the builder being inert.
+	ok := buildPathEntropyExclusions([]config.PathEntropyExclusion{
+		{Scheme: "https", Host: "docs.vendor.example", PathPrefix: "/document/d/"},
+	})
+	if len(ok) != 1 {
+		t.Fatalf("builder kept %d of 1 well-formed entries; every case below would pass for the wrong reason", len(ok))
+	}
+
+	for _, tt := range overBroadPathEntropyHosts() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			entry := tt.entry
+			entry.Scheme = "https"
+			if got := buildPathEntropyExclusions([]config.PathEntropyExclusion{entry}); len(got) != 0 {
+				t.Fatalf("builder kept %+v as %+v; %s", entry, got, tt.reason)
+			}
+		})
+	}
+}
+
+// overBroadPathEntropyHosts is shared by the refusal test and the builder test
+// so the two layers are proven against the SAME set. Two copies of this list
+// would let one layer quietly lose a case.
+func overBroadPathEntropyHosts() []struct {
+	name   string
+	entry  config.PathEntropyExclusion
+	reason string
+} {
+	return []struct {
+		name   string
+		entry  config.PathEntropyExclusion
+		reason string
+	}{
+		{
+			name:   "a public-suffix wildcard exempts most of the internet",
+			entry:  config.PathEntropyExclusion{Host: "*.com", PathPrefix: "/document/d/"},
+			reason: "MatchDomain matches *.com against every .com host, so the route prefix would exempt requests far outside the intended domain",
+		},
+		{
+			name:   "repeated trailing dots must not survive the breadth check",
+			entry:  config.PathEntropyExclusion{Host: "*.com..", PathPrefix: "/document/d/"},
+			reason: "one TrimSuffix left *.com. whose remaining dot read as a domain label, and runtime matching then stripped it and matched every .com host",
+		},
+		{
+			name:   "a single trailing dot is the same host and is still refused",
+			entry:  config.PathEntropyExclusion{Host: "*.com.", PathPrefix: "/document/d/"},
+			reason: "trailing dots are DNS-equivalent, so this is *.com by another spelling",
+		},
+		{
+			name:   "a bare dot host normalizes to nothing",
+			entry:  config.PathEntropyExclusion{Host: ".", PathPrefix: "/document/d/"},
+			reason: "an entry that cannot name a host is dead config",
+		},
+		{
+			name:   "a bare wildcard host is not a scoped route",
+			entry:  config.PathEntropyExclusion{Host: "*", PathPrefix: "/document/d/"},
+			reason: "a bare wildcard names no domain at all",
+		},
+		{
+			name:   "a wildcard in the middle is not a supported pattern",
+			entry:  config.PathEntropyExclusion{Host: "docs.*.example", PathPrefix: "/document/d/"},
+			reason: "only exact hosts and leading *. wildcards are supported",
+		},
+		{
+			// U+212A KELVIN SIGN lowercases to ASCII "k", so a host checked for
+			// ASCII only AFTER case folding reads as clean and would install an
+			// exemption for kexample.com. Written as a Go escape on purpose: an
+			// earlier version of this input lost the rune to a shell heredoc and
+			// became a plain ASCII "K", which is legitimately accepted and
+			// asserted nothing.
+			name:   "a rune that folds into ASCII must not install a retargeted exemption",
+			entry:  config.PathEntropyExclusion{Host: "\u212Aexample.com", PathPrefix: "/document/d/"},
+			reason: "the raw host is gated before folding, so the folded ASCII host is never exempted",
+		},
+		{
+			name:   "a host:port is not a hostname",
+			entry:  config.PathEntropyExclusion{Host: "docs.vendor.example:443", PathPrefix: "/document/d/"},
+			reason: "a port makes the pattern unmatchable and is refused rather than trimmed",
+		},
 	}
 }
 

--- a/internal/scanner/path_entropy_exclusion_test.go
+++ b/internal/scanner/path_entropy_exclusion_test.go
@@ -142,16 +142,20 @@ func TestPathEntropyExclusion_LeavesQueryEntropyEnforced(t *testing.T) {
 	}
 }
 
-// An entry that cannot name a route is dropped rather than treated as a
-// wildcard, so a malformed config cannot silently disable the gate. Validation
-// rejects these too; this is the second line, at the point of use.
+// An entry whose PATH PREFIX cannot name a route is dropped rather than treated
+// as a wildcard, so a malformed config cannot silently disable the gate.
+// Validation rejects these too; this is the second line, at the point of use.
+//
+// The host is well-formed in every case here, deliberately. A malformed HOST no
+// longer reaches this defense, because construction refuses it outright; that
+// boundary has its own test below.
 func TestPathEntropyExclusion_IncompleteEntriesAreInert(t *testing.T) {
 	t.Parallel()
 
 	for _, entry := range []config.PathEntropyExclusion{
-		{Host: "", PathPrefix: "/document/d/"},
 		{Host: "docs.vendor.example", PathPrefix: ""},
-		{Host: "   ", PathPrefix: "   "},
+		{Host: "docs.vendor.example", PathPrefix: "   "},
+		{Host: "docs.vendor.example", PathPrefix: "/"},
 	} {
 		s := pathExclusionScanner(t, entry)
 		parsed, err := url.Parse("https://docs.vendor.example/document/d/" + highEntropyID + "/edit")
@@ -163,6 +167,53 @@ func TestPathEntropyExclusion_IncompleteEntriesAreInert(t *testing.T) {
 		s.Close()
 		if res.Allowed {
 			t.Errorf("an incomplete entry %+v exempted the route; it must be inert", entry)
+		}
+	}
+}
+
+// A malformed HOST is refused at construction rather than dropped. Dropping it
+// would leave the operator reading a configuration the runtime is not running:
+// the exemption they wrote is gone, the gate is stricter than the YAML says,
+// and nothing reports the difference.
+func TestPathEntropyExclusion_MalformedHostIsRefusedAtConstruction(t *testing.T) {
+	t.Parallel()
+
+	for _, entry := range []config.PathEntropyExclusion{
+		{Host: "", PathPrefix: "/document/d/"},
+		{Host: "   ", PathPrefix: "/document/d/"},
+		{Host: "*.co.uk", PathPrefix: "/document/d/"},
+		{Host: "https://docs.vendor.example", PathPrefix: "/document/d/"},
+	} {
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.FetchProxy.Monitoring.PathEntropyExclusions = []config.PathEntropyExclusion{entry}
+
+		s, err := New(cfg)
+		if err == nil {
+			s.Close()
+			t.Errorf("New accepted a path-entropy exclusion with host %q; it must refuse rather than silently drop it", entry.Host)
+			continue
+		}
+		if !strings.Contains(err.Error(), "fetch_proxy.monitoring.path_entropy_exclusions[0].host") {
+			t.Errorf("New error %q does not name the field the operator has to edit", err)
+		}
+	}
+}
+
+// The builder's own drop stays in place behind the refusal above. It is
+// unreachable through New now, which is the point of a second line, so it is
+// exercised directly rather than deleted on the strength of the first.
+func TestPathEntropyExclusion_BuilderStillDropsMalformedHost(t *testing.T) {
+	t.Parallel()
+
+	for _, entry := range []config.PathEntropyExclusion{
+		{Scheme: "https", Host: "", PathPrefix: "/document/d/"},
+		{Scheme: "https", Host: "   ", PathPrefix: "/document/d/"},
+		{Scheme: "https", Host: "*.co.uk", PathPrefix: "/document/d/"},
+		{Scheme: "https", Host: "\u212Aexample.com", PathPrefix: "/document/d/"},
+	} {
+		if got := buildPathEntropyExclusions([]config.PathEntropyExclusion{entry}); len(got) != 0 {
+			t.Errorf("buildPathEntropyExclusions kept %+v as %+v; the point-of-use defense must still drop it", entry, got)
 		}
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -417,6 +417,22 @@ func New(cfg *config.Config) (*Scanner, error) {
 // overlays never mutate Config, so a Guard invocation cannot widen another
 // runtime built from the same configuration.
 func NewWithOptions(cfg *config.Config, opts Options) (*Scanner, error) {
+	// Construction is an ingest boundary: this signature accepts any *Config
+	// and nothing here can tell whether it passed through config.Validate.
+	// Every production caller today does arrive validated, by loading a config
+	// or by deriving one from a loaded config, so this is defense in depth
+	// rather than a live bypass. It is what keeps the host-pattern rules
+	// binding when a caller arrives that does not.
+	//
+	// Re-check every host-pattern list against the SAME rules validation
+	// applies, and refuse rather than installing a pattern that would match
+	// something the operator never wrote. Dropping the entry instead would
+	// move the enforced posture while the operator still reads their
+	// configuration as accepted.
+	if err := cfg.ValidateHostPatterns(); err != nil {
+		return nil, fmt.Errorf("invalid host pattern: %w", err)
+	}
+
 	// Only enforce the allowlist in strict mode. In balanced/audit modes,
 	// the allowlist is a config field but not enforced at the scanner level.
 	var allowlist []string


### PR DESCRIPTION
## What changed

Two boundaries accepted a Config that never went through `Validate`, so the host-pattern rules did not bind there: `scanner.New` assigned host-pattern lists straight onto the Scanner, and the reloader's exported validation path discarded its own error.

One invariant now walks all nine host-pattern lists that reach the Scanner and dispatches each to the validator `config.Validate` already uses for it, so there is no second copy of any rule to drift. It runs at scanner construction and at reload. An error names the field, the raw value and the normalized value.

This is defense in depth rather than a live operator bypass: the reloader's only production caller already validates through `config.Load`. The reload check buys ordering rather than a new denial. Without it, a reload carrying both a bad host pattern and a revoked entitlement tears down the conductor before the pattern is rejected downstream.

Nothing that loads today is refused. The invariant reuses the existing validators, and every shipped config still loads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid host patterns are now consistently rejected during configuration reloads and scanner setup.
  * Failed reloads preserve the currently active configuration instead of applying partial or invalid changes.
  * Error messages identify the affected configuration field and invalid pattern.
  * Valid host patterns continue to reload and operate as expected.

* **Tests**
  * Expanded coverage across allowlists, blocklists, trusted domains, routing rules, and entropy exclusions.
  * Added checks confirming invalid configurations do not disrupt active services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->