### PR TITLE
test: cover containment operation failures

### DIFF
--- a/internal/cli/contain/workspace_failure_test.go
+++ b/internal/cli/contain/workspace_failure_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package contain
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luckyPipewrench/pipelock/internal/cliutil"
+)
+
+func TestRunContainRun_InventoryFailureStopsBeforePreflight(t *testing.T) {
+	for _, malformed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("malformed=%t", malformed), func(t *testing.T) {
+			env := allPassEnv(t)
+			readFile := env.readFile
+			env.readFile = func(path string) ([]byte, error) {
+				if path == env.workspaceInvPath {
+					if malformed {
+						return []byte(`{"workspaces":`), nil
+					}
+					return nil, os.ErrPermission
+				}
+				return readFile(path)
+			}
+			postureCalls, launches := 0, 0
+			runEnv := containRunEnv{
+				probe: env,
+				launch: func(context.Context, *probeEnv, []string, io.Reader, io.Writer, io.Writer) error {
+					launches++
+					return nil
+				},
+				emitPosture: func(string, string, *probeEnv, []string) (string, error) {
+					postureCalls++
+					return "proof.json", nil
+				},
+			}
+			var out bytes.Buffer
+			err := runContainRun(context.Background(), strings.NewReader(""), &out, io.Discard, runEnv, containRunOptions{}, []string{"agent-tool"})
+			if cliutil.ExitCodeOf(err) != cliutil.ExitGeneral || err == nil || !strings.Contains(err.Error(), "read workspace inventory") {
+				t.Fatalf("run error = %v, want inventory failure with general exit code", err)
+			}
+			if !malformed && !errors.Is(err, os.ErrPermission) {
+				t.Fatalf("read error lost its cause: %v", err)
+			}
+			if out.Len() != 0 || postureCalls != 0 || launches != 0 {
+				t.Fatalf("unreadable inventory reached preflight/posture/launch: output=%q, posture=%d, launches=%d", out.String(), postureCalls, launches)
+			}
+		})
+	}
+}
+
+func TestWorkspacePartialCommandFailurePreservesInventory(t *testing.T) {
+	for _, revoke := range []bool{false, true} {
+		for _, commandError := range []bool{false, true} {
+			t.Run(fmt.Sprintf("revoke=%t/command_error=%t", revoke, commandError), func(t *testing.T) {
+				env, runner, out := newFakeEnv(t)
+				workspace := filepath.Join(t.TempDir(), "nested", "workspace")
+				if err := os.MkdirAll(workspace, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				initial := workspaceInventory{Workspaces: []workspaceGrant{
+					{Path: t.TempDir(), Mode: workspaceModeReadOnly, AgentUser: env.agentUserName},
+				}}
+				commands := workspaceACLCommands(workspace, env.agentUserName, workspaceModeReadOnly)
+				if revoke {
+					initial.Workspaces = append(initial.Workspaces, workspaceGrant{Path: workspace, Mode: workspaceModeReadOnly, AgentUser: env.agentUserName})
+					remaining := workspaceGrantsExcept(initial.Workspaces, workspace, env.agentUserName)
+					commands = workspaceRevokeCommands(workspace, env.agentUserName, ancestorsNeededBy(grantsForAgent(remaining, env.agentUserName)), true)
+				}
+				if len(commands) < 3 {
+					t.Fatalf("need a partial application sequence, got %d commands", len(commands))
+				}
+				if err := writeWorkspaceInventory(env, initial); err != nil {
+					t.Fatal(err)
+				}
+				before, err := os.ReadFile(env.workspaceInvPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantErr := errors.New("ACL command interrupted")
+				failed := commands[1]
+				if commandError {
+					runner.on(argvFor(failed.name, failed.args...), "", 0, wantErr)
+				} else {
+					runner.on(argvFor(failed.name, failed.args...), "ACL refused", 1, nil)
+				}
+				runner.calls = nil
+				out.Reset()
+				if revoke {
+					err = runRevokeWorkspace(context.Background(), env, workspace, workspaceOpts{})
+				} else {
+					err = runGrantWorkspace(context.Background(), env, workspace, workspaceOpts{})
+				}
+				if err == nil || cliutil.ExitCodeOf(err) != cliutil.ExitGeneral {
+					t.Fatalf("partial ACL application error = %v, want general failure", err)
+				}
+				if commandError && !errors.Is(err, wantErr) {
+					t.Fatalf("command failure lost its cause: %v", err)
+				}
+				if !commandError && !strings.Contains(err.Error(), "exit 1: ACL refused") {
+					t.Fatalf("command exit failure lost its output: %v", err)
+				}
+				if len(runner.calls) != 2 {
+					t.Fatalf("ran %d commands after second command failed: %+v", len(runner.calls), runner.calls)
+				}
+				for i, call := range runner.calls {
+					if argvFor(call.name, call.args...) != argvFor(commands[i].name, commands[i].args...) {
+						t.Fatalf("command %d = %+v, want %+v", i, call, commands[i])
+					}
+				}
+				after, err := os.ReadFile(env.workspaceInvPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(before, after) || out.Len() != 0 {
+					t.Fatalf("failed ACL operation recorded success: before=%s, after=%s, output=%q", before, after, out.String())
+				}
+			})
+		}
+	}
+}

--- a/internal/cli/contain/workspace_failure_test.go
+++ b/internal/cli/contain/workspace_failure_test.go
@@ -6,6 +6,7 @@ package contain
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -50,6 +51,12 @@ func TestRunContainRun_InventoryFailureStopsBeforePreflight(t *testing.T) {
 			}
 			if !malformed && !errors.Is(err, os.ErrPermission) {
 				t.Fatalf("read error lost its cause: %v", err)
+			}
+			if malformed {
+				var syntaxErr *json.SyntaxError
+				if !errors.As(err, &syntaxErr) {
+					t.Fatalf("malformed inventory error lost its cause: %v", err)
+				}
 			}
 			if out.Len() != 0 || postureCalls != 0 || launches != 0 {
 				t.Fatalf("unreadable inventory reached preflight/posture/launch: output=%q, posture=%d, launches=%d", out.String(), postureCalls, launches)

--- a/internal/filesentry/watcher_backend_failure_test.go
+++ b/internal/filesentry/watcher_backend_failure_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package filesentry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestStartReportsBackendFailureWithActiveContext(t *testing.T) {
+	backend, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backend.Close() })
+	backend.Errors = make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	watcher := &fsWatcher{watcher: backend}
+	result := make(chan error, 1)
+	go func() { result <- watcher.Start(ctx) }()
+	wantErr := fsnotify.ErrEventOverflow
+	backend.Errors <- wantErr
+	select {
+	case got := <-result:
+		if !errors.Is(got, wantErr) || !strings.Contains(got.Error(), "fsnotify backend error") {
+			t.Fatalf("Start() = %v, want wrapped backend overflow", got)
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("test reached cancellation path: %v", ctx.Err())
+		}
+	case <-time.After(filesentryPositiveBackstop):
+		t.Fatal("Start did not report lost filesystem observation")
+	}
+}


### PR DESCRIPTION
## What changed

Add regression tests for workspace inventory failures, interrupted ACL operations, and active file-watcher backend errors, including checks that failed operations preserve recorded state and report failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring workspace inventory read or parsing failures stop processing before posture reporting or agent launch.
  * Added coverage confirming partial workspace permission failures stop at the failing operation while preserving error details, inventory data, and command output.
  * Added coverage verifying filesystem watcher backend errors are reported accurately while the operation remains active, rather than being treated as cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->