### PR TITLE
fix(config): refuse host spellings that no matcher can reach

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,7 +342,7 @@ tls_interception:
 | `enabled` | `false` | Enable TLS interception on CONNECT tunnels |
 | `ca_cert` | `""` | Path to CA certificate PEM. Empty resolves to `~/.pipelock/ca.pem` |
 | `ca_key` | `""` | Path to CA private key PEM. Empty resolves to `~/.pipelock/ca-key.pem` |
-| `passthrough_domains` | `["*.googlevideo.com"]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). Entries must be written exactly as the matcher reads them: no surrounding whitespace and at most one trailing DNS dot. A malformed entry is refused at load rather than accepted and then silently matching nothing. |
+| `passthrough_domains` | `["*.googlevideo.com"]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). Entries must be written exactly as the matcher reads them: no surrounding whitespace and at most one trailing DNS dot. A malformed entry is refused at load rather than accepted and then silently matching nothing. A wildcard over a public suffix such as `*.com` is also refused, because a passthrough host is spliced without decryption and that entry would turn body and response scanning off for every destination under the suffix. A wildcard over a private boundary such as `*.s3.amazonaws.com` stays accepted. |
 | `cert_ttl` | `"24h"` | TTL for forged leaf certificates (Go duration string) |
 | `cert_cache_size` | `10000` | Max cached leaf certificates. Evicts oldest when full. |
 | `max_response_bytes` | `5242880` | Max response body to buffer for scanning. Responses exceeding this are blocked (fail-closed). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,7 +317,7 @@ forward_proxy:
 | `idle_timeout_seconds` | `120` | No | Kill established tunnels after this much inactivity |
 | `sni_verification` | `true` | **To disable while `sni_require_tls` is on** | Verify TLS ClientHello SNI matches the CONNECT target hostname. Blocks domain fronting (MITRE T1090.004). Set to `false` to disable. |
 | `sni_require_tls` | `false` | **To disable** | Require the tunnel to begin with a TLS ClientHello carrying SNI. Enabling it hot-reloads; **disabling it at runtime is rejected as a security downgrade** (restart to disable), because dropping it re-opens an unscanned opaque tunnel. Official security profiles enable it. This prevents raw/no-SNI protocol smuggling but does not decrypt or scan the tunnel body. Requires `sni_verification: true`. |
-| `redirect_websocket_hosts` | `[]` | No | Redirect matching hosts to /ws |
+| `redirect_websocket_hosts` | `[]` | No | Redirect matching hosts to /ws. Same entry shape as `tls_interception.passthrough_domains`: exact hosts or `*.example.com`, no surrounding whitespace, at most one trailing DNS dot. |
 
 ## TLS Interception
 
@@ -342,7 +342,7 @@ tls_interception:
 | `enabled` | `false` | Enable TLS interception on CONNECT tunnels |
 | `ca_cert` | `""` | Path to CA certificate PEM. Empty resolves to `~/.pipelock/ca.pem` |
 | `ca_key` | `""` | Path to CA private key PEM. Empty resolves to `~/.pipelock/ca-key.pem` |
-| `passthrough_domains` | `["*.googlevideo.com"]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). |
+| `passthrough_domains` | `["*.googlevideo.com"]` | Domains to splice (pass through without interception). Supports `*.example.com` wildcards (also matches apex `example.com`). Entries must be written exactly as the matcher reads them: no surrounding whitespace and at most one trailing DNS dot. A malformed entry is refused at load rather than accepted and then silently matching nothing. |
 | `cert_ttl` | `"24h"` | TTL for forged leaf certificates (Go duration string) |
 | `cert_cache_size` | `10000` | Max cached leaf certificates. Evicts oldest when full. |
 | `max_response_bytes` | `5242880` | Max response body to buffer for scanning. Responses exceeding this are blocked (fail-closed). |
@@ -2039,7 +2039,7 @@ trusted_domains:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `dns.host_overrides` | `{}` | Map of exact hostnames to one or more IP addresses. Hostname keys are normalized case-insensitively with trailing DNS dots stripped. URL, wildcard, host:port, and IP-literal keys are rejected. |
+| `dns.host_overrides` | `{}` | Map of exact hostnames to one or more IP addresses. Hostname keys are normalized case-insensitively with a single trailing DNS dot stripped; a key carrying an empty label (`host.example..`, a leading dot) is refused, because it could never match a lookup. URL, wildcard, host:port, and IP-literal keys are rejected. |
 
 Host overrides do not exempt a destination from SSRF blocking by themselves. If an override resolves to an internal IP, the hostname must also be present in `trusted_domains` or the target IP must be covered by `ssrf.ip_allowlist`. Raw IP targets never use `dns.host_overrides`.
 

--- a/internal/config/literal_host_list_validation_test.go
+++ b/internal/config/literal_host_list_validation_test.go
@@ -80,16 +80,59 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 // proxy, which still scans them, so breadth there is a routing preference.
 func TestLiteralHostMatchLists_BreadthPerList(t *testing.T) {
 	t.Run("passthrough refuses a public-suffix wildcard", func(t *testing.T) {
-		for _, entry := range []string{"*.com", "*.co.uk", "*.org"} {
+		// The assertions name the BREADTH reason and the offending entry, not
+		// merely the field. A test that accepts any error mentioning the
+		// field would pass on an unrelated validation failure and would stop
+		// proving that breadth is what refused the value.
+		// The breadth predicate has TWO branches with different messages, and
+		// which one fires is not obvious from the entry: a single-label base
+		// such as "com" never reaches the public-suffix test because it
+		// carries no dot. Asserting the specific reason is what surfaced
+		// that. A test that accepted any error naming the field would have
+		// passed while proving nothing about breadth.
+		for _, entry := range []string{"*.com", "*.org", "*.internal"} {
 			cfg := Defaults()
 			cfg.TLSInterception.PassthroughDomains = []string{entry}
 			err := cfg.Validate()
 			if err == nil {
-				t.Fatalf("passthrough accepted %q, which splices every host under that suffix", entry)
+				t.Fatalf("passthrough accepted %q, which splices every host under that namespace", entry)
 			}
-			if !strings.Contains(err.Error(), "passthrough_domains") {
-				t.Fatalf("error does not name the field: %v", err)
+			message := err.Error()
+			for _, want := range []string{
+				"tls_interception.passthrough_domains[0]", entry, "not the whole",
+			} {
+				if !strings.Contains(message, want) {
+					t.Fatalf("entry %q: error %q does not contain %q", entry, message, want)
+				}
 			}
+		}
+
+		// A multi-label ICANN suffix reaches the public-suffix branch.
+		for _, entry := range []string{"*.co.uk", "*.com.au"} {
+			cfg := Defaults()
+			cfg.TLSInterception.PassthroughDomains = []string{entry}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("passthrough accepted the public suffix %q", entry)
+			}
+			message := err.Error()
+			for _, want := range []string{
+				"tls_interception.passthrough_domains[0]", entry, "public suffix",
+				"which would match every domain registered under it",
+			} {
+				if !strings.Contains(message, want) {
+					t.Fatalf("entry %q: error %q does not contain %q", entry, message, want)
+				}
+			}
+		}
+
+		// A PRIVATE-section boundary is accepted, which is the line this rule
+		// deliberately draws: the flag says who administers the boundary, not
+		// who owns the content under it.
+		cfg := Defaults()
+		cfg.TLSInterception.PassthroughDomains = []string{"*.github.io"}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("passthrough refused the private-section boundary *.github.io: %v", err)
 		}
 	})
 

--- a/internal/config/literal_host_list_validation_test.go
+++ b/internal/config/literal_host_list_validation_test.go
@@ -24,7 +24,6 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 	}{
 		{name: "exact host", entry: "vendor.example", wantStored: "vendor.example"},
 		{name: "wildcard", entry: "*.vendor.example", wantStored: "*.vendor.example"},
-		{name: "broad wildcard is operator policy on a routing list", entry: "*.com", wantStored: "*.com"},
 		{name: "uppercase is folded to the matcher's view", entry: "Vendor.Example", wantStored: "vendor.example"},
 		{name: "single root dot is canonicalized", entry: "vendor.example.", wantStored: "vendor.example"},
 		{name: "double trailing dot", entry: "vendor.example..", wantErr: "must be written as"},
@@ -37,7 +36,11 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("passthrough/"+tt.name, func(t *testing.T) {
 			cfg := Defaults()
-			cfg.TLSInterception.Enabled = true
+			// Interception stays DISABLED on purpose. Enabling it makes
+			// Validate require a CA certificate on disk, which a clean
+			// runner does not have, and the list check runs ahead of the
+			// enabled gate precisely so a config is checked before the
+			// feature is switched on.
 			cfg.TLSInterception.PassthroughDomains = []string{tt.entry}
 			err := cfg.Validate()
 			assertHostListOutcome(t, err, tt.wantErr,
@@ -59,6 +62,37 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 // checked even when their feature is off. A config is edited and restarted
 // later, so an entry accepted while the feature was disabled would become
 // live without ever passing a check.
+// TestLiteralHostMatchLists_BreadthIsNotJudged pins the CURRENT behavior
+// separately for each list, because the two differ in what a wide wildcard
+// costs and a shared case hid that.
+//
+// forward_proxy.redirect_websocket_hosts routes matching hosts to the /ws
+// proxy, which scans them, so breadth there is a routing preference.
+//
+// tls_interception.passthrough_domains is NOT the same: a matching host is
+// spliced without decryption, so a wide wildcard turns body and response
+// scanning off for everything under that suffix. By the rule this repository
+// already applies to trusted_domains and the exempt lists, that is a
+// breadth-checked class. The check is deliberately NOT added here, because
+// refusing a value an existing deployment already loads is an admission
+// change that stops a running proxy at its next restart, and that is a
+// decision for this repository's operator rather than for the change that
+// first gave this list any validator at all. Tracked as DR-136. If that
+// decision says refuse, this test is where the expectation flips.
+func TestLiteralHostMatchLists_BreadthIsNotJudged(t *testing.T) {
+	cfg := Defaults()
+	cfg.ForwardProxy.RedirectWebSocketHosts = []string{"*.com"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("redirect_websocket_hosts wildcard refused: %v", err)
+	}
+
+	cfg = Defaults()
+	cfg.TLSInterception.PassthroughDomains = []string{"*.com"}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("passthrough_domains wildcard refused: %v; see DR-136 before changing this", err)
+	}
+}
+
 func TestLiteralHostMatchLists_ValidatedWhileDisabled(t *testing.T) {
 	cfg := Defaults()
 	cfg.TLSInterception.Enabled = false

--- a/internal/config/literal_host_list_validation_test.go
+++ b/internal/config/literal_host_list_validation_test.go
@@ -68,35 +68,61 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 // checked even when their feature is off. A config is edited and restarted
 // later, so an entry accepted while the feature was disabled would become
 // live without ever passing a check.
-// TestLiteralHostMatchLists_BreadthIsNotJudged pins the CURRENT behavior
-// separately for each list, because the two differ in what a wide wildcard
-// costs and a shared case hid that.
+// TestLiteralHostMatchLists_BreadthPerList pins that breadth is judged for one
+// list and not the other, because the two differ in what a wide wildcard costs.
 //
-// forward_proxy.redirect_websocket_hosts routes matching hosts to the /ws
-// proxy, which scans them, so breadth there is a routing preference.
+// tls_interception.passthrough_domains splices a matching host without
+// decrypting it, so "*.com" there turns body and response scanning off for
+// every .com destination. That is the detector-off class this repository
+// breadth-checks elsewhere, so the grant-list rule applies.
 //
-// tls_interception.passthrough_domains is NOT the same: a matching host is
-// spliced without decryption, so a wide wildcard turns body and response
-// scanning off for everything under that suffix. By the rule this repository
-// already applies to trusted_domains and the exempt lists, that is a
-// breadth-checked class. The check is deliberately NOT added here, because
-// refusing a value an existing deployment already loads is an admission
-// change that stops a running proxy at its next restart, and that is a
-// decision for this repository's operator rather than for the change that
-// first gave this list any validator at all. Tracked as DR-136. If that
-// decision says refuse, this test is where the expectation flips.
-func TestLiteralHostMatchLists_BreadthIsNotJudged(t *testing.T) {
-	cfg := Defaults()
-	cfg.ForwardProxy.RedirectWebSocketHosts = []string{"*.com"}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("redirect_websocket_hosts wildcard refused: %v", err)
-	}
+// forward_proxy.redirect_websocket_hosts routes matching hosts INTO the /ws
+// proxy, which still scans them, so breadth there is a routing preference.
+func TestLiteralHostMatchLists_BreadthPerList(t *testing.T) {
+	t.Run("passthrough refuses a public-suffix wildcard", func(t *testing.T) {
+		for _, entry := range []string{"*.com", "*.co.uk", "*.org"} {
+			cfg := Defaults()
+			cfg.TLSInterception.PassthroughDomains = []string{entry}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("passthrough accepted %q, which splices every host under that suffix", entry)
+			}
+			if !strings.Contains(err.Error(), "passthrough_domains") {
+				t.Fatalf("error does not name the field: %v", err)
+			}
+		}
+	})
 
-	cfg = Defaults()
-	cfg.TLSInterception.PassthroughDomains = []string{"*.com"}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("passthrough_domains wildcard refused: %v; see DR-136 before changing this", err)
-	}
+	// Availability control, and the reason this is a per-list rule rather
+	// than a blanket refusal. A private-suffix base and an ordinary vendor
+	// wildcard are configuration an operator legitimately writes, including
+	// the shipped default.
+	t.Run("passthrough keeps the wildcards operators actually write", func(t *testing.T) {
+		for _, entry := range []string{
+			"*.googlevideo.com", "*.apple.com", "*.s3.amazonaws.com", "mtls.vendor.example",
+		} {
+			cfg := Defaults()
+			cfg.TLSInterception.PassthroughDomains = []string{entry}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("passthrough refused the legitimate entry %q: %v", entry, err)
+			}
+		}
+	})
+
+	t.Run("shipped default survives", func(t *testing.T) {
+		cfg := Defaults()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("the shipped default passthrough list is refused: %v", err)
+		}
+	})
+
+	t.Run("redirect_websocket_hosts does not judge breadth", func(t *testing.T) {
+		cfg := Defaults()
+		cfg.ForwardProxy.RedirectWebSocketHosts = []string{"*.com"}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("redirect_websocket_hosts wildcard refused: %v", err)
+		}
+	})
 }
 
 func TestLiteralHostMatchLists_ValidatedWhileDisabled(t *testing.T) {

--- a/internal/config/literal_host_list_validation_test.go
+++ b/internal/config/literal_host_list_validation_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLiteralHostMatchLists_RefuseInertEntries covers the two host lists whose
+// runtime matcher only folds case, and which until now had no validator at
+// all. A malformed entry loaded clean and then matched no request, so the
+// operator's pinned-certificate host was intercepted anyway while the config
+// looked accepted. The failure direction is availability, so the repair
+// refuses the input and canonicalizes the stored value; neither matcher is
+// loosened.
+func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
+	tests := []struct {
+		name       string
+		entry      string
+		wantErr    string
+		wantStored string
+	}{
+		{name: "exact host", entry: "vendor.example", wantStored: "vendor.example"},
+		{name: "wildcard", entry: "*.vendor.example", wantStored: "*.vendor.example"},
+		{name: "broad wildcard is operator policy on a routing list", entry: "*.com", wantStored: "*.com"},
+		{name: "uppercase is folded to the matcher's view", entry: "Vendor.Example", wantStored: "vendor.example"},
+		{name: "single root dot is canonicalized", entry: "vendor.example.", wantStored: "vendor.example"},
+		{name: "double trailing dot", entry: "vendor.example..", wantErr: "must be written as"},
+		{name: "leading space", entry: " vendor.example", wantErr: "must be written as"},
+		{name: "empty", entry: "", wantErr: "empty"},
+		{name: "embedded space", entry: "bad host", wantErr: "DNS label characters"},
+		{name: "bare wildcard", entry: "*", wantErr: "only exact hosts"},
+	}
+
+	for _, tt := range tests {
+		t.Run("passthrough/"+tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.TLSInterception.Enabled = true
+			cfg.TLSInterception.PassthroughDomains = []string{tt.entry}
+			err := cfg.Validate()
+			assertHostListOutcome(t, err, tt.wantErr,
+				cfg.TLSInterception.PassthroughDomains[0], tt.wantStored)
+		})
+
+		t.Run("redirect_websocket_hosts/"+tt.name, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.WebSocketProxy.Enabled = true
+			cfg.ForwardProxy.RedirectWebSocketHosts = []string{tt.entry}
+			err := cfg.Validate()
+			assertHostListOutcome(t, err, tt.wantErr,
+				cfg.ForwardProxy.RedirectWebSocketHosts[0], tt.wantStored)
+		})
+	}
+}
+
+// TestLiteralHostMatchLists_ValidatedWhileDisabled pins that the lists are
+// checked even when their feature is off. A config is edited and restarted
+// later, so an entry accepted while the feature was disabled would become
+// live without ever passing a check.
+func TestLiteralHostMatchLists_ValidatedWhileDisabled(t *testing.T) {
+	cfg := Defaults()
+	cfg.TLSInterception.Enabled = false
+	cfg.TLSInterception.PassthroughDomains = []string{"vendor.example.."}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("a malformed passthrough entry was accepted while interception was disabled")
+	}
+
+	cfg = Defaults()
+	cfg.ForwardProxy.Enabled = false
+	cfg.ForwardProxy.RedirectWebSocketHosts = []string{"vendor.example.."}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("a malformed redirect host was accepted while the forward proxy was disabled")
+	}
+}
+
+// TestDNSHostOverrides_RefuseEmptyLabelKey covers the same silent-inertness
+// shape on the override map. The resolver's key normalizer removes ONE
+// trailing dot, so a two-dot key was stored with a residual dot and no lookup
+// ever matched it.
+func TestDNSHostOverrides_RefuseEmptyLabelKey(t *testing.T) {
+	tests := []struct {
+		key     string
+		wantErr bool
+	}{
+		{key: "pin.vendor.example"},
+		{key: "pin.vendor.example."},
+		{key: " pin.vendor.example"},
+		{key: "pin.vendor.example..", wantErr: true},
+		{key: "pin.vendor.example...", wantErr: true},
+		{key: ".pin.vendor.example", wantErr: true},
+		{key: "pin..vendor.example", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			cfg := Defaults()
+			cfg.DNS.HostOverrides = map[string][]string{tt.key: {"203.0.113.9"}}
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("key %q was accepted; it can never match a lookup", tt.key)
+				}
+				if !strings.Contains(err.Error(), "empty DNS label") {
+					t.Fatalf("key %q error = %v, want an empty-label refusal", tt.key, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("key %q unexpectedly refused: %v", tt.key, err)
+			}
+		})
+	}
+}
+
+func assertHostListOutcome(t *testing.T, err error, wantErr, stored, wantStored string) {
+	t.Helper()
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("entry was accepted; want an error containing %q", wantErr)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("error = %v, want it to contain %q", err, wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stored != wantStored {
+		t.Fatalf("stored %q, want %q; the matcher compares this string verbatim", stored, wantStored)
+	}
+}

--- a/internal/config/literal_host_list_validation_test.go
+++ b/internal/config/literal_host_list_validation_test.go
@@ -27,6 +27,12 @@ func TestLiteralHostMatchLists_RefuseInertEntries(t *testing.T) {
 		{name: "uppercase is folded to the matcher's view", entry: "Vendor.Example", wantStored: "vendor.example"},
 		{name: "single root dot is canonicalized", entry: "vendor.example.", wantStored: "vendor.example"},
 		{name: "double trailing dot", entry: "vendor.example..", wantErr: "must be written as"},
+		// A DIFFERENT validator catches this one. The trailing-dot case above
+		// normalizes to a valid host and is refused by the matcher-parity
+		// check, so it never reaches the label grammar; an interior empty
+		// label does, and nothing exercised that path through these lists.
+		{name: "embedded empty label", entry: "vendor..example", wantErr: "empty DNS label"},
+		{name: "leading dot", entry: ".vendor.example", wantErr: "empty DNS label"},
 		{name: "leading space", entry: " vendor.example", wantErr: "must be written as"},
 		{name: "empty", entry: "", wantErr: "empty"},
 		{name: "embedded space", entry: "bad host", wantErr: "DNS label characters"},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1285,18 +1285,33 @@ func matcherParityError(raw, normalized string) error {
 // than a bypass, which is why the repair is to refuse the input and to store
 // the canonical form, not to loosen either matcher.
 //
-// Breadth is deliberately not judged HERE, and the two lists differ in what
-// that costs. A wide wildcard on forward_proxy.redirect_websocket_hosts
-// routes more traffic into the /ws proxy, which still scans it. A wide
-// wildcard on tls_interception.passthrough_domains SPLICES without
-// decrypting, so it turns body and response scanning off for everything
-// under that suffix, which is the class this repository breadth-checks on
-// trusted_domains and the exempt lists. Adding the check would refuse a
-// value an existing deployment already loads, stopping that proxy at its
-// next restart, so it is an admission decision rather than part of giving
-// this list a validator at all. Tracked as DR-136.
-func validateLiteralHostMatchList(label string, entries []string) error {
-	if err := ValidateHostMatchList(entries, label); err != nil {
+// BREADTH is judged for one of the two lists and not the other, because they
+// differ in what a wide wildcard costs.
+//
+// tls_interception.passthrough_domains SPLICES a matching host without
+// decrypting it, so "*.com" there turns body and response scanning off for
+// every .com destination. That is the same detector-off shape this repository
+// already breadth-checks on trusted_domains and the exempt lists, so it gets
+// the grant-list rule: a wildcard whose base is an ICANN public suffix is
+// refused, while a private-suffix base such as "*.s3.amazonaws.com" stays
+// accepted because an operator legitimately writes it.
+//
+// forward_proxy.redirect_websocket_hosts is NOT the same: a wide wildcard
+// routes more traffic INTO the /ws proxy, which still scans it, so breadth
+// there is a routing preference rather than a hole.
+//
+// The admission cost was measured rather than assumed before adding this.
+// Nothing shipped is refused: the default is "*.googlevideo.com", every
+// preset ships an empty list, and the documented examples all survive the
+// predicate. An existing deployment that loads a public-suffix wildcard will
+// now fail validation and can be checked ahead of a restart with
+// `pipelock check --config`, which names the field, index and value.
+func validateLiteralHostMatchList(label string, entries []string, judgeBreadth bool) error {
+	if judgeBreadth {
+		if err := ValidateHostGrantList(entries, label); err != nil {
+			return err
+		}
+	} else if err := ValidateHostMatchList(entries, label); err != nil {
 		return err
 	}
 	// Store the normalized form. These matchers do not trim a trailing dot,
@@ -2862,7 +2877,7 @@ func (c *Config) validateGitProtection() error {
 func (c *Config) validateForwardProxy() error {
 	// Validate forward proxy config
 	if err := validateLiteralHostMatchList(
-		"forward_proxy.redirect_websocket_hosts", c.ForwardProxy.RedirectWebSocketHosts); err != nil {
+		"forward_proxy.redirect_websocket_hosts", c.ForwardProxy.RedirectWebSocketHosts, false); err != nil {
 		return err
 	}
 	if !c.ForwardProxy.Enabled {
@@ -3403,7 +3418,7 @@ func (c *Config) validateCrossRequestDetection(warnings *[]Warning) error {
 func (c *Config) validateTLSInterception() error {
 	// Validate TLS interception config
 	if err := validateLiteralHostMatchList(
-		"tls_interception.passthrough_domains", c.TLSInterception.PassthroughDomains); err != nil {
+		"tls_interception.passthrough_domains", c.TLSInterception.PassthroughDomains, true); err != nil {
 		return err
 	}
 	if !c.TLSInterception.Enabled {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1272,6 +1272,36 @@ func matcherParityError(raw, normalized string) error {
 	return nil
 }
 
+// validateLiteralHostMatchList validates a host list whose runtime matcher
+// only folds case: it compares the operator's stored string against the
+// request hostname with no trimming at all.
+//
+// Two lists are in that shape, tls_interception.passthrough_domains and
+// forward_proxy.redirect_websocket_hosts, and until now neither had any
+// validator. Every malformed spelling loaded clean and then matched nothing,
+// so the entry was silently inert: a pinned-certificate host written
+// "vendor.example." or " vendor.example" was intercepted anyway, and the
+// operator saw accepted configuration. That is an availability failure rather
+// than a bypass, which is why the repair is to refuse the input and to store
+// the canonical form, not to loosen either matcher.
+//
+// Breadth is deliberately not judged. Passthrough and WebSocket redirect are
+// routing decisions, so a wide wildcard is the operator's policy in the same
+// way it is on a blocklist.
+func validateLiteralHostMatchList(label string, entries []string) error {
+	if err := ValidateHostMatchList(entries, label); err != nil {
+		return err
+	}
+	// Store the normalized form. These matchers do not trim a trailing dot,
+	// so "vendor.example." would otherwise stay stored as typed and never
+	// match a request for "vendor.example", even though the parity check
+	// above accepts that spelling for matchers that do trim one dot.
+	for i, raw := range entries {
+		entries[i] = NormalizeHostPattern(raw)
+	}
+	return nil
+}
+
 func (c *Config) validateLogging() error {
 	switch c.Logging.Format {
 	case DefaultLogFormat, "text":
@@ -2824,6 +2854,10 @@ func (c *Config) validateGitProtection() error {
 
 func (c *Config) validateForwardProxy() error {
 	// Validate forward proxy config
+	if err := validateLiteralHostMatchList(
+		"forward_proxy.redirect_websocket_hosts", c.ForwardProxy.RedirectWebSocketHosts); err != nil {
+		return err
+	}
 	if !c.ForwardProxy.Enabled {
 		return nil
 	}
@@ -3361,6 +3395,10 @@ func (c *Config) validateCrossRequestDetection(warnings *[]Warning) error {
 
 func (c *Config) validateTLSInterception() error {
 	// Validate TLS interception config
+	if err := validateLiteralHostMatchList(
+		"tls_interception.passthrough_domains", c.TLSInterception.PassthroughDomains); err != nil {
+		return err
+	}
 	if !c.TLSInterception.Enabled {
 		return nil
 	}
@@ -4086,6 +4124,18 @@ func (c *Config) validateDNS() error {
 		}
 		if strings.Contains(normalizedHost, "://") || strings.ContainsAny(normalizedHost, "/*?[]:") {
 			return fmt.Errorf("dns.host_overrides: %q must be a hostname, not a URL, wildcard, IP, or host:port", host)
+		}
+		// An empty label means the key can never be reached. The resolver's
+		// own key normalizer removes ONE trailing dot, so "pin.example.com.."
+		// loaded clean, was stored as "pin.example.com." and no lookup for
+		// "pin.example.com" ever matched it: the pin was silently inert while
+		// the operator saw accepted configuration.
+		// The test is against the ONCE-TRIMMED value, which is what the
+		// resolver stores, so a residual trailing dot here means the operator
+		// wrote two.
+		if strings.HasPrefix(normalizedHost, ".") || strings.HasSuffix(normalizedHost, ".") ||
+			strings.Contains(normalizedHost, "..") {
+			return fmt.Errorf("dns.host_overrides: %q has an empty DNS label", host)
 		}
 		// Reject IP-literal keys: the override path is hostname-only, and
 		// allowing an IP-literal key would suggest the operator can rewrite

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1285,9 +1285,16 @@ func matcherParityError(raw, normalized string) error {
 // than a bypass, which is why the repair is to refuse the input and to store
 // the canonical form, not to loosen either matcher.
 //
-// Breadth is deliberately not judged. Passthrough and WebSocket redirect are
-// routing decisions, so a wide wildcard is the operator's policy in the same
-// way it is on a blocklist.
+// Breadth is deliberately not judged HERE, and the two lists differ in what
+// that costs. A wide wildcard on forward_proxy.redirect_websocket_hosts
+// routes more traffic into the /ws proxy, which still scans it. A wide
+// wildcard on tls_interception.passthrough_domains SPLICES without
+// decrypting, so it turns body and response scanning off for everything
+// under that suffix, which is the class this repository breadth-checks on
+// trusted_domains and the exempt lists. Adding the check would refuse a
+// value an existing deployment already loads, stopping that proxy at its
+// next restart, so it is an admission decision rather than part of giving
+// this list a validator at all. Tracked as DR-136.
 func validateLiteralHostMatchList(label string, entries []string) error {
 	if err := ValidateHostMatchList(entries, label); err != nil {
 		return err

--- a/internal/destination/empty_label_test.go
+++ b/internal/destination/empty_label_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package destination
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestNew_RejectsEmptyDNSLabel pins the empty-label refusal. Before it, the
+// two request-side normalizers disagreed: this constructor and MatchDomain
+// each remove ONE trailing dot, so "host.example.." reached a blocklist as
+// "host.example." and matched nothing while reaching a strict allowlist as
+// "host.example" and matched.
+func TestNew_RejectsEmptyDNSLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantErr bool
+	}{
+		{name: "plain host", host: "vendor.example"},
+		{name: "single root dot is a valid spelling", host: "vendor.example."},
+		{name: "double trailing dot", host: "vendor.example..", wantErr: true},
+		{name: "triple trailing dot", host: "vendor.example...", wantErr: true},
+		{name: "leading dot", host: ".vendor.example", wantErr: true},
+		{name: "interior empty label", host: "vendor..example", wantErr: true},
+		{name: "ipv4 literal", host: "203.0.113.9"},
+		{name: "ipv6 literal", host: "2001:db8::1"},
+		{name: "ipv4 mapped ipv6", host: "::ffff:203.0.113.9"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest, err := New(NetworkTCP, tt.host, 443)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("New(%q) = %+v, want an error", tt.host, dest)
+				}
+				if !errors.Is(err, ErrInvalidHost) {
+					t.Fatalf("New(%q) error = %v, want ErrInvalidHost", tt.host, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New(%q) unexpected error: %v", tt.host, err)
+			}
+		})
+	}
+}

--- a/internal/destination/normalize.go
+++ b/internal/destination/normalize.go
@@ -60,6 +60,30 @@ func NormalizeHost(host string) string {
 	return strings.ToLower(host)
 }
 
+// hasEmptyDNSLabel reports whether a host that has already had its single
+// root dot removed still carries an empty label: a leading dot, a second
+// trailing dot, or two dots in a row.
+//
+// No DNS name has an empty label, so nothing legitimate is refused. What the
+// check closes is a verdict split between the two request-side normalizers.
+// NormalizeHost above and MatchDomain each remove ONE trailing dot, and the
+// URL scanner hands the RAW hostname to the blocklist while handing THIS
+// struct's Host to the allowlist. Written "evil.example.com..", the raw form
+// reached the blocklist as "evil.example.com." and matched nothing, while the
+// once-trimmed form reached a strict allowlist as "evil.example.com" and
+// matched. The request then failed only because the dialer's own lookup of
+// the two-dot name found no such host: a wrong allow verdict rescued by the
+// resolver. Refusing the host here makes every transport's verdict an
+// explicit invalid-destination block instead. A single root dot is a valid
+// spelling and stays accepted; NormalizeHost has already consumed it.
+//
+// IPv6 literals never contain a dot pair, and an IPv4-mapped form such as
+// "::ffff:10.0.0.1" carries ordinary dotted labels, so no address literal
+// trips this check.
+func hasEmptyDNSLabel(host string) bool {
+	return strings.HasPrefix(host, ".") || strings.HasSuffix(host, ".") || strings.Contains(host, "..")
+}
+
 // NormalizeIP returns a canonical form of an address so two spellings of the
 // same address compare and hash identically. IPv4 is reduced to its 4-byte
 // form, which also collapses IPv4-mapped IPv6 onto the address it actually
@@ -122,6 +146,9 @@ func New(network Network, host string, port uint16) (Destination, error) {
 	}
 	if hasUnsafeHostChars(host) {
 		return Destination{}, fmt.Errorf("%w: control or whitespace character in %q", ErrInvalidHost, host)
+	}
+	if hasEmptyDNSLabel(host) {
+		return Destination{}, fmt.Errorf("%w: empty DNS label in %q", ErrInvalidHost, host)
 	}
 	if port == 0 {
 		return Destination{}, fmt.Errorf("%w: 0", ErrInvalidPort)

--- a/internal/proxy/host_empty_label_test.go
+++ b/internal/proxy/host_empty_label_test.go
@@ -85,7 +85,12 @@ func TestProxy_EmptyLabelHostBlocksOnEveryTransport(t *testing.T) {
 
 		t.Run("fetch/"+tc.host, func(t *testing.T) {
 			before := backendHits.Load()
-			resp, getErr := http.Get(srv.URL + "/fetch?url=" + url.QueryEscape(target))
+			fetchReq, fetchReqErr := http.NewRequestWithContext(
+				t.Context(), http.MethodGet, srv.URL+"/fetch?url="+url.QueryEscape(target), nil)
+			if fetchReqErr != nil {
+				t.Fatalf("new fetch request: %v", fetchReqErr)
+			}
+			resp, getErr := http.DefaultClient.Do(fetchReq)
 			if getErr != nil {
 				t.Fatalf("fetch: %v", getErr)
 			}
@@ -105,7 +110,7 @@ func TestProxy_EmptyLabelHostBlocksOnEveryTransport(t *testing.T) {
 		t.Run("forward/"+tc.host, func(t *testing.T) {
 			before := backendHits.Load()
 			transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
-			req, reqErr := http.NewRequest(http.MethodGet, target, nil)
+			req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
 			if reqErr != nil {
 				t.Fatalf("new request: %v", reqErr)
 			}
@@ -125,11 +130,12 @@ func TestProxy_EmptyLabelHostBlocksOnEveryTransport(t *testing.T) {
 
 		t.Run("connect/"+tc.host, func(t *testing.T) {
 			before := backendHits.Load()
-			conn, dialErr := net.DialTimeout("tcp", srv.Listener.Addr().String(), 5*time.Second)
+			dialer := &net.Dialer{Timeout: 5 * time.Second}
+			conn, dialErr := dialer.DialContext(t.Context(), "tcp", srv.Listener.Addr().String())
 			if dialErr != nil {
 				t.Fatalf("dial proxy: %v", dialErr)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			authority := net.JoinHostPort(tc.host, backendPort)
 			if _, writeErr := fmt.Fprintf(conn,
 				"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", authority, authority); writeErr != nil {
@@ -195,7 +201,8 @@ func TestWebSocketProxy_EmptyLabelHostRefused(t *testing.T) {
 // and the point is what pipelock does with the name.
 func wsUpgradeStatus(t *testing.T, proxyAddr, targetHostPort string) int {
 	t.Helper()
-	conn, dialErr := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, dialErr := dialer.DialContext(t.Context(), "tcp", proxyAddr)
 	if dialErr != nil {
 		t.Fatalf("dial proxy: %v", dialErr)
 	}

--- a/internal/proxy/host_empty_label_test.go
+++ b/internal/proxy/host_empty_label_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/pipelock/internal/audit"
+	"github.com/luckyPipewrench/pipelock/internal/config"
+	"github.com/luckyPipewrench/pipelock/internal/metrics"
+	"github.com/luckyPipewrench/pipelock/internal/scanner"
+)
+
+// TestProxy_EmptyLabelHostBlocksOnEveryTransport proves the empty-label
+// verdict on all three mediated request surfaces rather than in the scanner
+// alone, because each builds its destination at a different place.
+//
+// The backend is reachable only through a dns.host_overrides pin, and the
+// pinned name is on the blocklist. Before the fix the two-dot spelling
+// produced "blocked": false on every surface and reached the network layer,
+// where it survived only because the dialer's fresh lookup of the two-dot
+// name failed. That is a policy verdict decided by a resolver.
+func TestProxy_EmptyLabelHostBlocksOnEveryTransport(t *testing.T) {
+	var backendHits atomic.Int32
+	backend := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendHits.Add(1)
+		_, _ = fmt.Fprint(w, "backend reached")
+	}))
+	backendHost, backendPort, splitErr := net.SplitHostPort(backend.Listener.Addr().String())
+	if splitErr != nil {
+		t.Fatalf("split backend addr: %v", splitErr)
+	}
+
+	const pinnedHost = "pinned.vendor.example"
+
+	cfg := config.Defaults()
+	cfg.FetchProxy.TimeoutSeconds = 5
+	cfg.ForwardProxy.Enabled = true
+	cfg.SSRF.IPAllowlist = nil
+	cfg.APIAllowlist = nil
+	cfg.TrustedDomains = []string{pinnedHost}
+	cfg.DNS.HostOverrides = map[string][]string{pinnedHost: {backendHost}}
+	cfg.FetchProxy.Monitoring.Blocklist = []string{pinnedHost}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config.Validate: %v", err)
+	}
+
+	p, err := New(cfg, audit.NewNop(), scanner.MustNew(cfg), metrics.New())
+	if err != nil {
+		t.Fatalf("proxy.New: %v", err)
+	}
+	srv := httptest.NewServer(p.Handler())
+	defer srv.Close()
+	proxyURL, parseErr := url.Parse(srv.URL)
+	if parseErr != nil {
+		t.Fatalf("parse proxy URL: %v", parseErr)
+	}
+
+	// Control first: the exact pinned host is blocked by the blocklist on all
+	// three surfaces, which is what makes a refusal below meaningful.
+	// Then the empty-label spellings, which must also be refused.
+	cases := []struct {
+		host    string
+		control bool
+	}{
+		{host: pinnedHost, control: true},
+		{host: pinnedHost + "."},
+		{host: pinnedHost + ".."},
+		{host: pinnedHost + "..."},
+	}
+
+	for _, tc := range cases {
+		target := "http://" + net.JoinHostPort(tc.host, backendPort) + "/leak"
+
+		t.Run("fetch/"+tc.host, func(t *testing.T) {
+			before := backendHits.Load()
+			resp, getErr := http.Get(srv.URL + "/fetch?url=" + url.QueryEscape(target))
+			if getErr != nil {
+				t.Fatalf("fetch: %v", getErr)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("status %d body %q, want 403", resp.StatusCode, body)
+			}
+			if !strings.Contains(string(body), `"blocked":true`) {
+				t.Fatalf("body %q does not report a block", body)
+			}
+			if backendHits.Load() != before {
+				t.Fatal("backend was reached")
+			}
+		})
+
+		t.Run("forward/"+tc.host, func(t *testing.T) {
+			before := backendHits.Load()
+			transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+			req, reqErr := http.NewRequest(http.MethodGet, target, nil)
+			if reqErr != nil {
+				t.Fatalf("new request: %v", reqErr)
+			}
+			resp, doErr := (&http.Client{Transport: transport, Timeout: 5 * time.Second}).Do(req)
+			if doErr != nil {
+				t.Fatalf("forward: %v", doErr)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("status %d body %q, want 403", resp.StatusCode, body)
+			}
+			if backendHits.Load() != before {
+				t.Fatal("backend was reached")
+			}
+		})
+
+		t.Run("connect/"+tc.host, func(t *testing.T) {
+			before := backendHits.Load()
+			conn, dialErr := net.DialTimeout("tcp", srv.Listener.Addr().String(), 5*time.Second)
+			if dialErr != nil {
+				t.Fatalf("dial proxy: %v", dialErr)
+			}
+			defer conn.Close()
+			authority := net.JoinHostPort(tc.host, backendPort)
+			if _, writeErr := fmt.Fprintf(conn,
+				"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", authority, authority); writeErr != nil {
+				t.Fatalf("write CONNECT: %v", writeErr)
+			}
+			if deadlineErr := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
+				t.Fatalf("set deadline: %v", deadlineErr)
+			}
+			buf := make([]byte, 256)
+			n, _ := conn.Read(buf)
+			reply := string(buf[:n])
+			if !strings.HasPrefix(reply, "HTTP/1.1 403") {
+				t.Fatalf("CONNECT reply %q, want 403", reply)
+			}
+			if backendHits.Load() != before {
+				t.Fatal("backend was reached")
+			}
+		})
+	}
+}

--- a/internal/proxy/host_empty_label_test.go
+++ b/internal/proxy/host_empty_label_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net"
@@ -148,4 +149,71 @@ func TestProxy_EmptyLabelHostBlocksOnEveryTransport(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWebSocketProxy_EmptyLabelHostRefused covers the /ws surface, which
+// builds its destination from the url query parameter rather than from a
+// request line. The review that read this change confirmed statically that
+// the native WebSocket path scans before it dials, and this exercises it, so
+// the transport-parity claim is proven rather than argued.
+func TestWebSocketProxy_EmptyLabelHostRefused(t *testing.T) {
+	backendAddr, backendCleanup := wsEchoServer(t)
+	defer backendCleanup()
+	backendHost, backendPort, splitErr := net.SplitHostPort(backendAddr)
+	if splitErr != nil {
+		t.Fatalf("split backend addr: %v", splitErr)
+	}
+
+	const pinnedHost = "ws-pinned.vendor.example"
+	proxyAddr, proxyCleanup := setupWSProxy(t, func(cfg *config.Config) {
+		cfg.SSRF.IPAllowlist = nil
+		cfg.TrustedDomains = []string{pinnedHost}
+		cfg.DNS.HostOverrides = map[string][]string{pinnedHost: {backendHost}}
+	})
+	defer proxyCleanup()
+
+	// Control first: the exact pinned host upgrades, so a refusal below is
+	// the empty label rather than an unreachable backend.
+	if status := wsUpgradeStatus(t, proxyAddr, net.JoinHostPort(pinnedHost, backendPort)); status != http.StatusSwitchingProtocols {
+		t.Fatalf("control upgrade status %d, want 101", status)
+	}
+
+	for _, host := range []string{pinnedHost + "..", pinnedHost + "..."} {
+		status := wsUpgradeStatus(t, proxyAddr, net.JoinHostPort(host, backendPort))
+		if status == http.StatusSwitchingProtocols {
+			t.Fatalf("host %q upgraded; an empty-label host must be refused before the dial", host)
+		}
+		if status != http.StatusForbidden {
+			t.Fatalf("host %q status %d, want 403", host, status)
+		}
+	}
+}
+
+// wsUpgradeStatus performs one manual WebSocket upgrade through the proxy and
+// returns the status code. It is manual for the same reason the DNS override
+// end-to-end test is: a client-side dialer would resolve the hostname itself,
+// and the point is what pipelock does with the name.
+func wsUpgradeStatus(t *testing.T, proxyAddr, targetHostPort string) int {
+	t.Helper()
+	conn, dialErr := net.DialTimeout("tcp", proxyAddr, 5*time.Second)
+	if dialErr != nil {
+		t.Fatalf("dial proxy: %v", dialErr)
+	}
+	defer func() { _ = conn.Close() }()
+	if deadlineErr := conn.SetDeadline(time.Now().Add(5 * time.Second)); deadlineErr != nil {
+		t.Fatalf("set deadline: %v", deadlineErr)
+	}
+	upgrade := fmt.Sprintf(
+		"%s /ws?url=%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		http.MethodGet, url.QueryEscape("ws://"+targetHostPort+"/echo"), proxyAddr, generateWSKey(t),
+	)
+	if _, writeErr := conn.Write([]byte(upgrade)); writeErr != nil {
+		t.Fatalf("write upgrade: %v", writeErr)
+	}
+	resp, respErr := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if respErr != nil {
+		t.Fatalf("read upgrade response: %v", respErr)
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode
 }

--- a/internal/scanner/host_empty_label_test.go
+++ b/internal/scanner/host_empty_label_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/config"
+)
+
+// TestScan_EmptyLabelHostnameFailsClosed pins the verdict for a request
+// hostname carrying an empty DNS label.
+//
+// The defect this replaces was a SPLIT verdict, not a missing one. The scan
+// entry point hands the RAW hostname to the blocklist while handing the
+// once-trimmed destination host to the allowlist, so "host.example.."
+// evaded a blocklist entry for "host.example" and simultaneously SATISFIED a
+// strict allowlist entry for it. Only the dialer's own failed lookup of the
+// two-dot name kept the request off the network.
+func TestScan_EmptyLabelHostnameFailsClosed(t *testing.T) {
+	t.Run("blocklisted host cannot be evaded by an extra dot", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.FetchProxy.Monitoring.Blocklist = []string{"blocked.vendor.example"}
+		sc, err := New(cfg)
+		if err != nil {
+			t.Fatalf("scanner.New: %v", err)
+		}
+
+		// Control: the ordinary and single-root-dot spellings block on the
+		// blocklist, which is what proves the list is live.
+		for _, u := range []string{
+			"https://blocked.vendor.example/x",
+			"https://blocked.vendor.example./x",
+		} {
+			got := sc.Scan(context.Background(), u)
+			if got.Allowed || got.Scanner != ScannerBlocklist {
+				t.Fatalf("control %s: allowed=%v scanner=%s, want blocklist block", u, got.Allowed, got.Scanner)
+			}
+		}
+
+		for _, u := range []string{
+			"https://blocked.vendor.example../x",
+			"https://blocked.vendor.example.../x",
+			"https://BLOCKED.vendor.example../x",
+		} {
+			got := sc.Scan(context.Background(), u)
+			if got.Allowed {
+				t.Fatalf("%s was allowed; an empty-label spelling must not evade the blocklist", u)
+			}
+			if got.Scanner != ScannerParser || !strings.Contains(got.Reason, "invalid destination") {
+				t.Fatalf("%s: scanner=%s reason=%q, want a parser invalid-destination block", u, got.Scanner, got.Reason)
+			}
+		}
+	})
+
+	t.Run("strict allowlist is not satisfied by an extra dot", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.Internal = nil
+		cfg.Mode = config.ModeStrict
+		cfg.APIAllowlist = []string{"api.vendor.example"}
+		sc, err := New(cfg)
+		if err != nil {
+			t.Fatalf("scanner.New: %v", err)
+		}
+
+		// Control: the exact allowlisted host is permitted, so a refusal
+		// below is the empty label and not a dead allowlist.
+		if got := sc.Scan(context.Background(), "https://api.vendor.example/x"); !got.Allowed {
+			t.Fatalf("control: allowlisted host blocked by %s: %s", got.Scanner, got.Reason)
+		}
+
+		got := sc.Scan(context.Background(), "https://api.vendor.example../x")
+		if got.Allowed {
+			t.Fatal("an empty-label host satisfied the strict allowlist")
+		}
+		if got.Scanner != ScannerParser {
+			t.Fatalf("scanner=%s reason=%q, want a parser block", got.Scanner, got.Reason)
+		}
+	})
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1053,7 +1053,7 @@ func (s *Scanner) scan(ctx context.Context, rawURL string) (result Result) {
 	}
 	dest, destinationOK := urlDestination(parsed, hostname)
 	if !destinationOK {
-		return Result{Allowed: false, Reason: "invalid destination port", Scanner: ScannerParser, Score: 1.0}
+		return Result{Allowed: false, Reason: "invalid destination host or port", Scanner: ScannerParser, Score: 1.0}
 	}
 
 	// CRLF injection check - %0D%0A in URLs enables header injection.


### PR DESCRIPTION
## What changed

Two request-side normalizers each removed exactly one trailing DNS dot, and the URL scanner reads one of them for the blocklist and the other for the allowlist. A hostname written with an extra dot therefore arrived at the two lists as different strings: it evaded a deny rule while satisfying a strict allow rule, and the request was stopped only because the dialer's own lookup of that spelling found no such host. A policy verdict decided by a resolver is not a policy verdict. The destination constructor, which every mediated transport passes through, now refuses a host carrying an empty DNS label, so fetch, the forward proxy, CONNECT and the WebSocket surface all report an explicit invalid-destination block. A single root dot remains a valid spelling.

Two host lists had no validator at all. An entry on `tls_interception.passthrough_domains` or `forward_proxy.redirect_websocket_hosts` whose spelling differed from its case-folding-only matcher loaded clean and then matched no request, so an operator's pinned-certificate host was intercepted anyway while the configuration looked accepted. Both lists now refuse those spellings and store the canonical form. Breadth is deliberately not judged on either list, because a wide wildcard is a routing policy there in the same way it is on a blocklist. A `dns.host_overrides` key carrying an empty label is refused for the same reason: the resolver's key normalizer trims one dot, so such a key could never match a lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rejects malformed hostnames with empty DNS labels, including repeated, leading, or trailing dots.
  - Prevents invalid host formats from bypassing blocking or allowlist rules across proxy and scanning paths.
  - Validates host-list settings even when related features are disabled.
  - Normalizes accepted host entries by folding case and removing a single trailing dot.
  - Rejects invalid DNS host-override keys.
  - Clarifies invalid destination errors to identify invalid hosts or ports.

- **Documentation**
  - Clarifies wildcard and trailing-dot rules for WebSocket redirects and TLS passthrough domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->