### PR TITLE
fix(review): preserve judge evidence budget

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -2431,7 +2431,14 @@ def judge_findings(
     # Reserve room for changed-path summaries, repository evidence, and prompt
     # structure before accepting candidate context. The old first-candidate
     # exception could submit a single 200 KB line above the provider limit.
-    candidate_budget = max(1_000, budget - 3_000)
+    # Preserve the mandatory later sections before admitting context. Reserving
+    # only 3,000 let contexts consume the summary and repository-evidence floor,
+    # so the judge returned every retained candidate without calling a model.
+    candidate_budget = max(1_000, budget - 4_500)
+    context_token_cap = min(
+        MAX_JUDGE_CONTEXT_TOKENS,
+        max(200, candidate_budget // max(1, len(candidates)) - 100),
+    )
     for finding in candidates:
         addition = estimate_tokens(finding.title + finding.why + finding.fix + finding.path)
         context = fetched.get(finding.path)
@@ -2442,7 +2449,7 @@ def judge_findings(
             content = fetch_file_context(repo, finding.path, binding.head_sha, token, binding.correlation)
             if content is None:
                 return [], False, [], [], [], []
-            context = _line_context(content, finding.line)
+            context = _line_context(content, finding.line, max_tokens=context_token_cap)
             fetched[finding.path] = context
         if finding.path not in contexts:
             addition += estimate_tokens(context)
@@ -2455,7 +2462,9 @@ def judge_findings(
     candidates = retained
     if not candidates:
         return [], False, over_budget, over_files, [], []
-    summary_budget = max(500, min(budget // 4, budget - used - 2_100))
+    # Leave 1,000 tokens for prompt structure, 2,000 for requested evidence,
+    # and 1,000 for repository evidence after summaries are selected.
+    summary_budget = max(500, min(budget // 4, budget - used - 4_000))
     bounded_summaries, summaries_truncated = _bounded_change_summaries(
         change_summaries or [], {finding.path for finding in candidates}, summary_budget
     )

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -2024,6 +2024,35 @@ class JudgeEvidenceTest(unittest.TestCase):
         self.assertEqual(prompt["changed_path_summaries"][0]["path"], candidate.path)
         self.assertEqual(prompt["changed_path_summaries"][-1]["path"], "<truncated>")
 
+    def test_many_candidates_leave_room_for_an_actual_judge_call(self) -> None:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        candidates = [
+            pr_review.Finding(
+                "medium",
+                f"path/{index}.go",
+                50,
+                f"candidate {index}",
+                "a plausible failure premise that needs current-code judgment",
+                "repair the invariant",
+            )
+            for index in range(18)
+        ]
+        decisions = {
+            "findings": [
+                {"index": index, "verdict": "drop", "reason": "current code rejects the premise"}
+                for index in range(len(candidates))
+            ]
+        }
+        with mock.patch.object(pr_review, "fetch_file_context", return_value="line\n" * 2_000), mock.patch.object(
+            pr_review, "cross_file_evidence", return_value=("consumer evidence", False)
+        ), mock.patch.object(pr_review, "call_model", return_value=decisions) as model:
+            verified, judged, over_budget, over_files, unresolved, invalid = pr_review.judge_findings(
+                "owner/repo", "token", binding, "default", candidates
+            )
+        self.assertTrue(judged)
+        self.assertEqual(model.call_count, 1)
+        self.assertEqual((verified, over_budget, over_files, unresolved, invalid), ([], [], [], [], []))
+
     def test_a_mismatched_checkout_cannot_supply_judge_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)


### PR DESCRIPTION
## What changed
Scale candidate context to the review size and reserve the evidence sections before admitting candidates, so large reviews still reach current-code judgment instead of ending with an empty partial result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review processing for changes involving many candidates or large file contexts.
  * Preserved sufficient capacity for summary generation and repository evidence during review evaluation.
* **Tests**
  * Added coverage to verify that large reviews still complete a judge pass successfully without incorrectly reporting findings or budget-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->