### PR TITLE
fix(runtime): summarize file sentry startup failures

### DIFF
--- a/internal/cli/runtime/filesentry_arm_summary_test.go
+++ b/internal/cli/runtime/filesentry_arm_summary_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -79,6 +80,12 @@ func TestFileSentryArmFailureStandaloneSummary(t *testing.T) {
 			mustFailClosed:  true,
 			wantDetailLines: []string{"no watch paths armed"},
 			forbidFirstLine: []string{"no watch paths armed"},
+		},
+		{
+			name:            "uncounted generic failure",
+			armErr:          errors.New("watch backend unavailable"),
+			wantSummary:     "file sentry failed to arm watches (feature is enabled)",
+			wantDetailLines: []string{"watch backend unavailable"},
 		},
 		{
 			name:            "incomplete coverage best_effort applies",
@@ -177,34 +184,69 @@ func TestFileSentryArmFailureStandaloneSummary(t *testing.T) {
 // consumer must render the standalone summary (not the fused headline) while
 // keeping the fail-closed sentinel chain intact.
 func TestServer_StartFileSentryFailureShowsStandaloneSummary(t *testing.T) {
-	cfg := config.Defaults()
-	cfg.FileSentry.Enabled = true
-	cfg.FileSentry.WatchPaths = []config.WatchPath{
-		{Path: filepath.Join(t.TempDir(), "nonexistent-required"), Required: true},
+	for _, count := range []int{1, 3} {
+		t.Run(fmt.Sprintf("missing-%d", count), func(t *testing.T) {
+			root := t.TempDir()
+			cfg := config.Defaults()
+			cfg.FileSentry.Enabled = true
+			cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: root}}
+			for i := range count {
+				cfg.FileSentry.WatchPaths = append(cfg.FileSentry.WatchPaths, config.WatchPath{
+					Path: filepath.Join(root, fmt.Sprintf("missing-%d", i)), Required: true,
+				})
+			}
+			s, _ := newTestServer(t, nil)
+			_, err := s.startFileSentry(context.Background(), cfg, func() {})
+			if !errors.Is(err, filesentry.ErrRequiredWatchPath) {
+				t.Fatalf("required missing paths: got %v, want ErrRequiredWatchPath", err)
+			}
+			firstLine := strings.SplitN(err.Error(), "\n", 2)[0]
+			want := fmt.Sprintf("file sentry failed to arm watches (feature is enabled): %d skipped/unarmed watch subtree(s)", count)
+			if firstLine != want {
+				t.Fatalf("summary = %q, want %q", firstLine, want)
+			}
+			if !strings.Contains(err.Error(), "create missing required directories or correct their file_sentry.watch_paths entries") {
+				t.Fatalf("missing remedy for required directories: %v", err)
+			}
+			if strings.Contains(err.Error(), "set file_sentry.best_effort: true to trade coverage") {
+				t.Fatalf("required-root failure offered best_effort: %v", err)
+			}
+			// Apply the remedy to a partially armed configuration and retry startup.
+			for _, path := range cfg.FileSentry.WatchPaths[1:] {
+				if err := os.Mkdir(path.Path, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			stop, err := s.startFileSentry(context.Background(), cfg, func() {})
+			if err != nil {
+				t.Fatalf("startup after creating required directories: %v", err)
+			}
+			if err := stop(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
-	s, _ := newTestServer(t, nil)
+}
 
-	_, err := s.startFileSentry(context.Background(), cfg, func() {})
-	if err == nil {
-		t.Fatal("startFileSentry returned nil; a required nonexistent root must fail closed")
-	}
-	if !errors.Is(err, filesentry.ErrRequiredWatchPath) {
-		t.Fatalf("errors.Is(err, ErrRequiredWatchPath) = false; got %v", err)
-	}
-
-	firstLine := strings.SplitN(err.Error(), "\n", 2)[0]
-	if !strings.HasPrefix(firstLine, "file sentry failed to arm watches (feature is enabled): ") {
-		t.Fatalf("first line is not the standalone summary: %q", firstLine)
-	}
-	if !strings.Contains(firstLine, "skipped/unarmed watch subtree(s)") {
-		t.Fatalf("summary missing a real skipped/unarmed count: %q", firstLine)
-	}
-	if strings.Contains(firstLine, "incomplete watch coverage") {
-		t.Fatalf("headline fused with the joined detail chain: %q", firstLine)
-	}
-	// A required-root failure must not advertise best_effort as a fix.
-	if strings.Contains(err.Error(), "set file_sentry.best_effort: true to trade coverage") {
-		t.Errorf("required-root failure offered best_effort:\n%s", err.Error())
+func TestMcpProxyCmd_FileSentrySummaryCountsMissingPaths(t *testing.T) {
+	for _, count := range []int{1, 3} {
+		t.Run(fmt.Sprintf("missing-%d", count), func(t *testing.T) {
+			root := t.TempDir()
+			paths := make([]string, count)
+			for i := range paths {
+				paths[i] = filepath.Join(root, fmt.Sprintf("missing-%d", i))
+			}
+			cfg := writeMCPFileSentryConfig(t, false, paths...)
+			_, _, err := runMCPProxyCommand(t, cfg)
+			if err == nil {
+				t.Fatal("startup with zero armed paths succeeded")
+			}
+			firstLine := strings.SplitN(err.Error(), "\n", 2)[0]
+			want := fmt.Sprintf("file sentry failed to arm watches (feature is enabled): %d skipped/unarmed watch subtree(s)", count)
+			if firstLine != want {
+				t.Fatalf("summary = %q, want %q", firstLine, want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime/filesentry_arm_summary_test.go
+++ b/internal/cli/runtime/filesentry_arm_summary_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/filesentry"
+)
+
+// TestFileSentryArmFailureStandaloneSummary pins the operator-facing contract of
+// the reworked arm-failure renderer: the first line is a standalone summary
+// carrying the accurate skipped/unarmed subtree count, the applicable remedy
+// follows, and the original joined detail lines come last under "details:".
+// It also pins that the sentinel errors.Is chain survives the rewrap and that
+// best_effort is offered only for failures it can actually resolve.
+func TestFileSentryArmFailureStandaloneSummary(t *testing.T) {
+	requiredMultiPath := func() error {
+		inner := errors.Join(
+			fmt.Errorf("cannot monitor subtree %q beneath watch root %q: %w", "/srv/data/blocked", "/srv/data", fs.ErrPermission),
+			fmt.Errorf("cannot monitor subtree %q beneath watch root %q: %w", "/srv/data/secret", "/srv/data", fs.ErrPermission),
+		)
+		cause := errors.Join(filesentry.ErrRequiredWatchPath, inner)
+		return fmt.Errorf("filesentry: incomplete watch coverage: %w", cause)
+	}
+	noArmedWithCount := func() error {
+		cause := fmt.Errorf("cannot monitor subtree %q beneath watch root %q: %w", "/x/missing", "/x/missing", fs.ErrNotExist)
+		return fmt.Errorf("%w: %w", filesentry.ErrNoWatchPaths, cause)
+	}
+	incompleteBestEffort := func() error {
+		return fmt.Errorf("filesentry: incomplete watch coverage: %w",
+			fmt.Errorf("cannot monitor subtree %q beneath watch root %q: %w", "/tmp/w/blocked", "/tmp/w", fs.ErrPermission))
+	}
+
+	tests := []struct {
+		name            string
+		armErr          error
+		degraded        int
+		wantIs          error  // sentinel that must remain reachable via errors.Is
+		wantSummary     string // exact first line
+		mustFailClosed  bool   // true => best_effort must NOT be offered
+		wantDetailLines []string
+		forbidFirstLine []string // substrings that must not appear fused into the summary
+	}{
+		{
+			name:            "required multi-path failure",
+			armErr:          requiredMultiPath(),
+			degraded:        2,
+			wantIs:          filesentry.ErrRequiredWatchPath,
+			wantSummary:     "file sentry failed to arm watches (feature is enabled): 2 skipped/unarmed watch subtree(s)",
+			mustFailClosed:  true,
+			wantDetailLines: []string{"/srv/data/blocked", "/srv/data/secret", "permission denied", "required watch coverage unavailable"},
+			forbidFirstLine: []string{"incomplete watch coverage", "/srv/data", "required watch coverage unavailable"},
+		},
+		{
+			name:            "no armed paths with a counted root",
+			armErr:          noArmedWithCount(),
+			degraded:        1,
+			wantIs:          filesentry.ErrNoWatchPaths,
+			wantSummary:     "file sentry failed to arm watches (feature is enabled): 1 skipped/unarmed watch subtree(s)",
+			mustFailClosed:  true,
+			wantDetailLines: []string{"/x/missing", "no watch paths armed"},
+			forbidFirstLine: []string{"/x/missing", "no watch paths armed"},
+		},
+		{
+			name:            "zero-count no watchable paths",
+			armErr:          filesentry.ErrNoWatchPaths,
+			degraded:        0,
+			wantIs:          filesentry.ErrNoWatchPaths,
+			wantSummary:     "file sentry failed to arm watches (feature is enabled): no watch paths could be armed",
+			mustFailClosed:  true,
+			wantDetailLines: []string{"no watch paths armed"},
+			forbidFirstLine: []string{"no watch paths armed"},
+		},
+		{
+			name:            "incomplete coverage best_effort applies",
+			armErr:          incompleteBestEffort(),
+			degraded:        1,
+			wantIs:          nil,
+			wantSummary:     "file sentry failed to arm watches (feature is enabled): 1 skipped/unarmed watch subtree(s)",
+			mustFailClosed:  false,
+			wantDetailLines: []string{"/tmp/w/blocked", "permission denied"},
+			forbidFirstLine: []string{"incomplete watch coverage", "/tmp/w"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := fileSentryArmFailure(tt.armErr, tt.degraded)
+			got := rendered.Error()
+			if errors.Is(tt.armErr, filesentry.ErrNoWatchPaths) {
+				if !strings.Contains(got, "at least one file_sentry.watch_paths entry names an existing directory") {
+					t.Errorf("zero-coverage failure must explain how to establish coverage:\n%s", got)
+				}
+				for _, inertRemedy := range []string{"add a file_sentry.ignore_patterns entry", "drop required: true"} {
+					if strings.Contains(got, inertRemedy) {
+						t.Errorf("zero-coverage failure offered an ineffective remedy %q:\n%s", inertRemedy, got)
+					}
+				}
+			}
+
+			// Sentinel chain preserved through the rewrap.
+			if tt.wantIs != nil && !errors.Is(rendered, tt.wantIs) {
+				t.Fatalf("errors.Is(rendered, %v) = false; sentinel chain lost:\n%s", tt.wantIs, got)
+			}
+
+			lines := strings.SplitN(got, "\n", 2)
+			firstLine := lines[0]
+			if firstLine != tt.wantSummary {
+				t.Fatalf("first line = %q, want standalone summary %q\nfull:\n%s", firstLine, tt.wantSummary, got)
+			}
+			// A zero-count failure must never fabricate a "0" count.
+			if tt.degraded == 0 && strings.Contains(firstLine, "0 ") {
+				t.Errorf("zero-count summary fabricated a count: %q", firstLine)
+			}
+			for _, forbidden := range tt.forbidFirstLine {
+				if strings.Contains(firstLine, forbidden) {
+					t.Errorf("summary fused a detail into the first line: %q contains %q", firstLine, forbidden)
+				}
+			}
+
+			// Ordering: summary, then remedy, then details, then the detail lines.
+			iRemedy := strings.Index(got, "remedies:")
+			iDetails := strings.Index(got, "\ndetails:\n")
+			if iRemedy <= 0 {
+				t.Fatalf("no remedy rendered:\n%s", got)
+			}
+			if iDetails <= iRemedy {
+				t.Fatalf("details must follow the remedy (iRemedy=%d iDetails=%d):\n%s", iRemedy, iDetails, got)
+			}
+
+			// Remedy correctness: best_effort offered only when it can resolve.
+			offersBestEffort := strings.Contains(got, "set file_sentry.best_effort: true to trade coverage")
+			deniesBestEffort := strings.Contains(got, "does NOT apply to this failure")
+			if tt.mustFailClosed {
+				if strings.Contains(got, "drop required: true") {
+					t.Errorf("removing required alone cannot repair strict coverage:\n%s", got)
+				}
+				if offersBestEffort {
+					t.Errorf("must-fail-closed error offered best_effort:\n%s", got)
+				}
+				if !deniesBestEffort {
+					t.Errorf("must-fail-closed error missing the best_effort-does-not-apply note:\n%s", got)
+				}
+			} else {
+				if !offersBestEffort {
+					t.Errorf("resolvable failure did not offer best_effort:\n%s", got)
+				}
+			}
+
+			// Detail lines preserved verbatim, after the details label.
+			for _, want := range tt.wantDetailLines {
+				idx := strings.Index(got, want)
+				if idx < 0 {
+					t.Errorf("detail %q missing from rendered error:\n%s", want, got)
+					continue
+				}
+				if idx < iDetails {
+					t.Errorf("detail %q appeared before the details label:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestServer_StartFileSentryFailureShowsStandaloneSummary drives the real
+// watcher through the server startup seam: a required, nonexistent watch root
+// produces a genuine Arm failure with a real DegradedPathCount, and the
+// consumer must render the standalone summary (not the fused headline) while
+// keeping the fail-closed sentinel chain intact.
+func TestServer_StartFileSentryFailureShowsStandaloneSummary(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.FileSentry.Enabled = true
+	cfg.FileSentry.WatchPaths = []config.WatchPath{
+		{Path: filepath.Join(t.TempDir(), "nonexistent-required"), Required: true},
+	}
+	s, _ := newTestServer(t, nil)
+
+	_, err := s.startFileSentry(context.Background(), cfg, func() {})
+	if err == nil {
+		t.Fatal("startFileSentry returned nil; a required nonexistent root must fail closed")
+	}
+	if !errors.Is(err, filesentry.ErrRequiredWatchPath) {
+		t.Fatalf("errors.Is(err, ErrRequiredWatchPath) = false; got %v", err)
+	}
+
+	firstLine := strings.SplitN(err.Error(), "\n", 2)[0]
+	if !strings.HasPrefix(firstLine, "file sentry failed to arm watches (feature is enabled): ") {
+		t.Fatalf("first line is not the standalone summary: %q", firstLine)
+	}
+	if !strings.Contains(firstLine, "skipped/unarmed watch subtree(s)") {
+		t.Fatalf("summary missing a real skipped/unarmed count: %q", firstLine)
+	}
+	if strings.Contains(firstLine, "incomplete watch coverage") {
+		t.Fatalf("headline fused with the joined detail chain: %q", firstLine)
+	}
+	// A required-root failure must not advertise best_effort as a fix.
+	if strings.Contains(err.Error(), "set file_sentry.best_effort: true to trade coverage") {
+		t.Errorf("required-root failure offered best_effort:\n%s", err.Error())
+	}
+}
+
+func TestServer_StartFileSentryIgnoredRootRemedy(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Defaults()
+	cfg.FileSentry.Enabled = true
+	cfg.FileSentry.WatchPaths = []config.WatchPath{{Path: root}}
+	cfg.FileSentry.IgnorePatterns = []string{filepath.Base(root)}
+	s, _ := newTestServer(t, nil)
+
+	_, err := s.startFileSentry(context.Background(), cfg, func() {})
+	if !errors.Is(err, filesentry.ErrNoWatchPaths) {
+		t.Fatalf("ignored root error = %v, want ErrNoWatchPaths", err)
+	}
+	if !strings.Contains(err.Error(), "file_sentry.ignore_patterns does not exclude it") {
+		t.Fatalf("missing remedy for excluded watch root: %v", err)
+	}
+
+	// Apply the advertised remedy and prove startup can establish coverage.
+	cfg.FileSentry.IgnorePatterns = nil
+	stop, err := s.startFileSentry(context.Background(), cfg, func() {})
+	if err != nil {
+		t.Fatalf("startup after removing the root exclusion: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop file sentry: %v", err)
+	}
+}

--- a/internal/cli/runtime/mcp.go
+++ b/internal/cli/runtime/mcp.go
@@ -1806,12 +1806,14 @@ Key-free evidence capture:
 				// Arm synchronously before child launch.
 				if watcher != nil {
 					if armErr := watcher.Arm(); armErr != nil {
+						// Capture the watch failure count before closing the watcher.
+						degraded := watcher.DegradedPathCount()
 						_ = watcher.Close()
 						if cfg.FileSentry.BestEffort && !fileSentryArmErrorMustFailClosed(armErr) {
 							_, _ = fmt.Fprintf(logW, "pipelock: file sentry failed to arm watches (best_effort: continuing without file monitoring): %v\n", armErr)
 							watcher = nil
 						} else {
-							return fileSentryArmFailure(armErr)
+							return fileSentryArmFailure(armErr, degraded)
 						}
 					}
 				}

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -161,17 +161,20 @@ func fileSentryArmErrorMustFailClosed(err error) bool {
 // preserving the original error chain. The count includes omitted diagnostics.
 func fileSentryArmFailure(err error, degradedSubtrees int) error {
 	return fmt.Errorf("%s\n%s\ndetails:\n%w",
-		fileSentryArmFailureSummary(degradedSubtrees),
+		fileSentryArmFailureSummary(err, degradedSubtrees),
 		fileSentryArmRemedy(err),
 		err)
 }
 
-func fileSentryArmFailureSummary(degradedSubtrees int) string {
+func fileSentryArmFailureSummary(err error, degradedSubtrees int) string {
 	const head = "file sentry failed to arm watches (feature is enabled)"
 	if degradedSubtrees > 0 {
 		return fmt.Sprintf("%s: %d skipped/unarmed watch subtree(s)", head, degradedSubtrees)
 	}
-	return head + ": no watch paths could be armed"
+	if errors.Is(err, filesentry.ErrNoWatchPaths) {
+		return head + ": no watch paths could be armed"
+	}
+	return head
 }
 
 // fileSentryArmRemedy offers best_effort only when it can resolve the failure.
@@ -180,7 +183,7 @@ func fileSentryArmRemedy(err error) string {
 		return "remedies: ensure at least one file_sentry.watch_paths entry names an existing directory the user pipelock runs as can read and execute, and that file_sentry.ignore_patterns does not exclude it. file_sentry.best_effort does NOT apply to this failure: at least one path must be watchable"
 	}
 	if fileSentryArmErrorMustFailClosed(err) {
-		return "remedies: grant the user pipelock runs as read and execute access to each listed directory; or adjust file_sentry.ignore_patterns to exclude inaccessible paths while retaining at least one watchable directory. file_sentry.best_effort does NOT apply to this failure: required watch coverage must be available"
+		return "remedies: create missing required directories or correct their file_sentry.watch_paths entries; grant the user pipelock runs as read and execute access to each listed directory; or adjust file_sentry.ignore_patterns to exclude inaccessible paths while retaining at least one watchable directory. file_sentry.best_effort does NOT apply to this failure: required watch coverage must be available"
 	}
 	return "remedies: grant the user pipelock runs as read and execute access to each listed directory; add a file_sentry.ignore_patterns entry matching an inaccessible path; or set file_sentry.best_effort: true to trade coverage for availability"
 }

--- a/internal/cli/runtime/server_lifecycle.go
+++ b/internal/cli/runtime/server_lifecycle.go
@@ -91,12 +91,14 @@ func (s *Server) startFileSentry(ctx context.Context, cfg *config.Config, cancel
 	}
 
 	if err := watcher.Arm(); err != nil {
+		// Capture the watch failure count before closing the watcher.
+		degraded := watcher.DegradedPathCount()
 		_ = watcher.Close()
 		if cfg.FileSentry.BestEffort && !fileSentryArmErrorMustFailClosed(err) {
 			_, _ = fmt.Fprintf(s.opts.Stderr, "pipelock: file sentry failed to arm watches (best_effort: continuing without file monitoring): %v\n", err)
 			return func() error { return nil }, nil
 		}
-		return nil, fileSentryArmFailure(err)
+		return nil, fileSentryArmFailure(err, degraded)
 	}
 
 	var findingHook filesentry.FindingHook
@@ -155,16 +157,32 @@ func fileSentryArmErrorMustFailClosed(err error) bool {
 	return errors.Is(err, filesentry.ErrNoWatchPaths) || errors.Is(err, filesentry.ErrRequiredWatchPath)
 }
 
-// fileSentryArmFailure attaches operator remedies to an arming failure, naming
-// only controls the blocking path actually consults. best_effort is offered
-// solely for failures it can resolve: a required root and a no-watch-paths
-// error both stay fail-closed under best_effort, so advertising it there would
-// send an operator to a setting that cannot fix their failure.
-func fileSentryArmFailure(err error) error {
-	if fileSentryArmErrorMustFailClosed(err) {
-		return fmt.Errorf("file sentry failed to arm watches (feature is enabled): %w\nremedies: grant the user pipelock runs as read and execute access to each listed directory; add a file_sentry.ignore_patterns entry matching an inaccessible path; or drop required: true from the affected watch_paths entry. file_sentry.best_effort does NOT apply to this failure: a required root and a configuration with no watchable path both stay fail-closed", err)
+// fileSentryArmFailure keeps the summary and remedy ahead of joined details,
+// preserving the original error chain. The count includes omitted diagnostics.
+func fileSentryArmFailure(err error, degradedSubtrees int) error {
+	return fmt.Errorf("%s\n%s\ndetails:\n%w",
+		fileSentryArmFailureSummary(degradedSubtrees),
+		fileSentryArmRemedy(err),
+		err)
+}
+
+func fileSentryArmFailureSummary(degradedSubtrees int) string {
+	const head = "file sentry failed to arm watches (feature is enabled)"
+	if degradedSubtrees > 0 {
+		return fmt.Sprintf("%s: %d skipped/unarmed watch subtree(s)", head, degradedSubtrees)
 	}
-	return fmt.Errorf("file sentry failed to arm watches (feature is enabled): %w\nremedies: grant the user pipelock runs as read and execute access to each listed directory; add a file_sentry.ignore_patterns entry matching an inaccessible path; or set file_sentry.best_effort: true to trade coverage for availability", err)
+	return head + ": no watch paths could be armed"
+}
+
+// fileSentryArmRemedy offers best_effort only when it can resolve the failure.
+func fileSentryArmRemedy(err error) string {
+	if errors.Is(err, filesentry.ErrNoWatchPaths) {
+		return "remedies: ensure at least one file_sentry.watch_paths entry names an existing directory the user pipelock runs as can read and execute, and that file_sentry.ignore_patterns does not exclude it. file_sentry.best_effort does NOT apply to this failure: at least one path must be watchable"
+	}
+	if fileSentryArmErrorMustFailClosed(err) {
+		return "remedies: grant the user pipelock runs as read and execute access to each listed directory; or adjust file_sentry.ignore_patterns to exclude inaccessible paths while retaining at least one watchable directory. file_sentry.best_effort does NOT apply to this failure: required watch coverage must be available"
+	}
+	return "remedies: grant the user pipelock runs as read and execute access to each listed directory; add a file_sentry.ignore_patterns entry matching an inaccessible path; or set file_sentry.best_effort: true to trade coverage for availability"
 }
 
 // startupSummaryLine renders the one-line startup diagnostic. fetchAddr is the

--- a/internal/cli/runtime/server_test.go
+++ b/internal/cli/runtime/server_test.go
@@ -1574,7 +1574,7 @@ func TestServer_StartFileSentryBestEffortRejectsZeroArmedPaths(t *testing.T) {
 }
 
 func TestFileSentryArmFailureNamesWorkingRemedies(t *testing.T) {
-	err := fileSentryArmFailure(fmt.Errorf("filesentry: incomplete watch coverage: cannot monitor subtree %q beneath watch root %q: %w", "/tmp/watch/blocked", "/tmp/watch", fs.ErrPermission))
+	err := fileSentryArmFailure(fmt.Errorf("filesentry: incomplete watch coverage: cannot monitor subtree %q beneath watch root %q: %w", "/tmp/watch/blocked", "/tmp/watch", fs.ErrPermission), 1)
 	for _, want := range []string{
 		"/tmp/watch/blocked",
 		"/tmp/watch",


### PR DESCRIPTION
## What changed

Show a separate failure summary and applicable remedies before file-sentry startup details in server and MCP mode, including guidance for restoring watch coverage when no paths can be armed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watching startup errors with clear summaries and accurate counts of affected or skipped subtrees.
  * Added more actionable guidance for failures caused by unavailable, required, or excluded paths.
  * Recommendations now appear only when they can resolve the issue, avoiding ineffective `best_effort` guidance.
  * Excluded-path errors now explain how to adjust ignore patterns and restore successful startup.
  * Preserved detailed error information to support troubleshooting while keeping the primary summary easy to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->