### PR TITLE
fix(setup): replace recoverable older MCP wrappers

### DIFF
--- a/internal/cli/hermes/install_test.go
+++ b/internal/cli/hermes/install_test.go
@@ -105,9 +105,9 @@ func TestRunInstall_MCPOnlyDoesNotTrustForgedMarker(t *testing.T) {
 			break
 		}
 	}
-	wantSuffix := []string{"/tmp/attacker/pipelock", "mcp", "proxy", "--", "attacker-server"}
+	wantSuffix := []string{"attacker-server"}
 	if len(args) < 3 || args[0] != "mcp" || args[1] != "proxy" || separator < 0 || !slices.Equal(args[separator+1:], wantSuffix) {
-		t.Fatalf("foreign invocation was not preserved behind the new wrapper: %v", args)
+		t.Fatalf("invocation child was not recovered behind the current wrapper: %v", args)
 	}
 }
 

--- a/internal/cli/hermes/install_upgrade_test.go
+++ b/internal/cli/hermes/install_upgrade_test.go
@@ -60,3 +60,40 @@ func TestMCPOnlyInstallReplacesForeignWrapper(t *testing.T) {
 		t.Fatal("second install changed the current wrapper")
 	}
 }
+
+func TestMCPOnlyForeignRefusalPreservesConfig(t *testing.T) {
+	for _, seed := range []string{
+		"mcp_servers:\n  example:\n    command: /nonexistent/older-proxy\n    args: [mcp, proxy, --header-file, credentials.headers, --upstream, 'https://api.vendor.example/mcp']\n",
+		"mcp_servers:\n  example:\n    command: /nonexistent/older-proxy\n    args: [mcp, proxy, --upstream, 'https://api.vendor.example/mcp']\n    headers:\n      X-Example-Auth: test-only-value\n",
+	} {
+		dir := t.TempDir()
+		opts := fullOpts(dir)
+		opts.Mode = ModeMCPOnly
+		opts.PipelockConfig = filepath.Join(dir, "pipelock.yaml")
+		if err := os.WriteFile(opts.HermesConfig, []byte(seed), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		before, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmd := installCmd()
+		var output bytes.Buffer
+		cmd.SetOut(&output)
+		cmd.SetErr(&output)
+		if err := runInstall(cmd, opts); err == nil {
+			t.Fatal("refused wrapper reported successful install")
+		}
+		if !strings.Contains(output.String(), "cannot normalize wrapper") {
+			t.Fatalf("refusal warning missing: %s", output.String())
+		}
+		after, err := os.ReadFile(opts.HermesConfig)
+		if err != nil || !bytes.Equal(after, []byte(seed)) {
+			t.Fatalf("refusal changed config: %v", err)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil || len(entries) != len(before) {
+			t.Fatalf("refusal created a backup or sidecar: %v", err)
+		}
+	}
+}

--- a/internal/cli/hermes/install_upgrade_test.go
+++ b/internal/cli/hermes/install_upgrade_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -38,12 +40,15 @@ func TestMCPOnlyInstallReplacesForeignWrapper(t *testing.T) {
 		t.Fatal("missing server")
 	}
 	args := mcpwrap.InterfaceSliceToStrings(server["args"])
-	joined := strings.Join(args, " ")
-	if !mcpwrap.IsWrappedBySelf(server) || !strings.Contains(joined, "-- node server.js") || strings.Contains(joined, "older-proxy") || strings.Contains(joined, "old.yaml") {
-		t.Fatalf("upgrade did not produce one current wrapper: %v", server)
+	sep := slices.Index(args, "--")
+	if !mcpwrap.IsWrappedBySelf(server) || sep < 0 || !slices.Equal(args[sep+1:], []string{"node", "server.js"}) {
+		t.Fatalf("upgrade did not preserve the exact child: %v", server)
 	}
-	if !strings.Contains(joined, "--env EXAMPLE_MODE") {
-		t.Fatalf("env passthrough lost: %v", args)
+	if !slices.Equal(args[:sep], []string{"mcp", "proxy", "--config", opts.PipelockConfig, "--env", "EXAMPLE_MODE"}) {
+		t.Fatalf("unexpected wrapper flags: %v", args)
+	}
+	if !reflect.DeepEqual(server["env"], map[string]interface{}{"EXAMPLE_MODE": "local"}) {
+		t.Fatalf("environment values changed: %v", server["env"])
 	}
 	first, err := os.ReadFile(opts.HermesConfig)
 	if err != nil {

--- a/internal/cli/hermes/install_upgrade_test.go
+++ b/internal/cli/hermes/install_upgrade_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package hermes
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
+)
+
+func TestMCPOnlyInstallReplacesForeignWrapper(t *testing.T) {
+	dir := t.TempDir()
+	opts := fullOpts(dir)
+	opts.Mode = ModeMCPOnly
+	opts.PipelockConfig = filepath.Join(dir, "pipelock.yaml")
+	seed := "mcp_servers:\n  example:\n    command: /nonexistent/older-proxy\n    args: [mcp, proxy, --config, old.yaml, --env, EXAMPLE_MODE, --, node, server.js]\n    env:\n      EXAMPLE_MODE: local\n    _pipelock:\n      original_command: wrong-command\n"
+	if err := os.WriteFile(opts.HermesConfig, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := installCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	if err := runInstall(cmd, opts); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadHermesConfig(opts.HermesConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, ok := cfg.mcpServers()["example"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing server")
+	}
+	args := mcpwrap.InterfaceSliceToStrings(server["args"])
+	joined := strings.Join(args, " ")
+	if !mcpwrap.IsWrappedBySelf(server) || !strings.Contains(joined, "-- node server.js") || strings.Contains(joined, "older-proxy") || strings.Contains(joined, "old.yaml") {
+		t.Fatalf("upgrade did not produce one current wrapper: %v", server)
+	}
+	if !strings.Contains(joined, "--env EXAMPLE_MODE") {
+		t.Fatalf("env passthrough lost: %v", args)
+	}
+	first, err := os.ReadFile(opts.HermesConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runInstall(cmd, opts); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(opts.HermesConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("second install changed the current wrapper")
+	}
+}

--- a/internal/cli/setup/cline.go
+++ b/internal/cli/setup/cline.go
@@ -26,7 +26,7 @@ const (
 	clineConfigFilename = "mcp.json"
 	clineConfigDirname  = ".cline"
 	clineServersKey     = "mcpServers"
-	clineHTTPProbeType  = "http"
+	clineHTTPProbeType  = mcpHTTPWrapType
 )
 
 // clineMCPConfig represents Cline's mcp.json file. Unknown top-level fields
@@ -179,6 +179,9 @@ func runClineInstall(cmd *cobra.Command, override string, dryRun bool, configFil
 
 		newServer, meta, plan, err := wrapClineServer(server, exe, configFile, targetPath, name)
 		if err != nil {
+			if isNormalizationFailure(err) {
+				return fmt.Errorf("server %q: %w", name, err)
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue
 		}

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -442,6 +442,9 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 			action := codexActionWrapStdio
 			newArgs := wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile)
 			if classifyCodexWrapper(s) == stateForeignWrapper {
+				if codexURLTransportHasAuthOrHeaders(s.Transport) {
+					return nil, fmt.Errorf("server %q: %w: wrapper has HTTP authentication settings outside its invocation; restore the original server configuration before installing again", s.Name, mcpwrap.ErrCannotNormalize)
+				}
 				inner, err := mcpwrap.RecoverInner(s.Transport.Args)
 				if err != nil {
 					return nil, fmt.Errorf("server %q: %w", s.Name, err)

--- a/internal/cli/setup/codex.go
+++ b/internal/cli/setup/codex.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
 	"github.com/spf13/cobra"
 )
 
@@ -420,7 +421,7 @@ type codexInstallPlan struct {
 
 // planCodexInstall computes the wrap plan for each server. Pure function:
 // no I/O, no exec.
-func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) []codexInstallPlan {
+func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) ([]codexInstallPlan, error) {
 	plans := make([]codexInstallPlan, 0, len(servers))
 	for _, s := range servers {
 		unsupportedReason := unsupportedCodexInstallReason(s)
@@ -438,12 +439,26 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 				Reason: unsupportedReason,
 			})
 		case s.Transport.Type == codexTransportStdio && s.Transport.Command != "":
+			action := codexActionWrapStdio
+			newArgs := wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile)
+			if classifyCodexWrapper(s) == stateForeignWrapper {
+				inner, err := mcpwrap.RecoverInner(s.Transport.Args)
+				if err != nil {
+					return nil, fmt.Errorf("server %q: %w", s.Name, err)
+				}
+				if inner.Transport == mcpwrap.TransportUpstream {
+					action = codexActionWrapURL
+					newArgs = wrapCodexURL(inner.UpstreamURL, configFile)
+				} else {
+					newArgs = wrapCodexArgs(inner.Command, inner.Args, s.Transport.Env, configFile)
+				}
+			}
 			plans = append(plans, codexInstallPlan{
 				Server:   s.Name,
-				Action:   codexActionWrapStdio,
+				Action:   action,
 				Reason:   foreignCodexWrapperReason(s),
 				NewCmd:   pipelockBin,
-				NewArgs:  wrapCodexArgs(s.Transport.Command, s.Transport.Args, s.Transport.Env, configFile),
+				NewArgs:  newArgs,
 				Env:      copyStringMap(s.Transport.Env),
 				Original: s.Transport,
 			})
@@ -464,7 +479,7 @@ func planCodexInstall(servers []codexMCPServer, pipelockBin, configFile string) 
 			})
 		}
 	}
-	return plans
+	return plans, nil
 }
 
 // codexRemovePlan describes how to unwrap one server. Pure function output.
@@ -551,7 +566,10 @@ func runCodexInstall(cmd *cobra.Command, dryRun bool, configFile, codexPathOverr
 	if err != nil {
 		return err
 	}
-	plans := planCodexInstall(servers, pipelockBin, resolvedConfig.Path)
+	plans, err := planCodexInstall(servers, pipelockBin, resolvedConfig.Path)
+	if err != nil {
+		return err
+	}
 
 	wrapped, skipped := 0, 0
 	for _, p := range plans {
@@ -796,6 +814,6 @@ func foreignCodexWrapperReason(server codexMCPServer) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"runs %q with proxy arguments but that is not this pipelock binary; wrapping it, and remove-then-install for a single clean wrap",
+		"runs %q with proxy arguments from another binary; replacing the wrapper from its invocation",
 		server.Transport.Command)
 }

--- a/internal/cli/setup/codex_test.go
+++ b/internal/cli/setup/codex_test.go
@@ -475,7 +475,10 @@ func TestPlanCodexInstall(t *testing.T) {
 			},
 		},
 	}
-	plans := planCodexInstall(servers, pipelockBin, cfgPath)
+	plans, err := planCodexInstall(servers, pipelockBin, cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(plans) != 4 {
 		t.Fatalf("expected 4 plans, got %d", len(plans))
 	}
@@ -511,19 +514,7 @@ func TestPlanCodexInstall(t *testing.T) {
 }
 
 func TestPlanCodexInstall_DifferentPipelockBinIsWrapped(t *testing.T) {
-	// A server wrapped by a pipelock at ANOTHER path is wrapped again rather than
-	// skipped, and that inverts what this test used to assert.
-	//
-	// The old behaviour keyed on a "pipelock" basename plus the canonical argument
-	// prefix, so it was location-independent and idempotent across paths. That is a
-	// fail-open: any config can name an attacker binary "pipelock" and be skipped,
-	// leaving it unmediated. Identity cannot be forged by naming, and the installer
-	// cannot prove that some other file called pipelock is pipelock.
-	//
-	// The cost is the nesting this test's original comment worried about. It is
-	// accepted deliberately: the result is still mediated by this binary, the
-	// installer warns, and the operator can remove-then-install for a single clean
-	// wrap. Normalising the nested invocation instead is tracked separately.
+	// Recover the invocation child without trusting the old binary or marker.
 	servers := []codexMCPServer{{
 		Name: "old-wrap",
 		Transport: codexMCPTransport{
@@ -532,9 +523,18 @@ func TestPlanCodexInstall_DifferentPipelockBinIsWrapped(t *testing.T) {
 			Args:    []string{"mcp", "proxy", "--", "node", "x.js"},
 		},
 	}}
-	plans := planCodexInstall(servers, pipelockBin, "")
+	plans, err := planCodexInstall(servers, pipelockBin, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(plans) != 1 {
 		t.Fatalf("expected 1 plan, got %d", len(plans))
+	}
+	if !reflect.DeepEqual(plans[0].NewArgs, []string{"mcp", "proxy", "--", "node", "x.js"}) {
+		t.Fatalf("foreign wrapper survived: %v", plans[0].NewArgs)
+	}
+	if !reflect.DeepEqual(plans[0].Original, servers[0].Transport) {
+		t.Fatal("upgrade changed the rollback transport")
 	}
 	if plans[0].Action == codexActionSkipWrapped {
 		t.Errorf("a pipelock at another path was skipped; it cannot be proven to be pipelock, so it must be wrapped")
@@ -606,7 +606,10 @@ func TestPlanCodexInstall_SkipsUnsupportedCodexState(t *testing.T) {
 		},
 	}
 
-	plans := planCodexInstall(servers, pipelockBin, "")
+	plans, err := planCodexInstall(servers, pipelockBin, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(plans) != len(servers) {
 		t.Fatalf("expected %d plans, got %d", len(servers), len(plans))
 	}

--- a/internal/cli/setup/codex_upgrade_test.go
+++ b/internal/cli/setup/codex_upgrade_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
+)
+
+func TestCodexInstallForeignUpgradeAndRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		want   string
+		refuse bool
+	}{
+		{"stdio", []string{"mcp", "proxy", "--", "node", "server.js"}, "--env EXAMPLE_MODE -- node server.js", false},
+		{"upstream", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}, "--upstream https://api.vendor.example/mcp", false},
+		{"sidecar", []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}, "", true},
+		{"missing upstream URL", []string{"mcp", "proxy", "--upstream", "--header-file"}, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			servers := []codexMCPServer{
+				{Name: "fresh", Transport: codexMCPTransport{Type: codexTransportStdio, Command: "node", Args: []string{"fresh.js"}}},
+				{Name: "upgrading", Transport: codexMCPTransport{Type: codexTransportStdio, Command: foreignBinary, Args: tc.args, Env: map[string]string{"EXAMPLE_MODE": "local"}}},
+			}
+			list, err := json.Marshal(servers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bin, logPath := fakeCodex(t, string(list))
+			cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
+			if err := os.WriteFile(cfgPath, []byte("version: 1\nmode: balanced\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := newCodexTestRoot()
+			cmd.SetArgs([]string{"codex", "install", "--codex-path", bin, "--config", cfgPath})
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			installErr := cmd.Execute()
+			logData, err := os.ReadFile(filepath.Clean(logPath))
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			if tc.refuse {
+				if !errors.Is(installErr, mcpwrap.ErrCannotNormalize) {
+					t.Fatalf("install error = %v, want refusal; output: %s", installErr, output.String())
+				}
+				if len(bytes.TrimSpace(logData)) != 0 {
+					t.Fatalf("refusal modified a server: %s", logData)
+				}
+				return
+			}
+			if installErr != nil {
+				t.Fatal(installErr)
+			}
+			if strings.Contains(string(logData), foreignBinary) || !strings.Contains(string(logData), tc.want) {
+				t.Fatalf("upgrade did not replace the foreign wrapper: %s", logData)
+			}
+		})
+	}
+}

--- a/internal/cli/setup/codex_upgrade_test.go
+++ b/internal/cli/setup/codex_upgrade_test.go
@@ -69,3 +69,19 @@ func TestCodexInstallForeignUpgradeAndRefusal(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanCodexForeignAuthRefused(t *testing.T) {
+	for _, transport := range []codexMCPTransport{
+		{HTTPHeaders: json.RawMessage(`{"X-Example-Auth":"test-only-value"}`)},
+		{EnvHTTPHeaders: json.RawMessage(`{"X-Example-Auth":"EXAMPLE_AUTH"}`)},
+		{BearerTokenEnvVar: "EXAMPLE_AUTH"},
+	} {
+		transport.Type = codexTransportStdio
+		transport.Command = foreignBinary
+		transport.Args = []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}
+		plans, err := planCodexInstall([]codexMCPServer{{Name: "example", Transport: transport}}, "/current/proxy", "config.yaml")
+		if !errors.Is(err, mcpwrap.ErrCannotNormalize) || plans != nil {
+			t.Fatalf("ambiguous authentication produced a replacement plan: %v %v", plans, err)
+		}
+	}
+}

--- a/internal/cli/setup/codex_upgrade_test.go
+++ b/internal/cli/setup/codex_upgrade_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -19,17 +21,21 @@ func TestCodexInstallForeignUpgradeAndRefusal(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		args   []string
-		want   string
+		want   []string
 		refuse bool
 	}{
-		{"stdio", []string{"mcp", "proxy", "--", "node", "server.js"}, "--env EXAMPLE_MODE -- node server.js", false},
-		{"upstream", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}, "--upstream https://api.vendor.example/mcp", false},
-		{"sidecar", []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}, "", true},
-		{"missing upstream URL", []string{"mcp", "proxy", "--upstream", "--header-file"}, "", true},
+		{"stdio", []string{"mcp", "proxy", "--", "node", "server.js"}, []string{"--env", "EXAMPLE_MODE", "--", "node", "server.js"}, false},
+		{"upstream", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}, []string{"--upstream", "https://api.vendor.example/mcp"}, false},
+		{"sidecar", []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}, nil, true},
+		{"missing upstream URL", []string{"mcp", "proxy", "--upstream", "--header-file"}, nil, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			exe, err := resolvePipelockBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
 			servers := []codexMCPServer{
-				{Name: "fresh", Transport: codexMCPTransport{Type: codexTransportStdio, Command: "node", Args: []string{"fresh.js"}}},
+				{Name: "fresh", Transport: codexMCPTransport{Type: codexTransportStdio, Command: exe, Args: []string{"mcp", "proxy", "--", "node", "fresh.js"}}},
 				{Name: "upgrading", Transport: codexMCPTransport{Type: codexTransportStdio, Command: foreignBinary, Args: tc.args, Env: map[string]string{"EXAMPLE_MODE": "local"}}},
 			}
 			list, err := json.Marshal(servers)
@@ -37,6 +43,16 @@ func TestCodexInstallForeignUpgradeAndRefusal(t *testing.T) {
 				t.Fatal(err)
 			}
 			bin, logPath := fakeCodex(t, string(list))
+			// Preserve argv boundaries and separate invocations, including empty args.
+			script := fmt.Sprintf(`#!/bin/sh
+case "$1 $2" in
+"mcp list") cat %q; exit 0 ;;
+esac
+printf '%%s\000' "$@" >> %q
+printf '\000' >> %q
+`, filepath.Join(filepath.Dir(bin), "list.json"), logPath, logPath)
+			writeShellScript(t, bin, script)
+
 			cfgPath := filepath.Join(t.TempDir(), "pipelock.yaml")
 			if err := os.WriteFile(cfgPath, []byte("version: 1\nmode: balanced\n"), 0o600); err != nil {
 				t.Fatal(err)
@@ -63,8 +79,11 @@ func TestCodexInstallForeignUpgradeAndRefusal(t *testing.T) {
 			if installErr != nil {
 				t.Fatal(installErr)
 			}
-			if strings.Contains(string(logData), foreignBinary) || !strings.Contains(string(logData), tc.want) {
-				t.Fatalf("upgrade did not replace the foreign wrapper: %s", logData)
+			wantAdd := []string{"mcp", "add", "--env", "EXAMPLE_MODE=local", "upgrading", "--", exe, "mcp", "proxy", "--config", cfgPath}
+			wantAdd = append(wantAdd, tc.want...)
+			wantLog := strings.Join([]string{"mcp", "remove", "upgrading"}, "\x00") + "\x00\x00" + strings.Join(wantAdd, "\x00") + "\x00\x00"
+			if !slices.Equal(logData, []byte(wantLog)) {
+				t.Fatalf("upgrade invocations = %q, want %q (fresh server must remain untouched)", logData, wantLog)
 			}
 		})
 	}

--- a/internal/cli/setup/continue.go
+++ b/internal/cli/setup/continue.go
@@ -354,6 +354,15 @@ func continueServerName(server map[string]interface{}, index int) string {
 }
 
 func wrapContinueServer(server map[string]interface{}, exe, configFile string) (map[string]interface{}, error) {
+	// Normalize a foreign wrapper down to its bare child before wrapping, so an
+	// upgrade over a pipelock installed at a different path rewraps the ORIGINAL
+	// command instead of nesting proxy invocations. A recovered remote
+	// child needs no type (Continue infers streamable-http from url).
+	server, normErr := normalizeForeignWrapper(server, "")
+	if normErr != nil {
+		return nil, normErr
+	}
+
 	_, hasCommand := server[mcpFieldCommand]
 	_, hasURL := server[mcpFieldURL]
 	if hasCommand == hasURL {

--- a/internal/cli/setup/continue_test.go
+++ b/internal/cli/setup/continue_test.go
@@ -441,11 +441,13 @@ func TestContinueInstall_WarnsForForeignAndUnrestorableWrappers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("install: %v", err)
 	}
-	if !strings.Contains(stderr, "that is not this pipelock binary") {
+	if !strings.Contains(stderr, "from another binary") {
 		t.Fatalf("foreign-wrapper warning missing: %q", stderr)
 	}
-	// A foreign wrapper is wrapped again (the warning explains, it does not
-	// refuse); the foreign command survives as the recorded original.
+	// A foreign wrapper is normalized from its own invocation to a single clean
+	// wrap through this binary: the recovered INNER command (node
+	// server.js) becomes the recorded original, and the foreign binary path does
+	// not survive anywhere in the wrapped entry.
 	exe, err := resolvePipelockBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -454,8 +456,28 @@ func TestContinueInstall_WarnsForForeignAndUnrestorableWrappers(t *testing.T) {
 	if wrapped[0][mcpFieldCommand] != exe {
 		t.Fatalf("foreign wrapper was not wrapped by this binary: %#v", wrapped[0])
 	}
-	if meta, _ := wrapped[0][mcpFieldPipelock].(map[string]interface{}); meta["original_command"] != "/tmp/other-pipelock" {
-		t.Fatalf("foreign command not recorded as the original: %#v", wrapped[0][mcpFieldPipelock])
+	meta, _ := wrapped[0][mcpFieldPipelock].(map[string]interface{})
+	if meta["original_command"] != "node" {
+		t.Fatalf("recovered inner command not recorded as the original: %#v", wrapped[0][mcpFieldPipelock])
+	}
+	wrappedArgs := interfaceSliceToStrings(wrapped[0][mcpFieldArgs])
+	sep := -1
+	for i, a := range wrappedArgs {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 || len(wrappedArgs)-sep-1 < 2 {
+		t.Fatalf("wrapped args have no child tail: %#v", wrappedArgs)
+	}
+	if got := wrappedArgs[sep+1:]; len(got) != 2 || got[0] != "node" || got[1] != "server.js" {
+		t.Fatalf("child tail not the recovered inner command: %#v", got)
+	}
+	for _, a := range wrappedArgs {
+		if strings.Contains(a, "other-pipelock") {
+			t.Fatalf("foreign binary survived in the wrapped args (nested wrap): %#v", wrappedArgs)
+		}
 	}
 	const unrestorable = `mcpServers:
   - name: marked-but-direct

--- a/internal/cli/setup/continue_test.go
+++ b/internal/cli/setup/continue_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -474,10 +475,15 @@ func TestContinueInstall_WarnsForForeignAndUnrestorableWrappers(t *testing.T) {
 	if got := wrappedArgs[sep+1:]; len(got) != 2 || got[0] != "node" || got[1] != "server.js" {
 		t.Fatalf("child tail not the recovered inner command: %#v", got)
 	}
-	for _, a := range wrappedArgs {
-		if strings.Contains(a, "other-pipelock") {
-			t.Fatalf("foreign binary survived in the wrapped args (nested wrap): %#v", wrappedArgs)
-		}
+	encoded, err := yaml.Marshal(wrapped[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "other-pipelock") {
+		t.Fatalf("foreign binary survived in the server entry: %s", encoded)
+	}
+	if got := interfaceSliceToStrings(meta["original_args"]); !reflect.DeepEqual(got, []string{"server.js"}) {
+		t.Fatalf("recovered metadata args = %q", got)
 	}
 	const unrestorable = `mcpServers:
   - name: marked-but-direct
@@ -1009,4 +1015,37 @@ func TestWriteInstallerBackup_NeverFollowsTheBackupPath(t *testing.T) {
 			t.Fatalf("fresh backup mode = %o, want 600", info.Mode().Perm())
 		}
 	})
+}
+
+func TestContinueInstallForeignRefusalPreservesConfig(t *testing.T) {
+	for _, headers := range []bool{false, true} {
+		t.Run(map[bool]string{false: "sidecar", true: "header-map"}[headers], func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			path := filepath.Join(home, continueDirname, continueConfigName)
+			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			server := map[string]interface{}{"name": "foreign", "command": "/nonexistent/older-proxy", "args": []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}}
+			if headers {
+				server["args"] = []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}
+				server["headers"] = map[string]string{"X-Example-Auth": "test-only-value"}
+			}
+			data, err := yaml.Marshal(map[string]interface{}{"mcpServers": []interface{}{map[string]interface{}{"name": "fresh", "command": "node", "args": []string{"fresh.js"}}, server}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before := snapshotTree(t, home)
+			_, err = runContinueCmdWithOutput(t, "install")
+			if !errors.Is(err, mcpwrap.ErrCannotNormalize) {
+				t.Fatalf("install error = %v, want fatal normalization refusal", err)
+			}
+			if after := snapshotTree(t, home); !reflect.DeepEqual(before, after) {
+				t.Fatalf("refusal changed files: before=%v after=%v", before, after)
+			}
+		})
+	}
 }

--- a/internal/cli/setup/foreign_normalize_test.go
+++ b/internal/cli/setup/foreign_normalize_test.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// foreignBinary is a path that is never this test binary, so classifyWrapper
+// treats an entry running it through `mcp proxy` as a foreign wrapper.
+const foreignBinary = "/nonexistent/other-pipelock"
+
+func argsOf(t *testing.T, server map[string]interface{}) []string {
+	t.Helper()
+	return commandArgStrings(server[mcpFieldArgs])
+}
+
+func argsContain(args []string, sub string) bool {
+	for _, a := range args {
+		if strings.Contains(a, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// childTail returns the arguments after the `--` separator.
+func childTail(args []string) []string {
+	for i, a := range args {
+		if a == "--" {
+			return args[i+1:]
+		}
+	}
+	return nil
+}
+
+// TestNormalizeForeign_VscodeStdioSingleWrap is the upgrade case: installing
+// over a wrapper written by a pipelock at a different path must produce a single
+// clean wrap through THIS binary, recording the recovered inner command as the
+// original, with the foreign binary path and the foreign flags gone and the
+// env passthrough preserved.
+func TestNormalizeForeign_VscodeStdioSingleWrap(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs: []interface{}{
+			"mcp", "proxy", "--config", "/old/pipelock.yaml", "--env", "API_KEY", "--", "node", "server.js",
+		},
+		"env": map[string]interface{}{"API_KEY": "unused-by-key-extraction"},
+	}
+	result, meta, _, err := wrapVscodeServer(foreign, self, "/new/pipelock.yaml", t.TempDir(), "srv")
+	if err != nil {
+		t.Fatalf("wrapVscodeServer: %v", err)
+	}
+	if result[mcpFieldCommand] != self {
+		t.Fatalf("wrapped command = %v, want this binary %q", result[mcpFieldCommand], self)
+	}
+	if meta.OriginalCommand != "node" || strings.Join(meta.OriginalArgs, ",") != "server.js" {
+		t.Fatalf("recovered original from invocation wrong: cmd=%q args=%v", meta.OriginalCommand, meta.OriginalArgs)
+	}
+	args := argsOf(t, result)
+	if tail := childTail(args); len(tail) != 2 || tail[0] != "node" || tail[1] != "server.js" {
+		t.Fatalf("child tail = %v, want [node server.js]", tail)
+	}
+	if argsContain(args, "other-pipelock") {
+		t.Fatalf("foreign binary survived (nested wrap): %v", args)
+	}
+	if argsContain(args, "/old/pipelock.yaml") {
+		t.Fatalf("foreign --config survived instead of the current one: %v", args)
+	}
+	if !argsContain(args, "/new/pipelock.yaml") {
+		t.Fatalf("current --config not rebuilt: %v", args)
+	}
+	if !argsContain(args, "API_KEY") {
+		t.Fatalf("env passthrough not preserved: %v", args)
+	}
+	// The env flag is rebuilt from the env block, not duplicated from the
+	// foreign invocation's own --env flags.
+	envCount := 0
+	for _, a := range args {
+		if a == "--env" {
+			envCount++
+		}
+	}
+	if envCount != 1 {
+		t.Fatalf("--env flag count = %d, want 1 (no duplication)", envCount)
+	}
+}
+
+func TestNormalizeForeign_VscodeHTTPUpstream(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"},
+	}
+	result, meta, _, err := wrapVscodeServer(foreign, self, "", t.TempDir(), "srv")
+	if err != nil {
+		t.Fatalf("wrapVscodeServer: %v", err)
+	}
+	if meta.OriginalURL != "https://api.vendor.example/mcp" {
+		t.Fatalf("recovered upstream = %q", meta.OriginalURL)
+	}
+	args := argsOf(t, result)
+	if !argsContain(args, "--upstream") || !argsContain(args, "https://api.vendor.example/mcp") {
+		t.Fatalf("upstream not rebuilt: %v", args)
+	}
+	if argsContain(args, "other-pipelock") {
+		t.Fatalf("foreign binary survived: %v", args)
+	}
+}
+
+// TestNormalizeForeign_VscodeHTTPHeaderFileRefused proves the one case that must
+// refuse rather than guess: an older HTTP wrapper whose credentials live in a
+// header sidecar cannot be recovered from the invocation alone.
+func TestNormalizeForeign_VscodeHTTPHeaderFileRefused(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--header-file", "/old.headers", "--upstream", "https://api.vendor.example/mcp"},
+	}
+	_, _, _, err = wrapVscodeServer(foreign, self, "", t.TempDir(), "srv")
+	if err == nil {
+		t.Fatal("expected a refusal for a header-sidecar wrapper, got nil")
+	}
+	if !strings.Contains(err.Error(), "header sidecar") || !strings.Contains(err.Error(), "remove") {
+		t.Fatalf("refusal error lacks the credential reason or remedy: %v", err)
+	}
+}
+
+// TestNormalizeForeign_ForgedMetadataIgnored proves normalization reads the child
+// from the invocation, never from the _pipelock marker. A config-controlled
+// marker claiming a different original must not steer the result.
+func TestNormalizeForeign_ForgedMetadataIgnored(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "real-server", "--flag"},
+		mcpFieldPipelock: map[string]interface{}{
+			"original_command": "forged-server",
+			"original_args":    []interface{}{"forged"},
+		},
+	}
+	_, meta, _, err := wrapVscodeServer(foreign, self, "", t.TempDir(), "srv")
+	if err != nil {
+		t.Fatalf("wrapVscodeServer: %v", err)
+	}
+	if meta.OriginalCommand != "real-server" {
+		t.Fatalf("recovered original = %q, want the invocation's real-server (marker was forged)", meta.OriginalCommand)
+	}
+}
+
+func TestNormalizeForeign_OpenCodeArray(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	t.Run("stdio", func(t *testing.T) {
+		foreign := map[string]interface{}{
+			mcpFieldType: opencodeTypeLocal,
+			mcpFieldCommand: []interface{}{
+				foreignBinary, "mcp", "proxy", "--config", "/old.yaml", "--", "node", "server.js",
+			},
+		}
+		result, meta, _, err := wrapOpenCodeServer(foreign, self, "/new.yaml", t.TempDir(), "srv")
+		if err != nil {
+			t.Fatalf("wrapOpenCodeServer: %v", err)
+		}
+		if meta.OriginalCommand != "node" {
+			t.Fatalf("recovered inner = %q, want node", meta.OriginalCommand)
+		}
+		cmd := commandArgStrings(result[mcpFieldCommand])
+		if cmd[0] != self {
+			t.Fatalf("wrapped command[0] = %q, want this binary", cmd[0])
+		}
+		if argsContain(cmd, "other-pipelock") {
+			t.Fatalf("foreign binary survived: %v", cmd)
+		}
+		if tail := childTail(cmd); len(tail) != 2 || tail[0] != "node" || tail[1] != "server.js" {
+			t.Fatalf("child tail = %v, want [node server.js]", tail)
+		}
+	})
+	t.Run("http", func(t *testing.T) {
+		foreign := map[string]interface{}{
+			mcpFieldType: opencodeTypeLocal,
+			mcpFieldCommand: []interface{}{
+				foreignBinary, "mcp", "proxy", "--upstream", "https://api.vendor.example/mcp",
+			},
+		}
+		result, meta, _, err := wrapOpenCodeServer(foreign, self, "", t.TempDir(), "srv")
+		if err != nil {
+			t.Fatalf("wrapOpenCodeServer: %v", err)
+		}
+		if meta.OriginalURL != "https://api.vendor.example/mcp" {
+			t.Fatalf("recovered upstream = %q", meta.OriginalURL)
+		}
+		cmd := commandArgStrings(result[mcpFieldCommand])
+		if !argsContain(cmd, "--upstream") || argsContain(cmd, "other-pipelock") {
+			t.Fatalf("upstream not rebuilt cleanly: %v", cmd)
+		}
+	})
+	t.Run("header sidecar refused", func(t *testing.T) {
+		foreign := map[string]interface{}{
+			mcpFieldType: opencodeTypeLocal,
+			mcpFieldCommand: []interface{}{
+				foreignBinary, "mcp", "proxy", "--header-file", "/old.headers", "--upstream", "https://api.vendor.example/mcp",
+			},
+		}
+		_, _, _, err := wrapOpenCodeServer(foreign, self, "", t.TempDir(), "srv")
+		if err == nil {
+			t.Fatal("expected refusal for opencode header-sidecar wrapper, got nil")
+		}
+		if !strings.Contains(err.Error(), "header sidecar") {
+			t.Fatalf("refusal error lacks the credential reason: %v", err)
+		}
+	})
+}
+
+func TestNormalizeForeign_JetBrains(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--sandbox", "--workspace", "/old/ws", "--", "node"},
+	}
+	result, meta, err := wrapMCPServer(foreign, self, "/new.yaml", true, "/new/ws")
+	if err != nil {
+		t.Fatalf("wrapMCPServer: %v", err)
+	}
+	if meta.OriginalCommand != "node" {
+		t.Fatalf("recovered inner = %q, want node", meta.OriginalCommand)
+	}
+	args := argsOf(t, result)
+	if argsContain(args, "other-pipelock") || argsContain(args, "/old/ws") {
+		t.Fatalf("foreign binary or workspace survived: %v", args)
+	}
+	if !argsContain(args, "/new/ws") {
+		t.Fatalf("current --workspace not rebuilt: %v", args)
+	}
+}
+
+func TestNormalizeForeign_ContinueHTTPInfersTransport(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"},
+	}
+	result, err := wrapContinueServer(foreign, self, "")
+	if err != nil {
+		t.Fatalf("wrapContinueServer: %v", err)
+	}
+	meta, _ := result[mcpFieldPipelock].(map[string]interface{})
+	if meta["original_url"] != "https://api.vendor.example/mcp" {
+		t.Fatalf("recovered upstream not recorded: %#v", meta)
+	}
+	if meta["original_type"] != continueTypeStreamHTTP {
+		t.Fatalf("continue should infer streamable-http, got %v", meta["original_type"])
+	}
+	if argsContain(argsOf(t, result), "other-pipelock") {
+		t.Fatalf("foreign binary survived: %v", argsOf(t, result))
+	}
+}
+
+// TestNormalizeForeign_RepeatInstallIdempotent proves the normalized result is a
+// genuine self-wrap, so a SECOND install skips it (isWrappedBySelf) rather than
+// wrapping it again.
+func TestNormalizeForeign_RepeatInstallIdempotent(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "node", "server.js"},
+	}
+	result, _, _, err := wrapVscodeServer(foreign, self, "", t.TempDir(), "srv")
+	if err != nil {
+		t.Fatalf("wrapVscodeServer: %v", err)
+	}
+	if !isWrappedBySelf(result) {
+		t.Fatalf("normalized result is not self-wrapped, so a repeat install would nest it: %#v", result)
+	}
+}
+
+// TestNormalizeForeign_RoundTripRemovalRestoresRecoveredInner proves remove now
+// unwinds fully to the recovered inner command, not the foreign wrapper.
+func TestNormalizeForeign_RoundTripRemovalRestoresRecoveredInner(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	dir := t.TempDir()
+	foreign := map[string]interface{}{
+		mcpFieldType:    vsTypeStdio,
+		mcpFieldCommand: foreignBinary,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "node", "server.js"},
+	}
+	result, meta, _, err := wrapVscodeServer(foreign, self, "", dir, "srv")
+	if err != nil {
+		t.Fatalf("wrapVscodeServer: %v", err)
+	}
+	mj, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	var mm interface{}
+	if err := json.Unmarshal(mj, &mm); err != nil {
+		t.Fatalf("unmarshal meta: %v", err)
+	}
+	result[mcpFieldPipelock] = mm
+
+	restored, _, err := unwrapVscodeServer(result, dir, "srv")
+	if err != nil {
+		t.Fatalf("unwrapVscodeServer: %v", err)
+	}
+	if restored[mcpFieldCommand] != "node" {
+		t.Fatalf("restored command = %v, want the recovered inner node (not the foreign wrapper)", restored[mcpFieldCommand])
+	}
+	if got := commandArgStrings(restored[mcpFieldArgs]); len(got) != 1 || got[0] != "server.js" {
+		t.Fatalf("restored args = %v, want [server.js]", got)
+	}
+}
+
+// TestNormalizeForeign_NonForeignPassThrough is the positive clean case: a bare
+// server and a genuine self-wrapper are returned by the normalizer unchanged, so
+// ordinary installs are unaffected.
+func TestNormalizeForeign_NonForeignPassThrough(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	bare := map[string]interface{}{
+		mcpFieldCommand: "node",
+		mcpFieldArgs:    []interface{}{"server.js"},
+	}
+	got, err := normalizeForeignWrapper(bare, mcpHTTPWrapType)
+	if err != nil {
+		t.Fatalf("normalizeForeignWrapper(bare): %v", err)
+	}
+	if got[mcpFieldCommand] != "node" {
+		t.Fatalf("bare server was altered: %#v", got)
+	}
+
+	selfWrap := map[string]interface{}{
+		mcpFieldCommand: self,
+		mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", "node"},
+	}
+	got, err = normalizeForeignWrapper(selfWrap, mcpHTTPWrapType)
+	if err != nil {
+		t.Fatalf("normalizeForeignWrapper(self): %v", err)
+	}
+	if got[mcpFieldCommand] != self {
+		t.Fatalf("self-wrapper was altered: %#v", got)
+	}
+	// OpenCode variant: a non-foreign array command is returned unchanged.
+	bareOC := map[string]interface{}{mcpFieldCommand: []interface{}{"node", "server.js"}}
+	gotOC, err := normalizeForeignOpenCodeWrapper(bareOC)
+	if err != nil {
+		t.Fatalf("normalizeForeignOpenCodeWrapper(bare): %v", err)
+	}
+	if cmd := commandArgStrings(gotOC[mcpFieldCommand]); len(cmd) != 2 || cmd[0] != "node" {
+		t.Fatalf("bare opencode command altered: %#v", gotOC)
+	}
+}

--- a/internal/cli/setup/foreign_refusal_test.go
+++ b/internal/cli/setup/foreign_refusal_test.go
@@ -30,61 +30,73 @@ func TestInstallerForeignRefusalPreservesConfig(t *testing.T) {
 		{"opencode", OpenCodeCmd, "opencode.json", "mcp", false, true},
 		{"zed", ZedCmd, "settings.json", "context_servers", false, false},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Chdir(dir)
-			configPath := filepath.Join(dir, "pipelock.yaml")
-			if err := os.WriteFile(configPath, []byte("version: 1\nmode: balanced\n"), 0o600); err != nil {
-				t.Fatal(err)
+		for _, headerMap := range []bool{false, true} {
+			name := tc.name + "/sidecar"
+			if headerMap {
+				name = tc.name + "/header-map"
 			}
-			args := []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}
-			server := map[string]interface{}{"command": foreignBinary, "args": args}
-			if tc.array {
-				server = map[string]interface{}{"type": "local", "command": append([]string{foreignBinary}, args...)}
-			}
-			data, err := json.Marshal(map[string]interface{}{tc.key: map[string]interface{}{"example": server}})
-			if err != nil {
-				t.Fatal(err)
-			}
-			path := filepath.Join(dir, tc.path)
-			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(path, data, 0o600); err != nil {
-				t.Fatal(err)
-			}
-			before, err := os.ReadDir(filepath.Dir(path))
-			if err != nil {
-				t.Fatal(err)
-			}
-			cmd := tc.newCmd()
-			var output bytes.Buffer
-			cmd.SetOut(&output)
-			cmd.SetErr(&output)
-			cmdArgs := []string{"install", "--config", configPath}
-			if tc.project {
-				cmdArgs = append(cmdArgs, "--project")
-			} else {
-				cmdArgs = append(cmdArgs, "--path", path)
-			}
-			cmd.SetArgs(cmdArgs)
-			if err := cmd.Execute(); !errors.Is(err, mcpwrap.ErrCannotNormalize) {
-				t.Fatalf("install error = %v, want refusal; output: %s", err, output.String())
-			}
-			after, err := os.ReadFile(filepath.Clean(path))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(after, data) {
-				t.Fatal("refused install changed the configuration")
-			}
-			entries, err := os.ReadDir(filepath.Dir(path))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(entries) != len(before) {
-				t.Fatal("refused install created a backup or sidecar")
-			}
-		})
+			t.Run(name, func(t *testing.T) {
+				dir := t.TempDir()
+				t.Chdir(dir)
+				configPath := filepath.Join(dir, "pipelock.yaml")
+				if err := os.WriteFile(configPath, []byte("version: 1\nmode: balanced\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				args := []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}
+				if headerMap {
+					args = []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}
+				}
+				server := map[string]interface{}{"command": foreignBinary, "args": args}
+				if tc.array {
+					server = map[string]interface{}{"type": "local", "command": append([]string{foreignBinary}, args...)}
+				}
+				if headerMap {
+					server["headers"] = map[string]interface{}{"X-Example-Auth": "test-only-value"}
+				}
+				data, err := json.Marshal(map[string]interface{}{tc.key: map[string]interface{}{"example": server}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				path := filepath.Join(dir, tc.path)
+				if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				before, err := os.ReadDir(filepath.Dir(path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				cmd := tc.newCmd()
+				var output bytes.Buffer
+				cmd.SetOut(&output)
+				cmd.SetErr(&output)
+				cmdArgs := []string{"install", "--config", configPath}
+				if tc.project {
+					cmdArgs = append(cmdArgs, "--project")
+				} else {
+					cmdArgs = append(cmdArgs, "--path", path)
+				}
+				cmd.SetArgs(cmdArgs)
+				if err := cmd.Execute(); !errors.Is(err, mcpwrap.ErrCannotNormalize) {
+					t.Fatalf("install error = %v, want refusal; output: %s", err, output.String())
+				}
+				after, err := os.ReadFile(filepath.Clean(path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(after, data) {
+					t.Fatal("refused install changed the configuration")
+				}
+				entries, err := os.ReadDir(filepath.Dir(path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(entries) != len(before) {
+					t.Fatal("refused install created a backup or sidecar")
+				}
+			})
+		}
 	}
 }

--- a/internal/cli/setup/foreign_refusal_test.go
+++ b/internal/cli/setup/foreign_refusal_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/mcpwrap"
+	"github.com/spf13/cobra"
+)
+
+func TestInstallerForeignRefusalPreservesConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		newCmd  func() *cobra.Command
+		path    string
+		key     string
+		project bool
+		array   bool
+	}{
+		{"vscode", VscodeCmd, ".vscode/mcp.json", "servers", true, false},
+		{"jetbrains", JetbrainsCmd, ".junie/mcp/mcp.json", "mcpServers", true, false},
+		{"cline", ClineCmd, "mcp.json", "mcpServers", false, false},
+		{"opencode", OpenCodeCmd, "opencode.json", "mcp", false, true},
+		{"zed", ZedCmd, "settings.json", "context_servers", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			configPath := filepath.Join(dir, "pipelock.yaml")
+			if err := os.WriteFile(configPath, []byte("version: 1\nmode: balanced\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"mcp", "proxy", "--header-file", "credentials.headers", "--upstream", "https://api.vendor.example/mcp"}
+			server := map[string]interface{}{"command": foreignBinary, "args": args}
+			if tc.array {
+				server = map[string]interface{}{"type": "local", "command": append([]string{foreignBinary}, args...)}
+			}
+			data, err := json.Marshal(map[string]interface{}{tc.key: map[string]interface{}{"example": server}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, tc.path)
+			if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadDir(filepath.Dir(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := tc.newCmd()
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmdArgs := []string{"install", "--config", configPath}
+			if tc.project {
+				cmdArgs = append(cmdArgs, "--project")
+			} else {
+				cmdArgs = append(cmdArgs, "--path", path)
+			}
+			cmd.SetArgs(cmdArgs)
+			if err := cmd.Execute(); !errors.Is(err, mcpwrap.ErrCannotNormalize) {
+				t.Fatalf("install error = %v, want refusal; output: %s", err, output.String())
+			}
+			after, err := os.ReadFile(filepath.Clean(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, data) {
+				t.Fatal("refused install changed the configuration")
+			}
+			entries, err := os.ReadDir(filepath.Dir(path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != len(before) {
+				t.Fatal("refused install created a backup or sidecar")
+			}
+		})
+	}
+}

--- a/internal/cli/setup/jetbrains.go
+++ b/internal/cli/setup/jetbrains.go
@@ -167,6 +167,9 @@ func runJetbrainsInstall(cmd *cobra.Command, global, project, dryRun bool, confi
 
 		newServer, meta, err := wrapMCPServer(server, exe, resolvedConfig.Path, sandbox, workspace)
 		if err != nil {
+			if isNormalizationFailure(err) {
+				return fmt.Errorf("server %q: %w", name, err)
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue
 		}

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -437,7 +437,7 @@ func normalizeForeignWrapper(server map[string]interface{}, httpType string) (ma
 	if classifyWrapper(server) != stateForeignWrapper {
 		return server, nil
 	}
-	inner, err := mcpwrap.RecoverInner(commandArgStrings(server[mcpFieldArgs]))
+	inner, err := mcpwrap.RecoverServerInvocation(server, commandArgStrings(server[mcpFieldArgs]))
 	if err != nil {
 		if errors.Is(err, mcpwrap.ErrNotProxyInvocation) {
 			// Classified foreign but not a command/args-shaped proxy invocation;
@@ -474,7 +474,7 @@ func normalizeForeignOpenCodeWrapper(server map[string]interface{}) (map[string]
 	if len(command) == 0 {
 		return server, nil
 	}
-	inner, err := mcpwrap.RecoverInner(command[1:])
+	inner, err := mcpwrap.RecoverServerInvocation(server, command[1:])
 	if err != nil {
 		if errors.Is(err, mcpwrap.ErrNotProxyInvocation) {
 			return server, nil

--- a/internal/cli/setup/mcpwrap.go
+++ b/internal/cli/setup/mcpwrap.go
@@ -5,6 +5,7 @@ package setup
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +24,11 @@ const (
 	mcpFieldHeaders  = "headers"
 	mcpFieldType     = "type"
 	mcpFieldPipelock = "_pipelock"
+	// mcpHTTPWrapType is the transport label given to a remote child recovered
+	// from a foreign wrapper, so command/args installers whose wrap routes HTTP
+	// by an explicit type (JetBrains, VS Code) send it down their HTTP branch.
+	// Installers that infer the transport from url-presence pass "".
+	mcpHTTPWrapType = "http"
 )
 
 // mcpConfig is a generic MCP config file with a server map under a
@@ -88,6 +94,14 @@ func marshalMCPConfig(originalData []byte, cfg *mcpConfig, serversKey string) ([
 // wrapMCPServer wraps a single MCP server entry through pipelock mcp proxy.
 // Works for any IDE config format that uses command/args (stdio) or url (HTTP).
 func wrapMCPServer(server map[string]interface{}, exe, configFile string, sandbox bool, workspace string) (map[string]interface{}, *pipelockMeta, error) {
+	// Normalize a foreign wrapper (one written by a pipelock at a different path)
+	// down to the bare child it wraps, so we re-wrap the ORIGINAL command through
+	// this binary instead of nesting one proxy invocation inside another.
+	server, err := normalizeForeignWrapper(server, mcpHTTPWrapType)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	serverType, _ := server[mcpFieldType].(string)
 	typeOmitted := serverType == ""
 	if typeOmitted {
@@ -375,7 +389,7 @@ func warnForeignWrapper(w io.Writer, name string, server map[string]interface{})
 	case stateForeignWrapper:
 		binary := serverCommand(server)
 		_, _ = fmt.Fprintf(w,
-			"warning: server %q runs %q with proxy arguments but that is not this pipelock binary; wrapping it, and remove-then-install for a single clean wrap\n",
+			"warning: server %q runs %q with proxy arguments from another binary; checking its invocation before replacing the wrapper\n",
 			name, binary)
 	case stateNotWrapper:
 		if _, marked := server[mcpFieldPipelock]; marked {
@@ -398,4 +412,119 @@ func commandArgStrings(v interface{}) []string {
 	default:
 		return interfaceSliceToStrings(v)
 	}
+}
+
+// normalizeForeignWrapper rewrites a foreign proxy wrapper - a command/args
+// entry that runs `mcp proxy ...` through a pipelock at a DIFFERENT path - into
+// the bare child server it wraps, so the caller re-wraps the original command
+// through this binary instead of nesting one proxy invocation inside another
+// invocation. The child is read from the invocation, never from the _pipelock
+// marker, so a forged marker cannot steer it.
+//
+// This handles the conventional command+args shape (VS Code, Cline, JetBrains,
+// Continue); OpenCode's single command-array shape uses
+// normalizeForeignOpenCodeWrapper.
+//
+// httpType, when non-empty, is written as the recovered remote server's type so
+// a caller that routes HTTP by an explicit type sends it down its HTTP branch;
+// callers that infer the transport from url-presence pass "".
+//
+// A non-foreign entry is returned unchanged. An unrecoverable wrapper (unknown
+// proxy flags, a header-file credential sidecar, or an empty child) returns an
+// error carrying the operator remedy, which the caller surfaces on its existing
+// wrap-error path (an availability failure, not an unmediated path).
+func normalizeForeignWrapper(server map[string]interface{}, httpType string) (map[string]interface{}, error) {
+	if classifyWrapper(server) != stateForeignWrapper {
+		return server, nil
+	}
+	inner, err := mcpwrap.RecoverInner(commandArgStrings(server[mcpFieldArgs]))
+	if err != nil {
+		if errors.Is(err, mcpwrap.ErrNotProxyInvocation) {
+			// Classified foreign but not a command/args-shaped proxy invocation;
+			// leave it for the wrap path to reject on its own terms.
+			return server, nil
+		}
+		return nil, err
+	}
+
+	bare := passthroughServerFields(server)
+	switch inner.Transport {
+	case mcpwrap.TransportUpstream:
+		bare[mcpFieldURL] = inner.UpstreamURL
+		if httpType != "" {
+			bare[mcpFieldType] = httpType
+		}
+	default:
+		bare[mcpFieldCommand] = inner.Command
+		if len(inner.Args) > 0 {
+			bare[mcpFieldArgs] = stringsToInterfaces(inner.Args)
+		}
+	}
+	return bare, nil
+}
+
+// normalizeForeignOpenCodeWrapper is normalizeForeignWrapper for OpenCode's
+// single command-array shape, where the wrapping binary is element zero of the
+// command array and the recovered stdio child is rebuilt as an array.
+func normalizeForeignOpenCodeWrapper(server map[string]interface{}) (map[string]interface{}, error) {
+	if classifyWrapper(server) != stateForeignWrapper {
+		return server, nil
+	}
+	command := commandArgStrings(server[mcpFieldCommand])
+	if len(command) == 0 {
+		return server, nil
+	}
+	inner, err := mcpwrap.RecoverInner(command[1:])
+	if err != nil {
+		if errors.Is(err, mcpwrap.ErrNotProxyInvocation) {
+			return server, nil
+		}
+		return nil, err
+	}
+
+	bare := passthroughServerFields(server)
+	switch inner.Transport {
+	case mcpwrap.TransportUpstream:
+		bare[mcpFieldURL] = inner.UpstreamURL
+	default:
+		rebuilt := make([]interface{}, 0, len(inner.Args)+1)
+		rebuilt = append(rebuilt, inner.Command)
+		for _, a := range inner.Args {
+			rebuilt = append(rebuilt, a)
+		}
+		bare[mcpFieldCommand] = rebuilt
+	}
+	return bare, nil
+}
+
+// stringsToInterfaces reconstructs the []interface{} shape a JSON/YAML decode
+// produces, so a recovered child server is indistinguishable from a freshly read
+// one and the installers' args readers (which expect []interface{}) handle it.
+func stringsToInterfaces(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
+// passthroughServerFields copies every field that describes the server rather
+// than its wrapping - env and any host-specific extras - while dropping the
+// transport fields (rebuilt from the recovered child) and the _pipelock marker
+// (discarded, since normalization is metadata-free).
+func passthroughServerFields(server map[string]interface{}) map[string]interface{} {
+	bare := make(map[string]interface{}, len(server))
+	for k, v := range server {
+		switch k {
+		case mcpFieldCommand, mcpFieldArgs, mcpFieldURL, mcpFieldHeaders, mcpFieldType, mcpFieldPipelock:
+			// Replaced from the recovered child, or discarded.
+		default:
+			bare[k] = v
+		}
+	}
+	return bare
+}
+
+func isNormalizationFailure(err error) bool {
+	return errors.Is(err, mcpwrap.ErrCannotNormalize)
 }

--- a/internal/cli/setup/mcpwrap_test.go
+++ b/internal/cli/setup/mcpwrap_test.go
@@ -183,7 +183,7 @@ func TestWarnForeignWrapper(t *testing.T) {
 				mcpFieldCommand: "/usr/bin/attacker-server",
 				mcpFieldArgs:    []interface{}{"mcp", "proxy", "--", testEchoCmd},
 			},
-			want: "is not this pipelock binary",
+			want: "from another binary",
 		},
 		{
 			name: "marker beside a command that does not run the proxy",
@@ -376,7 +376,7 @@ func TestForeignCodexWrapperReason(t *testing.T) {
 		Args: []string{"mcp", "proxy", "--", "node", "x.js"},
 	}}
 	reason := foreignCodexWrapperReason(foreign)
-	if !strings.Contains(reason, "/other/bin/pipelock") || !strings.Contains(reason, "not this pipelock binary") {
+	if !strings.Contains(reason, "/other/bin/pipelock") || !strings.Contains(reason, "from another binary") {
 		t.Fatalf("note does not name the binary or the problem: %q", reason)
 	}
 

--- a/internal/cli/setup/opencode.go
+++ b/internal/cli/setup/opencode.go
@@ -186,6 +186,9 @@ func runOpenCodeInstall(cmd *cobra.Command, override string, dryRun bool, config
 
 		newServer, meta, plan, err := wrapOpenCodeServer(server, exe, configFile, targetPath, name)
 		if err != nil {
+			if isNormalizationFailure(err) {
+				return fmt.Errorf("server %q: %w", name, err)
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue
 		}
@@ -318,6 +321,16 @@ func runOpenCodeRemove(cmd *cobra.Command, override string, dryRun bool) error {
 }
 
 func wrapOpenCodeServer(server map[string]interface{}, exe, configFile, targetConfigPath, serverName string) (map[string]interface{}, *pipelockMeta, *sidecarOp, error) {
+	// Normalize a foreign wrapper down to its bare child before wrapping, so an
+	// upgrade over a pipelock installed at a different path rewraps the ORIGINAL
+	// command instead of nesting proxy invocations. OpenCode carries the
+	// command as a single array, so it uses the array-shaped normalizer; a
+	// recovered remote child needs no type (OpenCode infers it from url).
+	server, normErr := normalizeForeignOpenCodeWrapper(server)
+	if normErr != nil {
+		return nil, nil, nil, normErr
+	}
+
 	_, hasCommand := server[mcpFieldCommand]
 	_, hasURL := server[mcpFieldURL]
 	if hasCommand && hasURL {

--- a/internal/cli/setup/vscode.go
+++ b/internal/cli/setup/vscode.go
@@ -314,6 +314,9 @@ func runVscodeInstall(cmd *cobra.Command, global, project, dryRun bool, configFi
 
 		newServer, meta, plan, err := wrapVscodeServer(server, exe, configFile, targetPath, name)
 		if err != nil {
+			if isNormalizationFailure(err) {
+				return fmt.Errorf("server %q: %w", name, err)
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q: %v\n", name, err)
 			continue
 		}
@@ -496,6 +499,15 @@ func isVscodeHTTPType(t string) bool { return t != vsTypeStdio && t != "" }
 // remove applies deletes only after the restored config is committed; dry-run
 // skips the apply step entirely.
 func wrapVscodeServer(server map[string]interface{}, exe, configFile, targetConfigPath, serverName string) (map[string]interface{}, *pipelockMeta, *sidecarOp, error) {
+	// Normalize a foreign wrapper down to its bare child before wrapping, so an
+	// upgrade over a pipelock installed at a different path rewraps the ORIGINAL
+	// command instead of nesting proxy invocations. Cline and Zed reach
+	// this function through wrapClineServer, so they are covered here too.
+	server, normErr := normalizeForeignWrapper(server, mcpHTTPWrapType)
+	if normErr != nil {
+		return nil, nil, nil, normErr
+	}
+
 	serverType, _ := server["type"].(string)
 	typeOmitted := serverType == ""
 	if typeOmitted {

--- a/internal/cli/setup/zed.go
+++ b/internal/cli/setup/zed.go
@@ -344,6 +344,9 @@ func installZedPath(cmd *cobra.Command, targetPath, exe, configFile string, dryR
 
 		newServer, meta, plan, wrapErr := wrapClineServer(server, exe, configFile, targetPath, name)
 		if wrapErr != nil {
+			if isNormalizationFailure(wrapErr) {
+				return fmt.Errorf("server %q: %w", name, wrapErr)
+			}
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping server %q in %s: %v\n", name, targetPath, wrapErr)
 			continue
 		}

--- a/internal/mcpwrap/mcpwrap.go
+++ b/internal/mcpwrap/mcpwrap.go
@@ -59,7 +59,7 @@ const (
 // Names and metadata are not proof: both can be supplied by the config being
 // inspected.
 func ClassifyInvocation(command string, args []string) WrapperState {
-	if command == "" || len(args) < 2 || args[0] != "mcp" || args[1] != "proxy" {
+	if command == "" || len(args) < 2 || args[0] != subcmdMCP || args[1] != subcmdProxy {
 		return WrapperNone
 	}
 	self, err := os.Executable()
@@ -71,7 +71,7 @@ func ClassifyInvocation(command string, args []string) WrapperState {
 // target a different installed Pipelock path than the binary generating the
 // config.
 func ClassifyInvocationAgainst(command string, args []string, expected string) WrapperState {
-	if command == "" || expected == "" || len(args) < 2 || args[0] != "mcp" || args[1] != "proxy" {
+	if command == "" || expected == "" || len(args) < 2 || args[0] != subcmdMCP || args[1] != subcmdProxy {
 		return WrapperNone
 	}
 	return classifyExecutable(command, expected, nil)
@@ -198,6 +198,10 @@ func IsHTTPType(t string) bool { return t != TypeStdio && t != "" }
 //     these hosts infer from the `command` key - so no field foreign to the
 //     host's schema is introduced.
 func WrapServer(server map[string]interface{}, exe, configFile, targetConfigPath, serverName string) (map[string]interface{}, *Meta, *SidecarOp, error) {
+	server, err := recoverForeignServer(server)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	serverType, _ := server[FieldType].(string)
 	typeOmitted := serverType == ""
 	if typeOmitted {

--- a/internal/mcpwrap/recover.go
+++ b/internal/mcpwrap/recover.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpwrap
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// WrapperTransport identifies the transport of a child recovered from a proxy
+// invocation.
+type WrapperTransport int
+
+const (
+	// TransportStdio is a subprocess child, recovered from the `--` tail.
+	TransportStdio WrapperTransport = iota
+	// TransportUpstream is a remote child, recovered from `--upstream URL`.
+	TransportUpstream
+)
+
+// Proxy subcommand tokens and the argument-list flags a wrapper argv can carry.
+// These are exactly the flags pipelock's own installers emit; anything else in a
+// proxy invocation is unrecognized and forces a refusal rather than a guess.
+const (
+	subcmdMCP     = "mcp"
+	subcmdProxy   = "proxy"
+	argSeparator  = "--"
+	flagWorkspace = "--workspace"
+	flagEnv       = "--env"
+	flagSandbox   = "--sandbox"
+)
+
+// RecoveredInner is the child a `pipelock mcp proxy` invocation wraps, read from
+// the invocation arguments alone. It deliberately carries no recovered proxy
+// flags: --config, --sandbox, --workspace and --env belong to the pipelock that
+// wrote the wrapper and are rebuilt fresh by the installer performing the
+// re-wrap, so the normalized result is mediated by the CURRENT executable rather
+// than inheriting a foreign binary's flags.
+type RecoveredInner struct {
+	Transport   WrapperTransport
+	Command     string   // TransportStdio: the child binary
+	Args        []string // TransportStdio: the child arguments
+	UpstreamURL string   // TransportUpstream: the remote upstream URL
+}
+
+// ErrNotProxyInvocation reports that the arguments are not an `mcp proxy`
+// invocation, so there is no wrapper to normalize. Callers distinguish this from
+// a refusal: it means "leave the entry as-is", not "refuse the entry".
+var ErrNotProxyInvocation = errors.New("mcpwrap: not an mcp proxy invocation")
+
+// ErrCannotNormalize identifies a wrapper the installer cannot safely replace.
+var ErrCannotNormalize = errors.New("cannot normalize wrapper")
+
+// RecoverInner extracts the child that a `mcp proxy` invocation wraps, reading
+// only the invocation arguments and never the _pipelock restoration marker (a
+// config-controlled value that must not authorize anything).
+//
+// proxyArgs is the argument list that FOLLOWS the wrapping binary, e.g.
+// ["mcp","proxy","--config","p","--","srv","-x"] or
+// ["mcp","proxy","--upstream","https://h/mcp"].
+//
+// It fails closed. Arguments that are not the recognized wrapper flags, a
+// wrapper that carries both a `--` child and `--upstream`, an empty child, or a
+// `--header-file` credential sidecar (whose contents cannot be reconstructed
+// from the command) all return an error carrying an operator remedy. Returning
+// ErrNotProxyInvocation means the args are simply not a proxy invocation.
+func RecoverInner(proxyArgs []string) (RecoveredInner, error) {
+	if len(proxyArgs) < 2 || proxyArgs[0] != subcmdMCP || proxyArgs[1] != subcmdProxy {
+		return RecoveredInner{}, ErrNotProxyInvocation
+	}
+
+	haveUpstream := false
+	var upstream string
+
+	for i := 2; i < len(proxyArgs); i++ {
+		arg := proxyArgs[i]
+		switch arg {
+		case argSeparator:
+			if haveUpstream {
+				return RecoveredInner{}, refusef("wrapper mixes --upstream and a `--` child command; remove the server and re-add it so pipelock can wrap it freshly")
+			}
+			tail := proxyArgs[i+1:]
+			if len(tail) == 0 || tail[0] == "" {
+				return RecoveredInner{}, refusef("wrapper has no child command after `--`; remove the server and re-add the original")
+			}
+			if len(tail) >= 3 && tail[1] == subcmdMCP && tail[2] == subcmdProxy {
+				return RecoveredInner{}, refusef("wrapper contains another proxy invocation; restore the original server configuration before installing again")
+			}
+			return RecoveredInner{
+				Transport: TransportStdio,
+				Command:   tail[0],
+				Args:      append([]string(nil), tail[1:]...),
+			}, nil
+		case flagUpstream:
+			if haveUpstream {
+				return RecoveredInner{}, refusef("wrapper repeats --upstream; restore the original server configuration before installing again")
+			}
+			value, ok := valueAt(proxyArgs, i+1)
+			if !ok {
+				return RecoveredInner{}, refusef("wrapper has --upstream with no URL; remove the server and re-add the original")
+			}
+			upstream = value
+			haveUpstream = true
+			i++
+		case flagConfig, flagWorkspace, flagEnv:
+			// Recognized value flag from the wrapping pipelock; the value is
+			// rebuilt fresh by the re-wrap, so it is consumed and discarded.
+			if value, ok := valueAt(proxyArgs, i+1); !ok || value == "" || strings.HasPrefix(value, "-") {
+				return RecoveredInner{}, refusef("wrapper flag %q has no value; remove the server and re-add the original", arg)
+			}
+			i++
+		case flagSandbox:
+			// Recognized bool flag; rebuilt fresh by the re-wrap.
+		case flagHeaderFile:
+			return RecoveredInner{}, refusef(
+				"wrapper stores upstream credentials in a header sidecar file that cannot be recovered " +
+					"from the command alone; run the installer's remove then install again, or re-add the server by hand")
+		default:
+			return RecoveredInner{}, refusef(
+				"wrapper carries a proxy argument that this pipelock does not recognize; restore the original server configuration before installing again")
+		}
+	}
+
+	if haveUpstream {
+		if upstream == "" {
+			return RecoveredInner{}, refusef("wrapper has an empty --upstream URL; remove the server and re-add the original")
+		}
+		// Match the upstream scheme/host contract in the MCP command.
+		u, err := url.Parse(upstream)
+		if err != nil || u.Host == "" {
+			return RecoveredInner{}, refusef("wrapper has an invalid --upstream URL; restore the original server configuration before installing again")
+		}
+		switch u.Scheme {
+		case "http", "https", "ws", "wss":
+		default:
+			return RecoveredInner{}, refusef("wrapper has an unsupported --upstream URL scheme; restore the original server configuration before installing again")
+		}
+		return RecoveredInner{Transport: TransportUpstream, UpstreamURL: upstream}, nil
+	}
+	return RecoveredInner{}, refusef("wrapper has no child command or upstream; remove the server and re-add the original")
+}
+
+// valueAt returns the argument at i and whether the index is in range, so a
+// flag's value is read only after a bounds check the analyzer can see.
+func valueAt(args []string, i int) (string, bool) {
+	if i < 0 || i >= len(args) {
+		return "", false
+	}
+	return args[i], true
+}
+
+// refusef builds an unrecoverable-wrapper error. It is distinct from
+// ErrNotProxyInvocation: a refusal is an availability failure with a remedy, not
+// an instruction to leave the entry alone.
+func refusef(format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", ErrCannotNormalize, fmt.Sprintf(format, args...))
+}
+
+// recoverForeignServer adapts a conventional command/args entry for WrapServer.
+// The invocation supplies the child; restoration metadata is discarded.
+func recoverForeignServer(server map[string]interface{}) (map[string]interface{}, error) {
+	if ClassifyServer(server) != WrapperForeign {
+		return server, nil
+	}
+	args, err := stringArgs(server[FieldArgs])
+	if err != nil {
+		return nil, err
+	}
+	inner, err := RecoverInner(args)
+	if err != nil {
+		return nil, err
+	}
+	bare := make(map[string]interface{}, len(server))
+	for k, v := range server {
+		switch k {
+		case FieldCommand, FieldArgs, FieldURL, FieldHeaders, FieldType, FieldPipelock:
+		default:
+			bare[k] = v
+		}
+	}
+	if inner.Transport == TransportUpstream {
+		bare[FieldURL] = inner.UpstreamURL
+	} else {
+		bare[FieldCommand] = inner.Command
+		bare[FieldArgs] = inner.Args
+	}
+	return bare, nil
+}

--- a/internal/mcpwrap/recover.go
+++ b/internal/mcpwrap/recover.go
@@ -54,6 +54,24 @@ var ErrNotProxyInvocation = errors.New("mcpwrap: not an mcp proxy invocation")
 // ErrCannotNormalize identifies a wrapper the installer cannot safely replace.
 var ErrCannotNormalize = errors.New("cannot normalize wrapper")
 
+// RecoverServerInvocation refuses header settings whose use cannot be established
+// from the proxy invocation, then recovers the original server from its arguments.
+func RecoverServerInvocation(server map[string]interface{}, proxyArgs []string) (RecoveredInner, error) {
+	if headers, present := server[FieldHeaders]; present && headers != nil {
+		empty := false
+		switch h := headers.(type) {
+		case map[string]interface{}:
+			empty = len(h) == 0
+		case map[string]string:
+			empty = len(h) == 0
+		}
+		if !empty {
+			return RecoveredInner{}, refusef("wrapper has header settings outside its invocation; restore the original server configuration before installing again")
+		}
+	}
+	return RecoverInner(proxyArgs)
+}
+
 // RecoverInner extracts the child that a `mcp proxy` invocation wraps, reading
 // only the invocation arguments and never the _pipelock restoration marker (a
 // config-controlled value that must not authorize anything).
@@ -169,7 +187,17 @@ func recoverForeignServer(server map[string]interface{}) (map[string]interface{}
 	if err != nil {
 		return nil, err
 	}
-	inner, err := RecoverInner(args)
+	if _, scalar := server[FieldCommand].(string); !scalar {
+		if len(args) > 0 {
+			return nil, refusef("command-list wrapper also has a separate args field; restore the original server configuration before installing again")
+		}
+		command, err := stringArgs(server[FieldCommand])
+		if err != nil || len(command) < 2 {
+			return nil, refusef("wrapper has an invalid command list; restore the original server configuration before installing again")
+		}
+		args = command[1:]
+	}
+	inner, err := RecoverServerInvocation(server, args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcpwrap/recover_test.go
+++ b/internal/mcpwrap/recover_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Josh Waldrep
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpwrap
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRecoverInner_NotProxyInvocation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"nil", nil},
+		{"empty", []string{}},
+		{"too short", []string{"mcp"}},
+		{"wrong verb", []string{"mcp", "scan", "--", "srv"}},
+		{"wrong subcommand", []string{"proxy", "mcp", "--", "srv"}},
+		{"leading flag", []string{"--config", "x", "mcp", "proxy"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := RecoverInner(tc.args); !errors.Is(err, ErrNotProxyInvocation) {
+				t.Fatalf("RecoverInner(%v) err = %v, want ErrNotProxyInvocation", tc.args, err)
+			}
+		})
+	}
+}
+
+func TestRecoverInner_Stdio(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantCmd  string
+		wantArgs []string
+	}{
+		{
+			"bare command and args",
+			[]string{"mcp", "proxy", "--", "node", "server.js"},
+			"node",
+			[]string{"server.js"},
+		},
+		{
+			"command with no args",
+			[]string{"mcp", "proxy", "--", "node"},
+			"node", nil,
+		},
+		{
+			"all recognized flags are discarded",
+			[]string{"mcp", "proxy", "--config", "/c.yaml", "--sandbox", "--workspace", "/w", "--env", "API_KEY", "--", "node", "-x", "y"},
+			"node",
+			[]string{"-x", "y"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RecoverInner(tc.args)
+			if err != nil {
+				t.Fatalf("RecoverInner: %v", err)
+			}
+			if got.Transport != TransportStdio {
+				t.Fatalf("transport = %v, want stdio", got.Transport)
+			}
+			if got.Command != tc.wantCmd {
+				t.Fatalf("command = %q, want %q", got.Command, tc.wantCmd)
+			}
+			if strings.Join(got.Args, "\x00") != strings.Join(tc.wantArgs, "\x00") {
+				t.Fatalf("args = %#v, want %#v", got.Args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+func TestRecoverInner_ArgsAreCopied(t *testing.T) {
+	input := []string{"mcp", "proxy", "--", "node", "server.js"}
+	got, err := RecoverInner(input)
+	if err != nil {
+		t.Fatalf("RecoverInner: %v", err)
+	}
+	got.Args[0] = "mutated"
+	if input[4] != "server.js" {
+		t.Fatalf("RecoverInner aliased the input slice: %#v", input)
+	}
+}
+
+func TestRecoverInner_Upstream(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"bare upstream", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}, "https://api.vendor.example/mcp"},
+		{"http upstream", []string{"mcp", "proxy", "--upstream", "http://api.vendor.example/mcp"}, "http://api.vendor.example/mcp"},
+		{"ws upstream", []string{"mcp", "proxy", "--upstream", "ws://api.vendor.example/mcp"}, "ws://api.vendor.example/mcp"},
+		{"upstream after flags", []string{"mcp", "proxy", "--config", "/c.yaml", "--env", "TOKEN", "--upstream", "wss://api.vendor.example/mcp"}, "wss://api.vendor.example/mcp"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RecoverInner(tc.args)
+			if err != nil {
+				t.Fatalf("RecoverInner: %v", err)
+			}
+			if got.Transport != TransportUpstream {
+				t.Fatalf("transport = %v, want upstream", got.Transport)
+			}
+			if got.UpstreamURL != tc.want {
+				t.Fatalf("upstream = %q, want %q", got.UpstreamURL, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecoverInner_Refusals(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{"header sidecar credentials", []string{"mcp", "proxy", "--header-file", "/p.headers", "--upstream", "https://h/mcp"}, "header sidecar"},
+		{"unknown flag", []string{"mcp", "proxy", "--bogus", "x", "--", "node"}, "does not recognize"},
+		{"bare token before separator", []string{"mcp", "proxy", "node"}, "does not recognize"},
+		{"empty tail after separator", []string{"mcp", "proxy", "--"}, "no child command after"},
+		{"empty first tail element", []string{"mcp", "proxy", "--", ""}, "no child command after"},
+		{"mixes upstream and separator", []string{"mcp", "proxy", "--upstream", "https://h/mcp", "--", "node"}, "mixes --upstream"},
+		{"upstream missing value", []string{"mcp", "proxy", "--upstream"}, "--upstream with no URL"},
+		{"empty upstream value", []string{"mcp", "proxy", "--upstream", ""}, "empty --upstream"},
+		{"value flag missing value", []string{"mcp", "proxy", "--config"}, "has no value"},
+		{"no child or upstream", []string{"mcp", "proxy", "--config", "/c.yaml"}, "no child command or upstream"},
+		{"nested proxy", []string{"mcp", "proxy", "--", "older-proxy", "mcp", "proxy", "--", "node"}, "another proxy invocation"},
+		{"repeated upstream", []string{"mcp", "proxy", "--upstream", "https://a.example/mcp", "--upstream", "https://b.example/mcp"}, "repeats --upstream"},
+		{"flag instead of upstream", []string{"mcp", "proxy", "--upstream", "--header-file"}, "invalid --upstream URL"},
+		{"malformed upstream", []string{"mcp", "proxy", "--upstream", "https://%/mcp"}, "invalid --upstream URL"},
+		{"upstream without host", []string{"mcp", "proxy", "--upstream", "https:///mcp"}, "invalid --upstream URL"},
+		{"unsupported upstream scheme", []string{"mcp", "proxy", "--upstream", "file://example/mcp"}, "unsupported --upstream URL scheme"},
+		{"flag instead of config", []string{"mcp", "proxy", "--config", "--header-file", "--", "node"}, "has no value"},
+		{"empty env value", []string{"mcp", "proxy", "--env", "", "--", "node"}, "has no value"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := RecoverInner(tc.args)
+			if err == nil {
+				t.Fatalf("RecoverInner(%v) = nil error, want refusal", tc.args)
+			}
+			if !errors.Is(err, ErrCannotNormalize) {
+				t.Fatalf("refusal lost its typed signal: %v", err)
+			}
+			if errors.Is(err, ErrNotProxyInvocation) {
+				t.Fatalf("refusal misclassified as not-a-proxy: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err = %q, want it to mention %q", err.Error(), tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), "cannot normalize wrapper") {
+				t.Fatalf("err = %q, want the refusal prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestRecoverInnerRefusalOmitsArgumentValues(t *testing.T) {
+	const opaqueValue = "--unsupported=private-value"
+	_, err := RecoverInner([]string{"mcp", "proxy", opaqueValue, "--", "node"})
+	if !errors.Is(err, ErrCannotNormalize) || strings.Contains(err.Error(), opaqueValue) {
+		t.Fatalf("refusal must omit unknown argument values: %v", err)
+	}
+}
+
+func TestWrapServerRecoversForeignInvocation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		command string
+		url     string
+	}{
+		{"stdio", []string{"mcp", "proxy", "--", "node", "server.js"}, "node", ""},
+		{"remote", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"}, "", "https://api.vendor.example/mcp"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := map[string]interface{}{
+				FieldCommand:  "/nonexistent/older-proxy",
+				FieldArgs:     tc.args,
+				FieldPipelock: map[string]interface{}{"original_command": "wrong-command"},
+			}
+			wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.OriginalCommand != tc.command || meta.OriginalURL != tc.url {
+				t.Fatalf("metadata did not come from invocation: %+v", meta)
+			}
+			if wrapped[FieldCommand] != "/current/proxy" || plan != nil {
+				t.Fatalf("unexpected wrapper or sidecar: %v %v", wrapped, plan)
+			}
+			if _, ok := wrapped[FieldPipelock]; ok {
+				t.Fatal("stale restoration marker survived")
+			}
+		})
+	}
+}
+
+func TestWrapServerForeignRecoveryErrors(t *testing.T) {
+	for _, server := range []map[string]interface{}{
+		{FieldCommand: "/nonexistent/older-proxy", FieldArgs: []string{"mcp", "proxy", "--header-file", "credentials.headers"}},
+		{FieldCommand: []string{"/nonexistent/older-proxy", "mcp", "proxy"}, FieldArgs: []interface{}{false}},
+	} {
+		wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+		if err == nil || wrapped != nil || meta != nil || plan != nil {
+			t.Fatalf("invalid foreign wrapper produced a write plan: %v %v %v %v", wrapped, meta, plan, err)
+		}
+	}
+}

--- a/internal/mcpwrap/recover_test.go
+++ b/internal/mcpwrap/recover_test.go
@@ -104,6 +104,9 @@ func TestRecoverInner_Upstream(t *testing.T) {
 			if got.Transport != TransportUpstream {
 				t.Fatalf("transport = %v, want upstream", got.Transport)
 			}
+			if got.Command != "" || len(got.Args) != 0 {
+				t.Fatalf("upstream recovery contains child invocation: %+v", got)
+			}
 			if got.UpstreamURL != tc.want {
 				t.Fatalf("upstream = %q, want %q", got.UpstreamURL, tc.want)
 			}
@@ -128,6 +131,7 @@ func TestRecoverInner_Refusals(t *testing.T) {
 		{"value flag missing value", []string{"mcp", "proxy", "--config"}, "has no value"},
 		{"no child or upstream", []string{"mcp", "proxy", "--config", "/c.yaml"}, "no child command or upstream"},
 		{"nested proxy", []string{"mcp", "proxy", "--", "older-proxy", "mcp", "proxy", "--", "node"}, "another proxy invocation"},
+		{"upstream trailing positional", []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp", "unexpected-tail"}, "does not recognize"},
 		{"repeated upstream", []string{"mcp", "proxy", "--upstream", "https://a.example/mcp", "--upstream", "https://b.example/mcp"}, "repeats --upstream"},
 		{"flag instead of upstream", []string{"mcp", "proxy", "--upstream", "--header-file"}, "invalid --upstream URL"},
 		{"malformed upstream", []string{"mcp", "proxy", "--upstream", "https://%/mcp"}, "invalid --upstream URL"},
@@ -160,8 +164,13 @@ func TestRecoverInner_Refusals(t *testing.T) {
 func TestRecoverInnerRefusalOmitsArgumentValues(t *testing.T) {
 	const opaqueValue = "--unsupported=private-value"
 	_, err := RecoverInner([]string{"mcp", "proxy", opaqueValue, "--", "node"})
-	if !errors.Is(err, ErrCannotNormalize) || strings.Contains(err.Error(), opaqueValue) {
+	if !errors.Is(err, ErrCannotNormalize) {
 		t.Fatalf("refusal must omit unknown argument values: %v", err)
+	}
+	for _, fragment := range []string{opaqueValue, "private-value", "--unsupported"} {
+		if strings.Contains(err.Error(), fragment) {
+			t.Fatalf("refusal leaked component %q: %v", fragment, err)
+		}
 	}
 }
 

--- a/internal/mcpwrap/recover_test.go
+++ b/internal/mcpwrap/recover_test.go
@@ -201,10 +201,61 @@ func TestWrapServerForeignRecoveryErrors(t *testing.T) {
 	for _, server := range []map[string]interface{}{
 		{FieldCommand: "/nonexistent/older-proxy", FieldArgs: []string{"mcp", "proxy", "--header-file", "credentials.headers"}},
 		{FieldCommand: []string{"/nonexistent/older-proxy", "mcp", "proxy"}, FieldArgs: []interface{}{false}},
+		{FieldCommand: []string{"/nonexistent/older-proxy", "mcp", "proxy", "--", "node"}, FieldArgs: []string{"different-child"}},
 	} {
 		wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
 		if err == nil || wrapped != nil || meta != nil || plan != nil {
 			t.Fatalf("invalid foreign wrapper produced a write plan: %v %v %v %v", wrapped, meta, plan, err)
+		}
+	}
+}
+
+func TestRecoverServerInvocationHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers interface{}
+		refuse  bool
+	}{
+		{"null", nil, false},
+		{"empty decoded map", map[string]interface{}{}, false},
+		{"empty string map", map[string]string{}, false},
+		{"decoded headers", map[string]interface{}{"X-Example-Auth": "test-only-value"}, true},
+		{"string headers", map[string]string{"X-Example-Auth": "test-only-value"}, true},
+		{"malformed headers", "test-only-value", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := map[string]interface{}{
+				FieldCommand: "/nonexistent/older-proxy",
+				FieldArgs:    []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"},
+				FieldHeaders: tc.headers,
+			}
+			wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+			if tc.refuse {
+				if !errors.Is(err, ErrCannotNormalize) || wrapped != nil || meta != nil || plan != nil {
+					t.Fatalf("ambiguous headers produced a replacement: %v %v %v %v", wrapped, meta, plan, err)
+				}
+				if strings.Contains(err.Error(), "test-only-value") {
+					t.Fatal("refusal exposed a header value")
+				}
+			} else if err != nil || meta == nil || meta.OriginalURL != "https://api.vendor.example/mcp" {
+				t.Fatalf("empty headers prevented recovery: %v %v", meta, err)
+			}
+		})
+	}
+}
+
+func TestWrapServerForeignCommandList(t *testing.T) {
+	for _, command := range []interface{}{
+		[]string{"/nonexistent/older-proxy", "mcp", "proxy", "--", "node", "server.js"},
+		[]interface{}{"/nonexistent/older-proxy", "mcp", "proxy", "--", "node", "server.js"},
+	} {
+		server := map[string]interface{}{FieldCommand: command}
+		wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wrapped[FieldCommand] != "/current/proxy" || meta.OriginalCommand != "node" || strings.Join(meta.OriginalArgs, " ") != "server.js" || plan != nil {
+			t.Fatalf("command-list child was not recovered: %v %v %v", wrapped, meta, plan)
 		}
 	}
 }

--- a/internal/mcpwrap/recover_test.go
+++ b/internal/mcpwrap/recover_test.go
@@ -4,6 +4,7 @@
 package mcpwrap
 
 import (
+	"encoding/json"
 	"errors"
 	"slices"
 	"strings"
@@ -190,7 +191,11 @@ func TestWrapServerRecoversForeignInvocation(t *testing.T) {
 				FieldArgs:     tc.args,
 				FieldPipelock: map[string]interface{}{"original_command": "wrong-command"},
 			}
+			before := snapshotRecoveryServer(t, server)
 			wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+			if after := snapshotRecoveryServer(t, server); after != before {
+				t.Fatalf("recovery mutated input: before=%s after=%s", before, after)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -222,7 +227,11 @@ func TestWrapServerForeignRecoveryErrors(t *testing.T) {
 		{FieldCommand: []string{"/nonexistent/older-proxy", "mcp", "proxy"}, FieldArgs: []interface{}{false}},
 		{FieldCommand: []string{"/nonexistent/older-proxy", "mcp", "proxy", "--", "node"}, FieldArgs: []string{"different-child"}},
 	} {
+		before := snapshotRecoveryServer(t, server)
 		wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+		if after := snapshotRecoveryServer(t, server); after != before {
+			t.Fatalf("recovery mutated input: before=%s after=%s", before, after)
+		}
 		if err == nil || wrapped != nil || meta != nil || plan != nil {
 			t.Fatalf("invalid foreign wrapper produced a write plan: %v %v %v %v", wrapped, meta, plan, err)
 		}
@@ -248,7 +257,11 @@ func TestRecoverServerInvocationHeaders(t *testing.T) {
 				FieldArgs:    []string{"mcp", "proxy", "--upstream", "https://api.vendor.example/mcp"},
 				FieldHeaders: tc.headers,
 			}
+			before := snapshotRecoveryServer(t, server)
 			wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+			if after := snapshotRecoveryServer(t, server); after != before {
+				t.Fatalf("recovery mutated input: before=%s after=%s", before, after)
+			}
 			if tc.refuse {
 				if !errors.Is(err, ErrCannotNormalize) || wrapped != nil || meta != nil || plan != nil {
 					t.Fatalf("ambiguous headers produced a replacement: %v %v %v %v", wrapped, meta, plan, err)
@@ -256,8 +269,8 @@ func TestRecoverServerInvocationHeaders(t *testing.T) {
 				if strings.Contains(err.Error(), "test-only-value") {
 					t.Fatal("refusal exposed a header value")
 				}
-			} else if err != nil || meta == nil || meta.OriginalURL != "https://api.vendor.example/mcp" {
-				t.Fatalf("empty headers prevented recovery: %v %v", meta, err)
+			} else if err != nil || meta == nil || meta.OriginalURL != "https://api.vendor.example/mcp" || wrapped[FieldCommand] != "/current/proxy" || plan != nil {
+				t.Fatalf("unexpected empty-header recovery: wrapped=%v meta=%v plan=%v err=%v", wrapped, meta, plan, err)
 			}
 		})
 	}
@@ -269,7 +282,11 @@ func TestWrapServerForeignCommandList(t *testing.T) {
 		[]interface{}{"/nonexistent/older-proxy", "mcp", "proxy", "--", "node", "server.js"},
 	} {
 		server := map[string]interface{}{FieldCommand: command}
+		before := snapshotRecoveryServer(t, server)
 		wrapped, meta, plan, err := WrapServer(server, "/current/proxy", "new.yaml", "config.yaml", "example")
+		if after := snapshotRecoveryServer(t, server); after != before {
+			t.Fatalf("recovery mutated input: before=%s after=%s", before, after)
+		}
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -277,4 +294,14 @@ func TestWrapServerForeignCommandList(t *testing.T) {
 			t.Fatalf("command-list child was not recovered: %v %v %v", wrapped, meta, plan)
 		}
 	}
+}
+
+// snapshotRecoveryServer captures nested input values without retaining aliases.
+func snapshotRecoveryServer(t *testing.T, server map[string]interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/mcpwrap/recover_test.go
+++ b/internal/mcpwrap/recover_test.go
@@ -5,6 +5,7 @@ package mcpwrap
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -189,6 +190,15 @@ func TestWrapServerRecoversForeignInvocation(t *testing.T) {
 			}
 			if wrapped[FieldCommand] != "/current/proxy" || plan != nil {
 				t.Fatalf("unexpected wrapper or sidecar: %v %v", wrapped, plan)
+			}
+			wantArgs := []string{"mcp", "proxy", "--config", "new.yaml"}
+			if tc.command != "" {
+				wantArgs = append(wantArgs, "--", "node", "server.js")
+			} else {
+				wantArgs = append(wantArgs, "--upstream", "https://api.vendor.example/mcp")
+			}
+			if got := InterfaceSliceToStrings(wrapped[FieldArgs]); !slices.Equal(got, wantArgs) {
+				t.Fatalf("replacement args = %q, want %q", got, wantArgs)
 			}
 			if _, ok := wrapped[FieldPipelock]; ok {
 				t.Fatal("stale restoration marker survived")


### PR DESCRIPTION
## What changed

Replace an older MCP wrapper with one current wrapper when its invocation identifies the original server, preserving its arguments and environment. Refuse ambiguous or unrecoverable invocations before replacing the affected configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer upgrades now recognize wrappers from another Pipelock installation and rewrap the original server directly, avoiding nested wrappers.
  * Server commands, arguments, environment settings, and remote URLs are preserved during upgrades.
  * Repeated installations remain stable and idempotent across supported MCP clients.
  * Recovered remote servers receive the appropriate transport configuration.

* **Bug Fixes**
  * Unsupported or unsafe wrapper configurations now stop installation without changing existing configuration.
  * Warnings for wrappers from another installation are clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->