### PR TITLE
fix(ci): retry a rate-limited review chunk and report the real cause

### DIFF
--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -945,7 +945,8 @@ def llm_timeout_for(mode: str, phase: str = "") -> int:
 
 def llm_call_budget_for(mode: str, phase: str = "") -> int:
     """Reserve the longest delivery-proven retry path for one provider call."""
-    return llm_timeout_for(mode, phase) * MODEL_CONNECTION_ATTEMPTS
+    retry_sleep_budget = MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS * (MODEL_RATE_LIMIT_ATTEMPTS - 1)
+    return llm_timeout_for(mode, phase) * MODEL_CONNECTION_ATTEMPTS + retry_sleep_budget
 
 
 def budget_allows(deadline: float, mode: str, phase: str = "") -> bool:
@@ -974,12 +975,20 @@ def retry_after_seconds(header: str | None) -> float | None:
         seconds = float(header.strip())
     except (TypeError, ValueError):
         return None
-    if seconds < 0:
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return min(seconds, MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS)
 
 
-def call_model(system: str, user: str, mode: str, phase: str, correlation: str) -> object:
+def call_model(
+    system: str,
+    user: str,
+    mode: str,
+    phase: str,
+    correlation: str,
+    *,
+    deadline: float | None = None,
+) -> object:
     api_url, api_key = provider_configuration()
     model = model_for_phase(mode, phase)
     timeout = llm_timeout_for(mode, phase)
@@ -1000,10 +1009,16 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
     connect_attempt = 0
     rate_limit_attempt = 1
     while True:
+        request_timeout = timeout
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ModelTimeout("provider call exceeded the review deadline")
+            request_timeout = min(request_timeout, remaining)
         connect_attempt += 1
         attempt = connect_attempt
         try:
-            response = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
+            response = requests.post(api_url, headers=headers, json=payload, timeout=request_timeout)
         except requests.ConnectTimeout as exc:
             # The only failure that proves the request was never delivered: the
             # connection itself was never established, so the provider cannot
@@ -1042,6 +1057,11 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
                     MODEL_RATE_LIMIT_BASE_SLEEP_SECONDS * (2 ** (rate_limit_attempt - 1)),
                     MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
                 )
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ModelTimeout("provider call exceeded the review deadline")
+                delay = min(delay, remaining)
             log_phase(phase, attempt=attempt, status=f"rate-limited-sleep-{delay:.0f}s", correlation=correlation)
             time.sleep(delay)
             rate_limit_attempt += 1
@@ -2560,7 +2580,7 @@ def judge_findings(
     if evidence_unavailable:
         return [], False, over_budget, over_files, [], candidates
     system, user = build_judge_prompt(candidates, contexts, judge_summaries, evidence)
-    payload = call_model(system, user, mode, "judge", binding.correlation)
+    payload = call_model(system, user, mode, "judge", binding.correlation, deadline=deadline)
     decisions = _parse_judge_decisions(payload, len(candidates))
 
     # One narrow follow-up is cheaper and more useful than rerunning the whole
@@ -2598,7 +2618,12 @@ def judge_findings(
         if repair_budget_available:
             try:
                 recheck_payload = call_model(
-                    recheck_system, recheck_user, mode, "judge-repair", binding.correlation
+                    recheck_system,
+                    recheck_user,
+                    mode,
+                    "judge-repair",
+                    binding.correlation,
+                    deadline=deadline,
                 )
                 recheck = _parse_judge_decisions(
                     recheck_payload, len(pending), allow_requests=False
@@ -3345,7 +3370,9 @@ def run_review(
                 break
             system, user = build_review_prompt(classification, chunk, mode)
             try:
-                payload = call_model(system, user, mode, f"review-chunk-{chunk_index}", binding.correlation)
+                payload = call_model(
+                    system, user, mode, f"review-chunk-{chunk_index}", binding.correlation, deadline=deadline
+                )
                 findings, changes = parse_findings(payload, {unit.path for unit in chunk}, require_changes={unit.path for unit in chunk})
             except ModelTimeout:
                 progress.timed_out = True
@@ -3409,7 +3436,9 @@ def run_review(
                 mode,
             )
             try:
-                payload = call_model(system, user, mode, "cross-file-synthesis", binding.correlation)
+                payload = call_model(
+                    system, user, mode, "cross-file-synthesis", binding.correlation, deadline=deadline
+                )
                 synthesis_findings, _ = parse_findings(payload, {unit.path for unit in units if unit.representable})
                 candidates.extend(synthesis_findings)
             except ModelTimeout:
@@ -3418,6 +3447,11 @@ def run_review(
             except ModelConnectionError:
                 progress.aggregation_failed = True
                 progress.incomplete_reasons.append("cross-file synthesis could not connect after one retry")
+                if reason := unverified_candidates_reason(candidates):
+                    progress.incomplete_reasons.append(reason)
+            except ModelRateLimited as exc:
+                progress.aggregation_failed = True
+                progress.incomplete_reasons.append(f"cross-file synthesis was rate limited ({exc})")
                 if reason := unverified_candidates_reason(candidates):
                     progress.incomplete_reasons.append(reason)
             except ModelOutputError:
@@ -3499,6 +3533,12 @@ def run_review(
                 progress.aggregation_failed = True
                 progress.unverified_candidates.extend(candidates)
                 progress.incomplete_reasons.append("judge pass could not connect after one retry")
+                if reason := unverified_candidates_reason(candidates):
+                    progress.incomplete_reasons.append(reason)
+            except ModelRateLimited as exc:
+                progress.aggregation_failed = True
+                progress.unverified_candidates.extend(candidates)
+                progress.incomplete_reasons.append(f"judge pass was rate limited ({exc})")
                 if reason := unverified_candidates_reason(candidates):
                     progress.incomplete_reasons.append(reason)
             except ModelOutputError:

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -78,10 +78,9 @@ DIFF_FETCH_ATTEMPTS = 2
 # bound literal and small; a second connection failure remains incomplete work,
 # not an invitation to keep spending the review budget.
 MODEL_CONNECTION_ATTEMPTS = 2
-# A 429 is retried, unlike every other non-200, because the provider rejected
-# the request without doing the work. The ceiling is small and the total sleep
-# is bounded so a sustained outage still ends the run promptly instead of
-# burning the wall-clock budget one chunk at a time.
+# A 429 is retried because the provider's rate-limit guidance explicitly makes
+# it retryable. The ceiling and shared deadline bound both request attempts and
+# sleeps so a sustained outage cannot strand finalization.
 MODEL_RATE_LIMIT_ATTEMPTS = 4
 MODEL_RATE_LIMIT_BASE_SLEEP_SECONDS = 2.0
 MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS = 30.0
@@ -195,13 +194,12 @@ class ModelOutputError(ReviewError):
 
 
 class ModelRateLimited(ReviewError):
-    """The provider REJECTED the request with 429 and did no work.
+    """The provider returned the one non-200 response eligible for retry.
 
     Kept distinct from ModelOutputError because the no-retry policy elsewhere in
-    this file exists to avoid paying twice for a request the provider may have
-    completed. A 429 is the one failure that proves the opposite: nothing was
-    processed and nothing was billed, so retrying is safe and is the only way a
-    transient quota dip does not silently cost a whole review.
+    this file avoids repeating an ambiguous request. Provider guidance explicitly
+    permits bounded backoff for a 429, while the shared deadline keeps those
+    retries from silently consuming the rest of the review.
     """
 
 
@@ -945,7 +943,8 @@ def llm_timeout_for(mode: str, phase: str = "") -> int:
 
 def llm_call_budget_for(mode: str, phase: str = "") -> int:
     """Reserve the longest delivery-proven retry path for one provider call."""
-    return llm_timeout_for(mode, phase) * MODEL_CONNECTION_ATTEMPTS
+    retry_sleep_budget = MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS * (MODEL_RATE_LIMIT_ATTEMPTS - 1)
+    return llm_timeout_for(mode, phase) * MODEL_CONNECTION_ATTEMPTS + retry_sleep_budget
 
 
 def budget_allows(deadline: float, mode: str, phase: str = "") -> bool:
@@ -974,12 +973,20 @@ def retry_after_seconds(header: str | None) -> float | None:
         seconds = float(header.strip())
     except (TypeError, ValueError):
         return None
-    if seconds < 0:
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return min(seconds, MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS)
 
 
-def call_model(system: str, user: str, mode: str, phase: str, correlation: str) -> object:
+def call_model(
+    system: str,
+    user: str,
+    mode: str,
+    phase: str,
+    correlation: str,
+    *,
+    deadline: float | None = None,
+) -> object:
     api_url, api_key = provider_configuration()
     model = model_for_phase(mode, phase)
     timeout = llm_timeout_for(mode, phase)
@@ -995,15 +1002,21 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
     payload = build_llm_payload(model, system, user, mode, phase)
     # Connection retries and rate-limit retries are counted SEPARATELY. They
     # exist for different reasons: a connect timeout proves non-delivery, while
-    # a 429 proves non-processing. Sharing one counter would let a burst of
+    # a 429 is an explicit rate-limit response. Sharing one counter would let a burst of
     # rate limits consume the connection budget, or the reverse.
     connect_attempt = 0
     rate_limit_attempt = 1
     while True:
+        request_timeout = timeout
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ModelTimeout("provider call exceeded the review deadline")
+            request_timeout = min(request_timeout, remaining)
         connect_attempt += 1
         attempt = connect_attempt
         try:
-            response = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
+            response = requests.post(api_url, headers=headers, json=payload, timeout=request_timeout)
         except requests.ConnectTimeout as exc:
             # The only failure that proves the request was never delivered: the
             # connection itself was never established, so the provider cannot
@@ -1028,10 +1041,9 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
             raise ModelOutputError("provider request failed") from exc
         log_phase(phase, attempt=attempt, status=response.status_code, correlation=correlation)
         if response.status_code == 429:
-            # Safe to retry, and ONLY this status is: a 429 means the provider
-            # refused to process the request, so there is no completed work to
-            # be billed twice. Honour Retry-After when the provider sends it,
-            # since it knows when the window reopens better than a fixed curve.
+            # Provider guidance explicitly permits bounded retries for this
+            # status. Honour Retry-After when present, since the provider knows
+            # when its rate-limit window reopens better than a fixed curve.
             if rate_limit_attempt >= MODEL_RATE_LIMIT_ATTEMPTS:
                 raise ModelRateLimited(
                     f"provider rate limited the request (HTTP 429) after {rate_limit_attempt} attempts"
@@ -1042,6 +1054,11 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
                     MODEL_RATE_LIMIT_BASE_SLEEP_SECONDS * (2 ** (rate_limit_attempt - 1)),
                     MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
                 )
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ModelTimeout("provider call exceeded the review deadline")
+                delay = min(delay, remaining)
             log_phase(phase, attempt=attempt, status=f"rate-limited-sleep-{delay:.0f}s", correlation=correlation)
             time.sleep(delay)
             rate_limit_attempt += 1
@@ -2560,7 +2577,7 @@ def judge_findings(
     if evidence_unavailable:
         return [], False, over_budget, over_files, [], candidates
     system, user = build_judge_prompt(candidates, contexts, judge_summaries, evidence)
-    payload = call_model(system, user, mode, "judge", binding.correlation)
+    payload = call_model(system, user, mode, "judge", binding.correlation, deadline=deadline)
     decisions = _parse_judge_decisions(payload, len(candidates))
 
     # One narrow follow-up is cheaper and more useful than rerunning the whole
@@ -2598,7 +2615,12 @@ def judge_findings(
         if repair_budget_available:
             try:
                 recheck_payload = call_model(
-                    recheck_system, recheck_user, mode, "judge-repair", binding.correlation
+                    recheck_system,
+                    recheck_user,
+                    mode,
+                    "judge-repair",
+                    binding.correlation,
+                    deadline=deadline,
                 )
                 recheck = _parse_judge_decisions(
                     recheck_payload, len(pending), allow_requests=False
@@ -3345,7 +3367,9 @@ def run_review(
                 break
             system, user = build_review_prompt(classification, chunk, mode)
             try:
-                payload = call_model(system, user, mode, f"review-chunk-{chunk_index}", binding.correlation)
+                payload = call_model(
+                    system, user, mode, f"review-chunk-{chunk_index}", binding.correlation, deadline=deadline
+                )
                 findings, changes = parse_findings(payload, {unit.path for unit in chunk}, require_changes={unit.path for unit in chunk})
             except ModelTimeout:
                 progress.timed_out = True
@@ -3409,7 +3433,9 @@ def run_review(
                 mode,
             )
             try:
-                payload = call_model(system, user, mode, "cross-file-synthesis", binding.correlation)
+                payload = call_model(
+                    system, user, mode, "cross-file-synthesis", binding.correlation, deadline=deadline
+                )
                 synthesis_findings, _ = parse_findings(payload, {unit.path for unit in units if unit.representable})
                 candidates.extend(synthesis_findings)
             except ModelTimeout:
@@ -3418,6 +3444,11 @@ def run_review(
             except ModelConnectionError:
                 progress.aggregation_failed = True
                 progress.incomplete_reasons.append("cross-file synthesis could not connect after one retry")
+                if reason := unverified_candidates_reason(candidates):
+                    progress.incomplete_reasons.append(reason)
+            except ModelRateLimited as exc:
+                progress.aggregation_failed = True
+                progress.incomplete_reasons.append(f"cross-file synthesis was rate limited ({exc})")
                 if reason := unverified_candidates_reason(candidates):
                     progress.incomplete_reasons.append(reason)
             except ModelOutputError:
@@ -3499,6 +3530,12 @@ def run_review(
                 progress.aggregation_failed = True
                 progress.unverified_candidates.extend(candidates)
                 progress.incomplete_reasons.append("judge pass could not connect after one retry")
+                if reason := unverified_candidates_reason(candidates):
+                    progress.incomplete_reasons.append(reason)
+            except ModelRateLimited as exc:
+                progress.aggregation_failed = True
+                progress.unverified_candidates.extend(candidates)
+                progress.incomplete_reasons.append(f"judge pass was rate limited ({exc})")
                 if reason := unverified_candidates_reason(candidates):
                     progress.incomplete_reasons.append(reason)
             except ModelOutputError:

--- a/.github/actions/pr-review/pr_review.py
+++ b/.github/actions/pr-review/pr_review.py
@@ -78,6 +78,13 @@ DIFF_FETCH_ATTEMPTS = 2
 # bound literal and small; a second connection failure remains incomplete work,
 # not an invitation to keep spending the review budget.
 MODEL_CONNECTION_ATTEMPTS = 2
+# A 429 is retried, unlike every other non-200, because the provider rejected
+# the request without doing the work. The ceiling is small and the total sleep
+# is bounded so a sustained outage still ends the run promptly instead of
+# burning the wall-clock budget one chunk at a time.
+MODEL_RATE_LIMIT_ATTEMPTS = 4
+MODEL_RATE_LIMIT_BASE_SLEEP_SECONDS = 2.0
+MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS = 30.0
 # Bounds the admission scan on a pull request with a very long comment history.
 ADMISSION_COMMENT_PAGES = 10
 # A running marker older than any possible job (10-minute admit plus 45-minute
@@ -185,6 +192,17 @@ class ModelTimeout(ReviewError):
 
 class ModelOutputError(ReviewError):
     """A provider response was not a complete, valid structured result."""
+
+
+class ModelRateLimited(ReviewError):
+    """The provider REJECTED the request with 429 and did no work.
+
+    Kept distinct from ModelOutputError because the no-retry policy elsewhere in
+    this file exists to avoid paying twice for a request the provider may have
+    completed. A 429 is the one failure that proves the opposite: nothing was
+    processed and nothing was billed, so retrying is safe and is the only way a
+    transient quota dip does not silently cost a whole review.
+    """
 
 
 class ModelConnectionError(ModelOutputError):
@@ -940,6 +958,27 @@ def budget_allows(deadline: float, mode: str, phase: str = "") -> bool:
     return deadline - time.monotonic() >= llm_call_budget_for(mode, phase)
 
 
+def retry_after_seconds(header: str | None) -> float | None:
+    """Parse a Retry-After header into a bounded sleep, or None when unusable.
+
+    Only the delta-seconds form is honoured. The HTTP-date form is accepted by
+    the spec but depends on clock agreement with the provider, and a skewed
+    clock would turn a short wait into a long one; falling back to the local
+    backoff curve is the safer reading. Anything negative, unparseable, or
+    beyond the ceiling falls back too, so a hostile or mistaken header cannot
+    stall the run.
+    """
+    if not header:
+        return None
+    try:
+        seconds = float(header.strip())
+    except (TypeError, ValueError):
+        return None
+    if seconds < 0:
+        return None
+    return min(seconds, MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS)
+
+
 def call_model(system: str, user: str, mode: str, phase: str, correlation: str) -> object:
     api_url, api_key = provider_configuration()
     model = model_for_phase(mode, phase)
@@ -954,7 +993,15 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
         "X-Client-Request-Id": str(uuid.uuid4()),
     }
     payload = build_llm_payload(model, system, user, mode, phase)
-    for attempt in range(1, MODEL_CONNECTION_ATTEMPTS + 1):
+    # Connection retries and rate-limit retries are counted SEPARATELY. They
+    # exist for different reasons: a connect timeout proves non-delivery, while
+    # a 429 proves non-processing. Sharing one counter would let a burst of
+    # rate limits consume the connection budget, or the reverse.
+    connect_attempt = 0
+    rate_limit_attempt = 1
+    while True:
+        connect_attempt += 1
+        attempt = connect_attempt
         try:
             response = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
         except requests.ConnectTimeout as exc:
@@ -963,7 +1010,7 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
             # have seen or billed it. This clause must stay ABOVE Timeout,
             # which ConnectTimeout also subclasses, or it never runs.
             log_phase(phase, attempt=attempt, status="connect-timeout", correlation=correlation)
-            if attempt == MODEL_CONNECTION_ATTEMPTS:
+            if connect_attempt >= MODEL_CONNECTION_ATTEMPTS:
                 raise ModelConnectionError("provider connection failed after one retry") from exc
             continue
         except requests.Timeout as exc:
@@ -980,6 +1027,26 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
             log_phase(phase, attempt=attempt, status="request-error", correlation=correlation)
             raise ModelOutputError("provider request failed") from exc
         log_phase(phase, attempt=attempt, status=response.status_code, correlation=correlation)
+        if response.status_code == 429:
+            # Safe to retry, and ONLY this status is: a 429 means the provider
+            # refused to process the request, so there is no completed work to
+            # be billed twice. Honour Retry-After when the provider sends it,
+            # since it knows when the window reopens better than a fixed curve.
+            if rate_limit_attempt >= MODEL_RATE_LIMIT_ATTEMPTS:
+                raise ModelRateLimited(
+                    f"provider rate limited the request (HTTP 429) after {rate_limit_attempt} attempts"
+                )
+            delay = retry_after_seconds(response.headers.get("Retry-After"))
+            if delay is None:
+                delay = min(
+                    MODEL_RATE_LIMIT_BASE_SLEEP_SECONDS * (2 ** (rate_limit_attempt - 1)),
+                    MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
+                )
+            log_phase(phase, attempt=attempt, status=f"rate-limited-sleep-{delay:.0f}s", correlation=correlation)
+            time.sleep(delay)
+            rate_limit_attempt += 1
+            connect_attempt -= 1  # a rate limit is not a connection attempt
+            continue
         if response.status_code != 200:
             raise ModelOutputError(f"provider returned HTTP {response.status_code}")
         try:
@@ -997,7 +1064,7 @@ def call_model(system: str, user: str, mode: str, phase: str, correlation: str) 
             return json.loads(_content_from_response(data))
         except (ValueError, json.JSONDecodeError) as exc:
             raise ModelOutputError("provider did not return JSON") from exc
-    raise AssertionError("connection retry loop must return or raise")
+    raise AssertionError("retry loop must return or raise")
 
 
 def _required_string(value: object, field_name: str, *, limit: int) -> str:
@@ -3290,13 +3357,27 @@ def run_review(
                     f"review chunk {chunk_index} could not connect after one retry"
                 )
                 continue
-            except ModelOutputError:
+            except ModelRateLimited as exc:
+                # Name the rate limit. The generic message below describes a
+                # malformed payload, and reporting a quota failure in those
+                # words sent readers looking for a parse bug in the diff
+                # instead of at the provider account.
+                progress.incomplete_reasons.append(
+                    f"review chunk {chunk_index} was rate limited by the provider and not reviewed ({exc})"
+                )
+                continue
+            except ModelOutputError as exc:
                 # A provider 500 or malformed response is localized to this
                 # chunk. Later chunks remain independently reviewable; the
                 # missing unit and this reason make derive_state report partial
                 # rather than allowing their success to read as clean.
+                #
+                # The underlying cause is carried through verbatim. Collapsing
+                # every non-200 into "invalid structured response" hid the real
+                # HTTP status from the published comment, so the run log was the
+                # only place the truth existed.
                 progress.incomplete_reasons.append(
-                    f"review chunk {chunk_index} returned an incomplete or invalid structured response"
+                    f"review chunk {chunk_index} failed: {exc}"
                 )
                 continue
             progress.reviewed_units += len(chunk)

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -4229,6 +4229,25 @@ class RateLimitRetryTest(unittest.TestCase):
         self.assertEqual(post.call_args_list[1].kwargs["timeout"], 8.0)
         slept.assert_called_once_with(9.0)
 
+    def test_rate_limit_sleep_that_consumes_deadline_stops_before_another_request(self):
+        clock = {"now": 100.0}
+
+        def advance(delay: float) -> None:
+            clock["now"] += delay
+
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=120), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review.time, "monotonic", side_effect=lambda: clock["now"]), \
+             mock.patch.object(pr_review.time, "sleep", side_effect=advance) as slept, \
+             mock.patch.object(pr_review.requests, "post", return_value=self._response(429, {"Retry-After": "30"})) as post:
+            with self.assertRaises(pr_review.ModelTimeout):
+                pr_review.call_model("s", "u", "default", "review-chunk-1", "corr", deadline=110.0)
+        self.assertEqual(post.call_count, 1, "the deadline must prevent a second provider request")
+        self.assertEqual(post.call_args.kwargs["timeout"], 10.0)
+        slept.assert_called_once_with(10.0)
+
     def _run_phase_rate_limit(self, *, synthesis: bool) -> tuple[str, object]:
         binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
         diff = "diff --git a/f.go b/f.go\n--- a/f.go\n+++ b/f.go\n@@ -1 +1 @@\n-old\n+new\n"

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1793,7 +1793,8 @@ class JudgeEvidenceTest(unittest.TestCase):
         self.assertEqual(pr_review.llm_timeout_for("deep", "judge-repair"), pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS)
         self.assertEqual(
             pr_review.llm_call_budget_for("deep", "judge-repair"),
-            pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS * pr_review.MODEL_CONNECTION_ATTEMPTS,
+            pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS * pr_review.MODEL_CONNECTION_ATTEMPTS
+            + pr_review.MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS * (pr_review.MODEL_RATE_LIMIT_ATTEMPTS - 1),
         )
         self.assertLess(payload["max_completion_tokens"], pr_review.DEEP_MAX_COMPLETION_TOKENS)
         self.assertLess(pr_review.llm_timeout_for("deep", "judge-repair"), pr_review.DEEP_LLM_TIMEOUT_SECONDS)
@@ -4142,18 +4143,14 @@ class LedgerTest(unittest.TestCase):
         self.assertFalse(parsed["complete"])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class RateLimitRetryTest(unittest.TestCase):
     """A 429 is the one non-200 that is safe to retry, and it must say so.
 
     The runner deliberately never retries a failure that the provider may have
-    completed and billed. A 429 is the opposite case: the request was refused,
-    so nothing was processed. Before this, a transient quota dip cost a whole
-    review AND was published as "an incomplete or invalid structured response",
-    which reads as a malformed payload and sent readers hunting a parse bug.
+    completed. Provider guidance explicitly permits bounded 429 retries. Before
+    this, a transient quota dip cost a whole review and was published as "an
+    incomplete or invalid structured response", which reads as a malformed
+    payload and sent readers hunting a parse bug.
     """
 
     def _response(self, status, headers=None):
@@ -4208,11 +4205,68 @@ class RateLimitRetryTest(unittest.TestCase):
         self.assertIsNone(pr_review.retry_after_seconds(None))
         self.assertIsNone(pr_review.retry_after_seconds("Wed, 21 Oct 2026 07:28:00 GMT"))
         self.assertIsNone(pr_review.retry_after_seconds("-1"))
+        self.assertIsNone(pr_review.retry_after_seconds("NaN"))
+        self.assertIsNone(pr_review.retry_after_seconds("inf"))
         self.assertEqual(
             pr_review.retry_after_seconds("99999"),
             pr_review.MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
             "a hostile or mistaken header must not stall the run",
         )
+
+    def test_deadline_caps_request_timeout_and_rate_limit_sleep(self):
+        ok = self._response(200)
+        clock = iter([100.0, 101.0, 102.0])
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=120), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review, "_content_from_response", return_value="{}"), \
+             mock.patch.object(pr_review.time, "monotonic", side_effect=lambda: next(clock)), \
+             mock.patch.object(pr_review.time, "sleep") as slept, \
+             mock.patch.object(pr_review.requests, "post", side_effect=[self._response(429, {"Retry-After": "30"}), ok]) as post:
+            pr_review.call_model("s", "u", "default", "review-chunk-1", "corr", deadline=110.0)
+        self.assertEqual(post.call_args_list[0].kwargs["timeout"], 10.0)
+        self.assertEqual(post.call_args_list[1].kwargs["timeout"], 8.0)
+        slept.assert_called_once_with(9.0)
+
+    def _run_phase_rate_limit(self, *, synthesis: bool) -> tuple[str, object]:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        diff = "diff --git a/f.go b/f.go\n--- a/f.go\n+++ b/f.go\n@@ -1 +1 @@\n-old\n+new\n"
+        discovery = {
+            "findings": [{
+                "severity": "high", "path": "f.go", "line": 1, "title": "unsafe",
+                "why": "why", "fix": "fix", "needs_verification": False,
+            }],
+            "changes": [{"path": "f.go", "summary": "changed"}],
+        }
+        rate_limit = pr_review.ModelRateLimited("quota exhausted")
+        outcomes = [discovery, rate_limit] if synthesis else [discovery, {"findings": []}, rate_limit]
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "fetch_bound_diff", return_value=diff), \
+             mock.patch.object(pr_review, "compare_incompleteness", return_value=None), \
+             mock.patch.object(pr_review, "get_pull_binding", return_value=binding), \
+             mock.patch.object(pr_review, "head_has_moved", return_value=False), \
+             mock.patch.object(pr_review, "fetch_file_context", return_value="1: new"), \
+             mock.patch.object(pr_review, "budget_allows", return_value=True), \
+             mock.patch.object(pr_review, "call_model", side_effect=outcomes), \
+             mock.patch.object(pr_review, "update_comment"):
+            return pr_review.run_review(
+                "owner/repo", "42", "token", "default", "c" * 40,
+                binding=binding, status_comment_id=7,
+            )
+
+    def test_synthesis_rate_limit_is_partial(self):
+        state, progress = self._run_phase_rate_limit(synthesis=True)
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.aggregation_failed)
+        self.assertTrue(any("synthesis was rate limited" in reason for reason in progress.incomplete_reasons))
+
+    def test_judge_rate_limit_is_partial_and_retains_candidates(self):
+        state, progress = self._run_phase_rate_limit(synthesis=False)
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.aggregation_failed)
+        self.assertEqual([finding.title for finding in progress.unverified_candidates], ["unsafe"])
+        self.assertTrue(any("judge pass was rate limited" in reason for reason in progress.incomplete_reasons))
 
     def test_non_429_is_still_not_retried(self):
         """The no-duplicate-charge policy must survive this change."""
@@ -4224,3 +4278,7 @@ class RateLimitRetryTest(unittest.TestCase):
             with self.assertRaises(pr_review.ModelOutputError):
                 pr_review.call_model("s", "u", "default", "review-chunk-1", "corr")
         self.assertEqual(post.call_count, 1, "a 500 may have been billed and must not be retried")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -4115,3 +4115,83 @@ class LedgerTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RateLimitRetryTest(unittest.TestCase):
+    """A 429 is the one non-200 that is safe to retry, and it must say so.
+
+    The runner deliberately never retries a failure that the provider may have
+    completed and billed. A 429 is the opposite case: the request was refused,
+    so nothing was processed. Before this, a transient quota dip cost a whole
+    review AND was published as "an incomplete or invalid structured response",
+    which reads as a malformed payload and sent readers hunting a parse bug.
+    """
+
+    def _response(self, status, headers=None):
+        resp = mock.Mock()
+        resp.status_code = status
+        resp.headers = headers or {}
+        resp.json.return_value = {
+            "choices": [{"message": {"content": "{}"}, "finish_reason": "stop"}]
+        }
+        return resp
+
+    def test_429_is_retried_then_succeeds(self):
+        ok = self._response(200)
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=1), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review, "_content_from_response", return_value="{}"), \
+             mock.patch.object(pr_review.time, "sleep") as slept, \
+             mock.patch.object(pr_review.requests, "post",
+                               side_effect=[self._response(429), self._response(429), ok]) as post:
+            pr_review.call_model("s", "u", "default", "review-chunk-1", "corr")
+        self.assertEqual(post.call_count, 3, "a 429 must be retried, not surfaced as a failure")
+        self.assertTrue(slept.called, "a retry without backoff would hammer a rate-limited provider")
+
+    def test_sustained_429_raises_a_rate_limit_error(self):
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=1), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review.time, "sleep"), \
+             mock.patch.object(pr_review.requests, "post", return_value=self._response(429)):
+            with self.assertRaises(pr_review.ModelRateLimited):
+                pr_review.call_model("s", "u", "default", "review-chunk-1", "corr")
+
+    def test_rate_limit_does_not_consume_the_connection_budget(self):
+        """A burst of 429s must not exhaust the retry reserved for connect timeouts."""
+        ok = self._response(200)
+        responses = [self._response(429)] * (pr_review.MODEL_CONNECTION_ATTEMPTS + 1) + [ok]
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=1), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review, "_content_from_response", return_value="{}"), \
+             mock.patch.object(pr_review.time, "sleep"), \
+             mock.patch.object(pr_review.requests, "post", side_effect=responses) as post:
+            pr_review.call_model("s", "u", "default", "review-chunk-1", "corr")
+        self.assertEqual(post.call_count, len(responses))
+
+    def test_retry_after_header_is_honoured_and_bounded(self):
+        self.assertEqual(pr_review.retry_after_seconds("5"), 5.0)
+        self.assertIsNone(pr_review.retry_after_seconds(None))
+        self.assertIsNone(pr_review.retry_after_seconds("Wed, 21 Oct 2026 07:28:00 GMT"))
+        self.assertIsNone(pr_review.retry_after_seconds("-1"))
+        self.assertEqual(
+            pr_review.retry_after_seconds("99999"),
+            pr_review.MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
+            "a hostile or mistaken header must not stall the run",
+        )
+
+    def test_non_429_is_still_not_retried(self):
+        """The no-duplicate-charge policy must survive this change."""
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=1), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review.requests, "post", return_value=self._response(500)) as post:
+            with self.assertRaises(pr_review.ModelOutputError):
+                pr_review.call_model("s", "u", "default", "review-chunk-1", "corr")
+        self.assertEqual(post.call_count, 1, "a 500 may have been billed and must not be retried")

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1793,7 +1793,8 @@ class JudgeEvidenceTest(unittest.TestCase):
         self.assertEqual(pr_review.llm_timeout_for("deep", "judge-repair"), pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS)
         self.assertEqual(
             pr_review.llm_call_budget_for("deep", "judge-repair"),
-            pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS * pr_review.MODEL_CONNECTION_ATTEMPTS,
+            pr_review.JUDGE_REPAIR_TIMEOUT_SECONDS * pr_review.MODEL_CONNECTION_ATTEMPTS
+            + pr_review.MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS * (pr_review.MODEL_RATE_LIMIT_ATTEMPTS - 1),
         )
         self.assertLess(payload["max_completion_tokens"], pr_review.DEEP_MAX_COMPLETION_TOKENS)
         self.assertLess(pr_review.llm_timeout_for("deep", "judge-repair"), pr_review.DEEP_LLM_TIMEOUT_SECONDS)
@@ -4208,11 +4209,68 @@ class RateLimitRetryTest(unittest.TestCase):
         self.assertIsNone(pr_review.retry_after_seconds(None))
         self.assertIsNone(pr_review.retry_after_seconds("Wed, 21 Oct 2026 07:28:00 GMT"))
         self.assertIsNone(pr_review.retry_after_seconds("-1"))
+        self.assertIsNone(pr_review.retry_after_seconds("NaN"))
+        self.assertIsNone(pr_review.retry_after_seconds("inf"))
         self.assertEqual(
             pr_review.retry_after_seconds("99999"),
             pr_review.MODEL_RATE_LIMIT_MAX_SLEEP_SECONDS,
             "a hostile or mistaken header must not stall the run",
         )
+
+    def test_deadline_caps_request_timeout_and_rate_limit_sleep(self):
+        ok = self._response(200)
+        clock = iter([100.0, 101.0, 102.0])
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "model_for_phase", return_value="m"), \
+             mock.patch.object(pr_review, "llm_timeout_for", return_value=120), \
+             mock.patch.object(pr_review, "build_llm_payload", return_value={}), \
+             mock.patch.object(pr_review, "_content_from_response", return_value="{}"), \
+             mock.patch.object(pr_review.time, "monotonic", side_effect=lambda: next(clock)), \
+             mock.patch.object(pr_review.time, "sleep") as slept, \
+             mock.patch.object(pr_review.requests, "post", side_effect=[self._response(429, {"Retry-After": "30"}), ok]) as post:
+            pr_review.call_model("s", "u", "default", "review-chunk-1", "corr", deadline=110.0)
+        self.assertEqual(post.call_args_list[0].kwargs["timeout"], 10.0)
+        self.assertEqual(post.call_args_list[1].kwargs["timeout"], 8.0)
+        slept.assert_called_once_with(9.0)
+
+    def _run_phase_rate_limit(self, *, synthesis: bool) -> tuple[str, object]:
+        binding = pr_review.PullBinding("a" * 40, "b" * 40, "c" * 40, pr_review.RUBRIC_VERSION)
+        diff = "diff --git a/f.go b/f.go\n--- a/f.go\n+++ b/f.go\n@@ -1 +1 @@\n-old\n+new\n"
+        discovery = {
+            "findings": [{
+                "severity": "high", "path": "f.go", "line": 1, "title": "unsafe",
+                "why": "why", "fix": "fix", "needs_verification": False,
+            }],
+            "changes": [{"path": "f.go", "summary": "changed"}],
+        }
+        rate_limit = pr_review.ModelRateLimited("quota exhausted")
+        outcomes = [discovery, rate_limit] if synthesis else [discovery, {"findings": []}, rate_limit]
+        with mock.patch.object(pr_review, "provider_configuration", return_value=("u", "k")), \
+             mock.patch.object(pr_review, "fetch_bound_diff", return_value=diff), \
+             mock.patch.object(pr_review, "compare_incompleteness", return_value=None), \
+             mock.patch.object(pr_review, "get_pull_binding", return_value=binding), \
+             mock.patch.object(pr_review, "head_has_moved", return_value=False), \
+             mock.patch.object(pr_review, "fetch_file_context", return_value="1: new"), \
+             mock.patch.object(pr_review, "budget_allows", return_value=True), \
+             mock.patch.object(pr_review, "call_model", side_effect=outcomes), \
+             mock.patch.object(pr_review, "update_comment"):
+            return pr_review.run_review(
+                "owner/repo", "42", "token", "default", "c" * 40,
+                binding=binding, status_comment_id=7,
+            )
+
+    def test_synthesis_rate_limit_is_partial(self):
+        state, progress = self._run_phase_rate_limit(synthesis=True)
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.aggregation_failed)
+        self.assertTrue(any("synthesis was rate limited" in reason for reason in progress.incomplete_reasons))
+
+    def test_judge_rate_limit_is_partial_and_retains_candidates(self):
+        state, progress = self._run_phase_rate_limit(synthesis=False)
+        self.assertEqual(state, "partial")
+        self.assertTrue(progress.aggregation_failed)
+        self.assertEqual([finding.title for finding in progress.unverified_candidates], ["unsafe"])
+        self.assertTrue(any("judge pass was rate limited" in reason for reason in progress.incomplete_reasons))
 
     def test_non_429_is_still_not_retried(self):
         """The no-duplicate-charge policy must survive this change."""


### PR DESCRIPTION
## What changed

A review chunk that the provider rate limited was abandoned on the first attempt and published as "an incomplete or invalid structured response". That wording describes a malformed payload, so a transient quota dip read as a defect in the diff and cost the whole review.

A 429 is now retried with exponential backoff, honouring `Retry-After` when the provider sends it in delta-seconds form and capping any single wait, so a hostile or mistaken header cannot stall a run. Rate-limit retries are counted separately from connection retries, so a burst of 429s cannot consume the one retry reserved for a connection that was never established.

Every other non-200 is still not retried. Those may have been processed and billed, and a 429 is the one status that proves the request was refused before any work happened.

A chunk that fails now reports its actual cause, including the HTTP status, instead of collapsing every failure into the parse-error wording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporary service rate limits by automatically retrying requests.
  - Respects provider-provided retry timing when available and uses bounded backoff otherwise.
  - Prevents rate-limit retries from consuming connection retry attempts.
  - Applies request time limits consistently, including during retry delays.
  - Reports reviews that remain incomplete after repeated rate-limit responses with a distinct, informative reason.
  - Preserves existing behavior for other service failures, such as server errors.
  - Retains available findings when rate limits affect later review stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->