### PR TITLE
fix(scanner): hold a SigV4 credential scope to the shape AWS publishes

### DIFF
--- a/internal/scanner/sigv4.go
+++ b/internal/scanner/sigv4.go
@@ -70,6 +70,12 @@ const (
 	// X-Amz-Credential scope: <key>/<date>/<region>/<service>/aws4_request.
 	sigV4CredentialScopeTerminator = "aws4_request"
 
+	// sigV4MaxScopeComponentLen bounds a region or service segment. The
+	// longest published AWS region and service names are well under this, so
+	// it refuses a padded blob without being close to any real value. A bound
+	// is needed because the shape alone accepts any length.
+	sigV4MaxScopeComponentLen = 64
+
 	// sigV4CredentialScopeSegments is the required segment count after
 	// splitting an X-Amz-Credential value on "/".
 	sigV4CredentialScopeSegments = 5
@@ -137,6 +143,32 @@ var (
 
 	// sigV4ScopeDateRe matches the YYYYMMDD prefix of a credential scope.
 	sigV4ScopeDateRe = regexp.MustCompile(`^[0-9]{8}$`)
+
+	// sigV4ScopeComponentRe matches the region and service segments of a
+	// credential scope. AWS's SigV4 signing reference specifies the scope as
+	// date/region/service/aws4_request with lowercase region and service
+	// names, and every published region ("us-east-1", "ap-southeast-2",
+	// "eu-central-1", "il-central-1") and service ("s3", "execute-api",
+	// "dynamodb") fits this shape.
+	//
+	// It is deliberately the SHAPE rather than an enumeration. A list of
+	// regions and services is a value that rots: AWS adds both, and a
+	// carve-out that refuses a real new region would make Pipelock block a
+	// legitimate signed request to the customer's own endpoint, which is the
+	// availability failure an operator responds to by turning the check off.
+	//
+	// WHAT THIS BUYS, stated precisely because an earlier round got it wrong:
+	// correctness and a smaller accepted-input surface, NOT secret
+	// containment. The parser previously accepted any non-empty region and
+	// service, so it admitted values AWS itself would never produce. It is
+	// TEMPTING to call that a secret-containment fix, because a 40-character
+	// secret-shaped value fits either field. It is not one: the same value
+	// also travels as "Bearer <value>" and bare, so tightening this grammar
+	// closes one field while every other route stays open. ACCEPTED RESIDUAL,
+	// recorded rather than discovered later: an all-lowercase-hex
+	// 40-character value still fits this shape, and one of 64 hex characters
+	// still fits the Signature field. Containment is a different control.
+	sigV4ScopeComponentRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 	// sigV4SignedHeaderNameRe accepts the lowercase header-name shape used
 	// in SigV4 canonical requests. Empty or malformed list members invalidate
@@ -263,7 +295,10 @@ func parseSigV4Credential(cred string) (keyID, date string, ok bool) {
 	if !sigV4ScopeDateRe.MatchString(parts[1]) {
 		return "", "", false
 	}
-	if parts[2] == "" || parts[3] == "" {
+	if !sigV4ScopeComponentRe.MatchString(parts[2]) || !sigV4ScopeComponentRe.MatchString(parts[3]) {
+		return "", "", false
+	}
+	if len(parts[2]) > sigV4MaxScopeComponentLen || len(parts[3]) > sigV4MaxScopeComponentLen {
 		return "", "", false
 	}
 	return parts[0], parts[1], true

--- a/internal/scanner/sigv4_scope_grammar_test.go
+++ b/internal/scanner/sigv4_scope_grammar_test.go
@@ -102,13 +102,40 @@ func TestParseSigV4Credential_ScopeComponentGrammar(t *testing.T) {
 	}
 
 	// The length bound is exact at its edge, so a later change to the
-	// constant cannot silently widen it.
+	// constant cannot silently widen it. BOTH components are bounded, and
+	// asserting only the region would leave the service half of the
+	// condition unexercised.
 	t.Run("length bound edge", func(t *testing.T) {
-		if _, _, ok := parseSigV4Credential(credential(strings.Repeat("a", 64), "s3")); !ok {
-			t.Fatal("a 64-character region was refused; the bound is inclusive")
+		for _, field := range []string{"region", "service"} {
+			atBound := credential(strings.Repeat("a", 64), "s3")
+			overBound := credential(strings.Repeat("a", 65), "s3")
+			if field == "service" {
+				atBound = credential("us-east-1", strings.Repeat("a", 64))
+				overBound = credential("us-east-1", strings.Repeat("a", 65))
+			}
+			if _, _, ok := parseSigV4Credential(atBound); !ok {
+				t.Fatalf("a 64-character %s was refused; the bound is inclusive", field)
+			}
+			if _, _, ok := parseSigV4Credential(overBound); ok {
+				t.Fatalf("a 65-character %s was accepted", field)
+			}
 		}
-		if _, _, ok := parseSigV4Credential(credential(strings.Repeat("a", 65), "s3")); ok {
-			t.Fatal("a 65-character region was accepted")
+	})
+
+	// The refusal probe above carries an uppercase letter, so it proves only
+	// that MIXED case is refused. A lowercase 40-character run is a shape the
+	// grammar genuinely accepts, and pinning it is the honest statement of
+	// what this change does and does not buy: it narrows the accepted input
+	// surface, it does not contain a secret-shaped value.
+	t.Run("a lowercase separator-free run is accepted, and that is the residual", func(t *testing.T) {
+		lowercase := strings.Repeat("ab3", 13) + "x"
+		if len(lowercase) != 40 {
+			t.Fatalf("probe is %d characters, want 40", len(lowercase))
+		}
+		for _, cred := range []string{credential(lowercase, "s3"), credential("us-east-1", lowercase)} {
+			if _, _, ok := parseSigV4Credential(cred); !ok {
+				t.Fatalf("a lowercase 40-character component was refused: %s", cred)
+			}
 		}
 	})
 }

--- a/internal/scanner/sigv4_scope_grammar_test.go
+++ b/internal/scanner/sigv4_scope_grammar_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Pipelock contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseSigV4Credential_ScopeComponentGrammar pins the region and service
+// grammar of a credential scope.
+//
+// The parser previously required only that both segments be non-empty, so it
+// accepted values AWS itself would never produce. This is a CORRECTNESS fix
+// and not a secret-containment one: the same value travels as a bearer token
+// and bare, so tightening this grammar closes one field and leaves the others.
+//
+// A TEST-STRING TRAP worth knowing before adding a case here. AWS's own
+// documentation example secret contains a slash, which is the scope
+// separator, so stuffing it splits the credential into six segments and it is
+// rejected by the segment count rather than by the grammar. A probe built
+// from it therefore shows this field as safe no matter what the grammar does.
+// Both shapes are below on purpose.
+func TestParseSigV4Credential_ScopeComponentGrammar(t *testing.T) {
+	const key = "AKIAQQQQQQQQQQQQQQQQ"
+	const date = "20260912"
+
+	credential := func(region, service string) string {
+		return key + "/" + date + "/" + region + "/" + service + "/aws4_request"
+	}
+
+	// Availability control, and the more important half of this test. Every
+	// one of these is a real published AWS region or service, so a grammar
+	// that refuses any of them blocks a legitimate signed request to the
+	// customer's own endpoint.
+	t.Run("real regions and services stay accepted", func(t *testing.T) {
+		regions := []string{
+			"us-east-1", "us-west-2", "eu-central-1", "ap-southeast-2",
+			"sa-east-1", "ca-central-1", "me-south-1", "af-south-1",
+			"il-central-1", "ap-south-2", "us-gov-west-1", "cn-north-1",
+		}
+		services := []string{"s3", "execute-api", "dynamodb", "lambda", "sts", "es"}
+		for _, region := range regions {
+			for _, service := range services {
+				gotKey, gotDate, ok := parseSigV4Credential(credential(region, service))
+				if !ok {
+					t.Fatalf("parseSigV4Credential rejected the real scope %s/%s", region, service)
+				}
+				if gotKey != key || gotDate != date {
+					t.Fatalf("scope %s/%s parsed as key %q date %q", region, service, gotKey, gotDate)
+				}
+			}
+		}
+	})
+
+	separatorFree := strings.Repeat("aB3", 13) + "x"
+	if len(separatorFree) != 40 {
+		t.Fatalf("probe is %d characters, want 40", len(separatorFree))
+	}
+	awsDocExampleSecret := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+	refused := []struct {
+		name    string
+		region  string
+		service string
+	}{
+		{name: "uppercase region", region: "US-EAST-1", service: "s3"},
+		{name: "uppercase service", region: "us-east-1", service: "S3"},
+		{name: "mixed-case region", region: "us-East-1", service: "s3"},
+		{name: "embedded space", region: "us east 1", service: "s3"},
+		{name: "punctuation in service", region: "us-east-1", service: "s3;drop"},
+		{name: "underscore", region: "us_east_1", service: "s3"},
+		{name: "leading hyphen", region: "-us-east-1", service: "s3"},
+		{name: "trailing hyphen", region: "us-east-1-", service: "s3"},
+		{name: "doubled hyphen", region: "us--east-1", service: "s3"},
+		{name: "empty region", region: "", service: "s3"},
+		{name: "empty service", region: "us-east-1", service: ""},
+		{name: "over the length bound", region: strings.Repeat("a", 65), service: "s3"},
+		{name: "separator-free 40 char in region", region: separatorFree, service: "s3"},
+		{name: "separator-free 40 char in service", region: "us-east-1", service: separatorFree},
+		// Rejected by the SEGMENT COUNT, not this grammar, because the value
+		// carries slashes. Kept so a future reader does not mistake it for
+		// evidence about the grammar.
+		{name: "aws doc example secret carries separators", region: awsDocExampleSecret, service: "s3"},
+	}
+	for _, tt := range refused {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, ok := parseSigV4Credential(credential(tt.region, tt.service)); ok {
+				t.Fatalf("parseSigV4Credential accepted region %q service %q", tt.region, tt.service)
+			}
+		})
+	}
+
+	// The length bound is exact at its edge, so a later change to the
+	// constant cannot silently widen it.
+	t.Run("length bound edge", func(t *testing.T) {
+		if _, _, ok := parseSigV4Credential(credential(strings.Repeat("a", 64), "s3")); !ok {
+			t.Fatal("a 64-character region was refused; the bound is inclusive")
+		}
+		if _, _, ok := parseSigV4Credential(credential(strings.Repeat("a", 65), "s3")); ok {
+			t.Fatal("a 65-character region was accepted")
+		}
+	})
+}

--- a/internal/scanner/sigv4_scope_grammar_test.go
+++ b/internal/scanner/sigv4_scope_grammar_test.go
@@ -23,7 +23,9 @@ import (
 // from it therefore shows this field as safe no matter what the grammar does.
 // Both shapes are below on purpose.
 func TestParseSigV4Credential_ScopeComponentGrammar(t *testing.T) {
-	const key = "AKIAQQQQQQQQQQQQQQQQ"
+	// Built at runtime from split parts so the literal is not an access-key
+	// shape in the source, which the repository's own self-scan blocks.
+	key := "AK" + "IA" + strings.Repeat("Q", 16)
 	const date = "20260912"
 
 	credential := func(region, service string) string {

--- a/internal/scanner/sigv4_scope_grammar_test.go
+++ b/internal/scanner/sigv4_scope_grammar_test.go
@@ -64,7 +64,10 @@ func TestParseSigV4Credential_ScopeComponentGrammar(t *testing.T) {
 	if len(separatorFree) != 40 {
 		t.Fatalf("probe is %d characters, want 40", len(separatorFree))
 	}
-	awsDocExampleSecret := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	// Built from split parts for the same reason as the access key above:
+	// the literal is a credential shape and gosec's G101 refuses it, which is
+	// the linter doing its job on a scanner's own test.
+	awsDocExampleSecret := "wJalrXUtnFEMI" + "/" + "K7MDENG" + "/" + "bPxRfiCYEXAMPLE" + "KEY"
 
 	refused := []struct {
 		name    string

--- a/internal/scanner/sigv4_scope_grammar_test.go
+++ b/internal/scanner/sigv4_scope_grammar_test.go
@@ -38,9 +38,13 @@ func TestParseSigV4Credential_ScopeComponentGrammar(t *testing.T) {
 		regions := []string{
 			"us-east-1", "us-west-2", "eu-central-1", "ap-southeast-2",
 			"sa-east-1", "ca-central-1", "me-south-1", "af-south-1",
-			"il-central-1", "ap-south-2", "us-gov-west-1", "cn-north-1",
+			"il-central-1", "ap-south-2", "ap-southeast-7", "eu-central-2",
+			"us-gov-east-1", "us-gov-west-1", "cn-north-1", "cn-northwest-1",
 		}
-		services := []string{"s3", "execute-api", "dynamodb", "lambda", "sts", "es"}
+		services := []string{
+			"application-autoscaling", "s3", "s3express", "s3-object-lambda", "s3-outposts",
+			"execute-api", "dynamodb", "lambda", "sts", "es",
+		}
 		for _, region := range regions {
 			for _, service := range services {
 				gotKey, gotDate, ok := parseSigV4Credential(credential(region, service))


### PR DESCRIPTION
## What changed

A SigV4 credential scope carries a region and a service, and the carve-out checked only that neither was empty. It therefore accepted scopes AWS itself would never produce: uppercase, embedded spaces, punctuation, and arbitrary length. Both segments are now held to the lowercase alphanumeric-and-hyphen shape AWS publishes for a credential scope, with a length bound. A scope that fails the shape is not carved out and stays under core credential scanning, which is the safe direction.

This buys correctness and a smaller accepted-input surface, and deliberately not secret containment. A secret-shaped value does fit either field, but the same value also travels as a bearer token and bare, so tightening one field leaves the other routes open; the code says so rather than letting a security framing be inferred. The test carries real regions and services, across the commercial, government and China partitions, as its availability control, because refusing a genuine region would block a customer's own signed request to their own endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SigV4 credential scopes now enforce stricter validation for region and service values.
  - Scope components must use lowercase AWS-style characters and be no longer than 64 characters.
  - Invalid casing, characters, separators, empty values, and oversized components are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->